### PR TITLE
SystemInfo: Make getProcessNameByPid() more reliable on Windows

### DIFF
--- a/tests/common/systeminfotest.cpp
+++ b/tests/common/systeminfotest.cpp
@@ -135,7 +135,6 @@ TEST_F(SystemInfoTest, testGetProcessNameByPid)
                       << "[" << process.error() << "]" << std::endl;
             GTEST_FAIL();
         }
-        QThread::usleep(1); // GetModuleFileNameEx() fails without this tiny delay o_o
         ASSERT_EQ("librepcb", SystemInfo::getProcessNameByPid(process.processId()));
         process.kill();
         if (!success) {


### PR DESCRIPTION
The Windows API function `GetModuleFileNameExW()` seems to be a crappy nightmare :scream: Hopefully `QueryFullProcessImageNameW()` is more reliable. At least an ugly workaround in the unit tests seems to be needless now...

See https://blogs.msdn.microsoft.com/oldnewthing/20150716-00/?p=45131/ (very interesting!)

Windows... :sob:

P.S. LibrePCB will no longer run on Windows XP after this change (if it ever run on XP :wink:) because `QueryFullProcessImageNameW()` was introduced with Windows Vista.