### PR TITLE
graphics: Fix zooming on touch-pads

### DIFF
--- a/libs/librepcbcommon/graphics/graphicsview.cpp
+++ b/libs/librepcbcommon/graphics/graphicsview.cpp
@@ -142,7 +142,7 @@ void GraphicsView::handleMouseWheelEvent(QGraphicsSceneWheelEvent* event) noexce
     else
     {
         // Zoom to mouse
-        qreal scaleFactor = (event->delta() > 0) ? sZoomStepFactor : 1 / sZoomStepFactor;
+        qreal scaleFactor = qPow(sZoomStepFactor, event->delta()/qreal(120));
         scale(scaleFactor, scaleFactor);
     }
     event->setAccepted(true);


### PR DESCRIPTION
On scroll-wheels the ``event->delta()`` always returns +-120. On touch-pads the
events arise faster and have different values.