### PR TITLE
About Dialog

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -105,6 +105,8 @@ ControlPanel::ControlPanel(Workspace& workspace) :
     //        &Workspace::instance(), &Workspace::openLibraryEditor);
     connect(mUi->actionAbout_Qt, &QAction::triggered,
             qApp, &QApplication::aboutQt);
+    connect(mUi->actionAbout, &QAction::triggered,
+            qApp, &Application::about);
     connect(mUi->actionWorkspace_Settings, &QAction::triggered,
             &mWorkspace.getSettings(), &WorkspaceSettings::showSettingsDialog);
     connect(mLibraryManager.data(), &LibraryManager::openLibraryEditorTriggered,
@@ -422,12 +424,6 @@ void ControlPanel::projectEditorClosed() noexcept
 /*****************************************************************************************
  *  Actions
  ****************************************************************************************/
-
-void ControlPanel::on_actionAbout_triggered()
-{
-    AboutDialog* aboutDialog = new AboutDialog(this);
-    aboutDialog->exec();
-}
 
 void ControlPanel::on_actionNew_Project_triggered()
 {

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -38,6 +38,7 @@
 #include <librepcb/projecteditor/projecteditor.h>
 #include <librepcb/projecteditor/newprojectwizard/newprojectwizard.h>
 #include <librepcb/common/application.h>
+#include <librepcb/common/dialogs/aboutdialog.h>
 #include <librepcb/common/fileio/fileutils.h>
 #include "../markdown/markdownconverter.h"
 #include "projectlibraryupdater/projectlibraryupdater.h"
@@ -424,14 +425,8 @@ void ControlPanel::projectEditorClosed() noexcept
 
 void ControlPanel::on_actionAbout_triggered()
 {
-    QMessageBox::about(this, tr("About LibrePCB"), QString(tr(
-        "<h1>About LibrePCB</h1>"
-        "<p>LibrePCB is a free & open source schematic/layout-editor.</p>"
-        "<p>Version: %1 (%2)</p>"
-        "<p>Please see <a href='http://librepcb.org/'>librepcb.org</a> for more information.</p>"
-        "You can find the project on GitHub:<br>"
-        "<a href='https://github.com/LibrePCB/LibrePCB'>https://github.com/LibrePCB/LibrePCB</a>"))
-        .arg(qApp->getAppVersion().toPrettyStr(3), qApp->getGitVersion()));
+    AboutDialog* aboutDialog = new AboutDialog(this);
+    aboutDialog->exec();
 }
 
 void ControlPanel::on_actionNew_Project_triggered()

--- a/apps/librepcb/controlpanel/controlpanel.h
+++ b/apps/librepcb/controlpanel/controlpanel.h
@@ -107,7 +107,6 @@ class ControlPanel final : public QMainWindow
         void projectEditorClosed() noexcept;
 
         // Actions
-        void on_actionAbout_triggered();
         void on_actionNew_Project_triggered();
         void on_actionOpen_Project_triggered();
         void on_actionOpen_Library_Manager_triggered();

--- a/libs/librepcb/common/application.cpp
+++ b/libs/librepcb/common/application.cpp
@@ -23,6 +23,7 @@
 #include <QtCore>
 #include "application.h"
 #include "exceptions.h"
+#include "dialogs/aboutdialog.h"
 #include "font/strokefontpool.h"
 #include "units/all_length_units.h"
 
@@ -169,6 +170,17 @@ Application* Application::instance() noexcept
     Application* app = dynamic_cast<Application*>(QCoreApplication::instance());
     Q_ASSERT(app);
     return app;
+}
+
+/*****************************************************************************************
+ *  Slots
+ ****************************************************************************************/
+
+void Application::about() noexcept
+{
+    QWidget* parent = QApplication::activeWindow();
+    AboutDialog aboutDialog(parent);
+    aboutDialog.exec();
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/application.cpp
+++ b/libs/librepcb/common/application.cpp
@@ -53,6 +53,11 @@ Application::Application(int& argc, char** argv) noexcept :
         qWarning() << "Could not determine Git version. Check if Git is added to the PATH.";
     }
 
+    // set build timestamp
+    QDate buildDate = QLocale(QLocale::C).toDate(QString(__DATE__).simplified(), QLatin1String("MMM d yyyy"));
+    QTime buildTime = QTime::fromString(__TIME__, Qt::TextDate);
+    mBuildDate = QDateTime(buildDate, buildTime);
+
     // set and verify file format version
     mFileFormatVersion = Version(FILE_FORMAT_VERSION);
     Q_ASSERT(mFileFormatVersion.isValid());

--- a/libs/librepcb/common/application.h
+++ b/libs/librepcb/common/application.h
@@ -91,6 +91,9 @@ class Application final : public QApplication
         static Application* instance() noexcept;
 
 
+    public slots:
+        static void about() noexcept;
+
     private: // Data
         Version mAppVersion;
         QString mGitVersion;

--- a/libs/librepcb/common/application.h
+++ b/libs/librepcb/common/application.h
@@ -50,7 +50,7 @@ class StrokeFontPool;
  ****************************************************************************************/
 
 /**
- * @brief The Application class extends the QApplication with the exception-save method
+ * @brief The Application class extends the QApplication with the exception-safe method
  *        #notify()
  *
  * @author ubruhin
@@ -71,6 +71,7 @@ class Application final : public QApplication
         // Getters
         const Version& getAppVersion() const noexcept {return mAppVersion;}
         const QString& getGitVersion() const noexcept {return mGitVersion;}
+        const QDateTime& getBuildDate() const noexcept {return mBuildDate;}
         const Version& getFileFormatVersion() const noexcept {return mFileFormatVersion;}
         const FilePath& getResourcesDir() const noexcept {return mResourcesDir;}
         FilePath getResourcesFilePath(const QString& filepath) const noexcept;
@@ -93,6 +94,7 @@ class Application final : public QApplication
     private: // Data
         Version mAppVersion;
         QString mGitVersion;
+        QDateTime mBuildDate;
         Version mFileFormatVersion;
         FilePath mResourcesDir;
         QScopedPointer<StrokeFontPool> mStrokeFontPool; ///< all application stroke fonts

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -46,6 +46,7 @@ SOURCES += \
     cam/gerberaperturelist.cpp \
     cam/gerbergenerator.cpp \
     debug.cpp \
+    dialogs/aboutdialog.cpp \
     dialogs/boarddesignrulesdialog.cpp \
     dialogs/circlepropertiesdialog.cpp \
     dialogs/gridsettingsdialog.cpp \
@@ -144,6 +145,7 @@ HEADERS += \
     cam/gerberaperturelist.h \
     cam/gerbergenerator.h \
     debug.h \
+    dialogs/aboutdialog.h \
     dialogs/boarddesignrulesdialog.h \
     dialogs/circlepropertiesdialog.h \
     dialogs/gridsettingsdialog.h \
@@ -234,6 +236,7 @@ HEADERS += \
     widgets/statusbar.h \
 
 FORMS += \
+    dialogs/aboutdialog.ui \
     dialogs/boarddesignrulesdialog.ui \
     dialogs/circlepropertiesdialog.ui \
     dialogs/gridsettingsdialog.ui \

--- a/libs/librepcb/common/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/common/dialogs/aboutdialog.cpp
@@ -1,0 +1,114 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2018 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include "aboutdialog.h"
+#include "ui_aboutdialog.h"
+#include <librepcb/common/application.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+AboutDialog::AboutDialog(QWidget* parent) noexcept :
+    QDialog(parent),
+    mUi(new Ui::AboutDialog)
+{
+    // Set up base dialog
+    mUi->setupUi(this);
+
+    // Event handlers
+    connect(mUi->buttonBox, &QDialogButtonBox::clicked,
+            this, &AboutDialog::close);
+
+    // Layout
+    mUi->tabWidget->setCurrentIndex(0);
+
+    // Get some version information
+    const Version& appVersion = qApp->getAppVersion();
+    const QString& gitVersion = qApp->getGitVersion();
+    const QString& buildDate = qApp->getBuildDate().toString("yyyy-MM-dd hh:mm:ss (t)");
+
+    // Dynamic text
+    mUi->textVersion->setText(QString("Version: %1 (%2)<br>Build date: %3").arg(appVersion.toPrettyStr(3), gitVersion, buildDate));
+    mUi->textLinks->setText(tr("For more information, please check out <a href='%1'>librepcb.org</a> or our <a href='%2'>GitHub repository</a>.").arg("http://librepcb.org/", "https://github.com/LibrePCB/LibrePCB"));
+    mUi->textContributeFinancially->setText(
+        tr("Support sustainable development of LibrePCB by donating financially, either via <a href='%1'>Patreon</a> or via <a href='%2'>Bitcoin</a>!")
+        .arg("https://www.patreon.com/librepcb", "bitcoin:1FiXZxoXe3px1nNuNygRb1NwcYr6U8AvG8")
+    );
+    mUi->textContributeCode->setText(
+        tr("Check out our <a href='%1'>Contribution Guidelines</a> if you're interested in development of LibrePCB!")
+        .arg("https://github.com/LibrePCB/LibrePCB/blob/master/CONTRIBUTING.md")
+    );
+
+    // Format content
+    formatLabelHeading(mUi->headerLinks);
+    formatLabelHeading(mUi->headerLicense);
+    formatLabelHeading(mUi->headerContributeFinancially);
+    formatLabelHeading(mUi->headerContributeCode);
+    formatLabelHeading(mUi->headerContributeShare);
+    formatLabelText(mUi->textIntro, false, true);
+    formatLabelText(mUi->textVersion, true, false);
+    formatLabelText(mUi->textLinks, false, true);
+    formatLabelText(mUi->textLicense, false, true);
+    formatLabelText(mUi->textContributeFinancially, false, true);
+    formatLabelText(mUi->textContributeCode, false, true);
+    formatLabelText(mUi->textContributeShare, false, false);
+}
+
+/**
+ * @brief Format a heading label in the about dialog.
+ * @param label Pointer to the QLabel instance
+ */
+void AboutDialog::formatLabelHeading(QLabel* label) noexcept
+{
+    int headerMarginTop = 12;
+    int headerMarginBottom = 4;
+    label->setContentsMargins(0, headerMarginTop, 0, headerMarginBottom);
+}
+
+/**
+ * @brief Format a text label in the about dialog.
+ * @param label Pointer to the QLabel instance
+ * @param selectable Whether to make the text mouse-selectable
+ * @param containsLinks Whether to open links in external application (e.g. web browser)
+ */
+void AboutDialog::formatLabelText(QLabel* label, bool selectable, bool containsLinks) noexcept
+{
+    label->setOpenExternalLinks(containsLinks);
+    if (selectable) {
+        label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        if (containsLinks) {
+            qWarning() << "If text is selectable, external links won't work anymore!";
+        }
+    }
+}
+
+AboutDialog::~AboutDialog() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcb/common/dialogs/aboutdialog.h
+++ b/libs/librepcb/common/dialogs/aboutdialog.h
@@ -1,0 +1,76 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2018 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_ABOUTDIALOG_H
+#define LIBREPCB_ABOUTDIALOG_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QDialog>
+#include <QAbstractButton>
+#include <QLabel>
+#include "../version.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+namespace Ui {
+class AboutDialog;
+}
+
+/*****************************************************************************************
+ *  Class AboutDialog
+ ****************************************************************************************/
+
+/**
+ * @brief The AboutDialog class
+ */
+class AboutDialog final : public QDialog
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        AboutDialog() = delete;
+        AboutDialog(const AboutDialog& other) = delete;
+        explicit AboutDialog(QWidget* parent = nullptr) noexcept;
+        ~AboutDialog() noexcept;
+
+        // Operator Overloadings
+        AboutDialog& operator=(const AboutDialog& rhs) = delete;
+
+    private: // Methods
+        void formatLabelHeading(QLabel* label) noexcept;
+        void formatLabelText(QLabel* label, bool selectable, bool containsLinks) noexcept;
+
+    private: // Data
+        QScopedPointer<Ui::AboutDialog> mUi;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_ABOUTDIALOG_H

--- a/libs/librepcb/common/dialogs/aboutdialog.ui
+++ b/libs/librepcb/common/dialogs/aboutdialog.ui
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::AboutDialog</class>
+ <widget class="QDialog" name="librepcb::AboutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>440</width>
+    <height>438</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>About LibrePCB</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="logo">
+       <property name="minimumSize">
+        <size>
+         <width>64</width>
+         <height>64</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>64</width>
+         <height>64</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../../../../img/images.qrc">:/img/app/librepcb.png</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="heading">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>About LibrePCB</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="textVersion">
+     <property name="text">
+      <string notr="true">TEXT_VERSION</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>8</number>
+     </property>
+     <property name="bottomMargin">
+      <number>8</number>
+     </property>
+     <item>
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="currentIndex">
+        <number>1</number>
+       </property>
+       <widget class="QWidget" name="tabGeneral">
+        <attribute name="title">
+         <string>General</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <layout class="QVBoxLayout" name="tabGeneralLayout">
+           <item>
+            <widget class="QLabel" name="textIntro">
+             <property name="text">
+              <string>LibrePCB is a free &amp;amp; open source schematic/layout-editor. It is mainly developed by Urban Bruhin, with &lt;a href=&quot;https://github.com/LibrePCB/LibrePCB/graphs/contributors&quot;&gt;over a dozen other contributors&lt;/a&gt;!</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerLinks">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string notr="true">Links</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="textLinks">
+             <property name="text">
+              <string notr="true">TEXT_LINKS</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerLicense">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string notr="true">License</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="textLicense">
+             <property name="text">
+              <string>LibrePCB is free software, released under the GNU General Public License (GPL) version 3 or later. You can find the full license text &lt;a href=&quot;https://github.com/LibrePCB/LibrePCB/blob/master/LICENSE.txt&quot;&gt;in our source code&lt;/a&gt;.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="spacerGeneral">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tabContributing">
+        <attribute name="title">
+         <string>Contributing</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <layout class="QVBoxLayout" name="tabContributingLayout">
+           <item>
+            <widget class="QLabel" name="textContributingIntro">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibrePCB is a community project, and therefore it relies on contributions! There are different ways you can contribute:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerContributeFinancially">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Donate</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="textContributeFinancially">
+             <property name="text">
+              <string notr="true">TEXT_CONTRIBUTE_FINANCIALLY</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerContributeCode">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Contribute Code</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="textContributeCode">
+             <property name="text">
+              <string>TEXT_CONTRIBUTE_CODE</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerContributeShare">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Spread The Word</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="textContributeShare">
+             <property name="text">
+              <string>Speak about LibrePCB with your friends and colleagues, or write about it in the internet! Write a blogpost, or create a video tutorial. We're happy if more people can get to know LibrePCB.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="spacerContributing">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../../../img/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -25,6 +25,8 @@
 #include <QtWidgets>
 #include "libraryeditor.h"
 #include "ui_libraryeditor.h"
+#include <librepcb/common/application.h>
+#include <librepcb/common/dialogs/aboutdialog.h>
 #include <librepcb/common/fileio/fileutils.h>
 #include <librepcb/common/utils/undostackactiongroup.h>
 #include <librepcb/common/utils/exclusiveactiongroup.h>
@@ -85,6 +87,10 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, QSharedPointer<Library> l
             this, &LibraryEditor::currentTabChanged);
     connect(mUi->tabWidget, &QTabWidget::tabCloseRequested,
             this, &LibraryEditor::tabCloseRequested);
+    connect(mUi->actionAbout, &QAction::triggered,
+            qApp, &Application::about);
+    connect(mUi->actionAbout_Qt, &QAction::triggered,
+            qApp, &QApplication::aboutQt);
 
     // lock the library directory
     mLock.tryLock(); // can throw

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -28,12 +28,14 @@
 #include <librepcb/workspace/workspace.h>
 #include <librepcb/workspace/library/workspacelibrarydb.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
+#include <librepcb/common/application.h>
 #include <librepcb/common/undostack.h>
 #include <librepcb/common/utils/undostackactiongroup.h>
 #include <librepcb/common/utils/exclusiveactiongroup.h>
 #include <librepcb/project/boards/board.h>
 #include <librepcb/project/boards/items/bi_plane.h>
 #include <librepcb/project/circuit/circuit.h>
+#include <librepcb/common/dialogs/aboutdialog.h>
 #include <librepcb/common/dialogs/gridsettingsdialog.h>
 #include <librepcb/common/dialogs/boarddesignrulesdialog.h>
 #include "../dialogs/projectpropertieseditordialog.h"
@@ -110,6 +112,7 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project) :
     // connect some actions which are created with the Qt Designer
     connect(mUi->actionProjectSave, &QAction::triggered, &mProjectEditor, &ProjectEditor::saveProject);
     connect(mUi->actionQuit, &QAction::triggered, this, &BoardEditor::close);
+    connect(mUi->actionAbout, &QAction::triggered, qApp, &Application::about);
     connect(mUi->actionAboutQt, &QAction::triggered, qApp, &QApplication::aboutQt);
     connect(mUi->actionZoomIn, &QAction::triggered, mGraphicsView, &GraphicsView::zoomIn);
     connect(mUi->actionZoomOut, &QAction::triggered, mGraphicsView, &GraphicsView::zoomOut);

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -29,6 +29,7 @@
 #include <librepcb/workspace/workspace.h>
 #include <librepcb/workspace/library/workspacelibrarydb.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
+#include <librepcb/common/application.h>
 #include <librepcb/common/undostack.h>
 #include <librepcb/common/utils/undostackactiongroup.h>
 #include <librepcb/common/utils/exclusiveactiongroup.h>
@@ -37,6 +38,7 @@
 #include "../docks/ercmsgdock.h"
 #include "fsm/ses_fsm.h"
 #include <librepcb/project/circuit/circuit.h>
+#include <librepcb/common/dialogs/aboutdialog.h>
 #include <librepcb/common/dialogs/gridsettingsdialog.h>
 #include "../dialogs/projectpropertieseditordialog.h"
 #include <librepcb/project/settings/projectsettings.h>
@@ -88,6 +90,7 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
     // connect some actions which are created with the Qt Designer
     connect(mUi->actionSave_Project, &QAction::triggered, &mProjectEditor, &ProjectEditor::saveProject);
     connect(mUi->actionQuit, &QAction::triggered, this, &SchematicEditor::close);
+    connect(mUi->actionAbout, &QAction::triggered, qApp, &Application::about);
     connect(mUi->actionAbout_Qt, &QAction::triggered, qApp, &QApplication::aboutQt);
     connect(mUi->actionZoom_In, &QAction::triggered, mGraphicsView, &GraphicsView::zoomIn);
     connect(mUi->actionZoom_Out, &QAction::triggered, mGraphicsView, &GraphicsView::zoomOut);


### PR DESCRIPTION
This is a new about dialog for LibrePCB. Fixes most of #17.

Checklist from that issue:

- [x] Replace the `QMessageBox` with an own class derived from `QDialog`. This new class should be called `AboutDialog` and created in the directory [`libs/librepcb/common/dialogs/`](https://github.com/LibrePCB/LibrePCB/tree/master/libs/librepcb/common/dialogs)
- [x] Add the new about dialog to the "Help" menu of all main windows
  - [x] ControlPanel
  - [x] LibraryEditor
  - [x] SchematicEditor
  - [x] BoardEditor
- [x] Add more information to the new dialog, maybe splitted up in multiple tabs:
  - [x] A small description about LibrePCB (inclusive Logo)
  - [x] A link to LibrePCB's website (librepcb.org) and to the GitHub project site
  - [x] The application's version / commit hash (determined by `git describe`)
  - [x] Maybe the datetime of the last commit (-> build datetime)
  - [x] The license (a link to http://www.gnu.org/licenses/gpl-3.0.html, or the whole license text)
  - [x] Options for contribution (Bitcoin address, link to Patreon)
  - [x] Maybe a "how to contribute" section (see also #12)
  - [ ] ~~Maybe the rendered content of the [AUTHORS.md](https://github.com/LibrePCB/LibrePCB/blob/master/AUTHORS.md) file~~

Here's a screenshot:

![screenshot](https://tmp.dbrgn.ch/screenshots/screenshot-20180513033048-o7w4nzvd.png)

(The missing window decorations are due to my window manager.)

@ubruhin do you think we should add tabs, for things like "contributing" and the author list?b