### PR TITLE
Add .gitattributes to avoid automatic EOL conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Disable automatic end-of-line conversion for all files (same as "core.autocrlf=false").
+* -text


### PR DESCRIPTION
### The problem

Just tried to open a LibrePCB project on windows and got following error:
```
The suffix of the project file must be "lpp"! {C:/LibrePCB/LibrePCB/dev/demo-workspace/projects/Demo Brushless Controller/Demo Brushless Controller.lpp
} 
```
Note the line break before the closing curly bracket - it's a ```\r``` character :scream:

### Root of the problem

Git has a configuration called ```core.autocrlf``` to automatically convert line endings between LF and CRLF when checkout and/or commit files. On some *incredible crappy operating systems* this (anti-)feature is often activated (either by default, by accident or because of suggestions in the internet). **This is completely bullshit because LibrePCB does not work properly with CRLF line endings!**

All files created with LibrePCB **must be platform independent**, so we had to specify which line endings we will use for them (on all operating systems). Needless to say, we have chosen to use LF line endings (which is the default on every serious operating system). Because of this, nobody (**not even Git**) is allowed to just convert all of our line endings! :rage: :rage: :rage: 

Now I added a ```.gitattribute``` file to this project and to the [demo-workspace](https://github.com/LibrePCB/demo-workspace). The content of that file tells Git to disable automatic EOL conversion for all files in the repository. Hope this helps...

:sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob::shit::sob: