### PR TITLE
Provide installer for nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,20 @@ matrix:
     - os: linux
       dist: trusty
       compiler: gcc
-      env: BUILD_DOXYGEN=true DEPLOY_APPIMAGE=false QT_BASE="trusty"
+      env: BUILD_DOXYGEN=true DEPLOY_APPIMAGE=false DEPLOY_INSTALLER=false QT_BASE="trusty"
     # Ubuntu 14.04 + Clang + Qt from PPA (https://launchpad.net/~beineri) + AppImage deployment
     - os: linux
       dist: trusty
       compiler: clang
-      env: BUILD_DOXYGEN=false DEPLOY_APPIMAGE=true QT_BASE="qt59" QT_PPA="ppa:beineri/opt-qt591-trusty"
+      env: BUILD_DOXYGEN=false DEPLOY_APPIMAGE=true DEPLOY_INSTALLER=true QT_BASE="qt59" QT_PPA="ppa:beineri/opt-qt591-trusty"
     # OS X + GCC
     - os: osx
       compiler: gcc
-      env: BUILD_DOXYGEN=false DEPLOY_BUNDLE=false
+      env: BUILD_DOXYGEN=false DEPLOY_BUNDLE=false DEPLOY_INSTALLER=false
     # OS X + Clang
     - os: osx
       compiler: clang
-      env: BUILD_DOXYGEN=false DEPLOY_BUNDLE=true
+      env: BUILD_DOXYGEN=false DEPLOY_BUNDLE=true DEPLOY_INSTALLER=true
 
 install:
   - source ./ci/install_dependencies.sh # source required because it modifies the environment

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,12 @@ environment:
   global:
     MINGW: C:/Qt/Tools/mingw530_32
     QTDIR: C:/Qt/5.9/mingw53_32
+    QTIFWDIR: C:/Qt/QtIFW-3.0.1
     VCRT_DIR: 'C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/Redist/x86/Microsoft.VC120.CRT'
+    DEPLOY_INSTALLER: true
 
 init:
-  - set PATH=%QTDIR%/bin;%MINGW%/bin;C:/Qt/Tools/QtCreator/bin;C:/msys64/bin;C:/msys64/usr/bin;%PATH%
+  - set PATH=%QTDIR%/bin;%MINGW%/bin;C:/Qt/Tools/QtCreator/bin;%QTIFWDIR%/bin;C:/msys64/bin;C:/msys64/usr/bin;%PATH%
 
 install:
   - git submodule update --init --recursive

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -64,6 +64,31 @@ then
   cp -r ./build/install/opt/. ./artifacts/nightly_builds/librepcb-nightly-windows-x86/
 fi
 
+# Build installer
+if [ "$DEPLOY_INSTALLER" = "true" ]
+then
+  if [ "${TRAVIS_OS_NAME-}" = "linux" ]
+  then
+    TARGET="linux-x86_64"
+    EXECUTABLE_EXT="run"
+  elif [ "${TRAVIS_OS_NAME-}" = "osx" ]
+  then
+    TARGET="mac-x86_64"
+    EXECUTABLE_EXT="dmg"
+  elif [ -n "${APPVEYOR-}" ]
+  then
+    TARGET="windows-x86"
+    EXECUTABLE_EXT="exe"
+  fi
+  ./dist/installer/update_metadata.sh "$TARGET" "0.1.0"  # TODO: How to determine version number?
+  PACKAGES_DIR="./artifacts/installer_packages/$TARGET"
+  mkdir -p $PACKAGES_DIR/librepcb.nightly.app/data/nightly
+  cp -r ./dist/installer/output/packages/. $PACKAGES_DIR/
+  cp -r ./build/install/opt/. $PACKAGES_DIR/librepcb.nightly.app/data/nightly/
+  binarycreator --online-only -c ./dist/installer/output/config/config.xml -p $PACKAGES_DIR \
+                ./artifacts/nightly_builds/librepcb-installer-nightly-$TARGET.$EXECUTABLE_EXT
+fi
+
 # Build Doxygen documentation
 if [ "${BUILD_DOXYGEN-}" = "true" ]
 then

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+QTIFW_VERSION="3.0.4"
+QTIFW_URL_BASE="https://download.qt.io/official_releases/qt-installer-framework/$QTIFW_VERSION"
 LINUXDEPLOYQT_URL="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
 
 # Install dependencies on Linux
@@ -24,6 +26,12 @@ then
   sudo ln -s ../../bin/ccache /usr/lib/ccache/clang
   sudo ln -s ../../bin/ccache /usr/lib/ccache/clang++
 
+  # Qt Installer Framework
+  wget -cq "$QTIFW_URL_BASE/QtInstallerFramework-linux-x64.run" -O ./QtIFW.run
+  chmod a+x ./QtIFW.run
+  ./QtIFW.run --script ./ci/qtifw-installer-noninteractive.qs --no-force-installations --platform minimal -v
+  cp -rfv ~/Qt/QtIFW-$QTIFW_VERSION/bin ~/.local/
+
 # Install dependencies on OS X
 elif [ "${TRAVIS_OS_NAME-}" = "osx" ]
 then
@@ -32,6 +40,14 @@ then
   brew install qt5 ccache
   brew link --force qt5
   export PATH="/usr/local/opt/ccache/libexec:$PATH"
+
+  # Qt Installer Framework
+  wget -cq "$QTIFW_URL_BASE/QtInstallerFramework-mac-x64.dmg"
+  hdiutil attach ./QtInstallerFramework-mac-x64.dmg
+  QTIFW_PATH="/Volumes/QtInstallerFramework-mac-x64/QtInstallerFramework-mac-x64.app/Contents/MacOS/QtInstallerFramework-mac-x64"
+  chmod +x $QTIFW_PATH
+  $QTIFW_PATH --script ./ci/qtifw-installer-noninteractive.qs --no-force-installations -v
+  export PATH="/Users/travis/Qt/QtIFW-$QTIFW_VERSION/bin:$PATH"
 
   # Stop creating shit files (https://superuser.com/questions/259703/get-mac-tar-to-stop-putting-filenames-in-tar-archives)
   export COPYFILE_DISABLE=1

--- a/ci/qtifw-installer-noninteractive.qs
+++ b/ci/qtifw-installer-noninteractive.qs
@@ -1,0 +1,51 @@
+function Controller()
+{
+    installer.autoRejectMessageBoxes();
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.setMessageBoxAutomaticAnswer("stopProcessesForUpdates", QMessageBox.Ignore);
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    })
+}
+
+
+Controller.prototype.IntroductionPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.TargetDirectoryPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function()
+{
+    gui.currentPageWidget().AcceptLicenseRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.StartMenuDirectoryPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.PerformInstallationPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.FinishedPageCallback = function()
+{
+    gui.clickButton(buttons.FinishButton);
+}

--- a/dist/installer/.gitignore
+++ b/dist/installer/.gitignore
@@ -1,0 +1,2 @@
+output/
+librepcb-installer*

--- a/dist/installer/config/config.xml
+++ b/dist/installer/config/config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Installer>
+  <Name>LibrePCB</Name>
+  <Version>1.0.0</Version><!-- the installer version is static -->
+  <Title>LibrePCB</Title>
+  <Publisher>LibrePCB</Publisher>
+  <ProductUrl>http://librepcb.org/</ProductUrl>
+  <Logo>48x48.png</Logo>
+  <MaintenanceToolName>librepcb-maintenance</MaintenanceToolName>
+  <MaintenanceToolIniFile>librepcb-maintenance.ini</MaintenanceToolIniFile>
+  <TargetDir>DEFAULT_TARGET_DIR</TargetDir>
+  <AdminTargetDir>@ApplicationsDir@/LibrePCB</AdminTargetDir> <!-- UNIX only -->
+  <StartMenuDir>LibrePCB</StartMenuDir> <!-- Windows only -->
+  <RemoteRepositories>
+    <Repository>
+      <Url>https://download.librepcb.org/installer_packages/TARGET_NAME</Url>
+    </Repository>
+  </RemoteRepositories>
+</Installer>

--- a/dist/installer/packages/librepcb.common/meta/installscript.qs
+++ b/dist/installer/packages/librepcb.common/meta/installscript.qs
@@ -1,0 +1,45 @@
+function Component() {
+}
+
+function isRoot() {
+    var id = installer.execute("/usr/bin/id", new Array("-u"))[0];
+    id = id.replace(/(\r\n|\n|\r)/gm,"");
+    return (id === "0");
+}
+
+function getShareDirectory() {
+    if (isRoot()) {
+        return "/usr/local/share";
+    } else {
+        return "@HomeDir@/.local/share"
+    }
+}
+
+Component.prototype.createOperations = function() {
+    component.createOperations();
+
+    try {
+        if (systemInfo.productType === "windows") {
+            component.addOperation("CreateShortcut",
+                                   "@TargetDir@/librepcb-maintenance.exe",
+                                   "@StartMenuDir@/LibrePCB Maintenance Tool.lnk",
+                                   " --updater");
+        }
+
+        if (systemInfo.kernelType === "linux") {
+            component.addOperation("CreateDesktopEntry",
+                                   "librepcb-maintenance.desktop",
+                                   "Name=LibrePCB Maintenance Tool\n" +
+                                   "Comment=Manage the LibrePCB Installation\n" +
+                                   "Categories=Utility;\n" +
+                                   "Type=Application\n" +
+                                   "Terminal=false\n" +
+                                   "Exec=@TargetDir@/librepcb-maintenance --updater");
+            component.addOperation("Execute",
+                                   "update-desktop-database",
+                                   getShareDirectory() + "/applications");
+        }
+    } catch (e) {
+        print(e);
+    }
+}

--- a/dist/installer/packages/librepcb.common/meta/package.xml
+++ b/dist/installer/packages/librepcb.common/meta/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package>
+  <Name>librepcb.common</Name>
+  <DisplayName>Common Files</DisplayName>
+  <Description>Some commonly used files, for example the maintenance tool.</Description>
+  <Version>0.1.0</Version><!-- it's only a metapackage, so its version is static -->
+  <ReleaseDate>RELEASE_DATE</ReleaseDate>
+  <Script>installscript.qs</Script>
+  <ForcedInstallation>True</ForcedInstallation>
+  <SortingPriority>10</SortingPriority>
+</Package>

--- a/dist/installer/packages/librepcb.nightly.app/meta/installscript.qs
+++ b/dist/installer/packages/librepcb.nightly.app/meta/installscript.qs
@@ -1,0 +1,49 @@
+function Component() {
+}
+
+function isRoot() {
+    var id = installer.execute("/usr/bin/id", new Array("-u"))[0];
+    id = id.replace(/(\r\n|\n|\r)/gm,"");
+    return (id === "0");
+}
+
+function getShareDirectory() {
+    if (isRoot()) {
+        return "/usr/local/share";
+    } else {
+        return "@HomeDir@/.local/share"
+    }
+}
+
+Component.prototype.createOperations = function() {
+    component.createOperations();
+
+    try {
+        if (systemInfo.productType === "windows") {
+            component.addOperation("CreateShortcut",
+                                   "@TargetDir@/nightly/bin/librepcb.exe",
+                                   "@StartMenuDir@/LibrePCB Nightly.lnk");
+        }
+
+        if (systemInfo.kernelType === "linux") {
+            component.addOperation("InstallIcons",
+                                   "@TargetDir@/nightly/share/pixmaps");
+            component.addOperation("CreateDesktopEntry",
+                                   "librepcb-nightly-from-installer.desktop",
+                                   "Name=LibrePCB Nightly\n" +
+                                   "Comment=Design Schematics and PCBs\n" +
+                                   "GenericName=PCB Designer\n" +
+                                   "Categories=Development;Engineering;Electronics;\n" +
+                                   "Type=Application\n" +
+                                   "Terminal=false\n" +
+                                   "Icon=librepcb\n" +
+                                   "Exec=@TargetDir@/nightly/bin/librepcb %U\n" +
+                                   "MimeType=application/x-librepcb-project;");
+            component.addOperation("Execute",
+                                   "update-desktop-database",
+                                   getShareDirectory() + "/applications");
+        }
+    } catch (e) {
+        print(e);
+    }
+}

--- a/dist/installer/packages/librepcb.nightly.app/meta/package.xml
+++ b/dist/installer/packages/librepcb.nightly.app/meta/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package>
+  <Name>librepcb.nightly.app</Name>
+  <DisplayName>LibrePCB Nightly Build</DisplayName>
+  <Description>Latest automatically built version. Attention: These are unstable builds, DO NOT USE THEM FOR PRODUCTIVE USE!</Description>
+  <Version>APP_VERSION_NIGHTLY</Version>
+  <ReleaseDate>RELEASE_DATE</ReleaseDate>
+  <Default>true</Default>
+  <Script>installscript.qs</Script>
+  <Licenses>
+    <License name="GNU General Public License v3" file="license_gplv3.txt"/>
+  </Licenses>
+</Package>

--- a/dist/installer/packages/librepcb.nightly/meta/package.xml
+++ b/dist/installer/packages/librepcb.nightly/meta/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package>
+  <Name>librepcb.nightly</Name>
+  <DisplayName>Nightly Build</DisplayName>
+  <Description>Latest automatically built version. Attention: These are unstable builds, DO NOT USE THEM FOR PRODUCTIVE USE!</Description>
+  <Version>0.1.0</Version><!-- it's only a metapackage, so its version is static -->
+  <ReleaseDate>RELEASE_DATE</ReleaseDate>
+  <SortingPriority>1000</SortingPriority>
+</Package>

--- a/dist/installer/packages/librepcb.registerfileextensions/meta/installscript.qs
+++ b/dist/installer/packages/librepcb.registerfileextensions/meta/installscript.qs
@@ -1,0 +1,51 @@
+function Component() {
+}
+
+function isRoot() {
+    var id = installer.execute("/usr/bin/id", new Array("-u"))[0];
+    id = id.replace(/(\r\n|\n|\r)/gm,"");
+    return (id === "0");
+}
+
+function getShareDirectory() {
+    if (isRoot()) {
+        return "/usr/local/share";
+    } else {
+        return "@HomeDir@/.local/share"
+    }
+}
+
+Component.prototype.createOperations = function() {
+    component.createOperations();
+
+    try {
+        if (systemInfo.productType === "windows") {
+            // DON'T REMOVE THE QUOTES AROUND @TargetDir! It took me TWO HOURS
+            // to find out that this completely crappy operating system silently
+            // passes fucking 8.3 DOS filenames as argv if the quotes are
+            // missing!!! It's 2018, we want LONG FILENAMES!!! Fucking crap...
+            // https://blogs.msdn.microsoft.com/oldnewthing/20041020-00/?p=37523
+            // @Microsoft: Don't write blogs about that, fix this crappy shit!!!
+            component.addOperation("RegisterFileType",
+                                   "lpp",
+                                   "\"@TargetDir@\\nightly\\bin\\librepcb.exe\" \"%1\"",
+                                   "LibrePCB Project",
+                                   "text/plain",
+                                   "\"@TargetDir@\\nightly\\bin\\librepcb.exe\"",
+                                   "ProgId=LibrePCB.lpp");
+        }
+
+        if (systemInfo.kernelType === "linux") {
+            component.addOperation("Mkdir",
+                                   getShareDirectory() + "/mime/packages");
+            component.addOperation("Copy",
+                                   "@TargetDir@/registerfileextensions/mime/librepcb-from-installer.xml",
+                                   getShareDirectory() + "/mime/packages/librepcb-from-installer.xml");
+            component.addOperation("Execute",
+                                   "update-mime-database",
+                                   getShareDirectory() + "/mime");
+        }
+    } catch (e) {
+        print(e);
+    }
+}

--- a/dist/installer/packages/librepcb.registerfileextensions/meta/package.xml
+++ b/dist/installer/packages/librepcb.registerfileextensions/meta/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package>
+  <Name>librepcb.registerfileextensions</Name>
+  <DisplayName>Register File Extensions</DisplayName>
+  <Description>Register *.lpp file extension to open LibrePCB by double-clicking project files.</Description>
+  <Version>0.1.0</Version><!-- it's a special package, so its version is static -->
+  <ReleaseDate>RELEASE_DATE</ReleaseDate>
+  <Default>true</Default>
+  <Script>installscript.qs</Script>
+  <SortingPriority>20</SortingPriority>
+</Package>

--- a/dist/installer/update_metadata.sh
+++ b/dist/installer/update_metadata.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
+set -eu -o pipefail
+
+# get absolute path to installer root directory
+ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
+
+# get cli parameters
+TARGET_NAME="$1"
+APP_VERSION_FULL="$2"
+
+echo "Updating installer packages for $TARGET_NAME v$APP_VERSION_FULL..."
+
+# determine more parameters
+DESTINATION="$ROOT/output"
+APP_VERSION_SHORT="${APP_VERSION_FULL%.0}"  # remove patch version if it is zero
+COMMIT_COUNT="`git -C "$ROOT" rev-list --count HEAD`"
+DATE="`date +%Y-%m-%d`"
+
+# OS specific parameters
+if [[ "$TARGET_NAME" == windows* ]]
+then
+  DEFAULT_TARGET_DIR="@ApplicationsDirX86@/LibrePCB"
+elif [[ "$TARGET_NAME" == linux* ]]
+then
+  DEFAULT_TARGET_DIR="@homeDir@/LibrePCB"
+elif [[ "$TARGET_NAME" == mac* ]]
+then
+  DEFAULT_TARGET_DIR="@homeDir@/Applications/LibrePCB"
+fi
+
+# copy to destination directory
+echo "Copy data to $DESTINATION..."
+mkdir -p $DESTINATION
+cp -rf $ROOT/config $DESTINATION/
+cp -rf $ROOT/packages $DESTINATION/
+
+# copy additional files
+echo "Copy additional files to $DESTINATION/config..."
+cp $ROOT/../../img/logo/*.png $DESTINATION/config/
+cp $ROOT/../../LICENSE.txt $DESTINATION/packages/librepcb.nightly.app/meta/license_gplv3.txt
+REGFILEEXT_DIR=$DESTINATION/packages/librepcb.registerfileextensions/data/registerfileextensions
+mkdir -p $REGFILEEXT_DIR/mime
+cp $ROOT/../../share/mime/packages/librepcb.xml $REGFILEEXT_DIR/mime/librepcb-from-installer.xml
+
+# remove packages which are not supported by the selected target
+if [[ "$TARGET_NAME" == mac* ]]
+then
+  echo "Remove package 'librepcb.registerfileextensions'..."
+  rm -rf "$DESTINATION/packages/librepcb.registerfileextensions"
+fi
+
+# replace specific placeholders in a given file
+function replace {
+  FILE="$1"
+  FROM=$(sed 's/[^^]/[&]/g; s/\^/\\^/g' <<< "$2" )
+  TO=$(sed 's/[\/&]/\\&/g' <<< "$3" )
+  sed -i -e "s/$FROM/$TO/g" "$FILE"
+}
+
+# replace placeholders in all *.xml files
+for f in $(find "$DESTINATION" -name '*.xml')
+do
+  echo "Update metadata of $f..."
+  replace "$f" "TARGET_NAME"            "$TARGET_NAME"
+  replace "$f" "DEFAULT_TARGET_DIR"     "$DEFAULT_TARGET_DIR"
+  replace "$f" "APP_VERSION_FULL"       "$APP_VERSION_FULL"
+  replace "$f" "APP_VERSION_SHORT"      "$APP_VERSION_SHORT"
+  replace "$f" "APP_VERSION_NIGHTLY"    "$APP_VERSION_FULL-$COMMIT_COUNT"
+  replace "$f" "RELEASE_DATE"           "$DATE"
+done

--- a/share/mimelnk/application/x-librepcb-project.desktop
+++ b/share/mimelnk/application/x-librepcb-project.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Type=MimeType
-MimeType=application/x-librepcb-project
-Icon=librepcb
-Patterns=*.lpp
-Comment=LibrePCB Project


### PR DESCRIPTION
With this PR the CI now also builds an installer for Linux, Mac and Windows. The installer can be used to install and even to update LibrePCB to the latest version. This is especially useful for Windows which doesn't have a package manager.

The installers are built with the [Qt Installer Framework](https://doc.qt.io/qtinstallerframework/index.html) which is pretty cool. On Windows the installer also (optionally) registers LibrePCB as handler for *.lpp files, so project files can be opened with a double click in the explorer. For Linux and Mac I did not (yet) implement it, maybe I'll also give it a try...

The installers can currently be downloaded from here: https://download.librepcb.org/nightly_builds/installer/

Updates are hosted separately, the installer fetches them automatically from here: https://download.librepcb.org/installer_packages/

This is an important step for LibrePCB because now it's dead simple to install, update and use LibrePCB on Windows!

Fixes #256.