### PR TITLE
Travis: Update Qt bottle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
       sudo apt-get install -qq libglu1-mesa-dev
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]
     then 
-      brew update && curl -LO https://github.com/The-Compiler/homebrew-qt5-webkit/releases/download/v5.6.1-1/qt5-5.6.1.el_capitan.bottle.1.tar.gz && brew install qt5-*.bottle.1.tar.gz && brew link --force qt5
+      brew update && curl -LO https://github.com/The-Compiler/homebrew-qt5-webkit/releases/download/v5.6.1_1-1/qt5-5.6.1-1.yosemite.bottle.1.tar.gz && brew install qt5-*.bottle.1.tar.gz && brew link --force qt5
     fi
 
 script:


### PR DESCRIPTION
From upstream 5.6.1 to upstream 5.6.1-1

Not 100% sure if it'll work, for qutebrowser I can't load QtWebKit, but I might need to rebuild PyQt5... let's see if it works here!