### PR TITLE
Improve versioning system

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -40,14 +40,3 @@ CONFIG += c++11
 CONFIG += warn_on
 QMAKE_CXXFLAGS += -Wextra
 QMAKE_CXXFLAGS_DEBUG += -Wextra
-
-# set preprocessor defines
-DEFINES += GIT_VERSION="\\\"$(shell git -C \""$$_PRO_FILE_PWD_"\" describe --abbrev=7 --dirty --always --tags)\\\""
-DEFINES += LOCAL_RESOURCES_DIR="\\\"$${LOCAL_RESOURCES_DIR}\\\""
-DEFINES += INSTALLED_RESOURCES_DIR="\\\"$${INSTALLED_RESOURCES_DIR}\\\""
-DEFINES += INSTALLATION_PREFIX="\\\"$${PREFIX}\\\""
-
-# Define the application version
-DEFINES += APP_VERSION_MAJOR=0
-DEFINES += APP_VERSION_MINOR=1
-DEFINES += APP_VERSION_PATCH=0

--- a/librepcb/controlpanel/controlpanel.cpp
+++ b/librepcb/controlpanel/controlpanel.cpp
@@ -54,7 +54,7 @@ ControlPanel::ControlPanel(Workspace& workspace) :
     mUi->setupUi(this);
 
     setWindowTitle(QString(tr("Control Panel - LibrePCB %1"))
-                   .arg(Application::applicationVersion().toStr()));
+                   .arg(qApp->getAppVersion().toPrettyStr(2)));
     mUi->statusBar->addWidget(new QLabel(QString(tr("Workspace: %1"))
         .arg(mWorkspace.getPath().toNative())));
 
@@ -302,13 +302,14 @@ void ControlPanel::projectEditorClosed() noexcept
 
 void ControlPanel::on_actionAbout_triggered()
 {
-    QMessageBox::about(this, tr("About LibrePCB"), tr(
+    QMessageBox::about(this, tr("About LibrePCB"), QString(tr(
         "<h1>About LibrePCB</h1>"
         "<p>LibrePCB is a free & open source schematic/layout-editor.</p>"
-        "<p>Version: " GIT_VERSION "</p>"
+        "<p>Version: %1 (%2)</p>"
         "<p>Please see <a href='http://librepcb.org/'>librepcb.org</a> for more information.</p>"
         "You can find the project on GitHub:<br>"
-        "<a href='https://github.com/LibrePCB/LibrePCB'>https://github.com/LibrePCB/LibrePCB</a>"));
+        "<a href='https://github.com/LibrePCB/LibrePCB'>https://github.com/LibrePCB/LibrePCB</a>"))
+        .arg(qApp->getAppVersion().toPrettyStr(3), qApp->getGitVersion()));
 }
 
 void ControlPanel::on_actionNew_Project_triggered()

--- a/librepcb/main.cpp
+++ b/librepcb/main.cpp
@@ -112,8 +112,6 @@ static void setApplicationMetadata() noexcept
 #else
     Application::setApplicationName("LibrePCB");
 #endif
-    Application::setApplicationVersion(Version(QString("%1.%2.%3").arg(APP_VERSION_MAJOR)
-                                       .arg(APP_VERSION_MINOR).arg(APP_VERSION_PATCH)));
 }
 
 /*****************************************************************************************
@@ -125,7 +123,8 @@ static void writeLogHeader() noexcept
     // @TODO: After removing support for Qt versions below 5.5, we could use qInfo() here.
 
     // write application name and version to log
-    QString msg = QString("LibrePCB %1 (%2)").arg(qApp->applicationVersion(), GIT_VERSION);
+    QString msg = QString("LibrePCB %1 (%2)").arg(qApp->getAppVersion().toPrettyStr(3),
+                                                  qApp->getGitVersion());
     Debug::instance()->print(Debug::DebugLevel_t::Info, msg, __FILE__, __LINE__);
 
     // write Qt version to log
@@ -133,7 +132,7 @@ static void writeLogHeader() noexcept
     Debug::instance()->print(Debug::DebugLevel_t::Info, msg, __FILE__, __LINE__);
 
     // write resources directory path to log
-    msg = QString("Resources directory: %1").arg(Application::getResourcesDir().toNative());
+    msg = QString("Resources directory: %1").arg(qApp->getResourcesDir().toNative());
     Debug::instance()->print(Debug::DebugLevel_t::Info, msg, __FILE__, __LINE__);
 }
 

--- a/libs/librepcbcommon/application.h
+++ b/libs/librepcbcommon/application.h
@@ -34,6 +34,14 @@
 namespace librepcb {
 
 /*****************************************************************************************
+ *  Macros
+ ****************************************************************************************/
+#if defined(qApp)
+#undef qApp
+#endif
+#define qApp (static_cast<Application *>(QCoreApplication::instance()))
+
+/*****************************************************************************************
  *  Class Application
  ****************************************************************************************/
 
@@ -51,26 +59,32 @@ class Application final : public QApplication
     public:
 
         // Constructors / Destructor
-        Application(int& argc, char** argv);
-        ~Application();
+        Application() = delete;
+        Application(const Application& other) = delete;
+        Application(int& argc, char** argv) noexcept;
+        ~Application() noexcept;
 
         // Reimplemented from QApplication
         bool notify(QObject* receiver, QEvent* e);
 
+        // Operator Overloadings
+        Application& operator=(const Application& rhs) = delete;
+
         // Static Methods
-        static void setApplicationVersion(const Version& version) noexcept;
-        static Version applicationVersion() noexcept;
-        static int majorVersion() noexcept {return applicationVersion().getNumbers().first();}
-        static bool isRunningFromInstalledExecutable() noexcept;
-        static FilePath getResourcesDir() noexcept;
+        const Version& getAppVersion() const noexcept {return mAppVersion;}
+        const QString& getGitVersion() const noexcept {return mGitVersion;}
+        const Version& getFileFormatVersion() const noexcept {return mFileFormatVersion;}
+        bool isRunningFromInstalledExecutable() const noexcept {return mIsRunningFromInstalledExecutable;}
+        const FilePath& getResourcesDir() const noexcept {return mResourcesDir;}
 
 
-    private:
+    private: // Data
 
-        // make some methods inaccessible...
-        Application();
-        Application(const Application& other);
-        Application& operator=(const Application& rhs);
+        Version mAppVersion;
+        QString mGitVersion;
+        Version mFileFormatVersion;
+        bool mIsRunningFromInstalledExecutable;
+        FilePath mResourcesDir;
 };
 
 /*****************************************************************************************

--- a/libs/librepcbcommon/librepcbcommon.pro
+++ b/libs/librepcbcommon/librepcbcommon.pro
@@ -17,6 +17,13 @@ QT += core widgets xml opengl network
 
 CONFIG += staticlib
 
+# set preprocessor defines
+DEFINES += APP_VERSION="\\\"0.1.0\\\""
+DEFINES += FILE_FORMAT_VERSION="\\\"0.1\\\""
+DEFINES += GIT_VERSION="\\\"$(shell git -C \""$$_PRO_FILE_PWD_"\" describe --abbrev=7 --dirty --always --tags)\\\""
+DEFINES += LOCAL_RESOURCES_DIR="\\\"$${LOCAL_RESOURCES_DIR}\\\""
+DEFINES += INSTALLED_RESOURCES_DIR="\\\"$${INSTALLED_RESOURCES_DIR}\\\""
+DEFINES += INSTALLATION_PREFIX="\\\"$${PREFIX}\\\""
 #DEFINES += USE_32BIT_LENGTH_UNITS          # see units/length.h
 
 HEADERS += \

--- a/libs/librepcbcommon/version.cpp
+++ b/libs/librepcbcommon/version.cpp
@@ -55,15 +55,39 @@ Version::~Version() noexcept
  *  Getters
  ****************************************************************************************/
 
+bool Version::isPrefixOf(const Version& other) const noexcept
+{
+    if ((other.mNumbers.count() >= mNumbers.count()) && (mNumbers.count() > 0)) {
+        for (int i = 0; i < mNumbers.count(); i++) {
+            if (mNumbers.at(i) != other.mNumbers.at(i)) {
+                return false;
+            }
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+
 QString Version::toStr() const noexcept
 {
-    QString str;
-    for (int i = 0; i < mNumbers.count(); i++)
-    {
-        if (i > 0) str.append(".");
-        str.append(QString::number(mNumbers.at(i)));
+    return toPrettyStr(0);
+}
+
+QString Version::toPrettyStr(int minSegCount, int maxSegCount) const noexcept
+{
+    Q_ASSERT(maxSegCount >= minSegCount);
+
+    if (isValid()) {
+        QString str;
+        for (int i = 0; i < qMin(qMax(mNumbers.count(), minSegCount), maxSegCount); i++) {
+            if (i > 0) str.append(".");
+            str.append(QString::number((i < mNumbers.count()) ? mNumbers.at(i) : 0));
+        }
+        return str;
+    } else {
+        return QString();
     }
-    return str;
 }
 
 QString Version::toComparableStr() const noexcept
@@ -127,38 +151,52 @@ Version& Version::operator=(const Version& rhs) noexcept
 
 bool Version::operator>(const Version& rhs) const noexcept
 {
-    if (mNumbers.isEmpty()) return false;
-    return (compare(rhs) > 0);
+    if (isValid() && rhs.isValid()) {
+        return (compare(rhs) > 0);
+    } else {
+        return false;
+    }
 }
 
 bool Version::operator<(const Version& rhs) const  noexcept
 {
-    if (mNumbers.isEmpty()) return false;
-    return (compare(rhs) < 0);
+    if (isValid() && rhs.isValid()) {
+        return (compare(rhs) < 0);
+    } else {
+        return false;
+    }
 }
 
 bool Version::operator>=(const Version& rhs) const noexcept
 {
-    if (mNumbers.isEmpty()) return false;
-    return (compare(rhs) >= 0);
+    if (isValid() && rhs.isValid()) {
+        return (compare(rhs) >= 0);
+    } else {
+        return false;
+    }
 }
 
 bool Version::operator<=(const Version& rhs) const noexcept
 {
-    if (mNumbers.isEmpty()) return false;
-    return (compare(rhs) <= 0);
+    if (isValid() && rhs.isValid()) {
+        return (compare(rhs) <= 0);
+    } else {
+        return false;
+    }
 }
 
 bool Version::operator==(const Version& rhs) const noexcept
 {
-    if (mNumbers.isEmpty()) return false;
-    return (compare(rhs) == 0);
+    if (isValid() && rhs.isValid()) {
+        return (compare(rhs) == 0);
+    } else {
+        return false;
+    }
 }
 
 bool Version::operator!=(const Version& rhs) const noexcept
 {
-    if (mNumbers.isEmpty()) return false;
-    return (compare(rhs) != 0);
+    return !(*this == rhs);
 }
 
 /*****************************************************************************************

--- a/libs/librepcbcommon/version.h
+++ b/libs/librepcbcommon/version.h
@@ -52,8 +52,6 @@ namespace librepcb {
  *
  * @author ubruhin
  * @date 2014-10-30
- *
- * @todo Test all methods of this class! No idea if this class works as expected!
  */
 class Version final
 {
@@ -96,6 +94,18 @@ class Version final
         bool isValid() const noexcept {return (mNumbers.count() > 0);}
 
         /**
+         * @brief Check if this version is the prefix of another version
+         *
+         * Example: "1.2" is a prefix of "1.2", "1.2.0.1", "1.2.1"
+         *
+         * @param other     Another version
+         *
+         * @return  True if both versions are valid and "other" starts with the same
+         *          segments as all segments of this version. False in all other cases.
+         */
+        bool isPrefixOf(const Version& other) const noexcept;
+
+        /**
          * @brief Get the numbers in the version string
          *
          * The first item in the list is the major version number.
@@ -110,6 +120,20 @@ class Version final
          * @return The version as a string (empty string = invalid version)
          */
         QString toStr() const noexcept;
+
+        /**
+         * @brief Get the version as a string with trailing zeros (e.g. "1.2.0")
+         *
+         * @param minSegCount   If the version has less segments than specified by this
+         *                      parameter, trailing zeros will be appended.
+         *                      Example: "0.1" gets "0.1.0.0" with minSegCount = 4
+         * @param maxSegCount   If the version has more segments than specified by this
+         *                      parameter, trailing segments will be omitted.
+         *                      Example: "0.1.2.3.4" gets "0.1" with maxSegCount = 2
+         *
+         * @return The version as a string (empty string = invalid version)
+         */
+        QString toPrettyStr(int minSegCount, int maxSegCount = 10) const noexcept;
 
         /**
          * @brief Get the version as a comparable string (59 characters)
@@ -140,15 +164,18 @@ class Version final
         bool setVersion(const QString& version) noexcept;
 
 
+        // Operator overloadings
+        Version& operator=(const Version& rhs) noexcept;
+
         //@{
         /**
-         * @brief Operator overloadings
+         * @brief Comparison operators
          *
          * @param rhs   The other object to compare
          *
-         * @return If at least one of both objects is invalid, false will be returned!
+         * @return  If at least one of both objects is invalid, false will be returned
+         *          (except #operator!=() which would return true in this case)!
          */
-        Version& operator=(const Version& rhs) noexcept;
         bool operator>(const Version& rhs) const noexcept;
         bool operator<(const Version& rhs) const  noexcept;
         bool operator>=(const Version& rhs) const noexcept;

--- a/libs/librepcblibrary/librarybaseelement.cpp
+++ b/libs/librepcblibrary/librarybaseelement.cpp
@@ -27,6 +27,7 @@
 #include <librepcbcommon/fileio/xmldomdocument.h>
 #include <librepcbcommon/fileio/xmldomelement.h>
 #include <librepcbcommon/fileio/fileutils.h>
+#include <librepcbcommon/application.h>
 
 /*****************************************************************************************
  *  Namespace
@@ -94,11 +95,11 @@ LibraryBaseElement::LibraryBaseElement(const FilePath& elementDirectory,
 
     // read version number from version file
     mLoadingElementFileVersion = readFileVersionOfElementDirectory(mDirectory);
-    if (!(mLoadingElementFileVersion <= Version(qApp->applicationVersion()))) {
-        throw RuntimeError(__FILE__, __LINE__, QString::number(APP_VERSION_MAJOR),
+    if (!(mLoadingElementFileVersion <= qApp->getAppVersion())) {
+        throw RuntimeError(__FILE__, __LINE__, QString(),
             QString(tr("The library element %1 was created with a newer application "
                        "version. You need at least LibrePCB version %2 to open it."))
-            .arg(mDirectory.toNative()).arg(mLoadingElementFileVersion.toStr()));
+            .arg(mDirectory.toNative()).arg(mLoadingElementFileVersion.toPrettyStr(3)));
     }
 
     // open main XML file
@@ -199,7 +200,7 @@ void LibraryBaseElement::save() throw (Exception)
 
     // save version number file
     QScopedPointer<SmartVersionFile> versionFile(SmartVersionFile::create(
-        mDirectory.getPathTo(".version"), Version(QString::number(APP_VERSION_MAJOR))));
+        mDirectory.getPathTo(".version"), qApp->getFileFormatVersion()));
     versionFile->save(true);
 }
 

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.cpp
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizard.cpp
@@ -113,7 +113,7 @@ Project* NewProjectWizard::createProject() const throw (Exception)
 
     // copy readme file
     try {
-        FilePath source = Application::getResourcesDir().getPathTo("project/readme_template");
+        FilePath source = qApp->getResourcesDir().getPathTo("project/readme_template");
         FilePath destination = projectFilePath.getParentDir().getPathTo("README.md");
         QByteArray content = FileUtils::readFile(source); // can throw
         content.replace("{PROJECT_NAME}", mPageMetadata->getProjectName().toUtf8());
@@ -131,7 +131,7 @@ Project* NewProjectWizard::createProject() const throw (Exception)
     if (mPageVersionControl->getInitGitRepository()) {
         // copy .gitignore
         try {
-            FilePath source = Application::getResourcesDir().getPathTo("project/gitignore_template");
+            FilePath source = qApp->getResourcesDir().getPathTo("project/gitignore_template");
             FilePath destination = projectFilePath.getParentDir().getPathTo(".gitignore");
             FileUtils::copyFile(source, destination); // can throw
         } catch (Exception& e) {
@@ -139,7 +139,7 @@ Project* NewProjectWizard::createProject() const throw (Exception)
         }
         // copy .gitattributes
         try {
-            FilePath source = Application::getResourcesDir().getPathTo("project/gitattributes_template");
+            FilePath source = qApp->getResourcesDir().getPathTo("project/gitattributes_template");
             FilePath destination = projectFilePath.getParentDir().getPathTo(".gitattributes");
             FileUtils::copyFile(source, destination); // can throw
         } catch (Exception& e) {

--- a/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcbprojecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -103,7 +103,7 @@ FilePath NewProjectWizardPage_Metadata::getProjectLicenseFilePath() const noexce
 {
     QString licenseFileName = mUi->cbxLicense->currentData(Qt::UserRole).toString();
     if (!licenseFileName.isEmpty()) {
-        return Application::getResourcesDir().getPathTo(licenseFileName);
+        return qApp->getResourcesDir().getPathTo(licenseFileName);
     } else {
         return FilePath();
     }

--- a/libs/librepcbworkspace/workspace.cpp
+++ b/libs/librepcbworkspace/workspace.cpp
@@ -25,6 +25,7 @@
 #include "workspace.h"
 #include <librepcbcommon/exceptions.h>
 #include <librepcbcommon/fileio/filepath.h>
+#include <librepcbcommon/application.h>
 #include <librepcblibraryeditor/libraryeditor.h>
 #include <librepcbproject/project.h>
 #include "library/workspacelibrary.h"
@@ -51,7 +52,7 @@ namespace workspace {
 Workspace::Workspace(const FilePath& wsPath) throw (Exception) :
     QObject(0),
     mPath(wsPath), mLock(wsPath.getPathTo("workspace")),
-    mMetadataPath(wsPath.getPathTo(QString(".metadata/v%1").arg(APP_VERSION_MAJOR))),
+    mMetadataPath(wsPath.getPathTo(QString(".metadata/v%1").arg(qApp->getFileFormatVersion().getNumbers().value(0)))),
     mProjectsPath(wsPath.getPathTo("projects")),
     mLibraryPath(wsPath.getPathTo("library")),
     mWorkspaceSettings(0), mLibrary(0), mProjectTreeModel(0), mRecentProjectsModel(0),
@@ -189,7 +190,7 @@ bool Workspace::createNewWorkspace(const FilePath& path) noexcept
         return true;
 
     // create directory ".metadata/v#/" (and all needed parent directories)
-    return path.getPathTo(QString(".metadata/v%1").arg(APP_VERSION_MAJOR)).mkPath();
+    return path.getPathTo(QString(".metadata/v%1").arg(qApp->getFileFormatVersion().getNumbers().value(0))).mkPath();
 }
 
 FilePath Workspace::getMostRecentlyUsedWorkspacePath() noexcept

--- a/tests/common/applicationtest.cpp
+++ b/tests/common/applicationtest.cpp
@@ -43,43 +43,43 @@ class ApplicationTest : public ::testing::Test
  *  Test Methods
  ****************************************************************************************/
 
-TEST(ApplicationTest, testApplicationVersion)
+TEST(ApplicationTest, testAppVersion)
 {
     // read application version and check validity
-    Version v = Application::applicationVersion();
+    Version v = qApp->getAppVersion();
     EXPECT_TRUE(v.isValid());
 
     // compare with QApplication version
     Version v1(qApp->applicationVersion());
     EXPECT_TRUE(v1.isValid());
     EXPECT_EQ(v, v1);
-
-    // compare with defines
-    Version v2(QString("%1.%2.%3").arg(APP_VERSION_MAJOR).arg(APP_VERSION_MINOR).arg(APP_VERSION_PATCH));
-    EXPECT_TRUE(v2.isValid());
-    EXPECT_EQ(v, v2);
 }
 
-TEST(ApplicationTest, testMajorVersion)
+TEST(ApplicationTest, testFileFormatVersion)
 {
-    EXPECT_EQ(APP_VERSION_MAJOR, Application::majorVersion());
+    // check validity
+    EXPECT_TRUE(qApp->getFileFormatVersion().isValid());
+
+    // it can't be greater then the application version
+    EXPECT_LE(qApp->getFileFormatVersion(), qApp->getAppVersion());
 }
 
 TEST(ApplicationTest, testIsRunningFromInstalledExecutable)
 {
     // as there is no "make install" available for the unit tests, it can't be installed ;)
-    EXPECT_FALSE(Application::isRunningFromInstalledExecutable());
+    EXPECT_FALSE(qApp->isRunningFromInstalledExecutable());
 }
 
 TEST(ApplicationTest, testGetResourcesDir)
 {
-    // as the tests can't be installed, the resources must be located in LOCAL_RESOURCES_DIR
-    EXPECT_EQ(Application::getResourcesDir(), FilePath(LOCAL_RESOURCES_DIR));
-
     // check if the resources directory is valid, exists and is not empty
-    EXPECT_TRUE(Application::getResourcesDir().isValid());
-    EXPECT_TRUE(Application::getResourcesDir().isExistingDir());
-    EXPECT_FALSE(Application::getResourcesDir().isEmptyDir());
+    EXPECT_TRUE(qApp->getResourcesDir().isValid());
+    EXPECT_TRUE(qApp->getResourcesDir().isExistingDir());
+    EXPECT_FALSE(qApp->getResourcesDir().isEmptyDir());
+
+    // as the tests can't be installed, the resources must be located in the "generated" dir
+    FilePath generatedDir = qApp->getResourcesDir().getParentDir();
+    EXPECT_TRUE(FilePath(qApp->applicationFilePath()).isLocatedInDir(generatedDir));
 }
 
 /*****************************************************************************************

--- a/tests/common/versiontest.cpp
+++ b/tests/common/versiontest.cpp
@@ -1,0 +1,264 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+
+#include <QtCore>
+#include <gtest/gtest.h>
+#include <librepcbcommon/version.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*****************************************************************************************
+ *  Test Class
+ ****************************************************************************************/
+
+class VersionTest : public ::testing::Test
+{
+};
+
+/*****************************************************************************************
+ *  Test Methods
+ ****************************************************************************************/
+
+TEST(VersionTest, testDefaultConstructor)
+{
+    Version v;
+    EXPECT_FALSE(v.isValid());
+    EXPECT_EQ(0, v.getNumbers().count());
+    EXPECT_TRUE(v.toStr().isEmpty());
+    EXPECT_TRUE(v.toPrettyStr(0).isEmpty());
+    EXPECT_TRUE(v.toComparableStr().isEmpty());
+}
+
+TEST(VersionTest, testCopyConstructor)
+{
+    Version v1("1.2.3");
+    Version v2(v1);
+    EXPECT_EQ(v1.isValid(),         v2.isValid());
+    EXPECT_EQ(v1.getNumbers(),      v2.getNumbers());
+    EXPECT_EQ(v1.toStr(),           v2.toStr());
+    EXPECT_EQ(v1.toPrettyStr(0),    v2.toPrettyStr(0));
+    EXPECT_EQ(v1.toComparableStr(), v2.toComparableStr());
+}
+
+TEST(VersionTest, testConstructorWithString)
+{
+    Version v("0.1.2.3.0");
+    EXPECT_TRUE(v.isValid());
+    EXPECT_EQ(4, v.getNumbers().count());
+    EXPECT_EQ(QList<int>({0,1,2,3}), v.getNumbers());
+    EXPECT_EQ("0.1.2.3", v.toStr());
+    EXPECT_EQ("0.1.2.3", v.toPrettyStr(0));
+    EXPECT_EQ("00000.00001.00002.00003.00000.00000.00000.00000.00000.00000", v.toComparableStr());
+}
+
+TEST(VersionTest, testIsValid)
+{
+    // valid
+    EXPECT_TRUE(Version("0").isValid());
+    EXPECT_TRUE(Version("05.00000040").isValid());
+    EXPECT_TRUE(Version("00000.00001.00002.00003.00007.00000.00600.00000.08000.20000").isValid());
+
+    // invalid
+    EXPECT_FALSE(Version("").isValid());
+    EXPECT_FALSE(Version("-1").isValid());
+    EXPECT_FALSE(Version("1-0").isValid());
+    EXPECT_FALSE(Version("100000.55").isValid());
+    EXPECT_FALSE(Version("77.-11.9").isValid());
+    EXPECT_FALSE(Version("4.8.").isValid());
+    EXPECT_FALSE(Version(".4.8").isValid());
+    EXPECT_FALSE(Version("00000.00001.00002.00003.00007.00000.00600.00000.08000.20000.00030").isValid());
+    EXPECT_FALSE(Version("00000.00001.00002.00003.500007.00000.00600.00000.08000.20000").isValid());
+}
+
+TEST(VersionTest, testIsPrefixOf)
+{
+    EXPECT_TRUE(Version("0")        .isPrefixOf(Version("0")));
+    EXPECT_TRUE(Version("0.1")      .isPrefixOf(Version("0.1.0")));
+    EXPECT_TRUE(Version("1.2")      .isPrefixOf(Version("1.2.0.0.0.1")));
+    EXPECT_TRUE(Version("5.5.5.4")  .isPrefixOf(Version("5.5.5.4.1")));
+
+    EXPECT_FALSE(Version("")        .isPrefixOf(Version("0")));
+    EXPECT_FALSE(Version("0")       .isPrefixOf(Version("")));
+    EXPECT_FALSE(Version("1.2")     .isPrefixOf(Version("1")));
+    EXPECT_FALSE(Version("0.1")     .isPrefixOf(Version("0.2")));
+    EXPECT_FALSE(Version("5.5")     .isPrefixOf(Version("5.4.5")));
+}
+
+TEST(VersionTest, testGetNumbers)
+{
+    EXPECT_EQ(QList<int>({}),           Version("").getNumbers());
+    EXPECT_EQ(QList<int>({0}),          Version("0").getNumbers());
+    EXPECT_EQ(QList<int>({5,4,3}),      Version("5.4.3").getNumbers());
+    EXPECT_EQ(QList<int>({5,440,0,80}), Version("005.440.00.080.000").getNumbers());
+}
+
+TEST(VersionTest, testToStr)
+{
+    EXPECT_EQ(QString(),                            Version("-1").toStr());
+    EXPECT_EQ(QString("0"),                         Version("0").toStr());
+    EXPECT_EQ(QString("5.4.3"),                     Version("5.4.3").toStr());
+    EXPECT_EQ(QString("0.0.6.3.20"),                Version("0.00.6.003.20.0.0").toStr());
+    EXPECT_EQ(QString("5.440.0.80"),                Version("005.440.00.080.000").toStr());
+    EXPECT_EQ(QString("0.1.2.3.7.0.600.0.8000"),    Version("00000.00001.00002.00003.00007.00000.00600.00000.08000.00000").toStr());
+}
+
+TEST(VersionTest, testToPrettyStr)
+{
+    EXPECT_EQ(QString(),                            Version("-1").toPrettyStr(0, 10));
+    EXPECT_EQ(QString("0"),                         Version("0").toPrettyStr(0, 4));
+    EXPECT_EQ(QString("5.0"),                       Version("5").toPrettyStr(2, 3));
+    EXPECT_EQ(QString("5.4.3"),                     Version("5.04.3.6.7").toPrettyStr(2, 3));
+    EXPECT_EQ(QString("0.0.0.0"),                   Version("0").toPrettyStr(4, 4));
+}
+
+TEST(VersionTest, testToComparableStr)
+{
+    EXPECT_EQ(QString(),
+              Version("-1").toComparableStr());
+    EXPECT_EQ(QString("00000.00000.00000.00000.00000.00000.00000.00000.00000.00000"),
+              Version("0").toComparableStr());
+    EXPECT_EQ(QString("00000.00000.00000.00000.00000.00000.00000.00000.00000.00000"),
+              Version("0").toComparableStr());
+    EXPECT_EQ(QString("00000.00000.00003.00000.00600.00000.00000.00000.00000.00000"),
+              Version("0.0.3.0.600.0").toComparableStr());
+}
+
+TEST(VersionTest, testSetVersion)
+{
+    Version v;
+
+    // valid
+    EXPECT_TRUE(v.setVersion("0.1.02.3"));
+    EXPECT_EQ(QString("0.1.2.3"), v.toStr());
+    EXPECT_TRUE(v.setVersion("0.0.100.0.0"));
+    EXPECT_EQ(QString("0.0.100"), v.toStr());
+
+    // invalid
+    EXPECT_FALSE(v.setVersion("."));
+    EXPECT_EQ(QString(), v.toStr());
+    EXPECT_FALSE(v.setVersion("1.2.3.4.5.6.7.8.9.10.11"));
+    EXPECT_EQ(QString(), v.toStr());
+}
+
+TEST(VersionTest, testOperatorAssign)
+{
+    Version v1("1.2.3");
+    Version v2;
+    v2 = v1;
+    EXPECT_EQ(v1.isValid(),         v2.isValid());
+    EXPECT_EQ(v1.getNumbers(),      v2.getNumbers());
+    EXPECT_EQ(v1.toStr(),           v2.toStr());
+    EXPECT_EQ(v1.toPrettyStr(0),    v2.toPrettyStr(0));
+    EXPECT_EQ(v1.toComparableStr(), v2.toComparableStr());
+}
+
+TEST(VersionTest, testOperatorGreater)
+{
+    EXPECT_TRUE(Version("0.1") > Version("0.0.9"));
+    EXPECT_TRUE(Version("5.4") > Version("0.500.0"));
+    EXPECT_TRUE(Version("10.0.0.1") > Version("10"));
+
+    EXPECT_FALSE(Version("") > Version(""));
+    EXPECT_FALSE(Version("1") > Version(""));
+    EXPECT_FALSE(Version("") > Version("1"));
+    EXPECT_FALSE(Version("10") > Version("10.0.1"));
+    EXPECT_FALSE(Version("0.0.1") > Version("0.1.0"));
+}
+
+TEST(VersionTest, testOperatorLess)
+{
+    EXPECT_TRUE(Version("0.0.9") < Version("0.1"));
+    EXPECT_TRUE(Version("0.500.0") < Version("5.4"));
+    EXPECT_TRUE(Version("10") < Version("10.0.0.1"));
+
+    EXPECT_FALSE(Version("") < Version(""));
+    EXPECT_FALSE(Version("") < Version("1"));
+    EXPECT_FALSE(Version("1") < Version(""));
+    EXPECT_FALSE(Version("10.0.1") < Version("10"));
+    EXPECT_FALSE(Version("0.1.0") < Version("0.0.1"));
+}
+
+TEST(VersionTest, testOperatorGreaterEqual)
+{
+    EXPECT_TRUE(Version("0.1") >= Version("0.0.9"));
+    EXPECT_TRUE(Version("5.4") >= Version("0.500.0"));
+    EXPECT_TRUE(Version("10.0.0.1") >= Version("10"));
+    EXPECT_TRUE(Version("10.0.0.1") >= Version("10.0.0.1"));
+    EXPECT_TRUE(Version("5.0.0.5") >= Version("5.0.0.5.0"));
+
+    EXPECT_FALSE(Version("") >= Version(""));
+    EXPECT_FALSE(Version("1") >= Version(""));
+    EXPECT_FALSE(Version("") >= Version("1"));
+    EXPECT_FALSE(Version("10") >= Version("10.0.1"));
+    EXPECT_FALSE(Version("0.0.1") >= Version("0.1.0"));
+}
+
+TEST(VersionTest, testOperatorLessEqual)
+{
+    EXPECT_TRUE(Version("0.0.9") <= Version("0.1"));
+    EXPECT_TRUE(Version("0.500.0") <= Version("5.4"));
+    EXPECT_TRUE(Version("10") <= Version("10.0.0.1"));
+    EXPECT_TRUE(Version("10.0.0.1") <= Version("10.0.0.1"));
+    EXPECT_TRUE(Version("5.0.0.5") <= Version("5.0.0.5.0"));
+
+    EXPECT_FALSE(Version("") <= Version(""));
+    EXPECT_FALSE(Version("") <= Version("1"));
+    EXPECT_FALSE(Version("1") <= Version(""));
+    EXPECT_FALSE(Version("10.0.1") <= Version("10"));
+    EXPECT_FALSE(Version("0.1.0") <= Version("0.0.1"));
+}
+
+TEST(VersionTest, testOperatorEqual)
+{
+    EXPECT_TRUE(Version("10.0.0.1") == Version("10.0.0.1"));
+    EXPECT_TRUE(Version("5.0.0.5") == Version("5.0.0.5.0"));
+
+    EXPECT_FALSE(Version("") == Version(""));
+    EXPECT_FALSE(Version("") == Version("1"));
+    EXPECT_FALSE(Version("1") == Version(""));
+    EXPECT_FALSE(Version("10.0.1") == Version("10"));
+    EXPECT_FALSE(Version("0.1.0") == Version("0.0.1"));
+}
+
+TEST(VersionTest, testOperatorNotEqual)
+{
+    EXPECT_TRUE(Version("") != Version(""));
+    EXPECT_TRUE(Version("") != Version("1"));
+    EXPECT_TRUE(Version("1") != Version(""));
+    EXPECT_TRUE(Version("10.0.0.1") != Version("10.0.1"));
+    EXPECT_TRUE(Version("5.0.5") != Version("0.5.0.5"));
+
+    EXPECT_FALSE(Version("10.0.1") != Version("10.0.1"));
+    EXPECT_FALSE(Version("0.1.0") != Version("0.001.0.0.0"));
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace librepcb

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -42,8 +42,6 @@ int main(int argc, char *argv[])
     Application::setOrganizationName("LibrePCB");
     Application::setOrganizationDomain("librepcb.org");
     Application::setApplicationName("LibrePCB-UnitTests");
-    Application::setApplicationVersion(Version(QString("%1.%2.%3").arg(APP_VERSION_MAJOR)
-                                       .arg(APP_VERSION_MINOR).arg(APP_VERSION_PATCH)));
 
     // disable the whole debug output (we want only the output from gtest)
     Debug::instance()->setDebugLevelLogFile(Debug::DebugLevel_t::Nothing);

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -42,6 +42,7 @@ SOURCES += main.cpp \
     common/filepathtest.cpp \
     common/pointtest.cpp \
     common/scopeguardtest.cpp \
-    common/applicationtest.cpp
+    common/applicationtest.cpp \
+    common/versiontest.cpp
 
 HEADERS +=


### PR DESCRIPTION
Some general improvements in the versioning system. Parts of this are required for #114.

This pull request changes the file version type from Integer to a semantic version string. So a workspace/library/project can now have version ```0.1``` or ```1.2.3``` instead of only ```0```, ```1```, and so on. This is required to allow making multiple file format upgrades **before** version ```1``` (which indicates a stable version) while keeping the file format version equal to the application version. The file format version needs to be a prefix of the application version, e.g. format version ```0.1``` is used by application version ```0.1.x``` and format version ```1``` is used by application version ```1.x```.