### PR TITLE
Replace manual memory management with std::unique_ptr

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -33,8 +33,8 @@ lessThan(QT_MAJOR_VERSION, 5) {
     }
 }
 
-# c++14 is obligatory!
-CONFIG += c++14
+# c++11 is obligatory!
+CONFIG += c++11
 
 # enable compiler warnings
 CONFIG += warn_on

--- a/common.pri
+++ b/common.pri
@@ -33,8 +33,8 @@ lessThan(QT_MAJOR_VERSION, 5) {
     }
 }
 
-# c++11 is obligatory!
-CONFIG += c++11
+# c++14 is obligatory!
+CONFIG += c++14
 
 # enable compiler warnings
 CONFIG += warn_on

--- a/tests/common/filedownloadtest.cpp
+++ b/tests/common/filedownloadtest.cpp
@@ -54,11 +54,10 @@ class FileDownloadTest : public ::testing::TestWithParam<FileDownloadTestData>
     public:
 
         static void SetUpTestCase() {
-            sDownloadManager = new NetworkAccessManager();
+            sDownloadManager = std::make_unique<NetworkAccessManager>();
         }
 
         static void TearDownTestCase() {
-            delete sDownloadManager;
         }
 
         static FilePath getDestination(const FileDownloadTestData& data) {
@@ -76,10 +75,10 @@ class FileDownloadTest : public ::testing::TestWithParam<FileDownloadTestData>
     protected:
 
         NetworkRequestBaseSignalReceiver mSignalReceiver;
-        static NetworkAccessManager* sDownloadManager;
+        static std::unique_ptr<NetworkAccessManager> sDownloadManager;
 };
 
-NetworkAccessManager* FileDownloadTest::sDownloadManager = nullptr;
+std::unique_ptr<NetworkAccessManager> FileDownloadTest::sDownloadManager = nullptr;
 
 /*****************************************************************************************
  *  Test Methods

--- a/tests/common/filedownloadtest.cpp
+++ b/tests/common/filedownloadtest.cpp
@@ -54,7 +54,7 @@ class FileDownloadTest : public ::testing::TestWithParam<FileDownloadTestData>
     public:
 
         static void SetUpTestCase() {
-            sDownloadManager = std::make_unique<NetworkAccessManager>();
+            sDownloadManager = std::unique_ptr<NetworkAccessManager>(new NetworkAccessManager());
         }
 
         static void TearDownTestCase() {

--- a/tests/common/filedownloadtest.cpp
+++ b/tests/common/filedownloadtest.cpp
@@ -20,6 +20,7 @@
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
+#include <memory>
 #include <QtCore>
 #include <gtest/gtest.h>
 #include <librepcb/common/network/networkaccessmanager.h>

--- a/tests/common/networkrequesttest.cpp
+++ b/tests/common/networkrequesttest.cpp
@@ -52,7 +52,7 @@ class NetworkRequestTest : public ::testing::TestWithParam<NetworkRequestTestDat
     public:
 
         static void SetUpTestCase() {
-            sDownloadManager = std::make_unique<NetworkAccessManager>();
+            sDownloadManager = std::unique_ptr<NetworkAccessManager>(new NetworkAccessManager());
         }
 
         static void TearDownTestCase() {

--- a/tests/common/networkrequesttest.cpp
+++ b/tests/common/networkrequesttest.cpp
@@ -20,6 +20,7 @@
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
+#include <memory>
 #include <QtCore>
 #include <gtest/gtest.h>
 #include <librepcb/common/network/networkaccessmanager.h>

--- a/tests/common/networkrequesttest.cpp
+++ b/tests/common/networkrequesttest.cpp
@@ -52,20 +52,19 @@ class NetworkRequestTest : public ::testing::TestWithParam<NetworkRequestTestDat
     public:
 
         static void SetUpTestCase() {
-            sDownloadManager = new NetworkAccessManager();
+            sDownloadManager = std::make_unique<NetworkAccessManager>();
         }
 
         static void TearDownTestCase() {
-            delete sDownloadManager;
         }
 
     protected:
 
         NetworkRequestBaseSignalReceiver mSignalReceiver;
-        static NetworkAccessManager* sDownloadManager;
+        static std::unique_ptr<NetworkAccessManager> sDownloadManager;
 };
 
-NetworkAccessManager* NetworkRequestTest::sDownloadManager = nullptr;
+std::unique_ptr<NetworkAccessManager> NetworkRequestTest::sDownloadManager = nullptr;
 
 /*****************************************************************************************
  *  Test Methods


### PR DESCRIPTION
To be able to use features like std::make_unique() we need C++14.