### PR TITLE
Tests: Use test data from submodule instead of downloading them from the Internet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libs/googletest"]
 	path = libs/googletest
 	url = https://github.com/LibrePCB/googletest.git
+[submodule "tests/data"]
+	path = tests/data
+	url = https://github.com/LibrePCB/librepcb-test-data.git

--- a/tests/common/filedownloadtest.cpp
+++ b/tests/common/filedownloadtest.cpp
@@ -187,22 +187,22 @@ TEST_P(FileDownloadTest, testDownload)
  ****************************************************************************************/
 
 INSTANTIATE_TEST_CASE_P(FileDownloadTest, FileDownloadTest, ::testing::Values(
-    FileDownloadTestData({QUrl("https://github.com/LibrePCB/LibrePCB/archive/first_pcb.zip"),
+    FileDownloadTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/unit/FileDownloadTest/first_pcb.zip"),
                           QString("first_pcb_downloaded.zip"),
                           QString("first_pcb_extracted"),
                           QByteArray::fromHex("f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f89"),
                           true}),
-    FileDownloadTestData({QUrl("https://github.com/LibrePCB/LibrePCB/archive/first_pcb.zip"),
+    FileDownloadTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/unit/FileDownloadTest/first_pcb.zip"),
                           QString("first_pcb_downloaded.zip"),
                           QString(),
                           QByteArray::fromHex("f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f88"), // wrong
                           false}),
-    FileDownloadTestData({QUrl("https://api.librepcb.org/api/v1/libraries"),
+    FileDownloadTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/common/api/v1/libraries"),
                           QString("libraries.json"),
                           QString(),
                           QByteArray(),
                           true}),
-    FileDownloadTestData({QUrl("https://github.com/LibrePCB/some-invalid-url"),
+    FileDownloadTestData({QUrl::fromLocalFile("/some-invalid-url"),
                           QString("some-invalid-url"),
                           QString("some-invalid-url_extracted"),
                           QByteArray(),

--- a/tests/common/networkrequesttest.cpp
+++ b/tests/common/networkrequesttest.cpp
@@ -153,15 +153,15 @@ TEST_P(NetworkRequestTest, testDownload)
  ****************************************************************************************/
 
 INSTANTIATE_TEST_CASE_P(NetworkRequestTest, NetworkRequestTest, ::testing::Values(
-    NetworkRequestTestData({QUrl("https://api.librepcb.org/api/v1/libraries"),
+    NetworkRequestTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/common/api/v1/libraries"),
                             QByteArray("application/json"),
                             QByteArray("{"),
                             true}),
-    //NetworkRequestTestData({QUrl("https://api.librepcb.org/api/v1/libraries"),
+    //NetworkRequestTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/common/api/v1/libraries"),
     //                        QByteArray("text/html"),
     //                        QByteArray("<"),
     //                        true}),
-    NetworkRequestTestData({QUrl("https://api.librepcb.org/some-invalid-url"),
+    NetworkRequestTestData({QUrl::fromLocalFile("/some-invalid-url"),
                             QByteArray("text/html"),
                             QByteArray(""),
                             false})

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -13,6 +13,9 @@ GENERATED_DIR = ../generated
 # Use common project definitions
 include(../common.pri)
 
+# Set preprocessor defines
+DEFINES += TEST_DATA_DIR=\\\"$${PWD}/data\\\"
+
 QT += core widgets network printsupport xml opengl sql concurrent
 
 CONFIG += console


### PR DESCRIPTION
Some unit tests downloaded files from the Internet on every run. This was error prone (e.g. network timeouts, SSL certificate errors, ...) and also not really a good design because these tests were (more or less) non-deterministic.

So according to #126 I created the new repository [librepcb-test-data](https://github.com/LibrePCB/librepcb-test-data) where we can store all data required to run the unit tests. That repository is then added as a submodule to `./tests/data` of this repository.

Now the unit tests "download" their data from the submodule and thus an Internet connection is no longer required to run the tests.

The only drawback is that the unit tests do no longer really download files over HTTP/HTTPS. But I think this could be fixed some time by running a local webserver which provides the test data files through HTTP/HTTPS while running the tests...

Fixes #126.