### PR TITLE
Use markdown for project descriptions (instead of HTML)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = dev/demo-workspace
 	url = https://github.com/LibrePCB/demo-workspace.git
 	branch = library_refactoring
+[submodule "3rdparty/hoedown"]
+	path = 3rdparty/hoedown
+	url = https://github.com/LibrePCB/hoedown.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,10 @@ install:
     if [ "${TRAVIS_OS_NAME}" = "linux" ]
     then
       if [ "$CXX" = "g++" ];    then sudo apt-get install -qq gcc-4.8 g++-4.8; export CXX="g++-4.8" CC="gcc-4.8"; fi
-      if [ "$QT_BASE" = "52" ]; then sudo apt-get install -qq qt52base qt52tools qt52webkit-examples libxslt-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev; source /opt/qt52/bin/qt52-env.sh; fi
-      if [ "$QT_BASE" = "53" ]; then sudo apt-get install -qq qt53base qt53tools qt53webkit-examples; source /opt/qt53/bin/qt53-env.sh; fi
-      if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq qt54base qt54tools qt54webkit-examples; source /opt/qt54/bin/qt54-env.sh; fi
-      if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq qt55base qt55tools qt55webkit-examples; source /opt/qt55/bin/qt55-env.sh; fi
+      if [ "$QT_BASE" = "52" ]; then sudo apt-get install -qq qt52base qt52tools libxslt-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev; source /opt/qt52/bin/qt52-env.sh; fi
+      if [ "$QT_BASE" = "53" ]; then sudo apt-get install -qq qt53base qt53tools; source /opt/qt53/bin/qt53-env.sh; fi
+      if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq qt54base qt54tools; source /opt/qt54/bin/qt54-env.sh; fi
+      if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq qt55base qt55tools; source /opt/qt55/bin/qt55-env.sh; fi
       if [ "$BUILD_DOXYGEN" = "true" ]; then sudo apt-get install -qq doxygen graphviz; fi
       sudo apt-get install -qq libglu1-mesa-dev
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
       sudo apt-get install -qq libglu1-mesa-dev
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]
     then 
-      brew update && curl -LO https://github.com/The-Compiler/homebrew-qt5-webkit/releases/download/v5.6.1-1/qt5-5.6.1.el_capitan.bottle.1.tar.gz && brew install qt5-*.bottle.1.tar.gz && brew link --force qt5
+      brew update && brew install qt5 && brew link --force qt5
     fi
 
 script:

--- a/3rdparty/3rdparty.pro
+++ b/3rdparty/3rdparty.pro
@@ -1,4 +1,5 @@
 TEMPLATE = subdirs
 
 SUBDIRS = \
+    hoedown \
     gmock

--- a/3rdparty/gmock/gmock.pro
+++ b/3rdparty/gmock/gmock.pro
@@ -13,6 +13,8 @@ GENERATED_DIR = ../../generated
 # Use common project definitions
 include(../../common.pri)
 
+QT -= core gui widgets
+
 CONFIG -= qt app_bundle
 CONFIG += staticlib thread
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To compile LibrePCB, you need the following software components:
 #### Installation on Ubuntu 14.04 and later
 
 ```bash
-sudo apt-get install g++ qt5-default libqt5webkit5 libqt5webkit5-dev qttools5-dev-tools qt5-doc qtcreator libglu1-mesa-dev
+sudo apt-get install g++ qt5-default qttools5-dev-tools qt5-doc qtcreator libglu1-mesa-dev
 ```
 
 #### Installation on ArchLinux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ init:
   - git config --global core.autocrlf input
   - set PATH=%QTDIR%\bin;%MINGW%\bin;C:\Qt\Tools\QtCreator\bin;%PATH%
 
+install:
+  - git submodule update --init --recursive
+
 build_script:
   - mkdir build
   - cd build

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -4,14 +4,12 @@ FROM ubuntu:14.04
 RUN DEBIAN_FRONTEND=noninteractive \
      apt-get -q update \
   && apt-get -qy upgrade \
-  && apt-get -qy install git g++ qt5-default libqt5webkit5 libqt5webkit5-dev qttools5-dev-tools qt5-doc qtcreator libglu1-mesa-dev dia \
+  && apt-get -qy install git g++ qt5-default qttools5-dev-tools qt5-doc qtcreator libglu1-mesa-dev dia \
   && apt-get clean
 
 # checkout librepcb
-RUN git clone https://github.com/LibrePCB/LibrePCB.git /opt/LibrePCB \
-  && cd /opt/LibrePCB \
-  && git submodule init \
-  && git submodule update
+RUN git clone --recursive https://github.com/LibrePCB/LibrePCB.git /opt/LibrePCB \
+  && cd /opt/LibrePCB
 
 # build and install librepcb
 RUN /opt/LibrePCB/dev/docker/make_librepcb.sh

--- a/librepcb/controlpanel/controlpanel.h
+++ b/librepcb/controlpanel/controlpanel.h
@@ -112,6 +112,7 @@ class ControlPanel final : public QMainWindow
         // General private methods
         void saveSettings();
         void loadSettings();
+        void showProjectReadmeInBrowser(const FilePath& projectFilePath) noexcept;
 
         // Project Management
 

--- a/librepcb/controlpanel/controlpanel.ui
+++ b/librepcb/controlpanel/controlpanel.ui
@@ -334,20 +334,15 @@ QListView::item
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
-             <widget class="QWebView" name="webView">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
+             <widget class="QTextBrowser" name="textBrowser">
               <property name="styleSheet">
-               <string notr="true">background-color: rgba(255, 255, 255, 0);</string>
+               <string notr="true">background-color: transparent;</string>
               </property>
-              <property name="url">
-               <url>
-                <string>about:blank</string>
-               </url>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="openExternalLinks">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -367,7 +362,7 @@ QListView::item
      <x>0</x>
      <y>0</y>
      <width>873</width>
-     <height>27</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -498,13 +493,6 @@ QListView::item
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <customwidgets>
-  <customwidget>
-   <class>QWebView</class>
-   <extends>QWidget</extends>
-   <header>QtWebKitWidgets/QWebView</header>
-  </customwidget>
- </customwidgets>
  <resources>
   <include location="../../img/images.qrc"/>
  </resources>

--- a/librepcb/librepcb.pro
+++ b/librepcb/librepcb.pro
@@ -89,13 +89,15 @@ SOURCES += \
     controlpanel/controlpanel.cpp \
     firstrunwizard/firstrunwizard.cpp \
     firstrunwizard/firstrunwizardpage_welcome.cpp \
-    firstrunwizard/firstrunwizardpage_workspacepath.cpp
+    firstrunwizard/firstrunwizardpage_workspacepath.cpp \
+    markdown/markdownconverter.cpp
 
 HEADERS += \
     controlpanel/controlpanel.h \
     firstrunwizard/firstrunwizard.h \
     firstrunwizard/firstrunwizardpage_welcome.h \
-    firstrunwizard/firstrunwizardpage_workspacepath.h
+    firstrunwizard/firstrunwizardpage_workspacepath.h \
+    markdown/markdownconverter.h
 
 FORMS += \
     controlpanel/controlpanel.ui \

--- a/librepcb/librepcb.pro
+++ b/librepcb/librepcb.pro
@@ -45,6 +45,7 @@ unix:!macx {
 # Another order could end up in "undefined reference" errors!
 LIBS += \
     -L$${DESTDIR} \
+    -lhoedown \
     -llibrepcbprojecteditor \
     -llibrepcblibraryeditor \
     -llibrepcbworkspace \
@@ -53,9 +54,11 @@ LIBS += \
     -llibrepcbcommon
 
 INCLUDEPATH += \
+    ../3rdparty \
     ../libs
 
 DEPENDPATH += \
+    ../3rdparty/hoedown \
     ../libs/librepcbprojecteditor \
     ../libs/librepcblibraryeditor \
     ../libs/librepcbworkspace \
@@ -64,6 +67,7 @@ DEPENDPATH += \
     ../libs/librepcbcommon
 
 PRE_TARGETDEPS += \
+    $${DESTDIR}/libhoedown.a \
     $${DESTDIR}/liblibrepcbprojecteditor.a \
     $${DESTDIR}/liblibrepcblibraryeditor.a \
     $${DESTDIR}/liblibrepcbworkspace.a \

--- a/librepcb/librepcb.pro
+++ b/librepcb/librepcb.pro
@@ -13,7 +13,7 @@ GENERATED_DIR = ../generated
 # Use common project definitions
 include(../common.pri)
 
-QT += core widgets opengl webkitwidgets xml printsupport sql
+QT += core widgets opengl network xml printsupport sql
 
 exists(../.git):DEFINES += GIT_BRANCH=\\\"master\\\"
 

--- a/librepcb/markdown/markdownconverter.cpp
+++ b/librepcb/markdown/markdownconverter.cpp
@@ -1,0 +1,82 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 Urban Bruhin
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "markdownconverter.h"
+
+extern "C" {
+#include <hoedown/src/html.h>
+}
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Static Methods
+ ****************************************************************************************/
+
+QString MarkdownConverter::convertMarkdownToHtml(const FilePath& markdownFile) noexcept
+{
+    QFile file(markdownFile.toStr());
+    if (file.open(QFile::ReadOnly)) {
+        return convertMarkdownToHtml(file.readAll());
+    } else {
+        return QString();
+    }
+}
+
+QString MarkdownConverter::convertMarkdownToHtml(const QString& markdown) noexcept
+{
+    // create HTML renderer
+    hoedown_html_flags flags = static_cast<hoedown_html_flags>(0);
+    hoedown_renderer* renderer = hoedown_html_renderer_new(flags, 0);
+
+    // create document parser
+    hoedown_extensions extensions = static_cast<hoedown_extensions>(
+        HOEDOWN_EXT_TABLES | HOEDOWN_EXT_FENCED_CODE | HOEDOWN_EXT_AUTOLINK |
+        HOEDOWN_EXT_STRIKETHROUGH | HOEDOWN_EXT_NO_INTRA_EMPHASIS);
+    hoedown_document* document = hoedown_document_new(renderer, extensions, 16);
+
+    // render markdown
+    QByteArray markdownUtf8 = markdown.toUtf8();
+    const uchar* markdownData = reinterpret_cast<const uchar*>(markdownUtf8.constData());
+    hoedown_buffer* htmlBuffer = hoedown_buffer_new(64);
+    hoedown_document_render(document, htmlBuffer, markdownData, markdownUtf8.size());
+
+    // get HTML output
+    QString html = QString::fromUtf8(hoedown_buffer_cstr(htmlBuffer));
+
+    // clean up
+    hoedown_buffer_free(htmlBuffer);
+    hoedown_document_free(document);
+    hoedown_html_renderer_free(renderer);
+
+    return html;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/librepcb/markdown/markdownconverter.h
+++ b/librepcb/markdown/markdownconverter.h
@@ -1,0 +1,62 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 Urban Bruhin
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBREPCB_MARKDOWNCONVERTER_H
+#define LIBREPCB_MARKDOWNCONVERTER_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcbcommon/fileio/filepath.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class MarkdownConverter
+ ****************************************************************************************/
+
+/**
+ * @brief The MarkdownConverter class
+ */
+class MarkdownConverter final
+{
+    public:
+
+        // Static Methods
+        static QString convertMarkdownToHtml(const FilePath& markdownFile) noexcept;
+        static QString convertMarkdownToHtml(const QString& markdown) noexcept;
+
+    private:
+
+        // Constructors / Destructor
+        MarkdownConverter() = delete;
+        MarkdownConverter(const MarkdownConverter& other) = delete;
+        ~MarkdownConverter() = delete;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_MARKDOWNCONVERTER_H

--- a/libs/librepcbproject/cmd/cmdprojectsetmetadata.cpp
+++ b/libs/librepcbproject/cmd/cmdprojectsetmetadata.cpp
@@ -38,7 +38,6 @@ CmdProjectSetMetadata::CmdProjectSetMetadata(Project& project) noexcept :
     UndoCommand(tr("Change Project Metadata")),
     mProject(project),
     mOldName(mProject.getName()),               mNewName(mProject.getName()),
-    mOldDescription(mProject.getDescription()), mNewDescription(mProject.getDescription()),
     mOldAuthor(mProject.getAuthor()),           mNewAuthor(mProject.getAuthor()),
     mOldCreated(mProject.getCreated()),         mNewCreated(mProject.getCreated())
 {
@@ -56,12 +55,6 @@ void CmdProjectSetMetadata::setName(const QString& newName) noexcept
 {
     Q_ASSERT(!wasEverExecuted());
     mNewName = newName;
-}
-
-void CmdProjectSetMetadata::setDescription(const QString& newDescription) noexcept
-{
-    Q_ASSERT(!wasEverExecuted());
-    mNewDescription = newDescription;
 }
 
 void CmdProjectSetMetadata::setAuthor(const QString& newAuthor) noexcept
@@ -90,7 +83,6 @@ bool CmdProjectSetMetadata::performExecute() throw (Exception)
 void CmdProjectSetMetadata::performUndo() throw (Exception)
 {
     mProject.setName(mOldName);
-    mProject.setDescription(mOldDescription);
     mProject.setAuthor(mOldAuthor);
     mProject.setCreated(mOldCreated);
 }
@@ -98,7 +90,6 @@ void CmdProjectSetMetadata::performUndo() throw (Exception)
 void CmdProjectSetMetadata::performRedo() throw (Exception)
 {
     mProject.setName(mNewName);
-    mProject.setDescription(mNewDescription);
     mProject.setAuthor(mNewAuthor);
     mProject.setCreated(mNewCreated);
 }

--- a/libs/librepcbproject/cmd/cmdprojectsetmetadata.h
+++ b/libs/librepcbproject/cmd/cmdprojectsetmetadata.h
@@ -51,7 +51,6 @@ class CmdProjectSetMetadata final : public UndoCommand
 
         // Setters
         void setName(const QString& newName) noexcept;
-        void setDescription(const QString& newDescription) noexcept;
         void setAuthor(const QString& newAuthor) noexcept;
         void setCreated(const QDateTime& newCreated) noexcept;
 
@@ -78,8 +77,6 @@ class CmdProjectSetMetadata final : public UndoCommand
         // Misc
         QString mOldName;
         QString mNewName;
-        QString mOldDescription;
-        QString mNewDescription;
         QString mOldAuthor;
         QString mNewAuthor;
         QDateTime mOldCreated;

--- a/libs/librepcbproject/project.h
+++ b/libs/librepcbproject/project.h
@@ -171,13 +171,6 @@ class Project final : public QObject, public IF_AttributeProvider,
         const QString& getName() const noexcept {return mName;}
 
         /**
-         * @brief Get the description (in HTML) of the project
-         *
-         * @return The description of the project (HTML)
-         */
-        QString getDescription() const noexcept;
-
-        /**
          * @brief Get the author of the project
          *
          * @return The author of the project
@@ -209,15 +202,6 @@ class Project final : public QObject, public IF_AttributeProvider,
          * @undocmd{project#CmdProjectSetMetadata}
          */
         void setName(const QString& newName) noexcept;
-
-        /**
-         * @brief Set the description (in HTML) of the project
-         *
-         * @param newDescription    The new description (HTML)
-         *
-         * @undocmd{project#CmdProjectSetMetadata}
-         */
-        void setDescription(const QString& newDescription) noexcept;
 
         /**
          * @brief Set the author of the project
@@ -557,9 +541,6 @@ class Project final : public QObject, public IF_AttributeProvider,
         FileLock mFileLock; ///< See @ref doc_project_lock
         bool mIsRestored; ///< the constructor will set this to true if the project was restored
         bool mIsReadOnly; ///< the constructor will set this to true if the project was opened in read only mode
-
-        // Other Files
-        SmartTextFile* mDescriptionHtmlFile; ///< description/index.html
 
         // Attributes
         QString mName;              ///< the name of the project

--- a/libs/librepcbprojecteditor/dialogs/projectpropertieseditordialog.cpp
+++ b/libs/librepcbprojecteditor/dialogs/projectpropertieseditordialog.cpp
@@ -47,7 +47,6 @@ ProjectPropertiesEditorDialog::ProjectPropertiesEditorDialog(Project& project,
     mUi->setupUi(this);
 
     mUi->edtName->setText(mProject.getName());
-    mUi->edtDescription->setPlainText(mProject.getDescription());
     mUi->edtAuthor->setText(mProject.getAuthor());
     mUi->edtCreated->setDateTime(mProject.getCreated());
 }
@@ -94,7 +93,6 @@ bool ProjectPropertiesEditorDialog::applyChanges() noexcept
         // Metadata
         CmdProjectSetMetadata* cmd = new CmdProjectSetMetadata(mProject);
         cmd->setName(mUi->edtName->text());
-        cmd->setDescription(mUi->edtDescription->toPlainText());
         cmd->setAuthor(mUi->edtAuthor->text());
         cmd->setCreated(mUi->edtCreated->dateTime());
         mUndoStack.appendToCmdGroup(cmd);

--- a/libs/librepcbprojecteditor/dialogs/projectpropertieseditordialog.ui
+++ b/libs/librepcbprojecteditor/dialogs/projectpropertieseditordialog.ui
@@ -34,33 +34,23 @@
        <widget class="QLineEdit" name="edtName"/>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Description:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QTextEdit" name="edtDescription"/>
-      </item>
-      <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Author:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QLineEdit" name="edtAuthor"/>
       </item>
-      <item row="3" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Created:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="QDateTimeEdit" name="edtCreated">
         <property name="calendarPopup">
          <bool>true</bool>

--- a/tools/EagleImport/EagleImport.pro
+++ b/tools/EagleImport/EagleImport.pro
@@ -17,7 +17,7 @@ include(../../common.pri)
 isEmpty(UUID_LIST_FILEPATH):UUID_LIST_FILEPATH = $$absolute_path("UUID_List.ini")
 DEFINES += UUID_LIST_FILEPATH=\\\"$${UUID_LIST_FILEPATH}\\\"
 
-QT += core widgets opengl webkitwidgets xml printsupport sql
+QT += core widgets xml
 
 LIBS += \
     -L$${DESTDIR} \

--- a/tools/ProjectLibraryUpdater/ProjectLibraryUpdater.pro
+++ b/tools/ProjectLibraryUpdater/ProjectLibraryUpdater.pro
@@ -13,7 +13,7 @@ GENERATED_DIR = ../../generated
 # Use common project definitions
 include(../../common.pri)
 
-QT += core widgets opengl webkitwidgets xml printsupport sql
+QT += core widgets xml sql
 
 LIBS += \
     -L$${DESTDIR} \

--- a/tools/WorkspaceLibraryUpdater/WorkspaceLibraryUpdater.pro
+++ b/tools/WorkspaceLibraryUpdater/WorkspaceLibraryUpdater.pro
@@ -13,7 +13,7 @@ GENERATED_DIR = ../../generated
 # Use common project definitions
 include(../../common.pri)
 
-QT += core widgets opengl webkitwidgets xml printsupport sql
+QT += core widgets xml sql
 
 LIBS += \
     -L$${DESTDIR} \


### PR DESCRIPTION
- [Hoedown](https://github.com/hoedown/hoedown) is used to convert the README.md into HTML
- [QTextBrowser](http://doc.qt.io/qt-5/qtextbrowser.html) is used to display the HTML in the ControlPanel

Fixes #72 and #79.