### PR TITLE
Add a "new project"-wizard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - |
     if [ "${TRAVIS_OS_NAME}" = "linux" ]
     then
-      sudo apt-get install -qq libglu1-mesa-dev
+      sudo apt-get install -qq libglu1-mesa-dev xvfb
       if [ "$QT_BASE" = "trusty" ]; then sudo apt-get install -qq qt5-default qttools5-dev-tools; fi
       if [ -n "$QT_PPA" ]; then sudo apt-get install -qq "${QT_BASE}base" "${QT_BASE}tools"; source "/opt/${QT_BASE}/bin/${QT_BASE}-env.sh"; fi
       if [ "$BUILD_DOXYGEN" = "true" ]; then sudo apt-get install -qq doxygen graphviz; fi
@@ -53,7 +53,7 @@ install:
 
 script:
   - mkdir build && cd build && qmake ../librepcb.pro -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make -j8 && cd ../   # build librepcb
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./build/generated/unix/tests; fi                                 # run all unit tests (linux)
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then xvfb-run -a ./build/generated/unix/tests; fi                     # run all unit tests (linux, using xvfb)
   - if [ "${TRAVIS_OS_NAME}" = "osx" ];   then ./build/generated/mac/tests; fi                                  # run all unit tests (mac)
 
 # run doxygen and upload the html output to github (gh-pages of LibrePCB-Doxygen)

--- a/common.pri
+++ b/common.pri
@@ -12,6 +12,10 @@ macx:DESTDIR = $${GENERATED_DIR}/mac
 unix:!macx:DESTDIR = $${GENERATED_DIR}/unix
 win32:DESTDIR = $${GENERATED_DIR}/windows
 
+# set destination path for resources
+LOCAL_RESOURCES_DIR = $$shadowed($$absolute_path($${GENERATED_DIR}/res, $$_PRO_FILE_PWD_))
+INSTALLED_RESOURCES_DIR = $${PREFIX}/share/librepcb/res
+
 # use separate folders for different types of files
 OBJECTS_DIR = obj
 MOC_DIR = moc
@@ -20,7 +24,7 @@ UI_DIR = ui
 UI_HEADERS_DIR = ui
 UI_SOURCES_DIR = ui
 
-#is qt version sufficient
+# is qt version sufficient
 lessThan(QT_MAJOR_VERSION, 5) {
     error("Qt version $$[QT_VERSION] is too old, should be version 5.2 or newer!")
 } else {
@@ -37,7 +41,11 @@ CONFIG += warn_on
 QMAKE_CXXFLAGS += -Wextra
 QMAKE_CXXFLAGS_DEBUG += -Wextra
 
+# set preprocessor defines
 DEFINES += GIT_VERSION="\\\"$(shell git -C \""$$_PRO_FILE_PWD_"\" describe --abbrev=7 --dirty --always --tags)\\\""
+DEFINES += LOCAL_RESOURCES_DIR="\\\"$${LOCAL_RESOURCES_DIR}\\\""
+DEFINES += INSTALLED_RESOURCES_DIR="\\\"$${INSTALLED_RESOURCES_DIR}\\\""
+DEFINES += INSTALLATION_PREFIX="\\\"$${PREFIX}\\\""
 
 # Define the application version
 DEFINES += APP_VERSION_MAJOR=0

--- a/librepcb/controlpanel/controlpanel.h
+++ b/librepcb/controlpanel/controlpanel.h
@@ -117,13 +117,13 @@ class ControlPanel final : public QMainWindow
         // Project Management
 
         /**
-         * @brief Create a new project and open it with the editor
+         * @brief Open a project with the editor (or bring an already opened editor to front)
          *
-         * @param filepath  The filepath to the *.lpp project file of the project to create
+         * @param project       An already opened project (but without the editor)
          *
          * @return The pointer to the opened project editor (nullptr on error)
          */
-        project::ProjectEditor* createProject(const FilePath& filepath) noexcept;
+        project::ProjectEditor* openProject(project::Project& project) noexcept;
 
         /**
          * @brief Open a project with the editor (or bring an already opened editor to front)

--- a/librepcb/librepcb.pro
+++ b/librepcb/librepcb.pro
@@ -30,6 +30,8 @@ macx {
 unix:!macx {
     # Linux/UNIX-specific configurations
     target.path = $${PREFIX}/bin
+    resources.path = $${INSTALLED_RESOURCES_DIR}/../
+    resources.files = $${LOCAL_RESOURCES_DIR}
     icon.path = $${PREFIX}/share/pixmaps
     icon.files = ../packaging/unix/img/librepcb.svg
     desktop.path = $${PREFIX}/share/applications
@@ -38,7 +40,7 @@ unix:!macx {
     mimexml.files = ../packaging/unix/mime/librepcb.xml
     mimedesktop.path = $${PREFIX}/share/mimelnk/application
     mimedesktop.files = ../packaging/unix/mime/x-librepcb-project.desktop
-    INSTALLS += target icon desktop mimexml mimedesktop
+    INSTALLS += target resources icon desktop mimexml mimedesktop
 }
 
 # Note: The order of the libraries is very important for the linker!
@@ -117,3 +119,10 @@ lrelease.commands = $$QMAKE_LRELEASE ${QMAKE_FILE_IN} -qm ${QMAKE_FILE_PATH}/${Q
 lrelease.CONFIG += no_link
 QMAKE_EXTRA_COMPILERS += lrelease
 PRE_TARGETDEPS += compiler_lrelease_make_all
+
+# Copy resource files to output directory
+copydata.commands = $(COPY_DIR) "\"$$system_path($${PWD}/../res/.)\"" "\"$$system_path($${LOCAL_RESOURCES_DIR})\""
+first.depends = $(first) copydata
+export(first.depends)
+export(copydata.commands)
+QMAKE_EXTRA_TARGETS += first copydata

--- a/librepcb/main.cpp
+++ b/librepcb/main.cpp
@@ -41,6 +41,7 @@ using namespace librepcb::workspace;
  ****************************************************************************************/
 
 static void setApplicationMetadata() noexcept;
+static void writeLogHeader() noexcept;
 static void installTranslations() noexcept;
 static void init3rdPartyLibs() noexcept;
 static void cleanup3rdPartyLibs() noexcept;
@@ -65,6 +66,9 @@ int main(int argc, char* argv[])
     // Creates the Debug object which installs the message handler. This must be done as
     // early as possible, but *after* setting application metadata (organization + name).
     Debug::instance();
+
+    // Write some information about the application instance to the log.
+    writeLogHeader();
 
     // Install translation files. This must be done before any widget is shown.
     installTranslations();
@@ -110,6 +114,27 @@ static void setApplicationMetadata() noexcept
 #endif
     Application::setApplicationVersion(Version(QString("%1.%2.%3").arg(APP_VERSION_MAJOR)
                                        .arg(APP_VERSION_MINOR).arg(APP_VERSION_PATCH)));
+}
+
+/*****************************************************************************************
+ *  writeLogHeader()
+ ****************************************************************************************/
+
+static void writeLogHeader() noexcept
+{
+    // @TODO: After removing support for Qt versions below 5.5, we could use qInfo() here.
+
+    // write application name and version to log
+    QString msg = QString("LibrePCB %1 (%2)").arg(qApp->applicationVersion(), GIT_VERSION);
+    Debug::instance()->print(Debug::DebugLevel_t::Info, msg, __FILE__, __LINE__);
+
+    // write Qt version to log
+    msg = QString("Qt version: %1 (compiled against %2)").arg(qVersion(), QT_VERSION_STR);
+    Debug::instance()->print(Debug::DebugLevel_t::Info, msg, __FILE__, __LINE__);
+
+    // write resources directory path to log
+    msg = QString("Resources directory: %1").arg(Application::getResourcesDir().toNative());
+    Debug::instance()->print(Debug::DebugLevel_t::Info, msg, __FILE__, __LINE__);
 }
 
 /*****************************************************************************************

--- a/libs/librepcbcommon/application.cpp
+++ b/libs/librepcbcommon/application.cpp
@@ -75,6 +75,31 @@ Version Application::applicationVersion() noexcept
     return version;
 }
 
+bool Application::isRunningFromInstalledExecutable() noexcept
+{
+    // get the installation prefix directory
+    FilePath installationPrefixDir(INSTALLATION_PREFIX);
+    Q_ASSERT(installationPrefixDir.isValid());
+
+    // get the directory of the currently running executable
+    FilePath executableFilePath(qApp->applicationFilePath());
+    Q_ASSERT(executableFilePath.isValid());
+
+    // check if the running executable is located in the installation prefix directory
+    return executableFilePath.isLocatedInDir(installationPrefixDir);
+}
+
+FilePath Application::getResourcesDir() noexcept
+{
+    if (isRunningFromInstalledExecutable()) {
+        // the application is installed on the system -> use installed ressources
+        return FilePath(INSTALLED_RESOURCES_DIR);
+    } else {
+        // the application is not installed on the system -> use local resources
+        return FilePath(LOCAL_RESOURCES_DIR);
+    }
+}
+
 /*****************************************************************************************
  *  End of File
  ****************************************************************************************/

--- a/libs/librepcbcommon/application.h
+++ b/libs/librepcbcommon/application.h
@@ -26,6 +26,7 @@
 #include <QtCore>
 #include <QApplication>
 #include "version.h"
+#include "fileio/filepath.h"
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -60,6 +61,8 @@ class Application final : public QApplication
         static void setApplicationVersion(const Version& version) noexcept;
         static Version applicationVersion() noexcept;
         static int majorVersion() noexcept {return applicationVersion().getNumbers().first();}
+        static bool isRunningFromInstalledExecutable() noexcept;
+        static FilePath getResourcesDir() noexcept;
 
 
     private:

--- a/libs/librepcbcommon/debug.cpp
+++ b/libs/librepcbcommon/debug.cpp
@@ -80,16 +80,12 @@ void Debug::setDebugLevelLogFile(DebugLevel_t level)
         mLogFilepath.getParentDir().mkPath();
         mLogFile = new QFile(mLogFilepath.toStr());
         bool success = mLogFile->open(QFile::WriteOnly);
-        if (success)
-        {
+        if (success) {
             mDebugLevelLogFile = level; // activate logging to file immediately!
-            qDebug() << "enabled logging to file" << mLogFilepath.toNative();
-            qDebug() << "Qt version:" << qVersion();
-        }
-        else
-        {
-            qWarning() << "cannot enable logging to file" << mLogFilepath.toNative();
-            qWarning() << "error message:" << mLogFile->errorString();
+            qDebug() << "Enabled logging to file:" << mLogFilepath.toNative();
+        } else {
+            qWarning() << "Cannot enable logging to file" << mLogFilepath.toNative();
+            qWarning() << "Error message:" << mLogFile->errorString();
             delete mLogFile;
             mLogFile = 0;
         }

--- a/libs/librepcbcommon/fileio/filepath.h
+++ b/libs/librepcbcommon/fileio/filepath.h
@@ -117,7 +117,22 @@ namespace librepcb {
  */
 class FilePath final
 {
-    public:
+    public: // Types
+
+        enum CleanFileNameOption {
+            // spaces
+            KeepSpaces      = 0<<1,
+            ReplaceSpaces   = 1<<1,
+            // case
+            KeepCase        = 0<<2,
+            ToLowerCase     = 1<<2,
+            // default
+            Default         = KeepSpaces | KeepCase,
+        };
+        Q_DECLARE_FLAGS(CleanFileNameOptions, CleanFileNameOption);
+
+
+    public: // Methods
 
         // Constructors / Destructor
 
@@ -194,6 +209,13 @@ class FilePath final
          * @return True if the filepath is the filesystem root, false otherwise
          */
         bool isRoot() const noexcept;
+
+        /**
+         * @brief Check if the filepath is located inside another directory
+         *
+         * @return True if the filepath points to an item inside "dir", false otherwise
+         */
+        bool isLocatedInDir(const FilePath& dir) const noexcept;
 
         /**
          * @brief Get the absolute and well-formatted filepath as a QString
@@ -364,6 +386,29 @@ class FilePath final
          */
         static FilePath getRandomTempPath() noexcept;
 
+        /**
+         * @brief Clean a given string so that it becomes a valid filename
+         *
+         * Every time a file- or directory name needs to be constructed (e.g. from user
+         * input), you must use this function to replace/remove all characters which are
+         * not allowed for file/dir paths.
+         *
+         * These are the only allowed characters: A–Z a–z 0–9 . _ -
+         *
+         * In addition, the length of the filename will be limited to 120 characters.
+         *
+         * @param userInput An arbitrary string (may be directly from a user input field)
+         * @param options   Some options to define how the filename should be escaped
+         *
+         * @return A string which is either empty or a valid filename (based on userInput)
+         *
+         * @note    This function does exectly the same on all supported platforms, even
+         *          if the set of allowed characters depends on the platform. This way we
+         *          can guarantee that all created files/directories are platform
+         *          independent.
+         */
+        static QString cleanFileName(const QString& userInput, CleanFileNameOptions options) noexcept;
+
 
         // Operator Overloadings
 
@@ -421,5 +466,8 @@ QDebug& operator<<(QDebug& stream, const FilePath& filepath);
  ****************************************************************************************/
 
 } // namespace librepcb
+
+// QFlags
+Q_DECLARE_OPERATORS_FOR_FLAGS(librepcb::FilePath::CleanFileNameOptions)
 
 #endif // LIBREPCB_FILEPATH_H

--- a/libs/librepcbcommon/fileio/fileutils.h
+++ b/libs/librepcbcommon/fileio/fileutils.h
@@ -57,6 +57,29 @@ class FileUtils final
         // Static methods
 
         /**
+         * @brief Read the content of a file into a QByteArray
+         *
+         * @param filepath      The file to read
+         *
+         * @return              The content of the file
+         *
+         * @throws Exception    If an error occurs.
+         */
+        static QByteArray readFile(const FilePath& filepath) throw (Exception);
+
+        /**
+         * @brief Write the content of a QByteArray into a file
+         *
+         * If the file does not exist, it will be created (with all parent directories).
+         *
+         * @param filepath      The file to (over)write
+         * @param content       The content to write
+         *
+         * @throws Exception    If an error occurs.
+         */
+        static void writeFile(const FilePath& filepath, const QByteArray& content) throw (Exception);
+
+        /**
          * @brief Copy a single file
          *
          * @param source        Filepath to an existing file.

--- a/libs/librepcbcommon/fileio/smartfile.cpp
+++ b/libs/librepcbcommon/fileio/smartfile.cpp
@@ -104,15 +104,7 @@ const FilePath& SmartFile::prepareSaveAndReturnFilePath(bool toOriginal) throw (
         throw LogicError(__FILE__, __LINE__, QString(), tr("Cannot save read-only file!"));
     }
 
-    const FilePath& filepath(toOriginal ? mFilePath : mTmpFilePath);
-
-    if (!filepath.getParentDir().isExistingDir()) {
-        // try to create parent directories
-        if (!filepath.getParentDir().mkPath())
-            qWarning() << "could not make path for file" << filepath.toNative();
-    }
-
-    return filepath;
+    return toOriginal ? mFilePath : mTmpFilePath;
 }
 
 void SmartFile::updateMembersAfterSaving(bool toOriginal) noexcept
@@ -122,41 +114,6 @@ void SmartFile::updateMembersAfterSaving(bool toOriginal) noexcept
 
     if (toOriginal && mIsCreated)
         mIsCreated = false;
-}
-
-QByteArray SmartFile::readContentFromFile(const FilePath& filepath) throw (Exception)
-{
-    QFile file(filepath.toStr());
-    if (!file.open(QIODevice::ReadOnly)) {
-        throw RuntimeError(__FILE__, __LINE__, filepath.toStr(), QString(tr("Cannot "
-            "open file \"%1\": %2")).arg(filepath.toNative(), file.errorString()));
-    }
-    return file.readAll();
-}
-
-void SmartFile::saveContentToFile(const FilePath& filepath, const QByteArray& content) throw (Exception)
-{
-    QSaveFile file(filepath.toStr());
-    if (!file.open(QIODevice::WriteOnly)) {
-        throw RuntimeError(__FILE__, __LINE__, QString("%1: %2 [%3]")
-            .arg(filepath.toStr(), file.errorString()).arg(file.error()),
-            QString(tr("Could not open or create file \"%1\": %2"))
-            .arg(filepath.toNative(), file.errorString()));
-    }
-
-    qint64 written = file.write(content);
-    if (written != content.size()) {
-        throw RuntimeError(__FILE__, __LINE__,
-            QString("%1: %2 (only %3 of %4 bytes written)")
-            .arg(filepath.toStr(), file.errorString()).arg(written).arg(content.size()),
-            QString(tr("Could not write to file \"%1\": %2"))
-            .arg(filepath.toNative(), file.errorString()));
-    }
-
-    if (!file.commit()) {
-        throw RuntimeError(__FILE__, __LINE__, QString(), QString(tr("Could not write to "
-            "file \"%1\": %2")).arg(filepath.toNative(), file.errorString()));
-    }
 }
 
 /*****************************************************************************************

--- a/libs/librepcbcommon/fileio/smartfile.h
+++ b/libs/librepcbcommon/fileio/smartfile.h
@@ -137,6 +137,7 @@ class SmartFile
          */
         void removeFile(bool original) throw (Exception);
 
+
         // Operator Overloadings
         SmartFile& operator=(const SmartFile& rhs) = delete;
 
@@ -174,30 +175,6 @@ class SmartFile
          * @param toOriginal    Specifies whether the original or the backup file was saved.
          */
         void updateMembersAfterSaving(bool toOriginal) noexcept;
-
-        /**
-         * @brief Helper method to read the content from a file into a QByteArray
-         *
-         * @param filepath  The path to the file
-         *
-         * @return The file content
-         *
-         * @throw Exception     If an error occurs, this method throws an exception.
-         */
-        static QByteArray readContentFromFile(const FilePath& filepath) throw (Exception);
-
-        /**
-         * @brief Helper method to save the content of a QByteArray to a file
-         *
-         * This method can be used in derived classes of #SmartFile to simply write a
-         * QByteArray to a file.
-         *
-         * @param filepath      The path to the file
-         * @param content       The content which will be written to the file
-         *
-         * @throw Exception     If an error occurs, this method throws an exception.
-         */
-        static void saveContentToFile(const FilePath& filepath, const QByteArray& content) throw (Exception);
 
 
         // General Attributes

--- a/libs/librepcbcommon/fileio/smarttextfile.cpp
+++ b/libs/librepcbcommon/fileio/smarttextfile.cpp
@@ -22,6 +22,7 @@
  ****************************************************************************************/
 #include <QtCore>
 #include "smarttextfile.h"
+#include "fileutils.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -35,14 +36,11 @@ namespace librepcb {
 SmartTextFile::SmartTextFile(const FilePath& filepath, bool restore, bool readOnly, bool create) throw (Exception) :
     SmartFile(filepath, restore, readOnly, create)
 {
-    if (mIsCreated)
-    {
+    if (mIsCreated) {
         // nothing to do, leave "mContent" empty
-    }
-    else
-    {
+    } else {
         // read the content of the file
-        mContent = readContentFromFile(mOpenedFilePath);
+        mContent = FileUtils::readFile(mOpenedFilePath);
     }
 }
 
@@ -57,7 +55,7 @@ SmartTextFile::~SmartTextFile() noexcept
 void SmartTextFile::save(bool toOriginal) throw (Exception)
 {
     const FilePath& filepath = prepareSaveAndReturnFilePath(toOriginal);
-    saveContentToFile(filepath, mContent);
+    FileUtils::writeFile(filepath, mContent);
     updateMembersAfterSaving(toOriginal);
 }
 

--- a/libs/librepcbcommon/fileio/smarttextfile.h
+++ b/libs/librepcbcommon/fileio/smarttextfile.h
@@ -50,6 +50,8 @@ class SmartTextFile final : public SmartFile
     public:
 
         // Constructors / Destructor
+        SmartTextFile() = delete;
+        SmartTextFile(const SmartTextFile& other) = delete;
 
         /**
          * @brief The constructor to open an existing text file
@@ -107,6 +109,10 @@ class SmartTextFile final : public SmartFile
         void save(bool toOriginal) throw (Exception);
 
 
+        // Operator Overloadings
+        SmartTextFile& operator=(const SmartTextFile& rhs) = delete;
+
+
         // Static Methods
 
         /**
@@ -123,14 +129,6 @@ class SmartTextFile final : public SmartFile
          * @throw Exception If an error occurs
          */
         static SmartTextFile* create(const FilePath& filepath) throw (Exception);
-
-
-    private:
-
-        // make some methods inaccessible...
-        SmartTextFile();
-        SmartTextFile(const SmartTextFile& other);
-        SmartTextFile& operator=(const SmartTextFile& rhs);
 
 
     protected:

--- a/libs/librepcbcommon/fileio/smartversionfile.cpp
+++ b/libs/librepcbcommon/fileio/smartversionfile.cpp
@@ -22,6 +22,7 @@
  ****************************************************************************************/
 #include <QtCore>
 #include "smartversionfile.h"
+#include "fileutils.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -41,7 +42,7 @@ SmartVersionFile::SmartVersionFile(const FilePath& filepath, bool restore, bool 
     }
     else {
         // read the content of the file
-        QString content = QString(readContentFromFile(mOpenedFilePath));
+        QString content = QString(FileUtils::readFile(mOpenedFilePath));
         QStringList lines = content.split("\n", QString::KeepEmptyParts);
         mVersion.setVersion((lines.count() > 0) ? lines.first() : QString());
         if (!mVersion.isValid()) {
@@ -63,7 +64,7 @@ void SmartVersionFile::save(bool toOriginal) throw (Exception)
 {
     if (mVersion.isValid()) {
         const FilePath& filepath = prepareSaveAndReturnFilePath(toOriginal);
-        saveContentToFile(filepath, QString("%1\n").arg(mVersion.toStr()).toUtf8());
+        FileUtils::writeFile(filepath, QString("%1\n").arg(mVersion.toStr()).toUtf8());
         updateMembersAfterSaving(toOriginal);
     } else {
         throw LogicError(__FILE__, __LINE__, mVersion.toStr(), tr("Invalid version number"));

--- a/libs/librepcbcommon/fileio/smartxmlfile.cpp
+++ b/libs/librepcbcommon/fileio/smartxmlfile.cpp
@@ -22,6 +22,7 @@
  ****************************************************************************************/
 #include <QtCore>
 #include "smartxmlfile.h"
+#include "fileutils.h"
 #include "xmldomdocument.h"
 #include "xmldomelement.h"
 
@@ -50,13 +51,13 @@ SmartXmlFile::~SmartXmlFile() noexcept
 QSharedPointer<XmlDomDocument> SmartXmlFile::parseFileAndBuildDomTree() const throw (Exception)
 {
     return QSharedPointer<XmlDomDocument>(
-        new XmlDomDocument(readContentFromFile(mOpenedFilePath), mOpenedFilePath));
+        new XmlDomDocument(FileUtils::readFile(mOpenedFilePath), mOpenedFilePath));
 }
 
 void SmartXmlFile::save(const XmlDomDocument& domDocument, bool toOriginal) throw (Exception)
 {
     const FilePath& filepath = prepareSaveAndReturnFilePath(toOriginal);
-    saveContentToFile(filepath, domDocument.toByteArray());
+    FileUtils::writeFile(filepath, domDocument.toByteArray());
     updateMembersAfterSaving(toOriginal);
 }
 

--- a/libs/librepcbcommon/fileio/smartxmlfile.h
+++ b/libs/librepcbcommon/fileio/smartxmlfile.h
@@ -56,6 +56,8 @@ class SmartXmlFile final : public SmartFile
     public:
 
         // Constructors / Destructor
+        SmartXmlFile() = delete;
+        SmartXmlFile(const SmartXmlFile& other) = delete;
 
         /**
          * @brief The constructor to open an existing XML file
@@ -101,6 +103,10 @@ class SmartXmlFile final : public SmartFile
         void save(const XmlDomDocument& domDocument, bool toOriginal) throw (Exception);
 
 
+        // Operator Overloadings
+        SmartXmlFile& operator=(const SmartXmlFile& rhs) = delete;
+
+
         // Static Methods
 
         /**
@@ -119,15 +125,7 @@ class SmartXmlFile final : public SmartFile
         static SmartXmlFile* create(const FilePath &filepath) throw (Exception);
 
 
-    private:
-
-        // make some methods inaccessible...
-        SmartXmlFile();
-        SmartXmlFile(const SmartXmlFile& other);
-        SmartXmlFile& operator=(const SmartXmlFile& rhs);
-
-
-        // Private Methods
+    private: // Methods
 
         /**
          * @brief Constructor to create or open a XML file

--- a/libs/librepcbproject/project.cpp
+++ b/libs/librepcbproject/project.cpp
@@ -358,8 +358,16 @@ Schematic* Project::getSchematicByName(const QString& name) const noexcept
 
 Schematic* Project::createSchematic(const QString& name) throw (Exception)
 {
-    QString basename = name; /// @todo remove special characters to create a valid filename!
+    QString basename = FilePath::cleanFileName(name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
+    if (basename.isEmpty()) {
+        throw RuntimeError(__FILE__ , __LINE__, QString(),
+            QString(tr("Invalid schematic name: \"%1\"")).arg(name));
+    }
     FilePath filepath = mPath.getPathTo("schematics/" % basename % ".xml");
+    if (filepath.isExistingFile()) {
+        throw RuntimeError(__FILE__ , __LINE__, QString(),
+            QString(tr("The schematic exists already: \"%1\"")).arg(filepath.toNative()));
+    }
     return Schematic::create(*this, filepath, name);
 }
 
@@ -468,15 +476,31 @@ Board* Project::getBoardByName(const QString& name) const noexcept
 
 Board* Project::createBoard(const QString& name) throw (Exception)
 {
-    QString basename = name; /// @todo remove special characters to create a valid filename!
+    QString basename = FilePath::cleanFileName(name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
+    if (basename.isEmpty()) {
+        throw RuntimeError(__FILE__ , __LINE__, QString(),
+            QString(tr("Invalid board name: \"%1\"")).arg(name));
+    }
     FilePath filepath = mPath.getPathTo("boards/" % basename % ".xml");
+    if (filepath.isExistingFile()) {
+        throw RuntimeError(__FILE__ , __LINE__, QString(),
+            QString(tr("The board exists already: \"%1\"")).arg(filepath.toNative()));
+    }
     return Board::create(*this, filepath, name);
 }
 
 Board* Project::createBoard(const Board& other, const QString& name) throw (Exception)
 {
-    QString basename = name; /// @todo remove special characters to create a valid filename!
+    QString basename = FilePath::cleanFileName(name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
+    if (basename.isEmpty()) {
+        throw RuntimeError(__FILE__ , __LINE__, QString(),
+            QString(tr("Invalid board name: \"%1\"")).arg(name));
+    }
     FilePath filepath = mPath.getPathTo("boards/" % basename % ".xml");
+    if (filepath.isExistingFile()) {
+        throw RuntimeError(__FILE__ , __LINE__, QString(),
+            QString(tr("The board exists already: \"%1\"")).arg(filepath.toNative()));
+    }
     return new Board(other, filepath, name);
 }
 

--- a/libs/librepcbproject/project.cpp
+++ b/libs/librepcbproject/project.cpp
@@ -200,13 +200,7 @@ Project::Project(const FilePath& filepath, bool create, bool readOnly) throw (Ex
         mSchematicLayerProvider = new SchematicLayerProvider(*this);
 
         // Load all schematics
-        if (create)
-        {
-            FilePath fp = FilePath::fromRelative(mPath.getPathTo("schematics"), "main.xml");
-            Schematic* schematic = Schematic::create(*this, fp, "Main Page");
-            addSchematic(*schematic);
-        }
-        else
+        if (!create)
         {
             for (XmlDomElement* node = root->getFirstChild("schematics/schematic", true, false);
                  node; node = node->getNextSibling("schematic"))
@@ -219,13 +213,7 @@ Project::Project(const FilePath& filepath, bool create, bool readOnly) throw (Ex
         }
 
         // Load all boards
-        if (create)
-        {
-            FilePath fp = FilePath::fromRelative(mPath.getPathTo("boards"), "default.xml");
-            Board* board = Board::create(*this, fp, "Default");
-            addBoard(*board);
-        }
-        else
+        if (!create)
         {
             for (XmlDomElement* node = root->getFirstChild("boards/board", true, false);
                  node; node = node->getNextSibling("board"))

--- a/libs/librepcbprojecteditor/librepcbprojecteditor.pro
+++ b/libs/librepcbprojecteditor/librepcbprojecteditor.pro
@@ -71,7 +71,11 @@ SOURCES += \
     boardeditor/fabricationoutputdialog.cpp \
     cmd/cmdremovedevicefromboard.cpp \
     cmd/cmdremoveviafromboard.cpp \
-    cmd/cmddetachboardnetpointfromviaorpad.cpp
+    cmd/cmddetachboardnetpointfromviaorpad.cpp \
+    newprojectwizard/newprojectwizard.cpp \
+    newprojectwizard/newprojectwizardpage_metadata.cpp \
+    newprojectwizard/newprojectwizardpage_initialization.cpp \
+    newprojectwizard/newprojectwizardpage_versioncontrol.cpp
 
 HEADERS += \
     projecteditor.h \
@@ -124,7 +128,11 @@ HEADERS += \
     boardeditor/fabricationoutputdialog.h \
     cmd/cmdremovedevicefromboard.h \
     cmd/cmdremoveviafromboard.h \
-    cmd/cmddetachboardnetpointfromviaorpad.h
+    cmd/cmddetachboardnetpointfromviaorpad.h \
+    newprojectwizard/newprojectwizard.h \
+    newprojectwizard/newprojectwizardpage_metadata.h \
+    newprojectwizard/newprojectwizardpage_initialization.h \
+    newprojectwizard/newprojectwizardpage_versioncontrol.h
 
 FORMS += \
     schematiceditor/schematiceditor.ui \
@@ -139,5 +147,9 @@ FORMS += \
     dialogs/addcomponentdialog.ui \
     boardeditor/boardlayersdock.ui \
     boardeditor/boardviapropertiesdialog.ui \
-    boardeditor/fabricationoutputdialog.ui
+    boardeditor/fabricationoutputdialog.ui \
+    newprojectwizard/newprojectwizard.ui \
+    newprojectwizard/newprojectwizardpage_metadata.ui \
+    newprojectwizard/newprojectwizardpage_initialization.ui \
+    newprojectwizard/newprojectwizardpage_versioncontrol.ui
 

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.cpp
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.cpp
@@ -1,0 +1,161 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include "newprojectwizard.h"
+#include "ui_newprojectwizard.h"
+#include <librepcbcommon/application.h>
+#include <librepcbcommon/fileio/fileutils.h>
+#include <librepcbcommon/fileio/smarttextfile.h>
+#include <librepcbproject/project.h>
+#include <librepcbproject/settings/projectsettings.h>
+#include <librepcbworkspace/workspace.h>
+#include <librepcbworkspace/settings/workspacesettings.h>
+#include "newprojectwizardpage_metadata.h"
+#include "newprojectwizardpage_initialization.h"
+#include "newprojectwizardpage_versioncontrol.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+NewProjectWizard::NewProjectWizard(const workspace::Workspace& ws, QWidget* parent) noexcept :
+    QWizard(parent), mWorkspace(ws), mUi(new Ui::NewProjectWizard)
+{
+    mUi->setupUi(this);
+
+    addPage(mPageMetadata = new NewProjectWizardPage_Metadata(this));
+    addPage(mPageInitialization = new NewProjectWizardPage_Initialization(this));
+    addPage(mPageVersionControl = new NewProjectWizardPage_VersionControl(this));
+}
+
+NewProjectWizard::~NewProjectWizard() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Setters
+ ****************************************************************************************/
+
+void NewProjectWizard::setLocation(const FilePath& dir) noexcept
+{
+    mPageMetadata->setDefaultLocation(dir);
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+Project* NewProjectWizard::createProject() const throw (Exception)
+{
+    // create project and set some metadata
+    FilePath projectFilePath = mPageMetadata->getFullFilePath();
+    QScopedPointer<Project> project(Project::create(projectFilePath));
+    project->setName(mPageMetadata->getProjectName());
+    project->setAuthor(mPageMetadata->getProjectAuthor());
+
+    // set project settings (copy from workspace settings)
+    ProjectSettings& settings = project->getSettings();
+    settings.setLocaleOrder(mWorkspace.getSettings().getLibLocaleOrder().getLocaleOrder());
+    settings.setNormOrder(mWorkspace.getSettings().getLibNormOrder().getNormOrder());
+
+    // add schematic
+    if (mPageInitialization->getCreateSchematic()) {
+        Schematic* schematic = project->createSchematic(mPageInitialization->getSchematicName());
+        project->addSchematic(*schematic);
+    }
+
+    // add board
+    if (mPageInitialization->getCreateBoard()) {
+        Board* board = project->createBoard(mPageInitialization->getBoardName());
+        project->addBoard(*board);
+    }
+
+    // save project to filesystem
+    project->save(true);
+
+    // copy license file
+    if (mPageMetadata->isLicenseSet()) {
+        try {
+            FilePath source = mPageMetadata->getProjectLicenseFilePath();
+            FilePath destination = projectFilePath.getParentDir().getPathTo("LICENSE.txt");
+            FileUtils::copyFile(source, destination); // can throw
+        } catch (Exception& e) {
+            qCritical() << "Could not copy the license file:" << e.getUserMsg();
+        }
+    }
+
+    // copy readme file
+    try {
+        FilePath source = Application::getResourcesDir().getPathTo("project/readme_template");
+        FilePath destination = projectFilePath.getParentDir().getPathTo("README.md");
+        QByteArray content = FileUtils::readFile(source); // can throw
+        content.replace("{PROJECT_NAME}", mPageMetadata->getProjectName().toUtf8());
+        if (mPageMetadata->isLicenseSet()) {
+            content.replace("{LICENSE_TEXT}", "See [LICENSE.txt](LICENSE.txt).");
+        } else {
+            content.replace("{LICENSE_TEXT}", "No license set.");
+        }
+        FileUtils::writeFile(destination, content); // can throw
+    } catch (Exception& e) {
+        qCritical() << "Could not copy the readme file:" << e.getUserMsg();
+    }
+
+    // initialize git repository
+    if (mPageVersionControl->getInitGitRepository()) {
+        // copy .gitignore
+        try {
+            FilePath source = Application::getResourcesDir().getPathTo("project/gitignore_template");
+            FilePath destination = projectFilePath.getParentDir().getPathTo(".gitignore");
+            FileUtils::copyFile(source, destination); // can throw
+        } catch (Exception& e) {
+            qCritical() << "Could not copy the .gitignore file:" << e.getUserMsg();
+        }
+        // copy .gitattributes
+        try {
+            FilePath source = Application::getResourcesDir().getPathTo("project/gitattributes_template");
+            FilePath destination = projectFilePath.getParentDir().getPathTo(".gitattributes");
+            FileUtils::copyFile(source, destination); // can throw
+        } catch (Exception& e) {
+            qCritical() << "Could not copy the .gitattributes file:" << e.getUserMsg();
+        }
+        // TODO: git init
+        // TODO: create initial commit
+    }
+
+    // all done, return the new project
+    return project.take();
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.h
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.h
@@ -1,0 +1,100 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_NEWPROJECTWIZARD_H
+#define LIBREPCB_PROJECT_NEWPROJECTWIZARD_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include <librepcbcommon/exceptions.h>
+#include <librepcbcommon/fileio/filepath.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+
+namespace librepcb {
+
+namespace workspace {
+class Workspace;
+}
+
+namespace project {
+
+class Project;
+class NewProjectWizardPage_Metadata;
+class NewProjectWizardPage_Initialization;
+class NewProjectWizardPage_VersionControl;
+
+namespace Ui {
+class NewProjectWizard;
+}
+
+/*****************************************************************************************
+ *  Class NewProjectWizard
+ ****************************************************************************************/
+
+/**
+ * @brief The NewProjectWizard class
+ *
+ * @author ubruhin
+ * @date 2016-08-13
+ */
+class NewProjectWizard final : public QWizard
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        NewProjectWizard() = delete;
+        NewProjectWizard(const NewProjectWizard& other) = delete;
+        explicit NewProjectWizard(const workspace::Workspace& ws, QWidget* parent = nullptr) noexcept;
+        ~NewProjectWizard() noexcept;
+
+        // Setters
+        void setLocation(const FilePath& dir) noexcept;
+
+        // General Methods
+        Project* createProject() const throw (Exception);
+
+        // Operator Overloadings
+        NewProjectWizard& operator=(const NewProjectWizard& rhs) = delete;
+
+
+    private: // Data
+
+        const workspace::Workspace& mWorkspace;
+        QScopedPointer<Ui::NewProjectWizard> mUi;
+        NewProjectWizardPage_Metadata* mPageMetadata;
+        NewProjectWizardPage_Initialization* mPageInitialization;
+        NewProjectWizardPage_VersionControl* mPageVersionControl;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_NEWPROJECTWIZARD_H

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.ui
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.ui
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::project::NewProjectWizard</class>
+ <widget class="QWizard" name="librepcb::project::NewProjectWizard">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>531</width>
+    <height>370</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create New Project</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <property name="wizardStyle">
+   <enum>QWizard::ModernStyle</enum>
+  </property>
+  <property name="options">
+   <set>QWizard::IndependentPages|QWizard::NoBackButtonOnStartPage</set>
+  </property>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_initialization.cpp
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_initialization.cpp
@@ -1,0 +1,146 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include "newprojectwizardpage_initialization.h"
+#include "ui_newprojectwizardpage_initialization.h"
+#include <librepcbcommon/fileio/filepath.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+NewProjectWizardPage_Initialization::NewProjectWizardPage_Initialization(QWidget *parent) noexcept :
+    QWizardPage(parent), mUi(new Ui::NewProjectWizardPage_Initialization)
+{
+    mUi->setupUi(this);
+    setPixmap(QWizard::LogoPixmap, QPixmap(":/img/actions/plus_2.png"));
+    setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));
+
+    // signal/slot connections
+    connect(mUi->cbxAddSchematic, &QGroupBox::toggled,
+            this, &NewProjectWizardPage_Initialization::completeChanged);
+    connect(mUi->cbxAddBoard, &QGroupBox::toggled,
+            this, &NewProjectWizardPage_Initialization::completeChanged);
+    connect(mUi->edtSchematicName, &QLineEdit::textChanged,
+            this, &NewProjectWizardPage_Initialization::schematicNameChanged);
+    connect(mUi->edtBoardName, &QLineEdit::textChanged,
+            this, &NewProjectWizardPage_Initialization::boardNameChanged);
+
+    // insert values
+    mUi->edtSchematicName->setText("Main"); // do not translate this into other languages!
+    mUi->edtBoardName->setText("default");  // do not translate this into other languages!
+}
+
+NewProjectWizardPage_Initialization::~NewProjectWizardPage_Initialization() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Getters
+ ****************************************************************************************/
+
+bool NewProjectWizardPage_Initialization::getCreateSchematic() const noexcept
+{
+    return mUi->cbxAddSchematic->isChecked();
+}
+
+QString NewProjectWizardPage_Initialization::getSchematicName() const noexcept
+{
+    return mUi->edtSchematicName->text();
+}
+
+QString NewProjectWizardPage_Initialization::getSchematicFileName() const noexcept
+{
+    return mUi->lblSchematicFileName->text();
+}
+
+bool NewProjectWizardPage_Initialization::getCreateBoard() const noexcept
+{
+    return mUi->cbxAddBoard->isChecked();
+}
+
+QString NewProjectWizardPage_Initialization::getBoardName() const noexcept
+{
+    return mUi->edtBoardName->text();
+}
+
+QString NewProjectWizardPage_Initialization::getBoardFileName() const noexcept
+{
+    return mUi->lblBoardFileName->text();
+}
+
+/*****************************************************************************************
+ *  GUI Action Handlers
+ ****************************************************************************************/
+
+void NewProjectWizardPage_Initialization::schematicNameChanged(const QString& name) noexcept
+{
+    QString filename = FilePath::cleanFileName(name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
+    if (!filename.isEmpty()) filename.append(".xml");
+    mUi->lblSchematicFileName->setText(filename);
+    emit completeChanged();
+}
+
+void NewProjectWizardPage_Initialization::boardNameChanged(const QString& name) noexcept
+{
+    QString filename = FilePath::cleanFileName(name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
+    if (!filename.isEmpty()) filename.append(".xml");
+    mUi->lblBoardFileName->setText(filename);
+    emit completeChanged();
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+bool NewProjectWizardPage_Initialization::isComplete() const noexcept
+{
+    // check base class
+    if (!QWizardPage::isComplete()) return false;
+
+    // check schematic filename
+    if (mUi->cbxAddSchematic->isChecked() && mUi->lblSchematicFileName->text().isEmpty()) {
+        return false;
+    }
+
+    // check board filename
+    if (mUi->cbxAddBoard->isChecked() && mUi->lblBoardFileName->text().isEmpty()) {
+        return false;
+    }
+
+    return true;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_initialization.h
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_initialization.h
@@ -1,0 +1,97 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_INITIALIZATION_H
+#define LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_INITIALIZATION_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+
+namespace librepcb {
+namespace project {
+
+namespace Ui {
+class NewProjectWizardPage_Initialization;
+}
+
+/*****************************************************************************************
+ *  Class NewProjectWizardPage_Initialization
+ ****************************************************************************************/
+
+/**
+ * @brief The NewProjectWizardPage_Initialization class
+ *
+ * @author ubruhin
+ * @date 2016-08-13
+ */
+class NewProjectWizardPage_Initialization final : public QWizardPage
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+
+        explicit NewProjectWizardPage_Initialization(QWidget* parent = nullptr) noexcept;
+        NewProjectWizardPage_Initialization(const NewProjectWizardPage_Initialization& other) = delete;
+        ~NewProjectWizardPage_Initialization() noexcept;
+
+        // Getters
+        bool getCreateSchematic() const noexcept;
+        QString getSchematicName() const noexcept;
+        QString getSchematicFileName() const noexcept;
+        bool getCreateBoard() const noexcept;
+        QString getBoardName() const noexcept;
+        QString getBoardFileName() const noexcept;
+
+        // Operator Overloadings
+        NewProjectWizardPage_Initialization& operator=(const NewProjectWizardPage_Initialization& rhs) = delete;
+
+
+    private: // GUI Action Handlers
+
+        void schematicNameChanged(const QString& name) noexcept;
+        void boardNameChanged(const QString& name) noexcept;
+
+
+    private: // Methods
+
+        bool isComplete() const noexcept override;
+
+
+    private: // Data
+
+        QScopedPointer<Ui::NewProjectWizardPage_Initialization> mUi;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_INITIALIZATION_H

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_initialization.ui
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_initialization.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::project::NewProjectWizardPage_Initialization</class>
+ <widget class="QWizardPage" name="librepcb::project::NewProjectWizardPage_Initialization">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>391</width>
+    <height>214</height>
+   </rect>
+  </property>
+  <property name="title">
+   <string>Initialization</string>
+  </property>
+  <property name="subTitle">
+   <string>Specify how the project should be initialized.</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="cbxAddSchematic">
+     <property name="title">
+      <string>Add Schematic</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="edtSchematicName">
+        <property name="maxLength">
+         <number>250</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Filename:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="lblSchematicFileName">
+        <property name="text">
+         <string>-</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="cbxAddBoard">
+     <property name="title">
+      <string>Add Board</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="edtBoardName">
+        <property name="maxLength">
+         <number>250</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Filename:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="lblBoardFileName">
+        <property name="text">
+         <string>-</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -1,0 +1,215 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include "newprojectwizardpage_metadata.h"
+#include "ui_newprojectwizardpage_metadata.h"
+#include <librepcbcommon/application.h>
+#include <librepcbcommon/systeminfo.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(QWidget *parent) noexcept :
+    QWizardPage(parent), mUi(new Ui::NewProjectWizardPage_Metadata)
+{
+    mUi->setupUi(this);
+    setPixmap(QWizard::LogoPixmap, QPixmap(":/img/actions/plus_2.png"));
+    setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));
+
+    // signal/slot connections
+    connect(mUi->edtName, &QLineEdit::textChanged,
+            this, &NewProjectWizardPage_Metadata::nameChanged);
+    connect(mUi->edtLocation, &QLineEdit::textChanged,
+            this, &NewProjectWizardPage_Metadata::locationChanged);
+    connect(mUi->btnLocation, &QPushButton::clicked,
+            this, &NewProjectWizardPage_Metadata::chooseLocationClicked);
+
+    // insert values
+    mUi->edtAuthor->setText(SystemInfo::getFullUsername());
+    mUi->cbxLicense->addItem(QString("No License (not recommended)"),
+                             QString());
+    mUi->cbxLicense->addItem(tr("CC0-1.0 (no restrictions, recommended for open hardware projects)"),
+                             QString("licenses/cc0-1.0.txt"));
+    mUi->cbxLicense->addItem(tr("CC-BY-4.0 (requires attribution)"),
+                             QString("licenses/cc-by-4.0.txt"));
+    mUi->cbxLicense->addItem(tr("CC-BY-SA-4.0 (requires attribution + share alike)"),
+                             QString("licenses/cc-by-sa-4.0.txt"));
+    mUi->cbxLicense->setCurrentIndex(0); // no license
+}
+
+NewProjectWizardPage_Metadata::~NewProjectWizardPage_Metadata() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Setters
+ ****************************************************************************************/
+
+void NewProjectWizardPage_Metadata::setDefaultLocation(const FilePath& dir) noexcept
+{
+    mUi->edtLocation->setText(dir.toNative());
+    updateProjectFilePath();
+    emit completeChanged();
+}
+
+/*****************************************************************************************
+ *  Getters
+ ****************************************************************************************/
+
+QString NewProjectWizardPage_Metadata::getProjectName() const noexcept
+{
+    return mUi->edtName->text();
+}
+
+QString NewProjectWizardPage_Metadata::getProjectAuthor() const noexcept
+{
+    return mUi->edtAuthor->text();
+}
+
+bool NewProjectWizardPage_Metadata::isLicenseSet() const noexcept
+{
+    return !mUi->cbxLicense->currentData(Qt::UserRole).toString().isEmpty();
+}
+
+FilePath NewProjectWizardPage_Metadata::getProjectLicenseFilePath() const noexcept
+{
+    QString licenseFileName = mUi->cbxLicense->currentData(Qt::UserRole).toString();
+    if (!licenseFileName.isEmpty()) {
+        return Application::getResourcesDir().getPathTo(licenseFileName);
+    } else {
+        return FilePath();
+    }
+}
+
+FilePath NewProjectWizardPage_Metadata::getFullFilePath() const noexcept
+{
+    return mFullFilePath;
+}
+
+/*****************************************************************************************
+ *  GUI Action Handlers
+ ****************************************************************************************/
+
+void NewProjectWizardPage_Metadata::nameChanged(const QString& name) noexcept
+{
+    Q_UNUSED(name);
+    updateProjectFilePath();
+    emit completeChanged();
+}
+
+void NewProjectWizardPage_Metadata::locationChanged(const QString& dir) noexcept
+{
+    Q_UNUSED(dir);
+    updateProjectFilePath();
+    emit completeChanged();
+}
+
+void NewProjectWizardPage_Metadata::chooseLocationClicked() noexcept
+{
+    QString dir = QFileDialog::getExistingDirectory(this,
+        tr("Project's parent directory"), mUi->edtLocation->text());
+    if (!dir.isEmpty()) {
+        mUi->edtLocation->setText(FilePath(dir).toNative());
+        updateProjectFilePath();
+        emit completeChanged();
+    }
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void NewProjectWizardPage_Metadata::updateProjectFilePath() noexcept
+{
+    // invalidate filepath
+    mFullFilePath = FilePath();
+
+    // check filename
+    QString name = mUi->edtName->text();
+    QString filename = FilePath::cleanFileName(name, FilePath::ReplaceSpaces);
+    if (filename.isEmpty()) {
+        mUi->lblFullFilePath->setText(tr("Please enter a valid project name."));
+        return;
+    }
+
+    // check location
+    FilePath location(mUi->edtLocation->text());
+    if ((!location.isValid()) || (!location.isExistingDir())) {
+        mUi->lblFullFilePath->setText(tr("The location must be an existing directory."));
+        return;
+    }
+
+    // determine project directory and filepath
+    FilePath projDir = location.getPathTo(filename);
+    FilePath fullFilePath = projDir.getPathTo(filename % ".lpp");
+    if ((!projDir.isValid()) || (!fullFilePath.isValid())) {
+        mUi->lblFullFilePath->setText(tr("Oops, could not determine a valid filepath."));
+        return;
+    }
+
+    // the filepath is valid
+    mFullFilePath = fullFilePath;
+    mUi->lblFullFilePath->setText(fullFilePath.toNative());
+}
+
+bool NewProjectWizardPage_Metadata::isComplete() const noexcept
+{
+    // check base class
+    if (!QWizardPage::isComplete()) return false;
+
+    // check filepath
+    if (!mFullFilePath.isValid()) return false;
+
+    return true;
+}
+
+bool NewProjectWizardPage_Metadata::validatePage() noexcept
+{
+    // check base class
+    if (!QWizardPage::validatePage()) return false;
+
+    // check if the project's directory does not exists
+    FilePath projDir = mFullFilePath.getParentDir();
+    if ((projDir.isExistingDir() && !projDir.isEmptyDir()) || (projDir.isExistingFile())) {
+        QMessageBox::critical(this, tr("Invalid filepath"),
+            tr("The project's directory exists already and is not empty."));
+        return false;
+    }
+
+    return true;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.h
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.h
@@ -1,0 +1,103 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_METADATA_H
+#define LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_METADATA_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include <librepcbcommon/fileio/filepath.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+
+namespace librepcb {
+namespace project {
+
+namespace Ui {
+class NewProjectWizardPage_Metadata;
+}
+
+/*****************************************************************************************
+ *  Class NewProjectWizardPage_Metadata
+ ****************************************************************************************/
+
+/**
+ * @brief The NewProjectWizardPage_Metadata class
+ *
+ * @author ubruhin
+ * @date 2016-08-13
+ */
+class NewProjectWizardPage_Metadata final : public QWizardPage
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        explicit NewProjectWizardPage_Metadata(QWidget* parent = nullptr) noexcept;
+        NewProjectWizardPage_Metadata(const NewProjectWizardPage_Metadata& other) = delete;
+        ~NewProjectWizardPage_Metadata() noexcept;
+
+        // Setters
+        void setDefaultLocation(const FilePath& dir) noexcept;
+
+        // Getters
+        QString getProjectName() const noexcept;
+        QString getProjectAuthor() const noexcept;
+        bool isLicenseSet() const noexcept;
+        FilePath getProjectLicenseFilePath() const noexcept;
+        FilePath getFullFilePath() const noexcept;
+
+        // Operator Overloadings
+        NewProjectWizardPage_Metadata& operator=(const NewProjectWizardPage_Metadata& rhs) = delete;
+
+
+    private: // GUI Action Handlers
+
+        void nameChanged(const QString& name) noexcept;
+        void locationChanged(const QString& dir) noexcept;
+        void chooseLocationClicked() noexcept;
+
+
+    private: // Methods
+
+        void updateProjectFilePath() noexcept;
+        bool isComplete() const noexcept override;
+        bool validatePage() noexcept override;
+
+
+    private: // Data
+
+        QScopedPointer<Ui::NewProjectWizardPage_Metadata> mUi;
+        FilePath mFullFilePath;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_METADATA_H

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::project::NewProjectWizardPage_Metadata</class>
+ <widget class="QWizardPage" name="librepcb::project::NewProjectWizardPage_Metadata">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>586</width>
+    <height>214</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="title">
+   <string>Project Metadata</string>
+  </property>
+  <property name="subTitle">
+   <string>Specify some metadata of the project to be created.</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Name:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="edtName">
+     <property name="maxLength">
+      <number>250</number>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Author:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="edtAuthor">
+     <property name="maxLength">
+      <number>250</number>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>License:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Location:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLineEdit" name="edtLocation"/>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnLocation">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Full Path:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="lblFullFilePath">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="minimumSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../../../img/images.qrc">:/img/status/info.png</pixmap>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>A LibrePCB project consists of a whole directory, not only of a single file. Just select the new project's parent directory, and the subdirectory and filename will be set automatically.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QComboBox" name="cbxLicense">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToContents</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>https://en.wikipedia.org/wiki/Creative_Commons_license</string>
+       </property>
+       <property name="text">
+        <string>&lt;a href=&quot;https://en.wikipedia.org/wiki/Creative_Commons_license&quot;&gt;&lt;img src=&quot;:/img/status/info.png&quot; width=&quot;25&quot; height=&quot;25&quot;/&gt;&lt;/a&gt;</string>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../../img/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
@@ -1,0 +1,76 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include "newprojectwizardpage_versioncontrol.h"
+#include "ui_newprojectwizardpage_versioncontrol.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+NewProjectWizardPage_VersionControl::NewProjectWizardPage_VersionControl(QWidget *parent) noexcept :
+    QWizardPage(parent), mUi(new Ui::NewProjectWizardPage_VersionControl)
+{
+    mUi->setupUi(this);
+    setPixmap(QWizard::LogoPixmap, QPixmap(":/img/actions/plus_2.png"));
+    setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));
+}
+
+NewProjectWizardPage_VersionControl::~NewProjectWizardPage_VersionControl() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Getters
+ ****************************************************************************************/
+
+bool NewProjectWizardPage_VersionControl::getInitGitRepository() const noexcept
+{
+    return mUi->gbxInitGitRepo->isChecked();
+}
+
+/*****************************************************************************************
+ *  GUI Action Handlers
+ ****************************************************************************************/
+
+
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.h
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.h
@@ -1,0 +1,89 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_VERSIONCONTROL_H
+#define LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_VERSIONCONTROL_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+
+namespace librepcb {
+namespace project {
+
+namespace Ui {
+class NewProjectWizardPage_VersionControl;
+}
+
+/*****************************************************************************************
+ *  Class NewProjectWizardPage_VersionControl
+ ****************************************************************************************/
+
+/**
+ * @brief The NewProjectWizardPage_VersionControl class
+ *
+ * @author ubruhin
+ * @date 2016-08-13
+ *
+ * @todo Add more functionality (run "git init" and "git commit").
+ */
+class NewProjectWizardPage_VersionControl final : public QWizardPage
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+
+        explicit NewProjectWizardPage_VersionControl(QWidget* parent = nullptr) noexcept;
+        NewProjectWizardPage_VersionControl(const NewProjectWizardPage_VersionControl& other) = delete;
+        ~NewProjectWizardPage_VersionControl() noexcept;
+
+        // Getters
+        bool getInitGitRepository() const noexcept;
+
+        // Operator Overloadings
+        NewProjectWizardPage_VersionControl& operator=(const NewProjectWizardPage_VersionControl& rhs) = delete;
+
+
+    private: // GUI Action Handlers
+
+
+    private: // Methods
+
+
+    private: // Data
+
+        QScopedPointer<Ui::NewProjectWizardPage_VersionControl> mUi;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_NEWPROJECTWIZARDPAGE_VERSIONCONTROL_H

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.ui
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.ui
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::project::NewProjectWizardPage_VersionControl</class>
+ <widget class="QWizardPage" name="librepcb::project::NewProjectWizardPage_VersionControl">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>516</width>
+    <height>115</height>
+   </rect>
+  </property>
+  <property name="title">
+   <string>Version Control</string>
+  </property>
+  <property name="subTitle">
+   <string>Specify if the project should be put under version control.</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="gbxInitGitRepo">
+     <property name="title">
+      <string>Initialize Git repository</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>This will create the files &quot;.gitignore&quot; and &quot;.gitattributes&quot; in the project's directory. Initializing a Git repository is not yet supported, so you need to do this by yourself ;)</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/res/README.md
+++ b/res/README.md
@@ -1,0 +1,4 @@
+# Resources
+
+This directory contains additional resource files required by the LibrePCB application at runtime.
+When installing LibrePCB, these files will be copied into a system directory (e.g. /usr/share/).

--- a/res/licenses/cc-by-4.0.txt
+++ b/res/licenses/cc-by-4.0.txt
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public: 
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/res/licenses/cc-by-sa-4.0.txt
+++ b/res/licenses/cc-by-sa-4.0.txt
@@ -1,0 +1,427 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public: 
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+
+     including for purposes of Section 3(b); and
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/res/licenses/cc0-1.0.txt
+++ b/res/licenses/cc0-1.0.txt
@@ -1,0 +1,116 @@
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+  and translate a Work;
+
+  ii. moral rights retained by the original author(s) and/or performer(s);
+
+  iii. publicity and privacy rights pertaining to a person's image or likeness
+  depicted in a Work;
+
+  iv. rights protecting against unfair competition in regards to a Work,
+  subject to the limitations in paragraph 4(a), below;
+
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+  a Work;
+
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+  European Parliament and of the Council of 11 March 1996 on the legal
+  protection of databases, and under any national implementation thereof,
+  including any amended or successor version of such directive); and
+
+  vii. other similar, equivalent or corresponding rights throughout the world
+  based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+  surrendered, licensed or otherwise affected by this document.
+
+  b. Affirmer offers the Work as-is and makes no representations or warranties
+  of any kind concerning the Work, express, implied, statutory or otherwise,
+  including without limitation warranties of title, merchantability, fitness
+  for a particular purpose, non infringement, or the absence of latent or
+  other defects, accuracy, or the present or absence of errors, whether or not
+  discoverable, all to the greatest extent permissible under applicable law.
+
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+  that may apply to the Work or any use thereof, including without limitation
+  any person's Copyright and Related Rights in the Work. Further, Affirmer
+  disclaims responsibility for obtaining any necessary consents, permissions
+  or other rights required for any use of the Work.
+
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+  party to this document and has no duty or obligation with respect to this
+  CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>

--- a/res/project/gitattributes_template
+++ b/res/project/gitattributes_template
@@ -1,0 +1,7 @@
+# Note: 
+# This file may be overwritten by LibrePCB when upgrading the project to a newer version.
+# So, if you make any changes in this file, you should review/correct it after an upgrade.
+# If you think that something is missing here, please open a new issue on our issue tracker.
+
+# Disable automatic end-of-line conversion for all files (same as "core.autocrlf=false").
+* -text

--- a/res/project/gitignore_template
+++ b/res/project/gitignore_template
@@ -1,0 +1,17 @@
+# Note: 
+# This file may be overwritten by LibrePCB when upgrading the project to a newer version.
+# So, if you make any changes in this file, you should review/correct it after an upgrade.
+# If you think that something is missing here, please open a new issue on our issue tracker.
+
+# LibrePCB files
+user/
+.~lock.*
+*~
+
+# Files created by operating systems or file managers
+.DS_Store
+Thumbs.db
+
+# Files created by other applications
+*.autosave
+*.swp

--- a/res/project/readme_template
+++ b/res/project/readme_template
@@ -1,0 +1,10 @@
+# {PROJECT_NAME}
+
+## Description
+
+This is a [LibrePCB](http://librepcb.org) project!
+Just edit this file to add a description about it.
+
+## License
+
+{LICENSE_TEXT}

--- a/tests/common/applicationtest.cpp
+++ b/tests/common/applicationtest.cpp
@@ -1,0 +1,90 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+
+#include <QtCore>
+#include <gtest/gtest.h>
+#include <librepcbcommon/application.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*****************************************************************************************
+ *  Test Class
+ ****************************************************************************************/
+
+class ApplicationTest : public ::testing::Test
+{
+};
+
+/*****************************************************************************************
+ *  Test Methods
+ ****************************************************************************************/
+
+TEST(ApplicationTest, testApplicationVersion)
+{
+    // read application version and check validity
+    Version v = Application::applicationVersion();
+    EXPECT_TRUE(v.isValid());
+
+    // compare with QApplication version
+    Version v1(qApp->applicationVersion());
+    EXPECT_TRUE(v1.isValid());
+    EXPECT_EQ(v, v1);
+
+    // compare with defines
+    Version v2(QString("%1.%2.%3").arg(APP_VERSION_MAJOR).arg(APP_VERSION_MINOR).arg(APP_VERSION_PATCH));
+    EXPECT_TRUE(v2.isValid());
+    EXPECT_EQ(v, v2);
+}
+
+TEST(ApplicationTest, testMajorVersion)
+{
+    EXPECT_EQ(APP_VERSION_MAJOR, Application::majorVersion());
+}
+
+TEST(ApplicationTest, testIsRunningFromInstalledExecutable)
+{
+    // as there is no "make install" available for the unit tests, it can't be installed ;)
+    EXPECT_FALSE(Application::isRunningFromInstalledExecutable());
+}
+
+TEST(ApplicationTest, testGetResourcesDir)
+{
+    // as the tests can't be installed, the resources must be located in LOCAL_RESOURCES_DIR
+    EXPECT_EQ(Application::getResourcesDir(), FilePath(LOCAL_RESOURCES_DIR));
+
+    // check if the resources directory is valid, exists and is not empty
+    EXPECT_TRUE(Application::getResourcesDir().isValid());
+    EXPECT_TRUE(Application::getResourcesDir().isExistingDir());
+    EXPECT_FALSE(Application::getResourcesDir().isEmptyDir());
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace librepcb

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -23,6 +23,7 @@
 
 #include <QtCore>
 #include <gmock/gmock.h>
+#include <librepcbcommon/application.h>
 #include <librepcbcommon/debug.h>
 
 /*****************************************************************************************
@@ -36,6 +37,14 @@ using namespace librepcb;
 
 int main(int argc, char *argv[])
 {
+    // many classes rely on a QApplication instance, so we create it here
+    Application app(argc, argv);
+    Application::setOrganizationName("LibrePCB");
+    Application::setOrganizationDomain("librepcb.org");
+    Application::setApplicationName("LibrePCB-UnitTests");
+    Application::setApplicationVersion(Version(QString("%1.%2.%3").arg(APP_VERSION_MAJOR)
+                                       .arg(APP_VERSION_MINOR).arg(APP_VERSION_PATCH)));
+
     // disable the whole debug output (we want only the output from gtest)
     Debug::instance()->setDebugLevelLogFile(Debug::DebugLevel_t::Nothing);
     Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::Nothing);

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -13,8 +13,7 @@ GENERATED_DIR = ../generated
 # Use common project definitions
 include(../common.pri)
 
-QT += core
-QT -= gui widgets
+QT += core widgets
 
 CONFIG += console
 CONFIG -= app_bundle
@@ -42,6 +41,7 @@ PRE_TARGETDEPS += \
 SOURCES += main.cpp \
     common/filepathtest.cpp \
     common/pointtest.cpp \
-    common/scopeguardtest.cpp
+    common/scopeguardtest.cpp \
+    common/applicationtest.cpp
 
 HEADERS +=


### PR DESCRIPTION
### Description
This wizard makes it easier to create a new project, and it allows to specify some additional information how the project should be created. This fixes (at least parts of) #16.

### Issues
- The project's directory name and basename of the \*.lpp project file are automatically derived from the project's name (spaces are replaced by underscores, invalid characters are removed). But I'm not sure if this is the best way, because there is no way to choose another directory-/filename. On the other side, this does not confuse the user with too many input fields... **Any thoughts about this?**
- Initializing a Git repository is not yet possible. But as the files .gitignore and .gitattributes will already be copied into the project's directory, I think this is enough for the moment.

### Screenshots
![create new project_004](https://cloud.githubusercontent.com/assets/5374821/17652533/e5ab6900-627e-11e6-96c7-55fd806a4f7e.png)
![create new project_002](https://cloud.githubusercontent.com/assets/5374821/17652387/09636ea0-627b-11e6-9009-415ee62bbe92.png)
![create new project_003](https://cloud.githubusercontent.com/assets/5374821/17652388/0c34872c-627b-11e6-8e0e-c3622899461f.png)