### PR TITLE
FilePath: Fix/improve method cleanFileName()

### DIFF
--- a/libs/librepcb/common/fileio/filepath.cpp
+++ b/libs/librepcb/common/fileio/filepath.cpp
@@ -260,16 +260,16 @@ QString FilePath::cleanFileName(const QString& userInput, CleanFileNameOptions o
 {
     // perform compatibility decomposition (NFKD)
     QString ret = userInput.normalized(QString::NormalizationForm_KD);
+    // remove all invalid characters
+    ret.remove(QRegularExpression("[^-._ 0-9A-Za-z]"));
     // remove leading and trailing spaces
     ret = ret.trimmed();
-    // replace spaces with underscore
+    // replace remaining spaces with underscore (if corresponding option set)
     if (options.testFlag(CleanFileNameOption::ReplaceSpaces)) ret.replace(' ', '_');
-    // remove all invalid characters
-    QString validChars("_\\-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
-    ret.remove(QRegularExpression(QString("[^%1]").arg(validChars)));
-    // make all characters lowerspace
+    // change case of all characters (if corresponding options set)
     if (options.testFlag(CleanFileNameOption::ToLowerCase)) ret = ret.toLower();
-    // limit length to 120 characters
+    if (options.testFlag(CleanFileNameOption::ToUpperCase)) ret = ret.toUpper();
+    // limit length of string to a reasonable number of characters
     ret.truncate(120);
     return ret;
 }

--- a/libs/librepcb/common/fileio/filepath.h
+++ b/libs/librepcb/common/fileio/filepath.h
@@ -121,11 +121,12 @@ class FilePath final
 
         enum CleanFileNameOption {
             // spaces
-            KeepSpaces      = 0<<1,
+            KeepSpaces      = 0,
             ReplaceSpaces   = 1<<1,
             // case
-            KeepCase        = 0<<2,
+            KeepCase        = 0,
             ToLowerCase     = 1<<2,
+            ToUpperCase     = 1<<3,
             // default
             Default         = KeepSpaces | KeepCase,
         };
@@ -379,7 +380,7 @@ class FilePath final
          * input), you must use this function to replace/remove all characters which are
          * not allowed for file/dir paths.
          *
-         * These are the only allowed characters: A–Z a–z 0–9 . _ -
+         * These are the only allowed characters: "-._ 0-9A-Za-z"
          *
          * In addition, the length of the filename will be limited to 120 characters.
          *

--- a/tests/common/filepathtest.cpp
+++ b/tests/common/filepathtest.cpp
@@ -147,6 +147,24 @@ TEST_P(FilePathTest, testOperatorAssign)
     EXPECT_EQ(p1.toStr(), p2.toStr());
 }
 
+TEST(FilePathTest, testCleanFileName)
+{
+    QString input(" ∑ ;.'[a]*(/∮E⋅→∞∏g¼∀x∈ ℝ:T@st⌈x⌉α∧¬β=∨)⊆\nℕ ₀H₂Ω⌀,"
+                  "-=[];\\^με½τρ1ÖÄ23ά ειวชΚμ\tεチハ\r\n\r_+{}|\"?>< ~  ");
+    QString kskc = FilePath::cleanFileName(input, FilePath::KeepSpaces | FilePath::KeepCase);
+    EXPECT_EQ(".aEg14x RTstxN 0H2-121OA23 _", kskc) << qPrintable(kskc);
+    QString kslc = FilePath::cleanFileName(input, FilePath::KeepSpaces | FilePath::ToLowerCase);
+    EXPECT_EQ(".aeg14x rtstxn 0h2-121oa23 _", kslc) << qPrintable(kslc);
+    QString ksuc = FilePath::cleanFileName(input, FilePath::KeepSpaces | FilePath::ToUpperCase);
+    EXPECT_EQ(".AEG14X RTSTXN 0H2-121OA23 _", ksuc) << qPrintable(ksuc);
+    QString rskc = FilePath::cleanFileName(input, FilePath::ReplaceSpaces | FilePath::KeepCase);
+    EXPECT_EQ(".aEg14x_RTstxN_0H2-121OA23__", rskc) << qPrintable(rskc);
+    QString rslc = FilePath::cleanFileName(input, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
+    EXPECT_EQ(".aeg14x_rtstxn_0h2-121oa23__", rslc) << qPrintable(rslc);
+    QString rsuc = FilePath::cleanFileName(input, FilePath::ReplaceSpaces | FilePath::ToUpperCase);
+    EXPECT_EQ(".AEG14X_RTSTXN_0H2-121OA23__", rsuc) << qPrintable(rsuc);
+}
+
 /*****************************************************************************************
  *  Test Data
  ****************************************************************************************/


### PR DESCRIPTION
- Spaces were replaced even if CleanFileNameOption::KeepSpaces was used
- Simplify regex: use character ranges, remove escaping for minus sign
- Add CleanFileNameOption::ToUpperCase
- Improve comments
- Add test