### PR TITLE
Fix catch by value of polymorphic exceptions

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.cpp
@@ -275,7 +275,7 @@ bool BES_DrawPlane::start(Board& board, const Point& pos) noexcept
         mLastVertexPos = pos;
         makeSelectedLayerVisible();
         return true;
-    } catch (Exception e) {
+    } catch (const Exception& e) {
         QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         if (mSubState != SubState::Idle) abort(false);
         return false;
@@ -312,7 +312,7 @@ bool BES_DrawPlane::addSegment(Board& board, const Point& pos) noexcept
         mCmdEditCurrentPlane->setOutline(newPath, true);
         mLastVertexPos = pos;
         return true;
-    } catch (Exception e) {
+    } catch (const Exception& e) {
         QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         if (mSubState != SubState::Idle) abort(false);
         return false;
@@ -327,7 +327,7 @@ bool BES_DrawPlane::abort(bool showErrMsgBox) noexcept
         mUndoStack.abortCmdGroup(); // can throw
         mSubState = SubState::Idle;
         return true;
-    } catch (Exception& e) {
+    } catch (const Exception& e) {
         if (showErrMsgBox) QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         return false;
     }

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
@@ -279,7 +279,7 @@ bool BES_DrawPolygon::start(Board& board, const Point& pos) noexcept
         mLastSegmentPos = pos;
         makeSelectedLayerVisible();
         return true;
-    } catch (Exception e) {
+    } catch (const Exception& e) {
         QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         if (mSubState != SubState::Idle) abort(false);
         return false;
@@ -316,7 +316,7 @@ bool BES_DrawPolygon::addSegment(Board& board, const Point& pos) noexcept
         mCmdEditCurrentPolygon->setPath(newPath, true);
         mLastSegmentPos = pos;
         return true;
-    } catch (Exception e) {
+    } catch (const Exception& e) {
         QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         if (mSubState != SubState::Idle) abort(false);
         return false;
@@ -331,7 +331,7 @@ bool BES_DrawPolygon::abort(bool showErrMsgBox) noexcept
         mUndoStack.abortCmdGroup(); // can throw
         mSubState = SubState::Idle;
         return true;
-    } catch (Exception& e) {
+    } catch (const Exception& e) {
         if (showErrMsgBox) QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         return false;
     }

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
@@ -373,7 +373,7 @@ bool BES_DrawTrace::startPositioning(Board& board, const Point& pos,
 
         return true;
     }
-    catch (Exception e)
+    catch (const Exception& e)
     {
         QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         if (mSubState != SubState_Idle) {
@@ -408,11 +408,11 @@ bool BES_DrawTrace::addNextNetPoint(Board& board, const Point& pos) noexcept
             mUndoStack.appendToCmdGroup(cmd);
             finishCommand = cmd->hasCombinedSomeItems();
         }
-        catch (UserCanceled& e)
+        catch (const UserCanceled& e)
         {
             return false;
         }
-        catch (Exception& e)
+        catch (const Exception& e)
         {
             QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
             return false;
@@ -433,7 +433,7 @@ bool BES_DrawTrace::addNextNetPoint(Board& board, const Point& pos) noexcept
                 return startPositioning(board, pos, mPositioningNetPoint2);
             }
         }
-        catch (Exception e)
+        catch (const Exception& e)
         {
             QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
             if (mSubState != SubState_Idle) {
@@ -458,7 +458,7 @@ bool BES_DrawTrace::abortPositioning(bool showErrMsgBox) noexcept
         mUndoStack.abortCmdGroup(); // can throw
         return true;
     }
-    catch (Exception& e)
+    catch (const Exception& e)
     {
         if (showErrMsgBox) QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         return false;

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.cpp
@@ -337,7 +337,7 @@ bool SES_DrawWire::startPositioning(Schematic& schematic, const Point& pos,
 
         return true;
     }
-    catch (Exception e)
+    catch (const Exception& e)
     {
         QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         if (mSubState != SubState_Idle) {
@@ -378,11 +378,11 @@ bool SES_DrawWire::addNextNetPoint(Schematic& schematic, const Point& pos) noexc
             mUndoStack.appendToCmdGroup(cmdGroup.take());
             finishCommand = cmdCombineItems->hasCombinedSomeItems();
         }
-        catch (UserCanceled& e)
+        catch (const UserCanceled& e)
         {
             return false;
         }
-        catch (Exception& e)
+        catch (const Exception& e)
         {
             QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
             return false;
@@ -403,7 +403,7 @@ bool SES_DrawWire::addNextNetPoint(Schematic& schematic, const Point& pos) noexc
                 return startPositioning(schematic, pos, mPositioningNetPoint2);
             }
         }
-        catch (Exception e)
+        catch (const Exception& e)
         {
             QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
             if (mSubState != SubState_Idle) {
@@ -428,7 +428,7 @@ bool SES_DrawWire::abortPositioning(bool showErrMsgBox) noexcept
         mUndoStack.abortCmdGroup(); // can throw
         return true;
     }
-    catch (Exception& e)
+    catch (const Exception& e)
     {
         if (showErrMsgBox) QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
         return false;


### PR DESCRIPTION
Fixes a lot of `warning: catching polymorphic type ‘class
librepcb::Exception’ by value [-Wcatch-value=]` warnings.