### PR TITLE
Cleanup/Improve CmdRemoveSelectedBoardItems

### DIFF
--- a/libs/librepcbprojecteditor/cmd/cmddetachboardnetpointfromviaorpad.cpp
+++ b/libs/librepcbprojecteditor/cmd/cmddetachboardnetpointfromviaorpad.cpp
@@ -1,0 +1,133 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmddetachboardnetpointfromviaorpad.h"
+#include <librepcbcommon/scopeguard.h>
+#include <librepcbproject/boards/board.h>
+#include <librepcbproject/boards/items/bi_via.h>
+#include <librepcbproject/boards/items/bi_netpoint.h>
+#include <librepcbproject/boards/items/bi_netline.h>
+#include <librepcbproject/boards/cmd/cmdboardviaremove.h>
+#include <librepcbproject/boards/cmd/cmdboardnetpointedit.h>
+#include <librepcbproject/boards/cmd/cmdboardnetpointremove.h>
+#include <librepcbproject/boards/cmd/cmdboardnetlineadd.h>
+#include <librepcbproject/boards/cmd/cmdboardnetlineremove.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdDetachBoardNetPointFromViaOrPad::CmdDetachBoardNetPointFromViaOrPad(BI_NetPoint& p) noexcept :
+    UndoCommandGroup(tr("Detach netpoint from via or pad")),
+    mNetPoint(p)
+{
+}
+
+CmdDetachBoardNetPointFromViaOrPad::~CmdDetachBoardNetPointFromViaOrPad() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdDetachBoardNetPointFromViaOrPad::performExecute() throw (Exception)
+{
+    // if an error occurs, undo all already executed child commands
+    auto undoScopeGuard = scopeGuard([&](){performUndo();});
+
+    // decide what to do with the netpoint
+    if (mNetPoint.getLines().count() <= 1) {
+        removeNetPointWithAllNetlines(); // can throw
+    } else {
+        detachNetPoint(); // can throw
+    }
+
+    undoScopeGuard.dismiss(); // no undo required
+    return (getChildCount() > 0);
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void CmdDetachBoardNetPointFromViaOrPad::detachNetPoint() throw (Exception)
+{
+    // disconnect all netlines
+    QList<BI_NetLine*> netlines = mNetPoint.getLines();
+    foreach (BI_NetLine* netline, netlines) {
+        execNewChildCmd(new CmdBoardNetLineRemove(*netline));
+    }
+
+    // detach netpoint from via or pad
+    CmdBoardNetPointEdit* cmd = new CmdBoardNetPointEdit(mNetPoint);
+    cmd->setViaToAttach(nullptr);
+    cmd->setPadToAttach(nullptr);
+    execNewChildCmd(cmd); // can throw
+
+    // re-connect all netlines
+    foreach (BI_NetLine* netline, netlines) {
+        execNewChildCmd(new CmdBoardNetLineAdd(*netline));
+    }
+}
+
+void CmdDetachBoardNetPointFromViaOrPad::removeNetPointWithAllNetlines() throw (Exception)
+{
+    // remove all connected netlines
+    foreach (BI_NetLine* netline, mNetPoint.getLines()) { Q_ASSERT(netline);
+        removeNetLineWithUnusedNetpoints(*netline); // can throw
+    }
+
+    // the netpoint itself should be already removed now
+    Q_ASSERT(!mNetPoint.isAddedToBoard());
+}
+
+void CmdDetachBoardNetPointFromViaOrPad::removeNetLineWithUnusedNetpoints(BI_NetLine& l) throw (Exception)
+{
+    // remove the netline itself
+    execNewChildCmd(new CmdBoardNetLineRemove(l)); // can throw
+
+    // remove endpoints of the netline which are no longer required
+    removeNetpointIfUnused(l.getStartPoint()); // can throw
+    removeNetpointIfUnused(l.getEndPoint()); // can throw
+}
+
+void CmdDetachBoardNetPointFromViaOrPad::removeNetpointIfUnused(BI_NetPoint& p) throw (Exception)
+{
+    if (p.getLines().count() == 0) {
+        execNewChildCmd(new CmdBoardNetPointRemove(p)); // can throw
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcbprojecteditor/cmd/cmddetachboardnetpointfromviaorpad.h
+++ b/libs/librepcbprojecteditor/cmd/cmddetachboardnetpointfromviaorpad.h
@@ -1,0 +1,86 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDDETACHBOARDNETPOINTFROMVIAORPAD_H
+#define LIBREPCB_PROJECT_CMDDETACHBOARDNETPOINTFROMVIAORPAD_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcbcommon/undocommandgroup.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+class BI_NetPoint;
+class BI_NetLine;
+
+/*****************************************************************************************
+ *  Class CmdDetachBoardNetPointFromViaOrPad
+ ****************************************************************************************/
+
+/**
+ * @brief The CmdDetachBoardNetPointFromViaOrPad class
+ */
+class CmdDetachBoardNetPointFromViaOrPad final : public UndoCommandGroup
+{
+    public:
+
+        // Constructors / Destructor
+        CmdDetachBoardNetPointFromViaOrPad() = delete;
+        CmdDetachBoardNetPointFromViaOrPad(const CmdDetachBoardNetPointFromViaOrPad& other) = delete;
+        CmdDetachBoardNetPointFromViaOrPad(BI_NetPoint& p) noexcept;
+        ~CmdDetachBoardNetPointFromViaOrPad() noexcept;
+
+        // Operator Overloadings
+        CmdDetachBoardNetPointFromViaOrPad& operator=(const CmdDetachBoardNetPointFromViaOrPad& other) = delete;
+
+
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() throw (Exception) override;
+
+        // Helper Methods
+        void detachNetPoint() throw (Exception);
+        void removeNetPointWithAllNetlines() throw (Exception);
+        void removeNetLineWithUnusedNetpoints(BI_NetLine& l) throw (Exception);
+        void removeNetpointIfUnused(BI_NetPoint& p) throw (Exception);
+
+
+        // Private Member Variables
+
+        // Attributes from the constructor
+        BI_NetPoint& mNetPoint;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDDETACHBOARDNETPOINTFROMVIAORPAD_H

--- a/libs/librepcbprojecteditor/cmd/cmdremovedevicefromboard.cpp
+++ b/libs/librepcbprojecteditor/cmd/cmdremovedevicefromboard.cpp
@@ -1,0 +1,81 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdremovedevicefromboard.h"
+#include <librepcbcommon/scopeguard.h>
+#include <librepcbproject/boards/board.h>
+#include <librepcbproject/boards/items/bi_footprint.h>
+#include <librepcbproject/boards/items/bi_footprintpad.h>
+#include <librepcbproject/boards/items/bi_device.h>
+#include <librepcbproject/boards/cmd/cmddeviceinstanceremove.h>
+#include "cmddetachboardnetpointfromviaorpad.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdRemoveDeviceFromBoard::CmdRemoveDeviceFromBoard(BI_Device& device) noexcept :
+    UndoCommandGroup(tr("Remove device from board")),
+    mDevice(device)
+{
+}
+
+CmdRemoveDeviceFromBoard::~CmdRemoveDeviceFromBoard() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdRemoveDeviceFromBoard::performExecute() throw (Exception)
+{
+    // if an error occurs, undo all already executed child commands
+    auto undoScopeGuard = scopeGuard([&](){performUndo();});
+
+    // detach all used netpoints && remove all unused netpoints + netlines
+    foreach (BI_FootprintPad* pad, mDevice.getFootprint().getPads()) { Q_ASSERT(pad);
+        foreach (BI_NetPoint* netpoint, pad->getNetPoints()) { Q_ASSERT(netpoint);
+            execNewChildCmd(new CmdDetachBoardNetPointFromViaOrPad(*netpoint)); // can throw
+        }
+    }
+
+    // remove the device itself
+    execNewChildCmd(new CmdDeviceInstanceRemove(mDevice.getBoard(), mDevice)); // can throw
+
+    undoScopeGuard.dismiss(); // no undo required
+    return (getChildCount() > 0);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcbprojecteditor/cmd/cmdremovedevicefromboard.h
+++ b/libs/librepcbprojecteditor/cmd/cmdremovedevicefromboard.h
@@ -1,0 +1,79 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDREMOVEDEVICEFROMBOARD_H
+#define LIBREPCB_PROJECT_CMDREMOVEDEVICEFROMBOARD_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcbcommon/undocommandgroup.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+class BI_Device;
+
+/*****************************************************************************************
+ *  Class CmdRemoveDeviceFromBoard
+ ****************************************************************************************/
+
+/**
+ * @brief The CmdRemoveDeviceFromBoard class
+ */
+class CmdRemoveDeviceFromBoard final : public UndoCommandGroup
+{
+    public:
+
+        // Constructors / Destructor
+        CmdRemoveDeviceFromBoard() = delete;
+        CmdRemoveDeviceFromBoard(const CmdRemoveDeviceFromBoard& other) = delete;
+        CmdRemoveDeviceFromBoard(BI_Device& device) noexcept;
+        ~CmdRemoveDeviceFromBoard() noexcept;
+
+        // Operator Overloadings
+        CmdRemoveDeviceFromBoard& operator=(const CmdRemoveDeviceFromBoard& other) = delete;
+
+
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() throw (Exception) override;
+
+
+        // Private Member Variables
+
+        // Attributes from the constructor
+        BI_Device& mDevice;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDREMOVEDEVICEFROMBOARD_H

--- a/libs/librepcbprojecteditor/cmd/cmdremoveviafromboard.cpp
+++ b/libs/librepcbprojecteditor/cmd/cmdremoveviafromboard.cpp
@@ -1,0 +1,77 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdremoveviafromboard.h"
+#include <librepcbcommon/scopeguard.h>
+#include <librepcbproject/boards/board.h>
+#include <librepcbproject/boards/items/bi_via.h>
+#include <librepcbproject/boards/cmd/cmdboardviaremove.h>
+#include "cmddetachboardnetpointfromviaorpad.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdRemoveViaFromBoard::CmdRemoveViaFromBoard(BI_Via& via) noexcept :
+    UndoCommandGroup(tr("Remove via from board")),
+    mVia(via)
+{
+}
+
+CmdRemoveViaFromBoard::~CmdRemoveViaFromBoard() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdRemoveViaFromBoard::performExecute() throw (Exception)
+{
+    // if an error occurs, undo all already executed child commands
+    auto undoScopeGuard = scopeGuard([&](){performUndo();});
+
+    // detach all used netpoints && remove all unused netpoints + netlines
+    foreach (BI_NetPoint* netpoint, mVia.getNetPoints()) { Q_ASSERT(netpoint);
+        execNewChildCmd(new CmdDetachBoardNetPointFromViaOrPad(*netpoint)); // can throw
+    }
+
+    // remove the via itself
+    execNewChildCmd(new CmdBoardViaRemove(mVia)); // can throw
+
+    undoScopeGuard.dismiss(); // no undo required
+    return (getChildCount() > 0);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcbprojecteditor/cmd/cmdremoveviafromboard.h
+++ b/libs/librepcbprojecteditor/cmd/cmdremoveviafromboard.h
@@ -1,0 +1,79 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDREMOVEVIAFROMBOARD_H
+#define LIBREPCB_PROJECT_CMDREMOVEVIAFROMBOARD_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcbcommon/undocommandgroup.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+class BI_Via;
+
+/*****************************************************************************************
+ *  Class CmdRemoveViaFromBoard
+ ****************************************************************************************/
+
+/**
+ * @brief The CmdRemoveViaFromBoard class
+ */
+class CmdRemoveViaFromBoard final : public UndoCommandGroup
+{
+    public:
+
+        // Constructors / Destructor
+        CmdRemoveViaFromBoard() = delete;
+        CmdRemoveViaFromBoard(const CmdRemoveViaFromBoard& other) = delete;
+        CmdRemoveViaFromBoard(BI_Via& via) noexcept;
+        ~CmdRemoveViaFromBoard() noexcept;
+
+        // Operator Overloadings
+        CmdRemoveViaFromBoard& operator=(const CmdRemoveViaFromBoard& other) = delete;
+
+
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() throw (Exception) override;
+
+
+        // Private Member Variables
+
+        // Attributes from the constructor
+        BI_Via& mVia;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDREMOVEVIAFROMBOARD_H

--- a/libs/librepcbprojecteditor/librepcbprojecteditor.pro
+++ b/libs/librepcbprojecteditor/librepcbprojecteditor.pro
@@ -74,7 +74,10 @@ SOURCES += \
     cmd/cmdcombineallitemsunderboardnetpoint.cpp \
     boardeditor/boardviapropertiesdialog.cpp \
     boardeditor/fsm/bes_adddevice.cpp \
-    boardeditor/fabricationoutputdialog.cpp
+    boardeditor/fabricationoutputdialog.cpp \
+    cmd/cmdremovedevicefromboard.cpp \
+    cmd/cmdremoveviafromboard.cpp \
+    cmd/cmddetachboardnetpointfromviaorpad.cpp
 
 HEADERS += \
     projecteditor.h \
@@ -130,7 +133,10 @@ HEADERS += \
     cmd/cmdcombineallitemsunderboardnetpoint.h \
     boardeditor/boardviapropertiesdialog.h \
     boardeditor/fsm/bes_adddevice.h \
-    boardeditor/fabricationoutputdialog.h
+    boardeditor/fabricationoutputdialog.h \
+    cmd/cmdremovedevicefromboard.h \
+    cmd/cmdremoveviafromboard.h \
+    cmd/cmddetachboardnetpointfromviaorpad.h
 
 FORMS += \
     schematiceditor/schematiceditor.ui \


### PR DESCRIPTION
- Add high-level undo command CmdRemoveViaFromBoard
- Add high-level undo command CmdRemoveDeviceFromBoard
- Add high-level undo command CmdDetachBoardNetPointFromViaOrPad
- Removing vias should now work properly in all cases (did not work when
  netlines were connected to them)

Can be merged after #89 was merged, because I already used the new license header in all new source files.