### PR TITLE
Update/improve Readme and Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@
 - Make sure you have a [GitHub account](https://github.com/signup/free).
 - Open a new issue for your idea, assuming one does not already exist.
 - Fork the repository on GitHub.
-- Have a look at our [development resources](https://github.com/LibrePCB/LibrePCB/tree/master/dev), 
+- Have a look at our [development resources](https://github.com/LibrePCB/LibrePCB/tree/master/dev),
   especially at the [Doxygen documentation](http://librepcb.org/LibrePCB-Doxygen/master/).
 - When using QtCreator, import and use our [code style guide file](https://github.com/LibrePCB/LibrePCB/blob/master/dev/CodingStyle_QtCreator.xml).
 
@@ -24,7 +24,7 @@
 
 - Create a topic branch from where you want to base your work.
   - This is usually the master branch.
-  - To quickly create a topic branch based on master: 
+  - To quickly create a topic branch based on master:
     `git checkout -b my_contribution master`
   - Please avoid working directly on the `master` branch.
 - Write code which follows our [code style guides](http://librepcb.org/LibrePCB-Doxygen/master/df/d24/doc_code_style_guide.html)
@@ -44,7 +44,7 @@ Fixes #62
 - Make sure you have added the necessary tests for your changes.
 - Run all tests to ensure nothing else was accidentally broken.
   - This is done by running the binary `./generated/unix|mac|windows/tests`
-- If you like, feel free to add yourself to the 
+- If you like, feel free to add yourself to the
   [AUTHORS.md](https://github.com/LibrePCB/LibrePCB/blob/master/AUTHORS.md) file.
 
 ## Submitting Changes
@@ -60,14 +60,17 @@ This project welcomes non-code contributions, too! The following types of contri
 - **Ideas**: Participate in an issue thread or start your own to have your voice heard.
 - **Bugreports**: Found a bug in LibrePCB? Just open an issue and describe how to reproduce that bug.
 - **Small Fixes**: Fix typos, clarify language, and generally improve the quality of the content.
-- **Documentation**: Create/improve documentations for end-users or for developers of LibrePCB.
-- **Translations**: Add/improve [translations for LibrePCB](https://github.com/LibrePCB/LibrePCB/tree/master/i18n).
+- **Documentation**: Create/improve [documentations for users](https://github.com/LibrePCB/librepcb-doc)
+  or developers of LibrePCB.
+- ~~**Translations**: Add/improve [translations for LibrePCB](https://github.com/LibrePCB/LibrePCB/tree/master/i18n).~~
+  *(not yet applicable)*
 - **Website**: Improve our [website](http://librepcb.org) which is hosted in the repository [LibrePCB/LibrePCB.github.io](https://github.com/LibrePCB/LibrePCB.github.io).
 - **Sharing**: Speak about LibrePCB with your friends and colleagues, or write about it in the internet!
-- **Donations**: Donate to the LibrePCB developers with Bitcoin: [1FiXZxoXe3px1nNuNygRb1NwcYr6U8AvG8](bitcoin:1FiXZxoXe3px1nNuNygRb1NwcYr6U8AvG8)
+- **Donations**: [Become a Patron](https://www.patreon.com/librepcb)
+  or donate to the LibrePCB developers with Bitcoin:
+  [1FiXZxoXe3px1nNuNygRb1NwcYr6U8AvG8](bitcoin:1FiXZxoXe3px1nNuNygRb1NwcYr6U8AvG8)
 
 # Additional Resources
 
 - [General GitHub documentation](https://help.github.com/)
 - [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
-

--- a/README.md
+++ b/README.md
@@ -27,23 +27,27 @@ The project is still in a quite early development stage (no stable release avail
 - Automatic netlist synchronisation between schematic and board
 
 
-## Installation
-
-There are no stable releases available yet, so basically you need to compile
-LibrePCB by yourself. Nevertheless there are easier ways to get LibrePCB running:
-
-- For Windows there are nightly builds available to download: 
-  [librepcb-nightly.zip](https://ci.appveyor.com/api/projects/librepcb/librepcb/artifacts/build/librepcb-nightly.zip?branch=master)
-- For Linux there are nightly [AppImages](http://appimage.org/) available on [Bintray](https://bintray.com/librepcb):
-  [LibrePCB-Nightly-Linux-x86_64.AppImage](https://bintray.com/librepcb/LibrePCB-Nightly/download_file?file_path=LibrePCB-Nightly-Linux-x86_64.AppImage)
-- On Arch Linux you can install the package 
-  [librepcb-git](https://aur.archlinux.org/packages/librepcb-git/) from the AUR.
-- Using a [Docker](https://www.docker.com/) container you can build and run LibrePCB
-  on any Linux without cluttering up your system with all the requirements. Just follow
-  [these instructions](https://github.com/LibrePCB/LibrePCB/tree/master/dev/docker).
+## Installation & Usage
 
 *Warning: Because LibrePCB's file format is not yet considered as stable (i.e.
 breaking changes can occur), you should not yet use LibrePCB productively!*
+
+**Please read our [documentation](https://docs.librepcb.org/) to see how you can
+install and use LibrePCB.**
+The [Getting Started](https://docs.librepcb.org/getting_started/) guide
+gives you a quick introduction to LibrePCB.
+
+In addition to the installation methods described in the documentation, Arch
+Linux users can also install the package
+[librepcb-git](https://aur.archlinux.org/packages/librepcb-git/) from the AUR.
+The package clones and builds the latest (unstable!) version of the `master`
+branch from GitHub.
+
+
+## Contributing
+
+Contributions are welcome! See our [Contributing Guide](CONTRIBUTING.md) for
+details.
 
 
 ## Development
@@ -56,6 +60,13 @@ To compile LibrePCB, you need the following software components:
 - [Qt](http://www.qt.io/download-open-source/) >= 5.2
 - [zlib](http://www.zlib.net/)
 - [OpenSSL](https://www.openssl.org/)
+
+#### Prepared Docker Image
+
+Instead of installing the dependencies manually on your system (see instructions
+below), you can also use our [Docker](https://www.docker.com/) image with all
+dependencies pre-installed. Just follow
+[these instructions](https://github.com/LibrePCB/LibrePCB/tree/master/dev/docker).
 
 #### Installation on Debian/Ubuntu/Mint
 
@@ -80,9 +91,9 @@ sudo pacman -S qt5-doc qtcreator # optional
 
 #### Installation on Windows
 
-Download and run the 
-[Qt for Windows (MinGW) installer](http://download.qt.io/official_releases/qt/5.8/5.8.0/qt-opensource-windows-x86-mingw530-5.8.0.exe) 
-from [here](https://www.qt.io/download-open-source/). LibrePCB does not compile 
+Download and run the
+[Qt for Windows (MinGW) installer](http://download.qt.io/official_releases/qt/5.8/5.8.0/qt-opensource-windows-x86-mingw530-5.8.0.exe)
+from [here](https://www.qt.io/download-open-source/). LibrePCB does not compile
 with MSVC, so you must install following components with the Qt installer:
 
 - The MinGW compiler itself
@@ -139,18 +150,15 @@ On a Unix/Linux system, LibrePCB can be installed with `sudo make install`.
 ### Workspace
 
 At the first startup, LibrePCB asks for a workspace directory where the library
-elements and projects will be saved.  For developers there is a demo workspace
-inclusive library and projects in the submodule "dev/demo-workspace/".
-
-*Note: As LibrePCB is still under heavy developement, it's highly recommended to
-use this demo workspace. Otherwise you won't be able to create/use any 
-components and some parts of the application will not work properly.*
+elements and projects are located. For developers there is a demo workspace
+inclusive some libraries and projects in the submodule
+[`dev/demo-workspace/`](https://github.com/LibrePCB/demo-workspace).
 
 
 ## Credits
 
 - First of all, many thanks to all of our [contributors](AUTHORS.md)!
-- Thanks also to [cloudscale.ch](https://www.cloudscale.ch/) for sponsoring our 
+- Thanks also to [cloudscale.ch](https://www.cloudscale.ch/) for sponsoring our
   API server!
 
 


### PR DESCRIPTION
As there is now documentation for users available at docs.librepcb.org, I replaced the installation instructions with a link to the documentation. In addition, the demo workspace is no longer required for users, so I removed the corresponding note.

See also: #199, #205