### PR TITLE
Fix broken AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
 init:
   - git config --global core.autocrlf input
-  - set PATH=%PATH%;%QTDIR%\bin;%MINGW%\bin;C:\Qt\Tools\QtCreator\bin
+  - set PATH=%QTDIR%\bin;%MINGW%\bin;C:\Qt\Tools\QtCreator\bin;%PATH%
 
 build_script:
   - mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}-{branch}
+version: 0.1.{build}-{branch}
 os: Windows Server 2012
 configuration: Debug
 build: off


### PR DESCRIPTION
Windows has linked to the wrong Qt DLLs. With adding the directory of the correct Qt DLLs to the *front* of the PATH variable, the correct DLLs will now be loaded.

Fixes #68 (hopefully)