### PR TITLE
Convert about dialog to QML

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -23,6 +23,8 @@
 #include <QtCore>
 #include <QtWidgets>
 #include <QFileDialog>
+#include <QQuickView>
+#include <QQmlContext>
 #include "controlpanel.h"
 #include "ui_controlpanel.h"
 #include <librepcb/workspace/workspace.h>
@@ -411,14 +413,11 @@ void ControlPanel::projectEditorClosed() noexcept
 
 void ControlPanel::on_actionAbout_triggered()
 {
-    QMessageBox::about(this, tr("About LibrePCB"), QString(tr(
-        "<h1>About LibrePCB</h1>"
-        "<p>LibrePCB is a free & open source schematic/layout-editor.</p>"
-        "<p>Version: %1 (%2)</p>"
-        "<p>Please see <a href='http://librepcb.org/'>librepcb.org</a> for more information.</p>"
-        "You can find the project on GitHub:<br>"
-        "<a href='https://github.com/LibrePCB/LibrePCB'>https://github.com/LibrePCB/LibrePCB</a>"))
-        .arg(qApp->getAppVersion().toPrettyStr(3), qApp->getGitVersion()));
+    QQuickView *view = new QQuickView(QUrl("qrc:/qml/dialogs/about.qml"));
+    view->rootContext()->setContextProperty("view", view);
+    view->rootContext()->setContextProperty("appVersion", qApp->getAppVersion().toPrettyStr(3));
+    view->rootContext()->setContextProperty("gitVersion", qApp->getGitVersion());
+    view->show();
 }
 
 void ControlPanel::on_actionNew_Project_triggered()

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -16,7 +16,7 @@ include(../../common.pri)
 # Set preprocessor defines
 exists(../../.git):DEFINES += GIT_BRANCH=\\\"master\\\"
 
-QT += core widgets opengl network xml printsupport sql
+QT += core widgets opengl network xml printsupport sql quick
 
 win32 {
     # Windows-specific configurations
@@ -85,7 +85,8 @@ TRANSLATIONS = \
     ../../i18n/librepcb_gsw_CH.ts
 
 RESOURCES += \
-    ../../img/images.qrc
+    ../../img/images.qrc \
+    ../../qml/qml.qrc \
 
 SOURCES += \
     controlpanel/controlpanel.cpp \

--- a/qml/dialogs/about.qml
+++ b/qml/dialogs/about.qml
@@ -1,0 +1,51 @@
+import QtQuick 2.7
+import QtQuick.Controls 1.4
+import QtQuick.Layouts 1.2
+
+Item {
+    width: layout.width + 12
+    height: layout.height + 12
+
+    ColumnLayout {
+        id: layout
+        spacing: 12
+
+        Image {
+            source: "qrc:/img/logo/64x64.png"
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        Text {
+            text: qsTr("About LibrePCB")
+            font.pointSize: 18
+            font.bold: true
+        }
+
+        Text {
+            text: qsTr("LibrePCB is a free & open source schematic/layout-editor.")
+        }
+
+        Text {
+            text: qsTr("Version: %1 (%2)").arg(appVersion).arg(gitVersion)
+        }
+
+        Text {
+            text: qsTr("Please see %1 for more information.").arg("<a href='http://librepcb.org/'>librepcb.org</a>")
+            onLinkActivated: Qt.openUrlExternally(link)
+        }
+
+        Text {
+            text: qsTr("You can find the project on GitHub:<br>%1").arg("<a href='https://github.com/LibrePCB/LibrePCB'>https://github.com/LibrePCB/LibrePCB</a>")
+            onLinkActivated: Qt.openUrlExternally(link)
+        }
+
+        Button {
+            text: "Close"
+            anchors.horizontalCenter: parent.horizontalCenter
+            onClicked: {
+                view.close()
+            }
+        }
+    }
+
+}

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/qml">
+        <file>dialogs/about.qml</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
This is a first attempt at integrating QML based views into LibrePCB (#17).

The QML files are included as Qt resources, so they don't need to be distributed separately.

Data is passed to the `QQuickView` using `setContextProperty`. Maybe the version stuff could be wrapped into a separate `QObject`. I think QML objects can also expose their own slots and signals for full interaction with C++ code.

Layout is not very pretty yet, I haven't figured out how to do left/top margin yet.

Some initial feedback would be nice 🙂 