### PR TITLE
Scan workspace library on every program startup

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -120,6 +120,9 @@ ControlPanel::ControlPanel(Workspace& workspace) :
         if ((filepath.isExistingFile()) && (filepath.getSuffix() == "lpp"))
             openProject(filepath);
     }
+
+    // start scanning the workspace library (asynchronously)
+    mWorkspace.getLibraryDb().startLibraryRescan();
 }
 
 ControlPanel::~ControlPanel()

--- a/libs/librepcb/common/sqlitedatabase.cpp
+++ b/libs/librepcb/common/sqlitedatabase.cpp
@@ -81,11 +81,13 @@ SQLiteDatabase::SQLiteDatabase(const FilePath& filepath) throw (Exception) :
 
     // set SQLite options
     exec("PRAGMA foreign_keys = ON"); // can throw
+    enableSqliteWriteAheadLogging(); // can throw
 
     // check if all required features are available
     Q_ASSERT(mDb.driver() && mDb.driver()->hasFeature(QSqlDriver::Transactions));
     Q_ASSERT(mDb.driver() && mDb.driver()->hasFeature(QSqlDriver::PreparedQueries));
     Q_ASSERT(mDb.driver() && mDb.driver()->hasFeature(QSqlDriver::LastInsertId));
+    Q_ASSERT(getSqliteCompileOptions()["THREADSAFE"] == "1"); // can throw
 }
 
 SQLiteDatabase::~SQLiteDatabase() noexcept
@@ -186,6 +188,36 @@ void SQLiteDatabase::exec(const QString& query) throw (Exception)
 {
     QSqlQuery q = prepareQuery(query);
     exec(q);
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void SQLiteDatabase::enableSqliteWriteAheadLogging() throw (Exception)
+{
+    QSqlQuery query("PRAGMA journal_mode=WAL", mDb);
+    exec(query); // can throw
+    bool success = query.first();
+    QString result = query.value(0).toString();
+    if ((!success) || (result != "wal")) {
+        throw LogicError(__FILE__, __LINE__, QString(), QString(tr(
+            "Could not enable SQLite Write-Ahead Logging: \"%1\"")).arg(result));
+    }
+}
+
+QHash<QString, QString> SQLiteDatabase::getSqliteCompileOptions() throw (Exception)
+{
+    QHash<QString, QString> options;
+    QSqlQuery query("PRAGMA compile_options", mDb);
+    exec(query); // can throw
+    while (query.next()) {
+        QString option = query.value(0).toString();
+        QString key = option.section('=', 0, 0);
+        QString value = option.section('=', 1, -1);
+        options.insert(key, value);
+    }
+    return options;
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/sqlitedatabase.cpp
+++ b/libs/librepcb/common/sqlitedatabase.cpp
@@ -184,7 +184,7 @@ void SQLiteDatabase::exec(QSqlQuery& query) throw (Exception)
 
 void SQLiteDatabase::exec(const QString& query) throw (Exception)
 {
-    QSqlQuery q(query, mDb);
+    QSqlQuery q = prepareQuery(query);
     exec(q);
 }
 

--- a/libs/librepcb/common/sqlitedatabase.h
+++ b/libs/librepcb/common/sqlitedatabase.h
@@ -90,6 +90,29 @@ class SQLiteDatabase final : public QObject
         SQLiteDatabase& operator=(const SQLiteDatabase& rhs) = delete;
 
 
+    private: // Methods
+
+        /**
+         * @brief Enable the "Write-Ahead Logging" (WAL) featur of SQLite
+         *
+         * @note LibrePCB requires to enable WAL to avoid blocking readers by writers. If
+         *       not enabled, the library scanner would also block all read-only accesses
+         *       to the library database.
+         *
+         * @see http://www.sqlite.org/wal.html
+         */
+        void enableSqliteWriteAheadLogging() throw (Exception);
+
+        /**
+         * @brief Get compile options of the SQLite driver library
+         *
+         * @return A hashmap of all compile options (without the "SQLITE_" prefix)
+         *
+         * @see https://sqlite.org/pragma.html#pragma_compile_options
+         */
+        QHash<QString, QString> getSqliteCompileOptions() throw (Exception);
+
+
     private: // Data
 
         QSqlDatabase mDb;

--- a/tests/common/sqlitedatabasetest.cpp
+++ b/tests/common/sqlitedatabasetest.cpp
@@ -1,0 +1,257 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+
+#include <QtCore>
+#include <QtConcurrent>
+#include <gtest/gtest.h>
+#include <librepcb/common/sqlitedatabase.h>
+#include <librepcb/common/fileio/fileutils.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*****************************************************************************************
+ *  Test Class
+ ****************************************************************************************/
+
+class SQLiteDatabaseTest : public ::testing::Test
+{
+    protected:
+
+        virtual void SetUp() override
+        {
+            // create temporary, empty directory
+            mTempDir = FilePath::getApplicationTempPath().getPathTo("SQLiteDatabaseTest");
+            mTempDbFilePath = mTempDir.getPathTo("db.sqlite");
+            if (mTempDir.isExistingDir()) {
+                FileUtils::removeDirRecursively(mTempDir); // can throw
+            }
+            FileUtils::makePath(mTempDir);
+        }
+
+        virtual void TearDown() override
+        {
+            // remove temporary directory
+            FileUtils::removeDirRecursively(mTempDir); // can throw
+        }
+
+        enum ThreadOption {
+            READING = (0<<0),
+            WRITING = (1<<0),
+            NO_TRANSACTION = (0<<1),
+            TRANSACTION = (1<<1),
+        };
+
+        struct WorkerResult {
+            qint64 rowCount;
+            QString errorMsg;
+        };
+
+        static WorkerResult threadWorker(FilePath fp, int options, int duration) noexcept
+        {
+            try {
+                qint64 count = 0;
+                SQLiteDatabase db(fp);
+                if (options & TRANSACTION) {
+                    db.beginTransaction();
+                }
+                qint64 start = QDateTime::currentMSecsSinceEpoch();
+                while (QDateTime::currentMSecsSinceEpoch() < start + duration) {
+                    if (options & WRITING) {
+                        db.exec("INSERT INTO test (name) VALUES ('hello')");
+                    } else {
+                        db.exec("SELECT id, name FROM test WHERE id = 1");
+                    }
+                    ++count;
+                }
+                if (options & TRANSACTION) {
+                    db.commitTransaction();
+                }
+                return WorkerResult{count, QString()};
+            } catch (const Exception& e) {
+                return WorkerResult{-1, e.getUserMsg()};
+            }
+        }
+
+        QFuture<WorkerResult> startWorkerThread(QThreadPool* pool, int options, int duration) noexcept
+        {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)) // QtConcurrent::run(QThreadPool*, ...) requires Qt>=5.4
+            auto future = QtConcurrent::run(pool, threadWorker, mTempDbFilePath, options, duration);
+#else
+            if (QThreadPool::globalInstance()->maxThreadCount() < pool->maxThreadCount()) {
+                QThreadPool::globalInstance()->setMaxThreadCount(pool->maxThreadCount());
+            }
+            auto future = QtConcurrent::run(threadWorker, mTempDbFilePath, options, duration);
+#endif
+            mWorkerThreads.append(future);
+            return future;
+        }
+
+        void waitUntilAllWorkersFinished() noexcept
+        {
+            while (!mWorkerThreads.isEmpty()) {
+                mWorkerThreads.takeFirst().waitForFinished();
+            }
+        }
+
+        FilePath mTempDir;
+        FilePath mTempDbFilePath;
+        QList<QFuture<WorkerResult>> mWorkerThreads;
+};
+
+/*****************************************************************************************
+ *  Test Methods
+ ****************************************************************************************/
+
+TEST_F(SQLiteDatabaseTest, testIfContructorCreatesFile)
+{
+    EXPECT_FALSE(mTempDbFilePath.isExistingFile());
+    { SQLiteDatabase db(mTempDbFilePath); } // object is created and deleted on this line!
+    EXPECT_TRUE(mTempDbFilePath.isExistingFile());
+}
+
+TEST_F(SQLiteDatabaseTest, testExecQuery)
+{
+    SQLiteDatabase db(mTempDbFilePath);
+    db.exec("CREATE TABLE test (`id` INTEGER PRIMARY KEY NOT NULL)");
+}
+
+TEST_F(SQLiteDatabaseTest, testPreparedQuery)
+{
+    SQLiteDatabase db(mTempDbFilePath);
+    db.exec("CREATE TABLE test (`id` INTEGER PRIMARY KEY NOT NULL, `name` TEXT)");
+    QSqlQuery query = db.prepareQuery("INSERT INTO test (name) VALUES (:name)");
+    query.bindValue(":name", "hello");
+    db.exec(query);
+}
+
+TEST_F(SQLiteDatabaseTest, testInsert)
+{
+    SQLiteDatabase db(mTempDbFilePath);
+    db.exec("CREATE TABLE test (`id` INTEGER PRIMARY KEY NOT NULL, `name` TEXT)");
+    for (int i = 0; i < 100; ++i) {
+        QSqlQuery query = db.prepareQuery("INSERT INTO test (name) VALUES (:name)");
+        query.bindValue(":name", QString("row %1").arg(i));
+        int id = db.insert(query);
+        EXPECT_EQ(i + 1, id);
+    }
+}
+
+TEST_F(SQLiteDatabaseTest, testClearExistingTable)
+{
+    SQLiteDatabase db(mTempDbFilePath);
+    db.exec("CREATE TABLE test (`id` INTEGER PRIMARY KEY NOT NULL, `name` TEXT)");
+    db.exec("INSERT INTO test (name) VALUES ('hello')");
+    EXPECT_NO_THROW(db.clearTable("test"));
+    EXPECT_NO_THROW(db.clearTable("test")); // clearing an empty table should also work
+}
+
+TEST_F(SQLiteDatabaseTest, testClearNonExistingTable)
+{
+    SQLiteDatabase db(mTempDbFilePath);
+    EXPECT_THROW(db.clearTable("test"), Exception);
+}
+
+TEST_F(SQLiteDatabaseTest, testTransactionScopeGuardCommit)
+{
+    SQLiteDatabase db(mTempDbFilePath);
+    {
+        SQLiteDatabase::TransactionScopeGuard tsg(db);
+        db.exec("CREATE TABLE test (`id` INTEGER PRIMARY KEY NOT NULL, `name` TEXT)");
+        db.exec("INSERT INTO test (name) VALUES ('hello')");
+        tsg.commit();
+    }
+    EXPECT_NO_THROW(db.clearTable("test"));
+}
+
+TEST_F(SQLiteDatabaseTest, testTransactionScopeGuardRollback)
+{
+    SQLiteDatabase db(mTempDbFilePath);
+    {
+        SQLiteDatabase::TransactionScopeGuard tsg(db);
+        db.exec("CREATE TABLE test (`id` INTEGER PRIMARY KEY NOT NULL, `name` TEXT)");
+        db.exec("INSERT INTO test (name) VALUES ('hello')");
+    }
+    EXPECT_THROW(db.clearTable("test"), Exception);
+}
+
+TEST_F(SQLiteDatabaseTest, testMultipleInstancesInSameThread)
+{
+    SQLiteDatabase db1(mTempDbFilePath);
+    SQLiteDatabase db2(mTempDbFilePath);
+    db1.exec("CREATE TABLE test1 (`id` INTEGER PRIMARY KEY NOT NULL)");
+    db2.exec("CREATE TABLE test2 (`id` INTEGER PRIMARY KEY NOT NULL)");
+    EXPECT_NO_THROW(db1.clearTable("test2"));
+    EXPECT_NO_THROW(db1.clearTable("test1"));
+}
+
+TEST_F(SQLiteDatabaseTest, testConcurrentAccessFromMultipleThreads)
+{
+    // create thread pool to ensure that every worker really runs in a separate thread
+    QThreadPool pool;
+    pool.setMaxThreadCount(8);
+
+    // prepare database
+    SQLiteDatabase db(mTempDbFilePath);
+    db.exec("CREATE TABLE test (`id` INTEGER PRIMARY KEY NOT NULL, `name` TEXT)");
+
+    // run worker threads (2 sequential writers and 4 parallel readers)
+    qint64 startTime = QDateTime::currentMSecsSinceEpoch();
+    QFuture<WorkerResult> w1 = startWorkerThread(&pool, WRITING | TRANSACTION, 5000);
+    QFuture<WorkerResult> r1 = startWorkerThread(&pool, READING | TRANSACTION, 10000);
+    QFuture<WorkerResult> r2 = startWorkerThread(&pool, READING | TRANSACTION, 10000);
+    QFuture<WorkerResult> r3 = startWorkerThread(&pool, READING | NO_TRANSACTION, 10000);
+    QFuture<WorkerResult> r4 = startWorkerThread(&pool, READING | NO_TRANSACTION, 10000);
+    w1.waitForFinished();
+    QFuture<WorkerResult> w2 = startWorkerThread(&pool, WRITING | NO_TRANSACTION, 5000);
+    waitUntilAllWorkersFinished();
+    qint64 duration = QDateTime::currentMSecsSinceEpoch() - startTime;
+
+    // get row count
+    QSqlQuery query = db.prepareQuery("SELECT COUNT(*) FROM test");
+    db.exec(query);
+    ASSERT_TRUE(query.first());
+    qint64 rowCount = query.value(0).toLongLong();
+
+    // validate results
+    EXPECT_GT(w1.result().rowCount, 0) << qPrintable(w1.result().errorMsg);
+    EXPECT_GT(w2.result().rowCount, 0) << qPrintable(w2.result().errorMsg);
+    EXPECT_GT(r1.result().rowCount, 0) << qPrintable(r1.result().errorMsg);
+    EXPECT_GT(r2.result().rowCount, 0) << qPrintable(r2.result().errorMsg);
+    EXPECT_GT(r3.result().rowCount, 0) << qPrintable(r3.result().errorMsg);
+    EXPECT_GT(r4.result().rowCount, 0) << qPrintable(r4.result().errorMsg);
+    EXPECT_GT(rowCount, 0);
+    EXPECT_EQ(rowCount, w1.result().rowCount + w2.result().rowCount);
+    EXPECT_GE(duration, 10000);
+    EXPECT_LE(duration, 14000);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace librepcb

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -13,7 +13,7 @@ GENERATED_DIR = ../generated
 # Use common project definitions
 include(../common.pri)
 
-QT += core widgets network printsupport xml opengl
+QT += core widgets network printsupport xml opengl sql concurrent
 
 CONFIG += console
 CONFIG -= app_bundle
@@ -53,6 +53,7 @@ SOURCES += \
     common/networkrequesttest.cpp \
     common/pointtest.cpp \
     common/scopeguardtest.cpp \
+    common/sqlitedatabasetest.cpp \
     common/systeminfotest.cpp \
     common/uuidtest.cpp \
     common/versiontest.cpp \


### PR DESCRIPTION
Until now, the SQLite database of the workspace library is [put under version control](https://github.com/LibrePCB/demo-workspace/blob/36974bc36e875a28fb5affa3b291b699d5123dc1/v0.1/metadata/library_cache.sqlite) because it was not automatically generated.

This PR will force to (re)scan the workspace library on every program startup to ensure that it is always up to date. Because this is done completely asynchronously in a separate thread and can be interrupted at any time (e.g. on program exit), it should not have any negative impact on user experience (except maybe little decreased performance due to higher CPU load for a few seconds).

Thanks to this change I could [remove the SQLite database from version control](https://github.com/LibrePCB/demo-workspace/commit/eee0d43904412292418758c12e2c4867fedc3b82).