### PR TITLE
Disable unimplemented menu items and icons in the schematic and board editor

### DIFF
--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -51,18 +51,18 @@ ComponentSignalListEditorWidget::ComponentSignalListEditorWidget(QWidget* parent
     mTable->setHorizontalHeaderItem(COLUMN_NAME,          new QTableWidgetItem(tr("Name")));
     //mTable->setHorizontalHeaderItem(COLUMN_ROLE,          new QTableWidgetItem(tr("Role (ERC)")));
     mTable->setHorizontalHeaderItem(COLUMN_ISREQUIRED,    new QTableWidgetItem(tr("Required")));
-    mTable->setHorizontalHeaderItem(COLUMN_ISNEGATED,     new QTableWidgetItem(tr("Negated")));
-    mTable->setHorizontalHeaderItem(COLUMN_ISCLOCK,       new QTableWidgetItem(tr("Clock")));
+    //mTable->setHorizontalHeaderItem(COLUMN_ISNEGATED,     new QTableWidgetItem(tr("Negated")));
+    //mTable->setHorizontalHeaderItem(COLUMN_ISCLOCK,       new QTableWidgetItem(tr("Clock")));
     mTable->setHorizontalHeaderItem(COLUMN_FORCEDNETNAME, new QTableWidgetItem(tr("Forced Net")));
     mTable->setHorizontalHeaderItem(COLUMN_BUTTONS,       new QTableWidgetItem(""));
     mTable->horizontalHeaderItem(COLUMN_ISREQUIRED)->setTextAlignment(Qt::AlignCenter);
-    mTable->horizontalHeaderItem(COLUMN_ISNEGATED)->setTextAlignment(Qt::AlignCenter);
-    mTable->horizontalHeaderItem(COLUMN_ISCLOCK)->setTextAlignment(Qt::AlignCenter);
+    //mTable->horizontalHeaderItem(COLUMN_ISNEGATED)->setTextAlignment(Qt::AlignCenter);
+    //mTable->horizontalHeaderItem(COLUMN_ISCLOCK)->setTextAlignment(Qt::AlignCenter);
     mTable->horizontalHeader()->setSectionResizeMode(COLUMN_NAME,          QHeaderView::Stretch);
     //mTable->horizontalHeader()->setSectionResizeMode(COLUMN_ROLE,          QHeaderView::ResizeToContents);
     mTable->horizontalHeader()->setSectionResizeMode(COLUMN_ISREQUIRED,    QHeaderView::ResizeToContents);
-    mTable->horizontalHeader()->setSectionResizeMode(COLUMN_ISNEGATED,     QHeaderView::ResizeToContents);
-    mTable->horizontalHeader()->setSectionResizeMode(COLUMN_ISCLOCK,       QHeaderView::ResizeToContents);
+    //mTable->horizontalHeader()->setSectionResizeMode(COLUMN_ISNEGATED,     QHeaderView::ResizeToContents);
+    //mTable->horizontalHeader()->setSectionResizeMode(COLUMN_ISCLOCK,       QHeaderView::ResizeToContents);
     mTable->horizontalHeader()->setSectionResizeMode(COLUMN_FORCEDNETNAME, QHeaderView::Stretch);
     mTable->horizontalHeader()->setSectionResizeMode(COLUMN_BUTTONS,       QHeaderView::ResizeToContents);
     mTable->horizontalHeader()->setMinimumSectionSize(10);
@@ -166,7 +166,7 @@ void ComponentSignalListEditorWidget::isRequiredChanged(bool checked) noexcept
     }
 }
 
-void ComponentSignalListEditorWidget::isNegatedChanged(bool checked) noexcept
+/*void ComponentSignalListEditorWidget::isNegatedChanged(bool checked) noexcept
 {
     if (!mSignalList) return;
     int row = getRowOfTableCellWidget(sender());
@@ -182,7 +182,7 @@ void ComponentSignalListEditorWidget::isClockChanged(bool checked) noexcept
     if (isExistingSignalRow(row)) {
         setIsClock(getUuidOfRow(row), checked);
     }
-}
+}*/
 
 void ComponentSignalListEditorWidget::btnAddRemoveClicked() noexcept
 {
@@ -194,14 +194,16 @@ void ComponentSignalListEditorWidget::btnAddRemoveClicked() noexcept
         //    (mTable->cellWidget(row, COLUMN_ROLE)); Q_ASSERT(roleComboBox);
         const CenteredCheckBox* requiredCheckBox = dynamic_cast<const CenteredCheckBox*>
             (mTable->cellWidget(row, COLUMN_ISREQUIRED)); Q_ASSERT(requiredCheckBox);
-        const CenteredCheckBox* negatedCheckBox = dynamic_cast<const CenteredCheckBox*>
-            (mTable->cellWidget(row, COLUMN_ISNEGATED)); Q_ASSERT(negatedCheckBox);
-        const CenteredCheckBox* clockCheckBox = dynamic_cast<const CenteredCheckBox*>
-            (mTable->cellWidget(row, COLUMN_ISCLOCK)); Q_ASSERT(clockCheckBox);
+        //const CenteredCheckBox* negatedCheckBox = dynamic_cast<const CenteredCheckBox*>
+        //    (mTable->cellWidget(row, COLUMN_ISNEGATED)); Q_ASSERT(negatedCheckBox);
+        //const CenteredCheckBox* clockCheckBox = dynamic_cast<const CenteredCheckBox*>
+        //    (mTable->cellWidget(row, COLUMN_ISCLOCK)); Q_ASSERT(clockCheckBox);
         const QTableWidgetItem* netNameItem = mTable->item(row, COLUMN_FORCEDNETNAME); Q_ASSERT(netNameItem);
         addSignal(cleanName(nameItem->text()), /*roleComboBox->getCurrentItem(),*/
-                  requiredCheckBox->isChecked(), negatedCheckBox->isChecked(),
-                  clockCheckBox->isChecked(), cleanForcedNetName(netNameItem->text()));
+                  requiredCheckBox->isChecked(),
+                  //negatedCheckBox->isChecked(),
+                  //clockCheckBox->isChecked(),
+                  cleanForcedNetName(netNameItem->text()));
     } else if (isExistingSignalRow(row)) {
         removeSignal(getUuidOfRow(row));
     }
@@ -252,14 +254,14 @@ void ComponentSignalListEditorWidget::updateTable() noexcept
 
         // special row for adding a new signal
         setTableRowContent(newSignalRow(), Uuid(), "", /*SignalRole::passive(),*/ false,
-                           false, false, "");
+                           /*false, false,*/ "");
 
         // existing signals
         for (int i = 0; i < mSignalList->count(); ++i) {
             const ComponentSignal& signal = *mSignalList->at(i);
             setTableRowContent(indexToRow(i), signal.getUuid(), signal.getName(),
-                               /*signal.getRole(),*/ signal.isRequired(), signal.isNegated(),
-                               signal.isClock(), signal.getForcedNetName());
+                               /*signal.getRole(),*/ signal.isRequired(), /*signal.isNegated(),
+                               signal.isClock(),*/ signal.getForcedNetName());
             if (signal.getUuid() == mSelectedSignal) {
                 selectedRow = indexToRow(i);
             }
@@ -279,8 +281,8 @@ void ComponentSignalListEditorWidget::updateTable() noexcept
 }
 
 void ComponentSignalListEditorWidget::setTableRowContent(int row, const Uuid& uuid,
-    const QString& name, /*const SignalRole& role,*/ bool required, bool negated,
-    bool clock, const QString& forcedNetName) noexcept
+    const QString& name, /*const SignalRole& role,*/ bool required, /*bool negated,
+    bool clock,*/ const QString& forcedNetName) noexcept
 {
     // header
     QString header = uuid.isNull() ? tr("Add new signal:") : uuid.toStr().left(13) % "...";
@@ -313,20 +315,20 @@ void ComponentSignalListEditorWidget::setTableRowContent(int row, const Uuid& uu
     mTable->setCellWidget(row, COLUMN_ISREQUIRED, requiredCheckBox);
 
     // negated
-    CenteredCheckBox* negatedCheckBox = new CenteredCheckBox(this);
-    negatedCheckBox->setProperty("row", row);
-    negatedCheckBox->setChecked(negated);
-    connect(negatedCheckBox, &CenteredCheckBox::toggled,
-            this, &ComponentSignalListEditorWidget::isNegatedChanged);
-    mTable->setCellWidget(row, COLUMN_ISNEGATED, negatedCheckBox);
+    //CenteredCheckBox* negatedCheckBox = new CenteredCheckBox(this);
+    //negatedCheckBox->setProperty("row", row);
+    //negatedCheckBox->setChecked(negated);
+    //connect(negatedCheckBox, &CenteredCheckBox::toggled,
+    //        this, &ComponentSignalListEditorWidget::isNegatedChanged);
+    //mTable->setCellWidget(row, COLUMN_ISNEGATED, negatedCheckBox);
 
     // clock
-    CenteredCheckBox* clockCheckBox = new CenteredCheckBox(this);
-    clockCheckBox->setProperty("row", row);
-    clockCheckBox->setChecked(clock);
-    connect(clockCheckBox, &CenteredCheckBox::toggled,
-            this, &ComponentSignalListEditorWidget::isClockChanged);
-    mTable->setCellWidget(row, COLUMN_ISCLOCK, clockCheckBox);
+    //CenteredCheckBox* clockCheckBox = new CenteredCheckBox(this);
+    //clockCheckBox->setProperty("row", row);
+    //clockCheckBox->setChecked(clock);
+    //connect(clockCheckBox, &CenteredCheckBox::toggled,
+    //        this, &ComponentSignalListEditorWidget::isClockChanged);
+    //mTable->setCellWidget(row, COLUMN_ISCLOCK, clockCheckBox);
 
     // forced net name
     mTable->setItem(row, COLUMN_FORCEDNETNAME, new QTableWidgetItem(forcedNetName));
@@ -352,15 +354,15 @@ void ComponentSignalListEditorWidget::setTableRowContent(int row, const Uuid& uu
 }
 
 void ComponentSignalListEditorWidget::addSignal(const QString& name, /*const SignalRole& role,*/
-    bool required, bool negated, bool clock, const QString& forcedNetName) noexcept
+    bool required, /*bool negated, bool clock,*/ const QString& forcedNetName) noexcept
 {
     try {
         throwIfNameEmptyOrExists(name);
         std::shared_ptr<ComponentSignal> signal(new ComponentSignal(Uuid::createRandom(), name)); // can throw
         //signal->setRole(role);
         signal->setIsRequired(required);
-        signal->setIsNegated(negated);
-        signal->setIsClock(clock);
+        //signal->setIsNegated(negated);
+        //signal->setIsClock(clock);
         signal->setForcedNetName(forcedNetName);
         if (mUndoStack) {
             mUndoStack->execCmd(new CmdComponentSignalInsert(*mSignalList, signal));
@@ -440,7 +442,7 @@ void ComponentSignalListEditorWidget::setIsRequired(const Uuid& uuid, bool requi
     }
 }
 
-void ComponentSignalListEditorWidget::setIsNegated(const Uuid& uuid, bool negated) noexcept
+/*void ComponentSignalListEditorWidget::setIsNegated(const Uuid& uuid, bool negated) noexcept
 {
     try {
         ComponentSignal* signal = mSignalList->get(uuid).get(); // can throw
@@ -472,7 +474,7 @@ void ComponentSignalListEditorWidget::setIsClock(const Uuid& uuid, bool clock) n
     } catch (const Exception& e) {
         QMessageBox::critical(this, tr("Could not edit signal"), e.getMsg());
     }
-}
+}*/
 
 void ComponentSignalListEditorWidget::setForcedNetName(const Uuid& uuid, const QString& netname) noexcept
 {

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
@@ -57,8 +57,8 @@ class ComponentSignalListEditorWidget final : public QWidget,
             COLUMN_NAME = 0,
             //COLUMN_ROLE,
             COLUMN_ISREQUIRED,
-            COLUMN_ISNEGATED,
-            COLUMN_ISCLOCK,
+            //COLUMN_ISNEGATED,
+            //COLUMN_ISCLOCK,
             COLUMN_FORCEDNETNAME,
             COLUMN_BUTTONS,
             _COLUMN_COUNT
@@ -84,8 +84,8 @@ class ComponentSignalListEditorWidget final : public QWidget,
         void tableCellChanged(int row, int column) noexcept;
         //void signalRoleChanged(const SignalRole& role) noexcept;
         void isRequiredChanged(bool checked) noexcept;
-        void isNegatedChanged(bool checked) noexcept;
-        void isClockChanged(bool checked) noexcept;
+        //void isNegatedChanged(bool checked) noexcept;
+        //void isClockChanged(bool checked) noexcept;
         void btnAddRemoveClicked() noexcept;
 
 
@@ -99,16 +99,16 @@ class ComponentSignalListEditorWidget final : public QWidget,
     private: // Methods
         void updateTable() noexcept;
         void setTableRowContent(int row, const Uuid& uuid, const QString& name,
-                                /*const SignalRole& role,*/ bool required, bool negated,
-                                bool clock, const QString& forcedNetName) noexcept;
+                                /*const SignalRole& role,*/ bool required, /*bool negated,
+                                bool clock,*/ const QString& forcedNetName) noexcept;
         void addSignal(const QString& name, /*const SignalRole& role,*/ bool required,
-                       bool negated, bool clock, const QString& forcedNetName) noexcept;
+                       /*bool negated, bool clock,*/ const QString& forcedNetName) noexcept;
         void removeSignal(const Uuid& uuid) noexcept;
         bool setName(const Uuid& uuid, const QString& name) noexcept;
         //void setRole(const Uuid& uuid, const SignalRole& role) noexcept;
         void setIsRequired(const Uuid& uuid, bool required) noexcept;
-        void setIsNegated(const Uuid& uuid, bool negated) noexcept;
-        void setIsClock(const Uuid& uuid, bool clock) noexcept;
+        //void setIsNegated(const Uuid& uuid, bool negated) noexcept;
+        //void setIsClock(const Uuid& uuid, bool clock) noexcept;
         void setForcedNetName(const Uuid& uuid, const QString& netname) noexcept;
         int getRowOfTableCellWidget(QObject* obj) const noexcept;
         Uuid getUuidOfRow(int row) const noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -109,6 +109,9 @@
     <addaction name="actionToolDrawPolygon"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
     <property name="title">
      <string>Help</string>
     </property>
@@ -255,6 +258,9 @@
    </property>
   </action>
   <action name="actionPrint">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/print.png</normaloff>:/img/actions/print.png</iconset>
@@ -264,6 +270,9 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+P</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionQuit">
@@ -285,6 +294,9 @@
    </property>
    <property name="text">
     <string>PDF Export</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionShowControlPanel">
@@ -340,6 +352,9 @@
    <property name="shortcut">
     <string>F1</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionRotate_CCW">
    <property name="icon">
@@ -376,6 +391,9 @@
    <property name="shortcut">
     <string>Ctrl+C</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionCut">
    <property name="icon">
@@ -388,6 +406,9 @@
    <property name="shortcut">
     <string>Ctrl+X</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionPaste">
    <property name="icon">
@@ -399,6 +420,9 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+V</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionRemove">
@@ -467,6 +491,9 @@
    </property>
    <property name="toolTip">
     <string>Project Settings</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionAbout">

--- a/libs/librepcb/projecteditor/boardeditor/boardlayerstacksetupdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayerstacksetupdialog.ui
@@ -6,12 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>319</width>
-    <height>190</height>
+    <width>325</width>
+    <height>180</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Layer Stack Setup</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -33,7 +36,7 @@
      <item row="1" column="0" colspan="2">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -46,7 +49,7 @@
 };</string>
        </property>
        <property name="text">
-        <string>Disabling some of the inner copper layers just hides these layers, even if there are already traces located on them. As there is not yet a mechanism to avoid that situation, you need to be carefully when reducing the count of inner copper layers.</string>
+        <string>Disabling some inner copper layers just hides them, even if there are traces located on them. As we cannot yet avoid that situation, you need to be careful when reducing the number of inner copper layers.</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>

--- a/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.ui
@@ -19,14 +19,15 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>1</number>
+     <property name="enabled">
+      <bool>true</bool>
      </property>
-     <widget class="QWidget" name="tabGeneral">
-      <attribute name="title">
-       <string>General</string>
-      </attribute>
-     </widget>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="tabsClosable">
+      <bool>false</bool>
+     </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
        <string>Locales &amp;&amp; Norms</string>

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -61,6 +61,9 @@
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
     <property name="title">
      <string>Help</string>
     </property>
@@ -304,6 +307,9 @@
    <property name="shortcut">
     <string>Ctrl+P</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionPDF_Export">
    <property name="icon">
@@ -312,6 +318,9 @@
    </property>
    <property name="text">
     <string>PDF Export</string>
+   </property>
+   <property name="visible">
+    <bool>true</bool>
    </property>
   </action>
   <action name="actionShow_Control_Panel">
@@ -394,6 +403,9 @@
    <property name="shortcut">
     <string>F1</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionRotate_CCW">
    <property name="icon">
@@ -430,6 +442,9 @@
    <property name="shortcut">
     <string>Ctrl+C</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionCut">
    <property name="icon">
@@ -442,6 +457,9 @@
    <property name="shortcut">
     <string>Ctrl+X</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionPaste">
    <property name="icon">
@@ -453,6 +471,9 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+V</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionRemove">
@@ -522,6 +543,9 @@
    </property>
    <property name="text">
     <string>Layers</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionGrid">
@@ -598,6 +622,9 @@
    </property>
    <property name="text">
     <string>Settings</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionToolAddNetLabel">

--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.ui
@@ -120,6 +120,9 @@
       </item>
       <item>
        <widget class="QToolButton" name="btnSchematicUp">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -142,6 +145,9 @@
       </item>
       <item>
        <widget class="QToolButton" name="btnSchematicDown">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -74,6 +74,13 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Pos. X:</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="1">
          <widget class="QDoubleSpinBox" name="spbxSymbInstPosX">
           <property name="sizePolicy">
@@ -181,33 +188,6 @@
           </property>
           <property name="singleStep">
            <double>45.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Mirror:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QCheckBox" name="cbxSymbInstMirror">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Pos. X:</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Fixes #189 
Also makes the board layer stack setup dialog in the board editor resizeable on all platforms by explicitly enabling the size grip