### PR TITLE
travis: Use the Trusty build environement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: cpp
 
 cache: ccache
 
+dist: trusty
+
 matrix:
   include:
     - os: linux


### PR DESCRIPTION
See https://docs.travis-ci.com/user/trusty-ci-environment/

Maybe we can get rid of some apt-get stuff this way.