### PR TITLE
Add Ratio class to enable support for single precision FPUs

### DIFF
--- a/libs/librepcb/common/boarddesignrules.cpp
+++ b/libs/librepcb/common/boarddesignrules.cpp
@@ -51,7 +51,7 @@ BoardDesignRules::BoardDesignRules(const XmlDomElement& domElement) throw (Excep
     mDescription = domElement.getFirstChild("description", true)->getText<QString>(false);
     // stop mask
     if (XmlDomElement* e = domElement.getFirstChild("stopmask_clearance_ratio", false)) {
-        mStopMaskClearanceRatio = e->getText<qreal>(true);
+        mStopMaskClearanceRatio = e->getText<Ratio>(true);
     }
     if (XmlDomElement* e = domElement.getFirstChild("stopmask_clearance_min", false)) {
         mStopMaskClearanceMin = e->getText<Length>(true);
@@ -64,7 +64,7 @@ BoardDesignRules::BoardDesignRules(const XmlDomElement& domElement) throw (Excep
     }
     // cream mask
     if (XmlDomElement* e = domElement.getFirstChild("creammask_clearance_ratio", false)) {
-        mCreamMaskClearanceRatio = e->getText<qreal>(true);
+        mCreamMaskClearanceRatio = e->getText<Ratio>(true);
     }
     if (XmlDomElement* e = domElement.getFirstChild("creammask_clearance_min", false)) {
         mCreamMaskClearanceMin = e->getText<Length>(true);
@@ -74,7 +74,7 @@ BoardDesignRules::BoardDesignRules(const XmlDomElement& domElement) throw (Excep
     }
     // restring
     if (XmlDomElement* e = domElement.getFirstChild("restring_pad_ratio", false)) {
-        mRestringPadRatio = e->getText<qreal>(true);
+        mRestringPadRatio = e->getText<Ratio>(true);
     }
     if (XmlDomElement* e = domElement.getFirstChild("restring_pad_min", false)) {
         mRestringPadMin = e->getText<Length>(true);
@@ -83,7 +83,7 @@ BoardDesignRules::BoardDesignRules(const XmlDomElement& domElement) throw (Excep
         mRestringPadMax = e->getText<Length>(true);
     }
     if (XmlDomElement* e = domElement.getFirstChild("restring_via_ratio", false)) {
-        mRestringViaRatio = e->getText<qreal>(true);
+        mRestringViaRatio = e->getText<Ratio>(true);
     }
     if (XmlDomElement* e = domElement.getFirstChild("restring_via_min", false)) {
         mRestringViaMin = e->getText<Length>(true);
@@ -107,19 +107,19 @@ void BoardDesignRules::restoreDefaults() noexcept
     mName = tr("LibrePCB Default Design Rules");
     mDescription = QString();
     // stop mask
-    mStopMaskClearanceRatio = qreal(0);             // 0%
+    mStopMaskClearanceRatio = Ratio(0);             // 0%
     mStopMaskClearanceMin = Length(100000);         // 0.1mm
     mStopMaskClearanceMax = Length(100000);         // 0.1mm
     mStopMaskMaxViaDrillDiameter = Length(500000);  // 0.5mm
     // cream mask
-    mCreamMaskClearanceRatio = qreal(0.1);          // 10%
+    mCreamMaskClearanceRatio = Ratio(100000);       // 10%
     mCreamMaskClearanceMin = Length(0);             // 0.0mm
     mCreamMaskClearanceMax = Length(1000000);       // 1.0mm
     // restring
-    mRestringPadRatio = qreal(0.25);                // 25%
+    mRestringPadRatio = Ratio(250000);              // 25%
     mRestringPadMin = Length(250000);               // 0.25mm
     mRestringPadMax = Length(2000000);              // 2.0mm
-    mRestringViaRatio = qreal(0.25);                // 25%
+    mRestringViaRatio = Ratio(250000);              // 25%
     mRestringViaMin = Length(200000);               // 0.2mm
     mRestringViaMax = Length(2000000);              // 2.0mm
 }

--- a/libs/librepcb/common/boarddesignrules.h
+++ b/libs/librepcb/common/boarddesignrules.h
@@ -60,21 +60,21 @@ class BoardDesignRules final : public IF_XmlSerializableObject
         const QString& getDescription() const noexcept {return mDescription;}
 
         // Getters: Stop Mask
-        qreal getStopMaskClearanceRatio() const noexcept {return mStopMaskClearanceRatio;}
+        const Ratio& getStopMaskClearanceRatio() const noexcept {return mStopMaskClearanceRatio;}
         const Length& getStopMaskClearanceMin() const noexcept {return mStopMaskClearanceMin;}
         const Length& getStopMaskClearanceMax() const noexcept {return mStopMaskClearanceMax;}
         const Length& getStopMaskMaxViaDiameter() const noexcept {return mStopMaskMaxViaDrillDiameter;}
 
         // Getters: Cream Mask
-        qreal getCreamMaskClearanceRatio() const noexcept {return mCreamMaskClearanceRatio;}
+        const Ratio& getCreamMaskClearanceRatio() const noexcept {return mCreamMaskClearanceRatio;}
         const Length& getCreamMaskClearanceMin() const noexcept {return mCreamMaskClearanceMin;}
         const Length& getCreamMaskClearanceMax() const noexcept {return mCreamMaskClearanceMax;}
 
         // Getters: Restring
-        qreal getRestringPadRatio() const noexcept {return mRestringPadRatio;}
+        const Ratio& getRestringPadRatio() const noexcept {return mRestringPadRatio;}
         const Length& getRestringPadMin() const noexcept {return mRestringPadMin;}
         const Length& getRestringPadMax() const noexcept {return mRestringPadMax;}
-        qreal getRestringViaRatio() const noexcept {return mRestringViaRatio;}
+        const Ratio& getRestringViaRatio() const noexcept {return mRestringViaRatio;}
         const Length& getRestringViaMin() const noexcept {return mRestringViaMin;}
         const Length& getRestringViaMax() const noexcept {return mRestringViaMax;}
 
@@ -84,21 +84,21 @@ class BoardDesignRules final : public IF_XmlSerializableObject
         void setDescription(const QString& desc) noexcept {mDescription = desc;}
 
         // Setters: Stop Mask
-        void setStopMaskClearanceRatio(qreal ratio) noexcept {if (ratio > 0) mStopMaskClearanceRatio = ratio;}
+        void setStopMaskClearanceRatio(const Ratio& ratio) noexcept {if (ratio > 0) mStopMaskClearanceRatio = ratio;}
         void setStopMaskClearanceMin(const Length& min) noexcept {if (min >= 0) mStopMaskClearanceMin = min;}
         void setStopMaskClearanceMax(const Length& max) noexcept {if (max >= 0) mStopMaskClearanceMax = max;}
         void setStopMaskMaxViaDiameter(const Length& dia) noexcept {if (dia >= 0) mStopMaskMaxViaDrillDiameter = dia;}
 
         // Setters: Clear Mask
-        void setCreamMaskClearanceRatio(qreal ratio) noexcept {if (ratio > 0) mCreamMaskClearanceRatio = ratio;}
+        void setCreamMaskClearanceRatio(const Ratio& ratio) noexcept {if (ratio > 0) mCreamMaskClearanceRatio = ratio;}
         void setCreamMaskClearanceMin(const Length& min) noexcept {if (min >= 0) mCreamMaskClearanceMin = min;}
         void setCreamMaskClearanceMax(const Length& max) noexcept {if (max >= 0) mCreamMaskClearanceMax = max;}
 
         // Setters: Restring
-        void setRestringPadRatio(qreal ratio) noexcept {if (ratio > 0) mRestringPadRatio = ratio;}
+        void setRestringPadRatio(const Ratio& ratio) noexcept {if (ratio > 0) mRestringPadRatio = ratio;}
         void setRestringPadMin(const Length& min) noexcept {if (min >= 0) mRestringPadMin = min;}
         void setRestringPadMax(const Length& max) noexcept {if (max >= 0) mRestringPadMax = max;}
-        void setRestringViaRatio(qreal ratio) noexcept {if (ratio > 0) mRestringViaRatio = ratio;}
+        void setRestringViaRatio(const Ratio& ratio) noexcept {if (ratio > 0) mRestringViaRatio = ratio;}
         void setRestringViaMin(const Length& min) noexcept {if (min >= 0) mRestringViaMin = min;}
         void setRestringViaMax(const Length& max) noexcept {if (max >= 0) mRestringViaMax = max;}
 
@@ -130,21 +130,21 @@ class BoardDesignRules final : public IF_XmlSerializableObject
         QString mDescription;
 
         // Stop Mask
-        qreal mStopMaskClearanceRatio;
+        Ratio mStopMaskClearanceRatio;
         Length mStopMaskClearanceMin;
         Length mStopMaskClearanceMax;
         Length mStopMaskMaxViaDrillDiameter;
 
         // Cream Mask
-        qreal mCreamMaskClearanceRatio;
+        Ratio mCreamMaskClearanceRatio;
         Length mCreamMaskClearanceMin;
         Length mCreamMaskClearanceMax;
 
         // Restring
-        qreal mRestringPadRatio;
+        Ratio mRestringPadRatio;
         Length mRestringPadMin;
         Length mRestringPadMax;
-        qreal mRestringViaRatio;
+        Ratio mRestringViaRatio;
         Length mRestringViaMin;
         Length mRestringViaMax;
 };

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -81,6 +81,7 @@ SOURCES += \
     units/length.cpp \
     units/lengthunit.cpp \
     units/point.cpp \
+    units/ratio.cpp \
     utils/undostackactiongroup.cpp \
     uuid.cpp \
     version.cpp \
@@ -150,6 +151,7 @@ HEADERS += \
     units/length.h \
     units/lengthunit.h \
     units/point.h \
+    units/ratio.h \
     utils/undostackactiongroup.h \
     uuid.h \
     version.h \

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
@@ -81,19 +81,19 @@ void BoardDesignRulesDialog::updateWidgets() noexcept
     mUi->edtName->setText(mDesignRules.getName());
     mUi->txtDescription->setPlainText(mDesignRules.getDescription());
     // stop mask
-    mUi->spbxStopMaskClrRatio->setValue(mDesignRules.getStopMaskClearanceRatio()*100);
+    mUi->spbxStopMaskClrRatio->setValue(mDesignRules.getStopMaskClearanceRatio().toPercent());
     mUi->spbxStopMaskClrMin->setValue(mDesignRules.getStopMaskClearanceMin().toMm());
     mUi->spbxStopMaskClrMax->setValue(mDesignRules.getStopMaskClearanceMax().toMm());
     mUi->spbxStopMaskMaxViaDia->setValue(mDesignRules.getStopMaskMaxViaDiameter().toMm());
     // cream mask
-    mUi->spbxCreamMaskClrRatio->setValue(mDesignRules.getCreamMaskClearanceRatio()*100);
+    mUi->spbxCreamMaskClrRatio->setValue(mDesignRules.getCreamMaskClearanceRatio().toPercent());
     mUi->spbxCreamMaskClrMin->setValue(mDesignRules.getCreamMaskClearanceMin().toMm());
     mUi->spbxCreamMaskClrMax->setValue(mDesignRules.getCreamMaskClearanceMax().toMm());
     // restring
-    mUi->spbxRestringPadsRatio->setValue(mDesignRules.getRestringPadRatio()*100);
+    mUi->spbxRestringPadsRatio->setValue(mDesignRules.getRestringPadRatio().toPercent());
     mUi->spbxRestringPadsMin->setValue(mDesignRules.getRestringPadMin().toMm());
     mUi->spbxRestringPadsMax->setValue(mDesignRules.getRestringPadMax().toMm());
-    mUi->spbxRestringViasRatio->setValue(mDesignRules.getRestringViaRatio()*100);
+    mUi->spbxRestringViasRatio->setValue(mDesignRules.getRestringViaRatio().toPercent());
     mUi->spbxRestringViasMin->setValue(mDesignRules.getRestringViaMin().toMm());
     mUi->spbxRestringViasMax->setValue(mDesignRules.getRestringViaMax().toMm());
 }
@@ -104,19 +104,19 @@ void BoardDesignRulesDialog::applyRules() noexcept
     mDesignRules.setName(mUi->edtName->text());
     mDesignRules.setDescription(mUi->txtDescription->toPlainText());
     // stop mask
-    mDesignRules.setStopMaskClearanceRatio(mUi->spbxStopMaskClrRatio->value()/100);
+    mDesignRules.setStopMaskClearanceRatio(Ratio::fromPercent(mUi->spbxStopMaskClrRatio->value()));
     mDesignRules.setStopMaskClearanceMin(Length::fromMm(mUi->spbxStopMaskClrMin->value()));
     mDesignRules.setStopMaskClearanceMax(Length::fromMm(mUi->spbxStopMaskClrMax->value()));
     mDesignRules.setStopMaskMaxViaDiameter(Length::fromMm(mUi->spbxStopMaskMaxViaDia->value()));
     // cream mask
-    mDesignRules.setCreamMaskClearanceRatio(mUi->spbxCreamMaskClrRatio->value()/100);
+    mDesignRules.setCreamMaskClearanceRatio(Ratio::fromPercent(mUi->spbxCreamMaskClrRatio->value()));
     mDesignRules.setCreamMaskClearanceMin(Length::fromMm(mUi->spbxCreamMaskClrMin->value()));
     mDesignRules.setCreamMaskClearanceMax(Length::fromMm(mUi->spbxCreamMaskClrMax->value()));
     // restring
-    mDesignRules.setRestringPadRatio(mUi->spbxRestringPadsRatio->value()/100);
+    mDesignRules.setRestringPadRatio(Ratio::fromPercent(mUi->spbxRestringPadsRatio->value()));
     mDesignRules.setRestringPadMin(Length::fromMm(mUi->spbxRestringPadsMin->value()));
     mDesignRules.setRestringPadMax(Length::fromMm(mUi->spbxRestringPadsMax->value()));
-    mDesignRules.setRestringViaRatio(mUi->spbxRestringViasRatio->value()/100);
+    mDesignRules.setRestringViaRatio(Ratio::fromPercent(mUi->spbxRestringViasRatio->value()));
     mDesignRules.setRestringViaMin(Length::fromMm(mUi->spbxRestringViasMin->value()));
     mDesignRules.setRestringViaMax(Length::fromMm(mUi->spbxRestringViasMax->value()));
 }

--- a/libs/librepcb/common/fileio/xmldomelement.cpp
+++ b/libs/librepcb/common/fileio/xmldomelement.cpp
@@ -200,24 +200,6 @@ uint XmlDomElement::getText<uint>(bool throwIfEmpty, const uint& defaultValue) c
 }
 
 template <>
-qreal XmlDomElement::getText<qreal>(bool throwIfEmpty, const qreal& defaultValue) const throw (Exception)
-{
-    QString text = getText<QString>(throwIfEmpty);
-    bool ok = false;
-    static_assert(sizeof(qreal) == sizeof(double), "Unsupported size of qreal type!");
-    qreal value = text.toDouble(&ok);
-    if (ok)
-        return value;
-    else if ((text.isEmpty()) && (!throwIfEmpty))
-        return defaultValue;
-    else
-    {
-        throw FileParseError(__FILE__, __LINE__, getDocFilePath(), -1, -1, text,
-                             QString(tr("Invalid number in node \"%1\".")).arg(mName));
-    }
-}
-
-template <>
 QDateTime XmlDomElement::getText<QDateTime>(bool throwIfEmpty, const QDateTime& defaultValue) const throw (Exception)
 {
     QString text = getText<QString>(throwIfEmpty);
@@ -684,12 +666,6 @@ template <>
 XmlDomElement* XmlDomElement::appendTextChild(const QString& name, const bool& value) noexcept
 {
     return appendTextChild<QString>(name, value ? "true" : "false");
-}
-
-template <>
-XmlDomElement* XmlDomElement::appendTextChild(const QString& name, const qreal& value) noexcept
-{
-    return appendTextChild<QString>(name, QString::number(value, 'g', 6));
 }
 
 template <>

--- a/libs/librepcb/common/fileio/xmldomelement.cpp
+++ b/libs/librepcb/common/fileio/xmldomelement.cpp
@@ -307,6 +307,27 @@ LengthUnit XmlDomElement::getText<LengthUnit>(bool throwIfEmpty, const LengthUni
     }
 }
 
+template <>
+Ratio XmlDomElement::getText<Ratio>(bool throwIfEmpty, const Ratio& defaultValue) const throw (Exception)
+{
+    QString text = getText<QString>(throwIfEmpty);
+    try
+    {
+        Ratio obj = Ratio::fromNormalized(text);
+        return obj;
+    }
+    catch (Exception& exc)
+    {
+        if ((text.isEmpty()) && (!throwIfEmpty))
+            return defaultValue;
+        else
+        {
+            throw FileParseError(__FILE__, __LINE__, getDocFilePath(), -1, -1, text,
+                                 QString(tr("Invalid ratio in node \"%1\".")).arg(mName));
+        }
+    }
+}
+
 /*****************************************************************************************
  *  Attribute Handling Methods
  ****************************************************************************************/
@@ -699,6 +720,12 @@ template <>
 XmlDomElement* XmlDomElement::appendTextChild(const QString& name, const LengthUnit& value) noexcept
 {
     return appendTextChild<QString>(name, value.toString());
+}
+
+template <>
+XmlDomElement* XmlDomElement::appendTextChild(const QString& name, const Ratio& value) noexcept
+{
+    return appendTextChild<QString>(name, value.toNormalizedString());
 }
 
 XmlDomElement* XmlDomElement::getFirstChild(bool throwIfNotFound) const throw (Exception)

--- a/libs/librepcb/common/fileio/xmldomelement.h
+++ b/libs/librepcb/common/fileio/xmldomelement.h
@@ -163,7 +163,7 @@ class XmlDomElement final
          *
          * @tparam T    The text will be converted to this type. Available types:
          *              bool, uint, qreal, QString, QDateTime, #Uuid, #Version, #Length,
-         *              #LengthUnit (tbc)
+         *              #LengthUnit, #Ratio (tbc)
          *
          * @param throwIfEmpty  If true and the text is empty, an exception will be thrown.
          *                      If false and the text is empty, defaultValue will be returned.
@@ -272,7 +272,7 @@ class XmlDomElement final
          *
          * @tparam T        This type will be converted to the text string. Available types:
          *                  bool, qreal, QString, QDateTime, #Uuid, #Version, #Length,
-         *                  #LengthUnit (tbc)
+         *                  #LengthUnit, #Ratio (tbc)
          *
          * @param name      The tag name (see #isValidXmlTagName() for allowed characters)
          * @param value     The attribute value which will be converted to a QString

--- a/libs/librepcb/common/fileio/xmldomelement.h
+++ b/libs/librepcb/common/fileio/xmldomelement.h
@@ -162,7 +162,7 @@ class XmlDomElement final
          * @brief Get the text of this text element in the specified type
          *
          * @tparam T    The text will be converted to this type. Available types:
-         *              bool, uint, qreal, QString, QDateTime, #Uuid, #Version, #Length,
+         *              bool, uint, QString, QDateTime, #Uuid, #Version, #Length,
          *              #LengthUnit, #Ratio (tbc)
          *
          * @param throwIfEmpty  If true and the text is empty, an exception will be thrown.
@@ -271,7 +271,7 @@ class XmlDomElement final
          * @brief Create a new text child and append it to the list of childs
          *
          * @tparam T        This type will be converted to the text string. Available types:
-         *                  bool, qreal, QString, QDateTime, #Uuid, #Version, #Length,
+         *                  bool, QString, QDateTime, #Uuid, #Version, #Length,
          *                  #LengthUnit, #Ratio (tbc)
          *
          * @param name      The tag name (see #isValidXmlTagName() for allowed characters)

--- a/libs/librepcb/common/units/all_length_units.h
+++ b/libs/librepcb/common/units/all_length_units.h
@@ -2,3 +2,4 @@
 #include "length.h"
 #include "point.h"
 #include "angle.h"
+#include "ratio.h"

--- a/libs/librepcb/common/units/ratio.cpp
+++ b/libs/librepcb/common/units/ratio.cpp
@@ -1,0 +1,89 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "ratio.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class Ratio
+ ****************************************************************************************/
+
+// Static Methods
+
+Ratio Ratio::fromPercent(qreal percent) noexcept
+{
+    Ratio ratio;
+    ratio.setRatioPercent(percent);
+    return ratio;
+}
+
+Ratio Ratio::fromNormalized(qreal normalized) noexcept
+{
+    Ratio ratio;
+    ratio.setRatioNormalized(normalized);
+    return ratio;
+}
+
+Ratio Ratio::fromNormalized(const QString& normalized) throw (Exception)
+{
+    Ratio ratio;
+    ratio.setRatioNormalized(normalized);
+    return ratio;
+}
+
+// Private Static Methods
+
+qint32 Ratio::normalizedStringToPpm(const QString& normalized) throw (Exception)
+{
+    bool ok;
+    qreal ratio = qRound(QLocale::c().toDouble(normalized, &ok) * 1e6);
+    if (!ok) {
+        throw Exception(__FILE__, __LINE__, normalized,
+            QString(tr("Invalid ratio string: \"%1\"")).arg(normalized));
+    }
+    return ratio;
+}
+
+// Non-Member Functions
+
+QDataStream& operator<<(QDataStream& stream, const Ratio& ratio)
+{
+    stream << ratio.toNormalizedString();
+    return stream;
+}
+
+QDebug operator<<(QDebug stream, const Ratio& ratio)
+{
+    stream << QString("Ratio(%1%%°)").arg(ratio.toPercent());
+    return stream;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcb/common/units/ratio.h
+++ b/libs/librepcb/common/units/ratio.h
@@ -1,0 +1,247 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_RATIO_H
+#define LIBREPCB_RATIO_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "../exceptions.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class Ratio
+ ****************************************************************************************/
+
+/**
+ * @brief The Ratio class is used to represent a ratio number (e.g. 13.37%)
+ *
+ * @author ubruhin
+ * @date 2017-07-10
+ */
+class Ratio
+{
+        Q_DECLARE_TR_FUNCTIONS(Ratio)
+
+    public:
+
+        // Constructors / Destructor
+
+        /**
+         * @brief Default Constructor
+         */
+        Ratio() noexcept : Ratio(0) {}
+
+        /**
+         * @brief Copy Constructor
+         *
+         * @param ratio         Another Ratio object
+         */
+        Ratio(const Ratio& ratio) noexcept : mPpm(ratio.mPpm) {}
+
+        /**
+         * @brief Constructor with a ratio in PPM
+         *
+         * @param ppm           The ratio in PPM
+         */
+        explicit Ratio(qint32 ppm) noexcept : mPpm(ppm) {}
+
+        /**
+         * @brief Destructor
+         */
+        ~Ratio() noexcept {}
+
+
+        // Setters
+
+        /**
+         * @brief Set the ratio in PPM
+         *
+         * @param ppm           The ratio in PPM
+         */
+        void setRatioPpm(qint32 ppm) noexcept {mPpm = ppm;}
+
+        /**
+         * @brief Set the ratio in percent
+         *
+         * @param percent       The ratio in percent
+         *
+         * @warning If you want to set the ratio exactly to common values like 0%, 50% or
+         * 100%, you should not use this method. Please use #setRatioPpm() instead because
+         * it is more accurate (no use of floating point numbers). Or you can also use the
+         * static methods #percent0(), #percent50() and so on.
+         */
+        void setRatioPercent(qreal percent) noexcept {mPpm = percent * 1e4;}
+
+        /**
+         * @brief Set the ratio as a normalized number
+         *
+         * @param normalized    The normalized ratio
+         *
+         * @warning If you want to set the ratio exactly to common values like 0%, 50% or
+         * 100%, you should not use this method. Please use #setRatioPpm() instead because
+         * it is more accurate (no use of floating point numbers). Or you can also use the
+         * static methods #percent0(), #percent50() and so on.
+         */
+        void setRatioNormalized(qreal normalized) noexcept {mPpm = normalized * 1e6;}
+
+        /**
+         * @brief Set the ratio as a normalized number, represented in a QString
+         *
+         * This method is useful to read ratios from files (deserialization).
+         *
+         * @param normalized    See fromNormalized(const QString&)
+         *
+         * @throw Exception     If the argument is invalid, an Exception will be thrown
+         */
+        void setRatioNormalized(const QString& normalized) throw (Exception) {
+            mPpm = normalizedStringToPpm(normalized);
+        }
+
+
+        // Conversions
+
+        /**
+         * @brief Get the ratio in PPM
+         *
+         * @return The ratio in PPM
+         */
+        qint32 toPpm() const noexcept {return mPpm;}
+
+        /**
+         * @brief Get the ratio in percent
+         *
+         * @return The ratio in percent
+         */
+        qreal toPercent() const noexcept {return (qreal)mPpm / 1e4;}
+
+        /**
+         * @brief Get the ratio as a normalized number
+         *
+         * @return The normalized ratio
+         */
+        qreal toNormalized() const noexcept {return (qreal)mPpm / 1e6;}
+
+        /**
+         * @brief Get the ratio as a normalized QString
+         *
+         * @return The normalized ratio as a QString
+         *
+         * @note This method is useful to store ratios in files (serialization).
+         *
+         * @todo don't use double for this purpose!
+         */
+        QString toNormalizedString() const noexcept {
+            return QLocale::c().toString(toNormalized(), 'f', 6);
+        }
+
+
+        // Static Methods
+
+        /**
+         * @brief Get a Ratio object with a specific ratio
+         *
+         * @param percent   See #setRatioPercent()
+         *
+         * @return A new Ratio object with the specified ratio
+         */
+        static Ratio fromPercent(qreal percent) noexcept;
+
+        /**
+         * @brief Get a Ratio object with a specific ratio
+         *
+         * @param normalized   See #setRatioNormalized(qreal)
+         *
+         * @return A new Ratio object with the specified ratio
+         */
+        static Ratio fromNormalized(qreal normalized) noexcept;
+
+        /**
+         * @brief Get a Ratio object with a specific ratio
+         *
+         * This method can be used to create a Ratio object from a QString which
+         * contains a normalized floating point number, like QString("0.1234") for
+         * 12.34 percent. The string must not depend on the locale settings (see
+         * QLocale), it have always to represent a number in the "C" locale. The maximum
+         * count of decimals after the decimal point is 6, because the 6th decimal
+         * represents one ppm.
+         *
+         * @param normalized   See #setRatioNormalized(const QString&)
+         *
+         * @return A new Ratio object with the specified ratio
+         *
+         * @throw Exception     If the argument is invalid, an Exception will be thrown
+         */
+        static Ratio fromNormalized(const QString& normalized) throw (Exception);
+
+
+        // Static Methods to create often used ratios
+        static Ratio percent0()   noexcept {return Ratio(      0);}
+        static Ratio percent50()  noexcept {return Ratio( 500000);}
+        static Ratio percent100() noexcept {return Ratio(1000000);}
+
+
+        // Operators
+        Ratio&  operator=(const Ratio& rhs)         {mPpm = rhs.mPpm; return *this;}
+        bool    operator==(const Ratio& rhs) const  {return mPpm == rhs.mPpm;}
+        bool    operator!=(const Ratio& rhs) const  {return mPpm != rhs.mPpm;}
+        operator bool() const {return mPpm != 0;}
+
+    private:
+
+        // Private Static Functions
+
+        /**
+         * @brief Convert a normalized ratio from a QString to an integer (in PPM)
+         *
+         * This is a helper function for Ratio(const QString&) and fromNormalized(const QString&));.
+         *
+         * @param normalized    A QString which contains a floating point number with
+         *                      maximum six decimals after the decimal point. The locale
+         *                      of the string have to be "C"! Example: QString("-0.1234")
+         *                      for -12.34 percent.
+         *
+         * @return The ratio in PPM
+         *
+         * @todo    don't use double for this purpose!
+         */
+        static qint32 normalizedStringToPpm(const QString& normalized) throw (Exception);
+
+
+        // Private Member Variables
+        qint32 mPpm;   ///< the ratio in PPM
+};
+
+// Non-Member Functions
+QDataStream& operator<<(QDataStream& stream, const Ratio& ratio);
+QDebug operator<<(QDebug stream, const Ratio& ratio);
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_RATIO_H

--- a/tests/common/ratiotest.cpp
+++ b/tests/common/ratiotest.cpp
@@ -1,0 +1,225 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+
+#include <QtCore>
+#include <gtest/gtest.h>
+#include <librepcb/common/units/ratio.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*****************************************************************************************
+ *  Test Data Type
+ ****************************************************************************************/
+
+typedef struct {
+    Ratio ratio;
+    qint32 ppm;
+    qreal percent;
+    qreal normalized;
+    QString string;
+} RatioTestData_t;
+
+/*****************************************************************************************
+ *  Test Class
+ ****************************************************************************************/
+
+class RatioTest : public ::testing::TestWithParam<RatioTestData_t>
+{
+};
+
+/*****************************************************************************************
+ *  Test Methods
+ ****************************************************************************************/
+
+TEST(RatioTest, testDefaultConstructor)
+{
+    Ratio r;
+    EXPECT_EQ(0, r.toPpm());
+}
+
+TEST_P(RatioTest, testCopyConstructor)
+{
+    const RatioTestData_t& data = GetParam();
+
+    Ratio r(data.ratio);
+    EXPECT_EQ(data.ppm, r.toPpm());
+}
+
+TEST_P(RatioTest, testPpmConstructor)
+{
+    const RatioTestData_t& data = GetParam();
+
+    Ratio r(data.ppm);
+    EXPECT_EQ(data.ppm, r.toPpm());
+}
+
+TEST_P(RatioTest, testSetRatioPpm)
+{
+    const RatioTestData_t& data = GetParam();
+
+    Ratio r;
+    r.setRatioPpm(data.ppm);
+    EXPECT_EQ(data.ppm, r.toPpm());
+}
+
+TEST_P(RatioTest, testSetRatioPercent)
+{
+    const RatioTestData_t& data = GetParam();
+
+    Ratio r;
+    r.setRatioPercent(data.percent);
+    EXPECT_NEAR(data.ppm, r.toPpm(), 2);
+}
+
+TEST_P(RatioTest, testSetRatioNormalizedFloat)
+{
+    const RatioTestData_t& data = GetParam();
+
+    Ratio r;
+    r.setRatioNormalized(data.normalized);
+    EXPECT_NEAR(data.ppm, r.toPpm(), 2);
+}
+
+TEST_P(RatioTest, testSetRatioNormalizedString)
+{
+    const RatioTestData_t& data = GetParam();
+
+    Ratio r;
+    r.setRatioNormalized(data.string);
+    EXPECT_EQ(data.ppm, r.toPpm());
+}
+
+TEST_P(RatioTest, testToPpm)
+{
+    const RatioTestData_t& data = GetParam();
+    EXPECT_EQ(data.ppm, data.ratio.toPpm());
+}
+
+TEST_P(RatioTest, testToPercent)
+{
+    const RatioTestData_t& data = GetParam();
+    EXPECT_NEAR(data.percent, data.ratio.toPercent(), 0.0002);
+}
+
+TEST_P(RatioTest, testToNormalized)
+{
+    const RatioTestData_t& data = GetParam();
+    EXPECT_NEAR(data.normalized, data.ratio.toNormalized(), 0.000002);
+}
+
+TEST_P(RatioTest, testToNormalizedString)
+{
+    const RatioTestData_t& data = GetParam();
+    EXPECT_EQ(data.string, data.ratio.toNormalizedString());
+}
+
+TEST_P(RatioTest, testFromPercent)
+{
+    const RatioTestData_t& data = GetParam();
+    EXPECT_NEAR(data.ppm, Ratio::fromPercent(data.percent).toPpm(), 2);
+}
+
+TEST_P(RatioTest, testFromNormalizedFloat)
+{
+    const RatioTestData_t& data = GetParam();
+    EXPECT_NEAR(data.ppm, Ratio::fromNormalized(data.normalized).toPpm(), 2);
+}
+
+TEST_P(RatioTest, testFromNormalizedString)
+{
+    const RatioTestData_t& data = GetParam();
+    EXPECT_EQ(data.ppm, Ratio::fromNormalized(data.string).toPpm());
+}
+
+TEST(RatioTest, testStaticPercentMethods)
+{
+    EXPECT_NEAR(  0.0, Ratio::percent0().toPercent(),   0.0002);
+    EXPECT_NEAR( 50.0, Ratio::percent50().toPercent(),  0.0002);
+    EXPECT_NEAR(100.0, Ratio::percent100().toPercent(), 0.0002);
+}
+
+TEST_P(RatioTest, testOperatorAssign)
+{
+    const RatioTestData_t& data = GetParam();
+
+    Ratio r;
+    r = data.ratio;
+    EXPECT_EQ(data.ppm, r.toPpm());
+}
+
+TEST(RatioTest, testOperatorEqual)
+{
+    EXPECT_TRUE( Ratio(          ) == Ratio(          ));
+    EXPECT_TRUE( Ratio(          ) == Ratio(         0));
+    EXPECT_TRUE( Ratio(         0) == Ratio(         0));
+    EXPECT_TRUE( Ratio(      1234) == Ratio(      1234));
+    EXPECT_TRUE( Ratio(-987654321) == Ratio(-987654321));
+    EXPECT_FALSE(Ratio(         0) == Ratio(         1));
+    EXPECT_FALSE(Ratio(         5) == Ratio(        -6));
+    EXPECT_FALSE(Ratio(-987654321) == Ratio(-987654322));
+}
+
+TEST(RatioTest, testOperatorNotEqual)
+{
+    EXPECT_FALSE(Ratio(          ) != Ratio(          ));
+    EXPECT_FALSE(Ratio(          ) != Ratio(         0));
+    EXPECT_FALSE(Ratio(         0) != Ratio(         0));
+    EXPECT_FALSE(Ratio(      1234) != Ratio(      1234));
+    EXPECT_FALSE(Ratio(-987654321) != Ratio(-987654321));
+    EXPECT_TRUE( Ratio(         0) != Ratio(         1));
+    EXPECT_TRUE( Ratio(         5) != Ratio(        -6));
+    EXPECT_TRUE( Ratio(-987654321) != Ratio(-987654322));
+}
+
+TEST(RatioTest, testOperatorBool)
+{
+    EXPECT_FALSE(Ratio(          ));
+    EXPECT_FALSE(Ratio(         0));
+    EXPECT_TRUE( Ratio(         1));
+    EXPECT_TRUE( Ratio(      1234));
+    EXPECT_TRUE( Ratio(-987654321));
+}
+
+/*****************************************************************************************
+ *  Test Data
+ ****************************************************************************************/
+
+INSTANTIATE_TEST_CASE_P(RatioTest, RatioTest, ::testing::Values(
+    //              {            ratio,        ppm,     percent,  normalized,        string}
+    RatioTestData_t({Ratio(         0),          0,         0.0,         0.0,    "0.000000"}),
+    RatioTestData_t({Ratio(    500000),     500000,        50.0,         0.5,    "0.500000"}),
+    RatioTestData_t({Ratio(   1000000),    1000000,       100.0,         1.0,    "1.000000"}),
+    RatioTestData_t({Ratio( 123456789),  123456789,  12345.6789,  123.456789,  "123.456789"}),
+    RatioTestData_t({Ratio(-987654321), -987654321, -98765.4321, -987.654321, "-987.654321"})
+));
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace librepcb

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -55,6 +55,7 @@ SOURCES += \
     common/filepathtest.cpp \
     common/networkrequesttest.cpp \
     common/pointtest.cpp \
+    common/ratiotest.cpp \
     common/scopeguardtest.cpp \
     common/sqlitedatabasetest.cpp \
     common/systeminfotest.cpp \


### PR DESCRIPTION
Until now, `qreal` floating point numbers were used to represent ratios (e.g. 25%) in the board design rules (for example to specify clearances). Unfortunately there were two issues with that concept:

- The precision of a `qreal` depends on the available FPU (either single precision or double precision). So the design rules were slightly platform dependent.
- The serialization and deserialization of a `qreal` in the class `XmlDomElement` was implemented only for double precision FPUs. Compiling for single precision FPUs was explicitly prevented by a static assert. 

This PR adds a new class `Ratio` which is used to represent, serialize and deserialize ratios in a platform independent way (the underlaying type is `qint32` instead of `qreal`). The precision is always 1ppm.

Thanks to this change, LibrePCB works now also with single precision FPUs, which was [successfully tested on the Open Pandora](https://repo.openpandora.org/?page=detail&app=librepcb). This is the first time LibrePCB runs on an ARM processor! :smiley: 