### PR TITLE
Mirror support for schematic

### DIFF
--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.h
@@ -56,7 +56,8 @@ class CmdSymbolInstanceEdit final : public UndoCommand
         void setRotation(const Angle& angle, bool immediate) noexcept;
         void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
         void setMirrored(bool mirrored, bool immediate) noexcept;
-        void mirror(const Point& center, bool immediate) noexcept;
+        void mirror(const Point& center, Qt::Orientation orientation,
+                    bool immediate) noexcept;
 
 
     private:

--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.h
@@ -55,6 +55,8 @@ class CmdSymbolInstanceEdit final : public UndoCommand
         void setDeltaToStartPos(Point& deltaPos, bool immediate) noexcept;
         void setRotation(const Angle& angle, bool immediate) noexcept;
         void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
+        void setMirrored(bool mirrored, bool immediate) noexcept;
+        void mirror(const Point& center, bool immediate) noexcept;
 
 
     private:
@@ -81,6 +83,8 @@ class CmdSymbolInstanceEdit final : public UndoCommand
         Point mNewPos;
         Angle mOldRotation;
         Angle mNewRotation;
+        bool mOldMirrored;
+        bool mNewMirrored;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -247,7 +247,9 @@ void SGI_Symbol::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
         painter->translate(text.getPosition().toPxQPointF());
         if (props.mirrored) {
             static const QTransform gMirror(-1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
-            painter->translate(props.textRect.width() * props.scaleFactor, 0);
+            if (text.getAlign().getH() != HAlign::center()) {
+                painter->translate(props.textRect.width() * props.scaleFactor, 0);
+            }
             painter->setTransform(gMirror, true);
         }
         painter->rotate(-text.getRotation().toDeg());

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -139,7 +139,11 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept
         // check rotation
         Angle absAngle = text.getRotation() + mSymbol.getRotation();
         absAngle.mapTo180deg();
-        props.rotate180 = (absAngle <= -Angle::deg90() || absAngle > Angle::deg90());
+        props.mirrored = mSymbol.getMirrored();
+        if (!props.mirrored)
+            props.rotate180 = (absAngle <= -Angle::deg90() || absAngle > Angle::deg90());
+        else
+            props.rotate180 = (absAngle < -Angle::deg90() || absAngle >= Angle::deg90());
 
         // calculate text position
         scaledTextRect.translate(text.getPosition().toPxQPointF());
@@ -241,6 +245,11 @@ void SGI_Symbol::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
         // draw text or rect
         painter->save();
         painter->translate(text.getPosition().toPxQPointF());
+        if (props.mirrored) {
+            static const QTransform gMirror(-1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+            painter->translate(props.textRect.width() * props.scaleFactor, 0);
+            painter->setTransform(gMirror, true);
+        }
         painter->rotate(-text.getRotation().toDeg());
         painter->translate(-text.getPosition().toPxQPointF());
         painter->scale(props.scaleFactor, props.scaleFactor);

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.h
@@ -91,6 +91,7 @@ class SGI_SymbolPin final : public SGI_Base
         GraphicsLayer* mJunctionLayer;
         QStaticText mStaticText;
         bool mRotate180;
+        bool mMirrored;
         QRectF mBoundingRect;
         QPointF mTextOrigin;
         QRectF mTextBoundingRect;

--- a/libs/librepcb/project/schematics/items/si_symbol.h
+++ b/libs/librepcb/project/schematics/items/si_symbol.h
@@ -68,12 +68,13 @@ class SI_Symbol final : public SI_Base, public SerializableObject,
         explicit SI_Symbol(Schematic& schematic, const SExpression& node);
         explicit SI_Symbol(Schematic& schematic, ComponentInstance& cmpInstance,
                            const Uuid& symbolItem, const Point& position = Point(),
-                           const Angle& rotation = Angle());
+                           const Angle& rotation = Angle(), bool mirrored = false);
         ~SI_Symbol() noexcept;
 
         // Getters
         const Uuid& getUuid() const noexcept {return mUuid;}
         const Angle& getRotation() const noexcept {return mRotation;}
+        bool getMirrored() const noexcept {return mMirrored;}
         QString getName() const noexcept;
         SI_SymbolPin* getPin(const Uuid& pinUuid) const noexcept {return mPins.value(pinUuid);}
         const QHash<Uuid, SI_SymbolPin*>& getPins() const noexcept {return mPins;}
@@ -84,6 +85,7 @@ class SI_Symbol final : public SI_Base, public SerializableObject,
         // Setters
         void setPosition(const Point& newPos) noexcept;
         void setRotation(const Angle& newRotation) noexcept;
+        void setMirrored(bool newMirrored) noexcept;
 
         // General Methods
         void addToSchematic() override;
@@ -140,6 +142,7 @@ class SI_Symbol final : public SI_Base, public SerializableObject,
         Uuid mUuid;
         Point mPosition;
         Angle mRotation;
+        bool mMirrored;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/items/si_symbol.h
+++ b/libs/librepcb/project/schematics/items/si_symbol.h
@@ -128,6 +128,7 @@ class SI_Symbol final : public SI_Base, public SerializableObject,
     private:
 
         void init(const Uuid& symbVarItemUuid);
+        void updateGraphicsItemTransform() noexcept;
         bool checkAttributesValidity() const noexcept;
 
 

--- a/libs/librepcb/project/schematics/items/si_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.cpp
@@ -37,6 +37,9 @@
 namespace librepcb {
 namespace project {
 
+static const QTransform gMirror(-1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+static const QTransform gIdent(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+
 /*****************************************************************************************
  *  Constructors / Destructor
  ****************************************************************************************/
@@ -203,6 +206,7 @@ void SI_SymbolPin::updatePosition() noexcept
     mPosition = mSymbol.mapToScene(mSymbolPin->getPosition());
     mRotation = mSymbol.getRotation() + mSymbolPin->getRotation();
     mGraphicsItem->setPos(mPosition.toPxQPointF());
+    mGraphicsItem->setTransform(mSymbol.getMirrored() ? gMirror : gIdent, false);
     mGraphicsItem->setRotation(-mRotation.toDeg());
     mGraphicsItem->updateCacheAndRepaint();
     foreach (SI_NetLine* netline, mRegisteredNetLines) {

--- a/libs/librepcb/project/schematics/items/si_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.cpp
@@ -37,9 +37,6 @@
 namespace librepcb {
 namespace project {
 
-static const QTransform gMirror(-1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
-static const QTransform gIdent(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
-
 /*****************************************************************************************
  *  Constructors / Destructor
  ****************************************************************************************/
@@ -206,8 +203,7 @@ void SI_SymbolPin::updatePosition() noexcept
     mPosition = mSymbol.mapToScene(mSymbolPin->getPosition());
     mRotation = mSymbol.getRotation() + mSymbolPin->getRotation();
     mGraphicsItem->setPos(mPosition.toPxQPointF());
-    mGraphicsItem->setTransform(mSymbol.getMirrored() ? gMirror : gIdent, false);
-    mGraphicsItem->setRotation(-mRotation.toDeg());
+    updateGraphicsItemTransform();
     mGraphicsItem->updateCacheAndRepaint();
     foreach (SI_NetLine* netline, mRegisteredNetLines) {
         netline->updateLine();
@@ -241,6 +237,18 @@ void SI_SymbolPin::updateErcMessages() noexcept
 
     mErcMsgUnconnectedRequiredPin->setVisible(isAddedToSchematic() && isRequired()
                                               && (!isUsed()));
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void SI_SymbolPin::updateGraphicsItemTransform() noexcept
+{
+    QTransform t;
+    if (mSymbol.getMirrored()) t.scale(qreal(-1), qreal(1));
+    t.rotate(-mRotation.toDeg());
+    mGraphicsItem->setTransform(t);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/items/si_symbolpin.h
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.h
@@ -110,6 +110,9 @@ class SI_SymbolPin final : public SI_Base,
 
     private:
 
+        void updateGraphicsItemTransform() noexcept;
+
+
         // General
         SI_Symbol& mSymbol;
         const library::SymbolPin* mSymbolPin;

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
@@ -47,8 +47,10 @@ namespace editor {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-CmdMirrorSelectedSchematicItems::CmdMirrorSelectedSchematicItems(Schematic& schematic) noexcept :
-    UndoCommandGroup(tr("Mirror Schematic Elements")), mSchematic(schematic)
+CmdMirrorSelectedSchematicItems::CmdMirrorSelectedSchematicItems(
+        Schematic& schematic, Qt::Orientation orientation) noexcept :
+    UndoCommandGroup(tr("Mirror Schematic Elements")), mSchematic(schematic),
+    mOrientation(orientation)
 {
 }
 
@@ -95,17 +97,17 @@ bool CmdMirrorSelectedSchematicItems::performExecute()
     // mirror all selected elements
     foreach (SI_Symbol* symbol, query->getSymbols()) {
         CmdSymbolInstanceEdit* cmd = new CmdSymbolInstanceEdit(*symbol);
-        cmd->mirror(center, false);
+        cmd->mirror(center, mOrientation, false);
         appendChild(cmd);
     }
     foreach (SI_NetPoint* netpoint, query->getNetPoints()) {
         CmdSchematicNetPointEdit* cmd = new CmdSchematicNetPointEdit(*netpoint);
-        cmd->setPosition(netpoint->getPosition().mirrored(Qt::Horizontal, center), false);
+        cmd->setPosition(netpoint->getPosition().mirrored(mOrientation, center), false);
         appendChild(cmd);
     }
     foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
         CmdSchematicNetLabelEdit* cmd = new CmdSchematicNetLabelEdit(*netlabel);
-        cmd->setPosition(netlabel->getPosition().mirrored(Qt::Horizontal, center), false);
+        cmd->setPosition(netlabel->getPosition().mirrored(mOrientation, center), false);
         appendChild(cmd);
     }
 

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
@@ -1,0 +1,127 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "cmdmirrorselectedschematicitems.h"
+#include <librepcb/common/gridproperties.h>
+#include <librepcb/project/project.h>
+#include <librepcb/project/schematics/schematic.h>
+#include <librepcb/project/schematics/items/si_symbol.h>
+#include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/items/si_netpoint.h>
+#include <librepcb/project/schematics/items/si_netline.h>
+#include <librepcb/project/schematics/items/si_netlabel.h>
+#include <librepcb/project/schematics/cmd/cmdsymbolinstanceedit.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetpointedit.h>
+#include <librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.h>
+#include <librepcb/project/schematics/schematicselectionquery.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CmdMirrorSelectedSchematicItems::CmdMirrorSelectedSchematicItems(Schematic& schematic) noexcept :
+    UndoCommandGroup(tr("Mirror Schematic Elements")), mSchematic(schematic)
+{
+}
+
+CmdMirrorSelectedSchematicItems::~CmdMirrorSelectedSchematicItems() noexcept
+{
+}
+
+/*****************************************************************************************
+ *  Inherited from UndoCommand
+ ****************************************************************************************/
+
+bool CmdMirrorSelectedSchematicItems::performExecute()
+{
+    // get all selected items
+    std::unique_ptr<SchematicSelectionQuery> query(mSchematic.createSelectionQuery());
+    query->addSelectedSymbols();
+    query->addSelectedNetPoints();
+    query->addNetPointsOfNetLines();
+    query->addSelectedNetLabels();
+
+    // find the center of all elements
+    Point center = Point(0, 0);
+    int count = 0;
+    foreach (SI_Symbol* symbol, query->getSymbols()) {
+        center += symbol->getPosition();
+        ++count;
+    }
+    foreach (SI_NetPoint* netpoint, query->getNetPoints()) {
+        center += netpoint->getPosition();
+        ++count;
+    }
+    foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
+        center += netlabel->getPosition();
+        ++count;
+    }
+    if (count > 0) {
+        center /= count;
+        center.mapToGrid(mSchematic.getGridProperties().getInterval());
+    } else {
+        // no items selected --> nothing to do here
+        return false;
+    }
+
+    // mirror all selected elements
+    foreach (SI_Symbol* symbol, query->getSymbols()) {
+        CmdSymbolInstanceEdit* cmd = new CmdSymbolInstanceEdit(*symbol);
+        cmd->mirror(center, false);
+        appendChild(cmd);
+    }
+    foreach (SI_NetPoint* netpoint, query->getNetPoints()) {
+        CmdSchematicNetPointEdit* cmd = new CmdSchematicNetPointEdit(*netpoint);
+        cmd->setPosition(netpoint->getPosition().mirrored(Qt::Horizontal, center), false);
+        appendChild(cmd);
+    }
+    foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
+        CmdSchematicNetLabelEdit* cmd = new CmdSchematicNetLabelEdit(*netlabel);
+        cmd->setPosition(netlabel->getPosition().mirrored(Qt::Horizontal, center), false);
+        appendChild(cmd);
+    }
+
+    // if something was modified, trigger anchors update of all netlabels
+    if (getChildCount() > 0) {
+        appendChild(new CmdSchematicNetLabelAnchorsUpdate(mSchematic));
+    }
+
+    // execute all child commands
+    return UndoCommandGroup::performExecute(); // can throw
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace editor
+} // namespace project
+} // namespace librepcb

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.h
@@ -17,100 +17,62 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_PROJECT_SGI_SYMBOL_H
-#define LIBREPCB_PROJECT_SGI_SYMBOL_H
+#ifndef LIBREPCB_PROJECT_CMDMIRRORSELECTEDSCHEMATICITEMS_H
+#define LIBREPCB_PROJECT_CMDMIRRORSELECTEDSCHEMATICITEMS_H
 
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include <QtWidgets>
-#include "sgi_base.h"
+#include <librepcb/common/undocommandgroup.h>
+#include <librepcb/common/units/angle.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
  ****************************************************************************************/
 namespace librepcb {
-
-class Text;
-class GraphicsLayer;
-
-namespace library {
-class Symbol;
-}
-
 namespace project {
 
-class SI_Symbol;
+class Schematic;
 
+namespace editor {
 
 /*****************************************************************************************
- *  Class SGI_Symbol
+ *  Class CmdMirrorSelectedSchematicItems
  ****************************************************************************************/
 
 /**
- * @brief The SGI_Symbol class
- *
- * @author ubruhin
- * @date 2014-08-23
+ * @brief The CmdMirrorSelectedSchematicItems class
  */
-class SGI_Symbol final : public SGI_Base
+class CmdMirrorSelectedSchematicItems final : public UndoCommandGroup
 {
     public:
 
         // Constructors / Destructor
-        explicit SGI_Symbol(SI_Symbol& symbol) noexcept;
-        ~SGI_Symbol() noexcept;
-
-        // General Methods
-        void updateCacheAndRepaint() noexcept;
-
-        // Inherited from QGraphicsItem
-        QRectF boundingRect() const noexcept {return mBoundingRect;}
-        QPainterPath shape() const noexcept {return mShape;}
-        void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = 0);
+        CmdMirrorSelectedSchematicItems(Schematic& schematic) noexcept;
+        ~CmdMirrorSelectedSchematicItems() noexcept;
 
 
     private:
 
-        // make some methods inaccessible...
-        SGI_Symbol() = delete;
-        SGI_Symbol(const SGI_Symbol& other) = delete;
-        SGI_Symbol& operator=(const SGI_Symbol& rhs) = delete;
-
         // Private Methods
-        GraphicsLayer* getLayer(const QString& name) const noexcept;
+
+        /// @copydoc UndoCommand::performExecute()
+        bool performExecute() override;
 
 
-        // Types
+        // Private Member Variables
 
-        struct CachedTextProperties_t {
-            QString text;
-            int fontPixelSize;
-            qreal scaleFactor;
-            bool rotate180;
-            bool mirrored;
-            int flags;
-            QRectF textRect;    // not scaled
-        };
-
-
-        // General Attributes
-        SI_Symbol& mSymbol;
-        const library::Symbol& mLibSymbol;
-        QFont mFont;
-
-        // Cached Attributes
-        QRectF mBoundingRect;
-        QPainterPath mShape;
-        QHash<const Text*, CachedTextProperties_t> mCachedTextProperties;
+        // Attributes from the constructor
+        Schematic& mSchematic;
 };
 
 /*****************************************************************************************
  *  End of File
  ****************************************************************************************/
 
+} // namespace editor
 } // namespace project
 } // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_SGI_SYMBOL_H
+#endif // LIBREPCB_PROJECT_CMDMIRRORSELECTEDSCHEMATICITEMS_H

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.h
@@ -49,7 +49,8 @@ class CmdMirrorSelectedSchematicItems final : public UndoCommandGroup
     public:
 
         // Constructors / Destructor
-        CmdMirrorSelectedSchematicItems(Schematic& schematic) noexcept;
+        CmdMirrorSelectedSchematicItems(Schematic& schematic,
+                                        Qt::Orientation orientation) noexcept;
         ~CmdMirrorSelectedSchematicItems() noexcept;
 
 
@@ -65,6 +66,7 @@ class CmdMirrorSelectedSchematicItems final : public UndoCommandGroup
 
         // Attributes from the constructor
         Schematic& mSchematic;
+        Qt::Orientation mOrientation;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -47,6 +47,7 @@ SOURCES += \
     cmd/cmdcombinenetsignals.cpp \
     cmd/cmdcombineschematicnetsegments.cpp \
     cmd/cmdflipselectedboarditems.cpp \
+    cmd/cmdmirrorselectedschematicitems.cpp \
     cmd/cmdmoveselectedboarditems.cpp \
     cmd/cmdmoveselectedschematicitems.cpp \
     cmd/cmdremoveboarditems.cpp \
@@ -107,6 +108,7 @@ HEADERS += \
     cmd/cmdcombinenetsignals.h \
     cmd/cmdcombineschematicnetsegments.h \
     cmd/cmdflipselectedboarditems.h \
+    cmd/cmdmirrorselectedschematicitems.h \
     cmd/cmdmoveselectedboarditems.h \
     cmd/cmdmoveselectedschematicitems.h \
     cmd/cmdremoveboarditems.h \

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorevent.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorevent.h
@@ -66,6 +66,7 @@ class SEE_Base
             Edit_Paste,         ///< paste the elements from the clipboard (ctrl+v)
             Edit_RotateCCW,     ///< rotate the selected elements 90° CCW (r)
             Edit_RotateCW,      ///< rotate the selected elements 90° CW (Shift+r)
+            Edit_Mirror,        ///< mirror selected items (horizontally)
             Edit_Remove,        ///< remove the selected elements
             // Redirected QEvent's (SEE_RedirectedQEvent objects, with pointer to a QEvent)
             GraphicsViewEvent,  ///< event from #GraphicsView @see #project#SEE_RedirectedQEvent

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
@@ -416,7 +416,7 @@ bool SES_Select::mirrorSelectedItems() noexcept
 
     try
     {
-        CmdMirrorSelectedSchematicItems* cmd = new CmdMirrorSelectedSchematicItems(*schematic);
+        CmdMirrorSelectedSchematicItems* cmd = new CmdMirrorSelectedSchematicItems(*schematic, Qt::Horizontal);
         mUndoStack.execCmd(cmd);
         return true;
     }

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.h
@@ -81,6 +81,7 @@ class SES_Select final : public SES_Base
                                                 Schematic* schematic) noexcept;
         bool startMovingSelectedItems(Schematic& schematic, const Point& startPos) noexcept;
         bool rotateSelectedItems(const Angle& angle) noexcept;
+        bool mirrorSelectedItems() noexcept;
         bool removeSelectedItems() noexcept;
         void openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept;
         void openNetLabelPropertiesDialog(SI_NetLabel& netlabel) noexcept;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -139,6 +139,8 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
             [this](){mFsm->processEvent(new SEE_Base(SEE_Base::Edit_RotateCW), true);});
     connect(mUi->actionRotate_CCW, &QAction::triggered,
             [this](){mFsm->processEvent(new SEE_Base(SEE_Base::Edit_RotateCCW), true);});
+    connect(mUi->actionMirror, &QAction::triggered,
+            [this](){mFsm->processEvent(new SEE_Base(SEE_Base::Edit_Mirror), true);});
     connect(mUi->actionRemove, &QAction::triggered,
             [this](){mFsm->processEvent(new SEE_Base(SEE_Base::Edit_Remove), true);});
 

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -80,6 +80,7 @@
     <addaction name="separator"/>
     <addaction name="actionRotate_CCW"/>
     <addaction name="actionRotate_CW"/>
+    <addaction name="actionMirror"/>
     <addaction name="actionCopy"/>
     <addaction name="actionCut"/>
     <addaction name="actionPaste"/>
@@ -182,6 +183,7 @@
    </attribute>
    <addaction name="actionRotate_CCW"/>
    <addaction name="actionRotate_CW"/>
+   <addaction name="actionMirror"/>
    <addaction name="actionCut"/>
    <addaction name="actionCopy"/>
    <addaction name="actionPaste"/>
@@ -437,6 +439,18 @@
    </property>
    <property name="shortcut">
     <string>Shift+R</string>
+   </property>
+  </action>
+  <action name="actionMirror">
+   <property name="icon">
+    <iconset resource="../../../../img/images.qrc">
+     <normaloff>:/img/actions/flip_horizontal.png</normaloff>:/img/actions/flip_horizontal.png</iconset>
+   </property>
+   <property name="text">
+     <string>M&amp;irror</string>
+   </property>
+   <property name="shortcut">
+    <string>M</string>
    </property>
   </action>
   <action name="actionCopy">

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -81,6 +81,7 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(Project& project,
     mUi->spbxSymbInstPosX->setValue(mSymbol.getPosition().getX().toMm());
     mUi->spbxSymbInstPosY->setValue(mSymbol.getPosition().getY().toMm());
     mUi->spbxSymbInstAngle->setValue(mSymbol.getRotation().toDeg());
+    mUi->cbxMirror->setChecked(mSymbol.getMirrored());
 
     // Symbol Library Element Attributes
     mUi->lblSymbLibUuid->setText(htmlLink.arg(mSymbol.getLibSymbol().getFilePath().toQUrl().toString(),
@@ -143,9 +144,11 @@ bool SymbolInstancePropertiesDialog::applyChanges() noexcept
         Point pos(Length::fromMm(mUi->spbxSymbInstPosX->value()),
                   Length::fromMm(mUi->spbxSymbInstPosY->value()));
         Angle rotation = Angle::fromDeg(mUi->spbxSymbInstAngle->value());
+        bool mirrored = mUi->cbxMirror->isChecked();
         QScopedPointer<CmdSymbolInstanceEdit> cmdSym(new CmdSymbolInstanceEdit(mSymbol));
         cmdSym->setPosition(pos, false);
         cmdSym->setRotation(rotation, false);
+        cmdSym->setMirrored(mirrored, false);
         transaction.append(cmdSym.take());
 
         transaction.commit(); // can throw

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -191,6 +191,20 @@
           </property>
          </widget>
         </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Mirror:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="cbxMirror">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>


### PR DESCRIPTION
This enables flipping around symbol instances in the schematic editor.

(note: vertical flipping = horizontal flip + 180° rotate)