### PR TITLE
Add network access manager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "3rdparty/hoedown"]
 	path = 3rdparty/hoedown
 	url = https://github.com/LibrePCB/hoedown.git
+[submodule "3rdparty/quazip"]
+	path = 3rdparty/quazip
+	url = https://github.com/LibrePCB/quazip.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - |
     if [ "${TRAVIS_OS_NAME}" = "linux" ]
     then
-      sudo apt-get install -qq libglu1-mesa-dev xvfb
+      sudo apt-get install -qq libglu1-mesa-dev zlib1g zlib1g-dev openssl xvfb
       if [ "$QT_BASE" = "trusty" ]; then sudo apt-get install -qq qt5-default qttools5-dev-tools; fi
       if [ -n "$QT_PPA" ]; then sudo apt-get install -qq "${QT_BASE}base" "${QT_BASE}tools"; source "/opt/${QT_BASE}/bin/${QT_BASE}-env.sh"; fi
       if [ "$BUILD_DOXYGEN" = "true" ]; then sudo apt-get install -qq doxygen graphviz; fi
@@ -53,8 +53,10 @@ install:
 
 script:
   - mkdir build && cd build && qmake ../librepcb.pro -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make -j8 && cd ../   # build librepcb
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then xvfb-run -a ./build/generated/unix/tests; fi                     # run all unit tests (linux, using xvfb)
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ];   then ./build/generated/mac/tests; fi                                  # run all unit tests (mac)
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then xvfb-run -a ./build/generated/unix/qztest; fi                    # run quazip unit tests (linux)
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ];   then ./build/generated/mac/qztest; fi                                 # run quazip unit tests (mac)
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then xvfb-run -a ./build/generated/unix/tests; fi                     # run librepcb unit tests (linux, using xvfb)
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ];   then ./build/generated/mac/tests; fi                                  # run librepcb unit tests (mac)
 
 # run doxygen and upload the html output to github (gh-pages of LibrePCB-Doxygen)
 after_success:

--- a/3rdparty/3rdparty.pro
+++ b/3rdparty/3rdparty.pro
@@ -2,4 +2,5 @@ TEMPLATE = subdirs
 
 SUBDIRS = \
     hoedown \
-    gmock
+    gmock \
+    quazip

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ development stage (no stable release available).
 To compile LibrePCB, you need the following software components:
 - g++ >= 4.8, MinGW >= 4.8, or Clang >= 3.3 (C++11 support is required)
 - Qt >= 5.2 (http://www.qt.io/download-open-source/)
-- libglu1-mesa-dev (`sudo apt-get install libglu1-mesa-dev`)
+- `libglu1-mesa-dev` (`sudo apt-get install libglu1-mesa-dev`)
+- `zlib` / `zlib-dev` (http://www.zlib.net/)
+- `OpenSSL` (https://www.openssl.org/)
 
 #### Installation on Ubuntu 14.04 and later
 
 ```bash
-sudo apt-get install g++ qt5-default qttools5-dev-tools qt5-doc qtcreator libglu1-mesa-dev
+sudo apt-get install g++ qt5-default qttools5-dev-tools qt5-doc qtcreator libglu1-mesa-dev zlib1g zlib1g-dev openssl
 ```
 
 #### Installation on ArchLinux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ build_script:
   - cd build
   - qmake ..\librepcb.pro -r
   - mingw32-make -j 4
-  - .\generated\windows\tests.exe # run all unit tests
+  - .\generated\windows\qztest.exe # run quazip unit tests
+  - .\generated\windows\tests.exe # run librepcb unit tests
   - cd ..\
 

--- a/common.pri
+++ b/common.pri
@@ -40,3 +40,6 @@ CONFIG += c++11
 CONFIG += warn_on
 QMAKE_CXXFLAGS += -Wextra
 QMAKE_CXXFLAGS_DEBUG += -Wextra
+
+# QuaZIP: use as static library
+DEFINES += QUAZIP_STATIC

--- a/librepcb/librepcb.pro
+++ b/librepcb/librepcb.pro
@@ -53,10 +53,12 @@ LIBS += \
     -llibrepcbworkspace \
     -llibrepcbproject \
     -llibrepcblibrary \
-    -llibrepcbcommon
+    -llibrepcbcommon \
+    -lquazip -lz
 
 INCLUDEPATH += \
     ../3rdparty \
+    ../3rdparty/quazip \
     ../libs
 
 DEPENDPATH += \
@@ -66,7 +68,8 @@ DEPENDPATH += \
     ../libs/librepcbworkspace \
     ../libs/librepcbproject \
     ../libs/librepcblibrary \
-    ../libs/librepcbcommon
+    ../libs/librepcbcommon \
+    ../3rdparty/quazip
 
 PRE_TARGETDEPS += \
     $${DESTDIR}/libhoedown.a \
@@ -75,7 +78,8 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/liblibrepcbworkspace.a \
     $${DESTDIR}/liblibrepcbproject.a \
     $${DESTDIR}/liblibrepcblibrary.a \
-    $${DESTDIR}/liblibrepcbcommon.a
+    $${DESTDIR}/liblibrepcbcommon.a \
+    $${DESTDIR}/libquazip.a
 
 TRANSLATIONS = \
     ../i18n/librepcb_de.ts \

--- a/librepcb/main.cpp
+++ b/librepcb/main.cpp
@@ -26,6 +26,7 @@
 #include <librepcbcommon/application.h>
 #include <librepcbcommon/debug.h>
 #include <librepcbcommon/exceptions.h>
+#include <librepcbcommon/network/networkaccessmanager.h>
 #include <librepcbworkspace/workspace.h>
 #include "firstrunwizard/firstrunwizard.h"
 #include "controlpanel/controlpanel.h"
@@ -80,6 +81,9 @@ int main(int argc, char* argv[])
     // Initialize all 3rd party libraries
     init3rdPartyLibs();
 
+    // Start network access manager thread
+    QScopedPointer<NetworkAccessManager> networkAccessManager(new NetworkAccessManager());
+
     // --------------------------------- OPEN WORKSPACE ----------------------------------
 
     // Get the path of the workspace to open (may show the first run wizard)
@@ -93,9 +97,13 @@ int main(int argc, char* argv[])
 
     // -------------------------------- EXIT APPLICATION ---------------------------------
 
+    // Stop network access manager thread
+    networkAccessManager.reset();
+
     // Cleanup all 3rd party libraries
     cleanup3rdPartyLibs();
 
+    qDebug() << "Exit application with code" << retval;
     return retval;
 }
 

--- a/libs/librepcbcommon/application.cpp
+++ b/libs/librepcbcommon/application.cpp
@@ -36,6 +36,9 @@ namespace librepcb {
 Application::Application(int& argc, char** argv) noexcept :
     QApplication(argc, argv)
 {
+    // register meta types
+    qRegisterMetaType<FilePath>();
+
     // set application version
     mAppVersion = Version(APP_VERSION);
     QApplication::setApplicationVersion(mAppVersion.toPrettyStr(2));

--- a/libs/librepcbcommon/debug.cpp
+++ b/libs/librepcbcommon/debug.cpp
@@ -119,6 +119,8 @@ const FilePath& Debug::getLogFilepath() const
 
 void Debug::print(DebugLevel_t level, const QString& msg, const char* file, int line)
 {
+    QMutexLocker locker(&mMutex);
+
     if ((mDebugLevelStderr < level) && ((mDebugLevelLogFile < level) || (!mLogFile)))
         return; // if there is nothing to print, we will return immediately from this function
 

--- a/libs/librepcbcommon/debug.h
+++ b/libs/librepcbcommon/debug.h
@@ -170,6 +170,7 @@ class Debug final
         QTextStream* mStderrStream;     ///< the stream to stderr
         FilePath mLogFilepath;          ///< the filepath for the log file
         QFile* mLogFile;                ///< NULL if file logging is disabled
+        QMutex mMutex;                  ///< for thread safety
 
 };
 

--- a/libs/librepcbcommon/fileio/filepath.h
+++ b/libs/librepcbcommon/fileio/filepath.h
@@ -453,7 +453,7 @@ QDebug& operator<<(QDebug& stream, const FilePath& filepath);
 
 } // namespace librepcb
 
-// QFlags
+Q_DECLARE_METATYPE(librepcb::FilePath)
 Q_DECLARE_OPERATORS_FOR_FLAGS(librepcb::FilePath::CleanFileNameOptions)
 
 #endif // LIBREPCB_FILEPATH_H

--- a/libs/librepcbcommon/librepcbcommon.pro
+++ b/libs/librepcbcommon/librepcbcommon.pro
@@ -17,6 +17,9 @@ QT += core widgets xml opengl network sql
 
 CONFIG += staticlib
 
+INCLUDEPATH += \
+    ../../3rdparty/quazip
+
 # set preprocessor defines
 DEFINES += APP_VERSION="\\\"0.1.0\\\""
 DEFINES += FILE_FORMAT_VERSION="\\\"0.1\\\""

--- a/libs/librepcbcommon/librepcbcommon.pro
+++ b/libs/librepcbcommon/librepcbcommon.pro
@@ -85,7 +85,11 @@ HEADERS += \
     cam/excellongenerator.h \
     fileio/smartversionfile.h \
     fileio/fileutils.h \
-    sqlitedatabase.h
+    sqlitedatabase.h \
+    network/filedownload.h \
+    network/networkrequest.h \
+    network/networkrequestbase.h \
+    network/networkaccessmanager.h
 
 SOURCES += \
     attributes/attributetype.cpp \
@@ -136,7 +140,11 @@ SOURCES += \
     cam/excellongenerator.cpp \
     fileio/smartversionfile.cpp \
     fileio/fileutils.cpp \
-    sqlitedatabase.cpp
+    sqlitedatabase.cpp \
+    network/filedownload.cpp \
+    network/networkrequest.cpp \
+    network/networkrequestbase.cpp \
+    network/networkaccessmanager.cpp
 
 FORMS += \
     dialogs/gridsettingsdialog.ui \

--- a/libs/librepcbcommon/network/filedownload.cpp
+++ b/libs/librepcbcommon/network/filedownload.cpp
@@ -1,0 +1,170 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <quazip/JlCompress.h>
+#include "filedownload.h"
+#include "scopeguard.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+FileDownload::FileDownload(const QUrl& url, const FilePath& dest) noexcept :
+    NetworkRequestBase(url), mDestination(dest), mHashAlgorithm(QCryptographicHash::Md5),
+    mExpectedChecksum(), mExtractZipToDir()
+{
+}
+
+FileDownload::~FileDownload() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Public Methods
+ ****************************************************************************************/
+
+void FileDownload::setExpectedChecksum(QCryptographicHash::Algorithm algorithm,
+                                       const QByteArray& checksum) noexcept
+{
+    Q_ASSERT(!mStarted);
+    mHashAlgorithm = algorithm;
+    mExpectedChecksum = checksum;
+}
+
+void FileDownload::setZipExtractionDirectory(const FilePath& dir) noexcept
+{
+    Q_ASSERT(!mStarted);
+    mExtractZipToDir = dir;
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void FileDownload::prepareRequest() throw (Exception)
+{
+    // check destination filepath
+    if (mDestination.isExistingFile() || mDestination.isExistingDir()) {
+        throw RuntimeError(__FILE__, __LINE__, QString(),
+            QString("The destination file exists already: %1")
+            .arg(mDestination.toNative()));
+    }
+
+    // create destination directory
+    if (!mDestination.getParentDir().isEmptyDir()) {
+        if (!QDir().mkpath(mDestination.getParentDir().toStr())) {
+            throw RuntimeError(__FILE__, __LINE__, QString(),
+                QString("Could not create directory \"%1\".")
+                .arg(mDestination.getParentDir().toNative()));
+        }
+    }
+
+    // open temporary destination file
+    mFile.reset(new QSaveFile(mDestination.toStr(), this));
+    if (!mFile->open(QIODevice::WriteOnly)) {
+        throw RuntimeError(__FILE__, __LINE__, QString(),
+            QString("Could not open file \"%1\": %2")
+            .arg(mDestination.toNative(), mFile->errorString()));
+    }
+}
+
+void FileDownload::finalizeRequest() throw (Exception)
+{
+    // check destination filepath again
+    if (mDestination.isExistingFile() || mDestination.isExistingDir()) {
+        throw RuntimeError(__FILE__, __LINE__, QString(),
+            QString("The destination file exists already: %1")
+            .arg(mDestination.toNative()));
+    }
+
+    // save to destination file
+    if (!mFile->commit()) {
+        throw RuntimeError(__FILE__, __LINE__, QString(),
+            QString(tr("Error while writing file \"%1\": %2"))
+            .arg(mDestination.toNative(), mFile->errorString()));
+    }
+
+    // if an error occurs below this line, remove the downloaded file
+    auto sg = scopeGuard([this](){QFile::remove(mDestination.toStr());});
+
+    // verify checksum of downloaded file
+    if (!mExpectedChecksum.isEmpty()) {
+        emit progressState(tr("Verify checksum..."));
+        QFile file(mDestination.toStr());
+        if (!file.open(QFile::ReadOnly)) {
+            throw RuntimeError(__FILE__, __LINE__, QString(),
+                QString(tr("Error while readback file \"%1\": %2"))
+                .arg(mDestination.toNative(), file.errorString()));
+        }
+        QCryptographicHash hash(mHashAlgorithm);
+        hash.addData(&file);
+        QString result = hash.result().toHex();
+        QString expected = mExpectedChecksum.toHex();
+        if (result != expected) {
+            throw RuntimeError(__FILE__, __LINE__,
+                QString("%1 != %2").arg(result, expected),
+                tr("Checksum verification of downloaded file failed!"));
+        } else {
+            qDebug() << "Checksum verification of downloaded file was successful.";
+        }
+    }
+
+    // extract zip file if neccessary
+    if (mExtractZipToDir.isValid()) {
+        emit progressState(tr("Extract files..."));
+        QStringList files = JlCompress::extractDir(mDestination.toStr(),
+                                                   mExtractZipToDir.toStr());
+        if (files.isEmpty()) {
+            throw RuntimeError(__FILE__, __LINE__, QString(),
+                QString(tr("Error while extracting the ZIP file \"%1\"."))
+                .arg(mDestination.toNative()));
+        }
+    } else {
+        // do NOT remove the downloaded file
+        sg.dismiss();
+    }
+}
+
+void FileDownload::emitSuccessfullyFinishedSignals() noexcept
+{
+    emit fileDownloaded(mDestination);
+    if (mExtractZipToDir.isValid()) {
+        emit zipFileExtracted(mExtractZipToDir);
+    }
+}
+
+void FileDownload::fetchNewData() noexcept
+{
+    mFile->write(mReply->readAll());
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcbcommon/network/filedownload.h
+++ b/libs/librepcbcommon/network/filedownload.h
@@ -1,0 +1,142 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_FILEDOWNLOAD_H
+#define LIBREPCB_FILEDOWNLOAD_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "networkrequestbase.h"
+#include "../fileio/filepath.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class FileDownload
+ ****************************************************************************************/
+
+/**
+ * @brief This class is used to download a file asynchronously in a separate thread
+ *
+ * @see librepcb::NetworkRequestBase, librepcb::DownloadManager
+ *
+ * @author ubruhin
+ * @date 2016-09-12
+ */
+class FileDownload final : public NetworkRequestBase
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        FileDownload() = delete;
+        FileDownload(const FileDownload& other) = delete;
+
+        /**
+         * @brief Constructor
+         *
+         * @param url           The URL to the file to download
+         * @param dest          The path to the destination file (must not exist!)
+         */
+        FileDownload(const QUrl& url, const FilePath& dest) noexcept;
+
+        ~FileDownload() noexcept;
+
+
+        // Setters
+
+        /**
+         * @brief Set the expected checksum of the file to download
+         *
+         * If set, the checksum of the downloaded file will be compared with this
+         * checksum. If they differ, the file gets removed and an error will be reported.
+         *
+         * @param algorithm     The checksum algorithm to be used
+         * @param checksum      The expected checksum of the file to download
+         */
+        void setExpectedChecksum(QCryptographicHash::Algorithm algorithm,
+                                 const QByteArray& checksum) noexcept;
+
+        /**
+         * @brief Set extraction directory of the ZIP file to download
+         *
+         * If set (and valid), the downloaded file (must be a ZIP!) will be extracted into
+         * this directory after downloading it.
+         *
+         * @note The downloaded ZIP file will be removed after extracting it.
+         *
+         * @param dir           Destination directory (may or may not exist)
+         */
+        void setZipExtractionDirectory(const FilePath& dir) noexcept;
+
+
+        // Operator Overloadings
+        FileDownload& operator=(const FileDownload& rhs) = delete;
+
+
+    signals:
+
+        /**
+         * @brief File successfully downloaded signal (emited right before #finished())
+         *
+         * @note The parameter type is specified with the full namespace, reason see here:
+         *       http://stackoverflow.com/questions/21119397/emitting-signals-with-custom-types-does-not-work
+         */
+        void fileDownloaded(librepcb::FilePath filepath);
+
+        /**
+         * @brief ZIP file successfully extracted signal (emited right before #finished())
+         *
+         * @note The parameter type is specified with the full namespace, reason see here:
+         *       http://stackoverflow.com/questions/21119397/emitting-signals-with-custom-types-does-not-work
+         */
+        void zipFileExtracted(librepcb::FilePath directory);
+
+
+    private: // Methods
+
+        void prepareRequest() throw (Exception) override;
+        void finalizeRequest() throw (Exception) override;
+        void emitSuccessfullyFinishedSignals() noexcept override;
+        void fetchNewData() noexcept override;
+
+
+    private: // Data
+
+        FilePath mDestination;
+        QScopedPointer<QSaveFile> mFile;
+        QCryptographicHash::Algorithm mHashAlgorithm;
+        QByteArray mExpectedChecksum;
+        FilePath mExtractZipToDir;
+
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_FILEDOWNLOAD_H

--- a/libs/librepcbcommon/network/networkaccessmanager.cpp
+++ b/libs/librepcbcommon/network/networkaccessmanager.cpp
@@ -1,0 +1,129 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtNetwork>
+#include "networkaccessmanager.h"
+#include "../exceptions.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Static Variables
+ ****************************************************************************************/
+NetworkAccessManager* NetworkAccessManager::sInstance = nullptr;
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+NetworkAccessManager::NetworkAccessManager() noexcept :
+    QThread(nullptr), mThreadStartSemaphore(0), mManager(nullptr)
+{
+    // This thread must only be started once, and from within the main application thread!
+    Q_ASSERT(QThread::currentThread() == qApp->thread());
+    Q_ASSERT(sInstance == nullptr);
+    sInstance = this;
+
+    // ensure that this thread gets stopped *before* the main thread stops
+    connect(qApp, &QCoreApplication::aboutToQuit,
+            this, &NetworkAccessManager::stop, Qt::DirectConnection);
+
+    // start the thread and wait until the thread is started successfully
+    start();
+    mThreadStartSemaphore.acquire();
+}
+
+NetworkAccessManager::~NetworkAccessManager() noexcept
+{
+    Q_ASSERT(QThread::currentThread() == qApp->thread());
+    stop(); // blocks until the thread has stopped
+    sInstance = nullptr;
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+QNetworkReply* NetworkAccessManager::get(const QNetworkRequest& request) noexcept
+{
+    Q_ASSERT(QThread::currentThread() == this);
+
+    if (mManager) {
+        return mManager->get(request);
+    } else {
+        qCritical() << "No network access manager available! Thread not running?!";
+        return nullptr;
+    }
+}
+
+/*****************************************************************************************
+ *  Static Methods
+ ****************************************************************************************/
+
+NetworkAccessManager* NetworkAccessManager::instance() noexcept
+{
+    return sInstance;
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void NetworkAccessManager::run() noexcept
+{
+    Q_ASSERT(QThread::currentThread() == this);
+    qDebug() << "Started network access manager thread.";
+    mManager = new QNetworkAccessManager();
+    mThreadStartSemaphore.release();
+    try {
+        exec(); // event loop (blocking)
+    } catch (...) {
+        qCritical() << "Exception thrown in network access manager event loop!!!";
+        // do NOT exit the thread to avoid further problems due to deleted QNetworkAccessManager
+        while (true) {QThread::sleep(ULONG_MAX);}
+    }
+    delete mManager;    mManager = nullptr;
+    qDebug() << "Stopped network access manager thread.";
+}
+
+void NetworkAccessManager::stop() noexcept
+{
+    Q_ASSERT(QThread::currentThread() != this);
+    quit();
+    if (!wait(5000)) {
+        qWarning() << "Could not quit the network access manager thread!";
+        terminate();
+        if (!wait(1000)) {
+            qCritical() << "Could not terminate the network access manager thread!";
+        }
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcbcommon/network/networkaccessmanager.h
+++ b/libs/librepcbcommon/network/networkaccessmanager.h
@@ -1,0 +1,92 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_NETWORKACCESSMANAGER_H
+#define LIBREPCB_NETWORKACCESSMANAGER_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtNetwork>
+#include "../fileio/filepath.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class NetworkAccessManager
+ ****************************************************************************************/
+
+/**
+ * @brief A network access manager which processes network requests in a separate thread
+ *
+ * @note    One instance of this class must be created in the main application thread, and
+ *          must be deleted before stopping the main application thread. It's not allowed
+ *          to create a librepcb::NetworkAccessManager object in other threads, or to
+ *          create multiple instances at the same time.
+ *
+ * After the singleton was created, you can get it with the static method #instance().
+ * But for executing network requests, you don't need to access this object directly.
+ * You only need the classes librepcb::NetworkRequest and librepcb::FileDownload instead.
+
+ * @see librepcb::NetworkRequestBase, librepcb::NetworkRequest, librepcb::FileDownload
+ *
+ * @author ubruhin
+ * @date 2016-09-15
+ */
+class NetworkAccessManager final : public QThread
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        NetworkAccessManager() noexcept;
+        NetworkAccessManager(const NetworkAccessManager& other) = delete;
+        ~NetworkAccessManager() noexcept;
+
+        // General Methods
+        QNetworkReply* get(const QNetworkRequest& request) noexcept;
+
+        // Operator Overloadings
+        NetworkAccessManager& operator=(const NetworkAccessManager& rhs) = delete;
+
+        // Static Methods
+        static NetworkAccessManager* instance() noexcept;
+
+
+    private: // Methods
+
+        void run() noexcept override;
+        void stop() noexcept;
+
+
+    private: // Data
+
+        QSemaphore mThreadStartSemaphore;
+        QNetworkAccessManager* mManager;
+        static NetworkAccessManager* sInstance;
+};
+
+} // namespace librepcb
+
+#endif // LIBREPCB_NETWORKACCESSMANAGER_H

--- a/libs/librepcbcommon/network/networkrequest.cpp
+++ b/libs/librepcbcommon/network/networkrequest.cpp
@@ -1,0 +1,78 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "networkrequest.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+NetworkRequest::NetworkRequest(const QUrl& url) noexcept :
+    NetworkRequestBase(url), mReceivedData()
+{
+}
+
+NetworkRequest::~NetworkRequest() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void NetworkRequest::prepareRequest() throw (Exception)
+{
+    mReceivedData.clear();
+}
+
+void NetworkRequest::finalizeRequest() throw (Exception)
+{
+    if (mReceivedData.size() > 100*1000*1000) {
+        throw RuntimeError(__FILE__, __LINE__, QString(),
+            tr("The received content exceeds the 100MB size limit."));
+    }
+}
+
+void NetworkRequest::emitSuccessfullyFinishedSignals() noexcept
+{
+    emit dataReceived(mReceivedData);
+}
+
+void NetworkRequest::fetchNewData() noexcept
+{
+    QByteArray data = mReply->readAll();
+    if (mReceivedData.size() <= 100*1000*1000) {
+        mReceivedData.append(data);
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcbcommon/network/networkrequest.h
+++ b/libs/librepcbcommon/network/networkrequest.h
@@ -1,0 +1,89 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_NETWORKREQUEST_H
+#define LIBREPCB_NETWORKREQUEST_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "networkrequestbase.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class NetworkRequest
+ ****************************************************************************************/
+
+/**
+ * @brief This class is used to process general purpose network requests (up to 100MB)
+ *
+ * @see librepcb::NetworkRequestBase, librepcb::NetworkAccessManager
+ *
+ * @author ubruhin
+ * @date 2016-09-12
+ */
+class NetworkRequest final : public NetworkRequestBase
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        NetworkRequest() = delete;
+        NetworkRequest(const NetworkRequest& other) = delete;
+        NetworkRequest(const QUrl& url) noexcept;
+        ~NetworkRequest() noexcept;
+
+        // Operator Overloadings
+        NetworkRequest& operator=(const NetworkRequest& rhs) = delete;
+
+
+    signals:
+
+        /**
+         * @brief Data successfully received signal (emited right before #finished())
+         */
+        void dataReceived(QByteArray data);
+
+
+    private: // Methods
+
+        void prepareRequest() throw (Exception) override;
+        void finalizeRequest() throw (Exception) override;
+        void emitSuccessfullyFinishedSignals() noexcept override;
+        void fetchNewData() noexcept override;
+
+
+    private: // Data
+
+        QByteArray mReceivedData;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_NETWORKREQUEST_H

--- a/libs/librepcbcommon/network/networkrequestbase.cpp
+++ b/libs/librepcbcommon/network/networkrequestbase.cpp
@@ -1,0 +1,288 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "networkrequestbase.h"
+#include "networkaccessmanager.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+NetworkRequestBase::NetworkRequestBase(const QUrl& url) noexcept :
+    mUrl(url), mExpectedContentSize(-1), mStarted(false), mAborted(false),
+    mErrored(false), mFinished(false)
+{
+    Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
+
+    // set initial HTTP header fields
+    mRequest.setHeader(QNetworkRequest::UserAgentHeader, QString("%1/%2").arg(
+                       qApp->applicationName(), qApp->applicationVersion()));
+
+    // create queued connection to let executeRequest() execute in download thread
+    connect(this, &NetworkRequestBase::startRequested,
+            this, &NetworkRequestBase::executeRequest,
+            Qt::QueuedConnection);
+}
+
+NetworkRequestBase::~NetworkRequestBase() noexcept
+{
+    if (mStarted) {
+        Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+    } else {
+        Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
+    }
+}
+
+/*****************************************************************************************
+ *  Public Methods
+ ****************************************************************************************/
+
+void NetworkRequestBase::setHeaderField(const QByteArray& name, const QByteArray& value) noexcept
+{
+    Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
+    Q_ASSERT(!mStarted);
+    mRequest.setRawHeader(name, value);
+}
+
+void NetworkRequestBase::setExpectedReplyContentSize(qint64 bytes) noexcept
+{
+    Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
+    Q_ASSERT(!mStarted);
+    mExpectedContentSize = bytes;
+}
+
+void NetworkRequestBase::start() noexcept
+{
+    Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
+
+    NetworkAccessManager* nam = NetworkAccessManager::instance();
+    if (nam) {
+        mStarted = true;
+        moveToThread(nam); // move event processing of this object to the download thread
+        emit progressState(tr("Start request..."));
+        emit startRequested(); // execute executeRequest() in download thread
+    } else {
+        finalize(tr("Fatal error: Download manager is not running."));
+    }
+}
+
+void NetworkRequestBase::abort() noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+    if (mReply) {
+        emit progressState(tr("Abort request..."));
+        mAborted = true;
+        mReply->abort();
+    }
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void NetworkRequestBase::executeRequest() noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+
+    emit progressState(tr("Request started..."));
+
+    // get network access manager object
+    NetworkAccessManager* nam = NetworkAccessManager::instance();
+    if (!nam) {
+        finalize(tr("Network access manager is not running."));
+        return;
+    }
+
+    // prepare request
+    try {
+        prepareRequest(); // can throw
+    } catch (const Exception& e) {
+        finalize(e.getUserMsg());
+        return;
+    }
+
+    // start request
+    mRequest.setUrl(mUrl);
+    mReply.reset(nam->get(mRequest));
+    if (mReply.isNull()) {
+        finalize(tr("GET request failed! Network access manager thread not running?!"));
+        return;
+    }
+
+    // connect to signals of reply
+    connect(mReply.data(), &QNetworkReply::readyRead,
+            this, &NetworkRequestBase::replyReadyReadSlot);
+    connect(mReply.data(), static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>
+            (&QNetworkReply::error), this, &NetworkRequestBase::replyErrorSlot);
+    connect(mReply.data(), &QNetworkReply::sslErrors,
+            this, &NetworkRequestBase::replySslErrorsSlot);
+    connect(mReply.data(), &QNetworkReply::downloadProgress,
+            this, &NetworkRequestBase::replyDownloadProgressSlot);
+    connect(mReply.data(), &QNetworkReply::finished,
+            this, &NetworkRequestBase::replyFinishedSlot);
+}
+
+void NetworkRequestBase::replyReadyReadSlot() noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+    fetchNewData();
+}
+
+void NetworkRequestBase::replyErrorSlot(QNetworkReply::NetworkError code) noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+    mErrored = true;
+    finalize(QString(tr("%1 (%2)")).arg(mReply->errorString()).arg(code));
+}
+
+void NetworkRequestBase::replySslErrorsSlot(const QList<QSslError>& errors) noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+    mErrored = true;
+    QStringList errorsList;
+    foreach (const QSslError& e, errors) {errorsList.append(e.errorString());}
+    finalize(QString(tr("SSL errors occured:\n\n%1")).arg(errorsList.join("\n")));
+}
+
+void NetworkRequestBase::replyDownloadProgressSlot(qint64 bytesReceived, qint64 bytesTotal) noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+    if (mAborted || mErrored || mFinished) return;
+    if (mReply->attribute(QNetworkRequest::RedirectionTargetAttribute).isValid()) return;
+
+    qint64 estimatedTotal = (bytesTotal > 0) ? bytesTotal : mExpectedContentSize;
+    if (estimatedTotal < bytesReceived) {estimatedTotal = bytesReceived + 10e6;}
+    int estimatedPercent = (100 * bytesReceived) / qMax(estimatedTotal, qint64(1));
+    emit progressState(QString(tr("Receive data: %1")).arg(formatFileSize(bytesReceived)));
+    emit progressPercent(estimatedPercent);
+    emit progress(bytesReceived, bytesTotal, estimatedPercent);
+}
+
+void NetworkRequestBase::replyFinishedSlot() noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+
+    // check if an error was already handled
+    if (mErrored) {
+        return;
+    }
+
+    // check if the request was aborted
+    if (mAborted) {
+        finalize(tr("Network request aborted."));
+        return;
+    }
+
+    // check if we received a redirection
+    QUrl redirectUrl = mReply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+    if (!redirectUrl.isEmpty()) {
+        redirectUrl = mUrl.resolved(redirectUrl); // handle relative URLs
+        if (mRedirectedUrls.contains(redirectUrl)) {
+            finalize(tr("Redirection loop detected."));
+            return;
+        } else if (mRedirectedUrls.count() > 10) {
+            finalize(tr("Too many redirects."));
+            return;
+        } else {
+            // follow redirection
+            qDebug() << "Redirect from" << mUrl.toString() << "to" << redirectUrl.toString();
+            emit progressState(QString(tr("Redirect to %1...")).arg(redirectUrl.toString()));
+            mReply.take()->deleteLater();
+            mRedirectedUrls.append(mUrl);
+            mUrl = redirectUrl;
+            executeRequest(); // restart download with new url
+            return;
+        }
+    }
+
+    // check for download error
+    if (mReply->error() != QNetworkReply::NoError) {
+        finalize(QString(tr("%1 (%2)")).arg(mReply->errorString()).arg(mReply->error()));
+        return;
+    }
+
+    // finalize download
+    try {
+        finalizeRequest(); // can throw
+    } catch (const Exception& e) {
+        finalize(e.getUserMsg());
+        return;
+    }
+
+    // download successfully finished!
+    finalize();
+}
+
+void NetworkRequestBase::finalize(const QString& errorMsg) noexcept
+{
+    Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
+
+    if (errorMsg.isNull()) {
+        qDebug() << "Request successfully finished:" << mUrl.toString();
+        emit progressState(tr("Request successfully finished."));
+        emitSuccessfullyFinishedSignals();
+        emit succeeded();
+        emit finished(true);
+    } else if (mAborted) {
+        qDebug() << "Request aborted:" << mUrl.toString();
+        emit progressState(tr("Request aborted."));
+        emit aborted();
+        emit finished(false);
+    } else {
+        qDebug() << "Request failed:" << mUrl.toString();
+        qDebug() << "Network error:" << errorMsg;
+        emit progressState(QString(tr("Request failed: %1")).arg(errorMsg));
+        emit errored(errorMsg);
+        emit finished(false);
+    }
+    mFinished = true;
+    deleteLater();
+}
+
+/*****************************************************************************************
+ *  Static Methods
+ ****************************************************************************************/
+
+QString NetworkRequestBase::formatFileSize(qint64 bytes) noexcept
+{
+    qreal num = bytes;
+    QStringList list({"KB", "MB", "GB", "TB"});
+    QStringListIterator i(list);
+    QString unit("Bytes");
+    while (num >= 1024.0 && i.hasNext()) {
+        unit = i.next();
+        num /= 1024;
+    }
+    return QString::number(num, 'f', 2) % " " % unit;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcbcommon/network/networkrequestbase.h
+++ b/libs/librepcbcommon/network/networkrequestbase.h
@@ -1,0 +1,219 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_NETWORKREQUESTBASE_H
+#define LIBREPCB_NETWORKREQUESTBASE_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtNetwork>
+#include "../exceptions.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class NetworkRequestBase
+ ****************************************************************************************/
+
+/**
+ * @brief Base class for network requests which are processed in the network access manager
+ *
+ * This class lets you execute a network request without blocking the main application
+ * thread. After creating an object derived from #NetworkRequestBase, you can connect to
+ * signals of that class to track the progress of the request. Then you need to call
+ * #start() to start the request processing.
+ *
+ * @note    You need to ensure that an instance of librepcb::NetworkAccessManager exists
+ *          while starting a new network request. Otherwise the request will fail. Read
+ *          the documentation of librepcb::NetworkAccessManager for more information.
+ *
+ * @see librepcb::NetworkAccessManager
+ *
+ * @author ubruhin
+ * @date 2016-09-12
+ */
+class NetworkRequestBase : public QObject
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        NetworkRequestBase() = delete;
+        NetworkRequestBase(const NetworkRequestBase& other) = delete;
+        NetworkRequestBase(const QUrl& url) noexcept;
+        virtual ~NetworkRequestBase() noexcept;
+
+        // Setters
+
+        /**
+         * @brief Set a HTTP header field for the network request
+         *
+         * @param name      Header field name
+         * @param value     Header field value
+         */
+        void setHeaderField(const QByteArray& name, const QByteArray& value) noexcept;
+
+        /**
+         * @brief Set the expected size of the requested content
+         *
+         * If set, this size will be used to calculate the download progress in percent in
+         * case that there is no "Content-Length" attribute in the received HTTP header.
+         *
+         * @param bytes         Expected content size of the reply in bytes
+         */
+        void setExpectedReplyContentSize(qint64 bytes) noexcept;
+
+        // Operator Overloadings
+        NetworkRequestBase& operator=(const NetworkRequestBase& rhs) = delete;
+
+
+    public slots:
+
+        /**
+         * @brief Start downloading the requested content
+         *
+         * @warning It is not save to access this object after calling this method!
+         *          The object will be moved to another thread and will be deleted after
+         *          an error occurs or the request succeeds. Any further access to the
+         *          pointer which you have received from the constructor is unsave and
+         *          could cause an application crash.
+         */
+        void start() noexcept;
+
+        /**
+         * @brief Abort downloading the requested content
+         *
+         * @warning Because calling this method makes only sense *after* calling #start(),
+         *          but which is unsave as described in #start(), this method must only be
+         *          used indirectly with the signals/slots concept of Qt (Qt automatically
+         *          disconnects the callers signal from this slot as soon as this object
+         *          gets destroyed, so the connection is always safe).
+         */
+        void abort() noexcept;
+
+
+    signals:
+
+        /**
+         * @brief Internal signal, don't use it from outside
+         */
+        void startRequested();
+
+        /**
+         * @brief Reply progress / state changed signal
+         *
+         * This signal shows which actions are executed. Or in other words, it shows the
+         * current state of the request processing.
+         *
+         * @param action                Short description about the current action/state
+         */
+        void progressState(QString state);
+
+        /**
+         * @brief Reply content download progress signal (simple)
+         *
+         * @param percent               (Estimated) progress in percent (0..100)
+         */
+        void progressPercent(int percent);
+
+        /**
+         * @brief Reply content download progress signal (extended)
+         *
+         * @param bytesReceived         Count of bytes received
+         * @param bytesTotal            Count of total bytes (-1 if unknown)
+         * @param percent               (Estimated) progress in percent (0..100)
+         */
+        void progress(qint64 bytesReceived, qint64 bytesTotal, int percent);
+
+        /**
+         * @brief Request aborted signal (emited right before #finished())
+         */
+        void aborted();
+
+        /**
+         * @brief Request succeeded signal (emited right before #finished())
+         */
+        void succeeded();
+
+        /**
+         * @brief Request errored signal (emited right before #finished())
+         *
+         * @param errorMsg              An error message
+         */
+        void errored(QString errorMsg);
+
+        /**
+         * @brief Request finished signal
+         *
+         * This signal is emited right after #aborted(), #succeeded() or #errored().
+         *
+         * @param success               True if succeeded, false if aborted or errored
+         */
+        void finished(bool success);
+
+
+    public: // Methods
+
+        virtual void prepareRequest() throw (Exception) = 0;
+        virtual void finalizeRequest() throw (Exception) = 0;
+        virtual void emitSuccessfullyFinishedSignals() noexcept = 0;
+        virtual void fetchNewData() noexcept = 0;
+
+
+    private: // Methods
+
+        void executeRequest() noexcept;
+        void replyReadyReadSlot() noexcept;
+        void replyErrorSlot(QNetworkReply::NetworkError code) noexcept;
+        void replySslErrorsSlot(const QList<QSslError>& errors) noexcept;
+        void replyDownloadProgressSlot(qint64 bytesReceived, qint64 bytesTotal) noexcept;
+        void replyFinishedSlot() noexcept;
+        void finalize(const QString& errorMsg = QString()) noexcept;
+        static QString formatFileSize(qint64 bytes) noexcept;
+
+
+    protected: // Data
+
+        // from constructor
+        QUrl mUrl;
+        qint64 mExpectedContentSize;
+
+        // internal data
+        QList<QUrl> mRedirectedUrls;
+        QNetworkRequest mRequest;
+        QScopedPointer<QNetworkReply> mReply;
+        bool mStarted;
+        bool mAborted;
+        bool mErrored;
+        bool mFinished;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_NETWORKREQUESTBASE_H

--- a/tests/common/filedownloadtest.cpp
+++ b/tests/common/filedownloadtest.cpp
@@ -1,0 +1,217 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <gtest/gtest.h>
+#include <librepcbcommon/network/networkaccessmanager.h>
+#include <librepcbcommon/network/filedownload.h>
+#include <librepcbcommon/fileio/fileutils.h>
+#include "networkrequestbasesignalreceiver.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*****************************************************************************************
+ *  Test Data Type
+ ****************************************************************************************/
+
+typedef struct {
+    QUrl url;
+    QString destFilename;
+    QString extractDirname;
+    QByteArray sha256;
+    bool success;
+} FileDownloadTestData;
+
+/*****************************************************************************************
+ *  Test Class
+ ****************************************************************************************/
+
+class FileDownloadTest : public ::testing::TestWithParam<FileDownloadTestData>
+{
+    public:
+
+        static void SetUpTestCase() {
+            sDownloadManager = new NetworkAccessManager();
+        }
+
+        static void TearDownTestCase() {
+            delete sDownloadManager;
+        }
+
+        static FilePath getDestination(const FileDownloadTestData& data) {
+            return FilePath::getApplicationTempPath().getPathTo(data.destFilename);
+        }
+
+        static FilePath getExtractToDir(const FileDownloadTestData& data) {
+            if (!data.extractDirname.isEmpty()) {
+                return FilePath::getApplicationTempPath().getPathTo(data.extractDirname);
+            } else {
+                return FilePath();
+            }
+        }
+
+    protected:
+
+        NetworkRequestBaseSignalReceiver mSignalReceiver;
+        static NetworkAccessManager* sDownloadManager;
+};
+
+NetworkAccessManager* FileDownloadTest::sDownloadManager = nullptr;
+
+/*****************************************************************************************
+ *  Test Methods
+ ****************************************************************************************/
+
+TEST_P(FileDownloadTest, testConstructorAndSettersAndDestructor)
+{
+    const FileDownloadTestData& data = GetParam();
+
+    FileDownload dl(data.url, getDestination(data));
+    dl.setExpectedReplyContentSize(100);
+    dl.setExpectedChecksum(QCryptographicHash::Sha1, QByteArray("42"));
+    dl.setZipExtractionDirectory(getExtractToDir(data));
+}
+
+TEST_P(FileDownloadTest, testDownload)
+{
+    const FileDownloadTestData& data = GetParam();
+
+    // remove target file/directory
+    if (getDestination(data).isExistingFile()) {
+        FileUtils::removeFile(getDestination(data));
+    }
+    if (getExtractToDir(data).isExistingDir()) {
+        FileUtils::removeDirRecursively(getExtractToDir(data));
+    }
+
+    // start the file download
+    FileDownload* dl = new FileDownload(data.url, getDestination(data));
+    dl->setZipExtractionDirectory(getExtractToDir(data));
+    dl->setExpectedChecksum(QCryptographicHash::Sha256, data.sha256);
+    QObject::connect(dl, &FileDownload::progressState,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::progressState);
+    QObject::connect(dl, &FileDownload::progressPercent,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::progressPercent);
+    QObject::connect(dl, &FileDownload::progress,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::progress);
+    QObject::connect(dl, &FileDownload::aborted,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::aborted);
+    QObject::connect(dl, &FileDownload::succeeded,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::succeeded);
+    QObject::connect(dl, &FileDownload::errored,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::errored);
+    QObject::connect(dl, &FileDownload::finished,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::finished);
+    QObject::connect(dl, &FileDownload::fileDownloaded,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::fileDownloaded);
+    QObject::connect(dl, &FileDownload::zipFileExtracted,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::zipFileExtracted);
+    QObject::connect(dl, &FileDownload::destroyed,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::destroyed);
+    dl->start();
+
+    // wait until download finished (with timeout)
+    qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
+    auto currentTime = [](){return QDateTime::currentDateTime().toMSecsSinceEpoch();};
+    while ((!mSignalReceiver.mDestroyed) && (currentTime() - start < 30000)) {
+        QThread::msleep(100);
+        qApp->processEvents();
+    }
+
+    // check count and parameters of emited signals
+    EXPECT_TRUE(mSignalReceiver.mDestroyed) << "Download timed out!";
+    EXPECT_GT(mSignalReceiver.mProgressStateCallCount, 0);
+    EXPECT_EQ(mSignalReceiver.mAdvancedProgressCallCount,
+              mSignalReceiver.mSimpleProgressCallCount);
+    EXPECT_EQ(0, mSignalReceiver.mAbortedCallCount);
+    EXPECT_EQ(1, mSignalReceiver.mFinishedCallCount);
+    EXPECT_EQ(0, mSignalReceiver.mDataReceivedCallCount);
+    EXPECT_TRUE(mSignalReceiver.mReceivedData.isNull())
+            << qPrintable(mSignalReceiver.mReceivedData);
+    if (data.success) {
+        EXPECT_GE(mSignalReceiver.mSimpleProgressCallCount, 1);
+        EXPECT_EQ(1, mSignalReceiver.mSucceededCallCount);
+        EXPECT_EQ(0, mSignalReceiver.mErroredCallCount);
+        EXPECT_EQ(1, mSignalReceiver.mFileDownloadedCallCount);
+        EXPECT_TRUE(mSignalReceiver.mErrorMessage.isNull())
+                << qPrintable(mSignalReceiver.mErrorMessage);
+        EXPECT_TRUE(mSignalReceiver.mFinishedSuccess);
+        EXPECT_EQ(getDestination(data),     mSignalReceiver.mDownloadedToFilePath);
+        EXPECT_EQ(getExtractToDir(data),    mSignalReceiver.mExtractedToFilePath);
+        EXPECT_EQ(data.extractDirname.isNull(), getDestination(data).isExistingFile());
+    } else {
+        EXPECT_GE(mSignalReceiver.mSimpleProgressCallCount, 0);
+        EXPECT_EQ(0, mSignalReceiver.mSucceededCallCount);
+        EXPECT_EQ(1, mSignalReceiver.mErroredCallCount);
+        EXPECT_EQ(0, mSignalReceiver.mFileDownloadedCallCount);
+        EXPECT_FALSE(mSignalReceiver.mErrorMessage.isEmpty())
+                << qPrintable(mSignalReceiver.mErrorMessage);
+        EXPECT_FALSE(mSignalReceiver.mFinishedSuccess);
+        EXPECT_FALSE(getDestination(data).isExistingFile());
+    }
+    if (data.success && (!data.extractDirname.isNull())) {
+        EXPECT_EQ(1, mSignalReceiver.mZipFileExtractedCallCount);
+        EXPECT_TRUE(getExtractToDir(data).isExistingDir());
+        EXPECT_FALSE(getExtractToDir(data).isEmptyDir());
+    } else {
+        EXPECT_EQ(0, mSignalReceiver.mZipFileExtractedCallCount);
+        EXPECT_FALSE(getExtractToDir(data).isExistingDir());
+    }
+}
+
+/*****************************************************************************************
+ *  Test Data
+ ****************************************************************************************/
+
+INSTANTIATE_TEST_CASE_P(FileDownloadTest, FileDownloadTest, ::testing::Values(
+    FileDownloadTestData({QUrl("https://github.com/LibrePCB/LibrePCB/archive/first_pcb.zip"),
+                          QString("first_pcb_downloaded.zip"),
+                          QString("first_pcb_extracted"),
+                          QByteArray::fromHex("f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f89"),
+                          true}),
+    FileDownloadTestData({QUrl("https://github.com/LibrePCB/LibrePCB/archive/first_pcb.zip"),
+                          QString("first_pcb_downloaded.zip"),
+                          QString(),
+                          QByteArray::fromHex("f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f88"), // wrong
+                          false}),
+    FileDownloadTestData({QUrl("https://api.librepcb.org/api/v1/libraries/"),
+                          QString("libraries.json"),
+                          QString(),
+                          QByteArray(),
+                          true}),
+    FileDownloadTestData({QUrl("https://github.com/LibrePCB/some-invalid-url"),
+                          QString("some-invalid-url"),
+                          QString("some-invalid-url_extracted"),
+                          QByteArray(),
+                          false})
+));
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace librepcb

--- a/tests/common/networkrequestbasesignalreceiver.h
+++ b/tests/common/networkrequestbasesignalreceiver.h
@@ -1,0 +1,149 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NETWORKREQUESTBASESIGNALRECEIVER_H
+#define NETWORKREQUESTBASESIGNALRECEIVER_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcbcommon/fileio/filepath.h>
+#include <gtest/gtest.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*****************************************************************************************
+ *  Signal Receiver Class
+ ****************************************************************************************/
+
+class NetworkRequestBaseSignalReceiver final : public QObject
+{
+        Q_OBJECT
+
+    public:
+
+        QThread* mThread;
+        int mProgressStateCallCount;
+        int mSimpleProgressCallCount;
+        int mAdvancedProgressCallCount;
+        int mAbortedCallCount;
+        int mSucceededCallCount;
+        int mErroredCallCount;
+        int mFinishedCallCount;
+        int mDataReceivedCallCount;
+        int mFileDownloadedCallCount;
+        int mZipFileExtractedCallCount;
+        bool mDestroyed;
+        QString mErrorMessage;
+        bool mFinishedSuccess;
+        QByteArray mReceivedData;
+        FilePath mDownloadedToFilePath;
+        FilePath mExtractedToFilePath;
+
+        NetworkRequestBaseSignalReceiver() :
+            QObject(), mThread(QThread::currentThread()),
+            mProgressStateCallCount(0), mSimpleProgressCallCount(0),
+            mAdvancedProgressCallCount(0), mAbortedCallCount(0), mSucceededCallCount(0),
+            mErroredCallCount(0), mFinishedCallCount(0), mDataReceivedCallCount(0),
+            mFileDownloadedCallCount(0), mZipFileExtractedCallCount(0),
+            mDestroyed(false), mErrorMessage(), mFinishedSuccess(false)
+        {
+        }
+
+        void progressState(QString state) {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            EXPECT_FALSE(state.isEmpty());
+            mProgressStateCallCount++;
+        }
+
+        void progressPercent(int estimatedPercent) {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            EXPECT_GE(estimatedPercent, 0);
+            EXPECT_LE(estimatedPercent, 100);
+            mSimpleProgressCallCount++;
+        }
+
+        void progress(qint64 bytesReceived, qint64 bytesTotal, int estimatedPercent) {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            Q_UNUSED(bytesReceived);
+            Q_UNUSED(bytesTotal);
+            EXPECT_GE(estimatedPercent, 0);
+            EXPECT_LE(estimatedPercent, 100);
+            mAdvancedProgressCallCount++;
+        }
+
+        void aborted() {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            mAbortedCallCount++;
+        }
+
+        void succeeded() {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            mSucceededCallCount++;
+        }
+
+        void errored(QString errorMsg) {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            mErrorMessage = errorMsg;
+            mErroredCallCount++;
+        }
+
+        void finished(bool success) {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            mFinishedSuccess = success;
+            mFinishedCallCount++;
+        }
+
+        void dataReceived(QByteArray data) {
+            mReceivedData = data;
+            mDataReceivedCallCount++;
+        }
+
+        void fileDownloaded(FilePath filepath) {
+            mDownloadedToFilePath = filepath;
+            mFileDownloadedCallCount++;
+        }
+
+        void zipFileExtracted(FilePath directory) {
+            mExtractedToFilePath = directory;
+            mZipFileExtractedCallCount++;
+        }
+
+        void destroyed(QObject* obj) {
+            EXPECT_EQ(mThread, QThread::currentThread());
+            EXPECT_FALSE(mDestroyed);
+            Q_UNUSED(obj);
+            mDestroyed = true;
+        }
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace librepcb
+
+#endif // NETWORKREQUESTBASESIGNALRECEIVER_H
+

--- a/tests/common/networkrequesttest.cpp
+++ b/tests/common/networkrequesttest.cpp
@@ -1,0 +1,175 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <gtest/gtest.h>
+#include <librepcbcommon/network/networkaccessmanager.h>
+#include <librepcbcommon/network/networkrequest.h>
+#include "networkrequestbasesignalreceiver.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*****************************************************************************************
+ *  Test Data Type
+ ****************************************************************************************/
+
+typedef struct {
+    QUrl url;
+    QByteArray accept;
+    QByteArray contentStart;
+    bool success;
+} NetworkRequestTestData;
+
+/*****************************************************************************************
+ *  Test Class
+ ****************************************************************************************/
+
+class NetworkRequestTest : public ::testing::TestWithParam<NetworkRequestTestData>
+{
+    public:
+
+        static void SetUpTestCase() {
+            sDownloadManager = new NetworkAccessManager();
+        }
+
+        static void TearDownTestCase() {
+            delete sDownloadManager;
+        }
+
+    protected:
+
+        NetworkRequestBaseSignalReceiver mSignalReceiver;
+        static NetworkAccessManager* sDownloadManager;
+};
+
+NetworkAccessManager* NetworkRequestTest::sDownloadManager = nullptr;
+
+/*****************************************************************************************
+ *  Test Methods
+ ****************************************************************************************/
+
+TEST_P(NetworkRequestTest, testConstructorAndSettersAndDestructor)
+{
+    const NetworkRequestTestData& data = GetParam();
+
+    NetworkRequest request(data.url);
+    request.setExpectedReplyContentSize(5);
+}
+
+TEST_P(NetworkRequestTest, testDownload)
+{
+    const NetworkRequestTestData& data = GetParam();
+
+    // start the request
+    NetworkRequest* request = new NetworkRequest(data.url);
+    if (!data.accept.isEmpty()) {
+        request->setHeaderField("Accept", data.accept);
+    }
+    QObject::connect(request, &NetworkRequest::progressState,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::progressState);
+    QObject::connect(request, &NetworkRequest::progressPercent,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::progressPercent);
+    QObject::connect(request, &NetworkRequest::progress,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::progress);
+    QObject::connect(request, &NetworkRequest::aborted,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::aborted);
+    QObject::connect(request, &NetworkRequest::succeeded,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::succeeded);
+    QObject::connect(request, &NetworkRequest::errored,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::errored);
+    QObject::connect(request, &NetworkRequest::finished,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::finished);
+    QObject::connect(request, &NetworkRequest::dataReceived,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::dataReceived);
+    QObject::connect(request, &NetworkRequest::destroyed,
+            &mSignalReceiver, &NetworkRequestBaseSignalReceiver::destroyed);
+    request->start();
+
+    // wait until request finished (with timeout)
+    qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
+    auto currentTime = [](){return QDateTime::currentDateTime().toMSecsSinceEpoch();};
+    while ((!mSignalReceiver.mDestroyed) && (currentTime() - start < 30000)) {
+        QThread::msleep(100);
+        qApp->processEvents();
+    }
+
+    // check count and parameters of emited signals
+    EXPECT_TRUE(mSignalReceiver.mDestroyed) << "Request timed out!";
+    EXPECT_GT(mSignalReceiver.mProgressStateCallCount, 0);
+    EXPECT_EQ(mSignalReceiver.mAdvancedProgressCallCount,
+              mSignalReceiver.mSimpleProgressCallCount);
+    EXPECT_EQ(0, mSignalReceiver.mAbortedCallCount);
+    EXPECT_EQ(1, mSignalReceiver.mFinishedCallCount);
+    EXPECT_EQ(0, mSignalReceiver.mFileDownloadedCallCount);
+    EXPECT_EQ(0, mSignalReceiver.mZipFileExtractedCallCount);
+    if (data.success) {
+        EXPECT_GE(mSignalReceiver.mSimpleProgressCallCount, 1);
+        EXPECT_EQ(1, mSignalReceiver.mSucceededCallCount);
+        EXPECT_EQ(0, mSignalReceiver.mErroredCallCount);
+        EXPECT_EQ(1, mSignalReceiver.mDataReceivedCallCount);
+        EXPECT_TRUE(mSignalReceiver.mErrorMessage.isNull())
+                << qPrintable(mSignalReceiver.mErrorMessage);
+        EXPECT_TRUE(mSignalReceiver.mFinishedSuccess);
+        EXPECT_FALSE(mSignalReceiver.mReceivedData.isEmpty());
+    } else {
+        EXPECT_GE(mSignalReceiver.mSimpleProgressCallCount, 0);
+        EXPECT_EQ(0, mSignalReceiver.mSucceededCallCount);
+        EXPECT_EQ(1, mSignalReceiver.mErroredCallCount);
+        EXPECT_EQ(0, mSignalReceiver.mDataReceivedCallCount);
+        EXPECT_FALSE(mSignalReceiver.mErrorMessage.isEmpty())
+                << qPrintable(mSignalReceiver.mErrorMessage);
+        EXPECT_FALSE(mSignalReceiver.mFinishedSuccess);
+        EXPECT_TRUE(mSignalReceiver.mReceivedData.isEmpty());
+    }
+    EXPECT_TRUE(mSignalReceiver.mReceivedData.trimmed().startsWith(data.contentStart))
+            << qPrintable(mSignalReceiver.mReceivedData);
+}
+
+/*****************************************************************************************
+ *  Test Data
+ ****************************************************************************************/
+
+INSTANTIATE_TEST_CASE_P(NetworkRequestTest, NetworkRequestTest, ::testing::Values(
+    NetworkRequestTestData({QUrl("https://api.librepcb.org/api/v1/"),
+                            QByteArray("application/json"),
+                            QByteArray("{"),
+                            true}),
+    NetworkRequestTestData({QUrl("https://api.librepcb.org/api/v1/"),
+                            QByteArray("text/html"),
+                            QByteArray("<"),
+                            true}),
+    NetworkRequestTestData({QUrl("https://api.librepcb.org/some-invalid-url"),
+                            QByteArray("text/html"),
+                            QByteArray(""),
+                            false})
+));
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace librepcb

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -22,21 +22,25 @@ LIBS += \
     -L$${DESTDIR} \
     -lgmock \
     -llibrepcblibrary \    # Note: The order of the libraries is very important for the linker!
-    -llibrepcbcommon       # Another order could end up in "undefined reference" errors!
+    -llibrepcbcommon \     # Another order could end up in "undefined reference" errors!
+    -lquazip -lz
 
 INCLUDEPATH += \
     ../3rdparty/gmock/gtest/include \
     ../3rdparty/gmock/include \
+    ../3rdparty/quazip \
     ../libs
 
 DEPENDPATH += \
     ../libs/librepcblibrary \
-    ../libs/librepcbcommon
+    ../libs/librepcbcommon \
+    ../3rdparty/quazip \
 
 PRE_TARGETDEPS += \
     $${DESTDIR}/libgmock.a \
     $${DESTDIR}/liblibrepcblibrary.a \
-    $${DESTDIR}/liblibrepcbcommon.a
+    $${DESTDIR}/liblibrepcbcommon.a \
+    $${DESTDIR}/libquazip.a
 
 SOURCES += main.cpp \
     common/filepathtest.cpp \
@@ -46,6 +50,9 @@ SOURCES += main.cpp \
     common/versiontest.cpp \
     common/systeminfotest.cpp \
     common/directorylocktest.cpp \
-    common/uuidtest.cpp
+    common/uuidtest.cpp \
+    common/filedownloadtest.cpp \
+    common/networkrequesttest.cpp
 
-HEADERS +=
+HEADERS += \
+    common/networkrequestbasesignalreceiver.h


### PR DESCRIPTION
We need this network access manager to download zipped libraries and more from the Internet. The main features of that manager are:
- Follow HTTP redirects (transparently for the user of the network access manager)
- Process requests asynchronously in a separate thread (avoids a blocked GUI thread)
- Process multiple requests in parallel
- Verify checksum of downloaded files
- Extract ZIP files after download with [QuaZIP](http://quazip.sourceforge.net/)
- Report progress, errors and finished event with Qt's signals/slots mechanism (thread-safe)

I have slightly modified the project files of QuaZIP to integrate the library in LibrePCB. The modified project is now hosted here: https://github.com/LibrePCB/quazip