### PR TITLE
GraphicsView: Pan with middle mouse button instead of right button

### DIFF
--- a/libs/librepcb/common/graphics/graphicsview.cpp
+++ b/libs/librepcb/common/graphics/graphicsview.cpp
@@ -201,8 +201,8 @@ bool GraphicsView::eventFilter(QObject* obj, QEvent* event)
         {
             if (!underMouse()) break;
             QGraphicsSceneMouseEvent* e = dynamic_cast<QGraphicsSceneMouseEvent*>(event); Q_ASSERT(e);
-            if (e->buttons().testFlag(Qt::RightButton) && (!mPanningActive)) {
-                QPoint diff = mapFromScene(e->scenePos()) - mapFromScene(e->buttonDownScenePos(Qt::RightButton));
+            if (e->buttons().testFlag(Qt::MiddleButton) && (!mPanningActive)) {
+                QPoint diff = mapFromScene(e->scenePos()) - mapFromScene(e->buttonDownScenePos(Qt::MiddleButton));
                 mPanningActive = true; // avoid recursive calls (=> stack overflow)
                 horizontalScrollBar()->setValue(horizontalScrollBar()->value() - diff.x());
                 verticalScrollBar()->setValue(verticalScrollBar()->value() - diff.y());

--- a/libs/librepcb/common/graphics/graphicsview.h
+++ b/libs/librepcb/common/graphics/graphicsview.h
@@ -107,6 +107,7 @@ class GraphicsView final : public QGraphicsView
         bool mOriginCrossVisible;
         bool mUseOpenGl;
         volatile bool mPanningActive;
+        QCursor mCursorBeforePanning;
 
         // Static Variables
         static constexpr qreal sZoomStepFactor = 1.3;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.cpp
@@ -157,13 +157,12 @@ BES_FSM::State BES_FSM::processEventFromChild(BEE_Base* event) noexcept
             if ((e->type() == QEvent::GraphicsSceneMouseRelease) ||
                 (e->type() == QEvent::GraphicsSceneMouseDoubleClick))
             {
-                QGraphicsSceneMouseEvent* e2 = dynamic_cast<QGraphicsSceneMouseEvent*>(e);
-                Q_ASSERT(e2); if (!e2) return mCurrentState;
-                if ((e2->button() == Qt::RightButton) && (e2->screenPos() == e2->buttonDownScreenPos(Qt::RightButton)))
+                QGraphicsSceneMouseEvent* e2 = dynamic_cast<QGraphicsSceneMouseEvent*>(e); Q_ASSERT(e2);
+                if (e2->button() == Qt::RightButton) {
                     return (mPreviousState != State_NoState) ? mPreviousState : State_Select;
-                else
-                    return mCurrentState;
+                }
             }
+            return mCurrentState;
         }
         default:
             return mCurrentState;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
@@ -230,9 +230,6 @@ BES_Base::ProcRetVal BES_Select::proccessIdleSceneLeftClick(QGraphicsSceneMouseE
 BES_Base::ProcRetVal BES_Select::proccessIdleSceneRightMouseButtonReleased(
         QGraphicsSceneMouseEvent* mouseEvent, Board* board) noexcept
 {
-    if (mouseEvent->screenPos() != mouseEvent->buttonDownScreenPos(Qt::RightButton))
-        return PassToParentState; // mouse moved -> don't show context menu!
-
     // handle item selection
     QList<BI_Base*> items = board->getItemsAtScenePos(Point::fromPx(mouseEvent->scenePos()));
     if (items.isEmpty()) return PassToParentState;

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_fsm.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_fsm.cpp
@@ -160,13 +160,12 @@ SES_FSM::State SES_FSM::processEventFromChild(SEE_Base* event) noexcept
             if ((e->type() == QEvent::GraphicsSceneMouseRelease) ||
                 (e->type() == QEvent::GraphicsSceneMouseDoubleClick))
             {
-                QGraphicsSceneMouseEvent* e2 = dynamic_cast<QGraphicsSceneMouseEvent*>(e);
-                Q_ASSERT(e2); if (!e2) return mCurrentState;
-                if ((e2->button() == Qt::RightButton) && (e2->screenPos() == e2->buttonDownScreenPos(Qt::RightButton)))
+                QGraphicsSceneMouseEvent* e2 = dynamic_cast<QGraphicsSceneMouseEvent*>(e); Q_ASSERT(e2);
+                if (e2->button() == Qt::RightButton) {
                     return (mPreviousState != State_NoState) ? mPreviousState : State_Select;
-                else
-                    return mCurrentState;
+                }
             }
+            return mCurrentState;
         }
         default:
             return mCurrentState;

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
@@ -220,9 +220,6 @@ SES_Base::ProcRetVal SES_Select::proccessIdleSceneLeftClick(QGraphicsSceneMouseE
 SES_Base::ProcRetVal SES_Select::proccessIdleSceneRightMouseButtonReleased(
         QGraphicsSceneMouseEvent* mouseEvent, Schematic* schematic) noexcept
 {
-    if (mouseEvent->screenPos() != mouseEvent->buttonDownScreenPos(Qt::RightButton))
-        return PassToParentState; // mouse moved -> don't show context menu!
-
     // handle item selection
     QList<SI_Base*> items = schematic->getItemsAtScenePos(Point::fromPx(mouseEvent->scenePos()));
     if (items.isEmpty()) return PassToParentState;


### PR DESCRIPTION
Panning with right mouse button is quite annoying as it conflicts with context menus :sob: Now the middle mouse button is used instead. Was really hard to implement... :smile:

See also #4.