### PR TITLE
Add ability to place NPTH drills on boards

### DIFF
--- a/libs/librepcb/common/graphics/graphicslayer.cpp
+++ b/libs/librepcb/common/graphics/graphicslayer.cpp
@@ -258,7 +258,7 @@ void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr, QColo
         h.insert(sBoardSheetFrames,         {tr("Sheet Frames"),                Qt::lightGray,              Qt::white,                  true});
         h.insert(sBoardOutlines,            {tr("Board Outlines"),              QColor(255, 255, 255, 180), QColor(255, 255, 255, 220), true});
         h.insert(sBoardMillingPth,          {tr("Milling (PTH)"),               QColor(0, 255, 255, 150),   QColor(0, 255, 255, 220),   true});
-        h.insert(sBoardDrillsNpth,          {tr("Drills (NPTH)"),               QColor(255, 255, 255, 150), QColor(255, 255, 255, 220), true});
+        h.insert(sBoardDrillsNpth,          {tr("Drills (NPTH)"),               QColor(255, 255, 255, 200), QColor(255, 255, 255, 255), true});
         h.insert(sBoardPadsTht,             {tr("Pads"),                        QColor(0, 255, 0, 150),     QColor(0, 255, 0, 220),     true});
         h.insert(sBoardViasTht,             {tr("Vias"),                        QColor(0, 255, 0, 150),     QColor(0, 255, 0, 220),     true});
         h.insert(sBoardMeasures,            {tr("Measures"),                    Qt::gray,                   Qt::lightGray,              true});

--- a/libs/librepcb/common/graphics/holegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/holegraphicsitem.cpp
@@ -61,6 +61,15 @@ HoleGraphicsItem::~HoleGraphicsItem() noexcept
 }
 
 /*****************************************************************************************
+ *  Inherited from QGraphicsItem
+ ****************************************************************************************/
+
+QPainterPath HoleGraphicsItem::shape() const noexcept
+{
+    return PrimitiveEllipseGraphicsItem::shape() + mOriginCrossGraphicsItem->shape();
+}
+
+/*****************************************************************************************
  *  Private Methods
  ****************************************************************************************/
 
@@ -73,6 +82,14 @@ void HoleGraphicsItem::holeDiameterChanged(const Length& newDiameter) noexcept
 {
     setRadius(newDiameter / 2, newDiameter / 2);
     mOriginCrossGraphicsItem->setSize(mHole.getDiameter() + Length(500000));
+}
+
+QVariant HoleGraphicsItem::itemChange(GraphicsItemChange change, const QVariant& value) noexcept
+{
+    if (change == ItemSelectedChange && mOriginCrossGraphicsItem) {
+        mOriginCrossGraphicsItem->setSelected(value.toBool());
+    }
+    return QGraphicsItem::itemChange(change, value);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/graphics/holegraphicsitem.h
+++ b/libs/librepcb/common/graphics/holegraphicsitem.h
@@ -60,6 +60,9 @@ class HoleGraphicsItem final : public PrimitiveEllipseGraphicsItem, public IF_Ho
         // Getters
         Hole& getHole() noexcept {return mHole;}
 
+        // Inherited from QGraphicsItem
+        QPainterPath shape() const noexcept override;
+
         // Operator Overloadings
         HoleGraphicsItem& operator=(const HoleGraphicsItem& rhs) = delete;
 
@@ -67,6 +70,7 @@ class HoleGraphicsItem final : public PrimitiveEllipseGraphicsItem, public IF_Ho
     private: // Methods
         void holePositionChanged(const Point& newPos) noexcept override;
         void holeDiameterChanged(const Length& newDiameter) noexcept override;
+        QVariant itemChange(GraphicsItemChange change, const QVariant& value) noexcept override;
 
 
     private: // Data

--- a/libs/librepcb/common/graphics/primitiveellipsegraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitiveellipsegraphicsitem.h
@@ -71,9 +71,9 @@ class PrimitiveEllipseGraphicsItem : public QGraphicsItem, public IF_GraphicsLay
         void layerDestroyed(const GraphicsLayer& layer) noexcept override;
 
         // Inherited from QGraphicsItem
-        QRectF boundingRect() const noexcept override {return mBoundingRect;}
-        QPainterPath shape() const noexcept override {return mShape;}
-        void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = 0) noexcept override;
+        virtual QRectF boundingRect() const noexcept override {return mBoundingRect;}
+        virtual QPainterPath shape() const noexcept override {return mShape;}
+        virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = 0) noexcept override;
 
         // Operator Overloadings
         PrimitiveEllipseGraphicsItem& operator=(const PrimitiveEllipseGraphicsItem& rhs) = delete;

--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -59,6 +59,7 @@ class BI_NetPoint;
 class BI_NetLine;
 class BI_Polygon;
 class BI_StrokeText;
+class BI_Hole;
 class BI_Plane;
 class BoardLayerStack;
 class BoardFabricationOutputSettings;
@@ -172,6 +173,11 @@ class Board final : public QObject, public AttributeProvider,
         void addStrokeText(BI_StrokeText& text);
         void removeStrokeText(BI_StrokeText& text);
 
+        // Hole Methods
+        const QList<BI_Hole*>& getHoles() const noexcept {return mHoles;}
+        void addHole(BI_Hole& hole);
+        void removeHole(BI_Hole& hole);
+
         // General Methods
         void addToProject();
         void removeFromProject();
@@ -246,6 +252,7 @@ class Board final : public QObject, public AttributeProvider,
         QList<BI_Plane*> mPlanes;
         QList<BI_Polygon*> mPolygons;
         QList<BI_StrokeText*> mStrokeTexts;
+        QList<BI_Hole*> mHoles;
 
         // ERC messages
         QHash<Uuid, ErcMsg*> mErcMsgListUnplacedComponentInstances;

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -45,6 +45,7 @@
 #include "items/bi_plane.h"
 #include "items/bi_polygon.h"
 #include "items/bi_stroketext.h"
+#include "items/bi_hole.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -276,7 +277,11 @@ int BoardGerberExport::drawNpthDrills(ExcellonGenerator& gen) const
         }
     }
 
-    // TODO: board holes
+    // board holes
+    foreach (const BI_Hole* hole, mBoard.getHoles()) {
+        gen.drill(hole->getHole().getPosition(), hole->getHole().getDiameter());
+        ++count;
+    }
 
     return count;
 }

--- a/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
@@ -35,6 +35,7 @@
 #include "items/bi_netpoint.h"
 #include "items/bi_netline.h"
 #include "items/bi_polygon.h"
+#include "items/bi_hole.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -152,6 +153,14 @@ void BoardPlaneFragmentsBuilder::subtractOtherObjects()
             }
             c.AddPath(createPadCutOut(*pad), ClipperLib::ptClip, true);
         }
+    }
+
+    // subtract board holes
+    for (const BI_Hole* hole : mPlane.getBoard().getHoles()) {
+        Length dia = hole->getHole().getDiameter() + mPlane.getMinClearance() * 2;
+        Path path = Path::circle(dia).translated(hole->getHole().getPosition());
+        c.AddPath(ClipperHelpers::convert(path, maxArcTolerance()),
+                  ClipperLib::ptClip, true);
     }
 
     // subtract net segment items

--- a/libs/librepcb/project/boards/boardselectionquery.cpp
+++ b/libs/librepcb/project/boards/boardselectionquery.cpp
@@ -33,6 +33,7 @@
 #include "items/bi_plane.h"
 #include "items/bi_polygon.h"
 #include "items/bi_stroketext.h"
+#include "items/bi_hole.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -49,9 +50,11 @@ BoardSelectionQuery::BoardSelectionQuery(const QMap<Uuid, BI_Device*>& deviceIns
                                          const QList<BI_Plane*>& planes,
                                          const QList<BI_Polygon*>& polygons,
                                          const QList<BI_StrokeText*>& strokeTexts,
+                                         const QList<BI_Hole*>& holes,
                                          QObject* parent) :
     QObject(parent), mDevices(deviceInstances),
-    mNetSegments(netsegments), mPlanes(planes), mPolygons(polygons), mStrokeTexts(strokeTexts)
+    mNetSegments(netsegments), mPlanes(planes), mPolygons(polygons),
+    mStrokeTexts(strokeTexts), mHoles(holes)
 {
 }
 
@@ -72,7 +75,8 @@ int BoardSelectionQuery::getResultCount() const noexcept
             mResultVias.count() +
             mResultPlanes.count() +
             mResultPolygons.count() +
-            mResultStrokeTexts.count();
+            mResultStrokeTexts.count() +
+            mResultHoles.count();
 }
 
 /*****************************************************************************************
@@ -169,6 +173,15 @@ void BoardSelectionQuery::addSelectedFootprintStrokeTexts() noexcept
             if (text->isSelected()) {
                 mResultStrokeTexts.insert(text);
             }
+        }
+    }
+}
+
+void BoardSelectionQuery::addSelectedHoles() noexcept
+{
+    foreach (BI_Hole* hole, mHoles) {
+        if (hole->isSelected()) {
+            mResultHoles.insert(hole);
         }
     }
 }

--- a/libs/librepcb/project/boards/boardselectionquery.h
+++ b/libs/librepcb/project/boards/boardselectionquery.h
@@ -43,6 +43,7 @@ class BI_NetPoint;
 class BI_Plane;
 class BI_Polygon;
 class BI_StrokeText;
+class BI_Hole;
 
 /*****************************************************************************************
  *  Class BoardSelectionQuery
@@ -82,6 +83,7 @@ class BoardSelectionQuery final : public QObject
                             const QList<BI_Plane*>& planes,
                             const QList<BI_Polygon*>& polygons,
                             const QList<BI_StrokeText*>& strokeTexts,
+                            const QList<BI_Hole*>& holes,
                             QObject* parent = nullptr);
         ~BoardSelectionQuery() noexcept;
 
@@ -94,6 +96,7 @@ class BoardSelectionQuery final : public QObject
         const QSet<BI_Plane*>& getPlanes() const noexcept { return mResultPlanes; }
         const QSet<BI_Polygon*>& getPolygons() const noexcept { return mResultPolygons; }
         const QSet<BI_StrokeText*>& getStrokeTexts() const noexcept { return mResultStrokeTexts; }
+        const QSet<BI_Hole*>& getHoles() const noexcept { return mResultHoles; }
         int getResultCount() const noexcept;
         bool isResultEmpty() const noexcept { return (getResultCount() == 0); }
 
@@ -107,6 +110,7 @@ class BoardSelectionQuery final : public QObject
         void addSelectedPolygons() noexcept;
         void addSelectedBoardStrokeTexts() noexcept;
         void addSelectedFootprintStrokeTexts() noexcept;
+        void addSelectedHoles() noexcept;
 
         // Operator Overloadings
         BoardSelectionQuery& operator=(const BoardSelectionQuery& rhs) = delete;
@@ -123,6 +127,7 @@ class BoardSelectionQuery final : public QObject
         const QList<BI_Plane*>& mPlanes;
         const QList<BI_Polygon*>& mPolygons;
         const QList<BI_StrokeText*>& mStrokeTexts;
+        const QList<BI_Hole*>& mHoles;
 
         // query result
         //QSet<BI_Device*> mResultDeviceInstances;
@@ -133,6 +138,7 @@ class BoardSelectionQuery final : public QObject
         QSet<BI_Plane*> mResultPlanes;
         QSet<BI_Polygon*> mResultPolygons;
         QSet<BI_StrokeText*> mResultStrokeTexts;
+        QSet<BI_Hole*> mResultHoles;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(BoardSelectionQuery::NetPointFilters)

--- a/libs/librepcb/project/boards/cmd/cmdboardholeadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeadd.cpp
@@ -1,0 +1,74 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdboardholeadd.h"
+#include "../items/bi_hole.h"
+#include "../board.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdBoardHoleAdd::CmdBoardHoleAdd(BI_Hole& hole) noexcept :
+    UndoCommand(tr("Add hole to board")),
+    mBoard(hole.getBoard()), mHole(&hole)
+{
+}
+
+CmdBoardHoleAdd::~CmdBoardHoleAdd() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdBoardHoleAdd::performExecute()
+{
+    performRedo(); // can throw
+
+    return true;
+}
+
+void CmdBoardHoleAdd::performUndo()
+{
+    mBoard.removeHole(*mHole);
+}
+
+void CmdBoardHoleAdd::performRedo()
+{
+    mBoard.addHole(*mHole);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/project/boards/cmd/cmdboardholeadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeadd.h
@@ -1,0 +1,83 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDBOARDHOLEADD_H
+#define LIBREPCB_PROJECT_CMDBOARDHOLEADD_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcb/common/undocommand.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+class Board;
+class BI_Hole;
+
+/*****************************************************************************************
+ *  Class CmdBoardHoleAdd
+ ****************************************************************************************/
+
+/**
+ * @brief The CmdBoardHoleAdd class
+ */
+class CmdBoardHoleAdd final : public UndoCommand
+{
+    public:
+
+        // Constructors / Destructor
+        explicit CmdBoardHoleAdd(BI_Hole& hole) noexcept;
+        ~CmdBoardHoleAdd() noexcept;
+
+        // Getters
+        BI_Hole* getHole() const noexcept {return mHole;}
+
+
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() override;
+
+
+        // Private Member Variables
+        Board& mBoard;
+        BI_Hole* mHole;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDBOARDHOLEADD_H

--- a/libs/librepcb/project/boards/cmd/cmdboardholeremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeremove.cpp
@@ -1,0 +1,74 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdboardholeremove.h"
+#include "../board.h"
+#include "../items/bi_hole.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdBoardHoleRemove::CmdBoardHoleRemove(BI_Hole& hole) noexcept :
+    UndoCommand(tr("Remove hole from board")),
+    mBoard(hole.getBoard()), mHole(hole)
+{
+}
+
+CmdBoardHoleRemove::~CmdBoardHoleRemove() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdBoardHoleRemove::performExecute()
+{
+    performRedo(); // can throw
+
+    return true;
+}
+
+void CmdBoardHoleRemove::performUndo()
+{
+    mBoard.addHole(mHole); // can throw
+}
+
+void CmdBoardHoleRemove::performRedo()
+{
+    mBoard.removeHole(mHole); // can throw
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/project/boards/cmd/cmdboardholeremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeremove.h
@@ -1,0 +1,81 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDBOARDHOLEREMOVE_H
+#define LIBREPCB_PROJECT_CMDBOARDHOLEREMOVE_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <librepcb/common/undocommand.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+class Board;
+class BI_Hole;
+
+/*****************************************************************************************
+ *  Class CmdBoardHoleRemove
+ ****************************************************************************************/
+
+/**
+ * @brief The CmdBoardHoleRemove class
+ */
+class CmdBoardHoleRemove final : public UndoCommand
+{
+    public:
+
+        // Constructors / Destructor
+        explicit CmdBoardHoleRemove(BI_Hole& hole) noexcept;
+        ~CmdBoardHoleRemove() noexcept;
+
+
+    private:
+
+        // Private Methods
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() override;
+
+        /// @copydoc UndoCommand::performUndo()
+        void performUndo() override;
+
+        /// @copydoc UndoCommand::performRedo()
+        void performRedo() override;
+
+
+        // Private Member Variables
+
+        Board& mBoard;
+        BI_Hole& mHole;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_CMDBOARDHOLEREMOVE_H

--- a/libs/librepcb/project/boards/items/bi_base.h
+++ b/libs/librepcb/project/boards/items/bi_base.h
@@ -65,6 +65,7 @@ class BI_Base : public QObject
             FootprintPad,   ///< librepcb#project#BI_FootprintPad
             Polygon,        ///< librepcb#project#BI_Polygon
             StrokeText,     ///< librepcb#project#BI_StrokeText
+            Hole,           ///< librepcb#project#BI_Hole
             Plane,          ///< librepcb#project#BI_Plane
         };
 

--- a/libs/librepcb/project/boards/items/bi_hole.cpp
+++ b/libs/librepcb/project/boards/items/bi_hole.cpp
@@ -1,0 +1,135 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "bi_hole.h"
+#include "../board.h"
+#include "../boardlayerstack.h"
+#include "../../project.h"
+#include <librepcb/common/graphics/graphicsscene.h>
+#include <librepcb/common/graphics/holegraphicsitem.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+BI_Hole::BI_Hole(Board& board, const BI_Hole& other) :
+    BI_Base(board)
+{
+    mHole.reset(new Hole(Uuid::createRandom(), *other.mHole));
+    init();
+}
+
+BI_Hole::BI_Hole(Board& board, const SExpression& node) :
+    BI_Base(board)
+{
+    mHole.reset(new Hole(node));
+    init();
+
+}
+
+BI_Hole::BI_Hole(Board& board, const Hole& hole) :
+    BI_Base(board)
+{
+    mHole.reset(new Hole(hole));
+    init();
+}
+
+void BI_Hole::init()
+{
+    mGraphicsItem.reset(new HoleGraphicsItem(*mHole, mBoard.getLayerStack()));
+}
+
+BI_Hole::~BI_Hole() noexcept
+{
+    mGraphicsItem.reset();
+    mHole.reset();
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void BI_Hole::addToBoard()
+{
+    if (isAddedToBoard()) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+    BI_Base::addToBoard(mGraphicsItem.data());
+}
+
+void BI_Hole::removeFromBoard()
+{
+    if (!isAddedToBoard()) {
+        throw LogicError(__FILE__, __LINE__);
+    }
+    BI_Base::removeFromBoard(mGraphicsItem.data());
+}
+
+void BI_Hole::serialize(SExpression& root) const
+{
+    mHole->serialize(root);
+}
+
+/*****************************************************************************************
+ *  Inherited from BI_Base
+ ****************************************************************************************/
+
+const Point& BI_Hole::getPosition() const noexcept
+{
+    return mHole->getPosition();
+}
+
+QPainterPath BI_Hole::getGrabAreaScenePx() const noexcept
+{
+    return mGraphicsItem->sceneTransform().map(mGraphicsItem->shape());
+}
+
+const Uuid& BI_Hole::getUuid() const noexcept
+{
+    return mHole->getUuid();
+}
+
+bool BI_Hole::isSelectable() const noexcept
+{
+    const GraphicsLayer* layer = mBoard.getLayerStack().getLayer(GraphicsLayer::sBoardDrillsNpth);
+    return layer && layer->isVisible();
+}
+
+void BI_Hole::setSelected(bool selected) noexcept
+{
+    BI_Base::setSelected(selected);
+    mGraphicsItem->setSelected(selected);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/project/boards/items/bi_hole.h
+++ b/libs/librepcb/project/boards/items/bi_hole.h
@@ -1,0 +1,104 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_BI_HOLE_H
+#define LIBREPCB_PROJECT_BI_HOLE_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "bi_base.h"
+#include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/geometry/hole.h>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+class HoleGraphicsItem;
+
+namespace project {
+
+class Project;
+class Board;
+
+/*****************************************************************************************
+ *  Class BI_Hole
+ ****************************************************************************************/
+
+/**
+ * @brief The BI_Hole class
+ */
+class BI_Hole final : public BI_Base, public SerializableObject
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        BI_Hole() = delete;
+        BI_Hole(const BI_Hole& other) = delete;
+        BI_Hole(Board& board, const BI_Hole& other);
+        BI_Hole(Board& board, const SExpression& node);
+        BI_Hole(Board& board, const Hole& hole);
+        ~BI_Hole() noexcept;
+
+        // Getters
+        Hole& getHole() noexcept {return *mHole;}
+        const Hole& getHole() const noexcept {return *mHole;}
+        const Uuid& getUuid() const noexcept; // convenience function, e.g. for template usage
+        bool isSelectable() const noexcept override;
+
+        // General Methods
+        void addToBoard() override;
+        void removeFromBoard() override;
+
+        /// @copydoc librepcb::SerializableObject::serialize()
+        void serialize(SExpression& root) const override;
+
+        // Inherited from BI_Base
+        Type_t getType() const noexcept override {return BI_Base::Type_t::Hole;}
+        const Point& getPosition() const noexcept override;
+        bool getIsMirrored() const noexcept override {return false;}
+        QPainterPath getGrabAreaScenePx() const noexcept override;
+        void setSelected(bool selected) noexcept override;
+
+        // Operator Overloadings
+        BI_Hole& operator=(const BI_Hole& rhs) = delete;
+
+
+    private: // Methods
+        void init();
+
+
+    private: // Data
+        QScopedPointer<Hole> mHole;
+        QScopedPointer<HoleGraphicsItem> mGraphicsItem;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace project
+} // namespace librepcb
+
+#endif // LIBREPCB_PROJECT_BI_HOLE_H

--- a/libs/librepcb/project/project.pro
+++ b/libs/librepcb/project/project.pro
@@ -30,6 +30,8 @@ SOURCES += \
     boards/boardusersettings.cpp \
     boards/cmd/cmdboardadd.cpp \
     boards/cmd/cmdboarddesignrulesmodify.cpp \
+    boards/cmd/cmdboardholeadd.cpp \
+    boards/cmd/cmdboardholeremove.cpp \
     boards/cmd/cmdboardlayerstackedit.cpp \
     boards/cmd/cmdboardnetpointedit.cpp \
     boards/cmd/cmdboardnetsegmentadd.cpp \
@@ -64,6 +66,7 @@ SOURCES += \
     boards/items/bi_device.cpp \
     boards/items/bi_footprint.cpp \
     boards/items/bi_footprintpad.cpp \
+    boards/items/bi_hole.cpp \
     boards/items/bi_netline.cpp \
     boards/items/bi_netpoint.cpp \
     boards/items/bi_netsegment.cpp \
@@ -137,6 +140,8 @@ HEADERS += \
     boards/boardusersettings.h \
     boards/cmd/cmdboardadd.h \
     boards/cmd/cmdboarddesignrulesmodify.h \
+    boards/cmd/cmdboardholeadd.h \
+    boards/cmd/cmdboardholeremove.h \
     boards/cmd/cmdboardlayerstackedit.h \
     boards/cmd/cmdboardnetpointedit.h \
     boards/cmd/cmdboardnetsegmentadd.h \
@@ -171,6 +176,7 @@ HEADERS += \
     boards/items/bi_device.h \
     boards/items/bi_footprint.h \
     boards/items/bi_footprintpad.h \
+    boards/items/bi_hole.h \
     boards/items/bi_netline.h \
     boards/items/bi_netpoint.h \
     boards/items/bi_netsegment.h \

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -138,6 +138,7 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project) :
     mToolsActionGroup->addAction(BES_FSM::State::State_DrawPolygon, mUi->actionToolDrawPolygon);
     mToolsActionGroup->addAction(BES_FSM::State::State_DrawPlane, mUi->actionToolAddPlane);
     mToolsActionGroup->addAction(BES_FSM::State::State_AddStrokeText, mUi->actionToolAddText);
+    mToolsActionGroup->addAction(BES_FSM::State::State_AddHole, mUi->actionToolAddHole);
     mToolsActionGroup->setCurrentAction(mFsm->getCurrentState());
     connect(mFsm, &BES_FSM::stateChanged,
             mToolsActionGroup.data(), &ExclusiveActionGroup::setCurrentAction);
@@ -524,6 +525,9 @@ void BoardEditor::toolActionGroupChangeTriggered(const QVariant& newTool) noexce
             break;
         case BES_FSM::State::State_AddStrokeText:
             mFsm->processEvent(new BEE_Base(BEE_Base::StartAddStrokeText), true);
+            break;
+        case BES_FSM::State::State_AddHole:
+            mFsm->processEvent(new BEE_Base(BEE_Base::StartAddHole), true);
             break;
         default: Q_ASSERT(false); qCritical() << "Unknown tool triggered!"; break;
     }

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -108,6 +108,7 @@
     <addaction name="actionToolDrawTrace"/>
     <addaction name="actionToolDrawPolygon"/>
     <addaction name="actionToolAddText"/>
+    <addaction name="actionToolAddHole"/>
     <addaction name="actionToolAddPlane"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -216,6 +217,7 @@
    <addaction name="actionToolDrawTrace"/>
    <addaction name="actionToolDrawPolygon"/>
    <addaction name="actionToolAddText"/>
+   <addaction name="actionToolAddHole"/>
    <addaction name="actionToolAddPlane"/>
    <addaction name="separator"/>
    <addaction name="actionRebuildPlanes"/>
@@ -672,6 +674,15 @@
    </property>
    <property name="text">
     <string>Add Text</string>
+   </property>
+  </action>
+  <action name="actionToolAddHole">
+   <property name="icon">
+    <iconset resource="../../../../img/images.qrc">
+     <normaloff>:/img/actions/add_hole.png</normaloff>:/img/actions/add_hole.png</iconset>
+   </property>
+   <property name="text">
+    <string>Add Hole</string>
    </property>
   </action>
  </widget>

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.cpp
@@ -1,0 +1,253 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "bes_addhole.h"
+#include "../boardeditor.h"
+#include "ui_boardeditor.h"
+#include <librepcb/project/boards/board.h>
+#include <librepcb/project/boards/boardlayerstack.h>
+#include <librepcb/project/boards/cmd/cmdboardholeadd.h>
+#include <librepcb/common/geometry/hole.h>
+#include <librepcb/common/geometry/cmd/cmdholeedit.h>
+#include <librepcb/common/gridproperties.h>
+#include <librepcb/common/undostack.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+BES_AddHole::BES_AddHole(BoardEditor& editor, Ui::BoardEditor& editorUi,
+                         GraphicsView& editorGraphicsView, UndoStack& undoStack) :
+    BES_Base(editor, editorUi, editorGraphicsView, undoStack), mUndoCmdActive(false),
+    mHole(nullptr), mCurrentDiameter(1000000)
+{
+}
+
+BES_AddHole::~BES_AddHole()
+{
+    Q_ASSERT(mUndoCmdActive == false);
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+BES_Base::ProcRetVal BES_AddHole::process(BEE_Base* event) noexcept
+{
+    switch (event->getType()) {
+        case BEE_Base::GraphicsViewEvent:   return processSceneEvent(event);
+        default:                            return PassToParentState;
+    }
+}
+
+bool BES_AddHole::entry(BEE_Base* event) noexcept
+{
+    Q_UNUSED(event);
+    Board* board = mEditor.getActiveBoard();
+    if (!board) return false;
+
+    // clear board selection because selection does not make sense in this state
+    board->clearSelection();
+    makeLayerVisible();
+
+    // add a new stroke text
+    Point pos = mEditorGraphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
+    if (!addHole(*board, pos)) return false;
+
+    // add the "Diameter:" label to the toolbar
+    mDiameterLabel.reset(new QLabel(tr("Diameter:")));
+    mDiameterLabel->setIndent(10);
+    mEditorUi.commandToolbar->addWidget(mDiameterLabel.data());
+
+    // add the diameter spinbox to the toolbar
+    mDiameterSpinBox.reset(new QDoubleSpinBox());
+    mDiameterSpinBox->setMinimum(0.0001);
+    mDiameterSpinBox->setMaximum(100);
+    mDiameterSpinBox->setSingleStep(0.2);
+    mDiameterSpinBox->setDecimals(6);
+    mDiameterSpinBox->setValue(mCurrentDiameter.toMm());
+    connect(mDiameterSpinBox.data(),
+            static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+            this, &BES_AddHole::diameterSpinBoxValueChanged);
+    mEditorUi.commandToolbar->addWidget(mDiameterSpinBox.data());
+
+    // change the cursor
+    mEditorGraphicsView.setCursor(Qt::CrossCursor);
+
+    return true;
+}
+
+bool BES_AddHole::exit(BEE_Base* event) noexcept
+{
+    Q_UNUSED(event);
+
+    if (mUndoCmdActive) {
+        try {
+            mUndoStack.abortCmdGroup();
+            mUndoCmdActive = false;
+        } catch (Exception& e) {
+            QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
+            return false;
+        }
+    }
+
+    // Remove actions / widgets from the "command" toolbar
+    mDiameterSpinBox.reset();
+    mDiameterLabel.reset();
+
+    // change the cursor
+    mEditorGraphicsView.setCursor(Qt::ArrowCursor);
+
+    return true;
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+BES_Base::ProcRetVal BES_AddHole::processSceneEvent(BEE_Base* event) noexcept
+{
+    QEvent* qevent = BEE_RedirectedQEvent::getQEventFromBEE(event);
+    Q_ASSERT(qevent); if (!qevent) return PassToParentState;
+    Board* board = mEditor.getActiveBoard();
+    Q_ASSERT(board); if (!board) return PassToParentState;
+
+    switch (qevent->type()) {
+        case QEvent::GraphicsSceneMouseDoubleClick:
+        case QEvent::GraphicsSceneMousePress: {
+            QGraphicsSceneMouseEvent* sceneEvent = dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
+            Point pos = Point::fromPx(sceneEvent->scenePos(), board->getGridProperties().getInterval());
+            switch (sceneEvent->button()) {
+                case Qt::LeftButton: {
+                    fixHole(pos);
+                    addHole(*board, pos);
+                    updateHolePosition(pos);
+                    return ForceStayInState;
+                }
+                default:
+                    break;
+            }
+            break;
+        }
+
+        case QEvent::GraphicsSceneMouseRelease: {
+            return ForceStayInState;
+        }
+
+        case QEvent::GraphicsSceneMouseMove: {
+            QGraphicsSceneMouseEvent* sceneEvent = dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
+            Q_ASSERT(sceneEvent);
+            Point pos = Point::fromPx(sceneEvent->scenePos(), board->getGridProperties().getInterval());
+            updateHolePosition(pos);
+            return ForceStayInState;
+        }
+
+        default:
+            break;
+    }
+    return PassToParentState;
+}
+
+bool BES_AddHole::addHole(Board& board, const Point& pos) noexcept
+{
+    Q_ASSERT(mUndoCmdActive == false);
+
+    try {
+        mUndoStack.beginCmdGroup(tr("Add hole to board"));
+        mUndoCmdActive = true;
+        mHole = new BI_Hole(board, Hole(Uuid::createRandom(), pos, mCurrentDiameter));
+        QScopedPointer<CmdBoardHoleAdd> cmdAdd(new CmdBoardHoleAdd(*mHole));
+        mUndoStack.appendToCmdGroup(cmdAdd.take());
+        mEditCmd.reset(new CmdHoleEdit(mHole->getHole()));
+        return true;
+    } catch (Exception& e) {
+        if (mUndoCmdActive) {
+            try {mUndoStack.abortCmdGroup();} catch (...) {}
+            mUndoCmdActive = false;
+        }
+        mHole = nullptr;
+        QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
+        return false;
+    }
+}
+
+void BES_AddHole::updateHolePosition(const Point& pos) noexcept
+{
+    if (mEditCmd) {
+        mEditCmd->setPosition(pos, true);
+    }
+}
+
+bool BES_AddHole::fixHole(const Point& pos) noexcept
+{
+    Q_ASSERT(mUndoCmdActive == true);
+
+    try {
+        mEditCmd->setPosition(pos, false);
+        mUndoStack.appendToCmdGroup(mEditCmd.take());
+        mUndoStack.commitCmdGroup();
+        mUndoCmdActive = false;
+        mHole = nullptr;
+        return true;
+    } catch (Exception& e) {
+        if (mUndoCmdActive) {
+            try {mUndoStack.abortCmdGroup();} catch (...) {}
+            mUndoCmdActive = false;
+            mHole = nullptr;
+        }
+        QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
+        return false;
+    }
+}
+
+void BES_AddHole::diameterSpinBoxValueChanged(double value) noexcept
+{
+    mCurrentDiameter = Length::fromMm(value);
+    if (mEditCmd) {
+        mEditCmd->setDiameter(mCurrentDiameter, true);
+    }
+}
+
+void BES_AddHole::makeLayerVisible() noexcept
+{
+    Board* board = mEditor.getActiveBoard();
+    if (board) {
+        GraphicsLayer* layer = board->getLayerStack().getLayer(GraphicsLayer::sBoardDrillsNpth);
+        if (layer && layer->isEnabled()) layer->setVisible(true);
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace editor
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.h
@@ -17,75 +17,73 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_CMDMOVESELECTEDBOARDITEMS_H
-#define LIBREPCB_PROJECT_CMDMOVESELECTEDBOARDITEMS_H
+#ifndef LIBREPCB_PROJECT_EDITOR_BES_ADDHOLE_H
+#define LIBREPCB_PROJECT_EDITOR_BES_ADDHOLE_H
 
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include <librepcb/common/undocommandgroup.h>
-#include <librepcb/common/units/all_length_units.h>
+#include "bes_base.h"
+#include <librepcb/project/boards/items/bi_hole.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
  ****************************************************************************************/
 namespace librepcb {
 
-class CmdPolygonEdit;
-class CmdStrokeTextEdit;
 class CmdHoleEdit;
 
 namespace project {
 
 class Board;
-class CmdDeviceInstanceEdit;
-class CmdBoardViaEdit;
-class CmdBoardNetPointEdit;
-class CmdBoardPlaneEdit;
 
 namespace editor {
 
 /*****************************************************************************************
- *  Class CmdMoveSelectedBoardItems
+ *  Class BES_AddHole
  ****************************************************************************************/
 
 /**
- * @brief The CmdMoveSelectedBoardItems class
+ * @brief The BES_AddHole class
  */
-class CmdMoveSelectedBoardItems final : public UndoCommandGroup
+class BES_AddHole final : public BES_Base
 {
+        Q_OBJECT
+
     public:
 
         // Constructors / Destructor
-        CmdMoveSelectedBoardItems(Board& board, const Point& startPos) noexcept;
-        ~CmdMoveSelectedBoardItems() noexcept;
+        explicit BES_AddHole(BoardEditor& editor, Ui::BoardEditor& editorUi,
+                             GraphicsView& editorGraphicsView, UndoStack& undoStack);
+        ~BES_AddHole();
 
         // General Methods
-        void setCurrentPosition(const Point& pos) noexcept;
+        ProcRetVal process(BEE_Base* event) noexcept override;
+        bool entry(BEE_Base* event) noexcept override;
+        bool exit(BEE_Base* event) noexcept override;
 
 
     private:
 
         // Private Methods
+        ProcRetVal processSceneEvent(BEE_Base* event) noexcept;
+        bool addHole(Board& board, const Point& pos) noexcept;
+        void updateHolePosition(const Point& pos) noexcept;
+        bool fixHole(const Point& pos) noexcept;
+        void diameterSpinBoxValueChanged(double value) noexcept;
+        void makeLayerVisible() noexcept;
 
-        /// @copydoc UndoCommand::performExecute()
-        bool performExecute() override;
 
+        // State
+        bool mUndoCmdActive;
+        BI_Hole* mHole;
+        QScopedPointer<CmdHoleEdit> mEditCmd;
+        Length mCurrentDiameter;
 
-        // Private Member Variables
-        Board& mBoard;
-        Point mStartPos;
-        Point mDeltaPos;
-
-        // Move commands
-        QList<CmdDeviceInstanceEdit*> mDeviceEditCmds;
-        QList<CmdBoardViaEdit*> mViaEditCmds;
-        QList<CmdBoardNetPointEdit*> mNetPointEditCmds;
-        QList<CmdBoardPlaneEdit*> mPlaneEditCmds;
-        QList<CmdPolygonEdit*> mPolygonEditCmds;
-        QList<CmdStrokeTextEdit*> mStrokeTextEditCmds;
-        QList<CmdHoleEdit*> mHoleEditCmds;
+        // Widgets for the command toolbar
+        QScopedPointer<QLabel> mDiameterLabel;
+        QScopedPointer<QDoubleSpinBox> mDiameterSpinBox;
 };
 
 /*****************************************************************************************
@@ -96,4 +94,4 @@ class CmdMoveSelectedBoardItems final : public UndoCommandGroup
 } // namespace project
 } // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_CMDMOVESELECTEDBOARDITEMS_H
+#endif // LIBREPCB_PROJECT_EDITOR_BES_ADDHOLE_H

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.cpp
@@ -34,6 +34,7 @@
 #include "bes_addvia.h"
 #include "bes_adddevice.h"
 #include "bes_drawplane.h"
+#include "bes_addhole.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -59,6 +60,7 @@ BES_FSM::BES_FSM(BoardEditor& editor, Ui::BoardEditor& editorUi,
     mSubStates.insert(State_AddVia, new BES_AddVia(mEditor, mEditorUi, mEditorGraphicsView, mUndoStack));
     mSubStates.insert(State_AddDevice, new BES_AddDevice(mEditor, mEditorUi, mEditorGraphicsView, mUndoStack));
     mSubStates.insert(State_DrawPlane, new BES_DrawPlane(mEditor, mEditorUi, mEditorGraphicsView, mUndoStack));
+    mSubStates.insert(State_AddHole, new BES_AddHole(mEditor, mEditorUi, mEditorGraphicsView, mUndoStack));
 
     // go to state "Select"
     if (mSubStates[State_Select]->entry(nullptr)) {
@@ -167,6 +169,9 @@ BES_FSM::State BES_FSM::processEventFromChild(BEE_Base* event) noexcept
         case BEE_Base::StartAddStrokeText:
             event->setAccepted(true);
             return State_AddStrokeText;
+        case BEE_Base::StartAddHole:
+            event->setAccepted(true);
+            return State_AddHole;
         case BEE_Base::StartAddVia:
             event->setAccepted(true);
             return State_AddVia;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.h
@@ -53,6 +53,7 @@ class BES_FSM final : public BES_Base
             State_DrawTrace,    ///< @see #project#BES_DrawTrace
             State_DrawPolygon,  ///< @see librepcb#project#BES_DrawPolygon
             State_AddStrokeText,///< @see librepcb#project#BES_AddStrokeText
+            State_AddHole,      ///< @see librepcb#project#BES_AddHole
             State_AddVia,       ///< @see librepcb#project#BES_AddVia
             State_AddDevice,    ///< @see librepcb#project#BES_AddDevice
             State_DrawPlane,    ///< @see #project#BES_DrawPlane

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
@@ -34,6 +34,7 @@ namespace librepcb {
 class UndoCommandGroup;
 class Polygon;
 class StrokeText;
+class Hole;
 
 namespace project {
 
@@ -91,6 +92,7 @@ class BES_Select final : public BES_Base
         void openPlanePropertiesDialog(BI_Plane& plane) noexcept;
         void openPolygonPropertiesDialog(Board& board, Polygon& polygon) noexcept;
         void openStrokeTextPropertiesDialog(Board& board, StrokeText& text) noexcept;
+        void openHolePropertiesDialog(Board& board, Hole& hole) noexcept;
 
 
         // Types

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorevent.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorevent.h
@@ -62,6 +62,7 @@ class BEE_Base
             StartSelect,        ///< start command: select elements
             //StartMove,          ///< start command: move elements
             StartAddStrokeText, ///< start command: add stroke text
+            StartAddHole,       ///< start command: add hole
             //StartDrawRect,      ///< start command: draw rect
             StartDrawPolygon,   ///< start command: draw polygon
             //StartDrawCircle,    ///< start command: draw circle

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.cpp
@@ -37,6 +37,7 @@
 #include <librepcb/project/boards/cmd/cmdboardplaneremove.h>
 #include <librepcb/project/boards/cmd/cmdboardpolygonremove.h>
 #include <librepcb/project/boards/cmd/cmdboardstroketextremove.h>
+#include <librepcb/project/boards/cmd/cmdboardholeremove.h>
 #include <librepcb/project/boards/cmd/cmdfootprintstroketextremove.h>
 #include <librepcb/project/boards/boardselectionquery.h>
 #include "cmdremovedevicefromboard.h"
@@ -81,6 +82,7 @@ bool CmdRemoveSelectedBoardItems::performExecute()
     query->addSelectedPolygons();
     query->addSelectedBoardStrokeTexts();
     query->addSelectedFootprintStrokeTexts();
+    query->addSelectedHoles();
 
     // clear selection because these items will be removed now
     mBoard.clearSelection();
@@ -137,6 +139,11 @@ bool CmdRemoveSelectedBoardItems::performExecute()
         } else {
             execNewChildCmd(new CmdBoardStrokeTextRemove(*text)); // can throw
         }
+    }
+
+    // remove holes
+    foreach (BI_Hole* hole, query->getHoles()) {
+        execNewChildCmd(new CmdBoardHoleRemove(*hole)); // can throw
     }
 
     undoScopeGuard.dismiss(); // no undo required

--- a/libs/librepcb/projecteditor/cmd/cmdrotateselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdrotateselectedboarditems.cpp
@@ -26,6 +26,7 @@
 #include <librepcb/common/geometry/polygon.h>
 #include <librepcb/common/geometry/cmd/cmdpolygonedit.h>
 #include <librepcb/common/geometry/cmd/cmdstroketextedit.h>
+#include <librepcb/common/geometry/cmd/cmdholeedit.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/boards/board.h>
 #include <librepcb/project/boards/items/bi_device.h>
@@ -35,6 +36,7 @@
 #include <librepcb/project/boards/items/bi_plane.h>
 #include <librepcb/project/boards/items/bi_polygon.h>
 #include <librepcb/project/boards/items/bi_stroketext.h>
+#include <librepcb/project/boards/items/bi_hole.h>
 #include <librepcb/project/boards/cmd/cmddeviceinstanceedit.h>
 #include <librepcb/project/boards/cmd/cmdboardviaedit.h>
 #include <librepcb/project/boards/cmd/cmdboardnetpointedit.h>
@@ -78,6 +80,7 @@ bool CmdRotateSelectedBoardItems::performExecute()
     query->addSelectedPolygons();
     query->addSelectedBoardStrokeTexts();
     query->addSelectedFootprintStrokeTexts();
+    query->addSelectedHoles();
 
     // find the center of all elements
     Point center = Point(0, 0);
@@ -112,6 +115,10 @@ bool CmdRotateSelectedBoardItems::performExecute()
             center += text->getPosition();
             ++count;
         }
+    }
+    foreach (BI_Hole* hole, query->getHoles()) {
+        center += hole->getPosition();
+        ++count;
     }
 
     if (count > 0) {
@@ -152,6 +159,11 @@ bool CmdRotateSelectedBoardItems::performExecute()
     foreach (BI_StrokeText* text, query->getStrokeTexts()) { Q_ASSERT(text);
         CmdStrokeTextEdit* cmd = new CmdStrokeTextEdit(text->getText());
         cmd->rotate(mAngle, center, false);
+        appendChild(cmd);
+    }
+    foreach (BI_Hole* hole, query->getHoles()) { Q_ASSERT(hole);
+        CmdHoleEdit* cmd = new CmdHoleEdit(hole->getHole());
+        cmd->setPosition(hole->getPosition().rotated(mAngle, center), false);
         appendChild(cmd);
     }
 

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -29,6 +29,7 @@ SOURCES += \
     boardeditor/deviceinstancepropertiesdialog.cpp \
     boardeditor/fabricationoutputdialog.cpp \
     boardeditor/fsm/bes_adddevice.cpp \
+    boardeditor/fsm/bes_addhole.cpp \
     boardeditor/fsm/bes_addstroketext.cpp \
     boardeditor/fsm/bes_addvia.cpp \
     boardeditor/fsm/bes_base.cpp \
@@ -94,6 +95,7 @@ HEADERS += \
     boardeditor/deviceinstancepropertiesdialog.h \
     boardeditor/fabricationoutputdialog.h \
     boardeditor/fsm/bes_adddevice.h \
+    boardeditor/fsm/bes_addhole.h \
     boardeditor/fsm/bes_addstroketext.h \
     boardeditor/fsm/bes_addvia.h \
     boardeditor/fsm/bes_base.h \


### PR DESCRIPTION
~~*Note: Depends on #255, so this one must not yet be merged.*~~

Now it's possible to place NPTH drills directly on a board.
- They are subtracted from copper planes (with clearance)
- They are exported into the NPTH drills Excellon file

![demo brushless controller lpp - librepcb board editor_014](https://user-images.githubusercontent.com/5374821/39405480-f138e83a-4ba5-11e8-9c6b-f4512d525ed1.png)

Fixes #253.