### PR TITLE
Library: Fix application crash caused by SQL error

### DIFF
--- a/libs/librepcblibrary/library.h
+++ b/libs/librepcblibrary/library.h
@@ -69,6 +69,8 @@ class Library final : public QObject
     public:
 
         // Constructors / Destructor
+        Library() = delete;
+        Library(const Library& other) = delete;
 
         /**
         * @brief Constructor to open the library of an existing workspace
@@ -80,7 +82,7 @@ class Library final : public QObject
         *                  an exception.
         */
         explicit Library(const FilePath& libDirPath, const FilePath& cacheFilePath) throw (Exception);
-        ~Library();
+        ~Library() noexcept;
 
 
         // Getters: Library Elements by their UUID
@@ -119,14 +121,11 @@ class Library final : public QObject
          */
         int rescan() throw (Exception);
 
+        // Operator Overloadings
+        Library& operator=(const Library& rhs) = delete;
+
 
     private:
-
-        // make some methods inaccessible...
-        Library();
-        Library(const Library& other);
-        Library& operator=(const Library& rhs);
-
 
         // Private Methods
         template <typename ElementType>
@@ -138,12 +137,13 @@ class Library final : public QObject
         int addDevicesToDb(const QList<FilePath>& dirs, const QString& tablename,
                            const QString& id_rowname) throw (Exception);
         QMultiMap<Version, FilePath> getElementFilePathsFromDb(const QString& tablename,
-                                                               const Uuid& uuid) const noexcept;
+                                                               const Uuid& uuid) const throw (Exception);
         FilePath getLatestVersionFilePath(const QMultiMap<Version, FilePath>& list) const noexcept;
         QSet<Uuid> getCategoryChilds(const QString& tablename, const Uuid& categoryUuid) const throw (Exception);
         QSet<Uuid> getElementsByCategory(const QString& tablename, const QString& idrowname,
                                           const Uuid& categoryUuid) const throw (Exception);
-        void clearDatabaseAndCreateTables() throw (Exception);
+        void createAllTables() throw (Exception);
+        void clearAllTables() throw (Exception);
         QMultiMap<QString, FilePath> getAllElementDirectories() throw (Exception);
         QSqlQuery prepareQuery(const QString& query) const throw (Exception);
         int execQuery(QSqlQuery& query, bool checkId) const throw (Exception);


### PR DESCRIPTION
When the SQLite database does not exist and the user adds a component to
a schematic, an SQL error appears and the whole application crashes.
The thrown exception is caused by non-existing tables in the database.
The crash is caused by the method Library::getElementFilePathsFromDb()
which is mistakenly marked with the "noexcept" keyword although it can
thow exceptions.

This commit does:
- Avoid the thrown exception by creating all non-existing tables right
  after opening the database (ctor of Library).
- Fix the application crash by correcting the exception specifier of
  Library::getElementFilePathsFromDb().

Fixes #78