### PR TITLE
Make UUID handling consistent in all files

### DIFF
--- a/apps/EagleImport/polygonsimplifier.cpp
+++ b/apps/EagleImport/polygonsimplifier.cpp
@@ -73,7 +73,8 @@ void PolygonSimplifier<LibElemType>::convertLineRectsToPolygonRects(bool fillAre
         QString layerName = lines.first()->getLayerName();
         Length lineWidth = lines.first()->getLineWidth();
 
-        Polygon* rect = new Polygon(layerName, lineWidth, fillArea, isGrabArea, p1);
+        Polygon* rect = new Polygon(Uuid::createRandom(), layerName, lineWidth,
+                                    fillArea, isGrabArea, p1);
         rect->getSegments().append(std::make_shared<PolygonSegment>(p2, Angle::deg0()));
         rect->getSegments().append(std::make_shared<PolygonSegment>(p3, Angle::deg0()));
         rect->getSegments().append(std::make_shared<PolygonSegment>(p4, Angle::deg0()));

--- a/libs/librepcb/common/geometry/ellipse.h
+++ b/libs/librepcb/common/geometry/ellipse.h
@@ -80,13 +80,15 @@ class Ellipse : public SerializableObject
         // Constructors / Destructor
         Ellipse() = delete;
         Ellipse(const Ellipse& other) noexcept;
-        Ellipse(const QString& layerName, const Length& lineWidth, bool fill, bool isGrabArea,
-                const Point& center, const Length& radiusX, const Length& radiusY,
-                const Angle& rotation) noexcept;
+        Ellipse(const Uuid& uuid, const Ellipse& other) noexcept;
+        Ellipse(const Uuid& uuid, const QString& layerName, const Length& lineWidth,
+                bool fill, bool isGrabArea, const Point& center, const Length& radiusX,
+                const Length& radiusY, const Angle& rotation) noexcept;
         explicit Ellipse(const SExpression& node);
         virtual ~Ellipse() noexcept;
 
         // Getters
+        const Uuid& getUuid() const noexcept {return mUuid;}
         const QString& getLayerName() const noexcept {return mLayerName;}
         const Length& getLineWidth() const noexcept {return mLineWidth;}
         bool isFilled() const noexcept {return mIsFilled;}
@@ -109,9 +111,7 @@ class Ellipse : public SerializableObject
 
         // Transformations
         Ellipse& translate(const Point& offset) noexcept;
-        Ellipse translated(const Point& offset) const noexcept;
         Ellipse& rotate(const Angle& angle, const Point& center = Point(0, 0)) noexcept;
-        Ellipse rotated(const Angle& angle, const Point& center = Point(0, 0)) const noexcept;
 
         // General Methods
         void registerObserver(IF_EllipseObserver& object) const noexcept;
@@ -131,13 +131,14 @@ class Ellipse : public SerializableObject
 
 
     private: // Data
+        Uuid mUuid;
         QString mLayerName;
         Length mLineWidth;
         bool mIsFilled;
         bool mIsGrabArea;
         Point mCenter;
-        Length mRadiusX;
-        Length mRadiusY;
+        Length mRadiusX; // TODO: change radius (x/y) to size (width/height)
+        Length mRadiusY; // TODO: change radius (x/y) to size (width/height)
         Angle mRotation;
 
         // Misc

--- a/libs/librepcb/common/geometry/hole.h
+++ b/libs/librepcb/common/geometry/hole.h
@@ -74,11 +74,13 @@ class Hole final : public SerializableObject
         // Constructors / Destructor
         Hole() = delete;
         Hole(const Hole& other) noexcept;
-        Hole(const Point& position, const Length& diameter) noexcept;
+        Hole(const Uuid& uuid, const Hole& other) noexcept;
+        Hole(const Uuid& uuid, const Point& position, const Length& diameter) noexcept;
         explicit Hole(const SExpression& node);
         ~Hole() noexcept;
 
         // Getters
+        const Uuid& getUuid() const noexcept {return mUuid;}
         const Point& getPosition() const noexcept {return mPosition;}
         const Length& getDiameter() const noexcept {return mDiameter;}
 
@@ -104,6 +106,7 @@ class Hole final : public SerializableObject
 
 
     private: // Data
+        Uuid mUuid;
         Point mPosition;
         Length mDiameter;
 

--- a/libs/librepcb/common/geometry/polygon.h
+++ b/libs/librepcb/common/geometry/polygon.h
@@ -168,12 +168,14 @@ class Polygon final : public SerializableObject, private PolygonSegmentList::IF_
         // Constructors / Destructor
         Polygon() = delete;
         Polygon(const Polygon& other) noexcept;
-        Polygon(const QString& layerName, const Length& lineWidth, bool fill, bool isGrabArea,
-                const Point& startPos) noexcept;
+        Polygon(const Uuid& uuid, const Polygon& other) noexcept;
+        Polygon(const Uuid& uuid, const QString& layerName, const Length& lineWidth,
+                bool fill, bool isGrabArea, const Point& startPos) noexcept;
         explicit Polygon(const SExpression& node);
         ~Polygon() noexcept;
 
         // Getters
+        const Uuid& getUuid() const noexcept {return mUuid;}
         const QString& getLayerName() const noexcept {return mLayerName;}
         const Length& getLineWidth() const noexcept {return mLineWidth;}
         bool isFilled() const noexcept {return mIsFilled;}
@@ -196,11 +198,8 @@ class Polygon final : public SerializableObject, private PolygonSegmentList::IF_
 
         // Transformations
         Polygon& translate(const Point& offset) noexcept;
-        Polygon translated(const Point& offset) const noexcept;
         Polygon& rotate(const Angle& angle, const Point& center = Point(0, 0)) noexcept;
-        Polygon rotated(const Angle& angle, const Point& center = Point(0, 0)) const noexcept;
         Polygon& mirror(Qt::Orientation orientation, const Point& center = Point(0, 0)) noexcept;
-        Polygon mirrored(Qt::Orientation orientation, const Point& center = Point(0, 0)) const noexcept;
 
         // General Methods
         bool close() noexcept;
@@ -216,13 +215,17 @@ class Polygon final : public SerializableObject, private PolygonSegmentList::IF_
         Polygon& operator=(const Polygon& rhs) noexcept;
 
         // Static Methods
-        static Polygon* createLine(const QString& layerName, const Length& lineWidth, bool fill,
-                                   bool isGrabArea, const Point& p1, const Point& p2) noexcept;
-        static Polygon* createCurve(const QString& layerName, const Length& lineWidth, bool fill,
-                                    bool isGrabArea, const Point& p1, const Point& p2, const Angle& angle) noexcept;
-        static Polygon* createRect(const QString& layerName, const Length& lineWidth, bool fill,
-                                   bool isGrabArea, const Point& pos, const Length& width, const Length& height) noexcept;
-        static Polygon* createCenteredRect(const QString& layerName, const Length& lineWidth, bool fill,
+        static Polygon* createLine(const Uuid& uuid, const QString& layerName,
+                                   const Length& lineWidth, bool fill, bool isGrabArea,
+                                   const Point& p1, const Point& p2) noexcept;
+        static Polygon* createCurve(const Uuid& uuid, const QString& layerName,
+                                    const Length& lineWidth, bool fill, bool isGrabArea,
+                                    const Point& p1, const Point& p2, const Angle& angle) noexcept;
+        static Polygon* createRect(const Uuid& uuid, const QString& layerName,
+                                   const Length& lineWidth, bool fill, bool isGrabArea,
+                                   const Point& pos, const Length& width, const Length& height) noexcept;
+        static Polygon* createCenteredRect(const Uuid& uuid, const QString& layerName,
+                                           const Length& lineWidth, bool fill,
                                            bool isGrabArea, const Point& center,
                                            const Length& width, const Length& height) noexcept;
 
@@ -238,6 +241,7 @@ class Polygon final : public SerializableObject, private PolygonSegmentList::IF_
 
 
     private: // Data
+        Uuid mUuid;
         QString mLayerName;
         Length mLineWidth;
         bool mIsFilled;

--- a/libs/librepcb/common/geometry/text.h
+++ b/libs/librepcb/common/geometry/text.h
@@ -79,12 +79,15 @@ class Text final : public SerializableObject
         // Constructors / Destructor
         Text() = delete;
         Text(const Text& other) noexcept;
-        Text(const QString& layerName, const QString& text, const Point& pos, const Angle& rotation,
-             const Length& height, const Alignment& align) noexcept;
+        Text(const Uuid& uuid, const Text& other) noexcept;
+        Text(const Uuid& uuid, const QString& layerName, const QString& text,
+             const Point& pos, const Angle& rotation, const Length& height,
+             const Alignment& align) noexcept;
         explicit Text(const SExpression& node);
         ~Text() noexcept;
 
         // Getters
+        const Uuid& getUuid() const noexcept {return mUuid;}
         const QString& getLayerName() const noexcept {return mLayerName;}
         const Point& getPosition() const noexcept {return mPosition;}
         const Angle& getRotation() const noexcept {return mRotation;}
@@ -118,6 +121,7 @@ class Text final : public SerializableObject
 
 
     private: // Data
+        Uuid mUuid;
         QString mLayerName;
         QString mText;
         Point mPosition;

--- a/libs/librepcb/eagleimport/packageconverter.cpp
+++ b/libs/librepcb/eagleimport/packageconverter.cpp
@@ -141,7 +141,7 @@ std::unique_ptr<library::Package> PackageConverter::generate() const
     foreach (const parseagle::Hole& hole, mPackage.getHoles()) {
         Point pos = Point::fromMm(hole.getPosition().x, hole.getPosition().y);
         Length diameter = Length::fromMm(hole.getDiameter());
-        footprint->getHoles().append(std::make_shared<Hole>(pos, diameter));
+        footprint->getHoles().append(std::make_shared<Hole>(Uuid::createRandom(), pos, diameter));
     }
 
     foreach (const parseagle::ThtPad& pad, mPackage.getThtPads()) {

--- a/libs/librepcb/eagleimport/packageconverter.cpp
+++ b/libs/librepcb/eagleimport/packageconverter.cpp
@@ -97,8 +97,8 @@ std::unique_ptr<library::Package> PackageConverter::generate() const
         Length lineWidth = Length::fromMm(circle.getWidth());
         bool fill = (lineWidth == 0);
         bool isGrabArea = true;
-        footprint->getEllipses().append(std::make_shared<Ellipse>(layerName,
-            lineWidth, fill, isGrabArea, center, radius, radius, Angle::deg0()));
+        footprint->getEllipses().append(std::make_shared<Ellipse>(Uuid::createRandom(),
+            layerName, lineWidth, fill, isGrabArea, center, radius, radius, Angle::deg0()));
     }
 
     foreach (const parseagle::Polygon& polygon, mPackage.getPolygons()) {

--- a/libs/librepcb/eagleimport/packageconverter.cpp
+++ b/libs/librepcb/eagleimport/packageconverter.cpp
@@ -135,7 +135,7 @@ std::unique_ptr<library::Package> PackageConverter::generate() const
         Angle rot = Angle::fromDeg(text.getRotation().getAngle());
         Alignment align(HAlign::left(), VAlign::bottom());
         footprint->getTexts().append(std::make_shared<Text>(
-            layerName, textStr, pos, rot, height, align));
+            Uuid::createRandom(), layerName, textStr, pos, rot, height, align));
     }
 
     foreach (const parseagle::Hole& hole, mPackage.getHoles()) {

--- a/libs/librepcb/eagleimport/packageconverter.cpp
+++ b/libs/librepcb/eagleimport/packageconverter.cpp
@@ -69,7 +69,7 @@ std::unique_ptr<library::Package> PackageConverter::generate() const
         Point endpos = Point::fromMm(wire.getP2().x, wire.getP2().y);
         Angle angle = Angle::fromDeg(wire.getCurve());
         footprint->getPolygons().append(std::shared_ptr<Polygon>(Polygon::createCurve(
-            layerName, lineWidth, fill, isGrabArea, startpos, endpos, angle)));
+            Uuid::createRandom(), layerName, lineWidth, fill, isGrabArea, startpos, endpos, angle)));
     }
 
     foreach (const parseagle::Rectangle& rect, mPackage.getRectangles()) {
@@ -81,7 +81,8 @@ std::unique_ptr<library::Package> PackageConverter::generate() const
         Point p2 = Point::fromMm(rect.getP2().x, rect.getP1().y);
         Point p3 = Point::fromMm(rect.getP2().x, rect.getP2().y);
         Point p4 = Point::fromMm(rect.getP1().x, rect.getP2().y);
-        std::shared_ptr<Polygon> polygon(new Polygon(layerName, lineWidth, fill, isGrabArea, p1));
+        std::shared_ptr<Polygon> polygon(new Polygon(
+            Uuid::createRandom(), layerName, lineWidth, fill, isGrabArea, p1));
         polygon->getSegments().append(std::make_shared<PolygonSegment>(p2, Angle::deg0()));
         polygon->getSegments().append(std::make_shared<PolygonSegment>(p3, Angle::deg0()));
         polygon->getSegments().append(std::make_shared<PolygonSegment>(p4, Angle::deg0()));
@@ -105,7 +106,8 @@ std::unique_ptr<library::Package> PackageConverter::generate() const
         bool fill = false;
         bool isGrabArea = true;
         Length lineWidth = Length::fromMm(polygon.getWidth());
-        std::shared_ptr<Polygon> newPolygon(new Polygon(layerName, lineWidth, fill, isGrabArea, Point(0, 0)));
+        std::shared_ptr<Polygon> newPolygon(new Polygon(
+            Uuid::createRandom(), layerName, lineWidth, fill, isGrabArea, Point(0, 0)));
         for (int i = 0; i < polygon.getVertices().count(); ++i) {
             const parseagle::Vertex vertex = polygon.getVertices().at(i);
             Point p = Point::fromMm(vertex.getPosition().x, vertex.getPosition().y);

--- a/libs/librepcb/eagleimport/symbolconverter.cpp
+++ b/libs/librepcb/eagleimport/symbolconverter.cpp
@@ -93,8 +93,8 @@ std::unique_ptr<library::Symbol> SymbolConverter::generate() const
         Length lineWidth = Length::fromMm(circle.getWidth());
         bool fill = (lineWidth == 0);
         bool isGrabArea = true;
-        symbol->getEllipses().append(std::make_shared<Ellipse>(layerName,
-            lineWidth, fill, isGrabArea, center, radius, radius, Angle::deg0()));
+        symbol->getEllipses().append(std::make_shared<Ellipse>(Uuid::createRandom(),
+            layerName, lineWidth, fill, isGrabArea, center, radius, radius, Angle::deg0()));
     }
 
     foreach (const parseagle::Polygon& polygon, mSymbol.getPolygons()) {

--- a/libs/librepcb/eagleimport/symbolconverter.cpp
+++ b/libs/librepcb/eagleimport/symbolconverter.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<library::Symbol> SymbolConverter::generate() const
         Point endpos = Point::fromMm(wire.getP2().x, wire.getP2().y);
         Angle angle = Angle::fromDeg(wire.getCurve());
         symbol->getPolygons().append(std::shared_ptr<Polygon>(Polygon::createCurve(
-            layerName, lineWidth, fill, isGrabArea, startpos, endpos, angle)));
+            Uuid::createRandom(), layerName, lineWidth, fill, isGrabArea, startpos, endpos, angle)));
     }
 
     foreach (const parseagle::Rectangle& rect, mSymbol.getRectangles()) {
@@ -77,7 +77,8 @@ std::unique_ptr<library::Symbol> SymbolConverter::generate() const
         Point p2 = Point::fromMm(rect.getP2().x, rect.getP1().y);
         Point p3 = Point::fromMm(rect.getP2().x, rect.getP2().y);
         Point p4 = Point::fromMm(rect.getP1().x, rect.getP2().y);
-        std::shared_ptr<Polygon> polygon(new Polygon(layerName, lineWidth, fill, isGrabArea, p1));
+        std::shared_ptr<Polygon> polygon(new Polygon(
+            Uuid::createRandom(), layerName, lineWidth, fill, isGrabArea, p1));
         polygon->getSegments().append(std::make_shared<PolygonSegment>(p2, Angle::deg0()));
         polygon->getSegments().append(std::make_shared<PolygonSegment>(p3, Angle::deg0()));
         polygon->getSegments().append(std::make_shared<PolygonSegment>(p4, Angle::deg0()));
@@ -101,7 +102,8 @@ std::unique_ptr<library::Symbol> SymbolConverter::generate() const
         bool fill = false;
         bool isGrabArea = true;
         Length lineWidth = Length::fromMm(polygon.getWidth());
-        std::shared_ptr<Polygon> newPolygon(new Polygon(layerName, lineWidth, fill, isGrabArea, Point(0, 0)));
+        std::shared_ptr<Polygon> newPolygon(new Polygon(
+            Uuid::createRandom(), layerName, lineWidth, fill, isGrabArea, Point(0, 0)));
         for (int i = 0; i < polygon.getVertices().count(); ++i) {
             const parseagle::Vertex vertex = polygon.getVertices().at(i);
             Point p = Point::fromMm(vertex.getPosition().x, vertex.getPosition().y);

--- a/libs/librepcb/eagleimport/symbolconverter.cpp
+++ b/libs/librepcb/eagleimport/symbolconverter.cpp
@@ -131,7 +131,7 @@ std::unique_ptr<library::Symbol> SymbolConverter::generate() const
         Angle rot = Angle::fromDeg(text.getRotation().getAngle());
         Alignment align(HAlign::left(), VAlign::bottom());
         symbol->getTexts().append(std::make_shared<Text>(
-            layerName, textStr, pos, rot, height, align));
+            Uuid::createRandom(), layerName, textStr, pos, rot, height, align));
     }
 
     foreach (const parseagle::Pin& pin, mSymbol.getPins()) {

--- a/libs/librepcb/library/librarybaseelement.cpp
+++ b/libs/librepcb/library/librarybaseelement.cpp
@@ -100,7 +100,12 @@ LibraryBaseElement::LibraryBaseElement(const FilePath& elementDirectory,
     mLoadingFileDocument = sexprFile.parseFileAndBuildDomTree();
 
     // read attributes
-    mUuid = mLoadingFileDocument.getValueByPath<Uuid>("uuid", true);
+    if (mLoadingFileDocument.getChildByIndex(0).isString()) {
+        mUuid = mLoadingFileDocument.getChildByIndex(0).getValue<Uuid>(true);
+    } else {
+        // backward compatibility, remove this some time!
+        mUuid = mLoadingFileDocument.getValueByPath<Uuid>("uuid", true);
+    }
     mVersion = mLoadingFileDocument.getValueByPath<Version>("version", true);
     mAuthor = mLoadingFileDocument.getValueByPath<QString>("author", false);
     mCreated = mLoadingFileDocument.getValueByPath<QDateTime>("created", true);
@@ -248,7 +253,7 @@ void LibraryBaseElement::serialize(SExpression& root) const
             tr("The library element cannot be saved because it is not valid."));
     }
 
-    root.appendTokenChild("uuid", mUuid, true);
+    root.appendToken(mUuid);
     mNames.serialize(root);
     mDescriptions.serialize(root);
     mKeywords.serialize(root);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
@@ -129,7 +129,7 @@ bool PackageEditorState_AddHoles::startAddHole(const Point& pos) noexcept
     try {
         mStartPos = pos;
         mContext.undoStack.beginCmdGroup(tr("Add hole"));
-        mCurrentHole = new Hole(pos, mLastDiameter);
+        mCurrentHole = new Hole(Uuid::createRandom(), pos, mLastDiameter);
         mContext.undoStack.appendToCmdGroup(new CmdHoleInsert(
             mContext.currentFootprint->getHoles(), std::shared_ptr<Hole>(mCurrentHole)));
         mEditCmd.reset(new CmdHoleEdit(*mCurrentHole));

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawellipse.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawellipse.cpp
@@ -158,8 +158,8 @@ bool PackageEditorState_DrawEllipse::startAddEllipse(const Point& pos) noexcept
     try {
         mStartPos = pos;
         mContext.undoStack.beginCmdGroup(tr("Add symbol ellipse"));
-        mCurrentEllipse = new Ellipse(mLastLayerName, mLastLineWidth, mLastFill,
-                                      mLastGrabArea, pos, Length(0), Length(0),
+        mCurrentEllipse = new Ellipse(Uuid::createRandom(), mLastLayerName, mLastLineWidth,
+                                      mLastFill, mLastGrabArea, pos, Length(0), Length(0),
                                       Angle::deg0());
         mContext.undoStack.appendToCmdGroup(new CmdEllipseInsert(
             mContext.currentFootprint->getEllipses(), std::shared_ptr<Ellipse>(mCurrentEllipse)));

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -191,8 +191,8 @@ bool PackageEditorState_DrawPolygonBase::start(const Point& pos) noexcept
     try {
         // add polygon
         mContext.undoStack.beginCmdGroup(tr("Add symbol polygon"));
-        mCurrentPolygon.reset(new Polygon(mLastLayerName, mLastLineWidth, mLastFill,
-                                          mLastGrabArea, pos));
+        mCurrentPolygon.reset(new Polygon(Uuid::createRandom(), mLastLayerName,
+                                          mLastLineWidth, mLastFill, mLastGrabArea, pos));
         mContext.undoStack.appendToCmdGroup(
             new CmdPolygonInsert(mContext.currentFootprint->getPolygons(), mCurrentPolygon));
         mEditCmd.reset(new CmdPolygonEdit(*mCurrentPolygon));

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -179,7 +179,8 @@ bool PackageEditorState_DrawTextBase::startAddText(const Point& pos) noexcept
     try {
         mStartPos = pos;
         mContext.undoStack.beginCmdGroup(tr("Add footprint text"));
-        mCurrentText = new Text(mLastLayerName, mLastText, pos, mLastRotation, mLastHeight,
+        mCurrentText = new Text(Uuid::createRandom(), mLastLayerName, mLastText, pos,
+                                mLastRotation, mLastHeight,
                                 Alignment(HAlign::left(), VAlign::bottom()));
         mContext.undoStack.appendToCmdGroup(
             new CmdTextInsert(mContext.currentFootprint->getTexts(), std::shared_ptr<Text>(mCurrentText)));

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawellipse.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawellipse.cpp
@@ -158,8 +158,8 @@ bool SymbolEditorState_DrawEllipse::startAddEllipse(const Point& pos) noexcept
     try {
         mStartPos = pos;
         mContext.undoStack.beginCmdGroup(tr("Add symbol ellipse"));
-        mCurrentEllipse = new Ellipse(mLastLayerName, mLastLineWidth, mLastFill,
-                                      mLastGrabArea, pos, Length(0), Length(0),
+        mCurrentEllipse = new Ellipse(Uuid::createRandom(), mLastLayerName, mLastLineWidth,
+                                      mLastFill, mLastGrabArea, pos, Length(0), Length(0),
                                       Angle::deg0());
         mContext.undoStack.appendToCmdGroup(new CmdEllipseInsert(
             mContext.symbol.getEllipses(), std::shared_ptr<Ellipse>(mCurrentEllipse)));

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -190,8 +190,8 @@ bool SymbolEditorState_DrawPolygonBase::start(const Point& pos) noexcept
     try {
         // add polygon
         mContext.undoStack.beginCmdGroup(tr("Add symbol polygon"));
-        mCurrentPolygon.reset(new Polygon(mLastLayerName, mLastLineWidth, mLastFill,
-                                          mLastGrabArea, pos));
+        mCurrentPolygon.reset(new Polygon(Uuid::createRandom(), mLastLayerName,
+                                          mLastLineWidth, mLastFill, mLastGrabArea, pos));
         mContext.undoStack.appendToCmdGroup(
             new CmdPolygonInsert(mContext.symbol.getPolygons(), mCurrentPolygon));
         mEditCmd.reset(new CmdPolygonEdit(*mCurrentPolygon));

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -181,8 +181,8 @@ bool SymbolEditorState_DrawTextBase::startAddText(const Point& pos) noexcept
     try {
         mStartPos = pos;
         mContext.undoStack.beginCmdGroup(tr("Add symbol text"));
-        mCurrentText = new Text(mLastLayerName, mLastText, pos, mLastRotation,
-                                mLastHeight, getAlignment());
+        mCurrentText = new Text(Uuid::createRandom(), mLastLayerName, mLastText, pos,
+                                mLastRotation, mLastHeight, getAlignment());
         mContext.undoStack.appendToCmdGroup(
             new CmdTextInsert(mContext.symbol.getTexts(), std::shared_ptr<Text>(mCurrentText)));
         mEditCmd.reset(new CmdTextEdit(*mCurrentText));

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -177,7 +177,12 @@ Board::Board(Project& project, const FilePath& filepath, bool restore,
 
             // the board seems to be ready to open, so we will create all needed objects
 
-            mUuid = root.getValueByPath<Uuid>("uuid", true);
+            if (root.getChildByIndex(0).isString()) {
+                mUuid = root.getChildByIndex(0).getValue<Uuid>(true);
+            } else {
+                // backward compatibility, remove this some time!
+                mUuid = root.getValueByPath<Uuid>("uuid", true);
+            }
             mName = root.getValueByPath<QString>("name", true);
 
             // Load grid properties
@@ -664,7 +669,7 @@ void Board::serialize(SExpression& root) const
 {
     if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
-    root.appendTokenChild("uuid", mUuid, true);
+    root.appendToken(mUuid);
     root.appendStringChild("name", mName, true);
     root.appendChild(mGridProperties->serializeToDomElement("grid"), true);
     root.appendChild(mLayerStack->serializeToDomElement("layers"), true);

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -166,7 +166,7 @@ Board::Board(Project& project, const FilePath& filepath, bool restore,
             mUserSettings.reset(new BoardUserSettings(*this, restore, readOnly, create));
 
             // add 160x100mm board outline (Eurocard size)
-            QScopedPointer<Polygon> polygon(Polygon::createRect(GraphicsLayer::sBoardOutlines,
+            QScopedPointer<Polygon> polygon(Polygon::createRect(Uuid::createRandom(), GraphicsLayer::sBoardOutlines,
                 Length(0), false, false, Point(0, 0), Length(160000000), Length(100000000)));
             mPolygons.append(new BI_Polygon(*this, *polygon));
         }

--- a/libs/librepcb/project/boards/items/bi_polygon.cpp
+++ b/libs/librepcb/project/boards/items/bi_polygon.cpp
@@ -42,7 +42,7 @@ namespace project {
 BI_Polygon::BI_Polygon(Board& board, const BI_Polygon& other) :
     BI_Base(board)
 {
-    mPolygon.reset(new Polygon(*other.mPolygon));
+    mPolygon.reset(new Polygon(Uuid::createRandom(), *other.mPolygon));
     init();
 }
 
@@ -60,11 +60,11 @@ BI_Polygon::BI_Polygon(Board& board, const Polygon& polygon) :
     init();
 }
 
-BI_Polygon::BI_Polygon(Board& board, const QString& layerName, const Length& lineWidth, bool fill,
+BI_Polygon::BI_Polygon(Board& board, const Uuid& uuid, const QString& layerName, const Length& lineWidth, bool fill,
                        bool isGrabArea, const Point& startPos) :
     BI_Base(board)
 {
-    mPolygon.reset(new Polygon(layerName, lineWidth, fill, isGrabArea, startPos));
+    mPolygon.reset(new Polygon(uuid, layerName, lineWidth, fill, isGrabArea, startPos));
     init();
 }
 

--- a/libs/librepcb/project/boards/items/bi_polygon.h
+++ b/libs/librepcb/project/boards/items/bi_polygon.h
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 #include <QtCore>
 #include "bi_base.h"
+#include <librepcb/common/uuid.h>
 #include <librepcb/common/fileio/serializableobject.h>
 
 /*****************************************************************************************
@@ -63,8 +64,8 @@ class BI_Polygon final : public BI_Base, public SerializableObject
         BI_Polygon(Board& board, const BI_Polygon& other);
         BI_Polygon(Board& board, const SExpression& node);
         BI_Polygon(Board& board, const Polygon& polygon);
-        BI_Polygon(Board& board, const QString& layerName, const Length& lineWidth, bool fill,
-                   bool isGrabArea, const Point& startPos);
+        BI_Polygon(Board& board, const Uuid& uuid, const QString& layerName,
+                   const Length& lineWidth, bool fill, bool isGrabArea, const Point& startPos);
         ~BI_Polygon() noexcept;
 
         // Getters

--- a/libs/librepcb/project/metadata/projectmetadata.h
+++ b/libs/librepcb/project/metadata/projectmetadata.h
@@ -63,6 +63,7 @@ class ProjectMetadata final : public QObject, public SerializableObject
 
         // Getters
         Project& getProject() const noexcept {return mProject;}
+        const Uuid& getUuid() const noexcept {return mUuid;}
 
         /**
          * @brief Get the name of the project
@@ -182,6 +183,7 @@ class ProjectMetadata final : public QObject, public SerializableObject
         QScopedPointer<SmartSExprFile> mFile;
 
         // Metadata
+        Uuid mUuid;                 ///< the UUID of the project
         QString mName;              ///< the name of the project
         QString mAuthor;            ///< the author of the project
         QString mVersion;           ///< the version of the project (arbitrary string)

--- a/libs/librepcb/project/schematics/schematic.cpp
+++ b/libs/librepcb/project/schematics/schematic.cpp
@@ -77,7 +77,12 @@ Schematic::Schematic(Project& project, const FilePath& filepath, bool restore,
 
             // the schematic seems to be ready to open, so we will create all needed objects
 
-            mUuid = root.getValueByPath<Uuid>("uuid", true);
+            if (root.getChildByIndex(0).isString()) {
+                mUuid = root.getChildByIndex(0).getValue<Uuid>(true);
+            } else {
+                // backward compatibility, remove this some time!
+                mUuid = root.getValueByPath<Uuid>("uuid", true);
+            }
             mName = root.getValueByPath<QString>("name", true);
 
             // Load grid properties
@@ -487,7 +492,7 @@ void Schematic::serialize(SExpression& root) const
 {
     if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
-    root.appendTokenChild("uuid", mUuid, true);
+    root.appendToken(mUuid);
     root.appendStringChild("name", mName, true);
     root.appendChild(mGridProperties->serializeToDomElement("grid"), true);
     root.appendLineBreak();

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
@@ -270,10 +270,12 @@ bool BES_DrawPolygon::start(Board& board, const Point& pos) noexcept
         mSubState = SubState::Positioning;
 
         // add polygon with two segments
-        Polygon p(mCurrentLayerName, mCurrentWidth, mCurrentIsFilled, mCurrentIsFilled, pos);
-        p.getSegments().append(std::make_shared<PolygonSegment>(pos, Angle::deg0()));
-        p.getSegments().append(std::make_shared<PolygonSegment>(pos, Angle::deg0())); // back to startpoint
-        mCurrentPolygon = new BI_Polygon(board, p);
+        mCurrentPolygon = new BI_Polygon(board, Uuid::createRandom(), mCurrentLayerName,
+            mCurrentWidth, mCurrentIsFilled, mCurrentIsFilled, pos);
+        mCurrentPolygon->getPolygon().getSegments().append(
+            std::make_shared<PolygonSegment>(pos, Angle::deg0()));
+        mCurrentPolygon->getPolygon().getSegments().append(
+            std::make_shared<PolygonSegment>(pos, Angle::deg0())); // back to startpoint
         mUndoStack.appendToCmdGroup(new CmdBoardPolygonAdd(*mCurrentPolygon));
 
         // start edit commands


### PR DESCRIPTION
The handling of UUIDs was not really consistent until now. This PR should fix this with following changes:

#### Make UUID the first token in root node of every file

Old root node of a symbol: 
```lisp
(librepcb_symbol
 (uuid 2da144df-507b-4c51-8f16-174229e04572)
 (name "Trimmer Resistor")
```

New root node of a symbol: 
```lisp
(librepcb_symbol 2da144df-507b-4c51-8f16-174229e04572
 (name "Trimmer Resistor")
```

This is now consistent with other S-Expression nodes, like a component gate which looks like this:
```lisp
(gate 426e2b17-da88-400b-b1fb-248b24f9c541
   (symbol 9b75d0ce-ac4e-4a52-a88a-8777f66d3241)
   (pos 0.0 0.0) (rot 0.0) (required true) (suffix "")
```

#### Make projects, polygons, ellipses, holes and texts having a UUID

These objects had no UUID at all until now. But for some planned features, they will also need a UUID.

#### Other small adjustments in S-Expression files

In addition, I made some other small adjustments of some S-Expression nodes. You can take a look at the demo workspace to see what has changed exactly: https://github.com/LibrePCB/demo-workspace/compare/c0eaef4bb00b00d2952cd0a7a901389754bd3055...36b485972026661e6aa018d06d2a7b92c6147fda