### PR TITLE
Add hidden grab area layers

### DIFF
--- a/libs/librepcb/common/graphics/graphicslayer.cpp
+++ b/libs/librepcb/common/graphics/graphicslayer.cpp
@@ -179,6 +179,7 @@ const QStringList& GraphicsLayer::getSchematicGeometryElementLayerNames() noexce
 {
     static QStringList names = {
         sSymbolOutlines,
+        sSymbolHiddenGrabAreas,
         sSymbolNames,
         sSymbolValues,
         sSchematicSheetFrames,
@@ -201,6 +202,7 @@ const QStringList& GraphicsLayer::getBoardGeometryElementLayerNames() noexcept
         sBoardComments,
         sBoardcGuide,
         sTopPlacement,
+        sTopHiddenGrabAreas,
         sTopDocumentation,
         sTopNames,
         sTopValues,
@@ -210,6 +212,7 @@ const QStringList& GraphicsLayer::getBoardGeometryElementLayerNames() noexcept
         sTopSolderPaste,
         sTopStopMask,
         sBotPlacement,
+        sBotHiddenGrabAreas,
         sBotDocumentation,
         sBotNames,
         sBotValues,
@@ -239,6 +242,7 @@ void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr, QColo
         // symbol
         h.insert(sSymbolOutlines,           {tr("Outlines"),                    Qt::darkRed,                Qt::red,                    true});
         h.insert(sSymbolGrabAreas,          {tr("Grab Areas"),                  QColor(255, 255, 0, 30),    QColor(255, 255, 0, 50),    true});
+        h.insert(sSymbolHiddenGrabAreas,    {tr("Hidden Grab Areas"),           QColor(0, 0, 255, 30),      QColor(0, 0, 255, 50),      false});
         h.insert(sSymbolNames,              {tr("Names"),                       QColor(32, 32, 32, 255),    Qt::darkGray,               true});
         h.insert(sSymbolValues,             {tr("Values"),                      QColor(80, 80, 80, 255),    Qt::gray,                   true});
         h.insert(sSymbolPinCirclesOpt,      {tr("Optional Pins"),               QColor(0, 255, 0, 255),     QColor(0, 255, 0, 127),     true});
@@ -264,6 +268,8 @@ void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr, QColo
         h.insert(sBotDocumentation,         {tr("Bot Documentation"),           QColor(224, 224, 224, 150), QColor(224, 224, 224, 220), true});
         h.insert(sTopGrabAreas,             {tr("Top Grab Areas"),              QColor(255, 255, 255, 20),  QColor(255, 255, 255, 50),  false});
         h.insert(sBotGrabAreas,             {tr("Bot Grab Areas"),              QColor(255, 255, 255, 20),  QColor(255, 255, 255, 50),  false});
+        h.insert(sTopHiddenGrabAreas,       {tr("Top Hidden Grab Areas"),       QColor(255, 255, 255, 40),  QColor(255, 255, 255, 70),  false});
+        h.insert(sBotHiddenGrabAreas,       {tr("Bot Hidden Grab Areas"),       QColor(255, 255, 255, 40),  QColor(255, 255, 255, 70),  false});
         h.insert(sTopReferences,            {tr("Top References"),              QColor(255, 255, 255, 50),  QColor(255, 255, 255, 80),  true});
         h.insert(sBotReferences,            {tr("Bot References"),              QColor(255, 255, 255, 50),  QColor(255, 255, 255, 80),  true});
         h.insert(sTopNames,                 {tr("Top Names"),                   QColor(224, 224, 224, 150), QColor(224, 224, 224, 220), true});

--- a/libs/librepcb/common/graphics/graphicslayer.h
+++ b/libs/librepcb/common/graphics/graphicslayer.h
@@ -67,6 +67,7 @@ class GraphicsLayer : public QObject
         // symbol layers
         static constexpr const char* sSymbolOutlines          = "sym_outlines";           ///< dark red lines of symbols
         static constexpr const char* sSymbolGrabAreas         = "sym_grab_areas";         ///< optional yellow area of symbols
+        static constexpr const char* sSymbolHiddenGrabAreas   = "sym_hidden_grab_areas";  ///< hidden grab areas of symbols
         static constexpr const char* sSymbolNames             = "sym_names";              ///< text #NAME
         static constexpr const char* sSymbolValues            = "sym_values";             ///< text #VALUE
         static constexpr const char* sSymbolPinCirclesOpt     = "sym_pin_circles_opt";    ///< green circle of unconnected pins
@@ -97,6 +98,8 @@ class GraphicsLayer : public QObject
         static constexpr const char* sBotDocumentation        = "bot_documentation";      ///< like placement layers, but not for silk screen
         static constexpr const char* sTopGrabAreas            = "top_grab_areas";         ///< area where devices can be dragged
         static constexpr const char* sBotGrabAreas            = "bot_grab_areas";         ///< area where devices can be dragged
+        static constexpr const char* sTopHiddenGrabAreas      = "top_hidden_grab_areas";  ///< hidden area where devices can be dragged
+        static constexpr const char* sBotHiddenGrabAreas      = "bot_hidden_grab_areas";  ///< hidden area where devices can be dragged
         static constexpr const char* sTopReferences           = "top_references";         ///< origin crosses of devices
         static constexpr const char* sBotReferences           = "bot_references";         ///< origin crosses of devices
         static constexpr const char* sTopNames                = "top_names";              ///< text, may be used for silk screen

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -134,6 +134,7 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, QSharedPointer<Library> l
     addLayer(GraphicsLayer::sSchematicSheetFrames);
     addLayer(GraphicsLayer::sSymbolOutlines);
     addLayer(GraphicsLayer::sSymbolGrabAreas);
+    addLayer(GraphicsLayer::sSymbolHiddenGrabAreas, true); // force it to be visible!
     addLayer(GraphicsLayer::sSymbolPinCirclesOpt);
     addLayer(GraphicsLayer::sSymbolPinCirclesReq);
     addLayer(GraphicsLayer::sSymbolPinNames);
@@ -167,6 +168,8 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, QSharedPointer<Library> l
     addLayer(GraphicsLayer::sBotReferences);
     addLayer(GraphicsLayer::sTopGrabAreas);
     addLayer(GraphicsLayer::sBotGrabAreas);
+    addLayer(GraphicsLayer::sTopHiddenGrabAreas, true); // force it to be visible!
+    addLayer(GraphicsLayer::sBotHiddenGrabAreas, true); // force it to be visible!
     addLayer(GraphicsLayer::sTopPlacement);
     addLayer(GraphicsLayer::sBotPlacement);
     addLayer(GraphicsLayer::sTopDocumentation);
@@ -522,9 +525,11 @@ void LibraryEditor::closeEvent(QCloseEvent* event) noexcept
     }
 }
 
-void LibraryEditor::addLayer(const QString& name) noexcept
+void LibraryEditor::addLayer(const QString& name, bool forceVisible) noexcept
 {
-    mLayers.append(new GraphicsLayer(name));
+    QScopedPointer<GraphicsLayer> layer(new GraphicsLayer(name));
+    if (forceVisible) layer->setVisible(true);
+    mLayers.append(layer.take());
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/libraryeditor/libraryeditor.h
+++ b/libs/librepcb/libraryeditor/libraryeditor.h
@@ -154,7 +154,7 @@ class LibraryEditor final : public QMainWindow, public IF_GraphicsLayerProvider
         void setActiveEditorWidget(EditorWidgetBase* widget);
         void updateTabTitles() noexcept;
         void closeEvent(QCloseEvent* event) noexcept override;
-        void addLayer(const QString& name) noexcept;
+        void addLayer(const QString& name, bool forceVisible = false) noexcept;
 
 
     private: // Data

--- a/libs/librepcb/project/boards/boardlayerstack.cpp
+++ b/libs/librepcb/project/boards/boardlayerstack.cpp
@@ -144,6 +144,8 @@ void BoardLayerStack::addAllLayers() noexcept
     addLayer(GraphicsLayer::sBotReferences);
     addLayer(GraphicsLayer::sTopGrabAreas);
     addLayer(GraphicsLayer::sBotGrabAreas);
+    addLayer(GraphicsLayer::sTopHiddenGrabAreas, true);
+    addLayer(GraphicsLayer::sBotHiddenGrabAreas, true);
     addLayer(GraphicsLayer::sTopPlacement);
     addLayer(GraphicsLayer::sBotPlacement);
     addLayer(GraphicsLayer::sTopDocumentation);
@@ -175,10 +177,12 @@ void BoardLayerStack::addAllLayers() noexcept
 #endif
 }
 
-void BoardLayerStack::addLayer(const QString& name) noexcept
+void BoardLayerStack::addLayer(const QString& name, bool disable) noexcept
 {
     if (!getLayer(name)) {
-        addLayer(new GraphicsLayer(name));
+        QScopedPointer<GraphicsLayer> layer(new GraphicsLayer(name));
+        if (disable) layer->setEnabled(false);
+        addLayer(layer.take());
     }
 }
 

--- a/libs/librepcb/project/boards/boardlayerstack.h
+++ b/libs/librepcb/project/boards/boardlayerstack.h
@@ -94,7 +94,7 @@ class BoardLayerStack final : public QObject, public SerializableObject,
 
     private:
         void addAllLayers() noexcept;
-        void addLayer(const QString& name) noexcept;
+        void addLayer(const QString& name, bool disable = false) noexcept;
         void addLayer(GraphicsLayer* layer) noexcept;
 
 

--- a/libs/librepcb/project/schematics/schematiclayerprovider.cpp
+++ b/libs/librepcb/project/schematics/schematiclayerprovider.cpp
@@ -41,6 +41,7 @@ SchematicLayerProvider::SchematicLayerProvider(Project& project):
     addLayer(GraphicsLayer::sSchematicSheetFrames);
     addLayer(GraphicsLayer::sSymbolOutlines);
     addLayer(GraphicsLayer::sSymbolGrabAreas);
+    addLayer(GraphicsLayer::sSymbolHiddenGrabAreas);
     addLayer(GraphicsLayer::sSymbolPinCirclesOpt);
     addLayer(GraphicsLayer::sSymbolPinCirclesReq);
     addLayer(GraphicsLayer::sSymbolPinNames);


### PR DESCRIPTION
This adds new layers which can be used to draw hidden grab areas (e.g. polygons) in symbols and footprints. These layers are only visible in the library editor (to make them editable), but not in the schematic and board editors.

Details are described in https://github.com/LibrePCB/LibrePCB/issues/131#issuecomment-260089487.

Fixes #131