### PR TITLE
[WIP] Add repositories to workspace settings

### DIFF
--- a/libs/librepcbcommon/fileio/xmldomelement.cpp
+++ b/libs/librepcbcommon/fileio/xmldomelement.cpp
@@ -348,6 +348,12 @@ void XmlDomElement::setAttribute(const QString& name, const QColor& value) noexc
 }
 
 template <>
+void XmlDomElement::setAttribute(const QString& name, const QUrl& value) noexcept
+{
+    setAttribute<QString>(name, value.isValid() ? value.toString(QUrl::PrettyDecoded) : "");
+}
+
+template <>
 void XmlDomElement::setAttribute(const QString& name, const Uuid& value) noexcept
 {
     setAttribute<QString>(name, value.isNull() ? "" : value.toStr());
@@ -471,6 +477,22 @@ QColor XmlDomElement::getAttribute<QColor>(const QString& name, bool throwIfEmpt
     {
         throw FileParseError(__FILE__, __LINE__, getDocFilePath(), -1, -1, attr,
             QString(tr("Invalid Color attribute \"%1\" in node \"%2\".")).arg(name, mName));
+    }
+}
+
+template <>
+QUrl XmlDomElement::getAttribute<QUrl>(const QString& name, bool throwIfEmpty, const QUrl& defaultValue) const throw (Exception)
+{
+    QString attr = getAttribute<QString>(name, throwIfEmpty);
+    QUrl obj(attr, QUrl::StrictMode);
+    if (obj.isValid())
+        return obj;
+    else if ((attr.isEmpty()) && (!throwIfEmpty))
+        return defaultValue;
+    else
+    {
+        throw FileParseError(__FILE__, __LINE__, getDocFilePath(), -1, -1, attr,
+            QString(tr("Invalid Url attribute \"%1\" in node \"%2\": %3")).arg(name, mName, obj.errorString()));
     }
 }
 

--- a/libs/librepcbcommon/fileio/xmldomelement.h
+++ b/libs/librepcbcommon/fileio/xmldomelement.h
@@ -185,7 +185,7 @@ class XmlDomElement final
          * @brief Set or add an attribute to this element
          *
          * @tparam T        The text will be converted in this type. Available types:
-         *                  bool, const char*, QString, QColor, #Uuid, #LengthUnit,
+         *                  bool, const char*, QString, QColor, QUrl, #Uuid, #LengthUnit,
          *                  #Length, #Angle, #HAlign, #VAlign (tbc)
          *
          * @param name      The tag name (see #isValidXmlTagName() for allowed characters)
@@ -208,8 +208,8 @@ class XmlDomElement final
          * @brief Get the value of a specific attribute in the specified type
          *
          * @tparam T    The value will be converted in this type. Available types:
-         *              bool, uint, int, QString, QColor, #Uuid, #LengthUnit, #Length,
-         *              #Angle, #HAlign, #VAlign (tbc)
+         *              bool, uint, int, QString, QColor, QUrl, #Uuid, #LengthUnit,
+         *              #Length, #Angle, #HAlign, #VAlign (tbc)
          *
          * @param name          The tag name (see #isValidXmlTagName() for allowed characters)
          * @param throwIfEmpty  If true and the value is empty, an exception will be thrown

--- a/libs/librepcbcommon/librepcbcommon.pro
+++ b/libs/librepcbcommon/librepcbcommon.pro
@@ -89,7 +89,8 @@ HEADERS += \
     network/filedownload.h \
     network/networkrequest.h \
     network/networkrequestbase.h \
-    network/networkaccessmanager.h
+    network/networkaccessmanager.h \
+    network/repository.h
 
 SOURCES += \
     attributes/attributetype.cpp \
@@ -144,7 +145,8 @@ SOURCES += \
     network/filedownload.cpp \
     network/networkrequest.cpp \
     network/networkrequestbase.cpp \
-    network/networkaccessmanager.cpp
+    network/networkaccessmanager.cpp \
+    network/repository.cpp
 
 FORMS += \
     dialogs/gridsettingsdialog.ui \

--- a/libs/librepcbcommon/network/repository.cpp
+++ b/libs/librepcbcommon/network/repository.cpp
@@ -1,0 +1,141 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "repository.h"
+#include "fileio/xmldomelement.h"
+#include "network/networkrequest.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+Repository::Repository(const Repository& other) noexcept :
+    QObject(nullptr), mUrl(other.mUrl)
+{
+}
+
+Repository::Repository(const QUrl& url) noexcept :
+    QObject(nullptr), mUrl(url)
+{
+}
+
+Repository::Repository(const XmlDomElement& domElement) throw (Exception) :
+    QObject(nullptr), mUrl()
+{
+    mUrl = domElement.getAttribute<QUrl>("url", true); // can throw
+}
+
+Repository::~Repository() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Setters
+ ****************************************************************************************/
+
+bool Repository::setUrl(const QUrl& url) noexcept
+{
+    if (url.isValid()) {
+        mUrl = url;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void Repository::requestRepositoryList() noexcept
+{
+    requestRepositoryList(mUrl.resolved(QUrl("api/v1/libraries/")));
+}
+
+XmlDomElement* Repository::serializeToXmlDomElement() const throw (Exception)
+{
+    if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
+
+    QScopedPointer<XmlDomElement> root(new XmlDomElement("repository"));
+    root->setAttribute("url", mUrl);
+    return root.take();
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void Repository::requestRepositoryList(const QUrl& url) noexcept
+{
+    NetworkRequest* request = new NetworkRequest(url);
+    request->setHeaderField("Accept", "application/json;charset=UTF-8");
+    request->setHeaderField("Accept-Charset", "UTF-8");
+    connect(request, &NetworkRequest::errored,
+            this, &Repository::errorWhileFetchingRepositoryList, Qt::QueuedConnection);
+    connect(request, &NetworkRequest::dataReceived,
+            this, &Repository::requestedDataReceived, Qt::QueuedConnection);
+    request->start();
+}
+
+void Repository::requestedDataReceived(const QByteArray& data) noexcept
+{
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    if (doc.isNull() || doc.isEmpty() || (!doc.isObject())) {
+        emit errorWhileFetchingRepositoryList(tr("Received JSON object is not valid."));
+        return;
+    }
+    QJsonValue nextResultsLink = doc.object().value("next");
+    if (nextResultsLink.isString()) {
+        QUrl url = QUrl(nextResultsLink.toString());
+        if (url.isValid()) {
+            qDebug() << "Request more results from repository:" << url.toString();
+            requestRepositoryList(url);
+        } else {
+            qWarning() << "Invalid URL in received JSON object:" << nextResultsLink.toString();
+        }
+    }
+    QJsonValue reposVal = doc.object().value("results");
+    if ((reposVal.isNull()) || (!reposVal.isArray())) {
+        emit errorWhileFetchingRepositoryList(tr("Received JSON object does not contain "
+                                                 "any results."));
+        return;
+    }
+    emit repositoryListReceived(reposVal.toArray());
+}
+
+bool Repository::checkAttributesValidity() const noexcept
+{
+    if (!mUrl.isValid()) return false;
+    return true;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcbcommon/network/repository.h
+++ b/libs/librepcbcommon/network/repository.h
@@ -1,0 +1,100 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_REPOSITORY_H
+#define LIBREPCB_REPOSITORY_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "../fileio/if_xmlserializableobject.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class Repository
+ ****************************************************************************************/
+
+/**
+ * @brief The Repository class provides access to a LibrePCB API server
+ *
+ * @author ubruhin
+ * @date 2016-08-10
+ */
+class Repository final : public QObject, public IF_XmlSerializableObject
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        Repository() = delete;
+        explicit Repository(const Repository& other) noexcept;
+        explicit Repository(const QUrl& url) noexcept;
+        explicit Repository(const XmlDomElement& domElement) throw (Exception);
+        ~Repository() noexcept;
+
+        // Getters
+        bool isValid() const noexcept {return mUrl.isValid();}
+        const QUrl& getUrl() const noexcept {return mUrl;}
+
+        // Setters
+        bool setUrl(const QUrl& url) noexcept;
+
+        // General Methods
+        void requestRepositoryList() noexcept;
+
+        /// @copydoc IF_XmlSerializableObject#serializeToXmlDomElement()
+        XmlDomElement* serializeToXmlDomElement() const throw (Exception) override;
+
+        // Operators
+        Repository& operator=(const Repository& rhs) = delete;
+
+
+    signals:
+
+        void repositoryListReceived(const QJsonArray& repos);
+        void errorWhileFetchingRepositoryList(const QString& errorMsg);
+
+
+    private: // Methods
+
+        void requestRepositoryList(const QUrl& url) noexcept;
+        void requestedDataReceived(const QByteArray& data) noexcept;
+
+        /// @copydoc IF_XmlSerializableObject#checkAttributesValidity()
+        bool checkAttributesValidity() const noexcept override;
+
+
+    private: // Data
+
+        QUrl mUrl;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_REPOSITORY_H

--- a/libs/librepcbworkspace/librepcbworkspace.pro
+++ b/libs/librepcbworkspace/librepcbworkspace.pro
@@ -39,7 +39,8 @@ SOURCES += \
     library/workspacelibrarydb.cpp \
     library/cat/categorytreemodel.cpp \
     library/cat/categorytreeitem.cpp \
-    library/workspacelibraryscanner.cpp
+    library/workspacelibraryscanner.cpp \
+    settings/items/wsi_repositories.cpp
 
 HEADERS += \
     workspace.h \
@@ -60,7 +61,8 @@ HEADERS += \
     library/workspacelibrarydb.h \
     library/cat/categorytreemodel.h \
     library/cat/categorytreeitem.h \
-    library/workspacelibraryscanner.h
+    library/workspacelibraryscanner.h \
+    settings/items/wsi_repositories.h
 
 FORMS += \
     workspacechooserdialog.ui \

--- a/libs/librepcbworkspace/settings/items/wsi_repositories.cpp
+++ b/libs/librepcbworkspace/settings/items/wsi_repositories.cpp
@@ -1,0 +1,202 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include "wsi_repositories.h"
+#include <librepcbcommon/fileio/xmldomelement.h>
+#include <librepcbcommon/network/repository.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace workspace {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+WSI_Repositories::WSI_Repositories(const QString& xmlTagName, XmlDomElement* xmlElement) throw (Exception) :
+    WSI_Base(xmlTagName, xmlElement)
+{
+    if (xmlElement) {
+        // load setting
+        for (XmlDomElement* child = xmlElement->getFirstChild("repository", false);
+             child; child = child->getNextSibling("repository", false))
+        {
+            mList.append(new Repository(*child)); // can throw
+        }
+    } else {
+        // load defaults
+        mList.append(new Repository(QUrl("https://api.librepcb.org")));
+    }
+    foreach (const Repository* repository, mList) {
+        mListTmp.append(new Repository(*repository));
+    }
+
+    // create the QListWidget
+    mListWidget.reset(new QListWidget());
+    updateListWidgetItems();
+
+    // create a QLineEdit
+    mLineEdit.reset(new QLineEdit());
+    mLineEdit->setMaxLength(255);
+
+    // create all buttons
+    mBtnUp.reset(new QToolButton());
+    mBtnDown.reset(new QToolButton());
+    mBtnAdd.reset(new QToolButton());
+    mBtnRemove.reset(new QToolButton());
+    mBtnUp->setArrowType(Qt::UpArrow);
+    mBtnDown->setArrowType(Qt::DownArrow);
+    mBtnAdd->setIcon(QIcon(":/img/actions/plus_2.png"));
+    mBtnRemove->setIcon(QIcon(":/img/actions/minus.png"));
+    connect(mBtnUp.data(), &QToolButton::clicked, this, &WSI_Repositories::btnUpClicked);
+    connect(mBtnDown.data(), &QToolButton::clicked, this, &WSI_Repositories::btnDownClicked);
+    connect(mBtnAdd.data(), &QToolButton::clicked, this, &WSI_Repositories::btnAddClicked);
+    connect(mBtnRemove.data(), &QToolButton::clicked, this, &WSI_Repositories::btnRemoveClicked);
+
+    // create the QWidget
+    mWidget.reset(new QWidget());
+    QVBoxLayout* outerLayout = new QVBoxLayout(mWidget.data());
+    outerLayout->setContentsMargins(0, 0, 0, 0);
+    outerLayout->addWidget(mListWidget.data());
+    QHBoxLayout* innerLayout = new QHBoxLayout();
+    innerLayout->setContentsMargins(0, 0, 0, 0);
+    outerLayout->addLayout(innerLayout);
+    innerLayout->addWidget(mLineEdit.data());
+    innerLayout->addWidget(mBtnAdd.data());
+    innerLayout->addWidget(mBtnRemove.data());
+    innerLayout->addWidget(mBtnUp.data());
+    innerLayout->addWidget(mBtnDown.data());
+}
+
+WSI_Repositories::~WSI_Repositories() noexcept
+{
+    qDeleteAll(mList);      mList.clear();
+    qDeleteAll(mListTmp);   mListTmp.clear();
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void WSI_Repositories::restoreDefault() noexcept
+{
+    qDeleteAll(mListTmp);   mListTmp.clear();
+    mListTmp.append(new Repository(QUrl("https://api.librepcb.org")));
+    updateListWidgetItems();
+}
+
+void WSI_Repositories::apply() noexcept
+{
+    qDeleteAll(mList);   mList.clear();
+    foreach (const Repository* repository, mListTmp) {
+        mList.append(new Repository(*repository));
+    }
+}
+
+void WSI_Repositories::revert() noexcept
+{
+    qDeleteAll(mListTmp);   mListTmp.clear();
+    foreach (const Repository* repository, mList) {
+        mListTmp.append(new Repository(*repository));
+    }
+    updateListWidgetItems();
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void WSI_Repositories::btnUpClicked() noexcept
+{
+    int row = mListWidget->currentRow();
+    if (row > 0) {
+        mListTmp.move(row, row - 1);
+        mListWidget->insertItem(row - 1, mListWidget->takeItem(row));
+        mListWidget->setCurrentRow(row - 1);
+    }
+}
+
+void WSI_Repositories::btnDownClicked() noexcept
+{
+    int row = mListWidget->currentRow();
+    if ((row >= 0) && (row < mListWidget->count() - 1)) {
+        mListTmp.move(row, row + 1);
+        mListWidget->insertItem(row + 1, mListWidget->takeItem(row));
+        mListWidget->setCurrentRow(row + 1);
+    }
+}
+
+void WSI_Repositories::btnAddClicked() noexcept
+{
+    QUrl url = QUrl::fromUserInput(mLineEdit->text().trimmed());
+    QScopedPointer<Repository> repository(new Repository(url));
+    if (repository->isValid()) {
+        mListTmp.append(repository.take());
+        updateListWidgetItems();
+        mLineEdit->setText("");
+    } else {
+        QMessageBox::critical(mWidget.data(), tr("Error"), tr("The URL is not valid."));
+    }
+}
+
+void WSI_Repositories::btnRemoveClicked() noexcept
+{
+    if (mListWidget->currentRow() >= 0) {
+        delete mListTmp.takeAt(mListWidget->currentRow());
+        delete mListWidget->item(mListWidget->currentRow());
+    }
+}
+
+void WSI_Repositories::updateListWidgetItems() noexcept
+{
+    mListWidget->clear();
+    foreach (const Repository* repository, mListTmp) {
+        QString str = repository->getUrl().toDisplayString();
+        QListWidgetItem* item = new QListWidgetItem(str, mListWidget.data());
+        item->setData(Qt::UserRole, repository);
+    }
+}
+
+XmlDomElement* WSI_Repositories::serializeToXmlDomElement() const throw (Exception)
+{
+    QScopedPointer<XmlDomElement> root(WSI_Base::serializeToXmlDomElement());
+    foreach (const Repository* repository, mList) {
+        root->appendChild(repository->serializeToXmlDomElement()); // can throw
+    }
+    return root.take();
+}
+
+bool WSI_Repositories::checkAttributesValidity() const noexcept
+{
+    return true;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace workspace
+} // namespace librepcb

--- a/libs/librepcbworkspace/settings/items/wsi_repositories.h
+++ b/libs/librepcbworkspace/settings/items/wsi_repositories.h
@@ -1,0 +1,117 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_WORKSPACE_WSI_REPOSITORIES_H
+#define LIBREPCB_WORKSPACE_WSI_REPOSITORIES_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include "wsi_base.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+class Repository;
+
+namespace workspace {
+
+/*****************************************************************************************
+ *  Class WSI_Repositories
+ ****************************************************************************************/
+
+/**
+ * @brief The WSI_Repositories class contains a list of used repositories
+ *
+ * @author ubruhin
+ * @date 2016-08-10
+ */
+class WSI_Repositories final : public WSI_Base
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        WSI_Repositories() = delete;
+        WSI_Repositories(const WSI_Repositories& other) = delete;
+        WSI_Repositories(const QString& xmlTagName, XmlDomElement* xmlElement) throw (Exception);
+        ~WSI_Repositories() noexcept;
+
+        // Getters
+        const QList<const Repository*>& getRepositories() const noexcept {return mList;}
+
+        // Getters: Widgets
+        QWidget* getWidget() const noexcept {return mWidget.data();}
+
+        // General Methods
+        void restoreDefault() noexcept override;
+        void apply() noexcept override;
+        void revert() noexcept override;
+
+        /// @copydoc IF_XmlSerializableObject#serializeToXmlDomElement()
+        XmlDomElement* serializeToXmlDomElement() const throw (Exception) override;
+
+        // Operator Overloadings
+        WSI_Repositories& operator=(const WSI_Repositories& rhs) = delete;
+
+
+    private: // Methods
+
+        void btnUpClicked() noexcept;
+        void btnDownClicked() noexcept;
+        void btnAddClicked() noexcept;
+        void btnRemoveClicked() noexcept;
+        void updateListWidgetItems() noexcept;
+
+        /// @copydoc IF_XmlSerializableObject#checkAttributesValidity()
+        bool checkAttributesValidity() const noexcept override;
+
+
+    private: // Data
+
+        /**
+         * @brief The list of repositories in the right order
+         *
+         * The repository with the highest priority is at index 0 of the list. In case of
+         * version conflicts, the repository with the higher priority will be used.
+         */
+        QList<const Repository*> mList;
+        QList<const Repository*> mListTmp;
+
+        // Widgets
+        QScopedPointer<QWidget> mWidget;
+        QScopedPointer<QListWidget> mListWidget;
+        QScopedPointer<QLineEdit> mLineEdit;
+        QScopedPointer<QToolButton> mBtnUp;
+        QScopedPointer<QToolButton> mBtnDown;
+        QScopedPointer<QToolButton> mBtnAdd;
+        QScopedPointer<QToolButton> mBtnRemove;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace workspace
+} // namespace librepcb
+
+#endif // LIBREPCB_WORKSPACE_WSI_REPOSITORIES_H

--- a/libs/librepcbworkspace/settings/workspacesettings.cpp
+++ b/libs/librepcbworkspace/settings/workspacesettings.cpp
@@ -65,6 +65,7 @@ WorkspaceSettings::WorkspaceSettings(const Workspace& workspace) throw (Exceptio
     loadSettingsItem(mAppearance,               "appearance",                   root);
     loadSettingsItem(mLibraryLocaleOrder,       "lib_locale_order",             root);
     loadSettingsItem(mLibraryNormOrder,         "lib_norm_order",               root);
+    loadSettingsItem(mRepositories,             "repositories",                 root);
     loadSettingsItem(mDebugTools,               "debug_tools",                  root);
 
     // load the settings dialog

--- a/libs/librepcbworkspace/settings/workspacesettings.h
+++ b/libs/librepcbworkspace/settings/workspacesettings.h
@@ -35,6 +35,7 @@
 #include "items/wsi_librarynormorder.h"
 #include "items/wsi_debugtools.h"
 #include "items/wsi_appearance.h"
+#include "items/wsi_repositories.h"
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -85,6 +86,7 @@ class WorkspaceSettings final : public QObject, public IF_XmlSerializableObject
         WSI_Appearance& getAppearance() const noexcept {return *mAppearance;}
         WSI_LibraryLocaleOrder& getLibLocaleOrder() const noexcept {return *mLibraryLocaleOrder;}
         WSI_LibraryNormOrder& getLibNormOrder() const noexcept {return *mLibraryNormOrder;}
+        WSI_Repositories& getRepositories() const noexcept {return *mRepositories;}
         WSI_DebugTools& getDebugTools() const noexcept {return *mDebugTools;}
 
 
@@ -134,6 +136,7 @@ class WorkspaceSettings final : public QObject, public IF_XmlSerializableObject
         QScopedPointer<WSI_Appearance> mAppearance;
         QScopedPointer<WSI_LibraryLocaleOrder> mLibraryLocaleOrder;
         QScopedPointer<WSI_LibraryNormOrder> mLibraryNormOrder;
+        QScopedPointer<WSI_Repositories> mRepositories;
         QScopedPointer<WSI_DebugTools> mDebugTools;
 };
 

--- a/libs/librepcbworkspace/settings/workspacesettingsdialog.cpp
+++ b/libs/librepcbworkspace/settings/workspacesettingsdialog.cpp
@@ -62,12 +62,18 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(WorkspaceSettings& settings) :
     mUi->libraryLayout->addRow(mSettings.getLibNormOrder().getLabelText(),
                                mSettings.getLibNormOrder().getWidget());
 
+    // tab: repositories
+    mUi->repositoriesLayout->addWidget(mSettings.getRepositories().getWidget());
+
     // tab: debug tools
     mUi->tabWidget->addTab(mSettings.getDebugTools().getWidget(), tr("Debug Tools"));
 
     // load the window geometry
     QSettings clientSettings;
     restoreGeometry(clientSettings.value("workspace_settings_dialog/window_geometry").toByteArray());
+
+    // just in case that the wrong tab is selected in the UI designer:
+    mUi->tabWidget->setCurrentIndex(0);
 }
 
 WorkspaceSettingsDialog::~WorkspaceSettingsDialog()
@@ -89,6 +95,9 @@ WorkspaceSettingsDialog::~WorkspaceSettingsDialog()
     // tab: library
     mSettings.getLibLocaleOrder().getWidget()->setParent(0);
     mSettings.getLibNormOrder().getWidget()->setParent(0);
+
+    // tab: repositories
+    mSettings.getRepositories().getWidget()->setParent(0);
 
     // tab: debug tools
     mUi->tabWidget->removeTab(mUi->tabWidget->indexOf(mSettings.getDebugTools().getWidget()));

--- a/libs/librepcbworkspace/settings/workspacesettingsdialog.ui
+++ b/libs/librepcbworkspace/settings/workspacesettingsdialog.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
@@ -94,6 +94,27 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="repositoriesTab">
+      <attribute name="title">
+       <string>Repositories</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <layout class="QVBoxLayout" name="repositoriesLayout">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Repositories are used to browse, download and update libraries.&lt;br/&gt;You can add any server to this list which implements the LibrePCB API.&lt;br/&gt;The official LibrePCB server is &lt;a href=&quot;https://api.librepcb.org&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;https://api.librepcb.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="openExternalLinks">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
A repository is considered as a server which implements the LibrePCB API (which needs to be designed first :wink:, see issue #103).

The goal of this pull request is to integrate repositories into the application:
- [x] Create a new class ```Repository```.
- [ ] Add methods to interact with the API server.
- [x] Make it possible to specify the repositories to be used in the workspace settings dialog.

New tab in the workspace settings dialog:
![workspace settings_002](https://cloud.githubusercontent.com/assets/5374821/17571386/45d4ca1a-5f50-11e6-922a-a57d509743f2.png)
