### PR TITLE
Build and deploy nightly AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ matrix:
     - os: linux
       dist: trusty
       compiler: gcc
-      env: BUILD_DOXYGEN=true QT_BASE="trusty"
-    # Ubuntu 14.04 + Clang + Latest Qt from beineri PPA (https://launchpad.net/~beineri)
+      env: BUILD_DOXYGEN=true DEPLOY_APPIMAGE=false QT_BASE="trusty"
+    # Ubuntu 14.04 + Clang + Qt from PPA (https://launchpad.net/~beineri) + AppImage deployment
     - os: linux
       dist: trusty
       compiler: clang
-      env: BUILD_DOXYGEN=false QT_BASE="qt58" QT_PPA="ppa:beineri/opt-qt58-trusty"
+      env: BUILD_DOXYGEN=false DEPLOY_APPIMAGE=true QT_BASE="qt58" QT_PPA="ppa:beineri/opt-qt58-trusty"
     # OS X + GCC
     - os: osx
       compiler: gcc
@@ -35,4 +35,5 @@ script:
   - ./dev/travis/build.sh
   - ./dev/travis/run_tests.sh
   - ./dev/travis/update_doxygen.sh
+  - ./dev/travis/build_appimage.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,13 @@ script:
   - ./dev/travis/update_doxygen.sh
   - ./dev/travis/build_appimage.sh
 
+deploy:
+  provider: bintray
+  file: ./dev/travis/bintray.json
+  user: "${BINTRAY_USER}"
+  key: "${BINTRAY_API_KEY}"
+  skip_cleanup: true
+  on:
+    branch: master
+    condition: ${DEPLOY_APPIMAGE} = true
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ LibrePCB by yourself. Nevertheless there are easier ways to get LibrePCB running
 
 - For Windows there are nightly builds available to download: 
   [librepcb-nightly.zip](https://ci.appveyor.com/api/projects/librepcb/librepcb/artifacts/build/librepcb-nightly.zip?branch=master)
+- For Linux there are nightly [AppImages](http://appimage.org/) available on [Bintray](https://bintray.com/librepcb):
+  [LibrePCB-Nightly-Linux-x86_64.AppImage](https://bintray.com/librepcb/LibrePCB-Nightly/download_file?file_path=LibrePCB-Nightly-Linux-x86_64.AppImage)
 - On Arch Linux you can install the package 
   [librepcb-git](https://aur.archlinux.org/packages/librepcb-git/) from the AUR.
 - Using a [Docker](https://www.docker.com/) container you can build and run LibrePCB

--- a/dev/travis/bintray.json
+++ b/dev/travis/bintray.json
@@ -1,0 +1,30 @@
+{
+    "package": {
+        "name": "LibrePCB-Nightly-Linux-x86_64",
+        "repo": "LibrePCB-Nightly",
+        "subject": "librepcb",
+        "desc": "Nightly Builds from Travis-CI.",
+        "website_url": "http://librepcb.org",
+        "issue_tracker_url": "https://github.com/LibrePCB/LibrePCB/issues",
+        "vcs_url": "https://github.com/LibrePCB/LibrePCB.git",
+        "github_use_tag_release_notes": false,
+        "licenses": ["GPL-3.0"],
+        "public_download_numbers": false,
+        "public_stats": false
+    },
+    "version": {
+        "name": "nightly",
+        "desc": "Nightly Build from Travis-CI.",
+        "released": "today",
+        "vcs_tag": "master",
+        "gpgSign": false
+    },
+    "files": [
+        {
+            "includePattern": "LibrePCB-x86_64.AppImage",
+            "uploadPattern": "LibrePCB-Nightly-Linux-x86_64.AppImage",
+            "matrixParams": {"override": 1}
+        }
+    ],
+    "publish": true
+}

--- a/dev/travis/build_appimage.sh
+++ b/dev/travis/build_appimage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
+set -eufv -o pipefail
+
+# build AppImage
+if [ "${DEPLOY_APPIMAGE-}" = "true" ]
+then
+  mkdir -p ./build/librepcb.AppDir/opt/bin
+  cp -r ./build/generated/share ./build/librepcb.AppDir/opt/
+  cp ./build/generated/unix/librepcb ./build/librepcb.AppDir/opt/bin/librepcb
+  cp ./build/librepcb.AppDir/opt/share/pixmaps/librepcb.svg ./build/librepcb.AppDir/librepcb.svg
+  cp ./build/librepcb.AppDir/opt/share/applications/librepcb.desktop ./build/librepcb.AppDir/librepcb.desktop
+  LD_LIBRARY_PATH="" linuxdeployqt ./build/librepcb.AppDir/opt/bin/librepcb -appimage
+fi
+

--- a/dev/travis/install.sh
+++ b/dev/travis/install.sh
@@ -14,6 +14,11 @@ then
     sudo apt-get install -qq qt5-default qttools5-dev-tools
   fi
   sudo apt-get install -qq libglu1-mesa-dev zlib1g zlib1g-dev openssl xvfb doxygen graphviz
+  if [ "${DEPLOY_APPIMAGE}" = "true" ]
+  then
+    sudo wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" -O /usr/local/bin/linuxdeployqt
+    sudo chmod a+x /usr/local/bin/linuxdeployqt
+  fi
   sudo ln -s ../../bin/ccache /usr/lib/ccache/clang
   sudo ln -s ../../bin/ccache /usr/lib/ccache/clang++
 elif [ "${TRAVIS_OS_NAME}" = "osx" ]


### PR DESCRIPTION
Having [AppImage](http://appimage.org/) for nightly builds but also for stable releases would be pretty nice. With this PR I try to let them build on Travis-CI and upload to [Bintray](https://bintray.com/librepcb).

Basically it already works, but there are still some issues:
- [x] Runtime resources do not work inside the AppImage (see implementation in 5d80d1b96e89259b12092d35c54189fd19ac212b).
- [ ] ~~The icon of the *.AppImage file seems to be square instead of round (at least in Nemo). Maybe the background of the *.png is not transparent? Could we even use SVG instead?~~ Unfortunately the icon is no longer shown anyway (see https://github.com/probonopd/AppImageKit/issues/346).
- [x] At least on some systems the look of the LibrePCB application from an AppImage is not the same as without the AppImage. It seems that the system theme is not used properly.
- [ ] The file [bintray.json](https://github.com/LibrePCB/LibrePCB/blob/f57e907c1b6a2a8420f3e9ed2e67263ccaf044d4/dev/travis/bintray.json) contains only static information. How could we also use some dynamically determined information (e.g. datetime, version number, commit hash)?
- [ ] ~~At the moment Travis-CI downloads [`linuxdeployqt`](https://github.com/probonopd/linuxdeployqt) with every build directly from GitHub. I don't like to download and execute binaries this way because of possible security issues (a compromised binary could read secure environment variables). Is there another ("more official") way to get `linuxdeployqt`? Maybe building from source would be the best...~~ Actually the AppImages of `linuxdeployqt` are easy to use and work pretty good, and now I also know its source code and have more trust into `linuxdeployqt`, so I don't see this as a problem any more.
- [ ] Maybe some automatic testing of the generated packages would be useful.
- [x] As soon as everything is working properly, we should stop uploading packages to Bintray from branches other than `master`.