### PR TITLE
Improved the undo command concept and related classes

### DIFF
--- a/libs/librepcbcommon/librepcbcommon.pro
+++ b/libs/librepcbcommon/librepcbcommon.pro
@@ -64,7 +64,8 @@ HEADERS += \
     geometry/polygon.h \
     geometry/ellipse.h \
     geometry/text.h \
-    geometry/hole.h
+    geometry/hole.h \
+    undocommandgroup.h
 
 SOURCES += \
     attributes/attributetype.cpp \
@@ -106,7 +107,8 @@ SOURCES += \
     geometry/polygon.cpp \
     geometry/ellipse.cpp \
     geometry/text.cpp \
-    geometry/hole.cpp
+    geometry/hole.cpp \
+    undocommandgroup.cpp
 
 FORMS += \
     dialogs/gridsettingsdialog.ui

--- a/libs/librepcbcommon/undocommandgroup.cpp
+++ b/libs/librepcbcommon/undocommandgroup.cpp
@@ -1,0 +1,166 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 Urban Bruhin
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "undocommandgroup.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+UndoCommandGroup::UndoCommandGroup(const QString& text) noexcept :
+    UndoCommand(text)
+{
+}
+
+UndoCommandGroup::~UndoCommandGroup() noexcept
+{
+    // delete childs in reverse order
+    while (mChilds.count() > 0) {
+        delete mChilds.takeLast();
+    }
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+void UndoCommandGroup::performExecute() throw (Exception)
+{
+    // TODO: use scope guard
+
+    int i;
+
+    try
+    {
+        for (i = 0; i < mChilds.count(); i++) { // from bottom to top
+            mChilds[i]->execute();
+        }
+    }
+    catch (Exception&)
+    {
+        try
+        {
+            // could not execute the child with index "i"!
+            // try to revert the whole action --> undo the executed commands
+            for (; i >= 0; i--) { // from "i" to bottom
+                mChilds[i]->undo();
+            }
+        }
+        catch (Exception&)
+        {
+            qFatal("UndoCommandGroup: Internal Fatal Error");
+        }
+        throw;
+    }
+}
+
+void UndoCommandGroup::performUndo() throw (Exception)
+{
+    // TODO: use scope guard
+
+    int i;
+
+    try
+    {
+        for (i = mChilds.count()-1; i >= 0; i--) { // from top to bottom
+            mChilds[i]->undo();
+        }
+    }
+    catch (Exception&)
+    {
+        try
+        {
+            // could not undo the child with index "i"!
+            // try to revert the whole action --> redo the undoed commands
+            for (; i < mChilds.count(); i++) { // from "i" to top
+                mChilds[i]->redo();
+            }
+        }
+        catch (Exception&)
+        {
+            qFatal("UndoCommandGroup: Internal Fatal Error");
+        }
+        throw;
+    }
+}
+
+void UndoCommandGroup::performRedo() throw (Exception)
+{
+    // TODO: use scope guard
+
+    int i;
+
+    try
+    {
+        for (i = 0; i < mChilds.count(); i++) { // from bottom to top
+            mChilds[i]->redo();
+        }
+    }
+    catch (Exception&)
+    {
+        try
+        {
+            // could not undo the child with index "i"!
+            // try to revert the whole action --> undo the redoed commands
+            for (; i >= 0; i--) { // from "i" to bottom
+                mChilds[i]->undo();
+            }
+        }
+        catch (Exception&)
+        {
+            qFatal("UndoCommandGroup: Internal Fatal Error");
+        }
+        throw;
+    }
+}
+
+/*****************************************************************************************
+ *  Internal Methods
+ ****************************************************************************************/
+
+void UndoCommandGroup::appendChild(UndoCommand* cmd) throw (Exception)
+{
+    // make sure "cmd" is deleted when going out of scope (e.g. because of an exception)
+    QScopedPointer<UndoCommand> cmdScopeGuard(cmd);
+
+    if ((!cmd) || (mChilds.contains(cmd)) || (wasEverReverted())) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+
+    if (wasEverExecuted()) {
+        cmd->execute(); // can throw
+    }
+
+    mChilds.append(cmdScopeGuard.take());
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcbcommon/undocommandgroup.h
+++ b/libs/librepcbcommon/undocommandgroup.h
@@ -1,0 +1,111 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 Urban Bruhin
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_UNDOCOMMANDGROUP_H
+#define LIBREPCB_UNDOCOMMANDGROUP_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "undocommand.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class UndoCommandGroup
+ ****************************************************************************************/
+
+/**
+ * @brief The UndoCommandGroup class makes it possible to pack multiple undo commands
+ *        together (it acts as a parent of it's child commands)
+ *
+ * @author ubruhin
+ * @date 2016-03-11
+ */
+class UndoCommandGroup : public UndoCommand
+{
+        Q_DECLARE_TR_FUNCTIONS(UndoCommandGroup)
+
+    public:
+
+        // Constructors / Destructor
+        UndoCommandGroup() = delete;
+        UndoCommandGroup(const UndoCommandGroup& other) = delete;
+        explicit UndoCommandGroup(const QString& text) noexcept;
+        virtual ~UndoCommandGroup() noexcept;
+
+        // Getters
+        int getChildCount() const noexcept {return mChilds.count();}
+
+        // General Methods
+
+        /**
+         * @brief Append a new command to the list of child commands
+         *
+         * @param cmd       The command to add (must not be executed already)
+         *
+         * @note If this command was already executed (#execute() called), this method
+         *       will also immediately execute the newly added child command. Otherwise,
+         *       it will be executed as soon as #execute() is called.
+         *
+         * @warning This method must not be called after #undo() was called the first time.
+         */
+        void appendChild(UndoCommand* cmd) throw (Exception);
+
+        // Operator Overloadings
+        UndoCommandGroup& operator=(const UndoCommandGroup& rhs) = delete;
+
+
+    protected:
+
+        /// @copydoc UndoCommand::performExecute()
+        virtual void performExecute() throw (Exception) override;
+
+
+    private:
+
+        /// @copydoc UndoCommand::performUndo()
+        virtual void performUndo() throw (Exception) override final;
+
+        /// @copydoc UndoCommand::performRedo()
+        virtual void performRedo() throw (Exception) override;
+
+
+    private:
+
+        /**
+         * @brief All child commands
+         *
+         * The child which is executed first is at index zero, the last executed command
+         * is at the top of the list.
+         */
+        QList<UndoCommand*> mChilds;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_UNDOCOMMANDGROUP_H

--- a/libs/librepcbproject/boards/cmd/cmdboardadd.cpp
+++ b/libs/librepcbproject/boards/cmd/cmdboardadd.cpp
@@ -35,9 +35,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdBoardAdd::CmdBoardAdd(Project& project, const QString& name,
-                         UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add board"), parent),
+CmdBoardAdd::CmdBoardAdd(Project& project, const QString& name) noexcept :
+    UndoCommand(tr("Add board")),
     mProject(project), mName(name), mBoard(nullptr), mPageIndex(-1)
 {
 }
@@ -50,37 +49,20 @@ CmdBoardAdd::~CmdBoardAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdBoardAdd::redo() throw (Exception)
+void CmdBoardAdd::performExecute() throw (Exception)
 {
-    if (!mBoard) // only the first time
-        mBoard = mProject.createBoard(mName); // throws an exception on error
-
-    mProject.addBoard(mBoard, mPageIndex); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mProject.removeBoard(mBoard);
-        throw;
-    }
+    mBoard = mProject.createBoard(mName); // can throw
+    performRedo(); // can throw
 }
 
-void CmdBoardAdd::undo() throw (Exception)
+void CmdBoardAdd::performUndo() throw (Exception)
 {
-    mProject.removeBoard(mBoard); // throws an exception on error
+    mProject.removeBoard(mBoard); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mProject.addBoard(mBoard, mPageIndex);
-        throw;
-    }
+void CmdBoardAdd::performRedo() throw (Exception)
+{
+    mProject.addBoard(mBoard, mPageIndex); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/boards/cmd/cmdboardadd.h
+++ b/libs/librepcbproject/boards/cmd/cmdboardadd.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,18 +47,28 @@ class CmdBoardAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdBoardAdd(Project& project, const QString& name,
-                             UndoCommand* parent = 0) throw (Exception);
+        CmdBoardAdd(Project& project, const QString& name) noexcept;
         ~CmdBoardAdd() noexcept;
 
         // Getters
         Board* getBoard() const noexcept {return mBoard;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Project& mProject;
         QString mName;

--- a/libs/librepcbproject/boards/cmd/cmddeviceinstanceadd.h
+++ b/libs/librepcbproject/boards/cmd/cmddeviceinstanceadd.h
@@ -55,22 +55,31 @@ class CmdDeviceInstanceAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdDeviceInstanceAdd(Board& board, ComponentInstance& comp,
-                                      const Uuid& deviceUuid, const Uuid& footprintUuid,
-                                      const Point& position = Point(),
-                                      const Angle& rotation = Angle(),
-                                      UndoCommand* parent = 0) throw (Exception);
-        explicit CmdDeviceInstanceAdd(DeviceInstance& device, UndoCommand* parent = 0) throw (Exception);
+        CmdDeviceInstanceAdd(Board& board, ComponentInstance& comp, const Uuid& deviceUuid,
+                             const Uuid& footprintUuid, const Point& position = Point(),
+                             const Angle& rotation = Angle()) noexcept;
+        explicit CmdDeviceInstanceAdd(DeviceInstance& device) noexcept;
         ~CmdDeviceInstanceAdd() noexcept;
 
         // Getters
         DeviceInstance* getDeviceInstance() const noexcept {return mDeviceInstance;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Board& mBoard;

--- a/libs/librepcbproject/boards/cmd/cmddeviceinstanceedit.h
+++ b/libs/librepcbproject/boards/cmd/cmddeviceinstanceedit.h
@@ -47,7 +47,7 @@ class CmdDeviceInstanceEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdDeviceInstanceEdit(DeviceInstance& dev, UndoCommand* parent = 0) throw (Exception);
+        explicit CmdDeviceInstanceEdit(DeviceInstance& dev) noexcept;
         ~CmdDeviceInstanceEdit() noexcept;
 
         // General Methods
@@ -58,12 +58,22 @@ class CmdDeviceInstanceEdit final : public UndoCommand
         void setMirrored(bool mirrored, bool immediate) noexcept;
         void mirror(const Point& center, bool vertical, bool immediate) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
-
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         DeviceInstance& mDevice;

--- a/libs/librepcbproject/boards/cmd/cmddeviceinstanceremove.cpp
+++ b/libs/librepcbproject/boards/cmd/cmddeviceinstanceremove.cpp
@@ -35,16 +35,15 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdDeviceInstanceRemove::CmdDeviceInstanceRemove(Board& board, DeviceInstance& dev,
-                                                 UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove device instance"), parent),
+CmdDeviceInstanceRemove::CmdDeviceInstanceRemove(Board& board, DeviceInstance& dev) noexcept :
+    UndoCommand(tr("Remove device instance")),
     mBoard(board), mDevice(dev)
 {
 }
 
 CmdDeviceInstanceRemove::~CmdDeviceInstanceRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mDevice;
 }
 
@@ -52,34 +51,19 @@ CmdDeviceInstanceRemove::~CmdDeviceInstanceRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdDeviceInstanceRemove::redo() throw (Exception)
+void CmdDeviceInstanceRemove::performExecute() throw (Exception)
 {
-    mBoard.removeDeviceInstance(mDevice); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo();
-    }
-    catch (Exception &e)
-    {
-        mBoard.addDeviceInstance(mDevice); // throws an exception on error
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdDeviceInstanceRemove::undo() throw (Exception)
+void CmdDeviceInstanceRemove::performUndo() throw (Exception)
 {
-    mBoard.addDeviceInstance(mDevice); // throws an exception on error
+    mBoard.addDeviceInstance(mDevice); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception &e)
-    {
-        mBoard.removeDeviceInstance(mDevice); // throws an exception on error
-        throw;
-    }
+void CmdDeviceInstanceRemove::performRedo() throw (Exception)
+{
+    mBoard.removeDeviceInstance(mDevice); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/boards/cmd/cmddeviceinstanceremove.h
+++ b/libs/librepcbproject/boards/cmd/cmddeviceinstanceremove.h
@@ -47,16 +47,25 @@ class CmdDeviceInstanceRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdDeviceInstanceRemove(Board& board, DeviceInstance& dev,
-                                         UndoCommand* parent = 0) throw (Exception);
+        CmdDeviceInstanceRemove(Board& board, DeviceInstance& dev) noexcept;
         ~CmdDeviceInstanceRemove() noexcept;
-
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Board& mBoard;

--- a/libs/librepcbproject/circuit/cmd/cmdcompattrinstadd.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdcompattrinstadd.cpp
@@ -37,8 +37,8 @@ namespace project {
 
 CmdCompAttrInstAdd::CmdCompAttrInstAdd(ComponentInstance& cmp, const QString& key,
                                        const AttributeType& type, const QString& value,
-                                       const AttributeUnit* unit, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add component attribute"), parent),
+                                       const AttributeUnit* unit) noexcept :
+    UndoCommand(tr("Add component attribute")),
     mComponentInstance(cmp), mKey(key), mType(type), mValue(value), mUnit(unit),
     mAttrInstance(nullptr)
 {
@@ -46,7 +46,7 @@ CmdCompAttrInstAdd::CmdCompAttrInstAdd(ComponentInstance& cmp, const QString& ke
 
 CmdCompAttrInstAdd::~CmdCompAttrInstAdd() noexcept
 {
-    if (!isExecuted())
+    if (!isCurrentlyExecuted())
         delete mAttrInstance;
 }
 
@@ -54,37 +54,20 @@ CmdCompAttrInstAdd::~CmdCompAttrInstAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdCompAttrInstAdd::redo() throw (Exception)
+void CmdCompAttrInstAdd::performExecute() throw (Exception)
 {
-    if (!mAttrInstance) // only the first time
-        mAttrInstance = new ComponentAttributeInstance(mKey, mType, mValue, mUnit); // throws an exception on error
-
-    mComponentInstance.addAttribute(*mAttrInstance); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mComponentInstance.removeAttribute(*mAttrInstance);
-        throw;
-    }
+    mAttrInstance = new ComponentAttributeInstance(mKey, mType, mValue, mUnit); // can throw
+    performRedo(); // can throw
 }
 
-void CmdCompAttrInstAdd::undo() throw (Exception)
+void CmdCompAttrInstAdd::performUndo() throw (Exception)
 {
-    mComponentInstance.removeAttribute(*mAttrInstance); // throws an exception on error
+    mComponentInstance.removeAttribute(*mAttrInstance); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mComponentInstance.addAttribute(*mAttrInstance);
-        throw;
-    }
+void CmdCompAttrInstAdd::performRedo() throw (Exception)
+{
+    mComponentInstance.addAttribute(*mAttrInstance); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdcompattrinstadd.h
+++ b/libs/librepcbproject/circuit/cmd/cmdcompattrinstadd.h
@@ -51,19 +51,30 @@ class CmdCompAttrInstAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdCompAttrInstAdd(ComponentInstance& cmp, const QString& key,
-                                    const AttributeType& type, const QString& value,
-                                    const AttributeUnit* unit, UndoCommand* parent = 0) throw (Exception);
+        CmdCompAttrInstAdd(ComponentInstance& cmp, const QString& key,
+                           const AttributeType& type, const QString& value,
+                           const AttributeUnit* unit) noexcept;
         ~CmdCompAttrInstAdd() noexcept;
 
         // Getters
         ComponentAttributeInstance* getAttrInstance() const noexcept {return mAttrInstance;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         ComponentInstance& mComponentInstance;
         QString mKey;

--- a/libs/librepcbproject/circuit/cmd/cmdcompattrinstedit.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdcompattrinstedit.cpp
@@ -39,9 +39,8 @@ CmdCompAttrInstEdit::CmdCompAttrInstEdit(ComponentInstance& cmp,
                                                ComponentAttributeInstance& attr,
                                                const AttributeType& newType,
                                                const QString& newValue,
-                                               const AttributeUnit* newUnit,
-                                               UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Edit component attribute"), parent),
+                                               const AttributeUnit* newUnit) noexcept :
+    UndoCommand(tr("Edit component attribute")),
     mComponentInstance(cmp), mAttrInst(attr),
     mOldType(&attr.getType()), mNewType(&newType),
     mOldValue(attr.getValue()), mNewValue(newValue),
@@ -57,34 +56,21 @@ CmdCompAttrInstEdit::~CmdCompAttrInstEdit() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdCompAttrInstEdit::redo() throw (Exception)
+void CmdCompAttrInstEdit::performExecute() throw (Exception)
 {
-    try
-    {
-        mAttrInst.setTypeValueUnit(*mNewType, mNewValue, mNewUnit);
-        UndoCommand::redo();
-        emit mComponentInstance.attributesChanged();
-    }
-    catch (Exception &e)
-    {
-        mAttrInst.setTypeValueUnit(*mOldType, mOldValue, mOldUnit);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdCompAttrInstEdit::undo() throw (Exception)
+void CmdCompAttrInstEdit::performUndo() throw (Exception)
 {
-    try
-    {
-        mAttrInst.setTypeValueUnit(*mOldType, mOldValue, mOldUnit);
-        UndoCommand::undo();
-        emit mComponentInstance.attributesChanged();
-    }
-    catch (Exception& e)
-    {
-        mAttrInst.setTypeValueUnit(*mNewType, mNewValue, mNewUnit);
-        throw;
-    }
+    mAttrInst.setTypeValueUnit(*mOldType, mOldValue, mOldUnit); // can throw
+    emit mComponentInstance.attributesChanged();
+}
+
+void CmdCompAttrInstEdit::performRedo() throw (Exception)
+{
+    mAttrInst.setTypeValueUnit(*mNewType, mNewValue, mNewUnit); // can throw
+    emit mComponentInstance.attributesChanged();
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdcompattrinstedit.h
+++ b/libs/librepcbproject/circuit/cmd/cmdcompattrinstedit.h
@@ -51,19 +51,27 @@ class CmdCompAttrInstEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdCompAttrInstEdit(ComponentInstance& cmp,
-                                     ComponentAttributeInstance& attr,
-                                     const AttributeType& newType,
-                                     const QString& newValue,
-                                     const AttributeUnit* newUnit,
-                                     UndoCommand* parent = 0) throw (Exception);
+        CmdCompAttrInstEdit(ComponentInstance& cmp, ComponentAttributeInstance& attr,
+                            const AttributeType& newType, const QString& newValue,
+                            const AttributeUnit* newUnit) noexcept;
         ~CmdCompAttrInstEdit() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         ComponentInstance& mComponentInstance;

--- a/libs/librepcbproject/circuit/cmd/cmdcompattrinstremove.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdcompattrinstremove.cpp
@@ -36,16 +36,15 @@ namespace project {
  ****************************************************************************************/
 
 CmdCompAttrInstRemove::CmdCompAttrInstRemove(ComponentInstance& cmp,
-                                                   ComponentAttributeInstance& attr,
-                                                   UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove component attribute"), parent),
+                                             ComponentAttributeInstance& attr) noexcept :
+    UndoCommand(tr("Remove component attribute")),
     mComponentInstance(cmp), mAttrInstance(attr)
 {
 }
 
 CmdCompAttrInstRemove::~CmdCompAttrInstRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mAttrInstance;
 }
 
@@ -53,34 +52,19 @@ CmdCompAttrInstRemove::~CmdCompAttrInstRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdCompAttrInstRemove::redo() throw (Exception)
+void CmdCompAttrInstRemove::performExecute() throw (Exception)
 {
-    mComponentInstance.removeAttribute(mAttrInstance); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mComponentInstance.addAttribute(mAttrInstance);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdCompAttrInstRemove::undo() throw (Exception)
+void CmdCompAttrInstRemove::performUndo() throw (Exception)
 {
-    mComponentInstance.addAttribute(mAttrInstance); // throws an exception on error
+    mComponentInstance.addAttribute(mAttrInstance); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mComponentInstance.removeAttribute(mAttrInstance);
-        throw;
-    }
+void CmdCompAttrInstRemove::performRedo() throw (Exception)
+{
+    mComponentInstance.removeAttribute(mAttrInstance); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdcompattrinstremove.h
+++ b/libs/librepcbproject/circuit/cmd/cmdcompattrinstremove.h
@@ -47,16 +47,25 @@ class CmdCompAttrInstRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdCompAttrInstRemove(ComponentInstance& cmp,
-                                       ComponentAttributeInstance& attr,
-                                       UndoCommand* parent = 0) throw (Exception);
+        CmdCompAttrInstRemove(ComponentInstance& cmp, ComponentAttributeInstance& attr) noexcept;
         ~CmdCompAttrInstRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         ComponentInstance& mComponentInstance;
         ComponentAttributeInstance& mAttrInstance;

--- a/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceadd.h
+++ b/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceadd.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 #include <librepcbcommon/uuid.h>
 
 /*****************************************************************************************
@@ -54,18 +53,28 @@ class CmdComponentInstanceAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdComponentInstanceAdd(Circuit& circuit, const Uuid& cmp,
-                                         const Uuid& symbVar, UndoCommand* parent = 0) throw (Exception);
+        CmdComponentInstanceAdd(Circuit& circuit, const Uuid& cmp, const Uuid& symbVar) noexcept;
         ~CmdComponentInstanceAdd() noexcept;
 
         // Getters
         ComponentInstance* getComponentInstance() const noexcept {return mComponentInstance;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Circuit& mCircuit;

--- a/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceedit.h
+++ b/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceedit.h
@@ -26,7 +26,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -55,19 +54,29 @@ class CmdComponentInstanceEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdComponentInstanceEdit(Circuit& circuit, ComponentInstance& cmp,
-                                          UndoCommand* parent = 0) throw (Exception);
+        CmdComponentInstanceEdit(Circuit& circuit, ComponentInstance& cmp) noexcept;
         ~CmdComponentInstanceEdit() noexcept;
 
         // Setters
         void setName(const QString& name) noexcept;
         void setValue(const QString& value) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Circuit& mCircuit;

--- a/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceremove.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceremove.cpp
@@ -36,16 +36,15 @@ namespace project {
  ****************************************************************************************/
 
 CmdComponentInstanceRemove::CmdComponentInstanceRemove(Circuit& circuit,
-                                                       ComponentInstance& cmp,
-                                                       UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove component"), parent),
+                                                       ComponentInstance& cmp) noexcept :
+    UndoCommand(tr("Remove component")),
     mCircuit(circuit), mComponentInstance(cmp)
 {
 }
 
 CmdComponentInstanceRemove::~CmdComponentInstanceRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mComponentInstance;
 }
 
@@ -53,34 +52,19 @@ CmdComponentInstanceRemove::~CmdComponentInstanceRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdComponentInstanceRemove::redo() throw (Exception)
+void CmdComponentInstanceRemove::performExecute() throw (Exception)
 {
-    mCircuit.removeComponentInstance(mComponentInstance); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mCircuit.addComponentInstance(mComponentInstance);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdComponentInstanceRemove::undo() throw (Exception)
+void CmdComponentInstanceRemove::performUndo() throw (Exception)
 {
-    mCircuit.addComponentInstance(mComponentInstance); // throws an exception on error
+    mCircuit.addComponentInstance(mComponentInstance); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mCircuit.removeComponentInstance(mComponentInstance);
-        throw;
-    }
+void CmdComponentInstanceRemove::performRedo() throw (Exception)
+{
+    mCircuit.removeComponentInstance(mComponentInstance); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceremove.h
+++ b/libs/librepcbproject/circuit/cmd/cmdcomponentinstanceremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdComponentInstanceRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdComponentInstanceRemove(Circuit& circuit, ComponentInstance& cmp,
-                                            UndoCommand* parent = 0) throw (Exception);
+        CmdComponentInstanceRemove(Circuit& circuit, ComponentInstance& cmp) noexcept;
         ~CmdComponentInstanceRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Circuit& mCircuit;

--- a/libs/librepcbproject/circuit/cmd/cmdcompsiginstsetnetsignal.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdcompsiginstsetnetsignal.cpp
@@ -35,9 +35,8 @@ namespace project {
  ****************************************************************************************/
 
 CmdCompSigInstSetNetSignal::CmdCompSigInstSetNetSignal(ComponentSignalInstance& cmpSigInstance,
-                                                       NetSignal* netsignal,
-                                                       UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Change component signal net"), parent),
+                                                       NetSignal* netsignal) noexcept :
+    UndoCommand(tr("Change component signal net")),
     mComponentSignalInstance(cmpSigInstance), mNetSignal(netsignal),
     mOldNetSignal(cmpSigInstance.getNetSignal())
 {
@@ -51,34 +50,19 @@ CmdCompSigInstSetNetSignal::~CmdCompSigInstSetNetSignal() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdCompSigInstSetNetSignal::redo() throw (Exception)
+void CmdCompSigInstSetNetSignal::performExecute() throw (Exception)
 {
-    mComponentSignalInstance.setNetSignal(mNetSignal); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mComponentSignalInstance.setNetSignal(mOldNetSignal);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdCompSigInstSetNetSignal::undo() throw (Exception)
+void CmdCompSigInstSetNetSignal::performUndo() throw (Exception)
 {
-    mComponentSignalInstance.setNetSignal(mOldNetSignal); // throws an exception on error
+    mComponentSignalInstance.setNetSignal(mOldNetSignal); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mComponentSignalInstance.setNetSignal(mNetSignal);
-        throw;
-    }
+void CmdCompSigInstSetNetSignal::performRedo() throw (Exception)
+{
+    mComponentSignalInstance.setNetSignal(mNetSignal); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdcompsiginstsetnetsignal.h
+++ b/libs/librepcbproject/circuit/cmd/cmdcompsiginstsetnetsignal.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,16 +47,26 @@ class CmdCompSigInstSetNetSignal final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdCompSigInstSetNetSignal(ComponentSignalInstance& cmpSigInstance,
-                                            NetSignal* netsignal,
-                                            UndoCommand* parent = 0) throw (Exception);
+        CmdCompSigInstSetNetSignal(ComponentSignalInstance& cmpSigInstance,
+                                   NetSignal* netsignal) noexcept;
         ~CmdCompSigInstSetNetSignal() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         ComponentSignalInstance& mComponentSignalInstance;

--- a/libs/librepcbproject/circuit/cmd/cmdnetclassadd.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdnetclassadd.cpp
@@ -35,16 +35,15 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdNetClassAdd::CmdNetClassAdd(Circuit& circuit, const QString& name,
-                               UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add netclass"), parent),
+CmdNetClassAdd::CmdNetClassAdd(Circuit& circuit, const QString& name) noexcept :
+    UndoCommand(tr("Add netclass")),
     mCircuit(circuit), mName(name), mNetClass(nullptr)
 {
 }
 
 CmdNetClassAdd::~CmdNetClassAdd() noexcept
 {
-    if (!isExecuted())
+    if (!isCurrentlyExecuted())
         delete mNetClass;
 }
 
@@ -52,37 +51,21 @@ CmdNetClassAdd::~CmdNetClassAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdNetClassAdd::redo() throw (Exception)
+void CmdNetClassAdd::performExecute() throw (Exception)
 {
-    if (!mNetClass) // only the first time
-        mNetClass = new NetClass(mCircuit, mName); // throws an exception on error
+    mNetClass = new NetClass(mCircuit, mName); // can throw
 
-    mCircuit.addNetClass(*mNetClass); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mCircuit.removeNetClass(*mNetClass);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdNetClassAdd::undo() throw (Exception)
+void CmdNetClassAdd::performUndo() throw (Exception)
 {
-    mCircuit.removeNetClass(*mNetClass); // throws an exception on error
+    mCircuit.removeNetClass(*mNetClass); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mCircuit.addNetClass(*mNetClass);
-        throw;
-    }
+void CmdNetClassAdd::performRedo() throw (Exception)
+{
+    mCircuit.addNetClass(*mNetClass); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdnetclassadd.h
+++ b/libs/librepcbproject/circuit/cmd/cmdnetclassadd.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,18 +47,28 @@ class CmdNetClassAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdNetClassAdd(Circuit& circuit, const QString& name,
-                                UndoCommand* parent = 0) throw (Exception);
+        CmdNetClassAdd(Circuit& circuit, const QString& name) noexcept;
         ~CmdNetClassAdd() noexcept;
 
         // Getters
         NetClass* getNetClass() const noexcept {return mNetClass;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Circuit& mCircuit;
         QString mName;

--- a/libs/librepcbproject/circuit/cmd/cmdnetclassedit.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdnetclassedit.cpp
@@ -35,8 +35,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdNetClassEdit::CmdNetClassEdit(Circuit& circuit, NetClass& netclass, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Edit netclass"), parent), mCircuit(circuit), mNetClass(netclass),
+CmdNetClassEdit::CmdNetClassEdit(Circuit& circuit, NetClass& netclass) noexcept :
+    UndoCommand(tr("Edit netclass")), mCircuit(circuit), mNetClass(netclass),
     mOldName(netclass.getName()), mNewName(mOldName)
 {
 }
@@ -51,7 +51,7 @@ CmdNetClassEdit::~CmdNetClassEdit() noexcept
 
 void CmdNetClassEdit::setName(const QString& name) noexcept
 {
-    Q_ASSERT((mRedoCount == 0) && (mUndoCount == 0));
+    Q_ASSERT(!wasEverExecuted());
     mNewName = name;
 }
 
@@ -59,32 +59,19 @@ void CmdNetClassEdit::setName(const QString& name) noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdNetClassEdit::redo() throw (Exception)
+void CmdNetClassEdit::performExecute() throw (Exception)
 {
-    try
-    {
-        mCircuit.setNetClassName(mNetClass, mNewName);
-        UndoCommand::redo();
-    }
-    catch (Exception &e)
-    {
-        mCircuit.setNetClassName(mNetClass, mOldName);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdNetClassEdit::undo() throw (Exception)
+void CmdNetClassEdit::performUndo() throw (Exception)
 {
-    try
-    {
-        mCircuit.setNetClassName(mNetClass, mOldName);
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mCircuit.setNetClassName(mNetClass, mNewName);
-        throw;
-    }
+    mCircuit.setNetClassName(mNetClass, mOldName); // can throw
+}
+
+void CmdNetClassEdit::performRedo() throw (Exception)
+{
+    mCircuit.setNetClassName(mNetClass, mNewName); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdnetclassedit.h
+++ b/libs/librepcbproject/circuit/cmd/cmdnetclassedit.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,18 +47,28 @@ class CmdNetClassEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdNetClassEdit(Circuit& circuit, NetClass& netclass,
-                                 UndoCommand* parent = 0) throw (Exception);
+        CmdNetClassEdit(Circuit& circuit, NetClass& netclass) noexcept;
         ~CmdNetClassEdit() noexcept;
 
         // Setters
         void setName(const QString& name) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Circuit& mCircuit;

--- a/libs/librepcbproject/circuit/cmd/cmdnetclassremove.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdnetclassremove.cpp
@@ -35,16 +35,15 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdNetClassRemove::CmdNetClassRemove(Circuit& circuit, NetClass& netclass,
-                                     UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove netclass"), parent),
+CmdNetClassRemove::CmdNetClassRemove(Circuit& circuit, NetClass& netclass) noexcept :
+    UndoCommand(tr("Remove netclass")),
     mCircuit(circuit), mNetClass(netclass)
 {
 }
 
 CmdNetClassRemove::~CmdNetClassRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mNetClass;
 }
 
@@ -52,34 +51,19 @@ CmdNetClassRemove::~CmdNetClassRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdNetClassRemove::redo() throw (Exception)
+void CmdNetClassRemove::performExecute() throw (Exception)
 {
-    mCircuit.removeNetClass(mNetClass); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mCircuit.addNetClass(mNetClass);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdNetClassRemove::undo() throw (Exception)
+void CmdNetClassRemove::performUndo() throw (Exception)
 {
-    mCircuit.addNetClass(mNetClass); // throws an exception on error
+    mCircuit.addNetClass(mNetClass); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mCircuit.removeNetClass(mNetClass);
-        throw;
-    }
+void CmdNetClassRemove::performRedo() throw (Exception)
+{
+    mCircuit.removeNetClass(mNetClass); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdnetclassremove.h
+++ b/libs/librepcbproject/circuit/cmd/cmdnetclassremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdNetClassRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdNetClassRemove(Circuit& circuit, NetClass& netclass,
-                                   UndoCommand* parent = 0) throw (Exception);
+        CmdNetClassRemove(Circuit& circuit, NetClass& netclass) noexcept;
         ~CmdNetClassRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Circuit& mCircuit;
         NetClass& mNetClass;

--- a/libs/librepcbproject/circuit/cmd/cmdnetsignaladd.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdnetsignaladd.cpp
@@ -35,16 +35,15 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdNetSignalAdd::CmdNetSignalAdd(Circuit& circuit, NetClass& netclass,
-                                 const QString& name, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add netsignal"), parent),
+CmdNetSignalAdd::CmdNetSignalAdd(Circuit& circuit, NetClass& netclass, const QString& name) noexcept :
+    UndoCommand(tr("Add netsignal")),
     mCircuit(circuit), mNetClass(netclass), mName(name), mNetSignal(nullptr)
 {
 }
 
 CmdNetSignalAdd::~CmdNetSignalAdd() noexcept
 {
-    if (!isExecuted())
+    if (!isCurrentlyExecuted())
         delete mNetSignal;
 }
 
@@ -52,37 +51,21 @@ CmdNetSignalAdd::~CmdNetSignalAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdNetSignalAdd::redo() throw (Exception)
+void CmdNetSignalAdd::performExecute() throw (Exception)
 {
-    if (!mNetSignal) // only the first time
-        mNetSignal = mCircuit.createNetSignal(mNetClass, mName); // throws an exception on error
+    mNetSignal = mCircuit.createNetSignal(mNetClass, mName); // can throw
 
-    mCircuit.addNetSignal(*mNetSignal); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mCircuit.removeNetSignal(*mNetSignal);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdNetSignalAdd::undo() throw (Exception)
+void CmdNetSignalAdd::performUndo() throw (Exception)
 {
-    mCircuit.removeNetSignal(*mNetSignal); // throws an exception on error
+    mCircuit.removeNetSignal(*mNetSignal); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mCircuit.addNetSignal(*mNetSignal);
-        throw;
-    }
+void CmdNetSignalAdd::performRedo() throw (Exception)
+{
+    mCircuit.addNetSignal(*mNetSignal); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdnetsignaladd.h
+++ b/libs/librepcbproject/circuit/cmd/cmdnetsignaladd.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -49,19 +48,28 @@ class CmdNetSignalAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdNetSignalAdd(Circuit& circuit, NetClass& netclass,
-                                 const QString& name = QString(),
-                                 UndoCommand* parent = 0) throw (Exception);
+        CmdNetSignalAdd(Circuit& circuit, NetClass& netclass, const QString& name = QString()) noexcept;
         ~CmdNetSignalAdd() noexcept;
 
         // Getters
         NetSignal* getNetSignal() const noexcept {return mNetSignal;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Circuit& mCircuit;
         NetClass& mNetClass;

--- a/libs/librepcbproject/circuit/cmd/cmdnetsignaledit.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdnetsignaledit.cpp
@@ -35,9 +35,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdNetSignalEdit::CmdNetSignalEdit(Circuit& circuit, NetSignal& netsignal,
-                                         UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Edit netsignal"), parent), mCircuit(circuit), mNetSignal(netsignal),
+CmdNetSignalEdit::CmdNetSignalEdit(Circuit& circuit, NetSignal& netsignal) noexcept :
+    UndoCommand(tr("Edit netsignal")), mCircuit(circuit), mNetSignal(netsignal),
     mOldName(netsignal.getName()), mNewName(mOldName),
     mOldIsAutoName(netsignal.hasAutoName()), mNewIsAutoName(mOldIsAutoName)
 {
@@ -53,7 +52,7 @@ CmdNetSignalEdit::~CmdNetSignalEdit() noexcept
 
 void CmdNetSignalEdit::setName(const QString& name, bool isAutoName) noexcept
 {
-    Q_ASSERT((mRedoCount == 0) && (mUndoCount == 0));
+    Q_ASSERT(!wasEverExecuted());
     mNewName = name;
     mNewIsAutoName = isAutoName;
 }
@@ -62,32 +61,19 @@ void CmdNetSignalEdit::setName(const QString& name, bool isAutoName) noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdNetSignalEdit::redo() throw (Exception)
+void CmdNetSignalEdit::performExecute() throw (Exception)
 {
-    try
-    {
-        mCircuit.setNetSignalName(mNetSignal, mNewName, mNewIsAutoName);
-        UndoCommand::redo();
-    }
-    catch (Exception& e)
-    {
-        mCircuit.setNetSignalName(mNetSignal, mOldName, mOldIsAutoName);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdNetSignalEdit::undo() throw (Exception)
+void CmdNetSignalEdit::performUndo() throw (Exception)
 {
-    try
-    {
-        mCircuit.setNetSignalName(mNetSignal, mOldName, mOldIsAutoName);
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mCircuit.setNetSignalName(mNetSignal, mNewName, mNewIsAutoName);
-        throw;
-    }
+    mCircuit.setNetSignalName(mNetSignal, mOldName, mOldIsAutoName); // can throw
+}
+
+void CmdNetSignalEdit::performRedo() throw (Exception)
+{
+    mCircuit.setNetSignalName(mNetSignal, mNewName, mNewIsAutoName); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdnetsignaledit.h
+++ b/libs/librepcbproject/circuit/cmd/cmdnetsignaledit.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,18 +47,28 @@ class CmdNetSignalEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdNetSignalEdit(Circuit& circuit, NetSignal& netsignal,
-                                  UndoCommand* parent = 0) throw (Exception);
+        CmdNetSignalEdit(Circuit& circuit, NetSignal& netsignal) noexcept;
         ~CmdNetSignalEdit() noexcept;
 
         // Setters
         void setName(const QString& name, bool isAutoName) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Circuit& mCircuit;

--- a/libs/librepcbproject/circuit/cmd/cmdnetsignalremove.cpp
+++ b/libs/librepcbproject/circuit/cmd/cmdnetsignalremove.cpp
@@ -35,16 +35,15 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdNetSignalRemove::CmdNetSignalRemove(Circuit& circuit, NetSignal& netsignal,
-                                     UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove netsignal"), parent),
+CmdNetSignalRemove::CmdNetSignalRemove(Circuit& circuit, NetSignal& netsignal) noexcept :
+    UndoCommand(tr("Remove netsignal")),
     mCircuit(circuit), mNetSignal(netsignal)
 {
 }
 
 CmdNetSignalRemove::~CmdNetSignalRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mNetSignal;
 }
 
@@ -52,34 +51,19 @@ CmdNetSignalRemove::~CmdNetSignalRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdNetSignalRemove::redo() throw (Exception)
+void CmdNetSignalRemove::performExecute() throw (Exception)
 {
-    mCircuit.removeNetSignal(mNetSignal); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mCircuit.addNetSignal(mNetSignal);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdNetSignalRemove::undo() throw (Exception)
+void CmdNetSignalRemove::performUndo() throw (Exception)
 {
-    mCircuit.addNetSignal(mNetSignal); // throws an exception on error
+    mCircuit.addNetSignal(mNetSignal); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mCircuit.removeNetSignal(mNetSignal);
-        throw;
-    }
+void CmdNetSignalRemove::performRedo() throw (Exception)
+{
+    mCircuit.removeNetSignal(mNetSignal); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/cmd/cmdnetsignalremove.h
+++ b/libs/librepcbproject/circuit/cmd/cmdnetsignalremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdNetSignalRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdNetSignalRemove(Circuit& circuit, NetSignal& netsignal,
-                                   UndoCommand* parent = 0) throw (Exception);
+        CmdNetSignalRemove(Circuit& circuit, NetSignal& netsignal) noexcept;
         ~CmdNetSignalRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Circuit& mCircuit;
         NetSignal& mNetSignal;

--- a/libs/librepcbproject/cmd/cmdprojectsetmetadata.cpp
+++ b/libs/librepcbproject/cmd/cmdprojectsetmetadata.cpp
@@ -34,9 +34,9 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdProjectSetMetadata::CmdProjectSetMetadata(Project& project, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Change Project Metadata"), parent),
-    mProject(project), mRedoOrUndoCalled(false),
+CmdProjectSetMetadata::CmdProjectSetMetadata(Project& project) noexcept :
+    UndoCommand(tr("Change Project Metadata")),
+    mProject(project),
     mOldName(mProject.getName()),               mNewName(mProject.getName()),
     mOldDescription(mProject.getDescription()), mNewDescription(mProject.getDescription()),
     mOldAuthor(mProject.getAuthor()),           mNewAuthor(mProject.getAuthor()),
@@ -54,25 +54,25 @@ CmdProjectSetMetadata::~CmdProjectSetMetadata() noexcept
 
 void CmdProjectSetMetadata::setName(const QString& newName) noexcept
 {
-    Q_ASSERT(mRedoOrUndoCalled == false);
+    Q_ASSERT(!wasEverExecuted());
     mNewName = newName;
 }
 
 void CmdProjectSetMetadata::setDescription(const QString& newDescription) noexcept
 {
-    Q_ASSERT(mRedoOrUndoCalled == false);
+    Q_ASSERT(!wasEverExecuted());
     mNewDescription = newDescription;
 }
 
 void CmdProjectSetMetadata::setAuthor(const QString& newAuthor) noexcept
 {
-    Q_ASSERT(mRedoOrUndoCalled == false);
+    Q_ASSERT(!wasEverExecuted());
     mNewAuthor = newAuthor;
 }
 
 void CmdProjectSetMetadata::setCreated(const QDateTime& newCreated) noexcept
 {
-    Q_ASSERT(mRedoOrUndoCalled == false);
+    Q_ASSERT(!wasEverExecuted());
     mNewCreated = newCreated;
 }
 
@@ -80,66 +80,25 @@ void CmdProjectSetMetadata::setCreated(const QDateTime& newCreated) noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdProjectSetMetadata::redo() throw (Exception)
+void CmdProjectSetMetadata::performExecute() throw (Exception)
 {
-    mRedoOrUndoCalled = true;
-
-    if (mNewName != mOldName)
-        mProject.setName(mNewName);
-    if (mNewDescription != mOldDescription)
-        mProject.setDescription(mNewDescription);
-    if (mNewAuthor != mOldAuthor)
-        mProject.setAuthor(mNewAuthor);
-    if (mNewCreated != mOldCreated)
-        mProject.setCreated(mNewCreated);
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        if (mNewName != mOldName)
-            mProject.setName(mOldName);
-        if (mNewDescription != mOldDescription)
-            mProject.setDescription(mOldDescription);
-        if (mNewAuthor != mOldAuthor)
-            mProject.setAuthor(mOldAuthor);
-        if (mNewCreated != mOldCreated)
-            mProject.setCreated(mOldCreated);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdProjectSetMetadata::undo() throw (Exception)
+void CmdProjectSetMetadata::performUndo() throw (Exception)
 {
-    mRedoOrUndoCalled = true;
+    mProject.setName(mOldName);
+    mProject.setDescription(mOldDescription);
+    mProject.setAuthor(mOldAuthor);
+    mProject.setCreated(mOldCreated);
+}
 
-    if (mNewName != mOldName)
-        mProject.setName(mOldName);
-    if (mNewDescription != mOldDescription)
-        mProject.setDescription(mOldDescription);
-    if (mNewAuthor != mOldAuthor)
-        mProject.setAuthor(mOldAuthor);
-    if (mNewCreated != mOldCreated)
-        mProject.setCreated(mOldCreated);
-
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        if (mNewName != mOldName)
-            mProject.setName(mNewName);
-        if (mNewDescription != mOldDescription)
-            mProject.setDescription(mNewDescription);
-        if (mNewAuthor != mOldAuthor)
-            mProject.setAuthor(mNewAuthor);
-        if (mNewCreated != mOldCreated)
-            mProject.setCreated(mNewCreated);
-        throw;
-    }
+void CmdProjectSetMetadata::performRedo() throw (Exception)
+{
+    mProject.setName(mNewName);
+    mProject.setDescription(mNewDescription);
+    mProject.setAuthor(mNewAuthor);
+    mProject.setCreated(mNewCreated);
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/cmd/cmdprojectsetmetadata.h
+++ b/libs/librepcbproject/cmd/cmdprojectsetmetadata.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -47,7 +46,7 @@ class CmdProjectSetMetadata final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdProjectSetMetadata(Project& project, UndoCommand* parent = 0) throw (Exception);
+        explicit CmdProjectSetMetadata(Project& project) noexcept;
         ~CmdProjectSetMetadata() noexcept;
 
         // Setters
@@ -56,15 +55,25 @@ class CmdProjectSetMetadata final : public UndoCommand
         void setAuthor(const QString& newAuthor) noexcept;
         void setCreated(const QDateTime& newCreated) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
 
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
+
         // General
         Project& mProject;
-        bool mRedoOrUndoCalled;
 
         // Misc
         QString mOldName;

--- a/libs/librepcbproject/library/cmd/cmdprojectlibraryaddelement.cpp
+++ b/libs/librepcbproject/library/cmd/cmdprojectlibraryaddelement.cpp
@@ -37,9 +37,8 @@ namespace project {
 
 template <typename ElementType>
 CmdProjectLibraryAddElement<ElementType>::CmdProjectLibraryAddElement(ProjectLibrary& library,
-                                                                      ElementType& element,
-                                                                      UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add element to library"), parent),
+                                                                      ElementType& element) noexcept :
+    UndoCommand(tr("Add element to library")),
     mLibrary(library), mElement(element)
 {
 }
@@ -54,35 +53,21 @@ CmdProjectLibraryAddElement<ElementType>::~CmdProjectLibraryAddElement() noexcep
  ****************************************************************************************/
 
 template <typename ElementType>
-void CmdProjectLibraryAddElement<ElementType>::redo() throw (Exception)
+void CmdProjectLibraryAddElement<ElementType>::performExecute() throw (Exception)
 {
-    addElement(); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        removeElement(); // throws an exception on error
-        throw;
-    }
+    performRedo(); // can throw
 }
 
 template <typename ElementType>
-void CmdProjectLibraryAddElement<ElementType>::undo() throw (Exception)
+void CmdProjectLibraryAddElement<ElementType>::performUndo() throw (Exception)
 {
-    removeElement(); // throws an exception on error
+    removeElement(); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        addElement(); // throws an exception on error
-        throw;
-    }
+template <typename ElementType>
+void CmdProjectLibraryAddElement<ElementType>::performRedo() throw (Exception)
+{
+    addElement(); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/library/cmd/cmdprojectlibraryaddelement.h
+++ b/libs/librepcbproject/library/cmd/cmdprojectlibraryaddelement.h
@@ -48,16 +48,25 @@ class CmdProjectLibraryAddElement final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdProjectLibraryAddElement(ProjectLibrary& library,
-                                             ElementType& element,
-                                             UndoCommand* parent = 0) throw (Exception);
+        CmdProjectLibraryAddElement(ProjectLibrary& library, ElementType& element) noexcept;
         ~CmdProjectLibraryAddElement() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         void addElement();
         void removeElement();

--- a/libs/librepcbproject/project.cpp
+++ b/libs/librepcbproject/project.cpp
@@ -312,32 +312,42 @@ QString Project::getDescription() const noexcept
 
 void Project::setName(const QString& newName) noexcept
 {
-    mName = newName;
-    emit attributesChanged();
+    if (newName != mName) {
+        mName = newName;
+        emit attributesChanged();
+    }
 }
 
 void Project::setDescription(const QString& newDescription) noexcept
 {
-    mDescriptionHtmlFile->setContent(newDescription.toUtf8());
-    emit attributesChanged();
+    if (newDescription != mDescriptionHtmlFile->getContent()) {
+        mDescriptionHtmlFile->setContent(newDescription.toUtf8());
+        emit attributesChanged();
+    }
 }
 
 void Project::setAuthor(const QString& newAuthor) noexcept
 {
-    mAuthor = newAuthor;
-    emit attributesChanged();
+    if (newAuthor != mAuthor) {
+        mAuthor = newAuthor;
+        emit attributesChanged();
+    }
 }
 
 void Project::setCreated(const QDateTime& newCreated) noexcept
 {
-    mCreated = newCreated;
-    emit attributesChanged();
+    if (newCreated != mCreated) {
+        mCreated = newCreated;
+        emit attributesChanged();
+    }
 }
 
 void Project::setLastModified(const QDateTime& newLastModified) noexcept
 {
-    mLastModified = newLastModified;
-    emit attributesChanged();
+    if (newLastModified != mLastModified) {
+        mLastModified = newLastModified;
+        emit attributesChanged();
+    }
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicadd.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicadd.cpp
@@ -35,9 +35,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicAdd::CmdSchematicAdd(Project& project, const QString& name,
-                                 UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add schematic"), parent),
+CmdSchematicAdd::CmdSchematicAdd(Project& project, const QString& name) noexcept :
+    UndoCommand(tr("Add schematic")),
     mProject(project), mName(name), mSchematic(nullptr), mPageIndex(-1)
 {
 }
@@ -50,37 +49,21 @@ CmdSchematicAdd::~CmdSchematicAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicAdd::redo() throw (Exception)
+void CmdSchematicAdd::performExecute() throw (Exception)
 {
-    if (!mSchematic) // only the first time
-        mSchematic = mProject.createSchematic(mName); // throws an exception on error
+    mSchematic = mProject.createSchematic(mName); // can throw
 
-    mProject.addSchematic(mSchematic, mPageIndex); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mProject.removeSchematic(mSchematic);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicAdd::undo() throw (Exception)
+void CmdSchematicAdd::performUndo() throw (Exception)
 {
-    mProject.removeSchematic(mSchematic); // throws an exception on error
+    mProject.removeSchematic(mSchematic); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mProject.addSchematic(mSchematic, mPageIndex);
-        throw;
-    }
+void CmdSchematicAdd::performRedo() throw (Exception)
+{
+    mProject.addSchematic(mSchematic, mPageIndex); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicadd.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicadd.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,18 +47,28 @@ class CmdSchematicAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicAdd(Project& project, const QString& name,
-                                UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicAdd(Project& project, const QString& name) noexcept;
         ~CmdSchematicAdd() noexcept;
 
         // Getters
         Schematic* getSchematic() const noexcept {return mSchematic;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Project& mProject;
         QString mName;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlabeladd.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlabeladd.cpp
@@ -36,15 +36,15 @@ namespace project {
  ****************************************************************************************/
 
 CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(Schematic& schematic, NetSignal& netsignal,
-                                                 const Point& position, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add netlabel"), parent),
+                                                 const Point& position) noexcept :
+    UndoCommand(tr("Add netlabel")),
     mSchematic(schematic), mNetSignal(&netsignal), mPosition(position), mNetLabel(nullptr)
 {
 }
 
 CmdSchematicNetLabelAdd::~CmdSchematicNetLabelAdd() noexcept
 {
-    if ((mNetLabel) && (!isExecuted()))
+    if ((mNetLabel) && (!isCurrentlyExecuted()))
         delete mNetLabel;
 }
 
@@ -52,39 +52,21 @@ CmdSchematicNetLabelAdd::~CmdSchematicNetLabelAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicNetLabelAdd::redo() throw (Exception)
+void CmdSchematicNetLabelAdd::performExecute() throw (Exception)
 {
-    if (!mNetLabel) // only the first time
-    {
-        mNetLabel = mSchematic.createNetLabel(*mNetSignal, mPosition); // throws an exception on error
-    }
+    mNetLabel = mSchematic.createNetLabel(*mNetSignal, mPosition); // can throw
 
-    mSchematic.addNetLabel(*mNetLabel); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mSchematic.removeNetLabel(*mNetLabel);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicNetLabelAdd::undo() throw (Exception)
+void CmdSchematicNetLabelAdd::performUndo() throw (Exception)
 {
-    mSchematic.removeNetLabel(*mNetLabel); // throws an exception on error
+    mSchematic.removeNetLabel(*mNetLabel); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mSchematic.addNetLabel(*mNetLabel);
-        throw;
-    }
+void CmdSchematicNetLabelAdd::performRedo() throw (Exception)
+{
+    mSchematic.addNetLabel(*mNetLabel); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlabeladd.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlabeladd.h
@@ -26,7 +26,6 @@
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
 #include <librepcbcommon/units/point.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -50,18 +49,29 @@ class CmdSchematicNetLabelAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetLabelAdd(Schematic& schematic, NetSignal& netsignal,
-                                         const Point& position, UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicNetLabelAdd(Schematic& schematic, NetSignal& netsignal,
+                                const Point& position) noexcept;
         ~CmdSchematicNetLabelAdd() noexcept;
 
         // Getters
         SI_NetLabel* getNetLabel() const noexcept {return mNetLabel;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Schematic& mSchematic;
         NetSignal* mNetSignal;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlabeledit.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlabeledit.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 #include <librepcbcommon/units/all_length_units.h>
 
 /*****************************************************************************************
@@ -49,7 +48,7 @@ class CmdSchematicNetLabelEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetLabelEdit(SI_NetLabel& netlabel, UndoCommand* parent = 0) throw (Exception);
+        explicit CmdSchematicNetLabelEdit(SI_NetLabel& netlabel) noexcept;
         ~CmdSchematicNetLabelEdit() noexcept;
 
         // Setters
@@ -59,12 +58,22 @@ class CmdSchematicNetLabelEdit final : public UndoCommand
         void setRotation(const Angle& angle, bool immediate) noexcept;
         void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
-
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         SI_NetLabel& mNetLabel;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlabelremove.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlabelremove.cpp
@@ -36,16 +36,15 @@ namespace project {
  ****************************************************************************************/
 
 CmdSchematicNetLabelRemove::CmdSchematicNetLabelRemove(Schematic& schematic,
-                                                       SI_NetLabel& netlabel,
-                                                       UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove netlabel"), parent),
+                                                       SI_NetLabel& netlabel) noexcept :
+    UndoCommand(tr("Remove netlabel")),
     mSchematic(schematic), mNetLabel(netlabel)
 {
 }
 
 CmdSchematicNetLabelRemove::~CmdSchematicNetLabelRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mNetLabel;
 }
 
@@ -53,34 +52,19 @@ CmdSchematicNetLabelRemove::~CmdSchematicNetLabelRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicNetLabelRemove::redo() throw (Exception)
+void CmdSchematicNetLabelRemove::performExecute() throw (Exception)
 {
-    mSchematic.removeNetLabel(mNetLabel); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.addNetLabel(mNetLabel);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicNetLabelRemove::undo() throw (Exception)
+void CmdSchematicNetLabelRemove::performUndo() throw (Exception)
 {
-    mSchematic.addNetLabel(mNetLabel); // throws an exception on error
+    mSchematic.addNetLabel(mNetLabel); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.removeNetLabel(mNetLabel);
-        throw;
-    }
+void CmdSchematicNetLabelRemove::performRedo() throw (Exception)
+{
+    mSchematic.removeNetLabel(mNetLabel); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlabelremove.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlabelremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdSchematicNetLabelRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetLabelRemove(Schematic& schematic, SI_NetLabel& netlabel,
-                                            UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicNetLabelRemove(Schematic& schematic, SI_NetLabel& netlabel) noexcept;
         ~CmdSchematicNetLabelRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Schematic& mSchematic;
         SI_NetLabel& mNetLabel;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlineadd.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlineadd.cpp
@@ -36,15 +36,15 @@ namespace project {
  ****************************************************************************************/
 
 CmdSchematicNetLineAdd::CmdSchematicNetLineAdd(Schematic& schematic, SI_NetPoint& startPoint,
-                                               SI_NetPoint& endPoint, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add netline"), parent),
+                                               SI_NetPoint& endPoint) noexcept :
+    UndoCommand(tr("Add netline")),
     mSchematic(schematic), mStartPoint(startPoint), mEndPoint(endPoint), mNetLine(0)
 {
 }
 
 CmdSchematicNetLineAdd::~CmdSchematicNetLineAdd() noexcept
 {
-    if ((mNetLine) && (!isExecuted()))
+    if ((mNetLine) && (!isCurrentlyExecuted()))
         delete mNetLine;
 }
 
@@ -52,37 +52,21 @@ CmdSchematicNetLineAdd::~CmdSchematicNetLineAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicNetLineAdd::redo() throw (Exception)
+void CmdSchematicNetLineAdd::performExecute() throw (Exception)
 {
-    if (!mNetLine) // only the first time
-        mNetLine = mSchematic.createNetLine(mStartPoint, mEndPoint, Length(158750)); // throws an exception on error
+    mNetLine = mSchematic.createNetLine(mStartPoint, mEndPoint, Length(158750)); // can throw
 
-    mSchematic.addNetLine(*mNetLine); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mSchematic.removeNetLine(*mNetLine);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicNetLineAdd::undo() throw (Exception)
+void CmdSchematicNetLineAdd::performUndo() throw (Exception)
 {
-    mSchematic.removeNetLine(*mNetLine); // throws an exception on error
+    mSchematic.removeNetLine(*mNetLine); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mSchematic.addNetLine(*mNetLine);
-        throw;
-    }
+void CmdSchematicNetLineAdd::performRedo() throw (Exception)
+{
+    mSchematic.addNetLine(*mNetLine); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlineadd.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlineadd.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -49,18 +48,29 @@ class CmdSchematicNetLineAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetLineAdd(Schematic& schematic, SI_NetPoint& startPoint,
-                                        SI_NetPoint& endPoint, UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicNetLineAdd(Schematic& schematic, SI_NetPoint& startPoint,
+                               SI_NetPoint& endPoint) noexcept;
         ~CmdSchematicNetLineAdd() noexcept;
 
         // Getters
         SI_NetLine* getNetLine() const noexcept {return mNetLine;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Schematic& mSchematic;
         SI_NetPoint& mStartPoint;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlineremove.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlineremove.cpp
@@ -35,17 +35,15 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicNetLineRemove::CmdSchematicNetLineRemove(Schematic& schematic,
-                                                     SI_NetLine& netline,
-                                                     UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove netline"), parent),
+CmdSchematicNetLineRemove::CmdSchematicNetLineRemove(Schematic& schematic, SI_NetLine& netline) noexcept :
+    UndoCommand(tr("Remove netline")),
     mSchematic(schematic), mNetLine(netline)
 {
 }
 
 CmdSchematicNetLineRemove::~CmdSchematicNetLineRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mNetLine;
 }
 
@@ -53,34 +51,19 @@ CmdSchematicNetLineRemove::~CmdSchematicNetLineRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicNetLineRemove::redo() throw (Exception)
+void CmdSchematicNetLineRemove::performExecute() throw (Exception)
 {
-    mSchematic.removeNetLine(mNetLine); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.addNetLine(mNetLine);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicNetLineRemove::undo() throw (Exception)
+void CmdSchematicNetLineRemove::performUndo() throw (Exception)
 {
-    mSchematic.addNetLine(mNetLine); // throws an exception on error
+    mSchematic.addNetLine(mNetLine); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.removeNetLine(mNetLine);
-        throw;
-    }
+void CmdSchematicNetLineRemove::performRedo() throw (Exception)
+{
+    mSchematic.removeNetLine(mNetLine); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetlineremove.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetlineremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdSchematicNetLineRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetLineRemove(Schematic& schematic, SI_NetLine& netline,
-                                            UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicNetLineRemove(Schematic& schematic, SI_NetLine& netline) noexcept;
         ~CmdSchematicNetLineRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Schematic& mSchematic;
         SI_NetLine& mNetLine;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetpointadd.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetpointadd.cpp
@@ -36,16 +36,15 @@ namespace project {
  ****************************************************************************************/
 
 CmdSchematicNetPointAdd::CmdSchematicNetPointAdd(Schematic& schematic, NetSignal& netsignal,
-                                                 const Point& position, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add netpoint"), parent),
+                                                 const Point& position) noexcept :
+    UndoCommand(tr("Add netpoint")),
     mSchematic(schematic), mNetSignal(&netsignal), mAttachedToSymbol(false),
     mPosition(position), mSymbolPin(nullptr), mNetPoint(nullptr)
 {
 }
 
-CmdSchematicNetPointAdd::CmdSchematicNetPointAdd(Schematic& schematic, SI_SymbolPin& pin,
-                                                 UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Add netpoint"), parent),
+CmdSchematicNetPointAdd::CmdSchematicNetPointAdd(Schematic& schematic, SI_SymbolPin& pin) noexcept :
+    UndoCommand(tr("Add netpoint")),
     mSchematic(schematic), mNetSignal(nullptr), mAttachedToSymbol(true),
     mPosition(), mSymbolPin(&pin), mNetPoint(nullptr)
 {
@@ -53,7 +52,7 @@ CmdSchematicNetPointAdd::CmdSchematicNetPointAdd(Schematic& schematic, SI_Symbol
 
 CmdSchematicNetPointAdd::~CmdSchematicNetPointAdd() noexcept
 {
-    if ((mNetPoint) && (!isExecuted()))
+    if ((mNetPoint) && (!isCurrentlyExecuted()))
         delete mNetPoint;
 }
 
@@ -61,42 +60,25 @@ CmdSchematicNetPointAdd::~CmdSchematicNetPointAdd() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicNetPointAdd::redo() throw (Exception)
+void CmdSchematicNetPointAdd::performExecute() throw (Exception)
 {
-    if (!mNetPoint) // only the first time
-    {
-        if (mAttachedToSymbol)
-            mNetPoint = mSchematic.createNetPoint(*mSymbolPin); // throws an exception on error
-        else
-            mNetPoint = mSchematic.createNetPoint(*mNetSignal, mPosition); // throws an exception on error
+    if (mAttachedToSymbol) {
+        mNetPoint = mSchematic.createNetPoint(*mSymbolPin); // can throw
+    } else {
+        mNetPoint = mSchematic.createNetPoint(*mNetSignal, mPosition); // can throw
     }
 
-    mSchematic.addNetPoint(*mNetPoint); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mSchematic.removeNetPoint(*mNetPoint);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicNetPointAdd::undo() throw (Exception)
+void CmdSchematicNetPointAdd::performUndo() throw (Exception)
 {
-    mSchematic.removeNetPoint(*mNetPoint); // throws an exception on error
+    mSchematic.removeNetPoint(*mNetPoint); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mSchematic.addNetPoint(*mNetPoint);
-        throw;
-    }
+void CmdSchematicNetPointAdd::performRedo() throw (Exception)
+{
+    mSchematic.addNetPoint(*mNetPoint); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetpointadd.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetpointadd.h
@@ -26,7 +26,6 @@
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
 #include <librepcbcommon/units/point.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -51,20 +50,30 @@ class CmdSchematicNetPointAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetPointAdd(Schematic& schematic, NetSignal& netsignal,
-                                         const Point& position, UndoCommand* parent = 0) throw (Exception);
-        explicit CmdSchematicNetPointAdd(Schematic& schematic, SI_SymbolPin& pin,
-                                         UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicNetPointAdd(Schematic& schematic, NetSignal& netsignal,
+                                const Point& position) noexcept;
+        CmdSchematicNetPointAdd(Schematic& schematic, SI_SymbolPin& pin) noexcept;
         ~CmdSchematicNetPointAdd() noexcept;
 
         // Getters
         SI_NetPoint* getNetPoint() const noexcept {return mNetPoint;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Schematic& mSchematic;
         NetSignal* mNetSignal;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetpointdetach.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetpointdetach.cpp
@@ -34,8 +34,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicNetPointDetach::CmdSchematicNetPointDetach(SI_NetPoint& point, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Detach netpoint"), parent),
+CmdSchematicNetPointDetach::CmdSchematicNetPointDetach(SI_NetPoint& point) noexcept :
+    UndoCommand(tr("Detach netpoint")),
     mNetPoint(point), mSymbolPin(point.getSymbolPin())
 {
     Q_ASSERT(mSymbolPin);
@@ -49,34 +49,19 @@ CmdSchematicNetPointDetach::~CmdSchematicNetPointDetach() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicNetPointDetach::redo() throw (Exception)
+void CmdSchematicNetPointDetach::performExecute() throw (Exception)
 {
-    mNetPoint.detachFromPin(); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception &e)
-    {
-        mNetPoint.attachToPin(*mSymbolPin);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicNetPointDetach::undo() throw (Exception)
+void CmdSchematicNetPointDetach::performUndo() throw (Exception)
 {
-    mNetPoint.attachToPin(*mSymbolPin); // throws an exception on error
+    mNetPoint.attachToPin(*mSymbolPin); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo();
-    }
-    catch (Exception& e)
-    {
-        mNetPoint.detachFromPin();
-        throw;
-    }
+void CmdSchematicNetPointDetach::performRedo() throw (Exception)
+{
+    mNetPoint.detachFromPin(); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetpointdetach.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetpointdetach.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdSchematicNetPointDetach final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetPointDetach(SI_NetPoint& point, UndoCommand* parent = 0) throw (Exception);
+        explicit CmdSchematicNetPointDetach(SI_NetPoint& point) noexcept;
         ~CmdSchematicNetPointDetach() noexcept;
-
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         SI_NetPoint& mNetPoint;
         SI_SymbolPin* mSymbolPin;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetpointedit.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetpointedit.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 #include <librepcbcommon/units/point.h>
 
 /*****************************************************************************************
@@ -49,7 +48,7 @@ class CmdSchematicNetPointEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetPointEdit(SI_NetPoint& point, UndoCommand* parent = 0) throw (Exception);
+        explicit CmdSchematicNetPointEdit(SI_NetPoint& point) noexcept;
         ~CmdSchematicNetPointEdit() noexcept;
 
         // Setters
@@ -57,12 +56,22 @@ class CmdSchematicNetPointEdit final : public UndoCommand
         void setPosition(const Point& pos, bool immediate) noexcept;
         void setDeltaToStartPos(const Point& deltaPos, bool immediate) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
-
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         SI_NetPoint& mNetPoint;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetpointremove.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetpointremove.cpp
@@ -36,16 +36,15 @@ namespace project {
  ****************************************************************************************/
 
 CmdSchematicNetPointRemove::CmdSchematicNetPointRemove(Schematic& schematic,
-                                                       SI_NetPoint& netpoint,
-                                                       UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove netpoint"), parent),
+                                                       SI_NetPoint& netpoint) noexcept :
+    UndoCommand(tr("Remove netpoint")),
     mSchematic(schematic), mNetPoint(netpoint)
 {
 }
 
 CmdSchematicNetPointRemove::~CmdSchematicNetPointRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mNetPoint;
 }
 
@@ -53,34 +52,19 @@ CmdSchematicNetPointRemove::~CmdSchematicNetPointRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicNetPointRemove::redo() throw (Exception)
+void CmdSchematicNetPointRemove::performExecute() throw (Exception)
 {
-    mSchematic.removeNetPoint(mNetPoint); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.addNetPoint(mNetPoint);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicNetPointRemove::undo() throw (Exception)
+void CmdSchematicNetPointRemove::performUndo() throw (Exception)
 {
-    mSchematic.addNetPoint(mNetPoint); // throws an exception on error
+    mSchematic.addNetPoint(mNetPoint); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.removeNetPoint(mNetPoint);
-        throw;
-    }
+void CmdSchematicNetPointRemove::performRedo() throw (Exception)
+{
+    mSchematic.removeNetPoint(mNetPoint); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicnetpointremove.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicnetpointremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdSchematicNetPointRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetPointRemove(Schematic& schematic, SI_NetPoint& netpoint,
-                                            UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicNetPointRemove(Schematic& schematic, SI_NetPoint& netpoint) noexcept;
         ~CmdSchematicNetPointRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Schematic& mSchematic;
         SI_NetPoint& mNetPoint;

--- a/libs/librepcbproject/schematics/cmd/cmdschematicremove.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicremove.cpp
@@ -35,9 +35,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicRemove::CmdSchematicRemove(Project& project, Schematic* schematic,
-                                       UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove schematic"), parent),
+CmdSchematicRemove::CmdSchematicRemove(Project& project, Schematic* schematic) noexcept :
+    UndoCommand(tr("Remove schematic")),
     mProject(project), mSchematic(schematic), mPageIndex(-1)
 {
 }
@@ -50,35 +49,21 @@ CmdSchematicRemove::~CmdSchematicRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSchematicRemove::redo() throw (Exception)
+void CmdSchematicRemove::performExecute() throw (Exception)
 {
     mPageIndex = mProject.getSchematicIndex(mSchematic);
-    mProject.removeSchematic(mSchematic); // throws an exception on error
 
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mProject.addSchematic(mSchematic, mPageIndex);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSchematicRemove::undo() throw (Exception)
+void CmdSchematicRemove::performUndo() throw (Exception)
 {
-    mProject.addSchematic(mSchematic, mPageIndex); // throws an exception on error
+    mProject.addSchematic(mSchematic, mPageIndex); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mProject.removeSchematic(mSchematic);
-        throw;
-    }
+void CmdSchematicRemove::performRedo() throw (Exception)
+{
+    mProject.removeSchematic(mSchematic); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdschematicremove.h
+++ b/libs/librepcbproject/schematics/cmd/cmdschematicremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,15 +47,25 @@ class CmdSchematicRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicRemove(Project& project, Schematic* schematic,
-                                   UndoCommand* parent = 0) throw (Exception);
+        CmdSchematicRemove(Project& project, Schematic* schematic) noexcept;
         ~CmdSchematicRemove() noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Project& mProject;
         Schematic* mSchematic;

--- a/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceadd.h
+++ b/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceadd.h
@@ -27,7 +27,6 @@
 #include <librepcbcommon/uuid.h>
 #include <librepcbcommon/units/all_length_units.h>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -51,20 +50,31 @@ class CmdSymbolInstanceAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSymbolInstanceAdd(Schematic& schematic, ComponentInstance& cmpInstance,
-                                      const Uuid& symbolItem, const Point& position = Point(),
-                                      const Angle& angle = Angle(), UndoCommand* parent = 0) throw (Exception);
-        explicit CmdSymbolInstanceAdd(SI_Symbol& symbol, UndoCommand* parent = 0) throw (Exception);
+        CmdSymbolInstanceAdd(Schematic& schematic, ComponentInstance& cmpInstance,
+                             const Uuid& symbolItem, const Point& position = Point(),
+                             const Angle& angle = Angle()) noexcept;
+        explicit CmdSymbolInstanceAdd(SI_Symbol& symbol) noexcept;
         ~CmdSymbolInstanceAdd() noexcept;
 
         // Getters
         SI_Symbol* getSymbolInstance() const noexcept {return mSymbolInstance;}
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         Schematic& mSchematic;

--- a/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceedit.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceedit.cpp
@@ -34,8 +34,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSymbolInstanceEdit::CmdSymbolInstanceEdit(SI_Symbol& symbol, UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Edit symbol instance"), parent), mSymbol(symbol),
+CmdSymbolInstanceEdit::CmdSymbolInstanceEdit(SI_Symbol& symbol) noexcept :
+    UndoCommand(tr("Edit symbol instance")), mSymbol(symbol),
     mOldPos(symbol.getPosition()), mNewPos(mOldPos),
     mOldRotation(symbol.getRotation()), mNewRotation(mOldRotation)
 {
@@ -43,8 +43,7 @@ CmdSymbolInstanceEdit::CmdSymbolInstanceEdit(SI_Symbol& symbol, UndoCommand* par
 
 CmdSymbolInstanceEdit::~CmdSymbolInstanceEdit() noexcept
 {
-    if ((mRedoCount == 0) && (mUndoCount == 0))
-    {
+    if (!wasEverExecuted()) {
         mSymbol.setPosition(mOldPos);
         mSymbol.setRotation(mOldRotation);
     }
@@ -56,28 +55,28 @@ CmdSymbolInstanceEdit::~CmdSymbolInstanceEdit() noexcept
 
 void CmdSymbolInstanceEdit::setPosition(Point& pos, bool immediate) noexcept
 {
-    Q_ASSERT((mRedoCount == 0) && (mUndoCount == 0));
+    Q_ASSERT(!wasEverExecuted());
     mNewPos = pos;
     if (immediate) mSymbol.setPosition(mNewPos);
 }
 
 void CmdSymbolInstanceEdit::setDeltaToStartPos(Point& deltaPos, bool immediate) noexcept
 {
-    Q_ASSERT((mRedoCount == 0) && (mUndoCount == 0));
+    Q_ASSERT(!wasEverExecuted());
     mNewPos = mOldPos + deltaPos;
     if (immediate) mSymbol.setPosition(mNewPos);
 }
 
 void CmdSymbolInstanceEdit::setRotation(const Angle& angle, bool immediate) noexcept
 {
-    Q_ASSERT((mRedoCount == 0) && (mUndoCount == 0));
+    Q_ASSERT(!wasEverExecuted());
     mNewRotation = angle;
     if (immediate) mSymbol.setRotation(mNewRotation);
 }
 
 void CmdSymbolInstanceEdit::rotate(const Angle& angle, const Point& center, bool immediate) noexcept
 {
-    Q_ASSERT((mRedoCount == 0) && (mUndoCount == 0));
+    Q_ASSERT(!wasEverExecuted());
     mNewPos.rotate(angle, center);
     mNewRotation += angle;
     if (immediate)
@@ -91,36 +90,21 @@ void CmdSymbolInstanceEdit::rotate(const Angle& angle, const Point& center, bool
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSymbolInstanceEdit::redo() throw (Exception)
+void CmdSymbolInstanceEdit::performExecute() throw (Exception)
 {
-    try
-    {
-        mSymbol.setPosition(mNewPos);
-        mSymbol.setRotation(mNewRotation);
-        UndoCommand::redo();
-    }
-    catch (Exception &e)
-    {
-        mSymbol.setPosition(mOldPos);
-        mSymbol.setRotation(mOldRotation);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSymbolInstanceEdit::undo() throw (Exception)
+void CmdSymbolInstanceEdit::performUndo() throw (Exception)
 {
-    try
-    {
-        mSymbol.setPosition(mOldPos);
-        mSymbol.setRotation(mOldRotation);
-        UndoCommand::undo();
-    }
-    catch (Exception &e)
-    {
-        mSymbol.setPosition(mNewPos);
-        mSymbol.setRotation(mNewRotation);
-        throw;
-    }
+    mSymbol.setPosition(mOldPos);
+    mSymbol.setRotation(mOldRotation);
+}
+
+void CmdSymbolInstanceEdit::performRedo() throw (Exception)
+{
+    mSymbol.setPosition(mNewPos);
+    mSymbol.setRotation(mNewRotation);
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceedit.h
+++ b/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceedit.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 #include <librepcbcommon/units/all_length_units.h>
 
 /*****************************************************************************************
@@ -48,7 +47,7 @@ class CmdSymbolInstanceEdit final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSymbolInstanceEdit(SI_Symbol& symbol, UndoCommand* parent = 0) throw (Exception);
+        explicit CmdSymbolInstanceEdit(SI_Symbol& symbol) noexcept;
         ~CmdSymbolInstanceEdit() noexcept;
 
         // General Methods
@@ -57,12 +56,22 @@ class CmdSymbolInstanceEdit final : public UndoCommand
         void setRotation(const Angle& angle, bool immediate) noexcept;
         void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
-
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         SI_Symbol& mSymbol;

--- a/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceremove.cpp
+++ b/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceremove.cpp
@@ -35,16 +35,15 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSymbolInstanceRemove::CmdSymbolInstanceRemove(Schematic& schematic, SI_Symbol& symbol,
-                                                 UndoCommand* parent) throw (Exception) :
-    UndoCommand(tr("Remove symbol"), parent),
+CmdSymbolInstanceRemove::CmdSymbolInstanceRemove(Schematic& schematic, SI_Symbol& symbol) noexcept :
+    UndoCommand(tr("Remove symbol")),
     mSchematic(schematic), mSymbol(symbol)
 {
 }
 
 CmdSymbolInstanceRemove::~CmdSymbolInstanceRemove() noexcept
 {
-    if (isExecuted())
+    if (isCurrentlyExecuted())
         delete &mSymbol;
 }
 
@@ -52,34 +51,19 @@ CmdSymbolInstanceRemove::~CmdSymbolInstanceRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-void CmdSymbolInstanceRemove::redo() throw (Exception)
+void CmdSymbolInstanceRemove::performExecute() throw (Exception)
 {
-    mSchematic.removeSymbol(mSymbol); // throws an exception on error
-
-    try
-    {
-        UndoCommand::redo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.addSymbol(mSymbol);
-        throw;
-    }
+    performRedo(); // can throw
 }
 
-void CmdSymbolInstanceRemove::undo() throw (Exception)
+void CmdSymbolInstanceRemove::performUndo() throw (Exception)
 {
-    mSchematic.addSymbol(mSymbol); // throws an exception on error
+    mSchematic.addSymbol(mSymbol); // can throw
+}
 
-    try
-    {
-        UndoCommand::undo(); // throws an exception on error
-    }
-    catch (Exception& e)
-    {
-        mSchematic.removeSymbol(mSymbol);
-        throw;
-    }
+void CmdSymbolInstanceRemove::performRedo() throw (Exception)
+{
+    mSchematic.removeSymbol(mSymbol); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceremove.h
+++ b/libs/librepcbproject/schematics/cmd/cmdsymbolinstanceremove.h
@@ -25,7 +25,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -48,16 +47,25 @@ class CmdSymbolInstanceRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdSymbolInstanceRemove(Schematic& schematic, SI_Symbol& symbol,
-                                         UndoCommand* parent = 0) throw (Exception);
+        CmdSymbolInstanceRemove(Schematic& schematic, SI_Symbol& symbol) noexcept;
         ~CmdSymbolInstanceRemove() noexcept;
-
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
+
+        // Private Member Variables
 
         Schematic& mSchematic;
         SI_Symbol& mSymbol;

--- a/libs/librepcbproject/settings/cmd/cmdprojectsettingschange.h
+++ b/libs/librepcbproject/settings/cmd/cmdprojectsettingschange.h
@@ -46,8 +46,7 @@ class CmdProjectSettingsChange final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        explicit CmdProjectSettingsChange(ProjectSettings& settings,
-                                          UndoCommand* parent = 0) throw (Exception);
+        explicit CmdProjectSettingsChange(ProjectSettings& settings) noexcept;
         ~CmdProjectSettingsChange() noexcept;
 
         // Setters
@@ -55,13 +54,20 @@ class CmdProjectSettingsChange final : public UndoCommand
         void setLocaleOrder(const QStringList& locales) noexcept;
         void setNormOrder(const QStringList& norms) noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
 
         // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() throw (Exception) override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() throw (Exception) override;
+
         void applyNewSettings() throw (Exception);
         void applyOldSettings() throw (Exception);
 

--- a/libs/librepcbprojecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcbprojecteditor/boardeditor/fsm/bes_select.h
@@ -31,7 +31,7 @@
  ****************************************************************************************/
 namespace librepcb {
 
-class UndoCommand;
+class UndoCommandGroup;
 
 namespace project {
 
@@ -93,8 +93,8 @@ class BES_Select final : public BES_Base
         // Attributes
         SubState mSubState;     ///< the current substate
         Point mLastMouseMoveDeltaPos;   ///< used in the moving substate (mapped to grid)
-        UndoCommand* mParentCommand;    ///< the parent command for all moving commands
-                                        ///< (nullptr if no command is active)
+        UndoCommandGroup* mCommandGroup; ///< the command group for all moving commands
+                                         ///< (nullptr if no command is active)
         QList<CmdDeviceInstanceEdit*> mDeviceEditCmds; ///< all footprint move commands
 };
 

--- a/libs/librepcbprojecteditor/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcbprojecteditor/boardeditor/unplacedcomponentsdock.cpp
@@ -336,25 +336,25 @@ void UnplacedComponentsDock::addDevice(ComponentInstance& cmp, const Uuid& devic
 
     try
     {
-        mProjectEditor.getUndoStack().beginCommand(tr("Add device to board"));
+        mProjectEditor.getUndoStack().beginCmdGroup(tr("Add device to board"));
         cmdActive = true;
 
         // add device to board
         auto* cmd = new CmdAddDeviceToBoard(mProjectEditor.getWorkspace(), *mBoard, cmp,
                                             deviceUuid, footprintUuid, mNextPosition);
-        mProjectEditor.getUndoStack().appendToCommand(cmd);
+        mProjectEditor.getUndoStack().appendToCmdGroup(cmd);
         if (mNextPosition.getX() > Length::fromMm(200))
             mNextPosition = Point::fromMm(0, mNextPosition.getY().toMm() - 10);
         else
             mNextPosition += Point::fromMm(10, 0);
         mNextPosition.mapToGrid(mBoard->getGridProperties().getInterval());
 
-        mProjectEditor.getUndoStack().endCommand();
+        mProjectEditor.getUndoStack().commitCmdGroup();
         cmdActive = false;
     }
     catch (Exception& e)
     {
-        try {if (cmdActive) mProjectEditor.getUndoStack().abortCommand();} catch (...) {}
+        try {if (cmdActive) mProjectEditor.getUndoStack().abortCmdGroup();} catch (...) {}
         QMessageBox::critical(this, tr("Error"), e.getUserMsg());
     }
 }

--- a/libs/librepcbprojecteditor/cmd/cmdaddcomponenttocircuit.h
+++ b/libs/librepcbprojecteditor/cmd/cmdaddcomponenttocircuit.h
@@ -24,8 +24,7 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
+#include <librepcbcommon/undocommandgroup.h>
 #include <librepcbcommon/uuid.h>
 
 /*****************************************************************************************
@@ -54,24 +53,27 @@ class CmdComponentInstanceAdd;
 /**
  * @brief The CmdAddComponentToCircuit class
  */
-class CmdAddComponentToCircuit final : public UndoCommand
+class CmdAddComponentToCircuit final : public UndoCommandGroup
 {
     public:
 
         // Constructors / Destructor
-        explicit CmdAddComponentToCircuit(workspace::Workspace& workspace, Project& project,
-                                          const Uuid& component, const Uuid& symbolVariant,
-                                          UndoCommand* parent = 0) throw (Exception);
+        CmdAddComponentToCircuit(workspace::Workspace& workspace, Project& project,
+                                 const Uuid& component, const Uuid& symbolVariant) noexcept;
         ~CmdAddComponentToCircuit() noexcept;
 
         // Getters
         ComponentInstance* getComponentInstance() const noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
-
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         workspace::Workspace& mWorkspace;

--- a/libs/librepcbprojecteditor/cmd/cmdadddevicetoboard.h
+++ b/libs/librepcbprojecteditor/cmd/cmdadddevicetoboard.h
@@ -24,8 +24,7 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
+#include <librepcbcommon/undocommandgroup.h>
 #include <librepcbcommon/uuid.h>
 #include <librepcbcommon/units/all_length_units.h>
 
@@ -56,26 +55,30 @@ class CmdDeviceInstanceAdd;
 /**
  * @brief The CmdAddDeviceToBoard class
  */
-class CmdAddDeviceToBoard final : public UndoCommand
+class CmdAddDeviceToBoard final : public UndoCommandGroup
 {
     public:
 
         // Constructors / Destructor
-        explicit CmdAddDeviceToBoard(workspace::Workspace& workspace,
-                                     Board& board, ComponentInstance& cmpInstance,
-                                     const Uuid& deviceUuid, const Uuid& footprintUuid,
-                                     const Point& position = Point(),
-                                     const Angle& rotation = Angle(), UndoCommand* parent = 0) throw (Exception);
+        CmdAddDeviceToBoard(workspace::Workspace& workspace, Board& board,
+                            ComponentInstance& cmpInstance, const Uuid& deviceUuid,
+                            const Uuid& footprintUuid, const Point& position = Point(),
+                            const Angle& rotation = Angle()) noexcept;
         ~CmdAddDeviceToBoard() noexcept;
 
         // Getters
         DeviceInstance* getDeviceInstance() const noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         workspace::Workspace& mWorkspace;

--- a/libs/librepcbprojecteditor/cmd/cmdaddsymboltoschematic.h
+++ b/libs/librepcbprojecteditor/cmd/cmdaddsymboltoschematic.h
@@ -24,8 +24,7 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include <librepcbcommon/undocommand.h>
-#include <librepcbcommon/exceptions.h>
+#include <librepcbcommon/undocommandgroup.h>
 #include <librepcbcommon/uuid.h>
 #include <librepcbcommon/units/all_length_units.h>
 
@@ -56,25 +55,29 @@ class CmdSymbolInstanceAdd;
 /**
  * @brief The CmdAddSymbolToSchematic class
  */
-class CmdAddSymbolToSchematic final : public UndoCommand
+class CmdAddSymbolToSchematic final : public UndoCommandGroup
 {
     public:
 
         // Constructors / Destructor
-        explicit CmdAddSymbolToSchematic(workspace::Workspace& workspace,
-                                         Schematic& schematic, ComponentInstance& cmpInstance,
-                                         const Uuid& symbolItem, const Point& position = Point(),
-                                         const Angle& angle = Angle(), UndoCommand* parent = 0) throw (Exception);
+        CmdAddSymbolToSchematic(workspace::Workspace& workspace, Schematic& schematic,
+                                ComponentInstance& cmpInstance, const Uuid& symbolItem,
+                                const Point& position = Point(), const Angle& angle = Angle()) noexcept;
         ~CmdAddSymbolToSchematic() noexcept;
 
         // Getters
         SI_Symbol* getSymbolInstance() const noexcept;
 
-        // Inherited from UndoCommand
-        void redo() throw (Exception) override;
-        void undo() throw (Exception) override;
 
     private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        void performExecute() throw (Exception) override;
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
         workspace::Workspace& mWorkspace;

--- a/libs/librepcbprojecteditor/dialogs/editnetclassesdialog.cpp
+++ b/libs/librepcbprojecteditor/dialogs/editnetclassesdialog.cpp
@@ -51,7 +51,7 @@ EditNetClassesDialog::EditNetClassesDialog(Circuit& circuit, UndoStack& undoStac
     // The next line tries to begin a new command on the project's undo stack. This will
     // block all other commands (neccessary to avoid problems). If another command is
     // active at the moment, this line throws an exception and the constructor is exited.
-    mUndoStack.beginCommand(tr("Edit Netclasses"));
+    mUndoStack.beginCmdGroup(tr("Edit Netclasses"));
 
     int row = 0;
     mUi->tableWidget->setRowCount(mCircuit.getNetClasses().count());
@@ -79,9 +79,9 @@ EditNetClassesDialog::~EditNetClassesDialog() noexcept
 
     // end the active command
     if (result() == QDialog::Accepted)
-        try {mUndoStack.endCommand();} catch (...) {}
+        try {mUndoStack.commitCmdGroup();} catch (...) {}
     else
-        try {mUndoStack.abortCommand();} catch (...) {}
+        try {mUndoStack.abortCmdGroup();} catch (...) {}
 
     delete mUi;         mUi = 0;
 }
@@ -103,7 +103,7 @@ void EditNetClassesDialog::on_tableWidget_itemChanged(QTableWidgetItem *item)
             {
                 auto cmd = new CmdNetClassEdit(mCircuit, *netclass);
                 cmd->setName(item->text());
-                mUndoStack.appendToCommand(cmd);
+                mUndoStack.appendToCmdGroup(cmd);
             }
             catch (Exception& e)
             {
@@ -124,7 +124,7 @@ void EditNetClassesDialog::on_btnAdd_clicked()
     try
     {
         CmdNetClassAdd* cmd = new CmdNetClassAdd(mCircuit, name);
-        mUndoStack.appendToCommand(cmd);
+        mUndoStack.appendToCmdGroup(cmd);
 
         int row = mUi->tableWidget->rowCount();
         mUi->tableWidget->insertRow(row);
@@ -150,7 +150,7 @@ void EditNetClassesDialog::on_btnRemove_clicked()
     try
     {
         CmdNetClassRemove* cmd = new CmdNetClassRemove(mCircuit, *netclass);
-        mUndoStack.appendToCommand(cmd);
+        mUndoStack.appendToCmdGroup(cmd);
 
         mUi->tableWidget->removeRow(row);
     }

--- a/libs/librepcbprojecteditor/dialogs/projectpropertieseditordialog.cpp
+++ b/libs/librepcbprojecteditor/dialogs/projectpropertieseditordialog.cpp
@@ -88,7 +88,7 @@ bool ProjectPropertiesEditorDialog::applyChanges() noexcept
 {
     try
     {
-        mUndoStack.beginCommand(tr("Change project properties"));
+        mUndoStack.beginCmdGroup(tr("Change project properties"));
         mCommandActive = true;
 
         // Metadata
@@ -97,16 +97,16 @@ bool ProjectPropertiesEditorDialog::applyChanges() noexcept
         cmd->setDescription(mUi->edtDescription->toPlainText());
         cmd->setAuthor(mUi->edtAuthor->text());
         cmd->setCreated(mUi->edtCreated->dateTime());
-        mUndoStack.appendToCommand(cmd);
+        mUndoStack.appendToCmdGroup(cmd);
 
-        mUndoStack.endCommand();
+        mUndoStack.commitCmdGroup();
         mCommandActive = false;
         return true;
     }
     catch (Exception& e)
     {
         QMessageBox::critical(this, tr("Error"), e.getUserMsg());
-        try {if (mCommandActive) mUndoStack.abortCommand();} catch (...) {}
+        try {if (mCommandActive) mUndoStack.abortCmdGroup();} catch (...) {}
         return false;
     }
 }

--- a/libs/librepcbprojecteditor/projecteditor.cpp
+++ b/libs/librepcbprojecteditor/projecteditor.cpp
@@ -80,7 +80,7 @@ ProjectEditor::~ProjectEditor() noexcept
     // abort all active commands!
     mSchematicEditor->abortAllCommands();
     mBoardEditor->abortAllCommands();
-    Q_ASSERT(mUndoStack->isCommandActive() == false);
+    Q_ASSERT(!mUndoStack->isCommandGroupActive());
 
     // delete all command objects in the undo stack (must be done before other important
     // objects are deleted, as undo command objects can hold pointers/references to them!)
@@ -183,7 +183,7 @@ bool ProjectEditor::autosaveProject() noexcept
     if ((!mProject.isRestored()) && (mUndoStack->isClean()))
         return false; // do not save if there are no changes
 
-    if (mUndoStack->isCommandActive())
+    if (mUndoStack->isCommandGroupActive())
     {
         // the user is executing a command at the moment, so we should not save now,
         // try it a few seconds later instead...

--- a/libs/librepcbprojecteditor/schematiceditor/fsm/ses_addnetlabel.cpp
+++ b/libs/librepcbprojecteditor/schematiceditor/fsm/ses_addnetlabel.cpp
@@ -92,7 +92,7 @@ bool SES_AddNetLabel::exit(SEE_Base* event) noexcept
     {
         try
         {
-            mUndoStack.abortCommand();
+            mUndoStack.abortCmdGroup();
             mUndoCmdActive = false;
         }
         catch (Exception& e)
@@ -188,10 +188,10 @@ bool SES_AddNetLabel::addLabel(Schematic& schematic) noexcept
         if (!signal)
             throw RuntimeError(__FILE__, __LINE__, QString(), tr("No net signal found."));
 
-        mUndoStack.beginCommand(tr("Add net label to schematic"));
+        mUndoStack.beginCmdGroup(tr("Add net label to schematic"));
         mUndoCmdActive = true;
         CmdSchematicNetLabelAdd* cmdAdd = new CmdSchematicNetLabelAdd(schematic, *signal, Point());
-        mUndoStack.appendToCommand(cmdAdd);
+        mUndoStack.appendToCmdGroup(cmdAdd);
         mCurrentNetLabel = cmdAdd->getNetLabel();
         mEditCmd = new CmdSchematicNetLabelEdit(*mCurrentNetLabel);
         return true;
@@ -200,7 +200,7 @@ bool SES_AddNetLabel::addLabel(Schematic& schematic) noexcept
     {
         if (mUndoCmdActive)
         {
-            try {mUndoStack.abortCommand();} catch (...) {}
+            try {mUndoStack.abortCmdGroup();} catch (...) {}
             mUndoCmdActive = false;
         }
         QMessageBox::critical(&mEditor, tr("Error"), e.getUserMsg());
@@ -234,8 +234,8 @@ bool SES_AddNetLabel::fixLabel(const Point& pos) noexcept
     try
     {
         mEditCmd->setPosition(pos, false);
-        mUndoStack.appendToCommand(mEditCmd);
-        mUndoStack.endCommand();
+        mUndoStack.appendToCmdGroup(mEditCmd);
+        mUndoStack.commitCmdGroup();
         mUndoCmdActive = false;
         return true;
     }
@@ -243,7 +243,7 @@ bool SES_AddNetLabel::fixLabel(const Point& pos) noexcept
     {
         if (mUndoCmdActive)
         {
-            try {mUndoStack.abortCommand();} catch (...) {}
+            try {mUndoStack.abortCmdGroup();} catch (...) {}
             mUndoCmdActive = false;
         }
         QMessageBox::critical(&mEditor, tr("Error"), e.getUserMsg());

--- a/libs/librepcbprojecteditor/schematiceditor/fsm/ses_select.h
+++ b/libs/librepcbprojecteditor/schematiceditor/fsm/ses_select.h
@@ -31,7 +31,7 @@
  ****************************************************************************************/
 namespace librepcb {
 
-class UndoCommand;
+class UndoCommandGroup;
 
 namespace project {
 
@@ -96,8 +96,8 @@ class SES_Select final : public SES_Base
         // Attributes
         SubState mSubState;     ///< the current substate
         Point mLastMouseMoveDeltaPos;   ///< used in the moving substate (mapped to grid)
-        UndoCommand* mParentCommand;    ///< the parent command for all moving commands
-                                        ///< (nullptr if no command is active)
+        UndoCommandGroup* mCommandGroup; ///< the command group for all moving commands
+                                         ///< (nullptr if no command is active)
         QList<CmdSymbolInstanceEdit*> mSymbolEditCmds; ///< all symbol move commands
         QList<CmdSchematicNetPointEdit*> mNetPointEditCmds; ///< all netpoint edit commands
         QList<CmdSchematicNetLabelEdit*> mNetLabelEditCmds;

--- a/libs/librepcbprojecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcbprojecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -397,18 +397,18 @@ void SymbolInstancePropertiesDialog::execCmd(UndoCommand* cmd)
 {
     if (!mCommandActive)
     {
-        mUndoStack.beginCommand(QString(tr("Change properties of %1")).arg(mSymbol.getName()));
+        mUndoStack.beginCmdGroup(QString(tr("Change properties of %1")).arg(mSymbol.getName()));
         mCommandActive = true;
     }
 
-    mUndoStack.appendToCommand(cmd);
+    mUndoStack.appendToCmdGroup(cmd);
 }
 
 void SymbolInstancePropertiesDialog::endCmd()
 {
     if (mCommandActive)
     {
-        mUndoStack.endCommand();
+        mUndoStack.commitCmdGroup();
         mCommandActive = false;
     }
 }
@@ -417,7 +417,7 @@ void SymbolInstancePropertiesDialog::abortCmd()
 {
     if (mCommandActive)
     {
-        mUndoStack.abortCommand();
+        mUndoStack.abortCmdGroup();
         mCommandActive = false;
     }
 }


### PR DESCRIPTION
- UndoCommand: It is no longer possible to create child commands (reduces complexity)
- UndoCommand: In addition to the methods "undo()" and "redo()", there is now also the method "execute()" to explicitly specify that a command is executed the first time
- UndoCommand/UndoStack: Merging multiple undo commands togehter is no longer possible (it wasn't used anyway until now)
- UndoStack: renamed some methods (expandable commands are now called "command groups")
- To implement undo commands with child commands, there is a new class "UndoCommandGroup"
- Improved exception safety