### PR TITLE
Fix macOS deployment issue causing a crash

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -52,10 +52,14 @@ fi
 # Mac: Build application bundle
 if [ "${TRAVIS_OS_NAME-}" = "osx" ]
 then
-  macdeployqt "./build/install/opt/bin/librepcb.app" -dmg
+  # replace "bin" and "share" directories with the single librepcb.app directory
+  mv "./build/install/opt/bin/librepcb.app" "./build/install/opt/librepcb.app"
+  mv "./build/install/opt/share" "./build/install/opt/librepcb.app/Contents/share"
+  rmdir "./build/install/opt/bin"
+  macdeployqt "./build/install/opt/librepcb.app" -dmg
   if [ "${DEPLOY_BUNDLE-}" = "true" ]
   then
-    cp ./build/install/opt/bin/librepcb.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
+    mv ./build/install/opt/librepcb.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
   fi
 fi
 

--- a/libs/librepcb/common/application.cpp
+++ b/libs/librepcb/common/application.cpp
@@ -67,6 +67,12 @@ Application::Application(int& argc, char** argv) noexcept :
 
     // determine the path to the resources directory (e.g. /usr/share/librepcb)
     mResourcesDir = executableDirPath.getPathTo("../share/librepcb");
+#if defined(Q_OS_OSX)
+    if (!mResourcesDir.isExistingDir()) {
+        // for developer builds on mac, the "share" directory is outside the *.app directory
+        mResourcesDir = executableDirPath.getPathTo("../../../../share/librepcb");
+    }
+#endif
     Q_ASSERT(mResourcesDir.isValid());
 
     // load all stroke fonts


### PR DESCRIPTION
Adds the "share" directory to the macOS application bundle to make runtime resources available.

Hopefully fixes #274.