### PR TITLE
AppVeyor: Provide nightly builds for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.{build}-{branch}
+version: '{build}'
 os: Windows Server 2012
 configuration: Debug
 build: off
@@ -7,12 +7,11 @@ deploy: off
 
 environment:
   global:
-    MINGW: C:\Qt\Tools\mingw492_32
+    MINGW: C:\Qt\Tools\mingw530_32
   matrix:
-    - QTDIR: C:\Qt\5.5\mingw492_32
+    - QTDIR: C:\Qt\5.7\mingw53_32
 
 init:
-  - git config --global core.autocrlf input
   - set PATH=%QTDIR%\bin;%MINGW%\bin;C:\Qt\Tools\QtCreator\bin;%PATH%
 
 install:
@@ -21,9 +20,7 @@ install:
 build_script:
   - mkdir build
   - cd build
-  - qmake ..\librepcb.pro -r
+  - qmake -r ..\librepcb.pro
   - mingw32-make -j 4
   - .\generated\windows\qztest.exe # run quazip unit tests
-  - .\generated\windows\tests.exe # run librepcb unit tests
-  - cd ..\
-
+  - .\generated\windows\tests.exe  # run librepcb unit tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,16 @@ build_script:
   - mingw32-make -j 4
   - .\generated\windows\qztest.exe # run quazip unit tests
   - .\generated\windows\tests.exe  # run librepcb unit tests
+
+after_build:
+  - xcopy .\generated\share .\output\share /i /e          # resources
+  - xcopy .\generated\windows\librepcb.exe .\output\bin\  # executable
+  - xcopy C:\MinGW\bin\zlib1.dll .\output\bin\            # zlib DLL
+  - xcopy C:\OpenSSL-Win32\bin\*eay*.dll .\output\bin\    # OpenSSL DLLs
+  - xcopy %QTDIR%\bin\lib*.dll .\output\bin\              # MinGW DLLs
+  - windeployqt --compiler-runtime --force .\output\bin\librepcb.exe # Qt DLLs
+
+artifacts:
+  - path: build\output
+    name: librepcb-nightly
+    type: zip


### PR DESCRIPTION
Surprisingly, uploading build artifacts is quite easy with AppVeyor ;) So I started to use this feature to provide nightly builds for Windows. They can now be downloaded [here](https://ci.appveyor.com/api/projects/librepcb/librepcb/artifacts/build/librepcb-nightly.zip?branch=appveyor_nightly_builds). 

Just extract the downloaded ZIP archive and execute `bin\librepcb.exe`. Isn't this awesome?! :smiley: 

@nemofisch Maybe you would like to try if it works properly on your machine?

The only thing which is not yet working is to load runtime resources of LibrePCB (e.g. license template files). I think the resource system needs to be adjusted slightly...