### PR TITLE
Sort entries of HEADERS, SOURCES and FORMS in *.pro files

### DIFF
--- a/apps/EagleImport/EagleImport.pro
+++ b/apps/EagleImport/EagleImport.pro
@@ -38,10 +38,12 @@ PRE_TARGETDEPS += \
 SOURCES += \
     main.cpp \
     mainwindow.cpp \
-    polygonsimplifier.cpp
+    polygonsimplifier.cpp \
 
 HEADERS += \
     mainwindow.h \
-    polygonsimplifier.h
+    polygonsimplifier.h \
 
-FORMS += mainwindow.ui
+FORMS += \
+    mainwindow.ui \
+

--- a/apps/ProjectLibraryUpdater/ProjectLibraryUpdater.pro
+++ b/apps/ProjectLibraryUpdater/ProjectLibraryUpdater.pro
@@ -39,9 +39,11 @@ PRE_TARGETDEPS += \
 
 SOURCES += \
     main.cpp \
-    mainwindow.cpp
+    mainwindow.cpp \
 
 HEADERS += \
-    mainwindow.h
+    mainwindow.h \
 
-FORMS += mainwindow.ui
+FORMS += \
+    mainwindow.ui \
+

--- a/apps/WorkspaceLibraryUpdater/WorkspaceLibraryUpdater.pro
+++ b/apps/WorkspaceLibraryUpdater/WorkspaceLibraryUpdater.pro
@@ -39,9 +39,11 @@ PRE_TARGETDEPS += \
 
 SOURCES += \
     main.cpp \
-    mainwindow.cpp
+    mainwindow.cpp \
 
 HEADERS += \
-    mainwindow.h
+    mainwindow.h \
 
-FORMS += mainwindow.ui
+FORMS += \
+    mainwindow.ui \
+

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -93,25 +93,25 @@ RESOURCES += \
     ../../i18n/translations.qrc
 
 SOURCES += \
-    main.cpp \
     controlpanel/controlpanel.cpp \
     firstrunwizard/firstrunwizard.cpp \
     firstrunwizard/firstrunwizardpage_welcome.cpp \
     firstrunwizard/firstrunwizardpage_workspacepath.cpp \
-    markdown/markdownconverter.cpp
+    main.cpp \
+    markdown/markdownconverter.cpp \
 
 HEADERS += \
     controlpanel/controlpanel.h \
     firstrunwizard/firstrunwizard.h \
     firstrunwizard/firstrunwizardpage_welcome.h \
     firstrunwizard/firstrunwizardpage_workspacepath.h \
-    markdown/markdownconverter.h
+    markdown/markdownconverter.h \
 
 FORMS += \
     controlpanel/controlpanel.ui \
     firstrunwizard/firstrunwizard.ui \
     firstrunwizard/firstrunwizardpage_welcome.ui \
-    firstrunwizard/firstrunwizardpage_workspacepath.ui
+    firstrunwizard/firstrunwizardpage_workspacepath.ui \
 
 
 # Custom compiler "lrelease" for qm generation

--- a/dev/sort_qmake_file_entries.py
+++ b/dev/sort_qmake_file_entries.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import os 
+import glob
+from shutil import copyfile
+
+
+"""
+This script sorts the entries of HEADERS, SOURCES and FORMS variables in
+all qmake project files (*.pro) in alphabetical order (except those in 
+submodules). This reduces the risk of conflicts when merging or rebasing
+commits which modify *.pro files and makes those files cleaner and thus 
+easier to read.
+
+This script may be used as a pre-commit hook:
+ln -rsT sort_qmake_file_entries.py ../.git/hooks/pre-commit
+"""
+
+
+def get_repository_root_dir(start_dir):
+    if os.path.isdir(os.path.join(start_dir, '.git')):
+        return start_dir
+    else:
+        parent_dir = os.path.dirname(start_dir)
+        if parent_dir != start_dir:
+            return get_repository_root_dir(parent_dir)
+        else:
+            return None
+
+
+def sort_qmake_file(project_root, filepath):
+    with open(filepath, 'r') as file:
+        old_lines = list(file.readlines())
+        new_lines = list(old_lines)
+    block_start_index = None
+    for line_index, line in enumerate(old_lines):
+        if block_start_index is None:
+            is_headers = line.startswith("HEADERS += \\")
+            is_sources = line.startswith("SOURCES += \\")
+            is_forms = line.startswith("FORMS += \\")
+            if is_headers or is_sources or is_forms:
+                block_start_index = line_index + 1
+        else:
+            if not line.strip():
+                block_end_index = line_index
+                block_lines = sorted(old_lines[block_start_index:block_end_index])
+                for i, l in enumerate(block_lines):
+                    adjusted_line = l.replace("\\", "").rstrip() + " \\\n"
+                    new_lines[block_start_index+i] = adjusted_line
+                block_start_index = None
+    relative_path = os.path.relpath(filepath, project_root)
+    if new_lines != old_lines:
+        print("[M] {}".format(relative_path))
+        copyfile(filepath, filepath + '~')
+        with open(filepath, 'w') as file:
+            file.writelines(new_lines)
+        return 1
+    else:
+        print("[ ] {}".format(relative_path))
+        return 0
+
+
+def sort_qmake_files_in_dir(project_root, dir):
+    modified_files = 0
+    dot_git_file = os.path.join(dir, '.git')
+    if not os.path.isfile(dot_git_file):
+        has_qmake_file = False
+        for entry in glob.glob(os.path.join(dir, '*.pro')):
+            if os.path.isfile(entry):
+                has_qmake_file = True
+                modified_files += sort_qmake_file(project_root, entry)
+        if has_qmake_file is True:
+            for entry in glob.glob(os.path.join(dir, '*/')):
+                filename = os.path.basename(entry)
+                if not os.path.basename(entry).startswith('.'):
+                    modified_files += sort_qmake_files_in_dir(project_root, entry)
+    return modified_files
+
+
+def main():
+    # get the root directory of the project's repository
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    project_root_dir = get_repository_root_dir(script_dir)
+    if not os.path.isfile(os.path.join(project_root_dir, 'librepcb.pro')):
+        raise Exception("Could not find 'librepcb.pro' in the project's root directory!")
+
+    # search all *.pro files and sort their HEADERS, SOURCES and FORMS entries
+    print("Sort *.pro file entries...")
+    modified_files = sort_qmake_files_in_dir(project_root_dir, project_root_dir)
+    print("Finished: {} Files modified.".format(modified_files))
+    return modified_files
+
+
+if __name__ == "__main__":
+    # exit with code != 0 if files were modified
+    # -> aborts the commit when used as pre-commit hook!
+    exit(main())
+

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -30,6 +30,8 @@ DEFINES += INSTALLATION_PREFIX="\\\"$${PREFIX}\\\""
 #DEFINES += USE_32BIT_LENGTH_UNITS          # see units/length.h
 
 HEADERS += \
+    alignment.h \
+    application.h \
     attributes/attributetype.h \
     attributes/attributeunit.h \
     attributes/attrtypecapacitance.h \
@@ -38,61 +40,61 @@ HEADERS += \
     attributes/attrtyperesistance.h \
     attributes/attrtypestring.h \
     attributes/attrtypevoltage.h \
+    boarddesignrules.h \
+    boardlayer.h \
+    cam/excellongenerator.h \
+    cam/gerberaperturelist.h \
+    cam/gerbergenerator.h \
+    debug.h \
+    dialogs/boarddesignrulesdialog.h \
     dialogs/gridsettingsdialog.h \
+    exceptions.h \
     fileio/directorylock.h \
     fileio/filepath.h \
+    fileio/fileutils.h \
     fileio/if_xmlserializableobject.h \
     fileio/smartfile.h \
     fileio/smarttextfile.h \
+    fileio/smartversionfile.h \
     fileio/smartxmlfile.h \
     fileio/xmldomdocument.h \
     fileio/xmldomelement.h \
+    geometry/ellipse.h \
+    geometry/hole.h \
+    geometry/polygon.h \
+    geometry/text.h \
     graphics/graphicsitem.h \
     graphics/graphicsscene.h \
     graphics/graphicsview.h \
     graphics/if_graphicsvieweventhandler.h \
+    gridproperties.h \
+    if_attributeprovider.h \
+    if_boardlayerprovider.h \
+    if_schematiclayerprovider.h \
+    network/filedownload.h \
+    network/networkaccessmanager.h \
+    network/networkrequest.h \
+    network/networkrequestbase.h \
+    network/repository.h \
+    schematiclayer.h \
+    scopeguard.h \
+    scopeguardlist.h \
+    sqlitedatabase.h \
+    systeminfo.h \
+    undocommand.h \
+    undocommandgroup.h \
+    undostack.h \
     units/all_length_units.h \
     units/angle.h \
     units/length.h \
     units/lengthunit.h \
     units/point.h \
-    alignment.h \
-    application.h \
-    debug.h \
-    exceptions.h \
-    gridproperties.h \
-    if_attributeprovider.h \
-    schematiclayer.h \
-    systeminfo.h \
-    undocommand.h \
-    undostack.h \
-    version.h \
-    if_schematiclayerprovider.h \
-    boardlayer.h \
-    if_boardlayerprovider.h \
     uuid.h \
-    geometry/polygon.h \
-    geometry/ellipse.h \
-    geometry/text.h \
-    geometry/hole.h \
-    undocommandgroup.h \
-    scopeguard.h \
-    scopeguardlist.h \
-    boarddesignrules.h \
-    dialogs/boarddesignrulesdialog.h \
-    cam/gerbergenerator.h \
-    cam/gerberaperturelist.h \
-    cam/excellongenerator.h \
-    fileio/smartversionfile.h \
-    fileio/fileutils.h \
-    sqlitedatabase.h \
-    network/filedownload.h \
-    network/networkrequest.h \
-    network/networkrequestbase.h \
-    network/networkaccessmanager.h \
-    network/repository.h
+    version.h \
 
 SOURCES += \
+    alignment.cpp \
+    application.cpp \
     attributes/attributetype.cpp \
     attributes/attributeunit.cpp \
     attributes/attrtypecapacitance.cpp \
@@ -101,53 +103,52 @@ SOURCES += \
     attributes/attrtyperesistance.cpp \
     attributes/attrtypestring.cpp \
     attributes/attrtypevoltage.cpp \
+    boarddesignrules.cpp \
+    boardlayer.cpp \
+    cam/excellongenerator.cpp \
+    cam/gerberaperturelist.cpp \
+    cam/gerbergenerator.cpp \
+    debug.cpp \
+    dialogs/boarddesignrulesdialog.cpp \
     dialogs/gridsettingsdialog.cpp \
+    exceptions.cpp \
     fileio/directorylock.cpp \
     fileio/filepath.cpp \
+    fileio/fileutils.cpp \
     fileio/smartfile.cpp \
     fileio/smarttextfile.cpp \
+    fileio/smartversionfile.cpp \
     fileio/smartxmlfile.cpp \
     fileio/xmldomdocument.cpp \
     fileio/xmldomelement.cpp \
+    geometry/ellipse.cpp \
+    geometry/hole.cpp \
+    geometry/polygon.cpp \
+    geometry/text.cpp \
     graphics/graphicsitem.cpp \
     graphics/graphicsscene.cpp \
     graphics/graphicsview.cpp \
+    gridproperties.cpp \
+    if_attributeprovider.cpp \
+    network/filedownload.cpp \
+    network/networkaccessmanager.cpp \
+    network/networkrequest.cpp \
+    network/networkrequestbase.cpp \
+    network/repository.cpp \
+    schematiclayer.cpp \
+    sqlitedatabase.cpp \
+    systeminfo.cpp \
+    undocommand.cpp \
+    undocommandgroup.cpp \
+    undostack.cpp \
     units/angle.cpp \
     units/length.cpp \
     units/lengthunit.cpp \
     units/point.cpp \
-    alignment.cpp \
-    application.cpp \
-    debug.cpp \
-    exceptions.cpp \
-    gridproperties.cpp \
-    if_attributeprovider.cpp \
-    schematiclayer.cpp \
-    systeminfo.cpp \
-    undocommand.cpp \
-    undostack.cpp \
-    version.cpp \
-    boardlayer.cpp \
     uuid.cpp \
-    geometry/polygon.cpp \
-    geometry/ellipse.cpp \
-    geometry/text.cpp \
-    geometry/hole.cpp \
-    undocommandgroup.cpp \
-    boarddesignrules.cpp \
-    dialogs/boarddesignrulesdialog.cpp \
-    cam/gerbergenerator.cpp \
-    cam/gerberaperturelist.cpp \
-    cam/excellongenerator.cpp \
-    fileio/smartversionfile.cpp \
-    fileio/fileutils.cpp \
-    sqlitedatabase.cpp \
-    network/filedownload.cpp \
-    network/networkrequest.cpp \
-    network/networkrequestbase.cpp \
-    network/networkaccessmanager.cpp \
-    network/repository.cpp
+    version.cpp \
 
 FORMS += \
+    dialogs/boarddesignrulesdialog.ui \
     dialogs/gridsettingsdialog.ui \
-    dialogs/boarddesignrulesdialog.ui
+

--- a/libs/librepcb/library/library.pro
+++ b/libs/librepcb/library/library.pro
@@ -22,56 +22,56 @@ INCLUDEPATH += \
 
 HEADERS += \
     cat/componentcategory.h \
+    cat/librarycategory.h \
     cat/packagecategory.h \
+    cmp/component.h \
+    cmp/componentpinsignalmapitem.h \
+    cmp/componentsignal.h \
+    cmp/componentsymbolvariant.h \
+    cmp/componentsymbolvariantitem.h \
+    dev/device.h \
+    elements.h \
+    library.h \
+    librarybaseelement.h \
+    libraryelement.h \
+    libraryelementattribute.h \
     pkg/footprint.h \
+    pkg/footprintpad.h \
+    pkg/footprintpadpreviewgraphicsitem.h \
+    pkg/footprintpadsmt.h \
+    pkg/footprintpadtht.h \
+    pkg/footprintpreviewgraphicsitem.h \
     pkg/package.h \
+    pkg/packagepad.h \
     sym/symbol.h \
     sym/symbolpin.h \
     sym/symbolpinpreviewgraphicsitem.h \
     sym/symbolpreviewgraphicsitem.h \
-    librarybaseelement.h \
-    libraryelement.h \
-    libraryelementattribute.h \
-    pkg/footprintpad.h \
-    cat/librarycategory.h \
-    elements.h \
-    dev/device.h \
-    cmp/component.h \
-    cmp/componentsignal.h \
-    cmp/componentsymbolvariant.h \
-    cmp/componentsymbolvariantitem.h \
-    pkg/packagepad.h \
-    pkg/footprintpadtht.h \
-    pkg/footprintpadsmt.h \
-    cmp/componentpinsignalmapitem.h \
-    pkg/footprintpadpreviewgraphicsitem.h \
-    pkg/footprintpreviewgraphicsitem.h \
-    library.h
 
 SOURCES += \
     cat/componentcategory.cpp \
+    cat/librarycategory.cpp \
     cat/packagecategory.cpp \
+    cmp/component.cpp \
+    cmp/componentpinsignalmapitem.cpp \
+    cmp/componentsignal.cpp \
+    cmp/componentsymbolvariant.cpp \
+    cmp/componentsymbolvariantitem.cpp \
+    dev/device.cpp \
+    library.cpp \
+    librarybaseelement.cpp \
+    libraryelement.cpp \
+    libraryelementattribute.cpp \
     pkg/footprint.cpp \
+    pkg/footprintpad.cpp \
+    pkg/footprintpadpreviewgraphicsitem.cpp \
+    pkg/footprintpadsmt.cpp \
+    pkg/footprintpadtht.cpp \
+    pkg/footprintpreviewgraphicsitem.cpp \
     pkg/package.cpp \
+    pkg/packagepad.cpp \
     sym/symbol.cpp \
     sym/symbolpin.cpp \
     sym/symbolpinpreviewgraphicsitem.cpp \
     sym/symbolpreviewgraphicsitem.cpp \
-    librarybaseelement.cpp \
-    libraryelement.cpp \
-    libraryelementattribute.cpp \
-    pkg/footprintpad.cpp \
-    cat/librarycategory.cpp \
-    dev/device.cpp \
-    cmp/componentsignal.cpp \
-    cmp/componentsymbolvariant.cpp \
-    cmp/componentsymbolvariantitem.cpp \
-    cmp/component.cpp \
-    pkg/packagepad.cpp \
-    pkg/footprintpadtht.cpp \
-    pkg/footprintpadsmt.cpp \
-    cmp/componentpinsignalmapitem.cpp \
-    pkg/footprintpadpreviewgraphicsitem.cpp \
-    pkg/footprintpreviewgraphicsitem.cpp \
-    library.cpp
 

--- a/libs/librepcb/libraryeditor/libraryeditor.pro
+++ b/libs/librepcb/libraryeditor/libraryeditor.pro
@@ -21,11 +21,11 @@ INCLUDEPATH += \
     ../../
 
 SOURCES += \
-    libraryeditor.cpp
+    libraryeditor.cpp \
 
 HEADERS += \
-    libraryeditor.h
+    libraryeditor.h \
 
 FORMS += \
-    libraryeditor.ui
+    libraryeditor.ui \
 

--- a/libs/librepcb/librarymanager/librarymanager.pro
+++ b/libs/librepcb/librarymanager/librarymanager.pro
@@ -21,24 +21,25 @@ INCLUDEPATH += \
     ../../
 
 SOURCES += \
-    librarydownload.cpp \
-    librarylistwidgetitem.cpp \
-    libraryinfowidget.cpp \
     addlibrarywidget.cpp \
+    librarydownload.cpp \
+    libraryinfowidget.cpp \
+    librarylistwidgetitem.cpp \
     librarymanager.cpp \
-    repositorylibrarylistwidgetitem.cpp
+    repositorylibrarylistwidgetitem.cpp \
 
 HEADERS += \
-    librarydownload.h \
-    librarylistwidgetitem.h \
-    libraryinfowidget.h \
     addlibrarywidget.h \
+    librarydownload.h \
+    libraryinfowidget.h \
+    librarylistwidgetitem.h \
     librarymanager.h \
-    repositorylibrarylistwidgetitem.h
+    repositorylibrarylistwidgetitem.h \
 
 FORMS += \
-    librarylistwidgetitem.ui \
-    libraryinfowidget.ui \
     addlibrarywidget.ui \
+    libraryinfowidget.ui \
+    librarylistwidgetitem.ui \
     librarymanager.ui \
-    repositorylibrarylistwidgetitem.ui
+    repositorylibrarylistwidgetitem.ui \
+

--- a/libs/librepcb/project/project.pro
+++ b/libs/librepcb/project/project.pro
@@ -21,65 +21,38 @@ INCLUDEPATH += \
     ../../
 
 SOURCES += \
-    project.cpp \
-    circuit/circuit.cpp \
-    circuit/netclass.cpp \
-    circuit/netsignal.cpp \
-    circuit/cmd/cmdnetclassadd.cpp \
-    circuit/cmd/cmdnetclassremove.cpp \
-    circuit/cmd/cmdnetsignaladd.cpp \
-    circuit/cmd/cmdnetsignalremove.cpp \
-    circuit/cmd/cmdnetclassedit.cpp \
-    circuit/cmd/cmdnetsignaledit.cpp \
-    schematics/schematic.cpp \
-    schematics/cmd/cmdschematicadd.cpp \
-    schematics/cmd/cmdschematicremove.cpp \
-    schematics/cmd/cmdschematicnetpointadd.cpp \
-    schematics/cmd/cmdschematicnetpointremove.cpp \
-    schematics/cmd/cmdschematicnetlineadd.cpp \
-    schematics/cmd/cmdschematicnetlineremove.cpp \
-    schematics/cmd/cmdsymbolinstanceadd.cpp \
-    schematics/cmd/cmdsymbolinstanceremove.cpp \
-    schematics/cmd/cmdschematicnetlabeladd.cpp \
-    schematics/cmd/cmdschematicnetlabelremove.cpp \
-    schematics/cmd/cmdschematicnetlabeledit.cpp \
-    schematics/cmd/cmdschematicnetpointedit.cpp \
-    schematics/cmd/cmdsymbolinstanceedit.cpp \
-    schematics/items/si_base.cpp \
-    schematics/items/si_netlabel.cpp \
-    schematics/items/si_netline.cpp \
-    schematics/items/si_netpoint.cpp \
-    schematics/items/si_symbol.cpp \
-    schematics/items/si_symbolpin.cpp \
-    schematics/graphicsitems/sgi_base.cpp \
-    schematics/graphicsitems/sgi_netlabel.cpp \
-    schematics/graphicsitems/sgi_netline.cpp \
-    schematics/graphicsitems/sgi_netpoint.cpp \
-    schematics/graphicsitems/sgi_symbol.cpp \
-    schematics/graphicsitems/sgi_symbolpin.cpp \
     boards/board.cpp \
+    boards/boardgerberexport.cpp \
+    boards/boardlayerstack.cpp \
     boards/cmd/cmdboardadd.cpp \
-    boards/items/bi_base.cpp \
-    boards/items/bi_footprint.cpp \
-    boards/graphicsitems/bgi_base.cpp \
-    boards/graphicsitems/bgi_footprint.cpp \
-    boards/items/bi_footprintpad.cpp \
-    boards/graphicsitems/bgi_footprintpad.cpp \
-    library/projectlibrary.cpp \
-    erc/ercmsg.cpp \
-    erc/ercmsglist.cpp \
-    cmd/cmdprojectsetmetadata.cpp \
-    settings/projectsettings.cpp \
-    settings/cmd/cmdprojectsettingschange.cpp \
-    schematics/schematiclayerprovider.cpp \
-    library/cmd/cmdprojectlibraryaddelement.cpp \
-    boards/items/bi_device.cpp \
+    boards/cmd/cmdboarddesignrulesmodify.cpp \
+    boards/cmd/cmdboardnetlineadd.cpp \
+    boards/cmd/cmdboardnetlineremove.cpp \
+    boards/cmd/cmdboardnetpointadd.cpp \
+    boards/cmd/cmdboardnetpointedit.cpp \
+    boards/cmd/cmdboardnetpointremove.cpp \
+    boards/cmd/cmdboardviaadd.cpp \
+    boards/cmd/cmdboardviaedit.cpp \
+    boards/cmd/cmdboardviaremove.cpp \
     boards/cmd/cmddeviceinstanceadd.cpp \
     boards/cmd/cmddeviceinstanceedit.cpp \
     boards/cmd/cmddeviceinstanceremove.cpp \
-    circuit/componentinstance.cpp \
-    circuit/componentattributeinstance.cpp \
-    circuit/componentsignalinstance.cpp \
+    boards/graphicsitems/bgi_base.cpp \
+    boards/graphicsitems/bgi_footprint.cpp \
+    boards/graphicsitems/bgi_footprintpad.cpp \
+    boards/graphicsitems/bgi_netline.cpp \
+    boards/graphicsitems/bgi_netpoint.cpp \
+    boards/graphicsitems/bgi_polygon.cpp \
+    boards/graphicsitems/bgi_via.cpp \
+    boards/items/bi_base.cpp \
+    boards/items/bi_device.cpp \
+    boards/items/bi_footprint.cpp \
+    boards/items/bi_footprintpad.cpp \
+    boards/items/bi_netline.cpp \
+    boards/items/bi_netpoint.cpp \
+    boards/items/bi_polygon.cpp \
+    boards/items/bi_via.cpp \
+    circuit/circuit.cpp \
     circuit/cmd/cmdcompattrinstadd.cpp \
     circuit/cmd/cmdcompattrinstedit.cpp \
     circuit/cmd/cmdcompattrinstremove.cpp \
@@ -87,87 +60,86 @@ SOURCES += \
     circuit/cmd/cmdcomponentinstanceedit.cpp \
     circuit/cmd/cmdcomponentinstanceremove.cpp \
     circuit/cmd/cmdcompsiginstsetnetsignal.cpp \
-    boards/items/bi_polygon.cpp \
-    boards/graphicsitems/bgi_polygon.cpp \
-    boards/boardlayerstack.cpp \
-    boards/items/bi_netpoint.cpp \
-    boards/items/bi_netline.cpp \
-    boards/graphicsitems/bgi_netpoint.cpp \
-    boards/graphicsitems/bgi_netline.cpp \
-    boards/cmd/cmdboardnetlineadd.cpp \
-    boards/cmd/cmdboardnetlineremove.cpp \
-    boards/cmd/cmdboardnetpointadd.cpp \
-    boards/cmd/cmdboardnetpointedit.cpp \
-    boards/cmd/cmdboardnetpointremove.cpp \
-    boards/items/bi_via.cpp \
-    boards/graphicsitems/bgi_via.cpp \
-    boards/cmd/cmdboardviaadd.cpp \
-    boards/cmd/cmdboardviaremove.cpp \
-    boards/cmd/cmdboardviaedit.cpp \
-    boards/cmd/cmdboarddesignrulesmodify.cpp \
-    boards/boardgerberexport.cpp
+    circuit/cmd/cmdnetclassadd.cpp \
+    circuit/cmd/cmdnetclassedit.cpp \
+    circuit/cmd/cmdnetclassremove.cpp \
+    circuit/cmd/cmdnetsignaladd.cpp \
+    circuit/cmd/cmdnetsignaledit.cpp \
+    circuit/cmd/cmdnetsignalremove.cpp \
+    circuit/componentattributeinstance.cpp \
+    circuit/componentinstance.cpp \
+    circuit/componentsignalinstance.cpp \
+    circuit/netclass.cpp \
+    circuit/netsignal.cpp \
+    cmd/cmdprojectsetmetadata.cpp \
+    erc/ercmsg.cpp \
+    erc/ercmsglist.cpp \
+    library/cmd/cmdprojectlibraryaddelement.cpp \
+    library/projectlibrary.cpp \
+    project.cpp \
+    schematics/cmd/cmdschematicadd.cpp \
+    schematics/cmd/cmdschematicnetlabeladd.cpp \
+    schematics/cmd/cmdschematicnetlabeledit.cpp \
+    schematics/cmd/cmdschematicnetlabelremove.cpp \
+    schematics/cmd/cmdschematicnetlineadd.cpp \
+    schematics/cmd/cmdschematicnetlineremove.cpp \
+    schematics/cmd/cmdschematicnetpointadd.cpp \
+    schematics/cmd/cmdschematicnetpointedit.cpp \
+    schematics/cmd/cmdschematicnetpointremove.cpp \
+    schematics/cmd/cmdschematicremove.cpp \
+    schematics/cmd/cmdsymbolinstanceadd.cpp \
+    schematics/cmd/cmdsymbolinstanceedit.cpp \
+    schematics/cmd/cmdsymbolinstanceremove.cpp \
+    schematics/graphicsitems/sgi_base.cpp \
+    schematics/graphicsitems/sgi_netlabel.cpp \
+    schematics/graphicsitems/sgi_netline.cpp \
+    schematics/graphicsitems/sgi_netpoint.cpp \
+    schematics/graphicsitems/sgi_symbol.cpp \
+    schematics/graphicsitems/sgi_symbolpin.cpp \
+    schematics/items/si_base.cpp \
+    schematics/items/si_netlabel.cpp \
+    schematics/items/si_netline.cpp \
+    schematics/items/si_netpoint.cpp \
+    schematics/items/si_symbol.cpp \
+    schematics/items/si_symbolpin.cpp \
+    schematics/schematic.cpp \
+    schematics/schematiclayerprovider.cpp \
+    settings/cmd/cmdprojectsettingschange.cpp \
+    settings/projectsettings.cpp \
 
 HEADERS += \
-    project.h \
-    circuit/circuit.h \
-    circuit/netclass.h \
-    circuit/netsignal.h \
-    circuit/cmd/cmdnetclassadd.h \
-    circuit/cmd/cmdnetclassremove.h \
-    circuit/cmd/cmdnetsignaladd.h \
-    circuit/cmd/cmdnetsignalremove.h \
-    circuit/cmd/cmdnetclassedit.h \
-    circuit/cmd/cmdnetsignaledit.h \
-    schematics/schematic.h \
-    schematics/cmd/cmdschematicadd.h \
-    schematics/cmd/cmdschematicremove.h \
-    schematics/cmd/cmdschematicnetpointadd.h \
-    schematics/cmd/cmdschematicnetpointremove.h \
-    schematics/cmd/cmdschematicnetlineadd.h \
-    schematics/cmd/cmdschematicnetlineremove.h \
-    schematics/cmd/cmdsymbolinstanceadd.h \
-    schematics/cmd/cmdsymbolinstanceremove.h \
-    schematics/cmd/cmdschematicnetlabeladd.h \
-    schematics/cmd/cmdschematicnetlabelremove.h \
-    schematics/cmd/cmdschematicnetlabeledit.h \
-    schematics/cmd/cmdschematicnetpointedit.h \
-    schematics/cmd/cmdsymbolinstanceedit.h \
-    schematics/items/si_base.h \
-    schematics/items/si_netlabel.h \
-    schematics/items/si_netline.h \
-    schematics/items/si_netpoint.h \
-    schematics/items/si_symbol.h \
-    schematics/items/si_symbolpin.h \
-    schematics/graphicsitems/sgi_base.h \
-    schematics/graphicsitems/sgi_netlabel.h \
-    schematics/graphicsitems/sgi_netline.h \
-    schematics/graphicsitems/sgi_netpoint.h \
-    schematics/graphicsitems/sgi_symbol.h \
-    schematics/graphicsitems/sgi_symbolpin.h \
     boards/board.h \
+    boards/boardgerberexport.h \
+    boards/boardlayerstack.h \
     boards/cmd/cmdboardadd.h \
-    boards/items/bi_base.h \
-    boards/items/bi_footprint.h \
+    boards/cmd/cmdboarddesignrulesmodify.h \
+    boards/cmd/cmdboardnetlineadd.h \
+    boards/cmd/cmdboardnetlineremove.h \
+    boards/cmd/cmdboardnetpointadd.h \
+    boards/cmd/cmdboardnetpointedit.h \
+    boards/cmd/cmdboardnetpointremove.h \
+    boards/cmd/cmdboardviaadd.h \
+    boards/cmd/cmdboardviaedit.h \
+    boards/cmd/cmdboardviaremove.h \
+    boards/cmd/cmddeviceinstanceadd.h \
+    boards/cmd/cmddeviceinstanceedit.h \
+    boards/cmd/cmddeviceinstanceremove.h \
     boards/graphicsitems/bgi_base.h \
     boards/graphicsitems/bgi_footprint.h \
-    boards/items/bi_footprintpad.h \
     boards/graphicsitems/bgi_footprintpad.h \
-    library/projectlibrary.h \
-    erc/ercmsg.h \
-    erc/ercmsglist.h \
-    erc/if_ercmsgprovider.h \
-    cmd/cmdprojectsetmetadata.h \
-    settings/projectsettings.h \
-    settings/cmd/cmdprojectsettingschange.h \
-    schematics/schematiclayerprovider.h \
-    library/cmd/cmdprojectlibraryaddelement.h \
+    boards/graphicsitems/bgi_netline.h \
+    boards/graphicsitems/bgi_netpoint.h \
+    boards/graphicsitems/bgi_polygon.h \
+    boards/graphicsitems/bgi_via.h \
+    boards/items/bi_base.h \
     boards/items/bi_device.h \
-    boards/cmd/cmddeviceinstanceadd.h \
-    boards/cmd/cmddeviceinstanceremove.h \
-    boards/cmd/cmddeviceinstanceedit.h \
-    circuit/componentinstance.h \
-    circuit/componentattributeinstance.h \
-    circuit/componentsignalinstance.h \
+    boards/items/bi_footprint.h \
+    boards/items/bi_footprintpad.h \
+    boards/items/bi_netline.h \
+    boards/items/bi_netpoint.h \
+    boards/items/bi_polygon.h \
+    boards/items/bi_via.h \
+    circuit/circuit.h \
     circuit/cmd/cmdcompattrinstadd.h \
     circuit/cmd/cmdcompattrinstedit.h \
     circuit/cmd/cmdcompattrinstremove.h \
@@ -175,24 +147,52 @@ HEADERS += \
     circuit/cmd/cmdcomponentinstanceedit.h \
     circuit/cmd/cmdcomponentinstanceremove.h \
     circuit/cmd/cmdcompsiginstsetnetsignal.h \
-    boards/items/bi_polygon.h \
-    boards/graphicsitems/bgi_polygon.h \
-    boards/boardlayerstack.h \
-    boards/items/bi_netpoint.h \
-    boards/items/bi_netline.h \
-    boards/graphicsitems/bgi_netpoint.h \
-    boards/graphicsitems/bgi_netline.h \
-    boards/cmd/cmdboardnetlineadd.h \
-    boards/cmd/cmdboardnetlineremove.h \
-    boards/cmd/cmdboardnetpointadd.h \
-    boards/cmd/cmdboardnetpointedit.h \
-    boards/cmd/cmdboardnetpointremove.h \
-    boards/items/bi_via.h \
-    boards/graphicsitems/bgi_via.h \
-    boards/cmd/cmdboardviaadd.h \
-    boards/cmd/cmdboardviaremove.h \
-    boards/cmd/cmdboardviaedit.h \
-    boards/cmd/cmdboarddesignrulesmodify.h \
-    boards/boardgerberexport.h
+    circuit/cmd/cmdnetclassadd.h \
+    circuit/cmd/cmdnetclassedit.h \
+    circuit/cmd/cmdnetclassremove.h \
+    circuit/cmd/cmdnetsignaladd.h \
+    circuit/cmd/cmdnetsignaledit.h \
+    circuit/cmd/cmdnetsignalremove.h \
+    circuit/componentattributeinstance.h \
+    circuit/componentinstance.h \
+    circuit/componentsignalinstance.h \
+    circuit/netclass.h \
+    circuit/netsignal.h \
+    cmd/cmdprojectsetmetadata.h \
+    erc/ercmsg.h \
+    erc/ercmsglist.h \
+    erc/if_ercmsgprovider.h \
+    library/cmd/cmdprojectlibraryaddelement.h \
+    library/projectlibrary.h \
+    project.h \
+    schematics/cmd/cmdschematicadd.h \
+    schematics/cmd/cmdschematicnetlabeladd.h \
+    schematics/cmd/cmdschematicnetlabeledit.h \
+    schematics/cmd/cmdschematicnetlabelremove.h \
+    schematics/cmd/cmdschematicnetlineadd.h \
+    schematics/cmd/cmdschematicnetlineremove.h \
+    schematics/cmd/cmdschematicnetpointadd.h \
+    schematics/cmd/cmdschematicnetpointedit.h \
+    schematics/cmd/cmdschematicnetpointremove.h \
+    schematics/cmd/cmdschematicremove.h \
+    schematics/cmd/cmdsymbolinstanceadd.h \
+    schematics/cmd/cmdsymbolinstanceedit.h \
+    schematics/cmd/cmdsymbolinstanceremove.h \
+    schematics/graphicsitems/sgi_base.h \
+    schematics/graphicsitems/sgi_netlabel.h \
+    schematics/graphicsitems/sgi_netline.h \
+    schematics/graphicsitems/sgi_netpoint.h \
+    schematics/graphicsitems/sgi_symbol.h \
+    schematics/graphicsitems/sgi_symbolpin.h \
+    schematics/items/si_base.h \
+    schematics/items/si_netlabel.h \
+    schematics/items/si_netline.h \
+    schematics/items/si_netpoint.h \
+    schematics/items/si_symbol.h \
+    schematics/items/si_symbolpin.h \
+    schematics/schematic.h \
+    schematics/schematiclayerprovider.h \
+    settings/cmd/cmdprojectsettingschange.h \
+    settings/projectsettings.h \
 
 FORMS +=

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -21,135 +21,135 @@ INCLUDEPATH += \
     ../../
 
 SOURCES += \
-    projecteditor.cpp \
-    schematiceditor/schematiceditor.cpp \
-    schematiceditor/schematicpagesdock.cpp \
-    schematiceditor/fsm/schematiceditorevent.cpp \
-    schematiceditor/fsm/ses_select.cpp \
-    schematiceditor/fsm/ses_drawwire.cpp \
-    schematiceditor/fsm/ses_addcomponent.cpp \
-    schematiceditor/fsm/ses_base.cpp \
-    schematiceditor/fsm/ses_fsm.cpp \
-    schematiceditor/symbolinstancepropertiesdialog.cpp \
-    schematiceditor/fsm/ses_addnetlabel.cpp \
-    schematiceditor/schematicclipboard.cpp \
     boardeditor/boardeditor.cpp \
-    boardeditor/unplacedcomponentsdock.cpp \
+    boardeditor/boardlayersdock.cpp \
+    boardeditor/boardviapropertiesdialog.cpp \
+    boardeditor/fabricationoutputdialog.cpp \
+    boardeditor/fsm/bes_adddevice.cpp \
+    boardeditor/fsm/bes_addvia.cpp \
     boardeditor/fsm/bes_base.cpp \
-    boardeditor/fsm/boardeditorevent.cpp \
+    boardeditor/fsm/bes_drawtrace.cpp \
     boardeditor/fsm/bes_fsm.cpp \
     boardeditor/fsm/bes_select.cpp \
+    boardeditor/fsm/boardeditorevent.cpp \
+    boardeditor/unplacedcomponentsdock.cpp \
+    cmd/cmdaddcomponenttocircuit.cpp \
+    cmd/cmdadddevicetoboard.cpp \
+    cmd/cmdaddsymboltoschematic.cpp \
+    cmd/cmdcombineallitemsunderboardnetpoint.cpp \
+    cmd/cmdcombineallnetsignalsunderschematicnetpoint.cpp \
+    cmd/cmdcombineboardnetpoints.cpp \
+    cmd/cmdcombinenetsignals.cpp \
+    cmd/cmdcombineschematicnetpoints.cpp \
+    cmd/cmddetachboardnetpointfromviaorpad.cpp \
+    cmd/cmdflipselectedboarditems.cpp \
+    cmd/cmdmoveselectedboarditems.cpp \
+    cmd/cmdmoveselectedschematicitems.cpp \
+    cmd/cmdplaceboardnetpoint.cpp \
+    cmd/cmdplaceschematicnetpoint.cpp \
+    cmd/cmdremovedevicefromboard.cpp \
+    cmd/cmdremoveselectedboarditems.cpp \
+    cmd/cmdremoveselectedschematicitems.cpp \
+    cmd/cmdremoveunusednetsignals.cpp \
+    cmd/cmdremoveviafromboard.cpp \
+    cmd/cmdreplacedevice.cpp \
+    cmd/cmdrotateselectedboarditems.cpp \
+    cmd/cmdrotateselectedschematicitems.cpp \
+    dialogs/addcomponentdialog.cpp \
     dialogs/editnetclassesdialog.cpp \
     dialogs/projectpropertieseditordialog.cpp \
     dialogs/projectsettingsdialog.cpp \
     docks/ercmsgdock.cpp \
-    dialogs/addcomponentdialog.cpp \
-    boardeditor/boardlayersdock.cpp \
-    cmd/cmdaddcomponenttocircuit.cpp \
-    cmd/cmdaddsymboltoschematic.cpp \
-    cmd/cmdadddevicetoboard.cpp \
-    cmd/cmdcombinenetsignals.cpp \
-    cmd/cmdremoveselectedschematicitems.cpp \
-    cmd/cmdcombineschematicnetpoints.cpp \
-    cmd/cmdrotateselectedschematicitems.cpp \
-    cmd/cmdmoveselectedschematicitems.cpp \
-    cmd/cmdmoveselectedboarditems.cpp \
-    cmd/cmdrotateselectedboarditems.cpp \
-    cmd/cmdflipselectedboarditems.cpp \
-    cmd/cmdremoveselectedboarditems.cpp \
-    cmd/cmdreplacedevice.cpp \
-    cmd/cmdplaceschematicnetpoint.cpp \
-    cmd/cmdcombineallnetsignalsunderschematicnetpoint.cpp \
-    cmd/cmdremoveunusednetsignals.cpp \
-    boardeditor/fsm/bes_drawtrace.cpp \
-    boardeditor/fsm/bes_addvia.cpp \
-    cmd/cmdplaceboardnetpoint.cpp \
-    cmd/cmdcombineboardnetpoints.cpp \
-    cmd/cmdcombineallitemsunderboardnetpoint.cpp \
-    boardeditor/boardviapropertiesdialog.cpp \
-    boardeditor/fsm/bes_adddevice.cpp \
-    boardeditor/fabricationoutputdialog.cpp \
-    cmd/cmdremovedevicefromboard.cpp \
-    cmd/cmdremoveviafromboard.cpp \
-    cmd/cmddetachboardnetpointfromviaorpad.cpp \
     newprojectwizard/newprojectwizard.cpp \
-    newprojectwizard/newprojectwizardpage_metadata.cpp \
     newprojectwizard/newprojectwizardpage_initialization.cpp \
-    newprojectwizard/newprojectwizardpage_versioncontrol.cpp
+    newprojectwizard/newprojectwizardpage_metadata.cpp \
+    newprojectwizard/newprojectwizardpage_versioncontrol.cpp \
+    projecteditor.cpp \
+    schematiceditor/fsm/schematiceditorevent.cpp \
+    schematiceditor/fsm/ses_addcomponent.cpp \
+    schematiceditor/fsm/ses_addnetlabel.cpp \
+    schematiceditor/fsm/ses_base.cpp \
+    schematiceditor/fsm/ses_drawwire.cpp \
+    schematiceditor/fsm/ses_fsm.cpp \
+    schematiceditor/fsm/ses_select.cpp \
+    schematiceditor/schematicclipboard.cpp \
+    schematiceditor/schematiceditor.cpp \
+    schematiceditor/schematicpagesdock.cpp \
+    schematiceditor/symbolinstancepropertiesdialog.cpp \
 
 HEADERS += \
-    projecteditor.h \
-    schematiceditor/schematiceditor.h \
-    schematiceditor/schematicpagesdock.h \
-    schematiceditor/fsm/schematiceditorevent.h \
-    schematiceditor/fsm/ses_select.h \
-    schematiceditor/fsm/ses_drawwire.h \
-    schematiceditor/fsm/ses_addcomponent.h \
-    schematiceditor/fsm/ses_base.h \
-    schematiceditor/fsm/ses_fsm.h \
-    schematiceditor/symbolinstancepropertiesdialog.h \
-    schematiceditor/fsm/ses_addnetlabel.h \
-    schematiceditor/schematicclipboard.h \
     boardeditor/boardeditor.h \
-    boardeditor/unplacedcomponentsdock.h \
+    boardeditor/boardlayersdock.h \
+    boardeditor/boardviapropertiesdialog.h \
+    boardeditor/fabricationoutputdialog.h \
+    boardeditor/fsm/bes_adddevice.h \
+    boardeditor/fsm/bes_addvia.h \
     boardeditor/fsm/bes_base.h \
-    boardeditor/fsm/boardeditorevent.h \
+    boardeditor/fsm/bes_drawtrace.h \
     boardeditor/fsm/bes_fsm.h \
     boardeditor/fsm/bes_select.h \
+    boardeditor/fsm/boardeditorevent.h \
+    boardeditor/unplacedcomponentsdock.h \
+    cmd/cmdaddcomponenttocircuit.h \
+    cmd/cmdadddevicetoboard.h \
+    cmd/cmdaddsymboltoschematic.h \
+    cmd/cmdcombineallitemsunderboardnetpoint.h \
+    cmd/cmdcombineallnetsignalsunderschematicnetpoint.h \
+    cmd/cmdcombineboardnetpoints.h \
+    cmd/cmdcombinenetsignals.h \
+    cmd/cmdcombineschematicnetpoints.h \
+    cmd/cmddetachboardnetpointfromviaorpad.h \
+    cmd/cmdflipselectedboarditems.h \
+    cmd/cmdmoveselectedboarditems.h \
+    cmd/cmdmoveselectedschematicitems.h \
+    cmd/cmdplaceboardnetpoint.h \
+    cmd/cmdplaceschematicnetpoint.h \
+    cmd/cmdremovedevicefromboard.h \
+    cmd/cmdremoveselectedboarditems.h \
+    cmd/cmdremoveselectedschematicitems.h \
+    cmd/cmdremoveunusednetsignals.h \
+    cmd/cmdremoveviafromboard.h \
+    cmd/cmdreplacedevice.h \
+    cmd/cmdrotateselectedboarditems.h \
+    cmd/cmdrotateselectedschematicitems.h \
+    dialogs/addcomponentdialog.h \
     dialogs/editnetclassesdialog.h \
     dialogs/projectpropertieseditordialog.h \
     dialogs/projectsettingsdialog.h \
     docks/ercmsgdock.h \
-    dialogs/addcomponentdialog.h \
-    boardeditor/boardlayersdock.h \
-    cmd/cmdaddcomponenttocircuit.h \
-    cmd/cmdaddsymboltoschematic.h \
-    cmd/cmdadddevicetoboard.h \
-    cmd/cmdcombinenetsignals.h \
-    cmd/cmdremoveselectedschematicitems.h \
-    cmd/cmdcombineschematicnetpoints.h \
-    cmd/cmdrotateselectedschematicitems.h \
-    cmd/cmdmoveselectedschematicitems.h \
-    cmd/cmdmoveselectedboarditems.h \
-    cmd/cmdrotateselectedboarditems.h \
-    cmd/cmdflipselectedboarditems.h \
-    cmd/cmdremoveselectedboarditems.h \
-    cmd/cmdreplacedevice.h \
-    cmd/cmdplaceschematicnetpoint.h \
-    cmd/cmdcombineallnetsignalsunderschematicnetpoint.h \
-    cmd/cmdremoveunusednetsignals.h \
-    boardeditor/fsm/bes_drawtrace.h \
-    boardeditor/fsm/bes_addvia.h \
-    cmd/cmdplaceboardnetpoint.h \
-    cmd/cmdcombineboardnetpoints.h \
-    cmd/cmdcombineallitemsunderboardnetpoint.h \
-    boardeditor/boardviapropertiesdialog.h \
-    boardeditor/fsm/bes_adddevice.h \
-    boardeditor/fabricationoutputdialog.h \
-    cmd/cmdremovedevicefromboard.h \
-    cmd/cmdremoveviafromboard.h \
-    cmd/cmddetachboardnetpointfromviaorpad.h \
     newprojectwizard/newprojectwizard.h \
-    newprojectwizard/newprojectwizardpage_metadata.h \
     newprojectwizard/newprojectwizardpage_initialization.h \
-    newprojectwizard/newprojectwizardpage_versioncontrol.h
+    newprojectwizard/newprojectwizardpage_metadata.h \
+    newprojectwizard/newprojectwizardpage_versioncontrol.h \
+    projecteditor.h \
+    schematiceditor/fsm/schematiceditorevent.h \
+    schematiceditor/fsm/ses_addcomponent.h \
+    schematiceditor/fsm/ses_addnetlabel.h \
+    schematiceditor/fsm/ses_base.h \
+    schematiceditor/fsm/ses_drawwire.h \
+    schematiceditor/fsm/ses_fsm.h \
+    schematiceditor/fsm/ses_select.h \
+    schematiceditor/schematicclipboard.h \
+    schematiceditor/schematiceditor.h \
+    schematiceditor/schematicpagesdock.h \
+    schematiceditor/symbolinstancepropertiesdialog.h \
 
 FORMS += \
-    schematiceditor/schematiceditor.ui \
-    schematiceditor/schematicpagesdock.ui \
-    schematiceditor/symbolinstancepropertiesdialog.ui \
     boardeditor/boardeditor.ui \
+    boardeditor/boardlayersdock.ui \
+    boardeditor/boardviapropertiesdialog.ui \
+    boardeditor/fabricationoutputdialog.ui \
     boardeditor/unplacedcomponentsdock.ui \
+    dialogs/addcomponentdialog.ui \
     dialogs/editnetclassesdialog.ui \
     dialogs/projectpropertieseditordialog.ui \
     dialogs/projectsettingsdialog.ui \
     docks/ercmsgdock.ui \
-    dialogs/addcomponentdialog.ui \
-    boardeditor/boardlayersdock.ui \
-    boardeditor/boardviapropertiesdialog.ui \
-    boardeditor/fabricationoutputdialog.ui \
     newprojectwizard/newprojectwizard.ui \
-    newprojectwizard/newprojectwizardpage_metadata.ui \
     newprojectwizard/newprojectwizardpage_initialization.ui \
-    newprojectwizard/newprojectwizardpage_versioncontrol.ui
+    newprojectwizard/newprojectwizardpage_metadata.ui \
+    newprojectwizard/newprojectwizardpage_versioncontrol.ui \
+    schematiceditor/schematiceditor.ui \
+    schematiceditor/schematicpagesdock.ui \
+    schematiceditor/symbolinstancepropertiesdialog.ui \
 

--- a/libs/librepcb/workspace/workspace.pro
+++ b/libs/librepcb/workspace/workspace.pro
@@ -21,49 +21,50 @@ INCLUDEPATH += \
     ../../
 
 SOURCES += \
-    workspace.cpp \
-    projecttreemodel.cpp \
-    projecttreeitem.cpp \
-    recentprojectsmodel.cpp \
     favoriteprojectsmodel.cpp \
+    library/cat/categorytreeitem.cpp \
+    library/cat/categorytreemodel.cpp \
+    library/workspacelibrarydb.cpp \
+    library/workspacelibraryscanner.cpp \
+    projecttreeitem.cpp \
+    projecttreemodel.cpp \
+    recentprojectsmodel.cpp \
+    settings/items/wsi_appdefaultmeasurementunits.cpp \
+    settings/items/wsi_appearance.cpp \
+    settings/items/wsi_applocale.cpp \
+    settings/items/wsi_base.cpp \
+    settings/items/wsi_debugtools.cpp \
+    settings/items/wsi_librarylocaleorder.cpp \
+    settings/items/wsi_librarynormorder.cpp \
+    settings/items/wsi_projectautosaveinterval.cpp \
+    settings/items/wsi_repositories.cpp \
     settings/workspacesettings.cpp \
     settings/workspacesettingsdialog.cpp \
-    settings/items/wsi_base.cpp \
-    settings/items/wsi_applocale.cpp \
-    settings/items/wsi_projectautosaveinterval.cpp \
-    settings/items/wsi_librarylocaleorder.cpp \
-    settings/items/wsi_appdefaultmeasurementunits.cpp \
-    settings/items/wsi_librarynormorder.cpp \
-    settings/items/wsi_debugtools.cpp \
-    settings/items/wsi_appearance.cpp \
-    library/workspacelibrarydb.cpp \
-    library/cat/categorytreemodel.cpp \
-    library/cat/categorytreeitem.cpp \
-    library/workspacelibraryscanner.cpp \
-    settings/items/wsi_repositories.cpp
+    workspace.cpp \
 
 HEADERS += \
-    workspace.h \
-    projecttreemodel.h \
-    projecttreeitem.h \
-    recentprojectsmodel.h \
     favoriteprojectsmodel.h \
+    library/cat/categorytreeitem.h \
+    library/cat/categorytreemodel.h \
+    library/workspacelibrarydb.h \
+    library/workspacelibraryscanner.h \
+    projecttreeitem.h \
+    projecttreemodel.h \
+    recentprojectsmodel.h \
+    settings/items/wsi_appdefaultmeasurementunits.h \
+    settings/items/wsi_appearance.h \
+    settings/items/wsi_applocale.h \
+    settings/items/wsi_base.h \
+    settings/items/wsi_debugtools.h \
+    settings/items/wsi_librarylocaleorder.h \
+    settings/items/wsi_librarynormorder.h \
+    settings/items/wsi_projectautosaveinterval.h \
+    settings/items/wsi_repositories.h \
     settings/workspacesettings.h \
     settings/workspacesettingsdialog.h \
-    settings/items/wsi_base.h \
-    settings/items/wsi_applocale.h \
-    settings/items/wsi_projectautosaveinterval.h \
-    settings/items/wsi_librarylocaleorder.h \
-    settings/items/wsi_appdefaultmeasurementunits.h \
-    settings/items/wsi_librarynormorder.h \
-    settings/items/wsi_debugtools.h \
-    settings/items/wsi_appearance.h \
-    library/workspacelibrarydb.h \
-    library/cat/categorytreemodel.h \
-    library/cat/categorytreeitem.h \
-    library/workspacelibraryscanner.h \
-    settings/items/wsi_repositories.h
+    workspace.h \
 
 FORMS += \
+    settings/workspacesettingsdialog.ui \
     workspacechooserdialog.ui \
-    settings/workspacesettingsdialog.ui
+


### PR DESCRIPTION
The new script `sort_qmake_file_entries.py` sorts the entries of HEADERS, SOURCES and FORMS variables in all qmake project files (*.pro) in alphabetical order (except those in submodules). This reduces the risk of conflicts when merging or rebasing commits which modify *.pro files and makes those files cleaner and thus easier to read.

It may even be used as a pre-commit hook.

See also https://bugreports.qt.io/browse/QTCREATORBUG-553.