### PR TITLE
Use more restrictive compiler flags

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 build_script:
   - mkdir build
   - cd build
-  - qmake -r ..\librepcb.pro
+  - qmake -r ..\librepcb.pro QMAKE_CFLAGS="-Werror" QMAKE_CXXFLAGS="-Werror"
   - mingw32-make -j 4
   - .\generated\windows\qztest.exe # run quazip unit tests
   - .\generated\windows\tests.exe  # run librepcb unit tests

--- a/common.pri
+++ b/common.pri
@@ -43,8 +43,8 @@ CONFIG += c++11
 
 # enable compiler warnings
 CONFIG += warn_on
-QMAKE_CXXFLAGS += -Wextra
-QMAKE_CXXFLAGS_DEBUG += -Wextra
+QMAKE_CXXFLAGS += -Wextra -pedantic
+QMAKE_CXXFLAGS_DEBUG += -Wextra -pedantic
 
 # QuaZIP: use as static library
 DEFINES += QUAZIP_STATIC

--- a/dev/travis/build.sh
+++ b/dev/travis/build.sh
@@ -3,9 +3,13 @@
 # set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
 set -eufv -o pipefail
 
+# make all warnings into errors
+$CFLAGS = "-pedantic"
+$CXXFLAGS = "-pedantic"
+
 # set special flag for clang (see https://github.com/travis-ci/travis-ci/issues/5383)
-if [ "$CC" = "clang" ]; then CFLAGS="-Qunused-arguments"; else CFLAGS=""; fi
-if [ "$CXX" = "clang++" ]; then CXXFLAGS="-Qunused-arguments"; else CXXFLAGS=""; fi
+if [ "$CC" = "clang" ]; then $CFLAGS+=" -Qunused-arguments"; fi
+if [ "$CXX" = "clang++" ]; then $CXXFLAGS+=" -Qunused-arguments"; fi
 
 # build librepcb
 mkdir build

--- a/libs/librepcb/common/fileio/filepath.h
+++ b/libs/librepcb/common/fileio/filepath.h
@@ -130,7 +130,7 @@ class FilePath final
             // default
             Default         = KeepSpaces | KeepCase,
         };
-        Q_DECLARE_FLAGS(CleanFileNameOptions, CleanFileNameOption);
+        Q_DECLARE_FLAGS(CleanFileNameOptions, CleanFileNameOption)
 
 
     public: // Methods

--- a/libs/librepcb/common/widgets/statusbar.h
+++ b/libs/librepcb/common/widgets/statusbar.h
@@ -52,7 +52,7 @@ class StatusBar final : public QStatusBar
             AbsolutePosition    = 1<<0,
             ProgressBar         = 1<<1,
         };
-        Q_DECLARE_FLAGS(Fields, Field);
+        Q_DECLARE_FLAGS(Fields, Field)
 
         // Constructors / Destructor
         explicit StatusBar(QWidget* parent = nullptr) noexcept;

--- a/tests/common/filepathtest.cpp
+++ b/tests/common/filepathtest.cpp
@@ -169,17 +169,8 @@ TEST(FilePathTest, testCleanFileName)
  *  Test Data
  ****************************************************************************************/
 
-INSTANTIATE_TEST_CASE_P(FilePathTest, FilePathTest, ::testing::Values(
-
+INSTANTIATE_TEST_CASE_P(FilePathTestCommon, FilePathTest, ::testing::Values(
     // valid paths   {valid, "inputFilePath"         , "inputBasePath"  , "toStr"           , "toWindowsStyle"      , "toRelative"      }
-#ifdef Q_OS_WIN
-    FilePathTestData({true , "C:\\foo\\bar"          , "C:/foo"         , "C:/foo/bar"      , "C:\\foo\\bar"        , "bar"             }), // Win path to a dir
-    FilePathTestData({true , "C:\\foo\\bar\\"        , "C:/bar"         , "C:/foo/bar"      , "C:\\foo\\bar"        , "../foo/bar"      }), // Win path to a dir + backslash
-    FilePathTestData({true , "C:\\foo\\bar.txt"      , "C:/bar"         , "C:/foo/bar.txt"  , "C:\\foo\\bar.txt"    , "../foo/bar.txt"  }), // Win path to a file
-    FilePathTestData({true , "C:\\foo\\bar"          , "C:/foo\\bar"    , "C:/foo/bar"      , "C:\\foo\\bar"        , ""                }), // Win path with path==base
-    FilePathTestData({true , "C:\\\\foo\\..\\bar\\"  , "C:\\"           , "C:/bar"          , "C:\\bar"             , "bar"             }), // Win path with .. and double backslashes
-    FilePathTestData({true , "C:\\"                  , "C:\\foo"        , "C:"              , "C:"                  , ".."              }), // Win drive root path
-#endif
     FilePathTestData({true , "/foo/bar"              , "/foo"           , "/foo/bar"        , "\\foo\\bar"          , "bar"             }), // UNIX path to a dir
     FilePathTestData({true , "/foo/bar/"             , "/bar"           , "/foo/bar"        , "\\foo\\bar"          , "../foo/bar"      }), // UNIX path to a dir + slash
     FilePathTestData({true , "/foo/bar.txt"          , "/bar"           , "/foo/bar.txt"    , "\\foo\\bar.txt"      , "../foo/bar.txt"  }), // UNIX path to a file
@@ -189,14 +180,26 @@ INSTANTIATE_TEST_CASE_P(FilePathTest, FilePathTest, ::testing::Values(
     FilePathTestData({true , "/"                     , "/foo"           , "/"               , "\\"                  , ".."              }), // UNIX root path
 
     // invalid paths {valid, "inputFilePath"         , "inputBasePath"  , "toStr"           , "toWindowsStyle"      , "toRelative"      }
-#ifdef Q_OS_WIN
-    FilePathTestData({false, "foo\\bar"              , ""               , ""                , ""                    , ""                }), // rel. Win path to a dir
-    FilePathTestData({false, "foo\\bar.txt"          , ""               , ""                , ""                    , ""                }), // rel. Win path to a file
-#endif
     FilePathTestData({false, "foo/bar"               , ""               , ""                , ""                    , ""                }), // rel. UNIX path to a dir
     FilePathTestData({false, "foo/bar.txt"           , ""               , ""                , ""                    , ""                }), // rel. UNIX path to a file
     FilePathTestData({false, ""                      , ""               , ""                , ""                    , ""                })  // empty path
 ));
+
+#ifdef Q_OS_WIN
+INSTANTIATE_TEST_CASE_P(FilePathTestWindows, FilePathTest, ::testing::Values(
+    // valid paths   {valid, "inputFilePath"         , "inputBasePath"  , "toStr"           , "toWindowsStyle"      , "toRelative"      }
+    FilePathTestData({true , "C:\\foo\\bar"          , "C:/foo"         , "C:/foo/bar"      , "C:\\foo\\bar"        , "bar"             }), // Win path to a dir
+    FilePathTestData({true , "C:\\foo\\bar\\"        , "C:/bar"         , "C:/foo/bar"      , "C:\\foo\\bar"        , "../foo/bar"      }), // Win path to a dir + backslash
+    FilePathTestData({true , "C:\\foo\\bar.txt"      , "C:/bar"         , "C:/foo/bar.txt"  , "C:\\foo\\bar.txt"    , "../foo/bar.txt"  }), // Win path to a file
+    FilePathTestData({true , "C:\\foo\\bar"          , "C:/foo\\bar"    , "C:/foo/bar"      , "C:\\foo\\bar"        , ""                }), // Win path with path==base
+    FilePathTestData({true , "C:\\\\foo\\..\\bar\\"  , "C:\\"           , "C:/bar"          , "C:\\bar"             , "bar"             }), // Win path with .. and double backslashes
+    FilePathTestData({true , "C:\\"                  , "C:\\foo"        , "C:"              , "C:"                  , ".."              }), // Win drive root path
+
+    // invalid paths {valid, "inputFilePath"         , "inputBasePath"  , "toStr"           , "toWindowsStyle"      , "toRelative"      }
+    FilePathTestData({false, "foo\\bar"              , ""               , ""                , ""                    , ""                }), // rel. Win path to a dir
+    FilePathTestData({false, "foo\\bar.txt"          , ""               , ""                , ""                    , ""                })  // rel. Win path to a file
+));
+#endif
 
 /*****************************************************************************************
  *  End of File

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -21,6 +21,11 @@ QT += core widgets network printsupport xml opengl sql concurrent
 CONFIG += console
 CONFIG -= app_bundle
 
+# ignore warnings produced by macros from gtest
+# TODO: fix these warnings because actually the code is not valid!
+QMAKE_CXXFLAGS += -Wno-gnu-zero-variadic-macro-arguments
+QMAKE_CXXFLAGS_DEBUG += -Wno-gnu-zero-variadic-macro-arguments
+
 LIBS += \
     -L$${DESTDIR} \
     -lgoogletest \


### PR DESCRIPTION
I'm not yet sure if this would make sense, but I have created a branch where more restrictive compiler flags are used (which should help to increase code quality).

Added compiler flags: `-pedantic` and `-Weffc++` (only known by GCC)

In release mode, `-Werror` is also added (creating releases should not be possible as long as there are compiler warnings). In the Travis-CI config, I have extended the build matrix to always build in debug and release mode. This means that a build is only successful if there are no compiler warnings.

At the moment, `librepcbcommon` is the only project `g++` compiles without warnings. All other projects have to be adjusted before merging this pull request...
