### PR TITLE
README: Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## About LibrePCB
 
-LibrePCB is a free Schematic / Layout Editor to develop printed circuit boards. It runs on Linux, Windows and Mac. The project is still in a quite early development stage (no stable release available).
+LibrePCB is a free Schematic / Layout Editor to develop printed circuit boards.
+It runs on Linux, Windows and Mac. The project is still in a quite early
+development stage (no stable release available).
 
 ![Screenshot](doc/screenshot.png)
 
@@ -22,8 +24,9 @@ To compile LibrePCB, you need the following software components:
 
 ### Workspace
 
-At the first startup, LibrePCB asks for a workspace directory where the library elements and projects will be saved.
-For developers there is a demo workspace inclusive library and projects in this repository (subdirectory "dev/workspace/").
+At the first startup, LibrePCB asks for a workspace directory where the library
+elements and projects will be saved.  For developers there is a demo workspace
+inclusive library and projects in this repository (subdirectory "dev/workspace/").
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ way.  To keep build time as low as possible make sure to set the correct make
 flags to use all available CPU cores to build. See this [stackoverflow
 answer](https://stackoverflow.com/questions/8860712/setting-default-make-options-for-qt-creator).
 
+#### Using qmake and make
+
+Since qtcreator is also using qmake and make to build, it's easy to do the same
+on the command line:
+
+```bash
+% qmake librepcb.pro 
+% make -j 8
+```
+
+Then grab a coffee, since the compilation takes about two minutes on a decent
+laptop:
+```
+make -j8  819.54s user 44.92s system 726% cpu 1:58.93 total
+```
+
 ### Documentation
 
 - Doxygen: http://librepcb.github.io/LibrePCB-Doxygen/master/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ To compile LibrePCB, you need the following software components:
 - Qt >= 5.4 (http://www.qt.io/download-open-source/)
 - libglu1-mesa-dev (`sudo apt-get install libglu1-mesa-dev`)
 
+### Building
+
+#### Using qtcreator
+
+Building with [qtcreator](http://doc.qt.io/qtcreator/) is probably the easiest
+way.  To keep build time as low as possible make sure to set the correct make
+flags to use all available CPU cores to build. See this [stackoverflow
+answer](https://stackoverflow.com/questions/8860712/setting-default-make-options-for-qt-creator).
+
 ### Documentation
 
 - Doxygen: http://librepcb.github.io/LibrePCB-Doxygen/master/


### PR DESCRIPTION
I'm not sure if qtcreator is really needed. maybe one can get along with qmake and make. Also I stole the screen-shot from http://stackoverflow.com/questions/8860712/setting-default-make-options-for-qt-creator maybe we want to create our own.