### PR TITLE
BoardEditor: Save device properties on enter

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -109,9 +109,7 @@ void DeviceInstancePropertiesDialog::buttonBoxClicked(QAbstractButton* button) n
             applyChanges();
             break;
         case QDialogButtonBox::AcceptRole:
-            if (applyChanges()) {
-                accept();
-            }
+            accept();
             break;
         case QDialogButtonBox::RejectRole:
             reject();
@@ -135,7 +133,7 @@ void DeviceInstancePropertiesDialog::keyPressEvent(QKeyEvent* e)
     }
 }
 
-void DeviceInstancePropertiesDialog::accept()
+void DeviceInstancePropertiesDialog::accept() noexcept
 {
     if (applyChanges()) {
         QDialog::accept();

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -135,6 +135,13 @@ void DeviceInstancePropertiesDialog::keyPressEvent(QKeyEvent* e)
     }
 }
 
+void DeviceInstancePropertiesDialog::accept()
+{
+    if (applyChanges()) {
+        QDialog::accept();
+    }
+}
+
 bool DeviceInstancePropertiesDialog::applyChanges() noexcept
 {
     try {

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -118,7 +118,7 @@ void DeviceInstancePropertiesDialog::buttonBoxClicked(QAbstractButton* button) n
     }
 }
 
-void DeviceInstancePropertiesDialog::keyPressEvent(QKeyEvent* e)
+void DeviceInstancePropertiesDialog::keyPressEvent(QKeyEvent* e) noexcept
 {
     switch (e->key()) {
         case Qt::Key_Return:

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
@@ -73,7 +73,7 @@ class DeviceInstancePropertiesDialog final : public QDialog
     private: // Methods
         void buttonBoxClicked(QAbstractButton* button) noexcept;
         void keyPressEvent(QKeyEvent* e);
-        void accept();
+        void accept() noexcept override;
         bool applyChanges() noexcept;
 
 

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
@@ -73,6 +73,7 @@ class DeviceInstancePropertiesDialog final : public QDialog
     private: // Methods
         void buttonBoxClicked(QAbstractButton* button) noexcept;
         void keyPressEvent(QKeyEvent* e);
+        void accept();
         bool applyChanges() noexcept;
 
 

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
@@ -72,7 +72,7 @@ class DeviceInstancePropertiesDialog final : public QDialog
 
     private: // Methods
         void buttonBoxClicked(QAbstractButton* button) noexcept;
-        void keyPressEvent(QKeyEvent* e);
+        void keyPressEvent(QKeyEvent* e) noexcept override;
         void accept() noexcept override;
         bool applyChanges() noexcept;
 


### PR DESCRIPTION
The class was missing an `accept` override.