### PR TITLE
Increase max length of library directory paths

### DIFF
--- a/libs/librepcb/librarymanager/addlibrarywidget.ui
+++ b/libs/librepcb/librarymanager/addlibrarywidget.ui
@@ -143,7 +143,7 @@
        <item row="8" column="1">
         <widget class="QLineEdit" name="edtLocalDirectory">
          <property name="maxLength">
-          <number>60</number>
+          <number>255</number>
          </property>
          <property name="clearButtonEnabled">
           <bool>true</bool>
@@ -269,7 +269,7 @@ Note: This is mandatory to publish the library on librepcb.org!</string>
        <item row="3" column="1">
         <widget class="QLineEdit" name="edtDownloadZipDirectory">
          <property name="maxLength">
-          <number>60</number>
+          <number>255</number>
          </property>
          <property name="clearButtonEnabled">
           <bool>true</bool>


### PR DESCRIPTION
Fixes LibrePCB/librepcb-rfcs#9.