### PR TITLE
Improve PCB fabrication output generator

### DIFF
--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -119,6 +119,7 @@ class Board final : public QObject, public AttributeProvider,
         const GridProperties& getGridProperties() const noexcept {return *mGridProperties;}
         GraphicsScene& getGraphicsScene () const noexcept {return *mGraphicsScene;}
         BoardLayerStack& getLayerStack() noexcept {return *mLayerStack;}
+        const BoardLayerStack& getLayerStack() const noexcept {return *mLayerStack;}
         BoardDesignRules& getDesignRules() noexcept {return *mDesignRules;}
         const BoardDesignRules& getDesignRules() const noexcept {return *mDesignRules;}
         BoardFabricationOutputSettings& getFabricationOutputSettings() noexcept {return *mFabricationOutputSettings;}

--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -61,6 +61,7 @@ class BI_Polygon;
 class BI_StrokeText;
 class BI_Plane;
 class BoardLayerStack;
+class BoardFabricationOutputSettings;
 class BoardUserSettings;
 class BoardSelectionQuery;
 
@@ -120,6 +121,8 @@ class Board final : public QObject, public AttributeProvider,
         BoardLayerStack& getLayerStack() noexcept {return *mLayerStack;}
         BoardDesignRules& getDesignRules() noexcept {return *mDesignRules;}
         const BoardDesignRules& getDesignRules() const noexcept {return *mDesignRules;}
+        BoardFabricationOutputSettings& getFabricationOutputSettings() noexcept {return *mFabricationOutputSettings;}
+        const BoardFabricationOutputSettings& getFabricationOutputSettings() const noexcept {return *mFabricationOutputSettings;}
         bool isEmpty() const noexcept;
         QList<BI_Base*> getItemsAtScenePos(const Point& pos) const noexcept;
         QList<BI_Via*> getViasAtScenePos(const Point& pos, const NetSignal* netsignal) const noexcept;
@@ -226,6 +229,7 @@ class Board final : public QObject, public AttributeProvider,
         QScopedPointer<BoardLayerStack> mLayerStack;
         QScopedPointer<GridProperties> mGridProperties;
         QScopedPointer<BoardDesignRules> mDesignRules;
+        QScopedPointer<BoardFabricationOutputSettings> mFabricationOutputSettings;
         QScopedPointer<BoardUserSettings> mUserSettings;
         QRectF mViewRect;
 

--- a/libs/librepcb/project/boards/boardfabricationoutputsettings.cpp
+++ b/libs/librepcb/project/boards/boardfabricationoutputsettings.cpp
@@ -1,0 +1,199 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcb/common/graphics/graphicslayer.h>
+#include "boardfabricationoutputsettings.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+BoardFabricationOutputSettings::BoardFabricationOutputSettings() noexcept :
+    mOutputBasePath("./output/{{VERSION}}/gerber/{{PROJECT}}"),
+    mSuffixDrills("_DRILLS.drl"),
+    mSuffixDrillsNpth("_DRILLS-NPTH.drl"),
+    mSuffixDrillsPth("_DRILLS-PTH.drl"),
+    mSuffixOutlines("_OUTLINES.gbr"),
+    mSuffixCopperTop("_COPPER-TOP.gbr"),
+    mSuffixCopperInner("_COPPER-IN{{CU_LAYER}}.gbr"),
+    mSuffixCopperBot("_COPPER-BOTTOM.gbr"),
+    mSuffixSolderMaskTop("_SOLDERMASK-TOP.gbr"),
+    mSuffixSolderMaskBot("_SOLDERMASK-BOTTOM.gbr"),
+    mSuffixSilkscreenTop("_SILKSCREEN-TOP.gbr"),
+    mSuffixSilkscreenBot("_SILKSCREEN-BOTTOM.gbr"),
+    mSuffixSolderPasteTop("_SOLDERPASTE-TOP.gbr"),
+    mSuffixSolderPasteBot("_SOLDERPASTE-BOTTOM.gbr"),
+    mSilkscreenLayersTop({GraphicsLayer::sTopPlacement, GraphicsLayer::sTopNames}),
+    mSilkscreenLayersBot({GraphicsLayer::sBotPlacement, GraphicsLayer::sBotNames}),
+    mMergeDrillFiles(false),
+    mEnableSolderPasteTop(false),
+    mEnableSolderPasteBot(false)
+{
+}
+
+BoardFabricationOutputSettings::BoardFabricationOutputSettings(const BoardFabricationOutputSettings& other) noexcept :
+    BoardFabricationOutputSettings() // init and load defaults
+{
+    *this = other;
+}
+
+BoardFabricationOutputSettings::BoardFabricationOutputSettings(const SExpression& node) :
+    BoardFabricationOutputSettings() // init and load defaults
+{
+    mOutputBasePath        = node.getValueByPath<QString>("base_path"              , false);
+    mSuffixOutlines        = node.getValueByPath<QString>("outlines/suffix"        , false);
+    mSuffixCopperTop       = node.getValueByPath<QString>("copper_top/suffix"      , false);
+    mSuffixCopperInner     = node.getValueByPath<QString>("copper_inner/suffix"    , false);
+    mSuffixCopperBot       = node.getValueByPath<QString>("copper_bot/suffix"      , false);
+    mSuffixSolderMaskTop   = node.getValueByPath<QString>("soldermask_top/suffix"  , false);
+    mSuffixSolderMaskBot   = node.getValueByPath<QString>("soldermask_bot/suffix"  , false);
+    mSuffixSilkscreenTop   = node.getValueByPath<QString>("silkscreen_top/suffix"  , false);
+    mSuffixSilkscreenBot   = node.getValueByPath<QString>("silkscreen_bot/suffix"  , false);
+    mSuffixSolderPasteTop  = node.getValueByPath<QString>("solderpaste_top/suffix" , false);
+    mSuffixSolderPasteBot  = node.getValueByPath<QString>("solderpaste_bot/suffix" , false);
+    mSuffixDrillsPth       = node.getValueByPath<QString>("drills/suffix_pth"      , false);
+    mSuffixDrillsNpth      = node.getValueByPath<QString>("drills/suffix_npth"     , false);
+    mSuffixDrills          = node.getValueByPath<QString>("drills/suffix_merged"   , false);
+    mMergeDrillFiles       = node.getValueByPath<bool   >("drills/merge"           , false);
+    mEnableSolderPasteTop  = node.getValueByPath<bool   >("solderpaste_top/create" , false);
+    mEnableSolderPasteBot  = node.getValueByPath<bool   >("solderpaste_bot/create" , false);
+
+    mSilkscreenLayersTop.clear();
+    foreach (const SExpression& child, node.getChildByPath("silkscreen_top/layers").getChildren()) {
+        mSilkscreenLayersTop.append(child.getValue<QString>(false));
+    }
+
+    mSilkscreenLayersBot.clear();
+    foreach (const SExpression& child, node.getChildByPath("silkscreen_bot/layers").getChildren()) {
+        mSilkscreenLayersBot.append(child.getValue<QString>(false));
+    }
+}
+
+BoardFabricationOutputSettings::~BoardFabricationOutputSettings() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void BoardFabricationOutputSettings::serialize(SExpression& root) const
+{
+    root.appendStringChild("base_path"       , mOutputBasePath       , true);
+    root.appendList("outlines"        , true).appendStringChild("suffix", mSuffixOutlines       , false);
+    root.appendList("copper_top"      , true).appendStringChild("suffix", mSuffixCopperTop      , false);
+    root.appendList("copper_inner"    , true).appendStringChild("suffix", mSuffixCopperInner    , false);
+    root.appendList("copper_bot"      , true).appendStringChild("suffix", mSuffixCopperBot      , false);
+    root.appendList("soldermask_top"  , true).appendStringChild("suffix", mSuffixSolderMaskTop  , false);
+    root.appendList("soldermask_bot"  , true).appendStringChild("suffix", mSuffixSolderMaskBot  , false);
+
+    SExpression& silkscreenTop = root.appendList("silkscreen_top", true);
+    silkscreenTop.appendStringChild("suffix", mSuffixSilkscreenTop, false);
+    SExpression& silkscreenTopLayers = silkscreenTop.appendList("layers", true);
+    foreach (const QString& layer, mSilkscreenLayersTop) silkscreenTopLayers.appendToken(layer);
+
+    SExpression& silkscreenBot = root.appendList("silkscreen_bot", true);
+    silkscreenBot.appendStringChild("suffix", mSuffixSilkscreenBot, false);
+    SExpression& silkscreenBotLayers = silkscreenBot.appendList("layers", true);
+    foreach (const QString& layer, mSilkscreenLayersBot) silkscreenBotLayers.appendToken(layer);
+
+    SExpression& drills = root.appendList("drills", true);
+    drills.appendTokenChild("merge", mMergeDrillFiles, false);
+    drills.appendStringChild("suffix_pth"   , mSuffixDrillsPth , true);
+    drills.appendStringChild("suffix_npth"  , mSuffixDrillsNpth, true);
+    drills.appendStringChild("suffix_merged", mSuffixDrills    , true);
+
+    SExpression& solderPasteTop = root.appendList("solderpaste_top", true);
+    solderPasteTop.appendTokenChild("create", mEnableSolderPasteTop, false);
+    solderPasteTop.appendStringChild("suffix", mSuffixSolderPasteTop, false);
+
+    SExpression& solderPasteBot = root.appendList("solderpaste_bot", true);
+    solderPasteBot.appendTokenChild("create", mEnableSolderPasteBot, false);
+    solderPasteBot.appendStringChild("suffix", mSuffixSolderPasteBot, false);
+}
+
+/*****************************************************************************************
+ *  Operator Overloadings
+ ****************************************************************************************/
+
+BoardFabricationOutputSettings& BoardFabricationOutputSettings::operator=(
+    const BoardFabricationOutputSettings& rhs) noexcept
+{
+    mOutputBasePath        = rhs.mOutputBasePath       ;
+    mSuffixDrills          = rhs.mSuffixDrills         ;
+    mSuffixDrillsNpth      = rhs.mSuffixDrillsNpth     ;
+    mSuffixDrillsPth       = rhs.mSuffixDrillsPth      ;
+    mSuffixOutlines        = rhs.mSuffixOutlines       ;
+    mSuffixCopperTop       = rhs.mSuffixCopperTop      ;
+    mSuffixCopperInner     = rhs.mSuffixCopperInner    ;
+    mSuffixCopperBot       = rhs.mSuffixCopperBot      ;
+    mSuffixSolderMaskTop   = rhs.mSuffixSolderMaskTop  ;
+    mSuffixSolderMaskBot   = rhs.mSuffixSolderMaskBot  ;
+    mSuffixSilkscreenTop   = rhs.mSuffixSilkscreenTop  ;
+    mSuffixSilkscreenBot   = rhs.mSuffixSilkscreenBot  ;
+    mSuffixSolderPasteTop  = rhs.mSuffixSolderPasteTop ;
+    mSuffixSolderPasteBot  = rhs.mSuffixSolderPasteBot ;
+    mSilkscreenLayersTop   = rhs.mSilkscreenLayersTop  ;
+    mSilkscreenLayersBot   = rhs.mSilkscreenLayersBot  ;
+    mMergeDrillFiles       = rhs.mMergeDrillFiles      ;
+    mEnableSolderPasteTop  = rhs.mEnableSolderPasteTop ;
+    mEnableSolderPasteBot  = rhs.mEnableSolderPasteBot ;
+    return *this;
+}
+
+bool BoardFabricationOutputSettings::operator==(const BoardFabricationOutputSettings& rhs) const noexcept
+{
+    if (mOutputBasePath        != rhs.mOutputBasePath       ) return false;
+    if (mSuffixDrills          != rhs.mSuffixDrills         ) return false;
+    if (mSuffixDrillsNpth      != rhs.mSuffixDrillsNpth     ) return false;
+    if (mSuffixDrillsPth       != rhs.mSuffixDrillsPth      ) return false;
+    if (mSuffixOutlines        != rhs.mSuffixOutlines       ) return false;
+    if (mSuffixCopperTop       != rhs.mSuffixCopperTop      ) return false;
+    if (mSuffixCopperInner     != rhs.mSuffixCopperInner    ) return false;
+    if (mSuffixCopperBot       != rhs.mSuffixCopperBot      ) return false;
+    if (mSuffixSolderMaskTop   != rhs.mSuffixSolderMaskTop  ) return false;
+    if (mSuffixSolderMaskBot   != rhs.mSuffixSolderMaskBot  ) return false;
+    if (mSuffixSilkscreenTop   != rhs.mSuffixSilkscreenTop  ) return false;
+    if (mSuffixSilkscreenBot   != rhs.mSuffixSilkscreenBot  ) return false;
+    if (mSuffixSolderPasteTop  != rhs.mSuffixSolderPasteTop ) return false;
+    if (mSuffixSolderPasteBot  != rhs.mSuffixSolderPasteBot ) return false;
+    if (mSilkscreenLayersTop   != rhs.mSilkscreenLayersTop  ) return false;
+    if (mSilkscreenLayersBot   != rhs.mSilkscreenLayersBot  ) return false;
+    if (mMergeDrillFiles       != rhs.mMergeDrillFiles      ) return false;
+    if (mEnableSolderPasteTop  != rhs.mEnableSolderPasteTop ) return false;
+    if (mEnableSolderPasteBot  != rhs.mEnableSolderPasteBot ) return false;
+    return true;
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/project/boards/boardfabricationoutputsettings.h
+++ b/libs/librepcb/project/boards/boardfabricationoutputsettings.h
@@ -1,0 +1,132 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_BOARDFABRICATIONOUTPUTSETTINGS_H
+#define LIBREPCB_PROJECT_BOARDFABRICATIONOUTPUTSETTINGS_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcb/common/fileio/serializableobject.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Class BoardFabricationOutputSettings
+ ****************************************************************************************/
+
+/**
+ * @brief The BoardFabricationOutputSettings class
+ */
+class BoardFabricationOutputSettings final : public SerializableObject
+{
+    public:
+
+        // Constructors / Destructor
+        BoardFabricationOutputSettings() noexcept;
+        BoardFabricationOutputSettings(const BoardFabricationOutputSettings& other) noexcept;
+        explicit BoardFabricationOutputSettings(const SExpression& node);
+        ~BoardFabricationOutputSettings() noexcept;
+
+        // Getters
+        const QString& getOutputBasePath()          const noexcept {return mOutputBasePath;}
+        const QString& getSuffixDrills()            const noexcept {return mSuffixDrills;}
+        const QString& getSuffixDrillsNpth()        const noexcept {return mSuffixDrillsNpth;}
+        const QString& getSuffixDrillsPth()         const noexcept {return mSuffixDrillsPth;}
+        const QString& getSuffixOutlines()          const noexcept {return mSuffixOutlines;}
+        const QString& getSuffixCopperTop()         const noexcept {return mSuffixCopperTop;}
+        const QString& getSuffixCopperInner()       const noexcept {return mSuffixCopperInner;}
+        const QString& getSuffixCopperBot()         const noexcept {return mSuffixCopperBot;}
+        const QString& getSuffixSolderMaskTop()     const noexcept {return mSuffixSolderMaskTop;}
+        const QString& getSuffixSolderMaskBot()     const noexcept {return mSuffixSolderMaskBot;}
+        const QString& getSuffixSilkscreenTop()     const noexcept {return mSuffixSilkscreenTop;}
+        const QString& getSuffixSilkscreenBot()     const noexcept {return mSuffixSilkscreenBot;}
+        const QString& getSuffixSolderPasteTop()    const noexcept {return mSuffixSolderPasteTop;}
+        const QString& getSuffixSolderPasteBot()    const noexcept {return mSuffixSolderPasteBot;}
+        const QStringList& getSilkscreenLayersTop() const noexcept {return mSilkscreenLayersTop;}
+        const QStringList& getSilkscreenLayersBot() const noexcept {return mSilkscreenLayersBot;}
+        bool getMergeDrillFiles()                   const noexcept {return mMergeDrillFiles;}
+        bool getEnableSolderPasteTop()              const noexcept {return mEnableSolderPasteTop;}
+        bool getEnableSolderPasteBot()              const noexcept {return mEnableSolderPasteBot;}
+
+        // Setters
+        void setOutputBasePath(const QString& p)          noexcept {mOutputBasePath = p;}
+        void setSuffixDrills(const QString& s)            noexcept {mSuffixDrills = s;}
+        void setSuffixDrillsNpth(const QString& s)        noexcept {mSuffixDrillsNpth = s;}
+        void setSuffixDrillsPth(const QString& s)         noexcept {mSuffixDrillsPth = s;}
+        void setSuffixOutlines(const QString& s)          noexcept {mSuffixOutlines = s;}
+        void setSuffixCopperTop(const QString& s)         noexcept {mSuffixCopperTop = s;}
+        void setSuffixCopperInner(const QString& s)       noexcept {mSuffixCopperInner = s;}
+        void setSuffixCopperBot(const QString& s)         noexcept {mSuffixCopperBot = s;}
+        void setSuffixSolderMaskTop(const QString& s)     noexcept {mSuffixSolderMaskTop = s;}
+        void setSuffixSolderMaskBot(const QString& s)     noexcept {mSuffixSolderMaskBot = s;}
+        void setSuffixSilkscreenTop(const QString& s)     noexcept {mSuffixSilkscreenTop = s;}
+        void setSuffixSilkscreenBot(const QString& s)     noexcept {mSuffixSilkscreenBot = s;}
+        void setSuffixSolderPasteTop(const QString& s)    noexcept {mSuffixSolderPasteTop = s;}
+        void setSuffixSolderPasteBot(const QString& s)    noexcept {mSuffixSolderPasteBot = s;}
+        void setSilkscreenLayersTop(const QStringList& l) noexcept {mSilkscreenLayersTop = l;}
+        void setSilkscreenLayersBot(const QStringList& l) noexcept {mSilkscreenLayersBot = l;}
+        void setMergeDrillFiles(bool m)                   noexcept {mMergeDrillFiles = m;}
+        void setEnableSolderPasteTop(bool e)              noexcept {mEnableSolderPasteTop = e;}
+        void setEnableSolderPasteBot(bool e)              noexcept {mEnableSolderPasteBot = e;}
+
+        /// @copydoc librepcb::SerializableObject::serialize()
+        void serialize(SExpression& root) const override;
+
+        // Operator Overloadings
+        BoardFabricationOutputSettings& operator=(const BoardFabricationOutputSettings& rhs) noexcept;
+        bool operator==(const BoardFabricationOutputSettings& rhs) const noexcept;
+        bool operator!=(const BoardFabricationOutputSettings& rhs) const noexcept {return !(*this == rhs);}
+
+
+    private: // Data
+        QString mOutputBasePath;
+        QString mSuffixDrills; // NPTH and PTH combined
+        QString mSuffixDrillsNpth;
+        QString mSuffixDrillsPth;
+        QString mSuffixOutlines;
+        QString mSuffixCopperTop;
+        QString mSuffixCopperInner;
+        QString mSuffixCopperBot;
+        QString mSuffixSolderMaskTop;
+        QString mSuffixSolderMaskBot;
+        QString mSuffixSilkscreenTop;
+        QString mSuffixSilkscreenBot;
+        QString mSuffixSolderPasteTop;
+        QString mSuffixSolderPasteBot;
+        QStringList mSilkscreenLayersTop;
+        QStringList mSilkscreenLayersBot;
+        bool mMergeDrillFiles;
+        bool mEnableSolderPasteTop;
+        bool mEnableSolderPasteBot;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_BOARDFABRICATIONOUTPUTSETTINGS_H

--- a/libs/librepcb/project/boards/items/bi_footprint.h
+++ b/libs/librepcb/project/boards/items/bi_footprint.h
@@ -74,7 +74,7 @@ class BI_Footprint final : public BI_Base, public SerializableObject,
         const Uuid& getComponentInstanceUuid() const noexcept;
         BI_Device& getDeviceInstance() const noexcept {return mDevice;}
         BI_FootprintPad* getPad(const Uuid& padUuid) const noexcept {return mPads.value(padUuid);}
-        const QHash<Uuid, BI_FootprintPad*>& getPads() const noexcept {return mPads;}
+        const QMap<Uuid, BI_FootprintPad*>& getPads() const noexcept {return mPads;}
         const library::Footprint& getLibFootprint() const noexcept;
         const Angle& getRotation() const noexcept;
         bool isSelectable() const noexcept override;
@@ -131,7 +131,7 @@ class BI_Footprint final : public BI_Base, public SerializableObject,
         // General
         BI_Device& mDevice;
         QScopedPointer<BGI_Footprint> mGraphicsItem;
-        QHash<Uuid, BI_FootprintPad*> mPads; ///< key: footprint pad UUID
+        QMap<Uuid, BI_FootprintPad*> mPads; ///< key: footprint pad UUID
         QList<BI_StrokeText*> mStrokeTexts;
 };
 

--- a/libs/librepcb/project/boards/items/bi_polygon.cpp
+++ b/libs/librepcb/project/boards/items/bi_polygon.cpp
@@ -117,6 +117,11 @@ QPainterPath BI_Polygon::getGrabAreaScenePx() const noexcept
     return mGraphicsItem->sceneTransform().map(mGraphicsItem->shape());
 }
 
+const Uuid& BI_Polygon::getUuid() const noexcept
+{
+    return mPolygon->getUuid();
+}
+
 bool BI_Polygon::isSelectable() const noexcept
 {
     const GraphicsLayer* layer = mBoard.getLayerStack().getLayer(mPolygon->getLayerName());

--- a/libs/librepcb/project/boards/items/bi_polygon.h
+++ b/libs/librepcb/project/boards/items/bi_polygon.h
@@ -72,6 +72,7 @@ class BI_Polygon final : public BI_Base, public SerializableObject
         // Getters
         Polygon& getPolygon() noexcept {return *mPolygon;}
         const Polygon& getPolygon() const noexcept {return *mPolygon;}
+        const Uuid& getUuid() const noexcept; // convenience function, e.g. for template usage
         bool isSelectable() const noexcept override;
 
         // General Methods

--- a/libs/librepcb/project/boards/items/bi_stroketext.cpp
+++ b/libs/librepcb/project/boards/items/bi_stroketext.cpp
@@ -154,6 +154,11 @@ QPainterPath BI_StrokeText::getGrabAreaScenePx() const noexcept
     return mGraphicsItem->sceneTransform().map(mGraphicsItem->shape());
 }
 
+const Uuid& BI_StrokeText::getUuid() const noexcept
+{
+    return mText->getUuid();
+}
+
 bool BI_StrokeText::isSelectable() const noexcept
 {
     const GraphicsLayer* layer = mBoard.getLayerStack().getLayer(mText->getLayerName());

--- a/libs/librepcb/project/boards/items/bi_stroketext.h
+++ b/libs/librepcb/project/boards/items/bi_stroketext.h
@@ -69,6 +69,7 @@ class BI_StrokeText final : public BI_Base, public SerializableObject,
         // Getters
         StrokeText& getText() noexcept {return *mText;}
         const StrokeText& getText() const noexcept {return *mText;}
+        const Uuid& getUuid() const noexcept; // convenience function, e.g. for template usage
         bool isSelectable() const noexcept override;
 
         // General Methods

--- a/libs/librepcb/project/project.pro
+++ b/libs/librepcb/project/project.pro
@@ -22,6 +22,7 @@ INCLUDEPATH += \
 
 SOURCES += \
     boards/board.cpp \
+    boards/boardfabricationoutputsettings.cpp \
     boards/boardgerberexport.cpp \
     boards/boardlayerstack.cpp \
     boards/boardplanefragmentsbuilder.cpp \
@@ -128,6 +129,7 @@ SOURCES += \
 
 HEADERS += \
     boards/board.h \
+    boards/boardfabricationoutputsettings.h \
     boards/boardgerberexport.h \
     boards/boardlayerstack.h \
     boards/boardplanefragmentsbuilder.h \

--- a/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.cpp
@@ -23,10 +23,12 @@
 #include <QtCore>
 #include "fabricationoutputdialog.h"
 #include "ui_fabricationoutputdialog.h"
+#include <librepcb/common/graphics/graphicslayer.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/metadata/projectmetadata.h>
 #include <librepcb/project/boards/board.h>
 #include <librepcb/project/boards/boardgerberexport.h>
+#include <librepcb/project/boards/boardfabricationoutputsettings.h>
 
 /*****************************************************************************************
  *  Namespace
@@ -44,12 +46,45 @@ FabricationOutputDialog::FabricationOutputDialog(Board& board, QWidget *parent) 
     mUi(new Ui::FabricationOutputDialog)
 {
     mUi->setupUi(this);
+    connect(mUi->cbxDrillsMerge, &QCheckBox::toggled,
+            mUi->edtSuffixDrills, &QLineEdit::setEnabled);
+    connect(mUi->cbxDrillsMerge, &QCheckBox::toggled,
+            mUi->edtSuffixDrillsNpth, &QLineEdit::setDisabled);
+    connect(mUi->cbxDrillsMerge, &QCheckBox::toggled,
+            mUi->edtSuffixDrillsPth, &QLineEdit::setDisabled);
+    connect(mUi->cbxSolderPasteTop, &QCheckBox::toggled,
+            mUi->edtSuffixSolderPasteTop, &QLineEdit::setEnabled);
+    connect(mUi->cbxSolderPasteBot, &QCheckBox::toggled,
+            mUi->edtSuffixSolderPasteBot, &QLineEdit::setEnabled);
 
-    QString version = FilePath::cleanFileName(mProject.getMetadata().getVersion(),
-                      FilePath::ReplaceSpaces | FilePath::KeepCase);
-    QString outputDir = QString("output/%1/gerber").arg(version);
-    FilePath gerberDir = mProject.getPath().getPathTo(outputDir);
-    mUi->edtOutputDirPath->setText(gerberDir.toNative());
+    BoardFabricationOutputSettings s = mBoard.getFabricationOutputSettings();
+    mUi->edtBasePath->setText(s.getOutputBasePath());
+    mUi->edtSuffixOutlines->setText(s.getSuffixOutlines());
+    mUi->edtSuffixCopperTop->setText(s.getSuffixCopperTop());
+    mUi->edtSuffixCopperInner->setText(s.getSuffixCopperInner());
+    mUi->edtSuffixCopperBot->setText(s.getSuffixCopperBot());
+    mUi->edtSuffixSoldermaskTop->setText(s.getSuffixSolderMaskTop());
+    mUi->edtSuffixSoldermaskBot->setText(s.getSuffixSolderMaskBot());
+    mUi->edtSuffixSilkscreenTop->setText(s.getSuffixSilkscreenTop());
+    mUi->edtSuffixSilkscreenBot->setText(s.getSuffixSilkscreenBot());
+    mUi->edtSuffixDrillsNpth->setText(s.getSuffixDrillsNpth());
+    mUi->edtSuffixDrillsPth->setText(s.getSuffixDrillsPth());
+    mUi->edtSuffixDrills->setText(s.getSuffixDrills());
+    mUi->edtSuffixSolderPasteTop->setText(s.getSuffixSolderPasteTop());
+    mUi->edtSuffixSolderPasteBot->setText(s.getSuffixSolderPasteBot());
+    mUi->cbxDrillsMerge->setChecked(s.getMergeDrillFiles());
+    mUi->cbxSolderPasteTop->setChecked(s.getEnableSolderPasteTop());
+    mUi->cbxSolderPasteBot->setChecked(s.getEnableSolderPasteBot());
+
+    QStringList topSilkscreen = s.getSilkscreenLayersTop();
+    mUi->cbxSilkTopPlacement->setChecked(topSilkscreen.contains(GraphicsLayer::sTopPlacement));
+    mUi->cbxSilkTopNames->setChecked(topSilkscreen.contains(GraphicsLayer::sTopNames));
+    mUi->cbxSilkTopValues->setChecked(topSilkscreen.contains(GraphicsLayer::sTopValues));
+
+    QStringList botSilkscreen = s.getSilkscreenLayersBot();
+    mUi->cbxSilkBotPlacement->setChecked(botSilkscreen.contains(GraphicsLayer::sBotPlacement));
+    mUi->cbxSilkBotNames->setChecked(botSilkscreen.contains(GraphicsLayer::sBotNames));
+    mUi->cbxSilkBotValues->setChecked(botSilkscreen.contains(GraphicsLayer::sBotValues));
 }
 
 FabricationOutputDialog::~FabricationOutputDialog()
@@ -61,13 +96,40 @@ FabricationOutputDialog::~FabricationOutputDialog()
  *  Private Slots
  ****************************************************************************************/
 
-void FabricationOutputDialog::on_btnSelectDir_clicked()
+void FabricationOutputDialog::on_btnDefaultSuffixes_clicked()
 {
-    QString directory = QFileDialog::getExistingDirectory(this, tr("Select Output Directory"),
-                                                          mUi->edtOutputDirPath->text());
-    if (directory.isEmpty()) return;
+    mUi->edtSuffixOutlines->setText("_OUTLINES.gbr");
+    mUi->edtSuffixCopperTop->setText("_COPPER-TOP.gbr");
+    mUi->edtSuffixCopperInner->setText("_COPPER-IN{{CU_LAYER}}.gbr");
+    mUi->edtSuffixCopperBot->setText("_COPPER-BOTTOM.gbr");
+    mUi->edtSuffixSoldermaskTop->setText("_SOLDERMASK-TOP.gbr");
+    mUi->edtSuffixSoldermaskBot->setText("_SOLDERMASK-BOTTOM.gbr");
+    mUi->edtSuffixSilkscreenTop->setText("_SILKSCREEN-TOP.gbr");
+    mUi->edtSuffixSilkscreenBot->setText("_SILKSCREEN-BOTTOM.gbr");
+    mUi->edtSuffixDrillsNpth->setText("_DRILLS-NPTH.drl");
+    mUi->edtSuffixDrillsPth->setText("_DRILLS-PTH.drl");
+    mUi->edtSuffixDrills->setText("_DRILLS.drl");
+    mUi->edtSuffixSolderPasteTop->setText("_SOLDERPASTE-TOP.gbr");
+    mUi->edtSuffixSolderPasteBot->setText("_SOLDERPASTE-BOTTOM.gbr");
+    mUi->cbxDrillsMerge->setChecked(false);
+}
 
-    mUi->edtOutputDirPath->setText(FilePath(directory).toNative());
+void FabricationOutputDialog::on_btnProtelSuffixes_clicked()
+{
+    mUi->edtSuffixOutlines->setText(".gm1");
+    mUi->edtSuffixCopperTop->setText(".gtl");
+    mUi->edtSuffixCopperInner->setText(".g{{CU_LAYER}}");
+    mUi->edtSuffixCopperBot->setText(".gbl");
+    mUi->edtSuffixSoldermaskTop->setText(".gts");
+    mUi->edtSuffixSoldermaskBot->setText(".gbs");
+    mUi->edtSuffixSilkscreenTop->setText(".gto");
+    mUi->edtSuffixSilkscreenBot->setText(".gbo");
+    mUi->edtSuffixDrillsNpth->setText("_NPTH.txt");
+    mUi->edtSuffixDrillsPth->setText("_PTH.txt");
+    mUi->edtSuffixDrills->setText(".txt");
+    mUi->edtSuffixSolderPasteTop->setText(".gtp");
+    mUi->edtSuffixSolderPasteBot->setText(".gbp");
+    mUi->cbxDrillsMerge->setChecked(true);
 }
 
 void FabricationOutputDialog::on_btnGenerate_clicked()
@@ -77,8 +139,33 @@ void FabricationOutputDialog::on_btnGenerate_clicked()
         // rebuild planes because they may be outdated!
         mBoard.rebuildAllPlanes();
 
-        FilePath filepath(mUi->edtOutputDirPath->text());
-        BoardGerberExport grbExport(mBoard, filepath);
+        // update fabrication output settings if modified
+        BoardFabricationOutputSettings s = mBoard.getFabricationOutputSettings();
+        s.setOutputBasePath(mUi->edtBasePath->text().trimmed());
+        s.setSuffixDrills(mUi->edtSuffixDrills->text().trimmed());
+        s.setSuffixDrillsNpth(mUi->edtSuffixDrillsNpth->text().trimmed());
+        s.setSuffixDrillsPth(mUi->edtSuffixDrillsPth->text().trimmed());
+        s.setSuffixOutlines(mUi->edtSuffixOutlines->text().trimmed());
+        s.setSuffixCopperTop(mUi->edtSuffixCopperTop->text().trimmed());
+        s.setSuffixCopperInner(mUi->edtSuffixCopperInner->text().trimmed());
+        s.setSuffixCopperBot(mUi->edtSuffixCopperBot->text().trimmed());
+        s.setSuffixSolderMaskTop(mUi->edtSuffixSoldermaskTop->text().trimmed());
+        s.setSuffixSolderMaskBot(mUi->edtSuffixSoldermaskBot->text().trimmed());
+        s.setSuffixSilkscreenTop(mUi->edtSuffixSilkscreenTop->text().trimmed());
+        s.setSuffixSilkscreenBot(mUi->edtSuffixSilkscreenBot->text().trimmed());
+        s.setSuffixSolderPasteTop(mUi->edtSuffixSolderPasteTop->text().trimmed());
+        s.setSuffixSolderPasteBot(mUi->edtSuffixSolderPasteBot->text().trimmed());
+        s.setSilkscreenLayersTop(getTopSilkscreenLayers());
+        s.setSilkscreenLayersBot(getBotSilkscreenLayers());
+        s.setMergeDrillFiles(mUi->cbxDrillsMerge->isChecked());
+        s.setEnableSolderPasteTop(mUi->cbxSolderPasteTop->isChecked());
+        s.setEnableSolderPasteBot(mUi->cbxSolderPasteBot->isChecked());
+        if (s != mBoard.getFabricationOutputSettings()) {
+            mBoard.getFabricationOutputSettings() = s; // TODO: use undo command
+        }
+
+        // generate files
+        BoardGerberExport grbExport(mBoard);
         grbExport.exportAllLayers();
     }
     catch (Exception& e)
@@ -89,12 +176,35 @@ void FabricationOutputDialog::on_btnGenerate_clicked()
 
 void FabricationOutputDialog::on_btnBrowseOutputDir_clicked()
 {
-    FilePath filepath(mUi->edtOutputDirPath->text());
-    if (filepath.isExistingDir()) {
-        QDesktopServices::openUrl(QUrl::fromLocalFile(filepath.toStr()));
+    BoardGerberExport grbExport(mBoard);
+    FilePath dir = grbExport.getOutputDirectory();
+    if (dir.isExistingDir()) {
+        QDesktopServices::openUrl(QUrl::fromLocalFile(dir.toStr()));
     } else {
         QMessageBox::warning(this, tr("Warning"), tr("Directory does not exist."));
     }
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+QStringList FabricationOutputDialog::getTopSilkscreenLayers() const noexcept
+{
+    QStringList layers;
+    if (mUi->cbxSilkTopPlacement->isChecked())  { layers << GraphicsLayer::sTopPlacement; }
+    if (mUi->cbxSilkTopNames->isChecked())      { layers << GraphicsLayer::sTopNames; }
+    if (mUi->cbxSilkTopValues->isChecked())     { layers << GraphicsLayer::sTopValues; }
+    return layers;
+}
+
+QStringList FabricationOutputDialog::getBotSilkscreenLayers() const noexcept
+{
+    QStringList layers;
+    if (mUi->cbxSilkBotPlacement->isChecked())  { layers << GraphicsLayer::sBotPlacement; }
+    if (mUi->cbxSilkBotNames->isChecked())      { layers << GraphicsLayer::sBotNames; }
+    if (mUi->cbxSilkBotValues->isChecked())     { layers << GraphicsLayer::sBotValues; }
+    return layers;
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.h
@@ -65,13 +65,14 @@ class FabricationOutputDialog final : public QDialog
 
 
     private slots:
-
-        void on_btnSelectDir_clicked();
+        void on_btnDefaultSuffixes_clicked();
+        void on_btnProtelSuffixes_clicked();
         void on_btnGenerate_clicked();
         void on_btnBrowseOutputDir_clicked();
 
-
     private:
+        QStringList getTopSilkscreenLayers() const noexcept;
+        QStringList getBotSilkscreenLayers() const noexcept;
 
         Project& mProject;
         Board& mBoard;

--- a/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>974</width>
-    <height>242</height>
+    <width>704</width>
+    <height>621</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,10 +19,22 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="label_2">
+     <property name="styleSheet">
+      <string notr="true">QLabel {
+	background-color: rgb(255, 255, 127);
+	color: rgb(170, 0, 0);
+};</string>
+     </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a very simple RS-274X/Excellon file generator. It's still in an experimental state and does not yet support all possible board items.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;=&amp;gt; Please review the generated files before ordering PCBs!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;To open the generated files, you could use the free application &amp;quot;gerbv&amp;quot;: &lt;a href=&quot;http://gerbv.geda-project.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://gerbv.geda-project.org/&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a simple RS-274X X2 / Excellon file generator. It's still in an experimental state and thus may have some issues.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;=&amp;gt; Please review the generated files before ordering PCBs!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;To open the generated files, you could use the free application &lt;a href=&quot;http://gerbv.geda-project.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;gerbv&lt;/span&gt;&lt;/a&gt; or the &lt;a href=&quot;https://gerber.ucamco.com/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;official reference viewer from Ucamco&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>3</number>
+     </property>
+     <property name="openExternalLinks">
       <bool>true</bool>
      </property>
     </widget>
@@ -35,22 +47,331 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Output Files</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="edtSuffixSoldermaskTop">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Drills NPTH:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLineEdit" name="edtSuffixSilkscreenTop">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Top Copper:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLineEdit" name="edtSuffixSolderPasteTop">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="3">
+       <widget class="QLineEdit" name="edtSuffixSolderPasteBot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="3">
+       <widget class="QLineEdit" name="edtSuffixDrills">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbxDrillsMerge">
+        <property name="text">
+         <string>Merge PTH and NPTH drills into one file</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Outlines:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="3">
+       <widget class="QLineEdit" name="edtSuffixSilkscreenBot">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Top Silkscreen:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Drills Merged:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Bottom Soldermask:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="3">
+       <widget class="QLineEdit" name="edtBasePath">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Top Soldermask:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QLineEdit" name="edtSuffixSoldermaskBot">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="3">
+       <widget class="QLineEdit" name="edtSuffixDrillsPth">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Bottom Copper:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QLabel" name="label_13">
+        <property name="text">
+         <string>Drills PTH:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Base Path:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2">
+       <widget class="QCheckBox" name="cbxSolderPasteBot">
+        <property name="text">
+         <string>Bottom Paste Mask
+(Bottom Stencil):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLineEdit" name="edtSuffixCopperInner">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="edtSuffixOutlines">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="text">
+         <string>Predefined configs:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="edtSuffixDrillsNpth">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="edtSuffixCopperTop">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QPushButton" name="btnDefaultSuffixes">
+          <property name="text">
+           <string>Default (layer encoded in file name)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnProtelSuffixes">
+          <property name="text">
+           <string>Protel naming (layer encoded in file extension)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="8" column="0">
+       <widget class="QCheckBox" name="cbxSolderPasteTop">
+        <property name="text">
+         <string>Top Paste Mask
+(Top Stencil):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QLineEdit" name="edtSuffixCopperBot">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Bottom Silkscreen:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Inner Copper:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Output Directory:</string>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Top Silkscreen Layers</string>
        </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="cbxSilkTopPlacement">
+          <property name="text">
+           <string>Placement</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbxSilkTopNames">
+          <property name="text">
+           <string>Names</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbxSilkTopValues">
+          <property name="text">
+           <string>Values</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="edtOutputDirPath"/>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnSelectDir">
-       <property name="text">
-        <string>...</string>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Bottom Silkscreen Layers</string>
        </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="cbxSilkBotPlacement">
+          <property name="text">
+           <string>Placement</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbxSilkBotNames">
+          <property name="text">
+           <string>Names</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbxSilkBotValues">
+          <property name="text">
+           <string>Values</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
~~*Note: Depends on #254, so this one must not yet be merged.*~~

- Make Gerber/Excellon export settings configurable (output path, file suffixes, ...)
- Save these settings in board files
- Add support for inner copper layers
- Allow to generate separate drill files for NPTH and PTH
- Fix wrong export of NPTH drills (they appeared on all layers)
- Make output files reproducible by sorting all objects by their UUID
- Add link to official reference Gerber viewer

This is how the fabrication output generator dialog now looks like:

![fabrication output generator_010](https://user-images.githubusercontent.com/5374821/39099053-fd9cfe04-4673-11e8-9dbc-96acdf15def0.png)

Fixes #73, #215.