### PR TITLE
Travis: Make ccache also working with clang and OS X

### DIFF
--- a/dev/travis/build.sh
+++ b/dev/travis/build.sh
@@ -3,9 +3,13 @@
 # set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
 set -eufv -o pipefail
 
+# set special flag for clang (see https://github.com/travis-ci/travis-ci/issues/5383)
+if [ "$CC" = "clang" ]; then CFLAGS="-Qunused-arguments"; else CFLAGS=""; fi
+if [ "$CXX" = "clang++" ]; then CXXFLAGS="-Qunused-arguments"; else CXXFLAGS=""; fi
+
 # build librepcb
 mkdir build
 cd build
-qmake ../librepcb.pro -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC"
+qmake ../librepcb.pro -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" "QMAKE_CFLAGS=$CFLAGS" "QMAKE_CXXFLAGS=$CXXFLAGS"
 make -j8
 

--- a/dev/travis/install.sh
+++ b/dev/travis/install.sh
@@ -14,10 +14,13 @@ then
     sudo apt-get install -qq qt5-default qttools5-dev-tools
   fi
   sudo apt-get install -qq libglu1-mesa-dev zlib1g zlib1g-dev openssl xvfb doxygen graphviz
+  sudo ln -s ../../bin/ccache /usr/lib/ccache/clang
+  sudo ln -s ../../bin/ccache /usr/lib/ccache/clang++
 elif [ "${TRAVIS_OS_NAME}" = "osx" ]
 then
   brew update
-  brew install qt5
+  brew install qt5 ccache
   brew link --force qt5
+  export PATH="/usr/local/opt/ccache/libexec:$PATH"
 fi
 


### PR DESCRIPTION
Build times of the first run (caches for clang and osx not yet available):
![auswahl_010](https://cloud.githubusercontent.com/assets/5374821/23722170/baa4f6d2-0444-11e7-8504-bc83426f7d4d.png)

Build times after triggering a rebuild (caches from the first run are now available):
![auswahl_011](https://cloud.githubusercontent.com/assets/5374821/23728702/8db1aafc-045e-11e7-9ece-5b1d0614a529.png)

Fixes #90