### PR TITLE
Fix invisible project editor when no schematics/boards exist

### DIFF
--- a/libs/librepcbprojecteditor/projecteditor.cpp
+++ b/libs/librepcbprojecteditor/projecteditor.cpp
@@ -102,18 +102,14 @@ ProjectEditor::~ProjectEditor() noexcept
 
 bool ProjectEditor::windowIsAboutToClose(QMainWindow& window) noexcept
 {
-    int countOfOpenWindows = 0;
-    if (mSchematicEditor->isVisible())  {countOfOpenWindows++;}
-    if (mBoardEditor->isVisible())      {countOfOpenWindows++;}
-
-    if (countOfOpenWindows <= 1)
-    {
+    if (getCountOfVisibleEditorWindows() > 1) {
+        // this is not the last open window, so no problem to close it...
+        return true;
+    } else {
         // the last open window (schematic editor, board editor, ...) is about to close.
         // --> close the whole project
         return closeAndDestroy(&window);
     }
-
-    return true; // this is not the last open window, so no problem to close it...
 }
 
 /*****************************************************************************************
@@ -122,10 +118,14 @@ bool ProjectEditor::windowIsAboutToClose(QMainWindow& window) noexcept
 
 void ProjectEditor::showAllRequiredEditors() noexcept
 {
-    if (!mProject.getBoards().isEmpty())
-        showBoardEditor();
-    if (!mProject.getSchematics().isEmpty())
-        showSchematicEditor();
+    // show board editor if there is at least one board
+    if (!mProject.getBoards().isEmpty())        {showBoardEditor();}
+    // show schematic editor if there is at least one schematic
+    if (!mProject.getSchematics().isEmpty())    {showSchematicEditor();}
+    // if there aren't any boards or schematics, show the schematic editor anyway
+    if (getCountOfVisibleEditorWindows() < 1)   {showSchematicEditor();}
+    // verify if at least one editor window is now visible
+    Q_ASSERT(getCountOfVisibleEditorWindows() > 0);
 }
 
 void ProjectEditor::showSchematicEditor() noexcept
@@ -245,6 +245,18 @@ bool ProjectEditor::closeAndDestroy(bool askForSave, QWidget* msgBoxParent) noex
         default: // cancel, don't close the project
             return false;
     }
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+int ProjectEditor::getCountOfVisibleEditorWindows() const noexcept
+{
+    int count = 0;
+    if (mSchematicEditor->isVisible())  {count++;}
+    if (mBoardEditor->isVisible())      {count++;}
+    return count;
 }
 
 /*****************************************************************************************

--- a/libs/librepcbprojecteditor/projecteditor.h
+++ b/libs/librepcbprojecteditor/projecteditor.h
@@ -67,11 +67,13 @@ class ProjectEditor final : public QObject
     public:
 
         // Constructors / Destructor
+        ProjectEditor() = delete;
+        ProjectEditor(const Project& other) = delete;
 
         /**
          * @brief The constructor
          */
-        explicit ProjectEditor(workspace::Workspace& workspace, Project& project) throw (Exception);
+        ProjectEditor(workspace::Workspace& workspace, Project& project) throw (Exception);
 
         /**
          * @brief The destructor
@@ -113,13 +115,18 @@ class ProjectEditor final : public QObject
         bool windowIsAboutToClose(QMainWindow& window) noexcept;
 
 
+        // Operator Overloadings
+        ProjectEditor& operator=(const Project& rhs) = delete;
+
+
     public slots:
 
         /**
          * @brief Open the schematic and/or the board editor window
          *
          * Which editors this will open depends on whether the project has schematics
-         * and/or boards.
+         * and/or boards. If there aren't any boards or schematics, the schematic editor
+         * will be shown anyway (otherwise the whole project editor would be invisible).
          */
         void showAllRequiredEditors() noexcept;
 
@@ -196,19 +203,15 @@ class ProjectEditor final : public QObject
         void projectEditorClosed();
 
 
-    private:
+    private: // Methods
 
-        // make some methods inaccessible...
-        ProjectEditor() = delete;
-        ProjectEditor(const Project& other) = delete;
-        ProjectEditor& operator=(const Project& rhs) = delete;
+        int getCountOfVisibleEditorWindows() const noexcept;
 
 
-        // Attributes
+    private: // Data
+
         workspace::Workspace& mWorkspace;
         Project& mProject;
-
-        // General
         QTimer mAutoSaveTimer; ///< the timer for the periodically automatic saving functionality (see also @ref doc_project_save)
         UndoStack* mUndoStack; ///< See @ref doc_project_undostack
         SchematicEditor* mSchematicEditor; ///< The schematic editor (GUI)


### PR DESCRIPTION
When opened a project which has no schematics and boards, neither the schematic editor nor the board editor were shown and the whole project was invisible for the user.

This commit ensures that the schematic editor will be shown anyway in this special case.