### PR TITLE
Fix non-deterministic content in XML files

### DIFF
--- a/libs/librepcb/common/fileio/xmldomdocument.cpp
+++ b/libs/librepcb/common/fileio/xmldomdocument.cpp
@@ -89,13 +89,18 @@ XmlDomElement& XmlDomDocument::getRoot(const QString& expectedName) const throw 
  *  General Methods
  ****************************************************************************************/
 
-QByteArray XmlDomDocument::toByteArray() const noexcept
+QByteArray XmlDomDocument::toByteArray() const throw (Exception)
 {
-    QDomDocument doc;
-    doc.implementation().setInvalidDataPolicy(QDomImplementation::ReturnNullNode);
-    doc.setContent(QString("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"));
-    doc.appendChild(mRootElement->toQDomElement(doc));
-    return doc.toByteArray(1); // indent only 1 space to save disk space
+    QByteArray data;
+    QXmlStreamWriter writer(&data);
+    writer.setAutoFormatting(true);
+    writer.setAutoFormattingIndent(1); // indent only 1 space to save disk space
+    writer.setCodec("UTF-8");
+    writer.writeStartDocument("1.0", true);
+    mRootElement->writeToQXmlStreamWriter(writer);
+    writer.writeEndDocument();
+    if (writer.hasError()) throw LogicError(__FILE__, __LINE__);
+    return data;
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/fileio/xmldomdocument.h
+++ b/libs/librepcb/common/fileio/xmldomdocument.h
@@ -118,7 +118,7 @@ class XmlDomDocument final
          *
          * @return The XML DOM tree which can be written into an XML file
          */
-        QByteArray toByteArray() const noexcept;
+        QByteArray toByteArray() const throw (Exception);
 
 
         // Operator Overloadings

--- a/libs/librepcb/common/fileio/xmldomelement.cpp
+++ b/libs/librepcb/common/fileio/xmldomelement.cpp
@@ -826,27 +826,20 @@ XmlDomElement* XmlDomElement::getNextSibling(const QString& name, bool throwIfNo
  *  QDomElement Converter Methods
  ****************************************************************************************/
 
-QDomElement XmlDomElement::toQDomElement(QDomDocument& domDocument) const noexcept
+void XmlDomElement::writeToQXmlStreamWriter(QXmlStreamWriter& writer) const noexcept
 {
-    QDomElement element = domDocument.createElement(mName);
-
-    if (hasChilds())
-    {
-        foreach (XmlDomElement* child, mChilds)
-            element.appendChild(child->toQDomElement(domDocument));
+    writer.writeStartElement(mName);
+    foreach (const QString& key, mAttributes.keys()) {
+        writer.writeAttribute(key, mAttributes[key]);
     }
-    else if (!mText.isNull())
-    {
-        QDomText textNode = domDocument.createTextNode(mText);
-        element.appendChild(textNode);
+    if (hasChilds()) {
+        foreach (XmlDomElement* child, mChilds) {
+            child->writeToQXmlStreamWriter(writer);
+        }
+    } else if (!mText.isNull()) {
+        writer.writeCharacters(mText);
     }
-
-    foreach (const QString& key, mAttributes.keys())
-    {
-        element.setAttribute(key, mAttributes.value(key));
-    }
-
-    return element;
+    writer.writeEndElement();
 }
 
 XmlDomElement* XmlDomElement::fromQDomElement(QDomElement domElement, XmlDomDocument* doc) noexcept

--- a/libs/librepcb/common/fileio/xmldomelement.h
+++ b/libs/librepcb/common/fileio/xmldomelement.h
@@ -415,16 +415,14 @@ class XmlDomElement final
                                       bool throwIfNotFound = false) const throw (Exception);
 
 
-        // QDomElement Converter Methods
+        // Conversion Methods
 
         /**
-         * @brief Construct a QDomElement object from this XmlDomElement (recursively)
+         * @brief Serialize this XmlDomElement into a QXmlStreamWriter (recursively)
          *
-         * @param domDocument   The DOM Document of the newly created QDomElement
-         *
-         * @return The created QDomElement (which is added to the specified DOM document)
+         * @param writer        The QXmlStreamWriter object to write into
          */
-        QDomElement toQDomElement(QDomDocument& domDocument) const noexcept;
+        void writeToQXmlStreamWriter(QXmlStreamWriter& writer) const noexcept;
 
         /**
          * @brief Construct a XmlDomElement object from a QDomElement object (recursively)
@@ -481,7 +479,7 @@ class XmlDomElement final
         QString mName;              ///< the tag name of this element
         QString mText;              ///< the text of this element (only if there are no childs)
         QList<XmlDomElement*> mChilds;      ///< all child elements (only if there is no text)
-        QHash<QString, QString> mAttributes;///< all attributes of this element (key, value) in arbitrary order
+        QMap<QString, QString> mAttributes; ///< all attributes of this element (key, value) in alphabetical order
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/library/dev/device.h
+++ b/libs/librepcb/library/dev/device.h
@@ -63,7 +63,7 @@ class Device final : public LibraryElement
         void setPackageUuid(const Uuid& uuid) noexcept {mPackageUuid = uuid;}
 
         // Pad-Signal-Map Methods
-        const QHash<Uuid, Uuid>& getPadSignalMap() const noexcept {return mPadSignalMap;}
+        const QMap<Uuid, Uuid>& getPadSignalMap() const noexcept {return mPadSignalMap;}
         Uuid getSignalOfPad(const Uuid& pad) const noexcept {return mPadSignalMap.value(pad);}
         void addPadSignalMapping(const Uuid& pad, const Uuid& signal) noexcept;
         void removePadSignalMapping(const Uuid& pad) noexcept;
@@ -90,7 +90,7 @@ class Device final : public LibraryElement
         // Attributes
         Uuid mComponentUuid;
         Uuid mPackageUuid;
-        QHash<Uuid, Uuid> mPadSignalMap; ///< key: pad, value: signal
+        QMap<Uuid, Uuid> mPadSignalMap; ///< key: pad, value: signal
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/project/circuit/componentinstance.h
+++ b/libs/librepcb/project/circuit/componentinstance.h
@@ -183,7 +183,7 @@ class ComponentInstance : public QObject, public IF_AttributeProvider,
         QScopedPointer<AttributeList> mAttributes;
 
         /// @brief All signal instances (Key: component signal UUID)
-        QHash<Uuid, ComponentSignalInstance*> mSignals;
+        QMap<Uuid, ComponentSignalInstance*> mSignals;
 
 
         // Registered Elements

--- a/libs/librepcb/project/project.h
+++ b/libs/librepcb/project/project.h
@@ -200,6 +200,9 @@ class Project final : public QObject, public IF_AttributeProvider,
          * @brief Get the date and time when the project was last modified
          *
          * @return The local date and time of last modification
+         *
+         * @todo    Dynamically determine the datetime of the last modification from
+         *          version control system, file attributes or something like that.
          */
         const QDateTime& getLastModified() const noexcept {return mLastModified;}
 
@@ -239,15 +242,6 @@ class Project final : public QObject, public IF_AttributeProvider,
          * @undocmd{project#CmdProjectSetMetadata}
          */
         void setVersion(const QString& newVersion) noexcept;
-
-        /**
-         * @brief Set the date and time when the project was last modified
-         *
-         * @param newLastModified   The new last modified datetime
-         *
-         * @note This method is automatically called before saving the project.
-         */
-        void setLastModified(const QDateTime& newLastModified) noexcept;
 
         /**
          * @brief Set all project attributes


### PR DESCRIPTION
`QDomDocument` was not able to produce deterministic XML output because it stores attributes in a `QHash` and thus [their order is random](https://geidav.wordpress.com/2013/02/27/deterministic-attribute-order-in-xml-documents-in-qt-5/). This is very bad for version control systems because the diffs on these XML files is unnecessary large.

After some experiments with other XML libraries I noticed that `QXmlStreamWriter` does not have this issue and thus the generated XML files are deterministic. So I changed our serialization to use `QXmlStreamWriter` instead of `QDomDocument`.

Even if this PR does not introduce canonical XML as requested by #2, I think it should solve the issues with version control systems and thus #2 can be closed anyway.