### PR TITLE
Add possibility to highlight all items of a specific net signal

### DIFF
--- a/libs/librepcbproject/circuit/circuit.cpp
+++ b/libs/librepcbproject/circuit/circuit.cpp
@@ -277,6 +277,13 @@ void Circuit::setNetSignalName(NetSignal& netsignal, const QString& newName,
     netsignal.setName(newName, isAutoName); // can throw
 }
 
+void Circuit::setHighlightedNetSignal(NetSignal* signal) noexcept
+{
+    foreach (NetSignal* netsignal, mNetSignals) {
+        netsignal->setHighlighted(signal == netsignal);
+    }
+}
+
 /*****************************************************************************************
  *  ComponentInstance Methods
  ****************************************************************************************/

--- a/libs/librepcbproject/circuit/circuit.h
+++ b/libs/librepcbproject/circuit/circuit.h
@@ -99,6 +99,7 @@ class Circuit final : public QObject, public IF_XmlSerializableObject
         void addNetSignal(NetSignal& netsignal) throw (Exception);
         void removeNetSignal(NetSignal& netsignal) throw (Exception);
         void setNetSignalName(NetSignal& netsignal, const QString& newName, bool isAutoName) throw (Exception);
+        void setHighlightedNetSignal(NetSignal* signal) noexcept;
 
         // ComponentInstance Methods
         QString generateAutoComponentInstanceName(const QString& cmpPrefix) const noexcept;

--- a/libs/librepcbproject/circuit/netsignal.cpp
+++ b/libs/librepcbproject/circuit/netsignal.cpp
@@ -42,7 +42,7 @@ namespace project {
  ****************************************************************************************/
 
 NetSignal::NetSignal(Circuit& circuit, const XmlDomElement& domElement) throw (Exception) :
-    QObject(&circuit), mCircuit(circuit), mIsAddedToCircuit(false)
+    QObject(&circuit), mCircuit(circuit), mIsAddedToCircuit(false), mIsHighlighted(false)
 {
     mUuid = domElement.getAttribute<Uuid>("uuid", true);
     mName = domElement.getAttribute<QString>("name", true);
@@ -60,7 +60,7 @@ NetSignal::NetSignal(Circuit& circuit, const XmlDomElement& domElement) throw (E
 
 NetSignal::NetSignal(Circuit& circuit, NetClass& netclass, const QString& name,
                      bool autoName) throw (Exception) :
-    QObject(&circuit), mCircuit(circuit), mIsAddedToCircuit(false),
+    QObject(&circuit), mCircuit(circuit), mIsAddedToCircuit(false), mIsHighlighted(false),
     mUuid(Uuid::createRandom()), mName(name), mHasAutoName(autoName), mNetClass(&netclass)
 {
     if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
@@ -117,6 +117,14 @@ void NetSignal::setName(const QString& name, bool isAutoName) throw (Exception)
     mHasAutoName = isAutoName;
     updateErcMessages();
     emit nameChanged(mName);
+}
+
+void NetSignal::setHighlighted(bool hl) noexcept
+{
+    if (hl != mIsHighlighted) {
+        mIsHighlighted = hl;
+        emit highlightedChanged(mIsHighlighted);
+    }
 }
 
 /*****************************************************************************************

--- a/libs/librepcbproject/circuit/netsignal.h
+++ b/libs/librepcbproject/circuit/netsignal.h
@@ -69,6 +69,7 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public IF_XmlS
         const QString& getName() const noexcept {return mName;}
         bool hasAutoName() const noexcept {return mHasAutoName;}
         NetClass& getNetClass() const noexcept {return *mNetClass;}
+        bool isHighlighted() const noexcept {return mIsHighlighted;}
 
         // Getters: General
         Circuit& getCircuit() const noexcept {return mCircuit;}
@@ -81,6 +82,7 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public IF_XmlS
 
         // Setters
         void setName(const QString& name, bool isAutoName) throw (Exception);
+        void setHighlighted(bool hl) noexcept;
 
         // General Methods
         void addToCircuit() throw (Exception);
@@ -102,6 +104,7 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public IF_XmlS
     signals:
 
         void nameChanged(const QString& newName);
+        void highlightedChanged(bool isHighlighted);
 
 
     private:
@@ -115,6 +118,7 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public IF_XmlS
         // General
         Circuit& mCircuit;
         bool mIsAddedToCircuit;
+        bool mIsHighlighted;
 
         // Attributes
         Uuid mUuid;

--- a/libs/librepcbproject/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcbproject/schematics/graphicsitems/sgi_netlabel.cpp
@@ -104,11 +104,13 @@ void SGI_NetLabel::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     bool deviceIsPrinter = (dynamic_cast<QPrinter*>(painter->device()) != 0);
     const qreal lod = option->levelOfDetailFromTransform(painter->worldTransform());
 
+    bool highlight = mNetLabel.isSelected() || mNetLabel.getNetSignal().isHighlighted();
+
     SchematicLayer* layer = getSchematicLayer(SchematicLayer::OriginCrosses); Q_ASSERT(layer);
     if ((layer->isVisible()) && (lod > 2) && (!deviceIsPrinter))
     {
         // draw origin cross
-        painter->setPen(QPen(layer->getColor(mNetLabel.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->drawLines(sOriginCrossLines);
     }
 
@@ -116,7 +118,7 @@ void SGI_NetLabel::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     if ((layer->isVisible()) && ((deviceIsPrinter) || (lod > 1)))
     {
         // draw text
-        painter->setPen(QPen(layer->getColor(mNetLabel.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setFont(mFont);
         if (mRotate180)
         {
@@ -132,7 +134,7 @@ void SGI_NetLabel::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     {
         // draw filled rect
         painter->setPen(Qt::NoPen);
-        painter->setBrush(QBrush(layer->getColor(mNetLabel.isSelected()), Qt::Dense5Pattern));
+        painter->setBrush(QBrush(layer->getColor(highlight), Qt::Dense5Pattern));
         painter->drawRect(mBoundingRect);
     }
 
@@ -141,7 +143,7 @@ void SGI_NetLabel::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     if (layer->isVisible())
     {
         // draw bounding rect
-        painter->setPen(QPen(layer->getColor(mNetLabel.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setBrush(Qt::NoBrush);
         painter->drawRect(mBoundingRect);
     }
@@ -149,7 +151,7 @@ void SGI_NetLabel::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     if (layer->isVisible())
     {
         // draw text bounding rect
-        painter->setPen(QPen(layer->getColor(mNetLabel.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setBrush(Qt::NoBrush);
         painter->drawRect(QRectF(mTextOrigin, mStaticText.size()));
     }

--- a/libs/librepcbproject/schematics/graphicsitems/sgi_netline.cpp
+++ b/libs/librepcbproject/schematics/graphicsitems/sgi_netline.cpp
@@ -88,10 +88,12 @@ void SGI_NetLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* optio
     Q_UNUSED(option);
     Q_UNUSED(widget);
 
+    bool highlight = mNetLine.isSelected() || mNetLine.getNetSignal().isHighlighted();
+
     // draw line
     if (mLayer->isVisible())
     {
-        QPen pen(mLayer->getColor(mNetLine.isSelected()), mNetLine.getWidth().toPx(), Qt::SolidLine, Qt::RoundCap);
+        QPen pen(mLayer->getColor(highlight), mNetLine.getWidth().toPx(), Qt::SolidLine, Qt::RoundCap);
         painter->setPen(pen);
         painter->drawLine(mLineF);
     }
@@ -107,14 +109,14 @@ void SGI_NetLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* optio
         font.setFamily("Monospace");
         font.setPixelSize(3);
         painter->setFont(font);
-        painter->setPen(QPen(layer->getColor(mNetLine.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->drawText(mLineF.pointAt((qreal)0.5), mNetLine.getNetSignal().getName());
     }
     layer = getSchematicLayer(SchematicLayer::LayerID::DEBUG_GraphicsItemsBoundingRect); Q_ASSERT(layer);
     if (layer->isVisible())
     {
         // draw bounding rect
-        painter->setPen(QPen(layer->getColor(mNetLine.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setBrush(Qt::NoBrush);
         painter->drawRect(mBoundingRect);
     }

--- a/libs/librepcbproject/schematics/graphicsitems/sgi_netpoint.cpp
+++ b/libs/librepcbproject/schematics/graphicsitems/sgi_netpoint.cpp
@@ -27,6 +27,7 @@
 #include "../items/si_netpoint.h"
 #include "../schematic.h"
 #include "../../project.h"
+#include "../../circuit/netsignal.h"
 #include <librepcbcommon/schematiclayer.h>
 
 /*****************************************************************************************
@@ -83,10 +84,12 @@ void SGI_NetPoint::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     Q_UNUSED(option);
     Q_UNUSED(widget);
 
+    bool highlight = mNetPoint.isSelected() || mNetPoint.getNetSignal().isHighlighted();
+
     if (mLayer->isVisible() && mPointVisible)
     {
         painter->setPen(Qt::NoPen);
-        painter->setBrush(QBrush(mLayer->getColor(mNetPoint.isSelected()), Qt::SolidPattern));
+        painter->setBrush(QBrush(mLayer->getColor(highlight), Qt::SolidPattern));
         painter->drawEllipse(sBoundingRect);
     }
 
@@ -95,7 +98,7 @@ void SGI_NetPoint::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     if ((layer->isVisible()) && (!mPointVisible))
     {
         // draw circle
-        painter->setPen(QPen(layer->getColor(mNetPoint.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setBrush(Qt::NoBrush);
         painter->drawEllipse(sBoundingRect);
     }
@@ -103,7 +106,7 @@ void SGI_NetPoint::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     if (layer->isVisible())
     {
         // draw bounding rect
-        painter->setPen(QPen(layer->getColor(mNetPoint.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setBrush(Qt::NoBrush);
         painter->drawRect(sBoundingRect);
     }

--- a/libs/librepcbproject/schematics/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcbproject/schematics/graphicsitems/sgi_symbolpin.cpp
@@ -120,14 +120,14 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
     const bool deviceIsPrinter = (dynamic_cast<QPrinter*>(painter->device()) != 0);
     const qreal lod = option->levelOfDetailFromTransform(painter->worldTransform());
 
-    const ComponentSignalInstance* cmpSignal = mPin.getComponentSignalInstance();
-    const NetSignal* netsignal = (cmpSignal ? cmpSignal->getNetSignal() : nullptr);
+    const NetSignal* netsignal = mPin.getCompSigInstNetSignal();
+    bool highlight = mPin.isSelected() || (netsignal && netsignal->isHighlighted());
 
     // draw line
     SchematicLayer* layer = getSchematicLayer(SchematicLayer::SymbolOutlines); Q_ASSERT(layer);
     if (layer->isVisible())
     {
-        painter->setPen(QPen(layer->getColor(mPin.isSelected()), Length(158750).toPx(), Qt::SolidLine, Qt::RoundCap));
+        painter->setPen(QPen(layer->getColor(highlight), Length(158750).toPx(), Qt::SolidLine, Qt::RoundCap));
         painter->drawLine(QPointF(0, 0), Point(mLibPin.getLength(), 0).toPxQPointF());
     }
 
@@ -149,7 +149,7 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
             // draw text
             painter->save();
             if (mRotate180) painter->rotate(180);
-            painter->setPen(QPen(layer->getColor(mPin.isSelected()), 0));
+            painter->setPen(QPen(layer->getColor(highlight), 0));
             painter->setFont(mFont);
             painter->drawStaticText(mTextOrigin, mStaticText);
             painter->restore();
@@ -158,7 +158,7 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
         {
             // draw filled rect
             painter->setPen(Qt::NoPen);
-            painter->setBrush(QBrush(layer->getColor(mPin.isSelected()), Qt::Dense5Pattern));
+            painter->setBrush(QBrush(layer->getColor(highlight), Qt::Dense5Pattern));
             painter->drawRect(mTextBoundingRect);
         }
     }
@@ -174,7 +174,7 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
         font.setFamily("Monospace");
         font.setPixelSize(3);
         painter->setFont(font);
-        painter->setPen(QPen(layer->getColor(mPin.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->save();
         if (mRotate180) painter->rotate(180);
         painter->drawText(QRectF(), Qt::AlignHCenter | Qt::AlignBottom | Qt::TextSingleLine | Qt::TextDontClip, netsignal->getName());
@@ -184,7 +184,7 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
     if (layer->isVisible())
     {
         // draw bounding rect
-        painter->setPen(QPen(layer->getColor(mPin.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setBrush(Qt::NoBrush);
         painter->drawRect(mBoundingRect);
     }
@@ -192,7 +192,7 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
     if (layer->isVisible())
     {
         // draw text bounding rect
-        painter->setPen(QPen(layer->getColor(mPin.isSelected()), 0));
+        painter->setPen(QPen(layer->getColor(highlight), 0));
         painter->setBrush(Qt::NoBrush);
         painter->drawRect(mTextBoundingRect);
     }

--- a/libs/librepcbproject/schematics/items/si_netlabel.cpp
+++ b/libs/librepcbproject/schematics/items/si_netlabel.cpp
@@ -132,6 +132,8 @@ void SI_NetLabel::addToSchematic(GraphicsScene& scene) throw (Exception)
         throw LogicError(__FILE__, __LINE__);
     }
     mNetSignal->registerSchematicNetLabel(*this); // can throw
+    mHighlightChangedConnection = connect(mNetSignal, &NetSignal::highlightedChanged,
+                                          [this](){mGraphicsItem->update();});
     SI_Base::addToSchematic(scene, *mGraphicsItem);
 }
 
@@ -141,6 +143,7 @@ void SI_NetLabel::removeFromSchematic(GraphicsScene& scene) throw (Exception)
         throw LogicError(__FILE__, __LINE__);
     }
     mNetSignal->unregisterSchematicNetLabel(*this); // can throw
+    disconnect(mHighlightChangedConnection);
     SI_Base::removeFromSchematic(scene, *mGraphicsItem);
 }
 

--- a/libs/librepcbproject/schematics/items/si_netlabel.h
+++ b/libs/librepcbproject/schematics/items/si_netlabel.h
@@ -100,6 +100,7 @@ class SI_NetLabel final : public SI_Base, public IF_XmlSerializableObject
 
         // General
         QScopedPointer<SGI_NetLabel> mGraphicsItem;
+        QMetaObject::Connection mHighlightChangedConnection;
 
         // Attributes
         Uuid mUuid;

--- a/libs/librepcbproject/schematics/items/si_netline.cpp
+++ b/libs/librepcbproject/schematics/items/si_netline.cpp
@@ -152,6 +152,8 @@ void SI_NetLine::addToSchematic(GraphicsScene& scene) throw (Exception)
     mStartPoint->registerNetLine(*this); // can throw
     auto sg = scopeGuard([&](){mStartPoint->unregisterNetLine(*this);});
     mEndPoint->registerNetLine(*this); // can throw
+    mHighlightChangedConnection = connect(&getNetSignal(), &NetSignal::highlightedChanged,
+                                          [this](){mGraphicsItem->update();});
     SI_Base::addToSchematic(scene, *mGraphicsItem);
     sg.dismiss();
 }
@@ -164,6 +166,7 @@ void SI_NetLine::removeFromSchematic(GraphicsScene& scene) throw (Exception)
     mEndPoint->unregisterNetLine(*this); // can throw
     auto sg = scopeGuard([&](){mEndPoint->registerNetLine(*this);});
     mStartPoint->unregisterNetLine(*this); // can throw
+    disconnect(mHighlightChangedConnection);
     SI_Base::removeFromSchematic(scene, *mGraphicsItem);
     sg.dismiss();
 }

--- a/libs/librepcbproject/schematics/items/si_netline.h
+++ b/libs/librepcbproject/schematics/items/si_netline.h
@@ -100,6 +100,7 @@ class SI_NetLine final : public SI_Base, public IF_XmlSerializableObject
         // General
         QScopedPointer<SGI_NetLine> mGraphicsItem;
         Point mPosition; ///< the center of startpoint and endpoint
+        QMetaObject::Connection mHighlightChangedConnection;
 
         // Attributes
         Uuid mUuid;

--- a/libs/librepcbproject/schematics/items/si_netpoint.h
+++ b/libs/librepcbproject/schematics/items/si_netpoint.h
@@ -126,6 +126,7 @@ class SI_NetPoint final : public SI_Base, public IF_XmlSerializableObject,
 
         // General
         QScopedPointer<SGI_NetPoint> mGraphicsItem;
+        QMetaObject::Connection mHighlightChangedConnection;
 
         // Attributes
         Uuid mUuid;

--- a/libs/librepcbproject/schematics/items/si_symbolpin.cpp
+++ b/libs/librepcbproject/schematics/items/si_symbolpin.cpp
@@ -123,6 +123,15 @@ QString SI_SymbolPin::getDisplayText(bool returnCmpSignalNameIfEmpty,
     return text;
 }
 
+NetSignal* SI_SymbolPin::getCompSigInstNetSignal() const noexcept
+{
+    if (mComponentSignalInstance) {
+        return mComponentSignalInstance->getNetSignal();
+    } else {
+        return nullptr;
+    }
+}
+
 bool SI_SymbolPin::isRequired() const noexcept
 {
     if (mComponentSignalInstance) {
@@ -144,6 +153,10 @@ void SI_SymbolPin::addToSchematic(GraphicsScene& scene) throw (Exception)
     if (mComponentSignalInstance) {
         mComponentSignalInstance->registerSymbolPin(*this); // can throw
     }
+    if (getCompSigInstNetSignal()) {
+        mHighlightChangedConnection = connect(getCompSigInstNetSignal(), &NetSignal::highlightedChanged,
+                                              [this](){mGraphicsItem->update();});
+    }
     SI_Base::addToSchematic(scene, *mGraphicsItem);
     updateErcMessages();
 }
@@ -155,6 +168,9 @@ void SI_SymbolPin::removeFromSchematic(GraphicsScene& scene) throw (Exception)
     }
     if (mComponentSignalInstance) {
         mComponentSignalInstance->unregisterSymbolPin(*this); // can throw
+    }
+    if (getCompSigInstNetSignal()) {
+        disconnect(mHighlightChangedConnection);
     }
     SI_Base::removeFromSchematic(scene, *mGraphicsItem);
     updateErcMessages();

--- a/libs/librepcbproject/schematics/items/si_symbolpin.h
+++ b/libs/librepcbproject/schematics/items/si_symbolpin.h
@@ -75,8 +75,8 @@ class SI_SymbolPin final : public SI_Base, public IF_ErcMsgProvider
         SI_Symbol& getSymbol() const noexcept {return mSymbol;}
         SI_NetPoint* getNetPoint() const noexcept {return mRegisteredNetPoint;}
         const library::SymbolPin& getLibPin() const noexcept {return *mSymbolPin;}
-        //const library::ComponentSignal* getComponentSignal() const noexcept {return mComponentSignal;}
         ComponentSignalInstance* getComponentSignalInstance() const noexcept {return mComponentSignalInstance;}
+        NetSignal* getCompSigInstNetSignal() const noexcept;
         bool isRequired() const noexcept;
         bool isUsed() const noexcept {return mRegisteredNetPoint ? true : false;}
 
@@ -109,6 +109,7 @@ class SI_SymbolPin final : public SI_Base, public IF_ErcMsgProvider
         const library::SymbolPin* mSymbolPin;
         const library::ComponentPinSignalMapItem* mPinSignalMapItem;
         ComponentSignalInstance* mComponentSignalInstance;
+        QMetaObject::Connection mHighlightChangedConnection;
 
         // Misc
         Point mPosition;

--- a/libs/librepcbprojecteditor/schematiceditor/fsm/ses_drawwire.cpp
+++ b/libs/librepcbprojecteditor/schematiceditor/fsm/ses_drawwire.cpp
@@ -418,6 +418,9 @@ bool SES_DrawWire::startPositioning(Schematic& schematic, const Point& pos,
         // properly place the new netpoints/netlines according the current wire mode
         updateNetpointPositions(pos);
 
+        // highlight all elements of the current netsignal
+        mCircuit.setHighlightedNetSignal(netsignal);
+
         return true;
     }
     catch (Exception e)
@@ -495,6 +498,7 @@ bool SES_DrawWire::abortPositioning(bool showErrMsgBox) noexcept
 {
     try
     {
+        mCircuit.setHighlightedNetSignal(nullptr);
         mSubState = SubState_Idle;
         mFixedNetPoint = nullptr;
         mPositioningNetLine1 = nullptr;


### PR DESCRIPTION
When drawing a wire in the schematic editor, all other lines/pins of the same net signal will now be highlighted.