### PR TITLE
Rename "item" to "gate" in components and schematics

### DIFF
--- a/libs/librepcb/library/cmp/componentsymbolvariant.cpp
+++ b/libs/librepcb/library/cmp/componentsymbolvariant.cpp
@@ -62,6 +62,11 @@ ComponentSymbolVariant::ComponentSymbolVariant(const SExpression& node) :
     // Load all symbol variant items
     mSymbolItems.loadFromDomElement(node);
 
+    // backward compatibility, remove this some time!
+    foreach (const SExpression& node, node.getChildren("item")) {
+        mSymbolItems.append(std::make_shared<ComponentSymbolVariantItem>(node)); // can throw
+    }
+
     if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 }
 

--- a/libs/librepcb/library/cmp/componentsymbolvariantitem.h
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitem.h
@@ -51,6 +51,8 @@ namespace library {
  *  - UUID
  *  - Symbol UUID
  *  - Pin-signal-mapping
+ *
+ * @todo Rename class to "ComponentGate" (or similar) and rename related classes if needed
  */
 class ComponentSymbolVariantItem final : public SerializableObject
 {
@@ -112,7 +114,7 @@ class ComponentSymbolVariantItem final : public SerializableObject
  *  Class ComponentSymbolVariantItemList
  ****************************************************************************************/
 
-struct ComponentSymbolVariantItemListNameProvider {static constexpr const char* tagname = "item";};
+struct ComponentSymbolVariantItemListNameProvider {static constexpr const char* tagname = "gate";};
 using ComponentSymbolVariantItemList = SerializableObjectList<ComponentSymbolVariantItem, ComponentSymbolVariantItemListNameProvider>;
 using CmdComponentSymbolVariantItemInsert = CmdListElementInsert<ComponentSymbolVariantItem, ComponentSymbolVariantItemListNameProvider>;
 using CmdComponentSymbolVariantItemRemove = CmdListElementRemove<ComponentSymbolVariantItem, ComponentSymbolVariantItemListNameProvider>;

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -56,7 +56,13 @@ SI_Symbol::SI_Symbol(Schematic& schematic, const SExpression& node) :
     }
     mPosition = Point(node.getChildByPath("pos"));
     mRotation = node.getValueByPath<Angle>("rot", true);
-    Uuid symbVarItemUuid = node.getValueByPath<Uuid>("lib_item", true);
+    Uuid symbVarItemUuid;
+    if (node.tryGetChildByPath("lib_gate")) {
+        symbVarItemUuid = node.getValueByPath<Uuid>("lib_gate", true);
+    } else {
+        // backward compatibility, remove this some time!
+        symbVarItemUuid = node.getValueByPath<Uuid>("lib_item", true);
+    }
     init(symbVarItemUuid);
 }
 
@@ -189,7 +195,7 @@ void SI_Symbol::serialize(SExpression& root) const
 
     root.appendToken(mUuid);
     root.appendTokenChild("component", mComponentInstance->getUuid(), true);
-    root.appendTokenChild("lib_item", mSymbVarItem->getUuid(), true);
+    root.appendTokenChild("lib_gate", mSymbVarItem->getUuid(), true);
     root.appendChild(mPosition.serializeToDomElement("pos"), true);
     root.appendTokenChild("rot", mRotation, false);
 }


### PR DESCRIPTION
A component (resp. a symbol variant of it) consists of one or more independent symbols (for example an OpAmp could have one power symbol and one amplifier symbol). Such a symbol is currently called `ComponentSymbolVariantItem` in the source code, and `item` in files (resp. `lib_item` in schematic files).

But actually I wonder why I didn't name it `gate`, like other tools do :thinking:

I think `gate` is more expressive than `item` (?), so I would just rename that now...