### PR TITLE
Add more functionality to the component chooser dialog

### DIFF
--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -71,6 +71,7 @@ SOURCES += \
     geometry/hole.cpp \
     geometry/polygon.cpp \
     geometry/text.cpp \
+    graphics/defaultgraphicslayerprovider.cpp \
     graphics/ellipsegraphicsitem.cpp \
     graphics/graphicslayer.cpp \
     graphics/graphicsscene.cpp \
@@ -166,6 +167,7 @@ HEADERS += \
     geometry/hole.h \
     geometry/polygon.h \
     geometry/text.h \
+    graphics/defaultgraphicslayerprovider.h \
     graphics/ellipsegraphicsitem.h \
     graphics/graphicslayer.h \
     graphics/graphicsscene.h \

--- a/libs/librepcb/common/graphics/defaultgraphicslayerprovider.cpp
+++ b/libs/librepcb/common/graphics/defaultgraphicslayerprovider.cpp
@@ -1,0 +1,136 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "defaultgraphicslayerprovider.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+DefaultGraphicsLayerProvider::DefaultGraphicsLayerProvider() noexcept
+{
+    // schematic layers
+    addLayer(GraphicsLayer::sSchematicReferences);
+    addLayer(GraphicsLayer::sSchematicSheetFrames);
+    addLayer(GraphicsLayer::sSymbolOutlines);
+    addLayer(GraphicsLayer::sSymbolGrabAreas);
+    addLayer(GraphicsLayer::sSymbolHiddenGrabAreas);
+    addLayer(GraphicsLayer::sSymbolPinCirclesOpt);
+    addLayer(GraphicsLayer::sSymbolPinCirclesReq);
+    addLayer(GraphicsLayer::sSymbolPinNames);
+    addLayer(GraphicsLayer::sSymbolPinNumbers);
+    addLayer(GraphicsLayer::sSymbolNames);
+    addLayer(GraphicsLayer::sSymbolValues);
+    addLayer(GraphicsLayer::sSchematicNetLines);
+    addLayer(GraphicsLayer::sSchematicNetLabels);
+    addLayer(GraphicsLayer::sSchematicDocumentation);
+    addLayer(GraphicsLayer::sSchematicComments);
+    addLayer(GraphicsLayer::sSchematicGuide);
+
+    // asymmetric board layers
+    addLayer(GraphicsLayer::sBoardSheetFrames);
+    addLayer(GraphicsLayer::sBoardOutlines);
+    addLayer(GraphicsLayer::sBoardMillingPth);
+    addLayer(GraphicsLayer::sBoardDrillsNpth);
+    addLayer(GraphicsLayer::sBoardViasTht);
+    addLayer(GraphicsLayer::sBoardPadsTht);
+
+    // copper layers
+    addLayer(GraphicsLayer::sTopCopper);
+    for (int i = 1; i <= GraphicsLayer::getInnerLayerCount(); ++i) {
+        addLayer(GraphicsLayer::getInnerLayerName(i));
+    }
+    addLayer(GraphicsLayer::sBotCopper);
+
+    // symmetric board layers
+    addLayer(GraphicsLayer::sTopReferences);
+    addLayer(GraphicsLayer::sBotReferences);
+    addLayer(GraphicsLayer::sTopGrabAreas);
+    addLayer(GraphicsLayer::sBotGrabAreas);
+    addLayer(GraphicsLayer::sTopHiddenGrabAreas);
+    addLayer(GraphicsLayer::sBotHiddenGrabAreas);
+    addLayer(GraphicsLayer::sTopPlacement);
+    addLayer(GraphicsLayer::sBotPlacement);
+    addLayer(GraphicsLayer::sTopDocumentation);
+    addLayer(GraphicsLayer::sBotDocumentation);
+    addLayer(GraphicsLayer::sTopNames);
+    addLayer(GraphicsLayer::sBotNames);
+    addLayer(GraphicsLayer::sTopValues);
+    addLayer(GraphicsLayer::sBotValues);
+    addLayer(GraphicsLayer::sTopCourtyard);
+    addLayer(GraphicsLayer::sBotCourtyard);
+    addLayer(GraphicsLayer::sTopStopMask);
+    addLayer(GraphicsLayer::sBotStopMask);
+    addLayer(GraphicsLayer::sTopSolderPaste);
+    addLayer(GraphicsLayer::sBotSolderPaste);
+    addLayer(GraphicsLayer::sTopGlue);
+    addLayer(GraphicsLayer::sBotGlue);
+
+    // other asymmetric board layers
+    addLayer(GraphicsLayer::sBoardMeasures);
+    addLayer(GraphicsLayer::sBoardAlignment);
+    addLayer(GraphicsLayer::sBoardDocumentation);
+    addLayer(GraphicsLayer::sBoardComments);
+    addLayer(GraphicsLayer::sBoardcGuide);
+}
+
+DefaultGraphicsLayerProvider::~DefaultGraphicsLayerProvider() noexcept
+{
+    qDeleteAll(mLayers); mLayers.clear();
+}
+
+/*****************************************************************************************
+ *  Getters
+ ****************************************************************************************/
+
+GraphicsLayer* DefaultGraphicsLayerProvider::getLayer(const QString& name) const noexcept
+{
+    foreach (GraphicsLayer* layer, mLayers) {
+        if (layer->getName() == name) {
+            return layer;
+        }
+    }
+    return nullptr;
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void DefaultGraphicsLayerProvider::addLayer(const QString& name) noexcept
+{
+    if (!getLayer(name)) {
+        mLayers.append(new GraphicsLayer(name));
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcb/common/graphics/defaultgraphicslayerprovider.h
+++ b/libs/librepcb/common/graphics/defaultgraphicslayerprovider.h
@@ -1,0 +1,65 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_DEFAULTGRAPHICSLAYERPROVIDER_H
+#define LIBREPCB_DEFAULTGRAPHICSLAYERPROVIDER_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "graphicslayer.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class DefaultGraphicsLayerProvider
+ ****************************************************************************************/
+
+/**
+ * @brief The DefaultGraphicsLayerProvider class
+ */
+class DefaultGraphicsLayerProvider final : public IF_GraphicsLayerProvider
+{
+    public:
+
+        // Constructors / Destructor
+        DefaultGraphicsLayerProvider() noexcept;
+        ~DefaultGraphicsLayerProvider() noexcept;
+
+        // Getters
+        GraphicsLayer* getLayer(const QString& name) const noexcept override;
+        QList<GraphicsLayer*> getAllLayers() const noexcept override {return mLayers;}
+
+    private:
+        void addLayer(const QString& name) noexcept;
+
+        QList<GraphicsLayer*> mLayers;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_DEFAULTGRAPHICSLAYERPROVIDER_H

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.cpp
@@ -40,9 +40,10 @@ namespace project {
  ****************************************************************************************/
 
 CmdComponentInstanceAdd::CmdComponentInstanceAdd(Circuit& circuit, const Uuid& cmp,
-                                                 const Uuid& symbVar) noexcept :
+                                                 const Uuid& symbVar, const Uuid& defaultDevice) noexcept :
     UndoCommand(tr("Add component")),
-    mCircuit(circuit), mComponentUuid(cmp), mSymbVarUuid(symbVar), mComponentInstance(nullptr)
+    mCircuit(circuit), mComponentUuid(cmp), mSymbVarUuid(symbVar),
+    mDefaultDeviceUuid(defaultDevice), mComponentInstance(nullptr)
 {
 }
 
@@ -64,7 +65,8 @@ bool CmdComponentInstanceAdd::performExecute()
     }
     const QStringList& normOrder = mCircuit.getProject().getSettings().getNormOrder();
     QString name = mCircuit.generateAutoComponentInstanceName(cmp->getPrefixes().value(normOrder));
-    mComponentInstance = new ComponentInstance(mCircuit, *cmp, mSymbVarUuid, name); // can throw
+    mComponentInstance = new ComponentInstance(mCircuit, *cmp, mSymbVarUuid, name,
+                                               mDefaultDeviceUuid); // can throw
 
     performRedo(); // can throw
 

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.h
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.h
@@ -53,7 +53,8 @@ class CmdComponentInstanceAdd final : public UndoCommand
     public:
 
         // Constructors / Destructor
-        CmdComponentInstanceAdd(Circuit& circuit, const Uuid& cmp, const Uuid& symbVar) noexcept;
+        CmdComponentInstanceAdd(Circuit& circuit, const Uuid& cmp, const Uuid& symbVar,
+                                const Uuid& defaultDevice = Uuid()) noexcept;
         ~CmdComponentInstanceAdd() noexcept;
 
         // Getters
@@ -80,6 +81,7 @@ class CmdComponentInstanceAdd final : public UndoCommand
         Circuit& mCircuit;
         Uuid mComponentUuid;
         Uuid mSymbVarUuid;
+        Uuid mDefaultDeviceUuid;
 
         /// @brief The created component instance
         ComponentInstance* mComponentInstance;

--- a/libs/librepcb/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/project/circuit/componentinstance.cpp
@@ -61,6 +61,7 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node) 
     }
     Uuid symbVarUuid = node.getValueByPath<Uuid>("lib_variant", true);
     mCompSymbVar = mLibComponent->getSymbolVariants().get(symbVarUuid).get(); // can throw
+    mDefaultDeviceUuid = node.getValueByPath<Uuid>("lib_device", true);
 
     // load all component attributes
     mAttributes.reset(new AttributeList(node)); // can throw
@@ -87,10 +88,10 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node) 
 }
 
 ComponentInstance::ComponentInstance(Circuit& circuit, const library::Component& cmp,
-                                     const Uuid& symbVar, const QString& name) :
+        const Uuid& symbVar, const QString& name, const Uuid& defaultDevice) :
     QObject(&circuit), mCircuit(circuit), mIsAddedToCircuit(false),
-    mUuid(Uuid::createRandom()), mName(name), mLibComponent(&cmp), mCompSymbVar(nullptr),
-    mAttributes()
+    mUuid(Uuid::createRandom()), mName(name), mDefaultDeviceUuid(defaultDevice),
+    mLibComponent(&cmp), mCompSymbVar(nullptr), mAttributes()
 {
     if (mName.isEmpty()) {
         throw RuntimeError(__FILE__, __LINE__,
@@ -338,6 +339,7 @@ void ComponentInstance::serialize(SExpression& root) const
     root.appendToken(mUuid);
     root.appendTokenChild("lib_component", mLibComponent->getUuid(), true);
     root.appendTokenChild("lib_variant", mCompSymbVar->getUuid(), true);
+    root.appendTokenChild("lib_device", mDefaultDeviceUuid, true);
     root.appendStringChild("name", mName, true);
     root.appendStringChild("value", mValue, false);
     mAttributes->serialize(root);

--- a/libs/librepcb/project/circuit/componentinstance.h
+++ b/libs/librepcb/project/circuit/componentinstance.h
@@ -72,13 +72,15 @@ class ComponentInstance : public QObject, public AttributeProvider,
         ComponentInstance(const ComponentInstance& other) = delete;
         explicit ComponentInstance(Circuit& circuit, const SExpression& node);
         explicit ComponentInstance(Circuit& circuit, const library::Component& cmp,
-                                   const Uuid& symbVar, const QString& name);
+                                   const Uuid& symbVar, const QString& name,
+                                   const Uuid& defaultDevice = Uuid());
         ~ComponentInstance() noexcept;
 
         // Getters: Attributes
         const Uuid& getUuid() const noexcept {return mUuid;}
         const QString& getName() const noexcept {return mName;}
         QString getValue(bool replaceAttributes = false) const noexcept;
+        const Uuid& getDefaultDeviceUuid() const noexcept {return mDefaultDeviceUuid;}
         const library::Component& getLibComponent() const noexcept {return *mLibComponent;}
         const library::ComponentSymbolVariant& getSymbolVariant() const noexcept {return *mCompSymbVar;}
         ComponentSignalInstance* getSignalInstance(const Uuid& signalUuid) const noexcept {return mSignals.value(signalUuid);}
@@ -175,6 +177,9 @@ class ComponentInstance : public QObject, public AttributeProvider,
 
         /// @brief The value of this component instance in the circuit (e.g. the resistance of a resistor)
         QString mValue;
+
+        /// @brief THe default device when adding the component to a board
+        Uuid mDefaultDeviceUuid;
 
         /// @brief Pointer to the component in the project's library
         const library::Component* mLibComponent;

--- a/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.cpp
@@ -278,7 +278,10 @@ void UnplacedComponentsDock::setSelectedComponentInstance(ComponentInstance* cmp
             mUi->cbxSelectedDevice->addItem(text, deviceUuid.toStr());
         }
         if (mUi->cbxSelectedDevice->count() > 0) {
-            Uuid deviceUuid = mLastDeviceOfComponent.value(mSelectedComponent->getLibComponent().getUuid());
+            Uuid deviceUuid = mSelectedComponent->getDefaultDeviceUuid();
+            if (deviceUuid.isNull()) {
+                deviceUuid = mLastDeviceOfComponent.value(mSelectedComponent->getLibComponent().getUuid());
+            }
             int index = deviceUuid.isNull() ? 0 : mUi->cbxSelectedDevice->findData(deviceUuid.toStr());
             mUi->cbxSelectedDevice->setCurrentIndex(index);
         }

--- a/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.cpp
@@ -42,10 +42,12 @@ namespace editor {
  ****************************************************************************************/
 
 CmdAddComponentToCircuit::CmdAddComponentToCircuit(workspace::Workspace& workspace,
-        Project& project, const Uuid& component, const Uuid& symbolVariant) noexcept :
+        Project& project, const Uuid& component, const Uuid& symbolVariant,
+        const Uuid& defaultDevice) noexcept :
     UndoCommandGroup(tr("Add component")),
     mWorkspace(workspace), mProject(project),
     mComponentUuid(component), mSymbVarUuid(symbolVariant),
+    mDefaultDeviceUuid(defaultDevice),
     mCmdAddToCircuit(nullptr)
 {
 }
@@ -87,7 +89,8 @@ bool CmdAddComponentToCircuit::performExecute()
 
     // create child command to add a new component instance to the circuit
     mCmdAddToCircuit = new CmdComponentInstanceAdd(mProject.getCircuit(),
-                                                   mComponentUuid, mSymbVarUuid);
+                                                   mComponentUuid, mSymbVarUuid,
+                                                   mDefaultDeviceUuid);
     appendChild(mCmdAddToCircuit); // can throw
 
     // execute all child commands

--- a/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.h
+++ b/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.h
@@ -61,7 +61,8 @@ class CmdAddComponentToCircuit final : public UndoCommandGroup
 
         // Constructors / Destructor
         CmdAddComponentToCircuit(workspace::Workspace& workspace, Project& project,
-                                 const Uuid& component, const Uuid& symbolVariant) noexcept;
+                                 const Uuid& component, const Uuid& symbolVariant,
+                                 const Uuid& defaultDevice = Uuid()) noexcept;
         ~CmdAddComponentToCircuit() noexcept;
 
         // Getters
@@ -82,6 +83,7 @@ class CmdAddComponentToCircuit final : public UndoCommandGroup
         Project& mProject;
         Uuid mComponentUuid;
         Uuid mSymbVarUuid;
+        Uuid mDefaultDeviceUuid;
 
         // child commands
         CmdComponentInstanceAdd* mCmdAddToCircuit;

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
@@ -26,11 +26,15 @@
 #include "ui_addcomponentdialog.h"
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
+#include <librepcb/common/graphics/defaultgraphicslayerprovider.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/schematics/schematiclayerprovider.h>
 #include <librepcb/project/library/projectlibrary.h>
 #include <librepcb/library/cmp/component.h>
 #include <librepcb/library/cmp/componentsymbolvariant.h>
+#include <librepcb/library/dev/device.h>
+#include <librepcb/library/pkg/package.h>
+#include <librepcb/library/pkg/footprintpreviewgraphicsitem.h>
 #include <librepcb/library/sym/symbol.h>
 #include <librepcb/project/settings/projectsettings.h>
 #include <librepcb/library/sym/symbolpreviewgraphicsitem.h>
@@ -41,6 +45,8 @@
 #include <librepcb/library/cat/componentcategory.h>
 #include <librepcb/workspace/library/workspacelibrarydb.h>
 #include <librepcb/common/gridproperties.h>
+#include <librepcb/project/boards/board.h>
+#include <librepcb/project/boards/boardlayerstack.h>
 
 /*****************************************************************************************
  *  Namespace
@@ -56,19 +62,38 @@ namespace editor {
 AddComponentDialog::AddComponentDialog(workspace::Workspace& workspace, Project& project,
                                        QWidget* parent) :
     QDialog(parent), mWorkspace(workspace), mProject(project),
-    mUi(new Ui::AddComponentDialog), mPreviewScene(nullptr), mCategoryTreeModel(nullptr),
-    mSelectedComponent(nullptr), mSelectedSymbVar(nullptr)
+    mUi(new Ui::AddComponentDialog), mComponentPreviewScene(nullptr),
+    mDevicePreviewScene(nullptr), mCategoryTreeModel(nullptr),
+    mSelectedComponent(nullptr), mSelectedSymbVar(nullptr), mSelectedDevice(nullptr),
+    mSelectedPackage(nullptr), mPreviewFootprintGraphicsItem(nullptr)
 {
     mUi->setupUi(this);
+    mUi->treeComponents->setColumnCount(2);
+    mUi->treeComponents->header()->setStretchLastSection(false);
+    mUi->treeComponents->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    mUi->treeComponents->header()->setSectionResizeMode(1, QHeaderView::Stretch);
     mUi->lblCompDescription->hide();
     mUi->lblSymbVar->hide();
     mUi->cbxSymbVar->hide();
+    mUi->lblDeviceName->hide();
+    mUi->viewDevice->hide();
     connect(mUi->edtSearch, &QLineEdit::textChanged,
             this, &AddComponentDialog::searchEditTextChanged);
+    connect(mUi->treeComponents, &QTreeWidget::currentItemChanged,
+            this, &AddComponentDialog::treeComponents_currentItemChanged);
+    connect(mUi->treeComponents, &QTreeWidget::itemDoubleClicked,
+            this, &AddComponentDialog::treeComponents_itemDoubleClicked);
 
-    mPreviewScene = new GraphicsScene();
-    mUi->graphicsView->setScene(mPreviewScene);
-    mUi->graphicsView->setOriginCrossVisible(false);
+    mComponentPreviewScene = new GraphicsScene();
+    mUi->viewComponent->setScene(mComponentPreviewScene);
+    mUi->viewComponent->setOriginCrossVisible(false);
+
+    mDevicePreviewScene = new GraphicsScene();
+    mUi->viewDevice->setScene(mDevicePreviewScene);
+    mUi->viewDevice->setOriginCrossVisible(false);
+    mUi->viewDevice->setBackgroundBrush(QBrush(Qt::black, Qt::SolidPattern));
+
+    mGraphicsLayerProvider.reset(new DefaultGraphicsLayerProvider());
 
     const QStringList& localeOrder = mProject.getSettings().getLocaleOrder();
     mCategoryTreeModel = new workspace::ComponentCategoryTreeModel(mWorkspace.getLibraryDb(), localeOrder);
@@ -79,11 +104,15 @@ AddComponentDialog::AddComponentDialog(workspace::Workspace& workspace, Project&
 
 AddComponentDialog::~AddComponentDialog() noexcept
 {
+    delete mPreviewFootprintGraphicsItem;       mPreviewFootprintGraphicsItem = nullptr;
     qDeleteAll(mPreviewSymbolGraphicsItems);    mPreviewSymbolGraphicsItems.clear();
+    delete mSelectedPackage;                    mSelectedPackage = nullptr;
+    delete mSelectedDevice;                     mSelectedDevice = nullptr;
     mSelectedSymbVar = nullptr;
     delete mSelectedComponent;                  mSelectedComponent = nullptr;
     delete mCategoryTreeModel;                  mCategoryTreeModel = nullptr;
-    delete mPreviewScene;                       mPreviewScene = nullptr;
+    delete mDevicePreviewScene;                 mDevicePreviewScene = nullptr;
+    delete mComponentPreviewScene;              mComponentPreviewScene = nullptr;
     delete mUi;                                 mUi = nullptr;
 }
 
@@ -107,6 +136,14 @@ Uuid AddComponentDialog::getSelectedSymbVarUuid() const noexcept
         return Uuid();
 }
 
+Uuid AddComponentDialog::getSelectedDeviceUuid() const noexcept
+{
+    if (mSelectedComponent && mSelectedSymbVar && mSelectedDevice)
+        return mSelectedDevice->getUuid();
+    else
+        return Uuid();
+}
+
 /*****************************************************************************************
  *  Private Slots
  ****************************************************************************************/
@@ -125,45 +162,56 @@ void AddComponentDialog::searchEditTextChanged(const QString& text) noexcept
     }
 }
 
-void AddComponentDialog::treeCategories_currentItemChanged(const QModelIndex& current, const QModelIndex& previous)
+void AddComponentDialog::treeCategories_currentItemChanged(const QModelIndex& current,
+                                                           const QModelIndex& previous) noexcept
 {
     Q_UNUSED(previous);
 
-    try
-    {
+    try {
         Uuid categoryUuid = Uuid(current.data(Qt::UserRole).toString());
         setSelectedCategory(categoryUuid);
-    }
-    catch (Exception& e)
-    {
+    } catch (Exception& e) {
         QMessageBox::critical(this, tr("Error"), e.getMsg());
     }
 }
 
-void AddComponentDialog::on_listComponents_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous)
+void AddComponentDialog::treeComponents_currentItemChanged(QTreeWidgetItem *current,
+                                                           QTreeWidgetItem *previous) noexcept
 {
     Q_UNUSED(previous);
-    try
-    {
-        if (current)
-        {
-            library::Component* component = new library::Component(
-                FilePath(current->data(Qt::UserRole).toString()), true); // ugly...
-            setSelectedComponent(component);
-        }
-        else
-        {
+    try {
+        if (current) {
+            QTreeWidgetItem* cmpItem = current->parent() ? current->parent() : current;
+            FilePath cmpFp = FilePath(cmpItem->data(0, Qt::UserRole).toString());
+            if ((!mSelectedComponent) || (mSelectedComponent->getFilePath() != cmpFp)) {
+                library::Component* component = new library::Component(cmpFp, true);
+                setSelectedComponent(component);
+            }
+            if (current->parent()) {
+                FilePath devFp = FilePath(current->data(0, Qt::UserRole).toString());
+                if ((!mSelectedDevice) || (mSelectedDevice->getFilePath() != devFp)) {
+                    library::Device* device = new library::Device(devFp, true);
+                    setSelectedDevice(device);
+                }
+            } else {
+                setSelectedDevice(nullptr);
+            }
+        } else {
             setSelectedComponent(nullptr);
         }
-    }
-    catch (Exception& e)
-    {
+    } catch (Exception& e) {
         QMessageBox::critical(this, tr("Error"), e.getMsg());
         setSelectedComponent(nullptr);
     }
 }
 
-void AddComponentDialog::on_cbxSymbVar_currentIndexChanged(int index)
+void AddComponentDialog::treeComponents_itemDoubleClicked(QTreeWidgetItem* item, int column) noexcept
+{
+    Q_UNUSED(column);
+    if (item && item->parent()) accept(); // only accept device items (not components)
+}
+
+void AddComponentDialog::on_cbxSymbVar_currentIndexChanged(int index) noexcept
 {
     if ((mSelectedComponent) && (index >= 0))
         setSelectedSymbVar(mSelectedComponent->getSymbolVariants().find(Uuid(mUi->cbxSymbVar->itemData(index).toString())).get());
@@ -178,51 +226,114 @@ void AddComponentDialog::on_cbxSymbVar_currentIndexChanged(int index)
 void AddComponentDialog::searchComponents(const QString& input)
 {
     setSelectedComponent(nullptr);
-    mUi->listComponents->clear();
+    mUi->treeComponents->clear();
 
     if (input.length() > 1) { // avoid freeze on entering first character due to huge result
         const QStringList& localeOrder = mProject.getSettings().getLocaleOrder();
         QSet<Uuid> components = mWorkspace.getLibraryDb().getComponentsBySearchKeyword(input);
         foreach (const Uuid& cmpUuid, components) {
+            // component
             FilePath cmpFp = mWorkspace.getLibraryDb().getLatestComponent(cmpUuid);
             if (!cmpFp.isValid()) continue;
-            QString name;
-            mWorkspace.getLibraryDb().getElementTranslations<library::Component>(cmpFp, localeOrder, &name);
-            QListWidgetItem* item = new QListWidgetItem(name);
-            item->setData(Qt::UserRole, cmpFp.toStr());
-            mUi->listComponents->addItem(item);
+            QString cmpName;
+            mWorkspace.getLibraryDb().getElementTranslations<library::Component>(cmpFp, localeOrder, &cmpName);
+            QTreeWidgetItem* cmpItem = new QTreeWidgetItem(mUi->treeComponents);
+            cmpItem->setText(0, cmpName);
+            cmpItem->setData(0, Qt::UserRole, cmpFp.toStr());
+            // devices
+            QSet<Uuid> devices = mWorkspace.getLibraryDb().getDevicesOfComponent(cmpUuid);
+            foreach (const Uuid& devUuid, devices) {
+                try {
+                    FilePath devFp = mWorkspace.getLibraryDb().getLatestDevice(devUuid);
+                    if (!devFp.isValid()) continue;
+                    QString devName;
+                    mWorkspace.getLibraryDb().getElementTranslations<library::Device>(devFp, localeOrder, &devName);
+                    QTreeWidgetItem* devItem = new QTreeWidgetItem(cmpItem);
+                    devItem->setText(0, devName);
+                    devItem->setData(0, Qt::UserRole, devFp.toStr());
+                    // package
+                    Uuid pkgUuid;
+                    mWorkspace.getLibraryDb().getDeviceMetadata(devFp, &pkgUuid);
+                    if (!pkgUuid.isNull()) {
+                        FilePath pkgFp = mWorkspace.getLibraryDb().getLatestPackage(pkgUuid);
+                        if (pkgFp.isValid()) {
+                            QString pkgName;
+                            mWorkspace.getLibraryDb().getElementTranslations<library::Package>(pkgFp, localeOrder, &pkgName);
+                            devItem->setText(1, pkgName);
+                            devItem->setTextAlignment(1, Qt::AlignRight);
+                        }
+                    }
+                } catch (const Exception& e) {
+                    // what could we do here?
+                }
+            }
+            cmpItem->setText(1, QString("[%1]").arg(devices.count()));
+            cmpItem->setTextAlignment(1, Qt::AlignRight);
         }
     }
+
+    mUi->treeComponents->sortByColumn(0, Qt::AscendingOrder);
 }
 
 void AddComponentDialog::setSelectedCategory(const Uuid& categoryUuid)
 {
     setSelectedComponent(nullptr);
-    mUi->listComponents->clear();
+    mUi->treeComponents->clear();
 
     const QStringList& localeOrder = mProject.getSettings().getLocaleOrder();
 
     mSelectedCategoryUuid = categoryUuid;
     QSet<Uuid> components = mWorkspace.getLibraryDb().getComponentsByCategory(categoryUuid);
-    foreach (const Uuid& cmpUuid, components)
-    {
+    foreach (const Uuid& cmpUuid, components) {
+        // component
         FilePath cmpFp = mWorkspace.getLibraryDb().getLatestComponent(cmpUuid);
         if (!cmpFp.isValid()) continue;
-        QString name;
-        mWorkspace.getLibraryDb().getElementTranslations<library::Component>(cmpFp, localeOrder, &name);
-        QListWidgetItem* item = new QListWidgetItem(name);
-        item->setData(Qt::UserRole, cmpFp.toStr());
-        mUi->listComponents->addItem(item);
+        QString cmpName;
+        mWorkspace.getLibraryDb().getElementTranslations<library::Component>(cmpFp, localeOrder, &cmpName);
+        QTreeWidgetItem* cmpItem = new QTreeWidgetItem(mUi->treeComponents);
+        cmpItem->setText(0, cmpName);
+        cmpItem->setData(0, Qt::UserRole, cmpFp.toStr());
+        // devices
+        QSet<Uuid> devices = mWorkspace.getLibraryDb().getDevicesOfComponent(cmpUuid);
+        foreach (const Uuid& devUuid, devices) {
+            try {
+                FilePath devFp = mWorkspace.getLibraryDb().getLatestDevice(devUuid);
+                if (!devFp.isValid()) continue;
+                QString devName;
+                mWorkspace.getLibraryDb().getElementTranslations<library::Device>(devFp, localeOrder, &devName);
+                QTreeWidgetItem* devItem = new QTreeWidgetItem(cmpItem);
+                devItem->setText(0, devName);
+                devItem->setData(0, Qt::UserRole, devFp.toStr());
+                // package
+                Uuid pkgUuid;
+                mWorkspace.getLibraryDb().getDeviceMetadata(devFp, &pkgUuid);
+                if (!pkgUuid.isNull()) {
+                    FilePath pkgFp = mWorkspace.getLibraryDb().getLatestPackage(pkgUuid);
+                    if (pkgFp.isValid()) {
+                        QString pkgName;
+                        mWorkspace.getLibraryDb().getElementTranslations<library::Package>(pkgFp, localeOrder, &pkgName);
+                        devItem->setText(1, pkgName);
+                        devItem->setTextAlignment(1, Qt::AlignRight);
+                    }
+                }
+            } catch (const Exception& e) {
+                // what could we do here?
+            }
+        }
+        cmpItem->setText(1, QString("[%1]").arg(devices.count()));
+        cmpItem->setTextAlignment(1, Qt::AlignRight);
     }
+
+    mUi->treeComponents->sortByColumn(0, Qt::AscendingOrder);
 }
 
 void AddComponentDialog::setSelectedComponent(const library::Component* cmp)
 {
     if (cmp == mSelectedComponent) return;
 
-    mUi->lblCompUuid->setText(QString("00000000-0000-0000-0000-000000000000"));
     mUi->lblCompName->setText(tr("No component selected"));
     mUi->lblCompDescription->clear();
+    setSelectedDevice(nullptr);
     setSelectedSymbVar(nullptr);
     delete mSelectedComponent;
     mSelectedComponent = nullptr;
@@ -231,7 +342,6 @@ void AddComponentDialog::setSelectedComponent(const library::Component* cmp)
     {
         const QStringList& localeOrder = mProject.getSettings().getLocaleOrder();
 
-        mUi->lblCompUuid->setText(cmp->getUuid().toStr());
         mUi->lblCompName->setText(cmp->getNames().value(localeOrder));
         mUi->lblCompDescription->setText(cmp->getDescriptions().value(localeOrder));
 
@@ -265,14 +375,48 @@ void AddComponentDialog::setSelectedSymbVar(const library::ComponentSymbolVarian
             if (!symbolFp.isValid()) continue; // TODO: show warning
             const library::Symbol* symbol = new library::Symbol(symbolFp, true); // TODO: fix memory leak...
             library::SymbolPreviewGraphicsItem* graphicsItem = new library::SymbolPreviewGraphicsItem(
-                mProject.getLayers(), localeOrder, *symbol, mSelectedComponent, symbVar->getUuid(), item.getUuid());
+                *mGraphicsLayerProvider, localeOrder, *symbol, mSelectedComponent,
+                symbVar->getUuid(), item.getUuid());
             graphicsItem->setPos(item.getSymbolPosition().toPxQPointF());
             graphicsItem->setRotation(-item.getSymbolRotation().toDeg());
             mPreviewSymbolGraphicsItems.append(graphicsItem);
-            mPreviewScene->addItem(*graphicsItem);
-            mUi->graphicsView->zoomAll();
+            mComponentPreviewScene->addItem(*graphicsItem);
+            mUi->viewComponent->zoomAll();
         }
     }
+}
+
+void AddComponentDialog::setSelectedDevice(const library::Device* dev)
+{
+    if (dev == mSelectedDevice) return;
+
+    delete mPreviewFootprintGraphicsItem;   mPreviewFootprintGraphicsItem = nullptr;
+    delete mSelectedPackage;                mSelectedPackage = nullptr;
+    delete mSelectedDevice;                 mSelectedDevice = nullptr;
+
+    if (dev) {
+        mSelectedDevice = dev;
+        const QStringList& localeOrder = mProject.getSettings().getLocaleOrder();
+        FilePath pkgFp = mWorkspace.getLibraryDb().getLatestPackage(mSelectedDevice->getPackageUuid());
+        if (pkgFp.isValid()) {
+            mSelectedPackage = new library::Package(pkgFp, true);
+            mUi->lblDeviceName->setText(QString("%1 [%2]").arg(
+                mSelectedDevice->getNames().value(localeOrder),
+                mSelectedPackage->getNames().value(localeOrder)));
+            if (mSelectedPackage->getFootprints().count() > 0) {
+                mPreviewFootprintGraphicsItem = new library::FootprintPreviewGraphicsItem(
+                    *mGraphicsLayerProvider, localeOrder,
+                    *mSelectedPackage->getFootprints().first(), mSelectedPackage,
+                    mSelectedComponent);
+                mDevicePreviewScene->addItem(*mPreviewFootprintGraphicsItem);
+                mUi->viewDevice->zoomAll();
+            }
+        }
+    }
+
+    mUi->lblDeviceName->setVisible(dev ? true : false);
+    mUi->viewDevice->setVisible(dev ? true : false);
+    mUi->viewComponent->zoomAll();
 }
 
 void AddComponentDialog::accept() noexcept

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
@@ -88,7 +88,7 @@ class AddComponentDialog final : public QDialog
 
 
     private slots:
-
+        void searchEditTextChanged(const QString& text) noexcept;
         void treeCategories_currentItemChanged(const QModelIndex& current, const QModelIndex& previous);
         void on_listComponents_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
         void on_cbxSymbVar_currentIndexChanged(int index);
@@ -97,6 +97,7 @@ class AddComponentDialog final : public QDialog
     private:
 
         // Private Methods
+        void searchComponents(const QString& input);
         void setSelectedCategory(const Uuid& categoryUuid);
         void setSelectedComponent(const library::Component* cmp);
         void setSelectedSymbVar(const library::ComponentSymbolVariant* symbVar);

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
@@ -36,8 +36,12 @@
 namespace librepcb {
 
 class GraphicsScene;
+class DefaultGraphicsLayerProvider;
 
 namespace library {
+class Device;
+class Package;
+class FootprintPreviewGraphicsItem;
 class Component;
 class ComponentSymbolVariant;
 class Symbol;
@@ -85,13 +89,17 @@ class AddComponentDialog final : public QDialog
         // Getters
         Uuid getSelectedComponentUuid() const noexcept;
         Uuid getSelectedSymbVarUuid() const noexcept;
+        Uuid getSelectedDeviceUuid() const noexcept;
 
 
     private slots:
         void searchEditTextChanged(const QString& text) noexcept;
-        void treeCategories_currentItemChanged(const QModelIndex& current, const QModelIndex& previous);
-        void on_listComponents_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
-        void on_cbxSymbVar_currentIndexChanged(int index);
+        void treeCategories_currentItemChanged(const QModelIndex& current,
+                                               const QModelIndex& previous) noexcept;
+        void treeComponents_currentItemChanged(QTreeWidgetItem *current,
+                                               QTreeWidgetItem *previous) noexcept;
+        void treeComponents_itemDoubleClicked(QTreeWidgetItem* item, int column) noexcept;
+        void on_cbxSymbVar_currentIndexChanged(int index) noexcept;
 
 
     private:
@@ -101,6 +109,7 @@ class AddComponentDialog final : public QDialog
         void setSelectedCategory(const Uuid& categoryUuid);
         void setSelectedComponent(const library::Component* cmp);
         void setSelectedSymbVar(const library::ComponentSymbolVariant* symbVar);
+        void setSelectedDevice(const library::Device* dev);
         void accept() noexcept;
 
 
@@ -108,7 +117,9 @@ class AddComponentDialog final : public QDialog
         workspace::Workspace& mWorkspace;
         Project& mProject;
         Ui::AddComponentDialog* mUi;
-        GraphicsScene* mPreviewScene;
+        GraphicsScene* mComponentPreviewScene;
+        GraphicsScene* mDevicePreviewScene;
+        QScopedPointer<DefaultGraphicsLayerProvider> mGraphicsLayerProvider;
         workspace::ComponentCategoryTreeModel* mCategoryTreeModel;
 
 
@@ -116,7 +127,10 @@ class AddComponentDialog final : public QDialog
         Uuid mSelectedCategoryUuid;
         const library::Component* mSelectedComponent;
         const library::ComponentSymbolVariant* mSelectedSymbVar;
+        const library::Device* mSelectedDevice;
+        const library::Package* mSelectedPackage;
         QList<library::SymbolPreviewGraphicsItem*> mPreviewSymbolGraphicsItems;
+        library::FootprintPreviewGraphicsItem* mPreviewFootprintGraphicsItem;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>883</width>
-    <height>502</height>
+    <width>925</width>
+    <height>510</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,147 +15,147 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAsNeeded</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>863</width>
-        <height>451</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="4,5,4">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QLineEdit" name="edtSearch">
-           <property name="placeholderText">
-            <string>What are you looking for?</string>
-           </property>
-           <property name="clearButtonEnabled">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QTreeView" name="treeCategories">
-           <property name="editTriggers">
-            <set>QAbstractItemView::NoEditTriggers</set>
-           </property>
-           <property name="headerHidden">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QListWidget" name="listComponents">
-         <property name="minimumSize">
-          <size>
-           <width>150</width>
-           <height>0</height>
-          </size>
+        <widget class="QLineEdit" name="edtSearch">
+         <property name="placeholderText">
+          <string>What are you looking for?</string>
          </property>
-         <property name="sortingEnabled">
+         <property name="clearButtonEnabled">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <widget class="QTreeView" name="treeCategories">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="headerHidden">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QTreeWidget" name="treeComponents">
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
+       <property name="headerHidden">
+        <bool>true</bool>
+       </property>
+       <property name="columnCount">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,1,0,1">
+       <item>
+        <widget class="QLabel" name="lblCompName">
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>No component selected</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblCompDescription">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
          <item>
-          <widget class="QLabel" name="lblCompName">
-           <property name="font">
-            <font>
-             <pointsize>11</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
+          <widget class="QLabel" name="lblSymbVar">
            <property name="text">
-            <string>No component selected</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+            <string>Variant:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="lblCompDescription">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="lblCompUuid">
-           <property name="font">
-            <font>
-             <family>Liberation Mono</family>
-            </font>
-           </property>
-           <property name="text">
-            <string>00000000-0000-0000-0000-000000000000</string>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
-           <item>
-            <widget class="QLabel" name="lblSymbVar">
-             <property name="text">
-              <string>Variant:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="cbxSymbVar"/>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="GraphicsView" name="graphicsView">
-           <property name="verticalScrollBarPolicy">
-            <enum>Qt::ScrollBarAlwaysOff</enum>
-           </property>
-           <property name="horizontalScrollBarPolicy">
-            <enum>Qt::ScrollBarAlwaysOff</enum>
-           </property>
-          </widget>
+          <widget class="QComboBox" name="cbxSymbVar"/>
          </item>
         </layout>
        </item>
+       <item>
+        <widget class="GraphicsView" name="viewComponent">
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblDeviceName">
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>No device selected</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="GraphicsView" name="viewDevice">
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+        </widget>
+       </item>
       </layout>
-     </widget>
-    </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -179,8 +179,6 @@
  <tabstops>
   <tabstop>edtSearch</tabstop>
   <tabstop>treeCategories</tabstop>
-  <tabstop>listComponents</tabstop>
-  <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
@@ -33,11 +33,28 @@
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QTreeView" name="treeCategories">
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QLineEdit" name="edtSearch">
+           <property name="placeholderText">
+            <string>What are you looking for?</string>
+           </property>
+           <property name="clearButtonEnabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QTreeView" name="treeCategories">
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="headerHidden">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QListWidget" name="listComponents">
@@ -254,6 +271,12 @@
    <header location="global">librepcb/common/graphics/graphicsview.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtSearch</tabstop>
+  <tabstop>treeCategories</tabstop>
+  <tabstop>listComponents</tabstop>
+  <tabstop>scrollArea</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1124</width>
-    <height>592</height>
+    <width>883</width>
+    <height>502</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QScrollArea" name="scrollArea">
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
      <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarAsNeeded</enum>
      </property>
@@ -27,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1104</width>
-        <height>539</height>
+        <width>863</width>
+        <height>451</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
@@ -72,178 +75,80 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
-          <widget class="QGroupBox" name="gbxComponent">
-           <property name="title">
-            <string>Component</string>
+          <widget class="QLabel" name="lblCompName">
+           <property name="font">
+            <font>
+             <pointsize>11</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
            </property>
-           <layout class="QFormLayout" name="formLayout">
-            <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_4">
-              <property name="text">
-               <string>Name:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="lblCompName">
-              <property name="text">
-               <string>-</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>UUID:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="lblCompUuid">
-              <property name="font">
-               <font>
-                <family>Liberation Mono</family>
-               </font>
-              </property>
-              <property name="text">
-               <string>00000000-0000-0000-0000-000000000000</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_6">
-              <property name="text">
-               <string>Description:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLabel" name="lblCompDescription">
-              <property name="text">
-               <string>-</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <property name="text">
+            <string>No component selected</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           </property>
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="gbxSymbVar">
-           <property name="title">
-            <string>Symbol Variant</string>
+          <widget class="QLabel" name="lblCompDescription">
+           <property name="font">
+            <font>
+             <italic>true</italic>
+            </font>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
-            <item>
-             <layout class="QFormLayout" name="formLayout_3">
-              <property name="fieldGrowthPolicy">
-               <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>Name:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="cbxSymbVar"/>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label">
-                <property name="text">
-                 <string>UUID:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="lblSymbVarUuid">
-                <property name="font">
-                 <font>
-                  <family>Liberation Mono</family>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>00000000-0000-0000-0000-000000000000</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-                <property name="textInteractionFlags">
-                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_11">
-                <property name="text">
-                 <string>Description:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QLabel" name="lblSymbVarDescription">
-                <property name="text">
-                 <string>-</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-                <property name="textInteractionFlags">
-                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Norm:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QLabel" name="lblSymbVarNorm">
-                <property name="text">
-                 <string>-</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-                <property name="textInteractionFlags">
-                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="GraphicsView" name="graphicsView">
-              <property name="verticalScrollBarPolicy">
-               <enum>Qt::ScrollBarAlwaysOff</enum>
-              </property>
-              <property name="horizontalScrollBarPolicy">
-               <enum>Qt::ScrollBarAlwaysOff</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblCompUuid">
+           <property name="font">
+            <font>
+             <family>Liberation Mono</family>
+            </font>
+           </property>
+           <property name="text">
+            <string>00000000-0000-0000-0000-000000000000</string>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+           <item>
+            <widget class="QLabel" name="lblSymbVar">
+             <property name="text">
+              <string>Variant:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="cbxSymbVar"/>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="GraphicsView" name="graphicsView">
+           <property name="verticalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
           </widget>
          </item>
         </layout>

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
@@ -324,7 +324,8 @@ void SES_AddComponent::startAddingComponent(const Uuid& cmp, const Uuid& symbVar
             // add selected component to circuit
             auto cmd = new CmdAddComponentToCircuit(mWorkspace, mProject,
                 mAddComponentDialog->getSelectedComponentUuid(),
-                mAddComponentDialog->getSelectedSymbVarUuid());
+                mAddComponentDialog->getSelectedSymbVarUuid(),
+                mAddComponentDialog->getSelectedDeviceUuid());
             mUndoStack.appendToCmdGroup(cmd);
             mCurrentComponent = cmd->getComponentInstance();
         }

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -320,6 +320,32 @@ QSet<Uuid> WorkspaceLibraryDb::getDevicesOfComponent(const Uuid& component) cons
     return elements;
 }
 
+QSet<Uuid> WorkspaceLibraryDb::getComponentsBySearchKeyword(const QString& keyword) const
+{
+    QSqlQuery query = mDb->prepareQuery(
+        "SELECT components.uuid FROM components, components_tr, devices, devices_tr "
+        "ON components.id=components_tr.component_id "
+        "AND devices.id=devices_tr.device_id "
+        "AND devices.component_uuid=components.uuid "
+        "WHERE components_tr.name LIKE :keyword "
+        "OR components_tr.keywords LIKE :keyword "
+        "OR devices_tr.name LIKE :keyword "
+        "OR devices_tr.keywords LIKE :keyword ");
+    query.bindValue(":keyword", "%" + keyword + "%");
+    mDb->exec(query);
+
+    QSet<Uuid> elements;
+    while (query.next()) {
+        Uuid uuid(query.value(0).toString());
+        if (!uuid.isNull()) {
+            elements.insert(uuid);
+        } else {
+            throw LogicError(__FILE__, __LINE__);
+        }
+    }
+    return elements;
+}
+
 /*****************************************************************************************
  *  General Methods
  ****************************************************************************************/

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -106,6 +106,7 @@ class WorkspaceLibraryDb final : public QObject
         QSet<Uuid> getComponentsByCategory(const Uuid& category) const;
         QSet<Uuid> getDevicesByCategory(const Uuid& category) const;
         QSet<Uuid> getDevicesOfComponent(const Uuid& component) const;
+        QSet<Uuid> getComponentsBySearchKeyword(const QString& keyword) const;
 
         // General Methods
 


### PR DESCRIPTION
When adding a component to the schematic, it was not yet possible to choose a specific device. Devices were not even displayed in the dialog, so the user had no idea which devices (resp. packages) are available for the chosen component.

With this PR, all devices (and their packages) of every listed component are now also shown in the dialog. The user can now even choose a specific device (instead of a component), which is then automatically used when adding the component to the board later. But this is optional, the user can still only choose a component and then choose the exact device some time later.

In addition, this PR also adds a very powerful search field to the dialog, which allows to search in the whole workspace library for components and devices! This way the user is able to find components and devices very quickly.

![add component_010](https://user-images.githubusercontent.com/5374821/32121284-52a2a3c0-bb5c-11e7-9cd1-1a1b95adc4a6.png)