### PR TITLE
Combine schematic elements together with project::SI_NetSegment

### DIFF
--- a/libs/librepcb/common/graphics/defaultgraphicslayerprovider.cpp
+++ b/libs/librepcb/common/graphics/defaultgraphicslayerprovider.cpp
@@ -48,6 +48,7 @@ DefaultGraphicsLayerProvider::DefaultGraphicsLayerProvider() noexcept
     addLayer(GraphicsLayer::sSymbolValues);
     addLayer(GraphicsLayer::sSchematicNetLines);
     addLayer(GraphicsLayer::sSchematicNetLabels);
+    addLayer(GraphicsLayer::sSchematicNetLabelAnchors);
     addLayer(GraphicsLayer::sSchematicDocumentation);
     addLayer(GraphicsLayer::sSchematicComments);
     addLayer(GraphicsLayer::sSchematicGuide);

--- a/libs/librepcb/common/graphics/graphicslayer.cpp
+++ b/libs/librepcb/common/graphics/graphicslayer.cpp
@@ -236,6 +236,7 @@ void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr, QColo
         h.insert(sSchematicSheetFrames,     {tr("Sheet Frames"),                Qt::black,                  Qt::darkGray,               true});
         h.insert(sSchematicNetLines,        {tr("Netlines"),                    Qt::darkGreen,              Qt::green,                  true});
         h.insert(sSchematicNetLabels,       {tr("Netlabels"),                   Qt::darkGreen,              Qt::green,                  true});
+        h.insert(sSchematicNetLabelAnchors, {tr("Netlabel Anchors"),            Qt::darkGray,               Qt::gray,                   true});
         h.insert(sSchematicDocumentation,   {tr("Documentation"),               Qt::darkGray,               Qt::gray,                   true});
         h.insert(sSchematicComments,        {tr("Comments"),                    Qt::darkBlue,               Qt::blue,                   true});
         h.insert(sSchematicGuide,           {tr("Guide"),                       Qt::darkYellow,             Qt::yellow,                 true});

--- a/libs/librepcb/common/graphics/graphicslayer.h
+++ b/libs/librepcb/common/graphics/graphicslayer.h
@@ -60,6 +60,7 @@ class GraphicsLayer : public QObject
         static constexpr const char* sSchematicSheetFrames    = "sch_scheet_frames";      ///< e.g. A4 sheet frame + text boxes
         static constexpr const char* sSchematicNetLines       = "sch_net_lines";          ///< librepcb::project::SI_NetLine
         static constexpr const char* sSchematicNetLabels      = "sch_net_labels";         ///< librepcb::project::SI_NetLabel
+        static constexpr const char* sSchematicNetLabelAnchors= "sch_net_label_anchors";  ///< anchor line of librepcb::project::SI_NetLabel
         static constexpr const char* sSchematicDocumentation  = "sch_documentation";      ///< for documentation purposes, e.g. text
         static constexpr const char* sSchematicComments       = "sch_comments";           ///< for personal comments, e.g. text
         static constexpr const char* sSchematicGuide          = "sch_guide";              ///< e.g. for boxes around circuits

--- a/libs/librepcb/common/toolbox.cpp
+++ b/libs/librepcb/common/toolbox.cpp
@@ -51,6 +51,31 @@ QPainterPath Toolbox::shapeFromPath(const QPainterPath &path, const QPen &pen) n
     }
 }
 
+Point Toolbox::nearestPointOnLine(const Point& p, const Point& l1, const Point& l2) noexcept
+{
+    Point a = l2 - l1;
+    Point b = p - l1;
+    Point c = p - l2;
+    qreal d = ((b.getX().toMm() * a.getX().toMm()) + (b.getY().toMm() * a.getY().toMm()));
+    qreal e = ((a.getX().toMm() * a.getX().toMm()) + (a.getY().toMm() * a.getY().toMm()));
+    if (a.isOrigin() || b.isOrigin() || (d <= 0.0)) {
+        return l1;
+    } else if (c.isOrigin() || (e <= d)) {
+        return l2;
+    } else {
+        Q_ASSERT(e > 0.0);
+        return l1 + Point::fromMm(a.getX().toMm() * d / e, a.getY().toMm() * d / e);
+    }
+}
+
+Length Toolbox::shortestDistanceBetweenPointAndLine(const Point& p, const Point& l1,
+                                                    const Point& l2, Point* nearest) noexcept
+{
+    Point np = nearestPointOnLine(p, l1, l2);
+    if (nearest) { *nearest = np; }
+    return (p - np).getLength();
+}
+
 /*****************************************************************************************
  *  End of File
  ****************************************************************************************/

--- a/libs/librepcb/common/toolbox.h
+++ b/libs/librepcb/common/toolbox.h
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <QtWidgets>
+#include "units/point.h"
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -74,6 +75,33 @@ class Toolbox final
         }
 
         static QPainterPath shapeFromPath(const QPainterPath &path, const QPen &pen) noexcept;
+
+        /**
+         * @brief Calculate the point on a given line which is nearest to a given point
+         *
+         * @param p         An arbitrary point
+         * @param l1        Start point of the line
+         * @param l2        End point of the line
+         *
+         * @return Nearest point on the given line (either l1, l2, or a point between them)
+         *
+         * @warning This method works with floating point numbers and thus the result may
+         *          not be perfectly precise.
+         */
+        static Point nearestPointOnLine(const Point& p, const Point& l1, const Point& l2) noexcept;
+
+        /**
+         * @brief Calculate the shortest distance between a given point and a given line
+         *
+         * @param p         An arbitrary point
+         * @param l1        Start point of the line
+         * @param l2        End point of the line
+         * @param nearest   If not `nullptr`, the nearest point is returned here
+         *
+         * @return Shortest distance between the given point and the given line (>=0)
+         */
+        static Length shortestDistanceBetweenPointAndLine(const Point& p, const Point& l1,
+                                                          const Point& l2, Point* nearest = nullptr) noexcept;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -143,6 +143,7 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, QSharedPointer<Library> l
     addLayer(GraphicsLayer::sSymbolValues);
     addLayer(GraphicsLayer::sSchematicNetLines);
     addLayer(GraphicsLayer::sSchematicNetLabels);
+    addLayer(GraphicsLayer::sSchematicNetLabelAnchors);
     addLayer(GraphicsLayer::sSchematicDocumentation);
     addLayer(GraphicsLayer::sSchematicComments);
     addLayer(GraphicsLayer::sSchematicGuide);

--- a/libs/librepcb/project/circuit/netsignal.cpp
+++ b/libs/librepcb/project/circuit/netsignal.cpp
@@ -27,8 +27,7 @@
 #include "circuit.h"
 #include "../erc/ercmsg.h"
 #include "componentsignalinstance.h"
-#include "../schematics/items/si_netlabel.h"
-#include "../schematics/items/si_netpoint.h"
+#include "../schematics/items/si_netsegment.h"
 #include "../boards/items/bi_netpoint.h"
 #include "../boards/items/bi_via.h"
 
@@ -81,8 +80,7 @@ int NetSignal::getRegisteredElementsCount() const noexcept
 {
     int count = 0;
     count += mRegisteredComponentSignals.count();
-    count += mRegisteredSchematicNetPoints.count();
-    count += mRegisteredSchematicNetLabels.count();
+    count += mRegisteredSchematicNetSegments.count();
     count += mRegisteredBoardNetPoints.count();
     count += mRegisteredBoardVias.count();
     return count;
@@ -179,43 +177,23 @@ void NetSignal::unregisterComponentSignal(ComponentSignalInstance& signal)
     updateErcMessages();
 }
 
-void NetSignal::registerSchematicNetPoint(SI_NetPoint& netpoint)
+void NetSignal::registerSchematicNetSegment(SI_NetSegment& netsegment)
 {
-    if ((!mIsAddedToCircuit) || (mRegisteredSchematicNetPoints.contains(&netpoint))
-        || (netpoint.getCircuit() != mCircuit))
+    if ((!mIsAddedToCircuit) || (mRegisteredSchematicNetSegments.contains(&netsegment))
+        || (netsegment.getCircuit() != mCircuit))
     {
         throw LogicError(__FILE__, __LINE__);
     }
-    mRegisteredSchematicNetPoints.append(&netpoint);
+    mRegisteredSchematicNetSegments.append(&netsegment);
     updateErcMessages();
 }
 
-void NetSignal::unregisterSchematicNetPoint(SI_NetPoint& netpoint)
+void NetSignal::unregisterSchematicNetSegment(SI_NetSegment& netsegment)
 {
-    if ((!mIsAddedToCircuit) || (!mRegisteredSchematicNetPoints.contains(&netpoint))) {
+    if ((!mIsAddedToCircuit) || (!mRegisteredSchematicNetSegments.contains(&netsegment))) {
         throw LogicError(__FILE__, __LINE__);
     }
-    mRegisteredSchematicNetPoints.removeOne(&netpoint);
-    updateErcMessages();
-}
-
-void NetSignal::registerSchematicNetLabel(SI_NetLabel& netlabel)
-{
-    if ((!mIsAddedToCircuit) || (mRegisteredSchematicNetLabels.contains(&netlabel))
-        || (netlabel.getCircuit() != mCircuit))
-    {
-        throw LogicError(__FILE__, __LINE__);
-    }
-    mRegisteredSchematicNetLabels.append(&netlabel);
-    updateErcMessages();
-}
-
-void NetSignal::unregisterSchematicNetLabel(SI_NetLabel& netlabel)
-{
-    if ((!mIsAddedToCircuit) || (!mRegisteredSchematicNetLabels.contains(&netlabel))) {
-        throw LogicError(__FILE__, __LINE__);
-    }
-    mRegisteredSchematicNetLabels.removeOne(&netlabel);
+    mRegisteredSchematicNetSegments.removeOne(&netsegment);
     updateErcMessages();
 }
 

--- a/libs/librepcb/project/circuit/netsignal.h
+++ b/libs/librepcb/project/circuit/netsignal.h
@@ -38,8 +38,7 @@ namespace project {
 class Circuit;
 class NetClass;
 class ComponentSignalInstance;
-class SI_NetPoint;
-class SI_NetLabel;
+class SI_NetSegment;
 class BI_NetPoint;
 class BI_Via;
 class ErcMsg;
@@ -76,8 +75,7 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public Seriali
         // Getters: General
         Circuit& getCircuit() const noexcept {return mCircuit;}
         const QList<ComponentSignalInstance*>& getComponentSignals() const noexcept {return mRegisteredComponentSignals;}
-        const QList<SI_NetPoint*>& getSchematicNetPoints() const noexcept {return mRegisteredSchematicNetPoints;}
-        const QList<SI_NetLabel*>& getSchematicNetLabels() const noexcept {return mRegisteredSchematicNetLabels;}
+        const QList<SI_NetSegment*>& getSchematicNetSegments() const noexcept {return mRegisteredSchematicNetSegments;}
         const QList<BI_NetPoint*>& getBoardNetPoints() const noexcept {return mRegisteredBoardNetPoints;}
         const QList<BI_Via*>& getBoardVias() const noexcept {return mRegisteredBoardVias;}
         int getRegisteredElementsCount() const noexcept;
@@ -93,10 +91,8 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public Seriali
         void removeFromCircuit();
         void registerComponentSignal(ComponentSignalInstance& signal);
         void unregisterComponentSignal(ComponentSignalInstance& signal);
-        void registerSchematicNetPoint(SI_NetPoint& netpoint);
-        void unregisterSchematicNetPoint(SI_NetPoint& netpoint);
-        void registerSchematicNetLabel(SI_NetLabel& netlabel);
-        void unregisterSchematicNetLabel(SI_NetLabel& netlabel);
+        void registerSchematicNetSegment(SI_NetSegment& netsegment);
+        void unregisterSchematicNetSegment(SI_NetSegment& netsegment);
         void registerBoardNetPoint(BI_NetPoint& netpoint);
         void unregisterBoardNetPoint(BI_NetPoint& netpoint);
         void registerBoardVia(BI_Via& via);
@@ -107,6 +103,8 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public Seriali
 
         // Operator Overloadings
         NetSignal& operator=(const NetSignal& rhs) = delete;
+        bool operator==(const NetSignal& rhs) noexcept {return (this == &rhs);}
+        bool operator!=(const NetSignal& rhs) noexcept {return (this != &rhs);}
 
 
     signals:
@@ -133,8 +131,7 @@ class NetSignal final : public QObject, public IF_ErcMsgProvider, public Seriali
 
         // Registered Elements of this NetSignal
         QList<ComponentSignalInstance*> mRegisteredComponentSignals;
-        QList<SI_NetPoint*> mRegisteredSchematicNetPoints;
-        QList<SI_NetLabel*> mRegisteredSchematicNetLabels;
+        QList<SI_NetSegment*> mRegisteredSchematicNetSegments;
         QList<BI_NetPoint*> mRegisteredBoardNetPoints;
         QList<BI_Via*> mRegisteredBoardVias;
 

--- a/libs/librepcb/project/project.h
+++ b/libs/librepcb/project/project.h
@@ -379,7 +379,8 @@ class Project final : public QObject, public AttributeProvider
 
 
         // Operator Overloadings
-        Project& operator=(const Project& rhs) = delete;
+        bool operator==(const Project& rhs) noexcept {return (this == &rhs);}
+        bool operator!=(const Project& rhs) noexcept {return (this != &rhs);}
 
 
         // Static Methods

--- a/libs/librepcb/project/project.pro
+++ b/libs/librepcb/project/project.pro
@@ -78,13 +78,15 @@ SOURCES += \
     project.cpp \
     schematics/cmd/cmdschematicadd.cpp \
     schematics/cmd/cmdschematicnetlabeladd.cpp \
+    schematics/cmd/cmdschematicnetlabelanchorsupdate.cpp \
     schematics/cmd/cmdschematicnetlabeledit.cpp \
     schematics/cmd/cmdschematicnetlabelremove.cpp \
-    schematics/cmd/cmdschematicnetlineadd.cpp \
-    schematics/cmd/cmdschematicnetlineremove.cpp \
-    schematics/cmd/cmdschematicnetpointadd.cpp \
     schematics/cmd/cmdschematicnetpointedit.cpp \
-    schematics/cmd/cmdschematicnetpointremove.cpp \
+    schematics/cmd/cmdschematicnetsegmentadd.cpp \
+    schematics/cmd/cmdschematicnetsegmentaddelements.cpp \
+    schematics/cmd/cmdschematicnetsegmentedit.cpp \
+    schematics/cmd/cmdschematicnetsegmentremove.cpp \
+    schematics/cmd/cmdschematicnetsegmentremoveelements.cpp \
     schematics/cmd/cmdschematicremove.cpp \
     schematics/cmd/cmdsymbolinstanceadd.cpp \
     schematics/cmd/cmdsymbolinstanceedit.cpp \
@@ -99,10 +101,12 @@ SOURCES += \
     schematics/items/si_netlabel.cpp \
     schematics/items/si_netline.cpp \
     schematics/items/si_netpoint.cpp \
+    schematics/items/si_netsegment.cpp \
     schematics/items/si_symbol.cpp \
     schematics/items/si_symbolpin.cpp \
     schematics/schematic.cpp \
     schematics/schematiclayerprovider.cpp \
+    schematics/schematicselectionquery.cpp \
     settings/cmd/cmdprojectsettingschange.cpp \
     settings/projectsettings.cpp \
 
@@ -165,13 +169,15 @@ HEADERS += \
     project.h \
     schematics/cmd/cmdschematicadd.h \
     schematics/cmd/cmdschematicnetlabeladd.h \
+    schematics/cmd/cmdschematicnetlabelanchorsupdate.h \
     schematics/cmd/cmdschematicnetlabeledit.h \
     schematics/cmd/cmdschematicnetlabelremove.h \
-    schematics/cmd/cmdschematicnetlineadd.h \
-    schematics/cmd/cmdschematicnetlineremove.h \
-    schematics/cmd/cmdschematicnetpointadd.h \
     schematics/cmd/cmdschematicnetpointedit.h \
-    schematics/cmd/cmdschematicnetpointremove.h \
+    schematics/cmd/cmdschematicnetsegmentadd.h \
+    schematics/cmd/cmdschematicnetsegmentaddelements.h \
+    schematics/cmd/cmdschematicnetsegmentedit.h \
+    schematics/cmd/cmdschematicnetsegmentremove.h \
+    schematics/cmd/cmdschematicnetsegmentremoveelements.h \
     schematics/cmd/cmdschematicremove.h \
     schematics/cmd/cmdsymbolinstanceadd.h \
     schematics/cmd/cmdsymbolinstanceedit.h \
@@ -186,10 +192,12 @@ HEADERS += \
     schematics/items/si_netlabel.h \
     schematics/items/si_netline.h \
     schematics/items/si_netpoint.h \
+    schematics/items/si_netsegment.h \
     schematics/items/si_symbol.h \
     schematics/items/si_symbolpin.h \
     schematics/schematic.h \
     schematics/schematiclayerprovider.h \
+    schematics/schematicselectionquery.h \
     settings/cmd/cmdprojectsettingschange.h \
     settings/projectsettings.h \
 

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
@@ -24,6 +24,7 @@
 #include "cmdschematicnetlabeladd.h"
 #include "../schematic.h"
 #include "../items/si_netlabel.h"
+#include "../items/si_netsegment.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -35,10 +36,9 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(Schematic& schematic, NetSignal& netsignal,
-                                                 const Point& position) noexcept :
+CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(SI_NetSegment& segment, const Point& position) noexcept :
     UndoCommand(tr("Add netlabel")),
-    mSchematic(schematic), mNetSignal(&netsignal), mPosition(position), mNetLabel(nullptr)
+    mNetSegment(segment), mPosition(position), mNetLabel(nullptr)
 {
 }
 
@@ -52,7 +52,7 @@ CmdSchematicNetLabelAdd::~CmdSchematicNetLabelAdd() noexcept
 
 bool CmdSchematicNetLabelAdd::performExecute()
 {
-    mNetLabel = new SI_NetLabel(mSchematic, *mNetSignal, mPosition); // can throw
+    mNetLabel = new SI_NetLabel(mNetSegment, mPosition); // can throw
 
     performRedo(); // can throw
 
@@ -61,12 +61,12 @@ bool CmdSchematicNetLabelAdd::performExecute()
 
 void CmdSchematicNetLabelAdd::performUndo()
 {
-    mSchematic.removeNetLabel(*mNetLabel); // can throw
+    mNetSegment.removeNetLabel(*mNetLabel); // can throw
 }
 
 void CmdSchematicNetLabelAdd::performRedo()
 {
-    mSchematic.addNetLabel(*mNetLabel); // can throw
+    mNetSegment.addNetLabel(*mNetLabel); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
@@ -36,6 +36,7 @@ namespace project {
 class NetSignal;
 class Schematic;
 class SI_NetLabel;
+class SI_NetSegment;
 
 /*****************************************************************************************
  *  Class CmdSchematicNetLabelAdd
@@ -49,8 +50,7 @@ class CmdSchematicNetLabelAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        CmdSchematicNetLabelAdd(Schematic& schematic, NetSignal& netsignal,
-                                const Point& position) noexcept;
+        CmdSchematicNetLabelAdd(SI_NetSegment& segment, const Point& position) noexcept;
         ~CmdSchematicNetLabelAdd() noexcept;
 
         // Getters
@@ -73,8 +73,7 @@ class CmdSchematicNetLabelAdd final : public UndoCommand
 
         // Private Member Variables
 
-        Schematic& mSchematic;
-        NetSignal* mNetSignal;
+        SI_NetSegment& mNetSegment;
         Point mPosition;
         SI_NetLabel* mNetLabel;
 };

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.cpp
@@ -21,10 +21,8 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include "cmdschematicnetlabelremove.h"
+#include "cmdschematicnetlabelanchorsupdate.h"
 #include "../schematic.h"
-#include "../items/si_netlabel.h"
-#include "../items/si_netsegment.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -36,13 +34,12 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicNetLabelRemove::CmdSchematicNetLabelRemove(SI_NetLabel& netlabel) noexcept :
-    UndoCommand(tr("Remove netlabel")),
-    mNetSegment(netlabel.getNetSegment()), mNetLabel(netlabel)
+CmdSchematicNetLabelAnchorsUpdate::CmdSchematicNetLabelAnchorsUpdate(Schematic& schematic) noexcept :
+    UndoCommand(tr("Update netlabel anchors")), mSchematic(schematic)
 {
 }
 
-CmdSchematicNetLabelRemove::~CmdSchematicNetLabelRemove() noexcept
+CmdSchematicNetLabelAnchorsUpdate::~CmdSchematicNetLabelAnchorsUpdate() noexcept
 {
 }
 
@@ -50,21 +47,20 @@ CmdSchematicNetLabelRemove::~CmdSchematicNetLabelRemove() noexcept
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-bool CmdSchematicNetLabelRemove::performExecute()
+bool CmdSchematicNetLabelAnchorsUpdate::performExecute()
 {
     performRedo(); // can throw
-
     return true;
 }
 
-void CmdSchematicNetLabelRemove::performUndo()
+void CmdSchematicNetLabelAnchorsUpdate::performUndo()
 {
-    mNetSegment.addNetLabel(mNetLabel); // can throw
+    mSchematic.updateAllNetLabelAnchors();
 }
 
-void CmdSchematicNetLabelRemove::performRedo()
+void CmdSchematicNetLabelAnchorsUpdate::performRedo()
 {
-    mNetSegment.removeNetLabel(mNetLabel); // can throw
+    mSchematic.updateAllNetLabelAnchors();
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.h
@@ -17,55 +17,58 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETLABELANCHORSUPDATE_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICNETLABELANCHORSUPDATE_H
+
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include "cmdschematicnetlabelremove.h"
-#include "../schematic.h"
-#include "../items/si_netlabel.h"
-#include "../items/si_netsegment.h"
+#include <librepcb/common/undocommand.h>
 
 /*****************************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ****************************************************************************************/
 namespace librepcb {
 namespace project {
 
-/*****************************************************************************************
- *  Constructors / Destructor
- ****************************************************************************************/
-
-CmdSchematicNetLabelRemove::CmdSchematicNetLabelRemove(SI_NetLabel& netlabel) noexcept :
-    UndoCommand(tr("Remove netlabel")),
-    mNetSegment(netlabel.getNetSegment()), mNetLabel(netlabel)
-{
-}
-
-CmdSchematicNetLabelRemove::~CmdSchematicNetLabelRemove() noexcept
-{
-}
+class Schematic;
 
 /*****************************************************************************************
- *  Inherited from UndoCommand
+ *  Class CmdSchematicNetLabelAnchorsUpdate
  ****************************************************************************************/
 
-bool CmdSchematicNetLabelRemove::performExecute()
+/**
+ * @brief The CmdSchematicNetLabelAnchorsUpdate class
+ *
+ * This is just a convenience undo cummand to update all netlabel anchors in a schematic.
+ */
+class CmdSchematicNetLabelAnchorsUpdate final : public UndoCommand
 {
-    performRedo(); // can throw
+    public:
 
-    return true;
-}
+        // Constructors / Destructor
+        CmdSchematicNetLabelAnchorsUpdate(Schematic& schematic) noexcept;
+        ~CmdSchematicNetLabelAnchorsUpdate() noexcept;
 
-void CmdSchematicNetLabelRemove::performUndo()
-{
-    mNetSegment.addNetLabel(mNetLabel); // can throw
-}
 
-void CmdSchematicNetLabelRemove::performRedo()
-{
-    mNetSegment.removeNetLabel(mNetLabel); // can throw
-}
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() override;
+
+
+        // Private Member Variables
+        Schematic& mSchematic;
+};
 
 /*****************************************************************************************
  *  End of File
@@ -73,3 +76,5 @@ void CmdSchematicNetLabelRemove::performRedo()
 
 } // namespace project
 } // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETLABELANCHORSUPDATE_H

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
@@ -36,7 +36,6 @@ namespace project {
 
 CmdSchematicNetLabelEdit::CmdSchematicNetLabelEdit(SI_NetLabel& netlabel) noexcept :
     UndoCommand(tr("Edit netlabel")), mNetLabel(netlabel),
-    mOldNetSignal(&netlabel.getNetSignal()), mNewNetSignal(mOldNetSignal),
     mOldPos(netlabel.getPosition()), mNewPos(mOldPos),
     mOldRotation(netlabel.getRotation()), mNewRotation(mOldRotation)
 {
@@ -46,7 +45,6 @@ CmdSchematicNetLabelEdit::~CmdSchematicNetLabelEdit() noexcept
 {
     if (!wasEverExecuted()) {
         // revert temporary changes
-        mNetLabel.setNetSignal(*mOldNetSignal);
         mNetLabel.setPosition(mOldPos);
         mNetLabel.setRotation(mOldRotation);
     }
@@ -55,13 +53,6 @@ CmdSchematicNetLabelEdit::~CmdSchematicNetLabelEdit() noexcept
 /*****************************************************************************************
  *  Setters
  ****************************************************************************************/
-
-void CmdSchematicNetLabelEdit::setNetSignal(NetSignal& netsignal, bool immediate) noexcept
-{
-    Q_ASSERT(!wasEverExecuted());
-    mNewNetSignal = &netsignal;
-    if (immediate) mNetLabel.setNetSignal(*mNewNetSignal);
-}
 
 void CmdSchematicNetLabelEdit::setPosition(const Point& position, bool immediate) noexcept
 {
@@ -109,14 +100,12 @@ bool CmdSchematicNetLabelEdit::performExecute()
 
 void CmdSchematicNetLabelEdit::performUndo()
 {
-    mNetLabel.setNetSignal(*mOldNetSignal);
     mNetLabel.setPosition(mOldPos);
     mNetLabel.setRotation(mOldRotation);
 }
 
 void CmdSchematicNetLabelEdit::performRedo()
 {
-    mNetLabel.setNetSignal(*mNewNetSignal);
     mNetLabel.setPosition(mNewPos);
     mNetLabel.setRotation(mNewRotation);
 }

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
@@ -52,7 +52,6 @@ class CmdSchematicNetLabelEdit final : public UndoCommand
         ~CmdSchematicNetLabelEdit() noexcept;
 
         // Setters
-        void setNetSignal(NetSignal& netsignal, bool immediate) noexcept;
         void setPosition(const Point& position, bool immediate) noexcept;
         void setDeltaToStartPos(const Point& deltaPos, bool immediate) noexcept;
         void setRotation(const Angle& angle, bool immediate) noexcept;
@@ -79,8 +78,6 @@ class CmdSchematicNetLabelEdit final : public UndoCommand
         SI_NetLabel& mNetLabel;
 
         // Misc
-        NetSignal* mOldNetSignal;
-        NetSignal* mNewNetSignal;
         Point mOldPos;
         Point mNewPos;
         Angle mOldRotation;

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelremove.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelremove.h
@@ -34,6 +34,7 @@ namespace project {
 
 class Schematic;
 class SI_NetLabel;
+class SI_NetSegment;
 
 /*****************************************************************************************
  *  Class CmdSchematicNetLabelRemove
@@ -47,7 +48,7 @@ class CmdSchematicNetLabelRemove final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        CmdSchematicNetLabelRemove(Schematic& schematic, SI_NetLabel& netlabel) noexcept;
+        CmdSchematicNetLabelRemove(SI_NetLabel& netlabel) noexcept;
         ~CmdSchematicNetLabelRemove() noexcept;
 
 
@@ -67,7 +68,7 @@ class CmdSchematicNetLabelRemove final : public UndoCommand
 
         // Private Member Variables
 
-        Schematic& mSchematic;
+        SI_NetSegment& mNetSegment;
         SI_NetLabel& mNetLabel;
 };
 

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.cpp
@@ -37,7 +37,6 @@ namespace project {
 
 CmdSchematicNetPointEdit::CmdSchematicNetPointEdit(SI_NetPoint& point) noexcept :
     UndoCommand(tr("Edit netpoint")), mNetPoint(point),
-    mOldNetSignal(&point.getNetSignal()), mNewNetSignal(mOldNetSignal),
     mOldSymbolPin(point.getSymbolPin()), mNewSymbolPin(mOldSymbolPin),
     mOldPos(point.getPosition()), mNewPos(mOldPos)
 {
@@ -53,12 +52,6 @@ CmdSchematicNetPointEdit::~CmdSchematicNetPointEdit() noexcept
 /*****************************************************************************************
  *  Setters
  ****************************************************************************************/
-
-void CmdSchematicNetPointEdit::setNetSignal(NetSignal& netsignal) noexcept
-{
-    Q_ASSERT(!wasEverExecuted());
-    mNewNetSignal = &netsignal;
-}
 
 void CmdSchematicNetPointEdit::setPinToAttach(SI_SymbolPin* pin) noexcept
 {
@@ -94,8 +87,6 @@ bool CmdSchematicNetPointEdit::performExecute()
 void CmdSchematicNetPointEdit::performUndo()
 {
     ScopeGuardList sgl;
-    mNetPoint.setNetSignal(*mOldNetSignal); // can throw
-    sgl.add([&](){mNetPoint.setNetSignal(*mNewNetSignal);});
     mNetPoint.setPinToAttach(mOldSymbolPin); // can throw
     sgl.add([&](){mNetPoint.setPinToAttach(mNewSymbolPin);});
     mNetPoint.setPosition(mOldPos);
@@ -105,8 +96,6 @@ void CmdSchematicNetPointEdit::performUndo()
 void CmdSchematicNetPointEdit::performRedo()
 {
     ScopeGuardList sgl;
-    mNetPoint.setNetSignal(*mNewNetSignal); // can throw
-    sgl.add([&](){mNetPoint.setNetSignal(*mOldNetSignal);});
     mNetPoint.setPinToAttach(mNewSymbolPin); // can throw
     sgl.add([&](){mNetPoint.setPinToAttach(mOldSymbolPin);});
     mNetPoint.setPosition(mNewPos);

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.h
@@ -53,7 +53,6 @@ class CmdSchematicNetPointEdit final : public UndoCommand
         ~CmdSchematicNetPointEdit() noexcept;
 
         // Setters
-        void setNetSignal(NetSignal& netsignal) noexcept;
         void setPinToAttach(SI_SymbolPin* pin) noexcept;
         void setPosition(const Point& pos, bool immediate) noexcept;
         void setDeltaToStartPos(const Point& deltaPos, bool immediate) noexcept;
@@ -79,8 +78,6 @@ class CmdSchematicNetPointEdit final : public UndoCommand
         SI_NetPoint& mNetPoint;
 
         // General Attributes
-        NetSignal* mOldNetSignal;
-        NetSignal* mNewNetSignal;
         SI_SymbolPin* mOldSymbolPin;
         SI_SymbolPin* mNewSymbolPin;
         Point mOldPos;

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h
@@ -17,55 +17,65 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTADD_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTADD_H
+
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include "cmdschematicnetlabelremove.h"
-#include "../schematic.h"
-#include "../items/si_netlabel.h"
-#include "../items/si_netsegment.h"
+#include <librepcb/common/undocommand.h>
 
 /*****************************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ****************************************************************************************/
 namespace librepcb {
 namespace project {
 
-/*****************************************************************************************
- *  Constructors / Destructor
- ****************************************************************************************/
-
-CmdSchematicNetLabelRemove::CmdSchematicNetLabelRemove(SI_NetLabel& netlabel) noexcept :
-    UndoCommand(tr("Remove netlabel")),
-    mNetSegment(netlabel.getNetSegment()), mNetLabel(netlabel)
-{
-}
-
-CmdSchematicNetLabelRemove::~CmdSchematicNetLabelRemove() noexcept
-{
-}
+class NetSignal;
+class Schematic;
+class SI_NetSegment;
 
 /*****************************************************************************************
- *  Inherited from UndoCommand
+ *  Class CmdSchematicNetSegmentAdd
  ****************************************************************************************/
 
-bool CmdSchematicNetLabelRemove::performExecute()
+/**
+ * @brief The CmdSchematicNetSegmentAdd class
+ */
+class CmdSchematicNetSegmentAdd final : public UndoCommand
 {
-    performRedo(); // can throw
+    public:
 
-    return true;
-}
+        // Constructors / Destructor
+        explicit CmdSchematicNetSegmentAdd(SI_NetSegment& segment) noexcept;
+        CmdSchematicNetSegmentAdd(Schematic& schematic, NetSignal& netsignal) noexcept;
+        ~CmdSchematicNetSegmentAdd() noexcept;
 
-void CmdSchematicNetLabelRemove::performUndo()
-{
-    mNetSegment.addNetLabel(mNetLabel); // can throw
-}
+        // Getters
+        SI_NetSegment* getNetSegment() const noexcept {return mNetSegment;}
 
-void CmdSchematicNetLabelRemove::performRedo()
-{
-    mNetSegment.removeNetLabel(mNetLabel); // can throw
-}
+
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() override;
+
+
+        // Private Member Variables
+
+        Schematic& mSchematic;
+        NetSignal& mNetSignal;
+        SI_NetSegment* mNetSegment;
+};
 
 /*****************************************************************************************
  *  End of File
@@ -73,3 +83,5 @@ void CmdSchematicNetLabelRemove::performRedo()
 
 } // namespace project
 } // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTADD_H

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h
@@ -17,14 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETPOINTREMOVE_H
-#define LIBREPCB_PROJECT_CMDSCHEMATICNETPOINTREMOVE_H
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTADDELEMENTS_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTADDELEMENTS_H
 
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcb/common/undocommand.h>
+#include <librepcb/common/units/point.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -32,23 +33,33 @@
 namespace librepcb {
 namespace project {
 
-class Schematic;
+class NetSignal;
+class SI_NetSegment;
+class SI_SymbolPin;
 class SI_NetPoint;
+class SI_NetLine;
 
 /*****************************************************************************************
- *  Class CmdSchematicNetPointRemove
+ *  Class CmdSchematicNetSegmentAddElements
  ****************************************************************************************/
 
 /**
- * @brief The CmdSchematicNetPointRemove class
+ * @brief The CmdSchematicNetSegmentAddElements class
  */
-class CmdSchematicNetPointRemove final : public UndoCommand
+class CmdSchematicNetSegmentAddElements final : public UndoCommand
 {
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetPointRemove(SI_NetPoint& netpoint) noexcept;
-        ~CmdSchematicNetPointRemove() noexcept;
+        CmdSchematicNetSegmentAddElements(SI_NetSegment& segment) noexcept;
+        ~CmdSchematicNetSegmentAddElements() noexcept;
+
+        // General Methods
+        SI_NetPoint* addNetPoint(SI_NetPoint& netpoint);
+        SI_NetPoint* addNetPoint(const Point& position);
+        SI_NetPoint* addNetPoint(SI_SymbolPin& pin);
+        SI_NetLine* addNetLine(SI_NetLine& netline);
+        SI_NetLine* addNetLine(SI_NetPoint& startPoint, SI_NetPoint& endPoint);
 
 
     private:
@@ -67,8 +78,9 @@ class CmdSchematicNetPointRemove final : public UndoCommand
 
         // Private Member Variables
 
-        Schematic& mSchematic;
-        SI_NetPoint& mNetPoint;
+        SI_NetSegment& mNetSegment;
+        QList<SI_NetPoint*> mNetPoints;
+        QList<SI_NetLine*> mNetLines;
 };
 
 /*****************************************************************************************
@@ -78,4 +90,4 @@ class CmdSchematicNetPointRemove final : public UndoCommand
 } // namespace project
 } // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETPOINTREMOVE_H
+#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTADDELEMENTS_H

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.cpp
@@ -21,9 +21,7 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include "cmdschematicnetlabelremove.h"
-#include "../schematic.h"
-#include "../items/si_netlabel.h"
+#include "cmdschematicnetsegmentedit.h"
 #include "../items/si_netsegment.h"
 
 /*****************************************************************************************
@@ -36,35 +34,45 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicNetLabelRemove::CmdSchematicNetLabelRemove(SI_NetLabel& netlabel) noexcept :
-    UndoCommand(tr("Remove netlabel")),
-    mNetSegment(netlabel.getNetSegment()), mNetLabel(netlabel)
+CmdSchematicNetSegmentEdit::CmdSchematicNetSegmentEdit(SI_NetSegment& netsegment) noexcept :
+    UndoCommand(tr("Edit net segment")), mNetSegment(netsegment),
+    mOldNetSignal(&netsegment.getNetSignal()), mNewNetSignal(mOldNetSignal)
 {
 }
 
-CmdSchematicNetLabelRemove::~CmdSchematicNetLabelRemove() noexcept
+CmdSchematicNetSegmentEdit::~CmdSchematicNetSegmentEdit() noexcept
 {
+}
+
+/*****************************************************************************************
+ *  Setters
+ ****************************************************************************************/
+
+void CmdSchematicNetSegmentEdit::setNetSignal(NetSignal& netsignal) noexcept
+{
+    Q_ASSERT(!wasEverExecuted());
+    mNewNetSignal = &netsignal;
 }
 
 /*****************************************************************************************
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-bool CmdSchematicNetLabelRemove::performExecute()
+bool CmdSchematicNetSegmentEdit::performExecute()
 {
     performRedo(); // can throw
 
-    return true;
+    return (mNewNetSignal != mOldNetSignal);
 }
 
-void CmdSchematicNetLabelRemove::performUndo()
+void CmdSchematicNetSegmentEdit::performUndo()
 {
-    mNetSegment.addNetLabel(mNetLabel); // can throw
+    mNetSegment.setNetSignal(*mOldNetSignal); // can throw
 }
 
-void CmdSchematicNetLabelRemove::performRedo()
+void CmdSchematicNetSegmentEdit::performRedo()
 {
-    mNetSegment.removeNetLabel(mNetLabel); // can throw
+    mNetSegment.setNetSignal(*mNewNetSignal); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.h
@@ -17,54 +17,66 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTEDIT_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTEDIT_H
+
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include "cmdschematicnetlineremove.h"
-#include "../schematic.h"
-#include "../items/si_netline.h"
+#include <librepcb/common/undocommand.h>
 
 /*****************************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ****************************************************************************************/
 namespace librepcb {
 namespace project {
 
-/*****************************************************************************************
- *  Constructors / Destructor
- ****************************************************************************************/
-
-CmdSchematicNetLineRemove::CmdSchematicNetLineRemove(SI_NetLine& netline) noexcept :
-    UndoCommand(tr("Remove netline")),
-    mSchematic(netline.getSchematic()), mNetLine(netline)
-{
-}
-
-CmdSchematicNetLineRemove::~CmdSchematicNetLineRemove() noexcept
-{
-}
+class SI_NetSegment;
+class NetSignal;
 
 /*****************************************************************************************
- *  Inherited from UndoCommand
+ *  Class CmdSchematicNetSegmentEdit
  ****************************************************************************************/
 
-bool CmdSchematicNetLineRemove::performExecute()
+/**
+ * @brief The CmdSchematicNetSegmentEdit class
+ */
+class CmdSchematicNetSegmentEdit final : public UndoCommand
 {
-    performRedo(); // can throw
+    public:
 
-    return true;
-}
+        // Constructors / Destructor
+        explicit CmdSchematicNetSegmentEdit(SI_NetSegment& netsegment) noexcept;
+        ~CmdSchematicNetSegmentEdit() noexcept;
 
-void CmdSchematicNetLineRemove::performUndo()
-{
-    mSchematic.addNetLine(mNetLine); // can throw
-}
+        // Setters
+        void setNetSignal(NetSignal& netsignal) noexcept;
 
-void CmdSchematicNetLineRemove::performRedo()
-{
-    mSchematic.removeNetLine(mNetLine); // can throw
-}
+
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() override;
+
+
+        // Private Member Variables
+
+        // Attributes from the constructor
+        SI_NetSegment& mNetSegment;
+
+        // General Attributes
+        NetSignal* mOldNetSignal;
+        NetSignal* mNewNetSignal;
+};
 
 /*****************************************************************************************
  *  End of File
@@ -72,3 +84,5 @@ void CmdSchematicNetLineRemove::performRedo()
 
 } // namespace project
 } // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTEDIT_H

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.cpp
@@ -17,67 +17,54 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETLINEADD_H
-#define LIBREPCB_PROJECT_CMDSCHEMATICNETLINEADD_H
-
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include <librepcb/common/undocommand.h>
+#include "cmdschematicnetsegmentremove.h"
+#include "../schematic.h"
+#include "../items/si_netsegment.h"
 
 /*****************************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ****************************************************************************************/
 namespace librepcb {
 namespace project {
 
-class Schematic;
-class SI_NetPoint;
-class SI_NetLine;
-
 /*****************************************************************************************
- *  Class CmdSchematicNetLineAdd
+ *  Constructors / Destructor
  ****************************************************************************************/
 
-/**
- * @brief The CmdSchematicNetLineAdd class
- */
-class CmdSchematicNetLineAdd final : public UndoCommand
+CmdSchematicNetSegmentRemove::CmdSchematicNetSegmentRemove(SI_NetSegment& segment) noexcept :
+    UndoCommand(tr("Remove net segment")),
+    mSchematic(segment.getSchematic()), mNetSegment(segment)
 {
-    public:
+}
 
-        // Constructors / Destructor
-        explicit CmdSchematicNetLineAdd(SI_NetLine& netline) noexcept;
-        CmdSchematicNetLineAdd(Schematic& schematic, SI_NetPoint& startPoint,
-                               SI_NetPoint& endPoint) noexcept;
-        ~CmdSchematicNetLineAdd() noexcept;
+CmdSchematicNetSegmentRemove::~CmdSchematicNetSegmentRemove() noexcept
+{
+}
 
-        // Getters
-        SI_NetLine* getNetLine() const noexcept {return mNetLine;}
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
 
+bool CmdSchematicNetSegmentRemove::performExecute()
+{
+    performRedo(); // can throw
 
-    private:
+    return true;
+}
 
-        // Private Methods
+void CmdSchematicNetSegmentRemove::performUndo()
+{
+    mSchematic.addNetSegment(mNetSegment); // can throw
+}
 
-        /// @copydoc UndoCommand::performExecute()
-        bool performExecute() override;
-
-        /// @copydoc UndoCommand::performUndo()
-        void performUndo() override;
-
-        /// @copydoc UndoCommand::performRedo()
-        void performRedo() override;
-
-
-        // Private Member Variables
-
-        Schematic& mSchematic;
-        SI_NetPoint& mStartPoint;
-        SI_NetPoint& mEndPoint;
-        SI_NetLine* mNetLine;
-};
+void CmdSchematicNetSegmentRemove::performRedo()
+{
+    mSchematic.removeNetSegment(mNetSegment); // can throw
+}
 
 /*****************************************************************************************
  *  End of File
@@ -85,5 +72,3 @@ class CmdSchematicNetLineAdd final : public UndoCommand
 
 } // namespace project
 } // namespace librepcb
-
-#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETLINEADD_H

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETLINEREMOVE_H
-#define LIBREPCB_PROJECT_CMDSCHEMATICNETLINEREMOVE_H
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTREMOVE_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTREMOVE_H
 
 /*****************************************************************************************
  *  Includes
@@ -33,22 +33,22 @@ namespace librepcb {
 namespace project {
 
 class Schematic;
-class SI_NetLine;
+class SI_NetSegment;
 
 /*****************************************************************************************
- *  Class CmdSchematicNetLineRemove
+ *  Class CmdSchematicNetSegmentRemove
  ****************************************************************************************/
 
 /**
- * @brief The CmdSchematicNetLineRemove class
+ * @brief The CmdSchematicNetSegmentRemove class
  */
-class CmdSchematicNetLineRemove final : public UndoCommand
+class CmdSchematicNetSegmentRemove final : public UndoCommand
 {
     public:
 
         // Constructors / Destructor
-        explicit CmdSchematicNetLineRemove(SI_NetLine& netline) noexcept;
-        ~CmdSchematicNetLineRemove() noexcept;
+        explicit CmdSchematicNetSegmentRemove(SI_NetSegment& segment) noexcept;
+        ~CmdSchematicNetSegmentRemove() noexcept;
 
 
     private:
@@ -68,7 +68,7 @@ class CmdSchematicNetLineRemove final : public UndoCommand
         // Private Member Variables
 
         Schematic& mSchematic;
-        SI_NetLine& mNetLine;
+        SI_NetSegment& mNetSegment;
 };
 
 /*****************************************************************************************
@@ -78,4 +78,4 @@ class CmdSchematicNetLineRemove final : public UndoCommand
 } // namespace project
 } // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETLINEREMOVE_H
+#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTREMOVE_H

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.cpp
@@ -21,9 +21,11 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include "cmdschematicnetpointremove.h"
+#include "cmdschematicnetsegmentremoveelements.h"
 #include "../schematic.h"
 #include "../items/si_netpoint.h"
+#include "../items/si_netline.h"
+#include "../items/si_netsegment.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -35,35 +37,49 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdSchematicNetPointRemove::CmdSchematicNetPointRemove(SI_NetPoint& netpoint) noexcept :
-    UndoCommand(tr("Remove netpoint")),
-    mSchematic(netpoint.getSchematic()), mNetPoint(netpoint)
+CmdSchematicNetSegmentRemoveElements::CmdSchematicNetSegmentRemoveElements(SI_NetSegment& segment) noexcept :
+    UndoCommand(tr("Remove net segment elements")),
+    mNetSegment(segment)
 {
 }
 
-CmdSchematicNetPointRemove::~CmdSchematicNetPointRemove() noexcept
+CmdSchematicNetSegmentRemoveElements::~CmdSchematicNetSegmentRemoveElements() noexcept
 {
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void CmdSchematicNetSegmentRemoveElements::removeNetPoint(SI_NetPoint& netpoint)
+{
+    mNetPoints.append(&netpoint);
+}
+
+void CmdSchematicNetSegmentRemoveElements::removeNetLine(SI_NetLine& netline)
+{
+    mNetLines.append(&netline);
 }
 
 /*****************************************************************************************
  *  Inherited from UndoCommand
  ****************************************************************************************/
 
-bool CmdSchematicNetPointRemove::performExecute()
+bool CmdSchematicNetSegmentRemoveElements::performExecute()
 {
     performRedo(); // can throw
 
     return true;
 }
 
-void CmdSchematicNetPointRemove::performUndo()
+void CmdSchematicNetSegmentRemoveElements::performUndo()
 {
-    mSchematic.addNetPoint(mNetPoint); // can throw
+    mNetSegment.addNetPointsAndNetLines(mNetPoints, mNetLines); // can throw
 }
 
-void CmdSchematicNetPointRemove::performRedo()
+void CmdSchematicNetSegmentRemoveElements::performRedo()
 {
-    mSchematic.removeNetPoint(mNetPoint); // can throw
+    mNetSegment.removeNetPointsAndNetLines(mNetPoints, mNetLines); // can throw
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h
@@ -17,67 +17,65 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTREMOVEELEMENTS_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTREMOVEELEMENTS_H
+
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include "cmdschematicnetlineadd.h"
-#include "../schematic.h"
-#include "../items/si_netline.h"
+#include <librepcb/common/undocommand.h>
 
 /*****************************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ****************************************************************************************/
 namespace librepcb {
 namespace project {
 
-/*****************************************************************************************
- *  Constructors / Destructor
- ****************************************************************************************/
-
-CmdSchematicNetLineAdd::CmdSchematicNetLineAdd(SI_NetLine& netline) noexcept :
-    UndoCommand(tr("Add netline")),
-    mSchematic(netline.getSchematic()), mStartPoint(netline.getStartPoint()),
-    mEndPoint(netline.getEndPoint()), mNetLine(&netline)
-{
-}
-
-CmdSchematicNetLineAdd::CmdSchematicNetLineAdd(Schematic& schematic, SI_NetPoint& startPoint,
-                                               SI_NetPoint& endPoint) noexcept :
-    UndoCommand(tr("Add netline")),
-    mSchematic(schematic), mStartPoint(startPoint), mEndPoint(endPoint), mNetLine(nullptr)
-{
-}
-
-CmdSchematicNetLineAdd::~CmdSchematicNetLineAdd() noexcept
-{
-}
+class SI_NetSegment;
+class SI_NetPoint;
+class SI_NetLine;
 
 /*****************************************************************************************
- *  Inherited from UndoCommand
+ *  Class CmdSchematicNetSegmentRemoveElements
  ****************************************************************************************/
 
-bool CmdSchematicNetLineAdd::performExecute()
+/**
+ * @brief The CmdSchematicNetSegmentRemoveElements class
+ */
+class CmdSchematicNetSegmentRemoveElements final : public UndoCommand
 {
-    if (!mNetLine) {
-        // create new netline
-        mNetLine = new SI_NetLine(mSchematic, mStartPoint, mEndPoint, Length(158750)); // can throw
-    }
+    public:
 
-    performRedo(); // can throw
+        // Constructors / Destructor
+        CmdSchematicNetSegmentRemoveElements(SI_NetSegment& segment) noexcept;
+        ~CmdSchematicNetSegmentRemoveElements() noexcept;
 
-    return true;
-}
+        // General Methods
+        void removeNetPoint(SI_NetPoint& netpoint);
+        void removeNetLine(SI_NetLine& netline);
 
-void CmdSchematicNetLineAdd::performUndo()
-{
-    mSchematic.removeNetLine(*mNetLine); // can throw
-}
 
-void CmdSchematicNetLineAdd::performRedo()
-{
-    mSchematic.addNetLine(*mNetLine); // can throw
-}
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() override;
+
+
+        // Private Member Variables
+
+        SI_NetSegment& mNetSegment;
+        QList<SI_NetPoint*> mNetPoints;
+        QList<SI_NetLine*> mNetLines;
+};
 
 /*****************************************************************************************
  *  End of File
@@ -85,3 +83,5 @@ void CmdSchematicNetLineAdd::performRedo()
 
 } // namespace project
 } // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDSCHEMATICNETSEGMENTREMOVEELEMENTS_H

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.h
@@ -33,6 +33,7 @@
 namespace librepcb {
 
 class GraphicsLayer;
+class LineGraphicsItem;
 
 namespace project {
 
@@ -55,6 +56,7 @@ class SGI_NetLabel final : public SGI_Base
 
         // General Methods
         void updateCacheAndRepaint() noexcept;
+        void setAnchor(const Point& pos) noexcept;
 
         // Inherited from QGraphicsItem
         QRectF boundingRect() const {return mBoundingRect;}
@@ -74,6 +76,7 @@ class SGI_NetLabel final : public SGI_Base
 
         // Attributes
         SI_NetLabel& mNetLabel;
+        QScopedPointer<LineGraphicsItem> mAnchorGraphicsItem;
 
         // Cached Attributes
         QStaticText mStaticText;

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netline.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netline.cpp
@@ -62,6 +62,8 @@ SGI_NetLine::~SGI_NetLine() noexcept
 
 void SGI_NetLine::updateCacheAndRepaint() noexcept
 {
+    setToolTip(mNetLine.getNetSignalOfNetSegment().getName());
+
     prepareGeometryChange();
     mLineF.setP1(mNetLine.getStartPoint().getPosition().toPxQPointF());
     mLineF.setP2(mNetLine.getEndPoint().getPosition().toPxQPointF());
@@ -88,7 +90,7 @@ void SGI_NetLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* optio
     Q_UNUSED(option);
     Q_UNUSED(widget);
 
-    bool highlight = mNetLine.isSelected() || mNetLine.getNetSignal().isHighlighted();
+    bool highlight = mNetLine.isSelected() || mNetLine.getNetSignalOfNetSegment().isHighlighted();
 
     // draw line
     if (mLayer->isVisible())
@@ -110,7 +112,7 @@ void SGI_NetLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* optio
         font.setPixelSize(3);
         painter->setFont(font);
         painter->setPen(QPen(layer->getColor(highlight), 0));
-        painter->drawText(mLineF.pointAt((qreal)0.5), mNetLine.getNetSignal().getName());
+        painter->drawText(mLineF.pointAt((qreal)0.5), mNetLine.getNetSignalOfNetSegment().getName());
     }
     layer = getLayer(GraphicsLayer::sDebugGraphicsItemsBoundingRects); Q_ASSERT(layer);
     if (layer->isVisible())
@@ -129,7 +131,7 @@ void SGI_NetLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* optio
 
 GraphicsLayer* SGI_NetLine::getLayer(const QString& name) const noexcept
 {
-    return mNetLine.getSchematic().getProject().getLayers().getLayer(name);
+    return mNetLine.getProject().getLayers().getLayer(name);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.cpp
@@ -69,6 +69,8 @@ SGI_NetPoint::~SGI_NetPoint() noexcept
 
 void SGI_NetPoint::updateCacheAndRepaint() noexcept
 {
+    setToolTip(mNetPoint.getNetSignalOfNetSegment().getName());
+
     prepareGeometryChange();
     mIsVisibleJunction = mNetPoint.isVisibleJunction();
     mIsOpenLineEnd = mNetPoint.isOpenLineEnd();
@@ -86,7 +88,7 @@ void SGI_NetPoint::paint(QPainter* painter, const QStyleOptionGraphicsItem* opti
     Q_UNUSED(widget);
 
     const bool deviceIsPrinter = (dynamic_cast<QPrinter*>(painter->device()) != 0);
-    bool highlight = mNetPoint.isSelected() || mNetPoint.getNetSignal().isHighlighted();
+    bool highlight = mNetPoint.isSelected() || mNetPoint.getNetSignalOfNetSegment().isHighlighted();
 
     if (mLayer->isVisible() && mIsVisibleJunction) {
         painter->setPen(Qt::NoPen);

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -279,7 +279,7 @@ void SGI_Symbol::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
 
 GraphicsLayer* SGI_Symbol::getLayer(const QString& name) const noexcept
 {
-    return mSymbol.getSchematic().getProject().getLayers().getLayer(name);
+    return mSymbol.getProject().getLayers().getLayer(name);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.cpp
@@ -209,7 +209,7 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
 
 GraphicsLayer* SGI_SymbolPin::getLayer(const QString& name) const noexcept
 {
-    return mPin.getSymbol().getSchematic().getProject().getLayers().getLayer(name);
+    return mPin.getSymbol().getProject().getLayers().getLayer(name);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/items/si_base.cpp
+++ b/libs/librepcb/project/schematics/items/si_base.cpp
@@ -75,17 +75,21 @@ void SI_Base::setSelected(bool selected) noexcept
  *  General Methods
  ****************************************************************************************/
 
-void SI_Base::addToSchematic(GraphicsScene& scene, SGI_Base& item) noexcept
+void SI_Base::addToSchematic(SGI_Base* item) noexcept
 {
     Q_ASSERT(!mIsAddedToSchematic);
-    scene.addItem(item);
+    if (item) {
+        mSchematic.getGraphicsScene().addItem(*item);
+    }
     mIsAddedToSchematic = true;
 }
 
-void SI_Base::removeFromSchematic(GraphicsScene& scene, SGI_Base& item) noexcept
+void SI_Base::removeFromSchematic(SGI_Base* item) noexcept
 {
     Q_ASSERT(mIsAddedToSchematic);
-    scene.removeItem(item);
+    if (item) {
+        mSchematic.getGraphicsScene().removeItem(*item);
+    }
     mIsAddedToSchematic = false;
 }
 

--- a/libs/librepcb/project/schematics/items/si_base.h
+++ b/libs/librepcb/project/schematics/items/si_base.h
@@ -56,6 +56,7 @@ class SI_Base : public QObject
 
         // Types
         enum class Type_t {
+            NetSegment, ///< librepcb#project#SI_NetSegment
             NetPoint,   ///< librepcb#project#SI_NetPoint
             NetLine,    ///< librepcb#project#SI_NetLine
             NetLabel,   ///< librepcb#project#SI_NetLabel
@@ -83,8 +84,8 @@ class SI_Base : public QObject
         virtual void setSelected(bool selected) noexcept;
 
         // General Methods
-        virtual void addToSchematic(GraphicsScene& scene) = 0;
-        virtual void removeFromSchematic(GraphicsScene& scene) = 0;
+        virtual void addToSchematic() = 0;
+        virtual void removeFromSchematic() = 0;
 
         // Operator Overloadings
         SI_Base& operator=(const SI_Base& rhs) = delete;
@@ -93,8 +94,8 @@ class SI_Base : public QObject
     protected:
 
         // General Methods
-        void addToSchematic(GraphicsScene& scene, SGI_Base& item) noexcept;
-        void removeFromSchematic(GraphicsScene& scene, SGI_Base& item) noexcept;
+        void addToSchematic(SGI_Base* item) noexcept;
+        void removeFromSchematic(SGI_Base* item) noexcept;
 
 
     protected:

--- a/libs/librepcb/project/schematics/items/si_netlabel.h
+++ b/libs/librepcb/project/schematics/items/si_netlabel.h
@@ -37,6 +37,7 @@ namespace project {
 class Circuit;
 class Schematic;
 class NetSignal;
+class SI_NetSegment;
 
 /*****************************************************************************************
  *  Class SI_NetLabel
@@ -54,23 +55,24 @@ class SI_NetLabel final : public SI_Base, public SerializableObject
         // Constructors / Destructor
         SI_NetLabel() = delete;
         SI_NetLabel(const SI_NetLabel& other) = delete;
-        explicit SI_NetLabel(Schematic& schematic, const SExpression& node);
-        explicit SI_NetLabel(Schematic& schematic, NetSignal& netsignal, const Point& position);
+        explicit SI_NetLabel(SI_NetSegment& segment, const SExpression& node);
+        explicit SI_NetLabel(SI_NetSegment& segment, const Point& position);
         ~SI_NetLabel() noexcept;
 
         // Getters
         const Uuid& getUuid() const noexcept {return mUuid;}
         const Angle& getRotation() const noexcept {return mRotation;}
-        NetSignal& getNetSignal() const noexcept {return *mNetSignal;}
+        SI_NetSegment& getNetSegment() const noexcept {return mNetSegment;}
+        NetSignal& getNetSignalOfNetSegment() const noexcept;
 
         // Setters
-        void setNetSignal(NetSignal& netsignal) noexcept;
         void setPosition(const Point& position) noexcept;
         void setRotation(const Angle& rotation) noexcept;
 
         // General Methods
-        void addToSchematic(GraphicsScene& scene) override;
-        void removeFromSchematic(GraphicsScene& scene) override;
+        void updateAnchor() noexcept;
+        void addToSchematic() override;
+        void removeFromSchematic() override;
 
         /// @copydoc librepcb::SerializableObject::serialize()
         void serialize(SExpression& root) const override;
@@ -85,11 +87,6 @@ class SI_NetLabel final : public SI_Base, public SerializableObject
         SI_NetLabel& operator=(const SI_NetLabel& rhs) = delete;
 
 
-    private slots:
-
-        void netSignalNameChanged(const QString& newName) noexcept;
-
-
     private:
 
         void init();
@@ -101,10 +98,10 @@ class SI_NetLabel final : public SI_Base, public SerializableObject
         QMetaObject::Connection mHighlightChangedConnection;
 
         // Attributes
+        SI_NetSegment& mNetSegment;
         Uuid mUuid;
         Point mPosition;
         Angle mRotation;
-        NetSignal* mNetSignal;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/items/si_netline.h
+++ b/libs/librepcb/project/schematics/items/si_netline.h
@@ -36,6 +36,7 @@ namespace project {
 
 class NetSignal;
 class SI_NetPoint;
+class SI_NetSegment;
 
 /*****************************************************************************************
  *  Class SI_NetLine
@@ -53,25 +54,27 @@ class SI_NetLine final : public SI_Base, public SerializableObject
         // Constructors / Destructor
         SI_NetLine() = delete;
         SI_NetLine(const SI_NetLine& other) = delete;
-        SI_NetLine(Schematic& schematic, const SExpression& node);
-        SI_NetLine(Schematic& schematic, SI_NetPoint& startPoint, SI_NetPoint& endPoint,
+        SI_NetLine(SI_NetSegment& segment, const SExpression& node);
+        SI_NetLine(SI_NetPoint& startPoint, SI_NetPoint& endPoint,
                    const Length& width);
         ~SI_NetLine() noexcept;
 
         // Getters
+        SI_NetSegment& getNetSegment() const noexcept;
         const Uuid& getUuid() const noexcept {return mUuid;}
         const Length& getWidth() const noexcept {return mWidth;}
         SI_NetPoint& getStartPoint() const noexcept {return *mStartPoint;}
         SI_NetPoint& getEndPoint() const noexcept {return *mEndPoint;}
-        NetSignal& getNetSignal() const noexcept;
+        SI_NetPoint* getOtherPoint(const SI_NetPoint& firstPoint) const noexcept;
+        NetSignal& getNetSignalOfNetSegment() const noexcept;
         bool isAttachedToSymbol() const noexcept;
 
         // Setters
         void setWidth(const Length& width) noexcept;
 
         // General Methods
-        void addToSchematic(GraphicsScene& scene) override;
-        void removeFromSchematic(GraphicsScene& scene) override;
+        void addToSchematic() override;
+        void removeFromSchematic() override;
         void updateLine() noexcept;
 
         /// @copydoc librepcb::SerializableObject::serialize()

--- a/libs/librepcb/project/schematics/items/si_netpoint.cpp
+++ b/libs/librepcb/project/schematics/items/si_netpoint.cpp
@@ -25,6 +25,7 @@
 #include "si_netline.h"
 #include "si_symbol.h"
 #include "si_symbolpin.h"
+#include "si_netsegment.h"
 #include "../schematic.h"
 #include "../../project.h"
 #include "../../circuit/circuit.h"
@@ -44,8 +45,8 @@ namespace project {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-SI_NetPoint::SI_NetPoint(Schematic& schematic, const SExpression& node) :
-    SI_Base(schematic), mNetSignal(nullptr), mSymbolPin(nullptr)
+SI_NetPoint::SI_NetPoint(SI_NetSegment& segment, const SExpression& node) :
+    SI_Base(segment.getSchematic()), mNetSegment(segment), mSymbolPin(nullptr)
 {
     // read attributes
     mUuid = node.getChildByIndex(0).getValue<Uuid>(true);
@@ -67,19 +68,8 @@ SI_NetPoint::SI_NetPoint(Schematic& schematic, const SExpression& node) :
             throw RuntimeError(__FILE__, __LINE__,
                 QString(tr("Invalid symbol pin UUID: \"%1\"")).arg(pinUuid.toStr()));
         }
-        mNetSignal = mSymbolPin->getCompSigInstNetSignal();
-        if (!mNetSignal) {
-            throw RuntimeError(__FILE__, __LINE__, QString(tr("The pin "
-                "of the netpoint \"%1\" has no netsignal.")).arg(mUuid.toStr()));
-        }
         mPosition = mSymbolPin->getPosition();
     } else if (posNode && (!symNode) && (!pinNode)) {
-        Uuid netSignalUuid = node.getValueByPath<Uuid>("net", true);
-        mNetSignal = mSchematic.getProject().getCircuit().getNetSignalByUuid(netSignalUuid);
-        if(!mNetSignal) {
-            throw RuntimeError(__FILE__, __LINE__,
-                QString(tr("Invalid net signal UUID: \"%1\"")).arg(netSignalUuid.toStr()));
-        }
         mPosition = Point(node.getChildByPath("pos"));
     } else {
         throw RuntimeError(__FILE__, __LINE__, tr("Invalid combination of sym/pin/pos nodes."));
@@ -88,16 +78,16 @@ SI_NetPoint::SI_NetPoint(Schematic& schematic, const SExpression& node) :
     init();
 }
 
-SI_NetPoint::SI_NetPoint(Schematic& schematic, NetSignal& netsignal, const Point& position) :
-    SI_Base(schematic), mUuid(Uuid::createRandom()), mPosition(position),
-    mNetSignal(&netsignal), mSymbolPin(nullptr)
+SI_NetPoint::SI_NetPoint(SI_NetSegment& segment, const Point& position) :
+    SI_Base(segment.getSchematic()), mNetSegment(segment), mUuid(Uuid::createRandom()),
+    mPosition(position), mSymbolPin(nullptr)
 {
     init();
 }
 
-SI_NetPoint::SI_NetPoint(Schematic& schematic, NetSignal& netsignal, SI_SymbolPin& pin) :
-    SI_Base(schematic), mUuid(Uuid::createRandom()), mPosition(pin.getPosition()),
-    mNetSignal(&netsignal), mSymbolPin(&pin)
+SI_NetPoint::SI_NetPoint(SI_NetSegment& segment, SI_SymbolPin& pin) :
+    SI_Base(segment.getSchematic()), mNetSegment(segment), mUuid(Uuid::createRandom()),
+    mPosition(pin.getPosition()), mSymbolPin(&pin)
 {
     init();
 }
@@ -142,29 +132,14 @@ bool SI_NetPoint::isOpenLineEnd() const noexcept
     return ((mRegisteredLines.count() <= 1) && (!isAttachedToPin()));
 }
 
+NetSignal& SI_NetPoint::getNetSignalOfNetSegment() const noexcept
+{
+    return mNetSegment.getNetSignal();
+}
+
 /*****************************************************************************************
  *  Setters
  ****************************************************************************************/
-
-void SI_NetPoint::setNetSignal(NetSignal& netsignal)
-{
-    if (&netsignal == mNetSignal) {
-        return;
-    }
-    if ((isUsed()) || (netsignal.getCircuit() != getCircuit())) {
-        throw LogicError(__FILE__, __LINE__);
-    }
-    if (isAddedToSchematic()) {
-        if (isAttachedToPin()) {
-            throw LogicError(__FILE__, __LINE__);
-        }
-        mNetSignal->unregisterSchematicNetPoint(*this); // can throw
-        auto sg = scopeGuard([&](){mNetSignal->registerSchematicNetPoint(*this);});
-        netsignal.registerSchematicNetPoint(*this); // can throw
-        sg.dismiss();
-    }
-    mNetSignal = &netsignal;
-}
 
 void SI_NetPoint::setPinToAttach(SI_SymbolPin* pin)
 {
@@ -183,7 +158,7 @@ void SI_NetPoint::setPinToAttach(SI_SymbolPin* pin)
         }
         if (pin) {
             // attach to new pin
-            if (pin->getCompSigInstNetSignal() != mNetSignal) {
+            if (pin->getCompSigInstNetSignal() != &mNetSegment.getNetSignal()) {
                 throw LogicError(__FILE__, __LINE__);
             }
             pin->registerNetPoint(*this); // can throw
@@ -209,49 +184,44 @@ void SI_NetPoint::setPosition(const Point& position) noexcept
  *  General Methods
  ****************************************************************************************/
 
-void SI_NetPoint::addToSchematic(GraphicsScene& scene)
+void SI_NetPoint::addToSchematic()
 {
     if (isAddedToSchematic() || isUsed()) {
         throw LogicError(__FILE__, __LINE__);
     }
-    ScopeGuardList sgl;
-    mNetSignal->registerSchematicNetPoint(*this); // can throw
-    sgl.add([&](){mNetSignal->unregisterSchematicNetPoint(*this);});
+
     if (isAttachedToPin()) {
-        // check if mNetSignal is correct (would be a bug if not)
-        if (mSymbolPin->getCompSigInstNetSignal() != mNetSignal) {
+        // check if netsignal is correct (would be a bug if not)
+        if (mSymbolPin->getCompSigInstNetSignal() != &mNetSegment.getNetSignal()) {
             throw LogicError(__FILE__, __LINE__);
         }
         mSymbolPin->registerNetPoint(*this); // can throw
-        sgl.add([&](){mSymbolPin->unregisterNetPoint(*this);});
     }
-    mHighlightChangedConnection = connect(mNetSignal, &NetSignal::highlightedChanged,
+
+    mHighlightChangedConnection = connect(&getNetSignalOfNetSegment(),
+                                          &NetSignal::highlightedChanged,
                                           [this](){mGraphicsItem->update();});
     mErcMsgDeadNetPoint->setVisible(true);
-    SI_Base::addToSchematic(scene, *mGraphicsItem);
-    sgl.dismiss();
+    SI_Base::addToSchematic(mGraphicsItem.data());
 }
 
-void SI_NetPoint::removeFromSchematic(GraphicsScene& scene)
+void SI_NetPoint::removeFromSchematic()
 {
     if ((!isAddedToSchematic()) || isUsed()) {
         throw LogicError(__FILE__, __LINE__);
     }
-    ScopeGuardList sgl;
+
     if (isAttachedToPin()) {
-        // check if mNetSignal is correct (would be a bug if not)
-        if (mSymbolPin->getCompSigInstNetSignal() != mNetSignal) {
+        // check if netsignal is correct (would be a bug if not)
+        if (mSymbolPin->getCompSigInstNetSignal() != &mNetSegment.getNetSignal()) {
             throw LogicError(__FILE__, __LINE__);
         }
         mSymbolPin->unregisterNetPoint(*this); // can throw
-        sgl.add([&](){mSymbolPin->registerNetPoint(*this);});
     }
-    mNetSignal->unregisterSchematicNetPoint(*this); // can throw
-    sgl.add([&](){mNetSignal->registerSchematicNetPoint(*this);});
+
     disconnect(mHighlightChangedConnection);
     mErcMsgDeadNetPoint->setVisible(false);
-    SI_Base::removeFromSchematic(scene, *mGraphicsItem);
-    sgl.dismiss();
+    SI_Base::removeFromSchematic(mGraphicsItem.data());
 }
 
 void SI_NetPoint::registerNetLine(SI_NetLine& netline)
@@ -290,7 +260,6 @@ void SI_NetPoint::serialize(SExpression& root) const
     if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
     root.appendToken(mUuid);
-    root.appendTokenChild("net", mNetSignal->getUuid(), true);
     if (isAttachedToPin()) {
         root.appendTokenChild("sym", mSymbolPin->getSymbol().getUuid(), true);
         root.appendTokenChild("pin", mSymbolPin->getLibPinUuid(), false);
@@ -321,8 +290,7 @@ void SI_NetPoint::setSelected(bool selected) noexcept
 bool SI_NetPoint::checkAttributesValidity() const noexcept
 {
     if (mUuid.isNull())                             return false;
-    if (mNetSignal == nullptr)                      return false;
-    if (isAttachedToPin() && (mNetSignal != mSymbolPin->getCompSigInstNetSignal())) return false;
+    if (isAttachedToPin() && (&mNetSegment.getNetSignal() != mSymbolPin->getCompSigInstNetSignal())) return false;
     return true;
 }
 

--- a/libs/librepcb/project/schematics/items/si_netpoint.h
+++ b/libs/librepcb/project/schematics/items/si_netpoint.h
@@ -41,6 +41,7 @@ class NetSignal;
 class SI_NetLine;
 class SI_Symbol;
 class SI_SymbolPin;
+class SI_NetSegment;
 class ErcMsg;
 
 /*****************************************************************************************
@@ -61,9 +62,9 @@ class SI_NetPoint final : public SI_Base, public SerializableObject,
         // Constructors / Destructor
         SI_NetPoint() = delete;
         SI_NetPoint(const SI_NetPoint& other) = delete;
-        SI_NetPoint(Schematic& schematic, const SExpression& node);
-        SI_NetPoint(Schematic& schematic, NetSignal& netsignal, const Point& position);
-        SI_NetPoint(Schematic& schematic, NetSignal& netsignal, SI_SymbolPin& pin);
+        SI_NetPoint(SI_NetSegment& segment, const SExpression& node);
+        SI_NetPoint(SI_NetSegment& segment, const Point& position);
+        SI_NetPoint(SI_NetSegment& segment, SI_SymbolPin& pin);
         ~SI_NetPoint() noexcept;
 
         // Getters
@@ -71,19 +72,19 @@ class SI_NetPoint final : public SI_Base, public SerializableObject,
         bool isAttachedToPin() const noexcept {return (mSymbolPin ? true : false);}
         bool isVisibleJunction() const noexcept;
         bool isOpenLineEnd() const noexcept;
-        NetSignal& getNetSignal() const noexcept {return *mNetSignal;}
+        SI_NetSegment& getNetSegment() const noexcept {return mNetSegment;}
+        NetSignal& getNetSignalOfNetSegment() const noexcept;
         SI_SymbolPin* getSymbolPin() const noexcept {return mSymbolPin;}
         const QList<SI_NetLine*>& getLines() const noexcept {return mRegisteredLines;}
         bool isUsed() const noexcept {return (mRegisteredLines.count() > 0);}
 
         // Setters
-        void setNetSignal(NetSignal& netsignal);
         void setPinToAttach(SI_SymbolPin* pin);
         void setPosition(const Point& position) noexcept;
 
         // General Methods
-        void addToSchematic(GraphicsScene& scene) override;
-        void removeFromSchematic(GraphicsScene& scene) override;
+        void addToSchematic() override;
+        void removeFromSchematic() override;
         void registerNetLine(SI_NetLine& netline);
         void unregisterNetLine(SI_NetLine& netline);
         void updateLines() const noexcept;
@@ -115,9 +116,9 @@ class SI_NetPoint final : public SI_Base, public SerializableObject,
         QMetaObject::Connection mHighlightChangedConnection;
 
         // Attributes
+        SI_NetSegment& mNetSegment;
         Uuid mUuid;
         Point mPosition;
-        NetSignal* mNetSignal;
         SI_SymbolPin* mSymbolPin;   ///< only needed if the netpoint is attached to a pin
 
         // Registered Elements

--- a/libs/librepcb/project/schematics/items/si_netsegment.cpp
+++ b/libs/librepcb/project/schematics/items/si_netsegment.cpp
@@ -1,0 +1,555 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "si_netsegment.h"
+#include "si_netline.h"
+#include "si_netpoint.h"
+#include "si_netlabel.h"
+#include "si_symbolpin.h"
+#include "../schematic.h"
+#include "../../project.h"
+#include "../../circuit/circuit.h"
+#include "../../circuit/netsignal.h"
+#include "../../circuit/componentsignalinstance.h"
+#include <librepcb/common/scopeguardlist.h>
+#include <librepcb/common/toolbox.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+SI_NetSegment::SI_NetSegment(Schematic& schematic, const SExpression& node) :
+    SI_Base(schematic), mUuid(), mNetSignal(nullptr)
+{
+    try
+    {
+        mUuid = node.getChildByIndex(0).getValue<Uuid>(true);
+
+        Uuid netSignalUuid = node.getValueByPath<Uuid>("net", true);
+        mNetSignal = mSchematic.getProject().getCircuit().getNetSignalByUuid(netSignalUuid);
+        if(!mNetSignal) {
+            throw RuntimeError(__FILE__, __LINE__,
+                QString(tr("Invalid net signal UUID: \"%1\"")).arg(netSignalUuid.toStr()));
+        }
+
+        // Load all netpoints
+        foreach (const SExpression& child, node.getChildren("netpoint")) {
+            SI_NetPoint* netpoint = new SI_NetPoint(*this, child);
+            if (getNetPointByUuid(netpoint->getUuid())) {
+                throw RuntimeError(__FILE__, __LINE__,
+                    QString(tr("There is already a netpoint with the UUID \"%1\"!"))
+                    .arg(netpoint->getUuid().toStr()));
+            }
+            mNetPoints.append(netpoint);
+        }
+
+        // Load all netlines
+        foreach (const SExpression& child, node.getChildren("netline")) {
+            SI_NetLine* netline = new SI_NetLine(*this, child);
+            if (getNetLineByUuid(netline->getUuid())) {
+                throw RuntimeError(__FILE__, __LINE__,
+                    QString(tr("There is already a netline with the UUID \"%1\"!"))
+                    .arg(netline->getUuid().toStr()));
+            }
+            mNetLines.append(netline);
+        }
+
+        // Load all netlabels
+        foreach (const SExpression& child, node.getChildren("netlabel")) {
+            SI_NetLabel* netlabel = new SI_NetLabel(*this, child);
+            if (getNetLabelByUuid(netlabel->getUuid())) {
+                throw RuntimeError(__FILE__, __LINE__,
+                    QString(tr("There is already a netlabel with the UUID \"%1\"!"))
+                    .arg(netlabel->getUuid().toStr()));
+            }
+            mNetLabels.append(netlabel);
+        }
+
+        if (mNetPoints.count() < 2) {
+            throw RuntimeError(__FILE__, __LINE__,
+                QString(tr("The netsegment with the UUID \"%1\" has too few netpoints!"))
+                .arg(mUuid.toStr()));
+        }
+
+        if (!areAllNetPointsConnectedTogether()) {
+            throw RuntimeError(__FILE__, __LINE__,
+                QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+                .arg(mUuid.toStr()));
+        }
+
+        if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
+    }
+    catch (...)
+    {
+        // free the allocated memory in the reverse order of their allocation...
+        qDeleteAll(mNetLabels);         mNetLabels.clear();
+        qDeleteAll(mNetLines);          mNetLines.clear();
+        qDeleteAll(mNetPoints);         mNetPoints.clear();
+        throw; // ...and rethrow the exception
+    }
+}
+
+SI_NetSegment::SI_NetSegment(Schematic& schematic, NetSignal& signal) :
+    SI_Base(schematic), mUuid(Uuid::createRandom()), mNetSignal(&signal)
+{
+}
+
+SI_NetSegment::~SI_NetSegment() noexcept
+{
+    // delete all items
+    qDeleteAll(mNetLabels);         mNetLabels.clear();
+    qDeleteAll(mNetLines);          mNetLines.clear();
+    qDeleteAll(mNetPoints);         mNetPoints.clear();
+}
+
+/*****************************************************************************************
+ *  Getters
+ ****************************************************************************************/
+
+bool SI_NetSegment::isUsed() const noexcept
+{
+    return ((!mNetPoints.isEmpty()) || (!mNetLines.isEmpty()) || (!mNetLabels.isEmpty()));
+}
+
+int SI_NetSegment::getNetPointsAtScenePos(const Point& pos, QList<SI_NetPoint*>& points) const noexcept
+{
+    int count = 0;
+    foreach (SI_NetPoint* netpoint, mNetPoints) {
+        if (netpoint->getGrabAreaScenePx().contains(pos.toPxQPointF())) {
+            points.append(netpoint);
+            ++count;
+        }
+    }
+    return count;
+}
+
+int SI_NetSegment::getNetLinesAtScenePos(const Point& pos, QList<SI_NetLine*>& lines) const noexcept
+{
+    int count = 0;
+    foreach (SI_NetLine* netline, mNetLines) {
+        if (netline->getGrabAreaScenePx().contains(pos.toPxQPointF())) {
+            lines.append(netline);
+            ++count;
+        }
+    }
+    return count;
+}
+
+int SI_NetSegment::getNetLabelsAtScenePos(const Point& pos, QList<SI_NetLabel*>& labels) const noexcept
+{
+    int count = 0;
+    foreach (SI_NetLabel* netlabel, mNetLabels) {
+        if (netlabel->getGrabAreaScenePx().contains(pos.toPxQPointF())) {
+            labels.append(netlabel);
+            ++count;
+        }
+    }
+    return count;
+}
+
+QSet<QString> SI_NetSegment::getForcedNetNames() const noexcept
+{
+    QSet<QString> names;
+    foreach (SI_NetPoint* netpoint, mNetPoints) {
+        if (netpoint->isAttachedToPin()) {
+            SI_SymbolPin* pin = netpoint->getSymbolPin(); Q_ASSERT(pin);
+            ComponentSignalInstance* sig = pin->getComponentSignalInstance(); Q_ASSERT(sig);
+            if (sig->isNetSignalNameForced()) {
+                names.insert(sig->getForcedNetSignalName());
+            }
+        }
+    }
+    return names;
+}
+
+QString SI_NetSegment::getForcedNetName() const noexcept
+{
+    QSet<QString> names = getForcedNetNames();
+    if (names.count() == 1) {
+        return names.values().first();
+    } else {
+        return QString();
+    }
+}
+
+Point SI_NetSegment::calcNearestPoint(const Point& p) const noexcept
+{
+    Point pos = p;
+    Length dist;
+    for (int i = 0; i < mNetLines.count(); ++i) {
+        Point lp;
+        Length ld = Toolbox::shortestDistanceBetweenPointAndLine(p,
+            mNetLines.at(i)->getStartPoint().getPosition(),
+            mNetLines.at(i)->getEndPoint().getPosition(), &lp);
+        if ((i == 0) || (ld < dist)) {
+            dist = ld;
+            pos = lp;
+        }
+    }
+    return pos;
+}
+
+/*****************************************************************************************
+ *  Setters
+ ****************************************************************************************/
+
+void SI_NetSegment::setNetSignal(NetSignal& netsignal)
+{
+    if (&netsignal != mNetSignal) {
+        if ((isUsed() && isAddedToSchematic()) || (netsignal.getCircuit() != getCircuit())) {
+            throw LogicError(__FILE__, __LINE__);
+        }
+        if (isAddedToSchematic()) {
+            mNetSignal->unregisterSchematicNetSegment(*this); // can throw
+            auto sg = scopeGuard([&](){mNetSignal->registerSchematicNetSegment(*this);});
+            netsignal.registerSchematicNetSegment(*this); // can throw
+            sg.dismiss();
+        }
+        mNetSignal = &netsignal;
+    }
+}
+
+/*****************************************************************************************
+ *  NetPoint Methods
+ ****************************************************************************************/
+
+SI_NetPoint* SI_NetSegment::getNetPointByUuid(const Uuid& uuid) const noexcept
+{
+    foreach (SI_NetPoint* netpoint, mNetPoints) {
+        if (netpoint->getUuid() == uuid)
+            return netpoint;
+    }
+    return nullptr;
+}
+
+/*****************************************************************************************
+ *  NetLine Methods
+ ****************************************************************************************/
+
+SI_NetLine* SI_NetSegment::getNetLineByUuid(const Uuid& uuid) const noexcept
+{
+    foreach (SI_NetLine* netline, mNetLines) {
+        if (netline->getUuid() == uuid)
+            return netline;
+    }
+    return nullptr;
+}
+
+/*****************************************************************************************
+ *  NetPoint+NetLine Methods
+ ****************************************************************************************/
+
+void SI_NetSegment::addNetPointsAndNetLines(const QList<SI_NetPoint*>& netpoints,
+                                            const QList<SI_NetLine*>& netlines)
+{
+    if (!isAddedToSchematic()) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+
+    ScopeGuardList sgl(netpoints.count() + netlines.count());
+    foreach (SI_NetPoint* netpoint, netpoints) {
+        if ((mNetPoints.contains(netpoint)) || (&netpoint->getNetSegment() != this)) {
+            throw LogicError(__FILE__, __LINE__);
+        }
+        // check if there is no netpoint with the same uuid in the list
+        if (getNetPointByUuid(netpoint->getUuid())) {
+            throw RuntimeError(__FILE__, __LINE__,
+                QString(tr("There is already a netpoint with the UUID \"%1\"!"))
+                .arg(netpoint->getUuid().toStr()));
+        }
+        // add to schematic
+        netpoint->addToSchematic(); // can throw
+        mNetPoints.append(netpoint);
+        sgl.add([this, netpoint](){netpoint->removeFromSchematic(); mNetPoints.removeOne(netpoint);});
+    }
+    foreach (SI_NetLine* netline, netlines) {
+        if ((mNetLines.contains(netline)) || (&netline->getNetSegment() != this)) {
+            throw LogicError(__FILE__, __LINE__);
+        }
+        // check if there is no netline with the same uuid in the list
+        if (getNetLineByUuid(netline->getUuid())) {
+            throw RuntimeError(__FILE__, __LINE__,
+                QString(tr("There is already a netline with the UUID \"%1\"!"))
+                .arg(netline->getUuid().toStr()));
+        }
+        // add to schematic
+        netline->addToSchematic(); // can throw
+        mNetLines.append(netline);
+        sgl.add([this, netline](){netline->removeFromSchematic(); mNetLines.removeOne(netline);});
+    }
+
+    if (!areAllNetPointsConnectedTogether()) {
+        throw LogicError(__FILE__, __LINE__,
+            QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+            .arg(mUuid.toStr()));
+    }
+
+    updateAllNetLabelAnchors();
+
+    sgl.dismiss();
+}
+
+void SI_NetSegment::removeNetPointsAndNetLines(const QList<SI_NetPoint*>& netpoints,
+                                               const QList<SI_NetLine*>& netlines)
+{
+    if (!isAddedToSchematic()) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+
+    ScopeGuardList sgl(netpoints.count() + netlines.count());
+    foreach (SI_NetLine* netline, netlines) {
+        if (!mNetLines.contains(netline)) {
+            throw LogicError(__FILE__, __LINE__);
+        }
+        // remove from schematic
+        netline->removeFromSchematic(); // can throw
+        mNetLines.removeOne(netline);
+        sgl.add([this, netline](){netline->addToSchematic(); mNetLines.append(netline);});
+    }
+    foreach (SI_NetPoint* netpoint, netpoints) {
+        if (!mNetPoints.contains(netpoint)) {
+            throw LogicError(__FILE__, __LINE__);
+        }
+        // remove from schematic
+        netpoint->removeFromSchematic(); // can throw
+        mNetPoints.removeOne(netpoint);
+        sgl.add([this, netpoint](){netpoint->addToSchematic(); mNetPoints.append(netpoint);});
+    }
+
+    if (!areAllNetPointsConnectedTogether()) {
+        throw LogicError(__FILE__, __LINE__,
+            QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+            .arg(mUuid.toStr()));
+    }
+
+    updateAllNetLabelAnchors();
+
+    sgl.dismiss();
+}
+
+/*****************************************************************************************
+ *  NetLabel Methods
+ ****************************************************************************************/
+
+SI_NetLabel* SI_NetSegment::getNetLabelByUuid(const Uuid& uuid) const noexcept
+{
+    foreach (SI_NetLabel* netlabel, mNetLabels) {
+        if (netlabel->getUuid() == uuid)
+            return netlabel;
+    }
+    return nullptr;
+}
+
+void SI_NetSegment::addNetLabel(SI_NetLabel& netlabel)
+{
+    if ((!isAddedToSchematic()) || (mNetLabels.contains(&netlabel))
+        || (&netlabel.getNetSegment() != this))
+    {
+        throw LogicError(__FILE__, __LINE__);
+    }
+    // check if there is no netlabel with the same uuid in the list
+    if (getNetLabelByUuid(netlabel.getUuid())) {
+        throw RuntimeError(__FILE__, __LINE__,
+            QString(tr("There is already a netlabel with the UUID \"%1\"!"))
+            .arg(netlabel.getUuid().toStr()));
+    }
+    // add to schematic
+    netlabel.addToSchematic(); // can throw
+    mNetLabels.append(&netlabel);
+}
+
+void SI_NetSegment::removeNetLabel(SI_NetLabel& netlabel)
+{
+    if ((!isAddedToSchematic()) || (!mNetLabels.contains(&netlabel))) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+    // remove from schematic
+    netlabel.removeFromSchematic(); // can throw
+    mNetLabels.removeOne(&netlabel);
+}
+
+void SI_NetSegment::updateAllNetLabelAnchors() noexcept
+{
+    foreach (SI_NetLabel* netlabel, mNetLabels) {
+        netlabel->updateAnchor();
+    }
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void SI_NetSegment::addToSchematic()
+{
+    if (isAddedToSchematic()) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+
+    ScopeGuardList sgl(mNetPoints.count() + mNetLines.count() + mNetLabels.count() + 1);
+    mNetSignal->registerSchematicNetSegment(*this); // can throw
+    sgl.add([&](){mNetSignal->unregisterSchematicNetSegment(*this);});
+    foreach (SI_NetPoint* netpoint, mNetPoints) {
+        netpoint->addToSchematic(); // can throw
+        sgl.add([netpoint](){netpoint->removeFromSchematic();});
+    }
+    foreach (SI_NetLine* netline, mNetLines) {
+        netline->addToSchematic(); // can throw
+        sgl.add([netline](){netline->removeFromSchematic();});
+    }
+    foreach (SI_NetLabel* netlabel, mNetLabels) {
+        netlabel->addToSchematic(); // can throw
+        sgl.add([netlabel](){netlabel->removeFromSchematic();});
+    }
+
+    SI_Base::addToSchematic(nullptr);
+    sgl.dismiss();
+}
+
+void SI_NetSegment::removeFromSchematic()
+{
+    if ((!isAddedToSchematic())) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+
+    ScopeGuardList sgl(mNetPoints.count() + mNetLines.count() + mNetLabels.count() + 1);
+    foreach (SI_NetLabel* netlabel, mNetLabels) {
+        netlabel->removeFromSchematic(); // can throw
+        sgl.add([netlabel](){netlabel->addToSchematic();});
+    }
+    foreach (SI_NetLine* netline, mNetLines) {
+        netline->removeFromSchematic(); // can throw
+        sgl.add([netline](){netline->addToSchematic();});
+    }
+    foreach (SI_NetPoint* netpoint, mNetPoints) {
+        netpoint->removeFromSchematic(); // can throw
+        sgl.add([netpoint](){netpoint->addToSchematic();});
+    }
+    mNetSignal->unregisterSchematicNetSegment(*this); // can throw
+    sgl.add([&](){mNetSignal->registerSchematicNetSegment(*this);});
+
+    SI_Base::removeFromSchematic(nullptr);
+    sgl.dismiss();
+}
+
+void SI_NetSegment::setSelectionRect(const QRectF rectPx) noexcept
+{
+    foreach (SI_NetPoint* netpoint, mNetPoints)
+        netpoint->setSelected(netpoint->getGrabAreaScenePx().intersects(rectPx));
+    foreach (SI_NetLine* netline, mNetLines)
+        netline->setSelected(netline->getGrabAreaScenePx().intersects(rectPx));
+    foreach (SI_NetLabel* netlabel, mNetLabels)
+        netlabel->setSelected(netlabel->getGrabAreaScenePx().intersects(rectPx));
+}
+
+void SI_NetSegment::clearSelection() const noexcept
+{
+    foreach (SI_NetPoint* netpoint, mNetPoints)
+        netpoint->setSelected(false);
+    foreach (SI_NetLine* netline, mNetLines)
+        netline->setSelected(false);
+    foreach (SI_NetLabel* netlabel, mNetLabels)
+        netlabel->setSelected(false);
+}
+
+void SI_NetSegment::serialize(SExpression& root) const
+{
+    if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
+
+    root.appendToken(mUuid);
+    root.appendTokenChild("net", mNetSignal->getUuid(), true);
+    serializePointerContainer(root, mNetPoints, "netpoint");
+    serializePointerContainer(root, mNetLines, "netline");
+    serializePointerContainer(root, mNetLabels, "netlabel");
+}
+
+/*****************************************************************************************
+ *  Inherited from SI_Base
+ ****************************************************************************************/
+
+QPainterPath SI_NetSegment::getGrabAreaScenePx() const noexcept
+{
+    return QPainterPath();
+}
+
+bool SI_NetSegment::isSelected() const noexcept
+{
+    if (mNetLines.isEmpty()) return false;
+    foreach (const SI_NetLine* netline, mNetLines) {
+        if (!netline->isSelected()) return false;
+    }
+    return true;
+}
+
+void SI_NetSegment::setSelected(bool selected) noexcept
+{
+    SI_Base::setSelected(selected);
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+bool SI_NetSegment::checkAttributesValidity() const noexcept
+{
+    if (mUuid.isNull())                         return false;
+    if (mNetSignal == nullptr)                  return false;
+    if (mNetPoints.count() < 2)                 return false;
+    if (!areAllNetPointsConnectedTogether())    return false;
+    return true;
+}
+
+bool SI_NetSegment::areAllNetPointsConnectedTogether() const noexcept
+{
+    if (mNetPoints.count() > 1) {
+        const SI_NetPoint* firstPoint = mNetPoints.first();
+        QList<const SI_NetPoint*> points({firstPoint});
+        findAllConnectedNetPoints(*firstPoint, points);
+        return (points.count() == mNetPoints.count());
+    } else {
+        return true; // there is only 0 or 1 netpoint => must be "connected together" :)
+    }
+}
+
+void SI_NetSegment::findAllConnectedNetPoints(const SI_NetPoint& p, QList<const SI_NetPoint*>& points) const noexcept
+{
+    foreach (const SI_NetLine* line, mNetLines) {
+        const SI_NetPoint* p2 = line->getOtherPoint(p);
+        if ((p2) && (!points.contains(p2))) {
+            points.append(p2);
+            findAllConnectedNetPoints(*p2, points);
+        }
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/project/schematics/items/si_netsegment.h
+++ b/libs/librepcb/project/schematics/items/si_netsegment.h
@@ -1,0 +1,144 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_SI_NETSEGMENT_H
+#define LIBREPCB_PROJECT_SI_NETSEGMENT_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "si_base.h"
+#include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/uuid.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+class NetSignal;
+class SI_NetPoint;
+class SI_NetLine;
+class SI_NetLabel;
+
+/*****************************************************************************************
+ *  Class SI_NetSegment
+ ****************************************************************************************/
+
+/**
+ * @brief The SI_NetSegment class
+ *
+ * @todo Do not allow to create empty netsegments!
+ */
+class SI_NetSegment final : public SI_Base, public SerializableObject
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        SI_NetSegment() = delete;
+        SI_NetSegment(const SI_NetSegment& other) = delete;
+        SI_NetSegment(Schematic& schematic, const SExpression& node);
+        SI_NetSegment(Schematic& schematic, NetSignal& signal);
+        ~SI_NetSegment() noexcept;
+
+        // Getters
+        const Uuid& getUuid() const noexcept {return mUuid;}
+        NetSignal& getNetSignal() const noexcept {return *mNetSignal;}
+        bool isUsed() const noexcept;
+        int getNetPointsAtScenePos(const Point& pos, QList<SI_NetPoint*>& points) const noexcept;
+        int getNetLinesAtScenePos(const Point& pos, QList<SI_NetLine*>& lines) const noexcept;
+        int getNetLabelsAtScenePos(const Point& pos, QList<SI_NetLabel*>& labels) const noexcept;
+        QSet<QString> getForcedNetNames() const noexcept;
+        QString getForcedNetName() const noexcept;
+        Point calcNearestPoint(const Point& p) const noexcept;
+
+        // Setters
+        void setNetSignal(NetSignal& netsignal);
+
+        // NetPoint Methods
+        const QList<SI_NetPoint*>& getNetPoints() const noexcept {return mNetPoints;}
+        SI_NetPoint* getNetPointByUuid(const Uuid& uuid) const noexcept;
+
+        // NetLine Methods
+        const QList<SI_NetLine*>& getNetLines() const noexcept {return mNetLines;}
+        SI_NetLine* getNetLineByUuid(const Uuid& uuid) const noexcept;
+
+        // NetPoint+NetLine Methods
+        void addNetPointsAndNetLines(const QList<SI_NetPoint*>& netpoints,
+                                     const QList<SI_NetLine*>& netlines);
+        void removeNetPointsAndNetLines(const QList<SI_NetPoint*>& netpoints,
+                                        const QList<SI_NetLine*>& netlines);
+
+        // NetLabel Methods
+        const QList<SI_NetLabel*>& getNetLabels() const noexcept {return mNetLabels;}
+        SI_NetLabel* getNetLabelByUuid(const Uuid& uuid) const noexcept;
+        void addNetLabel(SI_NetLabel& netlabel);
+        void removeNetLabel(SI_NetLabel& netlabel);
+        void updateAllNetLabelAnchors() noexcept;
+
+        // General Methods
+        void addToSchematic() override;
+        void removeFromSchematic() override;
+        void setSelectionRect(const QRectF rectPx) noexcept;
+        void clearSelection() const noexcept;
+
+        /// @copydoc librepcb::SerializableObject::serialize()
+        void serialize(SExpression& root) const override;
+
+        // Inherited from SI_Base
+        Type_t getType() const noexcept override {return SI_Base::Type_t::NetSegment;}
+        const Point& getPosition() const noexcept override {static Point p(0, 0); return p;}
+        QPainterPath getGrabAreaScenePx() const noexcept override;
+        bool isSelected() const noexcept override;
+        void setSelected(bool selected) noexcept override;
+
+        // Operator Overloadings
+        SI_NetSegment& operator=(const SI_NetSegment& rhs) = delete;
+        bool operator==(const SI_NetSegment& rhs) noexcept {return (this == &rhs);}
+        bool operator!=(const SI_NetSegment& rhs) noexcept {return (this != &rhs);}
+
+
+    private:
+        bool checkAttributesValidity() const noexcept;
+        bool areAllNetPointsConnectedTogether() const noexcept;
+        void findAllConnectedNetPoints(const SI_NetPoint& p, QList<const SI_NetPoint*>& points) const noexcept;
+
+
+        // Attributes
+        Uuid mUuid;
+        NetSignal* mNetSignal;
+
+        // Items
+        QList<SI_NetPoint*> mNetPoints;
+        QList<SI_NetLine*> mNetLines;
+        QList<SI_NetLabel*> mNetLabels;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_SI_NETSEGMENT_H

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -151,7 +151,7 @@ void SI_Symbol::setRotation(const Angle& newRotation) noexcept
  *  General Methods
  ****************************************************************************************/
 
-void SI_Symbol::addToSchematic(GraphicsScene& scene)
+void SI_Symbol::addToSchematic()
 {
     if (isAddedToSchematic()) {
         throw LogicError(__FILE__, __LINE__);
@@ -160,26 +160,26 @@ void SI_Symbol::addToSchematic(GraphicsScene& scene)
     mComponentInstance->registerSymbol(*this); // can throw
     sgl.add([&](){mComponentInstance->unregisterSymbol(*this);});
     foreach (SI_SymbolPin* pin, mPins) {
-        pin->addToSchematic(scene); // can throw
-        sgl.add([pin, &scene](){pin->removeFromSchematic(scene);});
+        pin->addToSchematic(); // can throw
+        sgl.add([pin](){pin->removeFromSchematic();});
     }
-    SI_Base::addToSchematic(scene, *mGraphicsItem);
+    SI_Base::addToSchematic(mGraphicsItem.data());
     sgl.dismiss();
 }
 
-void SI_Symbol::removeFromSchematic(GraphicsScene& scene)
+void SI_Symbol::removeFromSchematic()
 {
     if (!isAddedToSchematic()) {
         throw LogicError(__FILE__, __LINE__);
     }
     ScopeGuardList sgl(mPins.count()+1);
     foreach (SI_SymbolPin* pin, mPins) {
-        pin->removeFromSchematic(scene); // can throw
-        sgl.add([pin, &scene](){pin->addToSchematic(scene);});
+        pin->removeFromSchematic(); // can throw
+        sgl.add([pin](){pin->addToSchematic();});
     }
     mComponentInstance->unregisterSymbol(*this); // can throw
     sgl.add([&](){mComponentInstance->registerSymbol(*this);});
-    SI_Base::removeFromSchematic(scene, *mGraphicsItem);
+    SI_Base::removeFromSchematic(mGraphicsItem.data());
     sgl.dismiss();
 }
 

--- a/libs/librepcb/project/schematics/items/si_symbol.h
+++ b/libs/librepcb/project/schematics/items/si_symbol.h
@@ -86,8 +86,8 @@ class SI_Symbol final : public SI_Base, public SerializableObject,
         void setRotation(const Angle& newRotation) noexcept;
 
         // General Methods
-        void addToSchematic(GraphicsScene& scene) override;
-        void removeFromSchematic(GraphicsScene& scene) override;
+        void addToSchematic() override;
+        void removeFromSchematic() override;
 
         /// @copydoc librepcb::SerializableObject::serialize()
         void serialize(SExpression& root) const override;

--- a/libs/librepcb/project/schematics/items/si_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.cpp
@@ -133,7 +133,7 @@ bool SI_SymbolPin::isRequired() const noexcept
  *  General Methods
  ****************************************************************************************/
 
-void SI_SymbolPin::addToSchematic(GraphicsScene& scene)
+void SI_SymbolPin::addToSchematic()
 {
     if (isAddedToSchematic() || isUsed()) {
         throw LogicError(__FILE__, __LINE__);
@@ -145,11 +145,11 @@ void SI_SymbolPin::addToSchematic(GraphicsScene& scene)
         mHighlightChangedConnection = connect(getCompSigInstNetSignal(), &NetSignal::highlightedChanged,
                                               [this](){mGraphicsItem->update();});
     }
-    SI_Base::addToSchematic(scene, *mGraphicsItem);
+    SI_Base::addToSchematic(mGraphicsItem.data());
     updateErcMessages();
 }
 
-void SI_SymbolPin::removeFromSchematic(GraphicsScene& scene)
+void SI_SymbolPin::removeFromSchematic()
 {
     if ((!isAddedToSchematic()) || isUsed()) {
         throw LogicError(__FILE__, __LINE__);
@@ -160,7 +160,7 @@ void SI_SymbolPin::removeFromSchematic(GraphicsScene& scene)
     if (getCompSigInstNetSignal()) {
         disconnect(mHighlightChangedConnection);
     }
-    SI_Base::removeFromSchematic(scene, *mGraphicsItem);
+    SI_Base::removeFromSchematic(mGraphicsItem.data());
     updateErcMessages();
 }
 
@@ -168,7 +168,7 @@ void SI_SymbolPin::registerNetPoint(SI_NetPoint& netpoint)
 {
     if ((!isAddedToSchematic()) || (!mComponentSignalInstance) || (mRegisteredNetPoint)
         || (netpoint.getSchematic() != mSchematic)
-        || (&netpoint.getNetSignal() != mComponentSignalInstance->getNetSignal()))
+        || (&netpoint.getNetSignalOfNetSegment() != mComponentSignalInstance->getNetSignal()))
     {
         throw LogicError(__FILE__, __LINE__);
     }
@@ -180,7 +180,7 @@ void SI_SymbolPin::unregisterNetPoint(SI_NetPoint& netpoint)
 {
     if ((!isAddedToSchematic()) || (!mComponentSignalInstance)
         || (mRegisteredNetPoint != &netpoint)
-        || (&netpoint.getNetSignal() != mComponentSignalInstance->getNetSignal()))
+        || (&netpoint.getNetSignalOfNetSegment() != mComponentSignalInstance->getNetSignal()))
     {
         throw LogicError(__FILE__, __LINE__);
     }

--- a/libs/librepcb/project/schematics/items/si_symbolpin.h
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.h
@@ -81,8 +81,8 @@ class SI_SymbolPin final : public SI_Base, public IF_ErcMsgProvider
         bool isUsed() const noexcept {return mRegisteredNetPoint ? true : false;}
 
         // General Methods
-        void addToSchematic(GraphicsScene& scene) override;
-        void removeFromSchematic(GraphicsScene& scene) override;
+        void addToSchematic() override;
+        void removeFromSchematic() override;
         void registerNetPoint(SI_NetPoint& netpoint);
         void unregisterNetPoint(SI_NetPoint& netpoint);
         void updatePosition() noexcept;

--- a/libs/librepcb/project/schematics/schematic.cpp
+++ b/libs/librepcb/project/schematics/schematic.cpp
@@ -29,6 +29,7 @@
 #include <librepcb/library/sym/symbolpin.h>
 #include "items/si_symbol.h"
 #include "items/si_symbolpin.h"
+#include "items/si_netsegment.h"
 #include "items/si_netpoint.h"
 #include "items/si_netline.h"
 #include "items/si_netlabel.h"
@@ -36,6 +37,7 @@
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/gridproperties.h>
 #include <librepcb/common/application.h>
+#include "schematicselectionquery.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -92,37 +94,15 @@ Schematic::Schematic(Project& project, const FilePath& filepath, bool restore,
                 mSymbols.append(symbol);
             }
 
-            // Load all netpoints
-            foreach (const SExpression& node, root.getChildren("netpoint")) {
-                SI_NetPoint* netpoint = new SI_NetPoint(*this, node);
-                if (getNetPointByUuid(netpoint->getUuid())) {
+            // Load all netsegments
+            foreach (const SExpression& node, root.getChildren("netsegment")) {
+                SI_NetSegment* netsegment = new SI_NetSegment(*this, node);
+                if (getNetSegmentByUuid(netsegment->getUuid())) {
                     throw RuntimeError(__FILE__, __LINE__,
-                        QString(tr("There is already a netpoint with the UUID \"%1\"!"))
-                        .arg(netpoint->getUuid().toStr()));
+                        QString(tr("There is already a netsegment with the UUID \"%1\"!"))
+                        .arg(netsegment->getUuid().toStr()));
                 }
-                mNetPoints.append(netpoint);
-            }
-
-            // Load all netlines
-            foreach (const SExpression& node, root.getChildren("netline")) {
-                SI_NetLine* netline = new SI_NetLine(*this, node);
-                if (getNetLineByUuid(netline->getUuid())) {
-                    throw RuntimeError(__FILE__, __LINE__,
-                        QString(tr("There is already a netline with the UUID \"%1\"!"))
-                        .arg(netline->getUuid().toStr()));
-                }
-                mNetLines.append(netline);
-            }
-
-            // Load all netlabels
-            foreach (const SExpression& node, root.getChildren("netlabel")) {
-                SI_NetLabel* netlabel = new SI_NetLabel(*this, node);
-                if (getNetLabelByUuid(netlabel->getUuid())) {
-                    throw RuntimeError(__FILE__, __LINE__,
-                        QString(tr("There is already a netlabel with the UUID \"%1\"!"))
-                        .arg(netlabel->getUuid().toStr()));
-                }
-                mNetLabels.append(netlabel);
+                mNetSegments.append(netsegment);
             }
         }
 
@@ -134,9 +114,7 @@ Schematic::Schematic(Project& project, const FilePath& filepath, bool restore,
     catch (...)
     {
         // free the allocated memory in the reverse order of their allocation...
-        qDeleteAll(mNetLabels);         mNetLabels.clear();
-        qDeleteAll(mNetLines);          mNetLines.clear();
-        qDeleteAll(mNetPoints);         mNetPoints.clear();
+        qDeleteAll(mNetSegments);       mNetSegments.clear();
         qDeleteAll(mSymbols);           mSymbols.clear();
         mGridProperties.reset();
         mFile.reset();
@@ -150,9 +128,7 @@ Schematic::~Schematic() noexcept
     Q_ASSERT(!mIsAddedToProject);
 
     // delete all items
-    qDeleteAll(mNetLabels);         mNetLabels.clear();
-    qDeleteAll(mNetLines);          mNetLines.clear();
-    qDeleteAll(mNetPoints);         mNetPoints.clear();
+    qDeleteAll(mNetSegments);       mNetSegments.clear();
     qDeleteAll(mSymbols);           mSymbols.clear();
 
     mGridProperties.reset();
@@ -166,108 +142,7 @@ Schematic::~Schematic() noexcept
 
 bool Schematic::isEmpty() const noexcept
 {
-    return (mSymbols.isEmpty() &&
-            mNetPoints.isEmpty() &&
-            mNetLines.isEmpty() &&
-            mNetLabels.isEmpty());
-}
-
-QList<SI_Base*> Schematic::getSelectedItems(bool symbolPins,
-                                            bool floatingPoints,
-                                            bool attachedPoints,
-                                            bool floatingPointsFromFloatingLines,
-                                            bool attachedPointsFromFloatingLines,
-                                            bool floatingPointsFromAttachedLines,
-                                            bool attachedPointsFromAttachedLines,
-                                            bool attachedPointsFromSymbols,
-                                            bool floatingLines,
-                                            bool attachedLines,
-                                            bool attachedLinesFromSymbols) const noexcept
-{
-    // TODO: this method is incredible ugly ;)
-
-    QList<SI_Base*> list;
-    foreach (SI_Symbol* symbol, mSymbols)
-    {
-        // symbol
-        if (symbol->isSelected())
-            list.append(symbol);
-
-        // pins
-        foreach (SI_SymbolPin* pin, symbol->getPins())
-        {
-            // pin
-            if (pin->isSelected() && symbolPins)
-                list.append(pin);
-
-            // attached netpoints & netlines
-            SI_NetPoint* attachedNetPoint = pin->getNetPoint();
-            if (symbol->isSelected() && attachedPointsFromSymbols && attachedNetPoint)
-            {
-                if (!list.contains(attachedNetPoint))
-                    list.append(attachedNetPoint);
-            }
-            if (symbol->isSelected() && attachedLinesFromSymbols && attachedNetPoint)
-            {
-                foreach (SI_NetLine* attachedNetLine, attachedNetPoint->getLines())
-                {
-                    if (!list.contains(attachedNetLine))
-                        list.append(attachedNetLine);
-                }
-            }
-        }
-    }
-    foreach (SI_NetPoint* netpoint, mNetPoints)
-    {
-        if (netpoint->isSelected())
-        {
-            if (((!netpoint->isAttachedToPin()) && floatingPoints)
-               || (netpoint->isAttachedToPin() && attachedPoints))
-            {
-                if (!list.contains(netpoint))
-                    list.append(netpoint);
-            }
-        }
-    }
-    foreach (SI_NetLine* netline, mNetLines)
-    {
-        if (netline->isSelected())
-        {
-            // netline
-            if (((!netline->isAttachedToSymbol()) && floatingLines)
-               || (netline->isAttachedToSymbol() && attachedLines))
-            {
-                if (!list.contains(netline))
-                    list.append(netline);
-            }
-            // netpoints from netlines
-            SI_NetPoint* p1 = &netline->getStartPoint();
-            SI_NetPoint* p2 = &netline->getEndPoint();
-            if ( ((!netline->isAttachedToSymbol()) && (!p1->isAttachedToPin()) && floatingPointsFromFloatingLines)
-              || ((!netline->isAttachedToSymbol()) && ( p1->isAttachedToPin()) && attachedPointsFromFloatingLines)
-              || (( netline->isAttachedToSymbol()) && (!p1->isAttachedToPin()) && floatingPointsFromAttachedLines)
-              || (( netline->isAttachedToSymbol()) && ( p1->isAttachedToPin()) && attachedPointsFromAttachedLines))
-            {
-                if (!list.contains(p1))
-                    list.append(p1);
-            }
-            if ( ((!netline->isAttachedToSymbol()) && (!p2->isAttachedToPin()) && floatingPointsFromFloatingLines)
-              || ((!netline->isAttachedToSymbol()) && ( p2->isAttachedToPin()) && attachedPointsFromFloatingLines)
-              || (( netline->isAttachedToSymbol()) && (!p2->isAttachedToPin()) && floatingPointsFromAttachedLines)
-              || (( netline->isAttachedToSymbol()) && ( p2->isAttachedToPin()) && attachedPointsFromAttachedLines))
-            {
-                if (!list.contains(p2))
-                    list.append(p2);
-            }
-        }
-    }
-    foreach (SI_NetLabel* netlabel, mNetLabels)
-    {
-        if (netlabel->isSelected())
-            list.append(netlabel);
-    }
-
-    return list;
+    return (mSymbols.isEmpty() && mNetSegments.isEmpty());
 }
 
 QList<SI_Base*> Schematic::getItemsAtScenePos(const Point& pos) const noexcept
@@ -275,37 +150,31 @@ QList<SI_Base*> Schematic::getItemsAtScenePos(const Point& pos) const noexcept
     QPointF scenePosPx = pos.toPxQPointF();
     QList<SI_Base*> list;   // Note: The order of adding the items is very important (the
                             // top most item must appear as the first item in the list)!
+
     // visible netpoints
-    foreach (SI_NetPoint* netpoint, mNetPoints)
-    {
-        if (!netpoint->isVisibleJunction()) continue;
-        if (netpoint->getGrabAreaScenePx().contains(scenePosPx))
+    const QList<SI_NetPoint*> netpoints(getNetPointsAtScenePos(pos));
+    foreach (SI_NetPoint* netpoint, netpoints) {
+        if (netpoint->isVisibleJunction()) {
             list.append(netpoint);
+        }
     }
     // hidden netpoints
-    foreach (SI_NetPoint* netpoint, mNetPoints)
-    {
-        if (netpoint->isVisibleJunction()) continue;
-        if (netpoint->getGrabAreaScenePx().contains(scenePosPx))
+    foreach (SI_NetPoint* netpoint, netpoints) {
+        if (!netpoint->isVisibleJunction()) {
             list.append(netpoint);
+        }
     }
     // netlines
-    foreach (SI_NetLine* netline, mNetLines)
-    {
-        if (netline->getGrabAreaScenePx().contains(scenePosPx))
-            list.append(netline);
+    foreach (SI_NetLine* netline, getNetLinesAtScenePos(pos)) {
+        list.append(netline);
     }
     // netlabels
-    foreach (SI_NetLabel* netlabel, mNetLabels)
-    {
-        if (netlabel->getGrabAreaScenePx().contains(scenePosPx))
-            list.append(netlabel);
+    foreach (SI_NetLabel* netlabel, getNetLabelsAtScenePos(pos)) {
+        list.append(netlabel);
     }
     // symbols & pins
-    foreach (SI_Symbol* symbol, mSymbols)
-    {
-        foreach (SI_SymbolPin* pin, symbol->getPins())
-        {
+    foreach (SI_Symbol* symbol, mSymbols) {
+        foreach (SI_SymbolPin* pin, symbol->getPins()) {
             if (pin->getGrabAreaScenePx().contains(scenePosPx))
                 list.append(pin);
         }
@@ -318,10 +187,8 @@ QList<SI_Base*> Schematic::getItemsAtScenePos(const Point& pos) const noexcept
 QList<SI_NetPoint*> Schematic::getNetPointsAtScenePos(const Point& pos) const noexcept
 {
     QList<SI_NetPoint*> list;
-    foreach (SI_NetPoint* netpoint, mNetPoints)
-    {
-        if (netpoint->getGrabAreaScenePx().contains(pos.toPxQPointF()))
-            list.append(netpoint);
+    foreach (SI_NetSegment* segment, mNetSegments) {
+        segment->getNetPointsAtScenePos(pos, list);
     }
     return list;
 }
@@ -329,10 +196,17 @@ QList<SI_NetPoint*> Schematic::getNetPointsAtScenePos(const Point& pos) const no
 QList<SI_NetLine*> Schematic::getNetLinesAtScenePos(const Point& pos) const noexcept
 {
     QList<SI_NetLine*> list;
-    foreach (SI_NetLine* netline, mNetLines)
-    {
-        if (netline->getGrabAreaScenePx().contains(pos.toPxQPointF()))
-            list.append(netline);
+    foreach (SI_NetSegment* segment, mNetSegments) {
+        segment->getNetLinesAtScenePos(pos, list);
+    }
+    return list;
+}
+
+QList<SI_NetLabel*> Schematic::getNetLabelsAtScenePos(const Point& pos) const noexcept
+{
+    QList<SI_NetLabel*> list;
+    foreach (SI_NetSegment* segment, mNetSegments) {
+        segment->getNetLabelsAtScenePos(pos, list);
     }
     return list;
 }
@@ -349,20 +223,6 @@ QList<SI_SymbolPin*> Schematic::getPinsAtScenePos(const Point& pos) const noexce
         }
     }
     return list;
-}
-
-QList<SI_Base*> Schematic::getAllItems() const noexcept
-{
-    QList<SI_Base*> items;
-    foreach (SI_Symbol* symbol, mSymbols)
-        items.append(symbol);
-    foreach (SI_NetPoint* netpoint, mNetPoints)
-        items.append(netpoint);
-    foreach (SI_NetLine* netline, mNetLines)
-        items.append(netline);
-    foreach (SI_NetLabel* netlabel, mNetLabels)
-        items.append(netlabel);
-    return items;
 }
 
 /*****************************************************************************************
@@ -401,7 +261,7 @@ void Schematic::addSymbol(SI_Symbol& symbol)
             .arg(symbol.getUuid().toStr()));
     }
     // add to schematic
-    symbol.addToSchematic(*mGraphicsScene); // can throw
+    symbol.addToSchematic(); // can throw
     mSymbols.append(&symbol);
 }
 
@@ -411,131 +271,49 @@ void Schematic::removeSymbol(SI_Symbol& symbol)
         throw LogicError(__FILE__, __LINE__);
     }
     // remove from schematic
-    symbol.removeFromSchematic(*mGraphicsScene); // can throw
+    symbol.removeFromSchematic(); // can throw
     mSymbols.removeOne(&symbol);
 }
 
 /*****************************************************************************************
- *  NetPoint Methods
+ *  NetSegment Methods
  ****************************************************************************************/
 
-SI_NetPoint* Schematic::getNetPointByUuid(const Uuid& uuid) const noexcept
+SI_NetSegment* Schematic::getNetSegmentByUuid(const Uuid& uuid) const noexcept
 {
-    foreach (SI_NetPoint* netpoint, mNetPoints) {
-        if (netpoint->getUuid() == uuid)
-            return netpoint;
+    foreach (SI_NetSegment* netsegment, mNetSegments) {
+        if (netsegment->getUuid() == uuid)
+            return netsegment;
     }
     return nullptr;
 }
 
-void Schematic::addNetPoint(SI_NetPoint& netpoint)
+void Schematic::addNetSegment(SI_NetSegment& netsegment)
 {
-    if ((!mIsAddedToProject) || (mNetPoints.contains(&netpoint))
-        || (&netpoint.getSchematic() != this))
+    if ((!mIsAddedToProject) || (mNetSegments.contains(&netsegment))
+        || (&netsegment.getSchematic() != this))
     {
         throw LogicError(__FILE__, __LINE__);
     }
-    // check if there is no netpoint with the same uuid in the list
-    if (getNetPointByUuid(netpoint.getUuid())) {
+    // check if there is no netsegment with the same uuid in the list
+    if (getNetSegmentByUuid(netsegment.getUuid())) {
         throw RuntimeError(__FILE__, __LINE__,
-            QString(tr("There is already a netpoint with the UUID \"%1\"!"))
-            .arg(netpoint.getUuid().toStr()));
+            QString(tr("There is already a netsegment with the UUID \"%1\"!"))
+            .arg(netsegment.getUuid().toStr()));
     }
     // add to schematic
-    netpoint.addToSchematic(*mGraphicsScene); // can throw
-    mNetPoints.append(&netpoint);
+    netsegment.addToSchematic(); // can throw
+    mNetSegments.append(&netsegment);
 }
 
-void Schematic::removeNetPoint(SI_NetPoint& netpoint)
+void Schematic::removeNetSegment(SI_NetSegment& netsegment)
 {
-    if ((!mIsAddedToProject) || (!mNetPoints.contains(&netpoint))) {
+    if ((!mIsAddedToProject) || (!mNetSegments.contains(&netsegment))) {
         throw LogicError(__FILE__, __LINE__);
     }
     // remove from schematic
-    netpoint.removeFromSchematic(*mGraphicsScene); // can throw an exception
-    mNetPoints.removeOne(&netpoint);
-}
-
-/*****************************************************************************************
- *  NetLine Methods
- ****************************************************************************************/
-
-SI_NetLine* Schematic::getNetLineByUuid(const Uuid& uuid) const noexcept
-{
-    foreach (SI_NetLine* netline, mNetLines) {
-        if (netline->getUuid() == uuid)
-            return netline;
-    }
-    return nullptr;
-}
-
-void Schematic::addNetLine(SI_NetLine& netline)
-{
-    if ((!mIsAddedToProject) || (mNetLines.contains(&netline))
-        || (&netline.getSchematic() != this))
-    {
-        throw LogicError(__FILE__, __LINE__);
-    }
-    // check if there is no netline with the same uuid in the list
-    if (getNetLineByUuid(netline.getUuid())) {
-        throw RuntimeError(__FILE__, __LINE__,
-            QString(tr("There is already a netline with the UUID \"%1\"!"))
-            .arg(netline.getUuid().toStr()));
-    }
-    // add to schematic
-    netline.addToSchematic(*mGraphicsScene); // can throw
-    mNetLines.append(&netline);
-}
-
-void Schematic::removeNetLine(SI_NetLine& netline)
-{
-    if ((!mIsAddedToProject) || (!mNetLines.contains(&netline))) {
-        throw LogicError(__FILE__, __LINE__);
-    }
-    // remove from schematic
-    netline.removeFromSchematic(*mGraphicsScene); // can throw
-    mNetLines.removeOne(&netline);
-}
-
-/*****************************************************************************************
- *  NetLabel Methods
- ****************************************************************************************/
-
-SI_NetLabel* Schematic::getNetLabelByUuid(const Uuid& uuid) const noexcept
-{
-    foreach (SI_NetLabel* netlabel, mNetLabels) {
-        if (netlabel->getUuid() == uuid)
-            return netlabel;
-    }
-    return nullptr;
-}
-
-void Schematic::addNetLabel(SI_NetLabel& netlabel)
-{
-    if ((!mIsAddedToProject) || (mNetLabels.contains(&netlabel))
-        || (&netlabel.getSchematic() != this))
-    {
-        throw LogicError(__FILE__, __LINE__);
-    }
-    // check if there is no netlabel with the same uuid in the list
-    if (getNetLabelByUuid(netlabel.getUuid())) {
-        throw RuntimeError(__FILE__, __LINE__,
-            QString(tr("There is already a netlabel with the UUID \"%1\"!"))
-            .arg(netlabel.getUuid().toStr()));
-    }
-    // add to schematic
-    netlabel.addToSchematic(*mGraphicsScene); // can throw
-    mNetLabels.append(&netlabel);
-}
-
-void Schematic::removeNetLabel(SI_NetLabel& netlabel)
-{
-    if ((!mIsAddedToProject) || (!mNetLabels.contains(&netlabel))) {
-        throw LogicError(__FILE__, __LINE__);
-    }
-    // remove from schematic
-    netlabel.removeFromSchematic(*mGraphicsScene); // can throw
-    mNetLabels.removeOne(&netlabel);
+    netsegment.removeFromSchematic(); // can throw
+    mNetSegments.removeOne(&netsegment);
 }
 
 /*****************************************************************************************
@@ -547,13 +325,17 @@ void Schematic::addToProject()
     if (mIsAddedToProject) {
         throw LogicError(__FILE__, __LINE__);
     }
-    QList<SI_Base*> items = getAllItems();
-    ScopeGuardList sgl(items.count());
-    for (int i = 0; i < items.count(); ++i) {
-        SI_Base* item = items.at(i);
-        item->addToSchematic(*mGraphicsScene); // can throw
-        sgl.add([this, item](){item->removeFromSchematic(*mGraphicsScene);});
+
+    ScopeGuardList sgl(mSymbols.count() + mNetSegments.count());
+    foreach (SI_Symbol* symbol, mSymbols) {
+        symbol->addToSchematic(); // can throw
+        sgl.add([this, symbol](){symbol->removeFromSchematic();});
     }
+    foreach (SI_NetSegment* segment, mNetSegments) {
+        segment->addToSchematic(); // can throw
+        sgl.add([this, segment](){segment->removeFromSchematic();});
+    }
+
     mIsAddedToProject = true;
     updateIcon();
     sgl.dismiss();
@@ -564,13 +346,17 @@ void Schematic::removeFromProject()
     if (!mIsAddedToProject) {
         throw LogicError(__FILE__, __LINE__);
     }
-    QList<SI_Base*> items = getAllItems();
-    ScopeGuardList sgl(items.count());
-    for (int i = items.count()-1; i >= 0; --i) {
-        SI_Base* item = items.at(i);
-        item->removeFromSchematic(*mGraphicsScene); // can throw
-        sgl.add([this, item](){item->addToSchematic(*mGraphicsScene);});
+
+    ScopeGuardList sgl(mSymbols.count() + mNetSegments.count());
+    foreach (SI_NetSegment* segment, mNetSegments) {
+        segment->removeFromSchematic(); // can throw
+        sgl.add([this, segment](){segment->addToSchematic();});
     }
+    foreach (SI_Symbol* symbol, mSymbols) {
+        symbol->removeFromSchematic(); // can throw
+        sgl.add([this, symbol](){symbol->addToSchematic();});
+    }
+
     mIsAddedToProject = false;
     sgl.dismiss();
 }
@@ -612,40 +398,46 @@ void Schematic::setSelectionRect(const Point& p1, const Point& p2, bool updateIt
     if (updateItems)
     {
         QRectF rectPx = QRectF(p1.toPxQPointF(), p2.toPxQPointF()).normalized();
-        foreach (SI_Symbol* symbol, mSymbols)
-        {
+        foreach (SI_Symbol* symbol, mSymbols) {
             bool selectSymbol = symbol->getGrabAreaScenePx().intersects(rectPx);
             symbol->setSelected(selectSymbol);
-            foreach (SI_SymbolPin* pin, symbol->getPins())
-            {
+            foreach (SI_SymbolPin* pin, symbol->getPins()) {
                 bool selectPin = pin->getGrabAreaScenePx().intersects(rectPx);
                 pin->setSelected(selectSymbol || selectPin);
             }
         }
-        foreach (SI_NetPoint* netpoint, mNetPoints)
-            netpoint->setSelected(netpoint->getGrabAreaScenePx().intersects(rectPx));
-        foreach (SI_NetLine* netline, mNetLines)
-            netline->setSelected(netline->getGrabAreaScenePx().intersects(rectPx));
-        foreach (SI_NetLabel* netlabel, mNetLabels)
-            netlabel->setSelected(netlabel->getGrabAreaScenePx().intersects(rectPx));
+        foreach (SI_NetSegment* segment, mNetSegments) {
+            segment->setSelectionRect(rectPx);
+        }
     }
 }
 
 void Schematic::clearSelection() const noexcept
 {
-    foreach (SI_Symbol* symbol, mSymbols)
+    foreach (SI_Symbol* symbol, mSymbols) {
         symbol->setSelected(false);
-    foreach (SI_NetPoint* netpoint, mNetPoints)
-        netpoint->setSelected(false);
-    foreach (SI_NetLine* netline, mNetLines)
-        netline->setSelected(false);
-    foreach (SI_NetLabel* netlabel, mNetLabels)
-        netlabel->setSelected(false);
+    }
+    foreach (SI_NetSegment* segment, mNetSegments) {
+        segment->clearSelection();
+    }
+}
+
+void Schematic::updateAllNetLabelAnchors() noexcept
+{
+    foreach (SI_NetSegment* netsegment, mNetSegments) {
+        netsegment->updateAllNetLabelAnchors();
+    }
 }
 
 void Schematic::renderToQPainter(QPainter& painter) const noexcept
 {
     mGraphicsScene->render(&painter, QRectF(), mGraphicsScene->itemsBoundingRect(), Qt::KeepAspectRatio);
+}
+
+std::unique_ptr<SchematicSelectionQuery> Schematic::createSelectionQuery() const noexcept
+{
+    return std::unique_ptr<SchematicSelectionQuery>(
+        new SchematicSelectionQuery(mSymbols, mNetSegments, const_cast<Schematic*>(this)));
 }
 
 /*****************************************************************************************
@@ -701,11 +493,7 @@ void Schematic::serialize(SExpression& root) const
     root.appendLineBreak();
     serializePointerContainer(root, mSymbols, "symbol");
     root.appendLineBreak();
-    serializePointerContainer(root, mNetPoints, "netpoint");
-    root.appendLineBreak();
-    serializePointerContainer(root, mNetLines, "netline");
-    root.appendLineBreak();
-    serializePointerContainer(root, mNetLabels, "netlabel");
+    serializePointerContainer(root, mNetSegments, "netsegment");
     root.appendLineBreak();
 }
 

--- a/libs/librepcb/project/schematics/schematiclayerprovider.cpp
+++ b/libs/librepcb/project/schematics/schematiclayerprovider.cpp
@@ -50,6 +50,7 @@ SchematicLayerProvider::SchematicLayerProvider(Project& project):
     addLayer(GraphicsLayer::sSymbolValues);
     addLayer(GraphicsLayer::sSchematicNetLines);
     addLayer(GraphicsLayer::sSchematicNetLabels);
+    addLayer(GraphicsLayer::sSchematicNetLabelAnchors);
     addLayer(GraphicsLayer::sSchematicDocumentation);
     addLayer(GraphicsLayer::sSchematicComments);
     addLayer(GraphicsLayer::sSchematicGuide);

--- a/libs/librepcb/project/schematics/schematicselectionquery.cpp
+++ b/libs/librepcb/project/schematics/schematicselectionquery.cpp
@@ -1,0 +1,155 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "schematicselectionquery.h"
+#include "schematic.h"
+#include "items/si_symbol.h"
+#include "items/si_symbolpin.h"
+#include "items/si_netsegment.h"
+#include "items/si_netpoint.h"
+#include "items/si_netline.h"
+#include "items/si_netlabel.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+SchematicSelectionQuery::SchematicSelectionQuery(const QList<SI_Symbol*>& symbols,
+                                                 const QList<SI_NetSegment*>& netsegments,
+                                                 QObject* parent) :
+    QObject(parent), mSymbols(symbols), mNetSegments(netsegments)
+{
+}
+
+SchematicSelectionQuery::~SchematicSelectionQuery() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Getters: General
+ ****************************************************************************************/
+
+int SchematicSelectionQuery::getResultCount() const noexcept
+{
+    return  mResultSymbols.count() +
+            mResultNetPoints.count() +
+            mResultNetLines.count() +
+            mResultNetLabels.count();
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void SchematicSelectionQuery::addSelectedSymbols() noexcept
+{
+    foreach (SI_Symbol* symbol, mSymbols) {
+        if (symbol->isSelected()) {
+            mResultSymbols.insert(symbol);
+        }
+    }
+}
+
+void SchematicSelectionQuery::addSelectedNetPoints(NetPointFilters f) noexcept
+{
+    foreach (SI_NetSegment* netsegment, mNetSegments) {
+        foreach (SI_NetPoint* netpoint, netsegment->getNetPoints()) {
+            if (netpoint->isSelected() && doesNetPointMatchFilter(*netpoint, f)) {
+                mResultNetPoints.insert(netpoint);
+            }
+        }
+    }
+}
+
+void SchematicSelectionQuery::addSelectedNetLines(NetLineFilters f) noexcept
+{
+    foreach (SI_NetSegment* netsegment, mNetSegments) {
+        foreach (SI_NetLine* netline, netsegment->getNetLines()) {
+            if (netline->isSelected() && doesNetLineMatchFilter(*netline, f)) {
+                mResultNetLines.insert(netline);
+            }
+        }
+    }
+}
+
+void SchematicSelectionQuery::addSelectedNetLabels() noexcept
+{
+    foreach (SI_NetSegment* netsegment, mNetSegments) {
+        foreach (SI_NetLabel* netlabel, netsegment->getNetLabels()) {
+            if (netlabel->isSelected()) {
+                mResultNetLabels.insert(netlabel);
+            }
+        }
+    }
+}
+
+void SchematicSelectionQuery::addNetPointsOfNetLines(NetLineFilters lf, NetPointFilters pf) noexcept
+{
+    foreach (SI_NetLine* netline, mResultNetLines) {
+        if (doesNetLineMatchFilter(*netline, lf)) {
+            if (doesNetPointMatchFilter(netline->getStartPoint(), pf)) {
+                mResultNetPoints.insert(&netline->getStartPoint());
+            }
+            if (doesNetPointMatchFilter(netline->getEndPoint(), pf)) {
+                mResultNetPoints.insert(&netline->getEndPoint());
+            }
+        }
+    }
+}
+
+bool SchematicSelectionQuery::doesNetPointMatchFilter(const SI_NetPoint& p, NetPointFilters f) noexcept
+{
+    if (f.testFlag(NetPointFilter::Floating) && (!p.isAttachedToPin())) return true;
+    if (f.testFlag(NetPointFilter::Attached) && (p.isAttachedToPin())) return true;
+    if (f.testFlag(NetPointFilter::AllConnectedLinesSelected)) {
+        bool allLinesSelected = true;
+        foreach (const SI_NetLine* netline, p.getLines()) {
+            if (!netline->isSelected()) {
+                allLinesSelected = false;
+                break;
+            }
+        }
+        if (allLinesSelected) return true;
+    }
+    return false;
+}
+
+bool SchematicSelectionQuery::doesNetLineMatchFilter(const SI_NetLine& l, NetLineFilters f) noexcept
+{
+    if (f.testFlag(NetLineFilter::Floating) && (!l.isAttachedToSymbol())) return true;
+    if (f.testFlag(NetLineFilter::Attached) && (l.isAttachedToSymbol())) return true;
+    return false;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/project/schematics/schematicselectionquery.h
+++ b/libs/librepcb/project/schematics/schematicselectionquery.h
@@ -1,0 +1,125 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_SCHEMATICSELECTIONQUERY_H
+#define LIBREPCB_PROJECT_SCHEMATICSELECTIONQUERY_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcb/common/exceptions.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+class SI_Symbol;
+class SI_SymbolPin;
+class SI_NetSegment;
+class SI_NetLine;
+class SI_NetPoint;
+class SI_NetLabel;
+
+/*****************************************************************************************
+ *  Class SchematicSelectionQuery
+ ****************************************************************************************/
+
+/**
+ * @brief The SchematicSelectionQuery class
+ */
+class SchematicSelectionQuery final : public QObject
+{
+        Q_OBJECT
+
+    public:
+
+        // Types
+        enum class NetPointFilter : uint32_t {
+            Floating = (1 << 0),
+            Attached = (1 << 1),
+            AllConnectedLinesSelected = (1 << 2),
+            All = (NetPointFilter::Floating | NetPointFilter::Attached)
+        };
+        Q_DECLARE_FLAGS(NetPointFilters, NetPointFilter)
+
+        enum class NetLineFilter : uint32_t {
+            Floating = (1 << 0),
+            Attached = (1 << 1),
+            All = (NetLineFilter::Floating | NetLineFilter::Attached)
+        };
+        Q_DECLARE_FLAGS(NetLineFilters, NetLineFilter)
+
+
+        // Constructors / Destructor
+        SchematicSelectionQuery() = delete;
+        SchematicSelectionQuery(const SchematicSelectionQuery& other) = delete;
+        SchematicSelectionQuery(const QList<SI_Symbol*>& symbols,
+                                const QList<SI_NetSegment*>& netsegments,
+                                QObject* parent = nullptr);
+        ~SchematicSelectionQuery() noexcept;
+
+        // Getters
+        const QSet<SI_Symbol*>& getSymbols() const noexcept { return mResultSymbols; }
+        const QSet<SI_NetPoint*>& getNetPoints() const noexcept { return mResultNetPoints; }
+        const QSet<SI_NetLine*>& getNetLines() const noexcept { return mResultNetLines; }
+        const QSet<SI_NetLabel*>& getNetLabels() const noexcept { return mResultNetLabels; }
+        int getResultCount() const noexcept;
+        bool isResultEmpty() const noexcept { return (getResultCount() == 0); }
+
+        // General Methods
+        void addSelectedSymbols() noexcept;
+        void addSelectedNetPoints(NetPointFilters f) noexcept;
+        void addSelectedNetLines(NetLineFilters f) noexcept;
+        void addSelectedNetLabels() noexcept;
+        void addNetPointsOfNetLines(NetLineFilters lf, NetPointFilters pf) noexcept;
+
+        // Operator Overloadings
+        SchematicSelectionQuery& operator=(const SchematicSelectionQuery& rhs) = delete;
+
+
+    private:
+
+        static bool doesNetPointMatchFilter(const SI_NetPoint& p, NetPointFilters f) noexcept;
+        static bool doesNetLineMatchFilter(const SI_NetLine& l, NetLineFilters f) noexcept;
+
+        // references to the Schematic object
+        const QList<SI_Symbol*>& mSymbols;
+        const QList<SI_NetSegment*>& mNetSegments;
+
+        // query result
+        QSet<SI_Symbol*> mResultSymbols;
+        QSet<SI_NetPoint*> mResultNetPoints;
+        QSet<SI_NetLine*> mResultNetLines;
+        QSet<SI_NetLabel*> mResultNetLabels;
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(SchematicSelectionQuery::NetPointFilters)
+Q_DECLARE_OPERATORS_FOR_FLAGS(SchematicSelectionQuery::NetLineFilters)
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_SCHEMATICSELECTIONQUERY_H

--- a/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.cpp
@@ -1,0 +1,133 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdchangenetsignalofschematicnetsegment.h"
+#include <librepcb/project/project.h>
+#include <librepcb/project/circuit/netsignal.h>
+#include <librepcb/project/circuit/componentsignalinstance.h>
+#include <librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.h>
+#include <librepcb/project/schematics/items/si_netsegment.h>
+#include <librepcb/project/schematics/items/si_netpoint.h>
+#include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.h>
+#include <librepcb/project/boards/items/bi_netpoint.h>
+#include <librepcb/project/boards/items/bi_footprintpad.h>
+#include "cmdcombinenetsignals.h"
+#include "cmddetachboardnetpointfromviaorpad.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdChangeNetSignalOfSchematicNetSegment::CmdChangeNetSignalOfSchematicNetSegment(
+        SI_NetSegment& seg, NetSignal& newSig) noexcept :
+    UndoCommandGroup(tr("Change netsignal of netsegment")),
+    mNetSegment(seg), mNewNetSignal(newSig)
+{
+}
+
+CmdChangeNetSignalOfSchematicNetSegment::~CmdChangeNetSignalOfSchematicNetSegment() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdChangeNetSignalOfSchematicNetSegment::performExecute()
+{
+    if (mNewNetSignal == mNetSegment.getNetSignal()) {
+        // nothing to do, the netsignal is already correct
+        return false;
+    } else if (mNetSegment.getNetSignal().getSchematicNetSegments().count() == 1) {
+        // this netsegment is the only one in its netsignal,
+        // we just need to combine both netsignals
+        Circuit& circuit = mNetSegment.getCircuit();
+        NetSignal& toBeRemoved = mNetSegment.getNetSignal();
+        NetSignal& result = mNewNetSignal;
+        appendChild(new CmdCombineNetSignals(circuit, toBeRemoved, result));
+    } else {
+        // there are still some other netsegments with the same netsignal
+        Q_ASSERT(mNetSegment.getNetSignal().getSchematicNetSegments().count() > 1);
+        changeNetSignalOfNetSegment();
+    }
+
+    // execute all child commands
+    return UndoCommandGroup::performExecute(); // can throw
+}
+
+void CmdChangeNetSignalOfSchematicNetSegment::changeNetSignalOfNetSegment()
+{
+    // remove netsegment
+    appendChild(new CmdSchematicNetSegmentRemove(mNetSegment));
+
+    // set netsignal of netsegment
+    CmdSchematicNetSegmentEdit* cmd = new CmdSchematicNetSegmentEdit(mNetSegment);
+    cmd->setNetSignal(mNewNetSignal);
+    appendChild(cmd);
+
+    // change netsignal of all connected symbol pins (resp. their component signals)
+    foreach (SI_NetPoint* netpoint, mNetSegment.getNetPoints()) { Q_ASSERT(netpoint);
+        if (netpoint->isAttachedToPin()) {
+            SI_SymbolPin* pin = netpoint->getSymbolPin(); Q_ASSERT(pin);
+            Q_ASSERT(pin->getCompSigInstNetSignal() == &mNetSegment.getNetSignal());
+            ComponentSignalInstance* sig = pin->getComponentSignalInstance();
+            if (sig) {
+                updateCompSigInstNetSignal(*sig);
+            }
+        }
+    }
+
+    // re-add netsegment
+    appendChild(new CmdSchematicNetSegmentAdd(mNetSegment));
+}
+
+void CmdChangeNetSignalOfSchematicNetSegment::updateCompSigInstNetSignal(ComponentSignalInstance& cmpSig)
+{
+    // disconnect traces from pads in all boards
+    foreach (BI_FootprintPad* pad, cmpSig.getRegisteredFootprintPads()) { Q_ASSERT(pad);
+        foreach (BI_NetPoint* netpoint, pad->getNetPoints()) { Q_ASSERT(netpoint);
+            appendChild(new CmdDetachBoardNetPointFromViaOrPad(*netpoint));
+        }
+    }
+
+    // change netsignal of component signal instance
+    appendChild(new CmdCompSigInstSetNetSignal(cmpSig, &mNewNetSignal));
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace editor
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.h
+++ b/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.h
@@ -17,14 +17,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
-#define LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
+#ifndef LIBREPCB_PROJECT_CMDCHANGENETSIGNALOFSCHEMATICNETSEGMENT_H
+#define LIBREPCB_PROJECT_CMDCHANGENETSIGNALOFSCHEMATICNETSEGMENT_H
 
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcb/common/undocommandgroup.h>
+#include <librepcb/common/uuid.h>
+#include <librepcb/common/units/all_length_units.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -32,26 +34,28 @@
 namespace librepcb {
 namespace project {
 
-class SI_NetPoint;
+class NetSignal;
+class ComponentSignalInstance;
+class SI_NetSegment;
 
 namespace editor {
 
 /*****************************************************************************************
- *  Class CmdCombineSchematicNetPoints
+ *  Class CmdChangeNetSignalOfSchematicNetSegment
  ****************************************************************************************/
 
 /**
- * @brief This undo command combines two schematic netpoints together
- *
- * @note Both netpoints must have the same netsegment!
+ * @brief The CmdChangeNetSignalOfSchematicNetSegment class
  */
-class CmdCombineSchematicNetPoints final : public UndoCommandGroup
+class CmdChangeNetSignalOfSchematicNetSegment final : public UndoCommandGroup
 {
     public:
 
         // Constructors / Destructor
-        CmdCombineSchematicNetPoints(SI_NetPoint& toBeRemoved, SI_NetPoint& result) noexcept;
-        ~CmdCombineSchematicNetPoints() noexcept;
+        CmdChangeNetSignalOfSchematicNetSegment() = delete;
+        CmdChangeNetSignalOfSchematicNetSegment(const CmdChangeNetSignalOfSchematicNetSegment& other) = delete;
+        CmdChangeNetSignalOfSchematicNetSegment(SI_NetSegment& seg, NetSignal& newSig) noexcept;
+        ~CmdChangeNetSignalOfSchematicNetSegment() noexcept;
 
 
     private:
@@ -61,10 +65,15 @@ class CmdCombineSchematicNetPoints final : public UndoCommandGroup
         /// @copydoc UndoCommand::performExecute()
         bool performExecute() override;
 
+        void changeNetSignalOfNetSegment();
+        void updateCompSigInstNetSignal(ComponentSignalInstance& cmpSig);
+
+
+        // Private Member Variables
 
         // Attributes from the constructor
-        SI_NetPoint& mNetPointToBeRemoved;
-        SI_NetPoint& mResultingNetPoint;
+        SI_NetSegment& mNetSegment;
+        NetSignal& mNewNetSignal;
 };
 
 /*****************************************************************************************
@@ -75,4 +84,4 @@ class CmdCombineSchematicNetPoints final : public UndoCommandGroup
 } // namespace project
 } // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
+#endif // LIBREPCB_PROJECT_CMDCHANGENETSIGNALOFSCHEMATICNETSEGMENT_H

--- a/libs/librepcb/projecteditor/cmd/cmdcombineallitemsunderschematicnetpoint.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineallitemsunderschematicnetpoint.cpp
@@ -1,0 +1,227 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdcombineallitemsunderschematicnetpoint.h"
+#include <librepcb/common/scopeguard.h>
+#include <librepcb/project/project.h>
+#include <librepcb/project/circuit/circuit.h>
+#include <librepcb/project/circuit/netclass.h>
+#include <librepcb/project/circuit/netsignal.h>
+#include <librepcb/project/circuit/componentsignalinstance.h>
+#include <librepcb/project/schematics/schematic.h>
+#include <librepcb/project/schematics/items/si_netpoint.h>
+#include <librepcb/project/schematics/items/si_netline.h>
+#include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/items/si_netsegment.h>
+#include <librepcb/project/circuit/cmd/cmdnetsignaledit.h>
+#include <librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetpointedit.h>
+#include "cmdcombinenetsignals.h"
+#include "cmdcombineschematicnetpoints.h"
+#include "cmdremoveunusednetsignals.h"
+#include "cmdchangenetsignalofschematicnetsegment.h"
+#include "cmdcombineschematicnetsegments.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdCombineAllItemsUnderSchematicNetPoint::CmdCombineAllItemsUnderSchematicNetPoint(
+        SI_NetPoint& netpoint) noexcept :
+    UndoCommandGroup(tr("Combine Schematic Items")),
+    mCircuit(netpoint.getCircuit()), mSchematic(netpoint.getSchematic()), mNetPoint(netpoint),
+    mHasCombinedSomeItems(false)
+{
+}
+
+CmdCombineAllItemsUnderSchematicNetPoint::~CmdCombineAllItemsUnderSchematicNetPoint() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdCombineAllItemsUnderSchematicNetPoint::performExecute()
+{
+    // if an error occurs, undo all already executed child commands
+    auto undoScopeGuard = scopeGuard([&](){performUndo();});
+
+    // TODO:
+    // - Add a more sophisticated algorithm to determine the resulting netsignal
+    // - Maybe a callback is required to let the user choose the resulting netsignal if
+    //   the resulting netsignal cannot be determined automatically.
+
+    // get all netpoints, netlines and symbol pins under the netpoint
+    QList<SI_NetPoint*> netpointsUnderCursor = mSchematic.getNetPointsAtScenePos(mNetPoint.getPosition());
+    QList<SI_NetLine*> netlinesUnderCursor = mSchematic.getNetLinesAtScenePos(mNetPoint.getPosition());
+    QList<SI_SymbolPin*> pinsUnderCursor = mSchematic.getPinsAtScenePos(mNetPoint.getPosition());
+
+    // get all other netsegments/netsignals of the items under the netpoint
+    QSet<SI_NetSegment*> netSegmentsUnderCursor;
+    QSet<NetSignal*> netSignalsUnderCursor;
+    QSet<QString> forcedNetNames;
+    foreach (SI_NetPoint* netpoint, netpointsUnderCursor) {
+        netSegmentsUnderCursor.insert(&netpoint->getNetSegment());
+        netSignalsUnderCursor.insert(&netpoint->getNetSignalOfNetSegment());
+    }
+    foreach (SI_NetLine* netline, netlinesUnderCursor) {
+        netSegmentsUnderCursor.insert(&netline->getNetSegment());
+        netSignalsUnderCursor.insert(&netline->getNetSignalOfNetSegment());
+    }
+    foreach (SI_SymbolPin* pin, pinsUnderCursor) {
+        NetSignal* signal = pin->getCompSigInstNetSignal();
+        if (signal) {
+            netSignalsUnderCursor.insert(signal);
+        }
+        ComponentSignalInstance* cmpSig = pin->getComponentSignalInstance();
+        if ((cmpSig) && (cmpSig->isNetSignalNameForced())) {
+            forcedNetNames.insert(cmpSig->getForcedNetSignalName());
+        }
+    }
+    foreach (NetSignal* netsignal, netSignalsUnderCursor) {
+        if (netsignal->isNameForced()) {
+            forcedNetNames.insert(netsignal->getName());
+        }
+    }
+
+    // check forced net names
+    QString nameOfResultingNetSignal;
+    if (forcedNetNames.count() == 0) {
+        nameOfResultingNetSignal = mNetPoint.getNetSignalOfNetSegment().getName();
+    } else if (forcedNetNames.count() == 1) {
+        nameOfResultingNetSignal = *forcedNetNames.constBegin();
+    } else if (forcedNetNames.count() > 1) {
+        // TODO: what should we do here?
+        throw RuntimeError(__FILE__, __LINE__,
+             tr("There are multiple different nets with forced names at this position."));
+    }
+    Q_ASSERT(!nameOfResultingNetSignal.isEmpty());
+
+    // determine resulting netsignal
+    NetSignal* resultingNetSignal = mCircuit.getNetSignalByName(nameOfResultingNetSignal);
+    if (!resultingNetSignal) {
+        // rename current netsignal
+        CmdNetSignalEdit* cmd = new CmdNetSignalEdit(mCircuit, mNetPoint.getNetSignalOfNetSegment());
+        cmd->setName(nameOfResultingNetSignal, false);
+        execNewChildCmd(cmd); // can throw
+        resultingNetSignal = &mNetPoint.getNetSignalOfNetSegment();
+    }
+    Q_ASSERT(resultingNetSignal);
+
+    // change netsignal of all netsegments
+    foreach (SI_NetSegment* netsegment, netSegmentsUnderCursor) { Q_ASSERT(netsegment);
+        execNewChildCmd(new CmdChangeNetSignalOfSchematicNetSegment(
+                            *netsegment, *resultingNetSignal)); // can throw
+    }
+
+    // combine all netsegments together
+    SI_NetSegment& resultingNetSegment = mNetPoint.getNetSegment();
+    foreach (SI_NetSegment* netsegment, netSegmentsUnderCursor) { Q_ASSERT(netsegment);
+        if (netsegment != &resultingNetSegment) {
+            execNewChildCmd(new CmdCombineSchematicNetSegments(*netsegment, mNetPoint)); // can throw
+            mHasCombinedSomeItems = true;
+        }
+    }
+
+    // combine with netpoints & netlines of the same netsegment under the cursor
+    netpointsUnderCursor.clear();
+    resultingNetSegment.getNetPointsAtScenePos(mNetPoint.getPosition(), netpointsUnderCursor);
+    netpointsUnderCursor.removeOne(&mNetPoint);
+    if (netpointsUnderCursor.count() > 0) {
+        foreach (SI_NetPoint* netpoint, netpointsUnderCursor) {
+            execNewChildCmd(new CmdCombineSchematicNetPoints(*netpoint, mNetPoint)); // can throw
+            mHasCombinedSomeItems = true;
+        }
+    } else {
+        netlinesUnderCursor.clear();
+        resultingNetSegment.getNetLinesAtScenePos(mNetPoint.getPosition(), netlinesUnderCursor);
+        QList<SI_NetLine*> netlinesOfNetpoint = mNetPoint.getLines();
+        foreach (SI_NetLine* netline, netlinesUnderCursor) {
+            if (!netlinesOfNetpoint.contains(netline)) {
+                // TODO: do not create redundant netlines!
+                auto* cmdAdd = new CmdSchematicNetSegmentAddElements(resultingNetSegment);
+                auto* cmdRemove = new CmdSchematicNetSegmentRemoveElements(resultingNetSegment);
+                cmdRemove->removeNetLine(*netline);
+                cmdAdd->addNetLine(mNetPoint, netline->getStartPoint());
+                cmdAdd->addNetLine(mNetPoint, netline->getEndPoint());
+                execNewChildCmd(cmdAdd); // can throw
+                execNewChildCmd(cmdRemove); // can throw
+                mHasCombinedSomeItems = true;
+            }
+        }
+    }
+
+    // TODO: connect all pins under the cursor to the netsegment
+    if (pinsUnderCursor.count() == 1) {
+        SI_SymbolPin* pin = pinsUnderCursor.first();
+        if (mNetPoint.getSymbolPin() != pin) {
+            if (mNetPoint.getSymbolPin() == nullptr) {
+                // connect pin to netsignal
+                ComponentSignalInstance* cmpSig = pin->getComponentSignalInstance();
+                if (cmpSig->getNetSignal() != resultingNetSignal) {
+                    // TODO: this does not work in all cases?!
+                    execNewChildCmd(new CmdCompSigInstSetNetSignal(*cmpSig, resultingNetSignal)); // can throw
+                }
+                // attach netpoint to pin
+                execNewChildCmd(new CmdSchematicNetSegmentRemove(resultingNetSegment)); // can throw
+                CmdSchematicNetPointEdit* cmd = new CmdSchematicNetPointEdit(mNetPoint);
+                cmd->setPinToAttach(pin);
+                execNewChildCmd(cmd); // can throw
+                execNewChildCmd(new CmdSchematicNetSegmentAdd(resultingNetSegment)); // can throw
+                mHasCombinedSomeItems = true;
+            } else {
+                throw RuntimeError(__FILE__, __LINE__, tr("Sorry, not yet implemented..."));
+            }
+        }
+    } else if (pinsUnderCursor.count() > 1) {
+        throw RuntimeError(__FILE__, __LINE__, tr("Sorry, not yet implemented..."));
+    }
+
+    if (getChildCount() > 0) {
+        // remove netsignals which are no longer required
+        execNewChildCmd(new CmdRemoveUnusedNetSignals(mSchematic.getProject().getCircuit())); // can throw
+    }
+
+    undoScopeGuard.dismiss(); // no undo required
+    return (getChildCount() > 0);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace editor
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/projecteditor/cmd/cmdcombineallitemsunderschematicnetpoint.h
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineallitemsunderschematicnetpoint.h
@@ -17,14 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
-#define LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
+#ifndef LIBREPCB_PROJECT_CMDCOMBINEALLITEMSUNDERSCHEMATICNETPOINT_H
+#define LIBREPCB_PROJECT_CMDCOMBINEALLITEMSUNDERSCHEMATICNETPOINT_H
 
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
 #include <librepcb/common/undocommandgroup.h>
+#include <librepcb/common/units/point.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -32,26 +33,29 @@
 namespace librepcb {
 namespace project {
 
+class Circuit;
+class Schematic;
 class SI_NetPoint;
 
 namespace editor {
 
 /*****************************************************************************************
- *  Class CmdCombineSchematicNetPoints
+ *  Class CmdCombineAllItemsUnderSchematicNetPoint
  ****************************************************************************************/
 
 /**
- * @brief This undo command combines two schematic netpoints together
- *
- * @note Both netpoints must have the same netsegment!
+ * @brief The CmdCombineAllItemsUnderSchematicNetPoint class
  */
-class CmdCombineSchematicNetPoints final : public UndoCommandGroup
+class CmdCombineAllItemsUnderSchematicNetPoint final : public UndoCommandGroup
 {
     public:
 
         // Constructors / Destructor
-        CmdCombineSchematicNetPoints(SI_NetPoint& toBeRemoved, SI_NetPoint& result) noexcept;
-        ~CmdCombineSchematicNetPoints() noexcept;
+        CmdCombineAllItemsUnderSchematicNetPoint(SI_NetPoint& netpoint) noexcept;
+        ~CmdCombineAllItemsUnderSchematicNetPoint() noexcept;
+
+        // Getters
+        bool hasCombinedSomeItems() const noexcept {return mHasCombinedSomeItems;}
 
 
     private:
@@ -63,8 +67,12 @@ class CmdCombineSchematicNetPoints final : public UndoCommandGroup
 
 
         // Attributes from the constructor
-        SI_NetPoint& mNetPointToBeRemoved;
-        SI_NetPoint& mResultingNetPoint;
+        Circuit& mCircuit;
+        Schematic& mSchematic;
+        SI_NetPoint& mNetPoint;
+
+        // Private Member Variables
+        bool mHasCombinedSomeItems;
 };
 
 /*****************************************************************************************
@@ -75,4 +83,4 @@ class CmdCombineSchematicNetPoints final : public UndoCommandGroup
 } // namespace project
 } // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
+#endif // LIBREPCB_PROJECT_CMDCOMBINEALLITEMSUNDERSCHEMATICNETPOINT_H

--- a/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
@@ -1,0 +1,165 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdcombineschematicnetsegments.h"
+#include <librepcb/common/scopeguard.h>
+#include <librepcb/project/circuit/netsignal.h>
+#include <librepcb/project/schematics/items/si_netsegment.h>
+#include <librepcb/project/schematics/items/si_netpoint.h>
+#include <librepcb/project/schematics/items/si_netline.h>
+#include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h>
+#include "cmdremoveunusednetsignals.h"
+#include "cmdcombineschematicnetpoints.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdCombineSchematicNetSegments::CmdCombineSchematicNetSegments(SI_NetSegment& toBeRemoved,
+                                                               SI_NetPoint& junction) noexcept :
+    UndoCommandGroup(tr("Combine Schematic Netsegments")),
+    mNetSegmentToBeRemoved(toBeRemoved), mJunctionNetPoint(junction)
+{
+}
+
+CmdCombineSchematicNetSegments::~CmdCombineSchematicNetSegments() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdCombineSchematicNetSegments::performExecute()
+{
+    // if an error occurs, undo all already executed child commands
+    auto undoScopeGuard = scopeGuard([&](){performUndo();});
+
+    // check arguments validity
+    if (mNetSegmentToBeRemoved == mJunctionNetPoint.getNetSegment())
+        throw LogicError(__FILE__, __LINE__);
+    if (mNetSegmentToBeRemoved.getNetSignal() != mJunctionNetPoint.getNetSignalOfNetSegment())
+        throw LogicError(__FILE__, __LINE__);
+
+    // find all interception netpoints
+    QList<SI_NetPoint*> netpointsUnderJunction;
+    mNetSegmentToBeRemoved.getNetPointsAtScenePos(mJunctionNetPoint.getPosition(), netpointsUnderJunction);
+
+    // create exactly one interception netpoint
+    SI_NetPoint* interceptionNetPoint = nullptr;
+    if (netpointsUnderJunction.count() == 0) {
+        QList<SI_NetLine*> netlinesUnderJunction;
+        mNetSegmentToBeRemoved.getNetLinesAtScenePos(mJunctionNetPoint.getPosition(), netlinesUnderJunction);
+        if (netlinesUnderJunction.count() == 0) {
+            throw LogicError(__FILE__, __LINE__);
+        } else {
+            Q_ASSERT(netlinesUnderJunction.count() > 0);
+            SI_NetLine* netline = netlinesUnderJunction.first(); Q_ASSERT(netline);
+            interceptionNetPoint = &addNetPointInMiddleOfNetLine(*netline, mJunctionNetPoint.getPosition());
+        }
+    } else if (netpointsUnderJunction.count() == 1) {
+        interceptionNetPoint = netpointsUnderJunction.first();
+    } else {
+        Q_ASSERT(netpointsUnderJunction.count() > 1);
+        interceptionNetPoint = netpointsUnderJunction.first();
+        foreach (SI_NetPoint* netpoint, netpointsUnderJunction) {
+            if (netpoint != interceptionNetPoint) {
+                execNewChildCmd(new CmdCombineSchematicNetPoints(
+                                    *netpoint, *interceptionNetPoint)); // can throw
+            }
+        }
+    }
+    Q_ASSERT(interceptionNetPoint);
+
+    // move all required netpoints/netlines to the resulting netsegment
+    CmdSchematicNetSegmentAddElements* cmdAdd = new CmdSchematicNetSegmentAddElements(mJunctionNetPoint.getNetSegment());
+    QHash<SI_NetPoint*, SI_NetPoint*> netPointMap;
+    foreach (SI_NetPoint* netpoint, mNetSegmentToBeRemoved.getNetPoints()) {
+        if (netpoint == interceptionNetPoint) {
+            netPointMap.insert(netpoint, &mJunctionNetPoint);
+        } else if (netpoint->isAttachedToPin()) {
+            SI_SymbolPin* pin = netpoint->getSymbolPin(); Q_ASSERT(pin);
+            SI_NetPoint* newNetPoint = cmdAdd->addNetPoint(*pin); Q_ASSERT(newNetPoint);
+            netPointMap.insert(netpoint, newNetPoint);
+        } else {
+            SI_NetPoint* newNetPoint = cmdAdd->addNetPoint(netpoint->getPosition()); Q_ASSERT(newNetPoint);
+            netPointMap.insert(netpoint, newNetPoint);
+        }
+    }
+    foreach (SI_NetLine* netline, mNetSegmentToBeRemoved.getNetLines()) {
+        SI_NetPoint* startPoint = netPointMap.value(&netline->getStartPoint()); Q_ASSERT(startPoint);
+        SI_NetPoint* endPoint = netPointMap.value(&netline->getEndPoint()); Q_ASSERT(endPoint);
+        SI_NetLine* newNetLine = cmdAdd->addNetLine(*startPoint, *endPoint); Q_ASSERT(newNetLine);
+    }
+    execNewChildCmd(new CmdSchematicNetSegmentRemove(mNetSegmentToBeRemoved)); // can throw
+    execNewChildCmd(cmdAdd); // can throw
+
+
+    if (getChildCount() > 0) {
+        // remove netsignals which are no longer required
+        execNewChildCmd(new CmdRemoveUnusedNetSignals(mJunctionNetPoint.getCircuit())); // can throw
+    }
+
+    undoScopeGuard.dismiss(); // no undo required
+    return true;
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+SI_NetPoint& CmdCombineSchematicNetSegments::addNetPointInMiddleOfNetLine(
+        SI_NetLine& l, const Point& pos)
+{
+    // add netpoint + 2 netlines
+    CmdSchematicNetSegmentAddElements* cmdAdd = new CmdSchematicNetSegmentAddElements(l.getNetSegment());
+    SI_NetPoint* netpoint = cmdAdd->addNetPoint(pos); Q_ASSERT(netpoint);
+    SI_NetLine* netline1 = cmdAdd->addNetLine(l.getStartPoint(), *netpoint); Q_ASSERT(netline1);
+    SI_NetLine* netline2 = cmdAdd->addNetLine(l.getEndPoint(), *netpoint); Q_ASSERT(netline2);
+    execNewChildCmd(cmdAdd); // can throw
+
+    // remove netline
+    CmdSchematicNetSegmentRemoveElements* cmdRemove = new CmdSchematicNetSegmentRemoveElements(l.getNetSegment());
+    cmdRemove->removeNetLine(l);
+    execNewChildCmd(cmdRemove); // can throw
+
+    return *netpoint;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace editor
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.h
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.h
@@ -17,13 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
-#define LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
+#ifndef LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETSEGMENTS_H
+#define LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETSEGMENTS_H
 
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
+#include <librepcb/common/units/point.h>
 #include <librepcb/common/undocommandgroup.h>
 
 /*****************************************************************************************
@@ -32,26 +33,33 @@
 namespace librepcb {
 namespace project {
 
+class SI_NetSegment;
 class SI_NetPoint;
+class SI_NetLine;
 
 namespace editor {
 
 /*****************************************************************************************
- *  Class CmdCombineSchematicNetPoints
+ *  Class CmdCombineSchematicNetSegments
  ****************************************************************************************/
 
 /**
- * @brief This undo command combines two schematic netpoints together
+ * @brief This undo command combines two schematic netsegments together
  *
- * @note Both netpoints must have the same netsegment!
+ * @note Both netsegments must have the same netsignal!
  */
-class CmdCombineSchematicNetPoints final : public UndoCommandGroup
+class CmdCombineSchematicNetSegments final : public UndoCommandGroup
 {
     public:
 
         // Constructors / Destructor
-        CmdCombineSchematicNetPoints(SI_NetPoint& toBeRemoved, SI_NetPoint& result) noexcept;
-        ~CmdCombineSchematicNetPoints() noexcept;
+        CmdCombineSchematicNetSegments() = delete;
+        CmdCombineSchematicNetSegments(const CmdCombineSchematicNetSegments& other) = delete;
+        CmdCombineSchematicNetSegments(SI_NetSegment& toBeRemoved, SI_NetPoint& junction) noexcept;
+        ~CmdCombineSchematicNetSegments() noexcept;
+
+        // Operator Overloadings
+        CmdCombineSchematicNetSegments& operator=(const CmdCombineSchematicNetSegments& rhs) = delete;
 
 
     private:
@@ -61,10 +69,12 @@ class CmdCombineSchematicNetPoints final : public UndoCommandGroup
         /// @copydoc UndoCommand::performExecute()
         bool performExecute() override;
 
+        SI_NetPoint& addNetPointInMiddleOfNetLine(SI_NetLine& l, const Point& pos);
+
 
         // Attributes from the constructor
-        SI_NetPoint& mNetPointToBeRemoved;
-        SI_NetPoint& mResultingNetPoint;
+        SI_NetSegment& mNetSegmentToBeRemoved;
+        SI_NetPoint& mJunctionNetPoint;
 };
 
 /*****************************************************************************************
@@ -75,4 +85,4 @@ class CmdCombineSchematicNetPoints final : public UndoCommandGroup
 } // namespace project
 } // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETPOINTS_H
+#endif // LIBREPCB_PROJECT_CMDCOMBINESCHEMATICNETSEGMENTS_H

--- a/libs/librepcb/projecteditor/cmd/cmddetachboardnetpointfromviaorpad.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmddetachboardnetpointfromviaorpad.cpp
@@ -105,8 +105,10 @@ void CmdDetachBoardNetPointFromViaOrPad::removeNetPointWithAllNetlines()
         removeNetLineWithUnusedNetpoints(*netline); // can throw
     }
 
-    // the netpoint itself should be already removed now
-    Q_ASSERT(!mNetPoint.isAddedToBoard());
+    // remove the netpoint itself if not already done
+    if (mNetPoint.isAddedToBoard()) {
+        execNewChildCmd(new CmdBoardNetPointRemove(mNetPoint)); // can throw
+    }
 }
 
 void CmdDetachBoardNetPointFromViaOrPad::removeNetLineWithUnusedNetpoints(BI_NetLine& l)

--- a/libs/librepcb/projecteditor/cmd/cmdplaceschematicnetpoint.h
+++ b/libs/librepcb/projecteditor/cmd/cmdplaceschematicnetpoint.h
@@ -36,6 +36,7 @@ namespace project {
 class Circuit;
 class Schematic;
 class SI_NetPoint;
+class SI_NetSegment;
 class NetSignal;
 
 namespace editor {
@@ -52,8 +53,7 @@ class CmdPlaceSchematicNetPoint final : public UndoCommandGroup
     public:
 
         // Constructors / Destructor
-        CmdPlaceSchematicNetPoint(Schematic& schematic, const Point& pos,
-                                  const QString& netclass, const QString& netsignal) noexcept;
+        CmdPlaceSchematicNetPoint(Schematic& schematic, const Point& pos) noexcept;
         ~CmdPlaceSchematicNetPoint() noexcept;
 
         SI_NetPoint* getNetPoint() const noexcept {return mNetPoint;}
@@ -67,8 +67,9 @@ class CmdPlaceSchematicNetPoint final : public UndoCommandGroup
         bool performExecute() override;
 
         bool buildAndExecuteChildCommands();
-        NetSignal* getOrCreateNewNetSignal();
-        SI_NetPoint* createNewNetPoint(NetSignal& netsignal);
+        NetSignal& createNewNetSignal();
+        SI_NetSegment& createNewNetSegment(NetSignal& netsignal);
+        SI_NetPoint& createNewNetPoint(SI_NetSegment& netsegment);
 
 
         // Private Member Variables
@@ -77,8 +78,6 @@ class CmdPlaceSchematicNetPoint final : public UndoCommandGroup
         Circuit& mCircuit;
         Schematic& mSchematic;
         Point mPosition;
-        QString mNetClassName;
-        QString mNetSignalName;
 
         // Member Variables
         SI_NetPoint* mNetPoint;

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
@@ -23,33 +23,45 @@
 #include <QtCore>
 #include "cmdremoveselectedschematicitems.h"
 #include <librepcb/common/scopeguard.h>
+#include <librepcb/common/toolbox.h>
 #include <librepcb/project/project.h>
+#include <librepcb/project/circuit/circuit.h>
 #include <librepcb/project/circuit/netsignal.h>
 #include <librepcb/project/circuit/componentinstance.h>
 #include <librepcb/project/circuit/componentsignalinstance.h>
 #include <librepcb/project/circuit/cmd/cmdcomponentinstanceremove.h>
 #include <librepcb/project/circuit/cmd/cmdnetsignalremove.h>
 #include <librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.h>
+#include <librepcb/project/circuit/cmd/cmdnetsignaladd.h>
 #include <librepcb/project/schematics/schematic.h>
 #include <librepcb/project/schematics/items/si_symbol.h>
 #include <librepcb/project/schematics/items/si_symbolpin.h>
 #include <librepcb/project/schematics/items/si_netpoint.h>
 #include <librepcb/project/schematics/items/si_netline.h>
 #include <librepcb/project/schematics/items/si_netlabel.h>
+#include <librepcb/project/schematics/items/si_netsegment.h>
 #include <librepcb/project/schematics/cmd/cmdsymbolinstanceremove.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetlineadd.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetlineremove.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetpointremove.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetlabelremove.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetpointedit.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h>
 #include <librepcb/project/boards/board.h>
+#include <librepcb/project/boards/items/bi_footprint.h>
 #include <librepcb/project/boards/items/bi_footprintpad.h>
 #include <librepcb/project/boards/items/bi_netpoint.h>
 #include <librepcb/project/boards/items/bi_netline.h>
+#include <librepcb/project/boards/items/bi_device.h>
 #include <librepcb/project/boards/cmd/cmddeviceinstanceremove.h>
-#include <librepcb/project/boards/cmd/cmdboardnetpointremove.h>
-#include <librepcb/project/boards/cmd/cmdboardnetlineremove.h>
 #include "cmdremoveunusednetsignals.h"
+#include <librepcb/project/schematics/schematicselectionquery.h>
+#include "cmdchangenetsignalofschematicnetsegment.h"
+#include "cmdremovedevicefromboard.h"
+#include "cmddetachboardnetpointfromviaorpad.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -81,64 +93,58 @@ bool CmdRemoveSelectedSchematicItems::performExecute()
     auto undoScopeGuard = scopeGuard([&](){performUndo();});
 
     // get all selected items
-    QList<SI_Base*> items = mSchematic.getSelectedItems(false, true, true, true, true, true,
-                                                        true, true, true, true, false);
+    std::unique_ptr<SchematicSelectionQuery> query(mSchematic.createSelectionQuery());
+    query->addSelectedSymbols();
+    query->addSelectedNetLines(SchematicSelectionQuery::NetLineFilter::All);
+    query->addSelectedNetLabels();
+    query->addNetPointsOfNetLines(SchematicSelectionQuery::NetLineFilter::All,
+                                  SchematicSelectionQuery::NetPointFilter::AllConnectedLinesSelected);
 
     // clear selection because these items will be removed now
     mSchematic.clearSelection();
 
-    // remove all netlabels
-    foreach (SI_Base* item, items) {
-        if (item->getType() == SI_Base::Type_t::NetLabel) {
-            SI_NetLabel* netlabel = dynamic_cast<SI_NetLabel*>(item); Q_ASSERT(netlabel);
-            execNewChildCmd(new CmdSchematicNetLabelRemove(mSchematic, *netlabel)); // can throw
-        }
+    // determine all affected netsegments and their items
+    NetSegmentItemList netSegmentItems;
+    foreach (SI_NetPoint* netpoint, query->getNetPoints()) {
+        NetSegmentItems& items = netSegmentItems[&netpoint->getNetSegment()];
+        items.netpoints.insert(netpoint);
+    }
+    foreach (SI_NetLine* netline, query->getNetLines()) {
+        NetSegmentItems& items = netSegmentItems[&netline->getNetSegment()];
+        items.netlines.insert(netline);
+    }
+    foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
+        NetSegmentItems& items = netSegmentItems[&netlabel->getNetSegment()];
+        items.netlabels.insert(netlabel);
     }
 
-    // remove all netlines
-    foreach (SI_Base* item, items) {
-        if (item->getType() == SI_Base::Type_t::NetLine) {
-            SI_NetLine* netline = dynamic_cast<SI_NetLine*>(item); Q_ASSERT(netline);
-            execNewChildCmd(new CmdSchematicNetLineRemove(*netline)); // can throw
-        }
-    }
-
-    // remove all netpoints
-    foreach (SI_Base* item, items) {
-        if (item->getType() == SI_Base::Type_t::NetPoint) {
-            SI_NetPoint* netpoint = dynamic_cast<SI_NetPoint*>(item); Q_ASSERT(netpoint);
-            if (netpoint->isAttachedToPin()) {
-                detachNetPointFromSymbolPin(*netpoint); // can throw
+    // remove netlines/netpoints/netlabels/netsegments
+    foreach (SI_NetSegment* netsegment, netSegmentItems.keys()) {
+        const NetSegmentItems& items = netSegmentItems.value(netsegment);
+        if (items.netlines.count() == 0) {
+            // only netlabels of this netsegment are selected
+            Q_ASSERT(items.netpoints.count() == 0);
+            foreach (SI_NetLabel* netlabel, items.netlabels) { Q_ASSERT(netlabel);
+                removeNetLabel(*netlabel); // can throw
             }
-            if (netpoint->getLines().count() == 0) {
-                execNewChildCmd(new CmdSchematicNetPointRemove(*netpoint)); // can throw
-            }
+        } else if (items.netlines.count() == netsegment->getNetLines().count()) {
+            // all lines of the netsegment are selected --> remove the whole netsegment
+            removeNetSegment(*netsegment); // can throw
+        } else if (items.netlines.count() < netsegment->getNetLines().count()) {
+            // only some of the netsegment's lines are selected --> split up the netsegment
+            splitUpNetSegment(*netsegment, items); // can throw
+        } else {
+            throw new LogicError(__FILE__, __LINE__);
         }
     }
 
     // remove all symbols, devices and component instances
-    foreach (SI_Base* item, items) {
-        if (item->getType() == SI_Base::Type_t::Symbol) {
-            SI_Symbol* symbol = dynamic_cast<SI_Symbol*>(item); Q_ASSERT(symbol);
-            execNewChildCmd(new CmdSymbolInstanceRemove(mSchematic, *symbol)); // can throw
-
-            ComponentInstance* component = &symbol->getComponentInstance(); Q_ASSERT(component);
-            if (component->getPlacedSymbolsCount() == 0) {
-                foreach (Board* board, mSchematic.getProject().getBoards()) {
-                    BI_Device* device = board->getDeviceInstanceByComponentUuid(component->getUuid());
-                    if (device) {
-                        // TODO: does not work if traces are connected to the device!
-                        execNewChildCmd(new CmdDeviceInstanceRemove(*board, *device)); // can throw
-                    }
-                }
-                execNewChildCmd(new CmdComponentInstanceRemove(mSchematic.getProject().getCircuit(),
-                                                              *component)); // can throw
-            }
-        }
+    foreach (SI_Symbol* symbol, query->getSymbols()) {
+        removeSymbol(*symbol); // can throw
     }
 
+    // remove netsignals which are no longer required
     if (getChildCount() > 0) {
-        // remove netsignals which are no longer required
         execNewChildCmd(new CmdRemoveUnusedNetSignals(mSchematic.getProject().getCircuit())); // can throw
     }
 
@@ -146,58 +152,321 @@ bool CmdRemoveSelectedSchematicItems::performExecute()
     return (getChildCount() > 0);
 }
 
+void CmdRemoveSelectedSchematicItems::removeNetSegment(SI_NetSegment& netsegment)
+{
+    // determine component signal instances to be disconnected
+    QList<ComponentSignalInstance*> cmpSigInstToBeDisconnected;
+    foreach (SI_NetPoint* netpoint, netsegment.getNetPoints()) {
+        // check if this was the last symbol pin of the component signal
+        ComponentSignalInstance* cmpSig = getCmpSigInstToBeDisconnected(*netpoint);
+        if (cmpSig) {
+            cmpSigInstToBeDisconnected.append(cmpSig);
+        }
+    }
+
+    // remove netsegment
+    execNewChildCmd(new CmdSchematicNetSegmentRemove(netsegment)); // can throw
+
+    // disconnect component signal instances
+    foreach (ComponentSignalInstance* cmpSig, cmpSigInstToBeDisconnected) {
+        disconnectComponentSignalInstance(*cmpSig); // can throw
+    }
+}
+
+void CmdRemoveSelectedSchematicItems::splitUpNetSegment(SI_NetSegment& netsegment,
+                                                        const NetSegmentItems& selectedItems)
+{
+    // determine all resulting sub-netsegments
+    QList<NetSegmentItems> subsegments = getNonCohesiveNetSegmentSubSegments(
+                                             netsegment, selectedItems);
+
+    // remove all selected netlines & netpoints
+    QSet<ComponentSignalInstance*> cmpSigsToBeDisconnected;
+    foreach (SI_NetPoint* netpoint, selectedItems.netpoints) {
+        // check if this was the last symbol pin of the component signal
+        ComponentSignalInstance* cmpSig = getCmpSigInstToBeDisconnected(*netpoint);
+        if (cmpSig) {
+            cmpSigsToBeDisconnected.insert(cmpSig);
+        }
+    }
+
+    // remove the whole netsegment
+    execNewChildCmd(new CmdSchematicNetSegmentRemove(netsegment));
+
+    // disconnect component signal instances
+    foreach (ComponentSignalInstance* cmpSig, cmpSigsToBeDisconnected) {
+        disconnectComponentSignalInstance(*cmpSig); // can throw
+    }
+
+    // create new sub-netsegments
+    QList<SI_NetSegment*> newSubsegments;
+    foreach (const NetSegmentItems& subsegment, subsegments) {
+        newSubsegments.append(createNewSubNetSegment(netsegment, subsegment)); // can throw
+    }
+
+    // assign new netsignal to each subsegment (with some exceptions)
+    foreach (SI_NetSegment* subsegment, newSubsegments) {
+        NetSignal* newNetSignal = nullptr;
+        QString forcedName = subsegment->getForcedNetName();
+        if (!forcedName.isEmpty()) {
+            // set netsignal to forced name
+            if (subsegment->getNetSignal().getName() != forcedName) {
+                newNetSignal = mSchematic.getProject().getCircuit().getNetSignalByName(forcedName);
+                if (!newNetSignal) {
+                    // create new netsignal
+                    CmdNetSignalAdd* cmdAddNetSignal = new CmdNetSignalAdd(subsegment->getCircuit(),
+                        subsegment->getNetSignal().getNetClass(), forcedName);
+                    execNewChildCmd(cmdAddNetSignal); // can throw
+                    newNetSignal = cmdAddNetSignal->getNetSignal(); Q_ASSERT(newNetSignal);
+                }
+            }
+        } else if (subsegment->getNetLabels().isEmpty()) {
+            // create new netsignal with auto-name
+            CmdNetSignalAdd* cmdAddNetSignal = new CmdNetSignalAdd(subsegment->getCircuit(),
+                subsegment->getNetSignal().getNetClass());
+            execNewChildCmd(cmdAddNetSignal); // can throw
+            newNetSignal = cmdAddNetSignal->getNetSignal(); Q_ASSERT(newNetSignal);
+        }
+        if (newNetSignal) {
+            execNewChildCmd(new CmdChangeNetSignalOfSchematicNetSegment(*subsegment, *newNetSignal));
+        }
+    }
+}
+
+SI_NetSegment* CmdRemoveSelectedSchematicItems::createNewSubNetSegment(
+    SI_NetSegment& netsegment, const NetSegmentItems& items)
+{
+    // create new netsegment
+    CmdSchematicNetSegmentAdd* cmdAddNetSegment = new CmdSchematicNetSegmentAdd(
+        netsegment.getSchematic(), netsegment.getNetSignal());
+    execNewChildCmd(cmdAddNetSegment); // can throw
+    SI_NetSegment* newNetSegment = cmdAddNetSegment->getNetSegment(); Q_ASSERT(newNetSegment);
+
+    // create new netpoints and netlines
+    CmdSchematicNetSegmentAddElements* cmdAddElements = new CmdSchematicNetSegmentAddElements(*newNetSegment);
+    QHash<const SI_NetPoint*, SI_NetPoint*> netPointMap;
+    foreach (const SI_NetPoint* netpoint, items.netpoints) {
+        SI_NetPoint* newNetPoint;
+        if (netpoint->isAttachedToPin()) {
+            SI_SymbolPin* pin = netpoint->getSymbolPin(); Q_ASSERT(pin);
+            newNetPoint = cmdAddElements->addNetPoint(*pin);
+        } else {
+            newNetPoint = cmdAddElements->addNetPoint(netpoint->getPosition());
+        }
+        Q_ASSERT(newNetPoint);
+        netPointMap.insert(netpoint, newNetPoint);
+    }
+    foreach (const SI_NetLine* netline, items.netlines) {
+        SI_NetPoint* p1 = netPointMap.value(&netline->getStartPoint()); Q_ASSERT(p1);
+        SI_NetPoint* p2 = netPointMap.value(&netline->getEndPoint()); Q_ASSERT(p2);
+        SI_NetLine* newNetLine = cmdAddElements->addNetLine(*p1, *p2);
+        Q_ASSERT(newNetLine);
+    }
+    execNewChildCmd(cmdAddElements); // can throw
+
+    // create new netlabels
+    foreach (const SI_NetLabel* netlabel, items.netlabels) {
+        CmdSchematicNetLabelAdd* cmdAdd = new CmdSchematicNetLabelAdd(*newNetSegment,
+                                                                      netlabel->getPosition());
+        execNewChildCmd(cmdAdd);
+        CmdSchematicNetLabelEdit* cmdEdit = new CmdSchematicNetLabelEdit(*cmdAdd->getNetLabel());
+        cmdEdit->setRotation(netlabel->getRotation(), false);
+        execNewChildCmd(cmdEdit);
+    }
+
+    return newNetSegment;
+}
+
+void CmdRemoveSelectedSchematicItems::removeNetLabel(SI_NetLabel& netlabel)
+{
+    // remove the netlabel
+    execNewChildCmd(new CmdSchematicNetLabelRemove(netlabel)); // can throw
+
+    // was this the last label of the netsegment?
+    if (netlabel.getNetSegment().getNetLabels().isEmpty()) {
+        // are there any forced net names of the net segment?
+        CmdNetSignalAdd* cmd;
+        NetClass& netclass = netlabel.getNetSignalOfNetSegment().getNetClass();
+        QSet<QString> names = netlabel.getNetSegment().getForcedNetNames();
+        if (names.isEmpty()) {
+            // create new netsignal with auto-name
+            cmd = new CmdNetSignalAdd(mSchematic.getProject().getCircuit(), netclass);
+        } else if (names.values().first() != netlabel.getNetSignalOfNetSegment().getName()) {
+            // create new netsignal with (first) forced name
+            cmd = new CmdNetSignalAdd(mSchematic.getProject().getCircuit(), netclass, names.values().first());
+        } else {
+            // keep current name, as it is forced anyway
+            return;
+        }
+        execNewChildCmd(cmd); // can throw
+        NetSignal* netsignal = cmd->getNetSignal(); Q_ASSERT(netsignal);
+        // change the netsignal of the netsegment
+        execNewChildCmd(new CmdChangeNetSignalOfSchematicNetSegment(netlabel.getNetSegment(), *netsignal)); // can throw
+    }
+}
+
+
+void CmdRemoveSelectedSchematicItems::removeSymbol(SI_Symbol& symbol)
+{
+    // disconnect all netpoints from pins
+    foreach (SI_SymbolPin* pin, symbol.getPins()) {
+        SI_NetPoint* netpoint = pin->getNetPoint();
+        if (netpoint) {
+            detachNetPointFromSymbolPin(*netpoint); // can throw
+        }
+    }
+
+    // remove symbol
+    execNewChildCmd(new CmdSymbolInstanceRemove(mSchematic, symbol)); // can throw
+
+    // do we also need to remove the component instance?
+    ComponentInstance& component = symbol.getComponentInstance();
+    if (component.getPlacedSymbolsCount() == 0) {
+        foreach (Board* board, mSchematic.getProject().getBoards()) {
+            BI_Device* device = board->getDeviceInstanceByComponentUuid(component.getUuid());
+            if (device) {
+                execNewChildCmd(new CmdRemoveDeviceFromBoard(*device)); // can throw
+            }
+        }
+        execNewChildCmd(new CmdComponentInstanceRemove(mSchematic.getProject().getCircuit(),
+                                                      component)); // can throw
+    }
+}
+
 void CmdRemoveSelectedSchematicItems::detachNetPointFromSymbolPin(SI_NetPoint& netpoint)
 {
-    SI_SymbolPin* pin = netpoint.getSymbolPin();
-    if (!pin) throw LogicError(__FILE__, __LINE__);
-    ComponentSignalInstance* cmpSig = pin->getComponentSignalInstance();
-    if (!cmpSig) throw LogicError(__FILE__, __LINE__);
+    Q_ASSERT(netpoint.isAttachedToPin());
+    SI_SymbolPin* pin = netpoint.getSymbolPin(); Q_ASSERT(pin);
 
-    // disconnect all netlines
-    QList<SI_NetLine*> netlines = netpoint.getLines();
-    foreach (SI_NetLine* netline, netlines) {
-        execNewChildCmd(new CmdSchematicNetLineRemove(*netline)); // can throw
-    }
+    // remove netsegment
+    execNewChildCmd(new CmdSchematicNetSegmentRemove(netpoint.getNetSegment())); // can throw
 
     // detach netpoint from symbol pin
     CmdSchematicNetPointEdit* cmd = new CmdSchematicNetPointEdit(netpoint);
     cmd->setPinToAttach(nullptr);
     execNewChildCmd(cmd); // can throw
 
-    // reconnect all netlines
-    foreach (SI_NetLine* netline, netlines) {
-        execNewChildCmd(new CmdSchematicNetLineAdd(*netline)); // can throw
-    }
-
-    // check if this was the last symbol pin of the component signal
-    bool componentSignalMustBeDisconnected = true;
-    foreach (const SI_SymbolPin* pin, cmpSig->getRegisteredSymbolPins()) {
-        if (pin->getNetPoint()) {
-            componentSignalMustBeDisconnected = false;
-            break;
-        }
-    }
-
-    // if required, disconnect the component signal from the net signal now
-    if (componentSignalMustBeDisconnected) {
-        disconnectComponentSignalInstance(*cmpSig); // can throw
-    }
+    // re-add netsegment
+    execNewChildCmd(new CmdSchematicNetSegmentAdd(netpoint.getNetSegment())); // can throw
 }
 
-void CmdRemoveSelectedSchematicItems::disconnectComponentSignalInstance(ComponentSignalInstance& signal)
+ComponentSignalInstance* CmdRemoveSelectedSchematicItems::getCmpSigInstToBeDisconnected(
+        SI_NetPoint& netpoint) const noexcept
+{
+    SI_SymbolPin* symbolPin = netpoint.getSymbolPin();
+    if (!symbolPin) return nullptr;
+
+    ComponentSignalInstance* cmpSig = symbolPin->getComponentSignalInstance();
+    if (!cmpSig) return nullptr;
+
+    foreach (const SI_SymbolPin* pin, cmpSig->getRegisteredSymbolPins()) {
+        if ((pin != symbolPin) && (pin->getNetPoint())) {
+            return nullptr;
+        }
+    }
+    return cmpSig;
+}
+
+void CmdRemoveSelectedSchematicItems::disconnectComponentSignalInstance(
+        ComponentSignalInstance& signal)
 {
     // disconnect board items
     foreach (BI_FootprintPad* pad, signal.getRegisteredFootprintPads()) {
         foreach (BI_NetPoint* netpoint, pad->getNetPoints()) {
-            foreach (BI_NetLine* netline, netpoint->getLines()) {
-                execNewChildCmd(new CmdBoardNetLineRemove(*netline)); // can throw
-            }
-            execNewChildCmd(new CmdBoardNetPointRemove(*netpoint)); // can throw
+            execNewChildCmd(new CmdDetachBoardNetPointFromViaOrPad(*netpoint));
         }
     }
 
     // disconnect the component signal instance from the net signal
     execNewChildCmd(new CmdCompSigInstSetNetSignal(signal, nullptr)); // can throw
+}
+
+QList<CmdRemoveSelectedSchematicItems::NetSegmentItems>
+CmdRemoveSelectedSchematicItems::getNonCohesiveNetSegmentSubSegments(
+        SI_NetSegment& segment, const NetSegmentItems& removedItems) noexcept
+{
+    // get all netpoints, netlines and netlabels of the segment
+    QSet<SI_NetPoint*> netpoints = segment.getNetPoints().toSet() - removedItems.netpoints;
+    QSet<SI_NetLine*> netlines = segment.getNetLines().toSet() - removedItems.netlines;
+    QSet<SI_NetLabel*> netlabels = segment.getNetLabels().toSet() - removedItems.netlabels;
+
+    // find all separate segments of the netsegment
+    QList<NetSegmentItems> segments;
+    while (netpoints.count() > 0) {
+        NetSegmentItems seg;
+        findAllConnectedNetPointsAndNetLines(*netpoints.values().first(),
+                                             netpoints, netlines,
+                                             seg.netpoints, seg.netlines);
+        foreach (SI_NetPoint* p, seg.netpoints) netpoints.remove(p);
+        foreach (SI_NetLine* l, seg.netlines) netlines.remove(l);
+        segments.append(seg);
+    }
+
+    // re-assign all netlabels to the resulting netsegments
+    foreach (SI_NetLabel* netlabel, netlabels) {
+        int index = getNearestNetSegmentOfNetLabel(*netlabel, segments);
+        segments[index].netlabels.insert(netlabel);
+    }
+
+    return segments;
+}
+
+void CmdRemoveSelectedSchematicItems::findAllConnectedNetPointsAndNetLines(SI_NetPoint& netpoint,
+        QSet<SI_NetPoint*>& availableNetPoints, QSet<SI_NetLine*>& availableNetLines,
+        QSet<SI_NetPoint*>& netpoints, QSet<SI_NetLine*>& netlines) const noexcept
+{
+    Q_ASSERT(!netpoints.contains(&netpoint));
+    Q_ASSERT(availableNetPoints.contains(&netpoint));
+    netpoints.insert(&netpoint);
+    foreach (SI_NetLine* line, netpoint.getLines()) {
+        if (availableNetLines.contains(line)) {
+            netlines.insert(line);
+            SI_NetPoint* p2 = line->getOtherPoint(netpoint); Q_ASSERT(p2);
+            if ((availableNetPoints.contains(p2)) && (!netpoints.contains(p2))) {
+                findAllConnectedNetPointsAndNetLines(*p2, availableNetPoints,
+                                                     availableNetLines, netpoints, netlines);
+            }
+        }
+    }
+}
+
+int CmdRemoveSelectedSchematicItems::getNearestNetSegmentOfNetLabel(
+    const SI_NetLabel& netlabel, const QList<NetSegmentItems>& segments) const noexcept
+{
+    int nearestIndex = -1;
+    Length nearestDistance;
+    for (int i = 0; i < segments.count(); ++i) {
+        Length distance = getDistanceBetweenNetLabelAndNetSegment(netlabel, segments.at(i));
+        if ((distance < nearestDistance) || (nearestIndex < 0)) {
+            nearestIndex = i;
+            nearestDistance = distance;
+        }
+    }
+    return nearestIndex;
+}
+
+Length CmdRemoveSelectedSchematicItems::getDistanceBetweenNetLabelAndNetSegment(
+    const SI_NetLabel& netlabel, const NetSegmentItems& netsegment) const noexcept
+{
+    bool firstRun = true;
+    Length nearestDistance;
+    foreach (const SI_NetPoint* netpoint, netsegment.netpoints) {
+        Length distance = (netpoint->getPosition() - netlabel.getPosition()).getLength();
+        if ((distance < nearestDistance) || firstRun) {
+            nearestDistance = distance;
+            firstRun = false;
+        }
+    }
+    foreach (const SI_NetLine* netline, netsegment.netlines) {
+        Length distance = Toolbox::shortestDistanceBetweenPointAndLine(netlabel.getPosition(),
+            netline->getStartPoint().getPosition(), netline->getEndPoint().getPosition());
+        if ((distance < nearestDistance) || firstRun) {
+            nearestDistance = distance;
+            firstRun = false;
+        }
+    }
+    Q_ASSERT(firstRun == false);
+    return nearestDistance;
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -37,11 +37,13 @@ SOURCES += \
     cmd/cmdaddcomponenttocircuit.cpp \
     cmd/cmdadddevicetoboard.cpp \
     cmd/cmdaddsymboltoschematic.cpp \
+    cmd/cmdchangenetsignalofschematicnetsegment.cpp \
     cmd/cmdcombineallitemsunderboardnetpoint.cpp \
-    cmd/cmdcombineallnetsignalsunderschematicnetpoint.cpp \
+    cmd/cmdcombineallitemsunderschematicnetpoint.cpp \
     cmd/cmdcombineboardnetpoints.cpp \
     cmd/cmdcombinenetsignals.cpp \
     cmd/cmdcombineschematicnetpoints.cpp \
+    cmd/cmdcombineschematicnetsegments.cpp \
     cmd/cmddetachboardnetpointfromviaorpad.cpp \
     cmd/cmdflipselectedboarditems.cpp \
     cmd/cmdmoveselectedboarditems.cpp \
@@ -95,11 +97,13 @@ HEADERS += \
     cmd/cmdaddcomponenttocircuit.h \
     cmd/cmdadddevicetoboard.h \
     cmd/cmdaddsymboltoschematic.h \
+    cmd/cmdchangenetsignalofschematicnetsegment.h \
     cmd/cmdcombineallitemsunderboardnetpoint.h \
-    cmd/cmdcombineallnetsignalsunderschematicnetpoint.h \
+    cmd/cmdcombineallitemsunderschematicnetpoint.h \
     cmd/cmdcombineboardnetpoints.h \
     cmd/cmdcombinenetsignals.h \
     cmd/cmdcombineschematicnetpoints.h \
+    cmd/cmdcombineschematicnetsegments.h \
     cmd/cmddetachboardnetpointfromviaorpad.h \
     cmd/cmdflipselectedboarditems.h \
     cmd/cmdmoveselectedboarditems.h \

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.h
@@ -66,8 +66,8 @@ class SES_AddNetLabel final : public SES_Base
 
         // Private Methods
         ProcRetVal processSceneEvent(SEE_Base* event) noexcept;
-        bool addLabel(Schematic& schematic) noexcept;
-        bool updateLabel(Schematic& schematic, const Point& pos) noexcept;
+        bool addLabel(Schematic& schematic, const Point& pos) noexcept;
+        bool updateLabel(const Point& pos) noexcept;
         bool fixLabel(const Point& pos) noexcept;
 
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.h
@@ -114,14 +114,6 @@ class SES_DrawWire final : public SES_Base
         // Widgets for the command toolbar
         QHash<WireMode, QAction*> mWireModeActions;
         QList<QAction*> mActionSeparators;
-        QLabel* mNetClassLabel;
-        QComboBox* mNetClassComboBox;
-        QMetaObject::Connection mNetClassAddCon;
-        QMetaObject::Connection mNetClassRemoveCon;
-        QLabel* mNetSignalLabel;
-        QComboBox* mNetSignalComboBox;
-        QMetaObject::Connection mNetSignalAddCon;
-        QMetaObject::Connection mNetSignalRemoveCon;
         QLabel* mWidthLabel;
         QComboBox* mWidthComboBox;
 };


### PR DESCRIPTION
The new element SI_NetSegment combines following elements together:
- SI_NetPoint
- SI_NetLine
- SI_NetLabel

This is required to make the schematic editor logic more sophisticated because cohesive net segments (points + lines + labels which are connected together) are now explicitly visible in the data structure.

The ERC might also benefit from this fact (to produce better warnings/errors).

Note: This intruduces a new file structure for schematic XML files.
