### PR TITLE
README: Add donation buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# LibrePCB [![Travis Build Status](https://travis-ci.org/LibrePCB/LibrePCB.svg?branch=master)](https://travis-ci.org/LibrePCB/LibrePCB) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/3npw66djux4kv82f/branch/master?svg=true)](https://ci.appveyor.com/project/ubruhin/librepcb/branch/master)
+# LibrePCB
+
+[![Travis Build Status](https://travis-ci.org/LibrePCB/LibrePCB.svg?branch=master)](https://travis-ci.org/LibrePCB/LibrePCB)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/3npw66djux4kv82f/branch/master?svg=true)](https://ci.appveyor.com/project/ubruhin/librepcb/branch/master)
+[![Flattr this project](https://img.shields.io/badge/flattr-donate-yellow.svg)](https://flattr.com/submit/auto?user_id=LibrePCB&url=https://github.com/LibrePCB/LibrePCB&title=LibrePCB&language=&tags=github&category=software)
+[![Donate with Bitcoin](https://img.shields.io/badge/bitcoin-donate-yellow.svg)](https://blockchain.info/address/1FiXZxoXe3px1nNuNygRb1NwcYr6U8AvG8)
 
 ## About LibrePCB
 


### PR DESCRIPTION
This adds a Flattr and a Bitcoin donation button to the README. The Bitcoin button is just a link to [blockchain.info](https://blockchain.info/address/1FiXZxoXe3px1nNuNygRb1NwcYr6U8AvG8), where our Bitcoin address and a QR code is shown. In future we may create a donation section on our [website](http://librepcb.org) and link to there, but at the moment this is the easiest solution ;)