### PR TITLE
Add Git Bugtraq Config

### DIFF
--- a/.gitbugtraq
+++ b/.gitbugtraq
@@ -1,0 +1,14 @@
+# Git Bugtraq Configuration for LibrePCB
+# See https://github.com/mstrap/bugtraq
+
+[bugtraq "github-pullrequests"]
+  url = "https://github.com/LibrePCB/LibrePCB/pull/%BUGID%"
+  logfilterregex = "[Pp]ull [Rr]equest #\\d+"
+  loglinkregex = "#\\d+"
+  logregex = "\\d+"
+
+[bugtraq "github-issues"]
+  url = "https://github.com/LibrePCB/LibrePCB/issues/%BUGID%"
+  logfilterregex = "(?<![Pp]ull [Rr]equest) #\\d+"
+  loglinkregex = "#\\d+"
+  logregex = "\\d+"


### PR DESCRIPTION
With this [Git Bugtraq](https://github.com/mstrap/bugtraq) configuration, Git clients like [SmartGit](http://www.syntevo.com/smartgit/) are able to display issue and pull request numbers in commit messages as hyperlinks:

![auswahl_014](https://user-images.githubusercontent.com/5374821/31320042-3c55ede0-ac6e-11e7-871b-d8132f5fb845.png)
