### PR TITLE
Update to new API for fetching libraries

### DIFF
--- a/libs/librepcb/common/network/networkrequestbase.cpp
+++ b/libs/librepcb/common/network/networkrequestbase.cpp
@@ -23,6 +23,7 @@
 #include <QtCore>
 #include "networkrequestbase.h"
 #include "networkaccessmanager.h"
+#include "../application.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -40,8 +41,11 @@ NetworkRequestBase::NetworkRequestBase(const QUrl& url) noexcept :
     Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
 
     // set initial HTTP header fields
-    mRequest.setHeader(QNetworkRequest::UserAgentHeader, QString("%1/%2").arg(
-                       qApp->applicationName(), qApp->applicationVersion()));
+    QString userAgent = QString("LibrePCB/%1").arg(qApp->getAppVersion().toStr());
+    mRequest.setHeader(QNetworkRequest::UserAgentHeader, userAgent);
+    mRequest.setRawHeader("X-LibrePCB-AppVersion", qApp->getAppVersion().toStr().toUtf8());
+    mRequest.setRawHeader("X-LibrePCB-AppVersionGit", qApp->getGitVersion().toUtf8());
+    mRequest.setRawHeader("X-LibrePCB-FileFormatVersion", qApp->getFileFormatVersion().toStr().toUtf8());
 
     // create queued connection to let executeRequest() execute in download thread
     connect(this, &NetworkRequestBase::startRequested,

--- a/libs/librepcb/common/network/repository.cpp
+++ b/libs/librepcb/common/network/repository.cpp
@@ -23,6 +23,7 @@
 #include <QtCore>
 #include "repository.h"
 #include "network/networkrequest.h"
+#include "../application.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -73,7 +74,8 @@ bool Repository::setUrl(const QUrl& url) noexcept
 
 void Repository::requestLibraryList() const noexcept
 {
-    requestLibraryList(QUrl(mUrl.toString() % "/api/v1/libraries"));
+    QString path = "/api/v1/libraries/v" % qApp->getFileFormatVersion().toStr();
+    requestLibraryList(QUrl(mUrl.toString() % path));
 }
 
 void Repository::serialize(SExpression& root) const

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -140,9 +140,9 @@ void RepositoryLibraryListWidgetItem::startDownloadIfSelected() noexcept
         mUi->prgProgress->setVisible(true);
 
         // read ZIP metadata from JSON
-        QUrl url = QUrl(mJsonObject.value("zip_url").toString());
-        qint64 zipSize = mJsonObject.value("zip_size").toInt(-1);
-        QByteArray zipSha256 = mJsonObject.value("zip_sha256").toString().toUtf8();
+        QUrl url = QUrl(mJsonObject.value("download_url").toString());
+        qint64 zipSize = mJsonObject.value("download_size").toInt(-1);
+        QByteArray zipSha256 = mJsonObject.value("download_sha256").toString().toUtf8();
 
         // determine destination directory
         QString libDirName = mUuid.toStr() % ".lplib";


### PR DESCRIPTION
We have updated the API to fetch the list of available libraries because the old API did not allow to fetch only libraries which have a compatible file format.

Now the request contains the file format version number in the URL, so the server is able to deliver only libraries which are compatible with the client's application version. For file format 0.1 the URL is now https://api.librepcb.org/api/v1/libraries/v0.1 instead of https://api.librepcb.org/api/v1/libraries.

Links:
- Motivation/discussion about this change: https://github.com/LibrePCB/librepcb-api/issues/5
- Documentation of new API: https://docs.librepcb.org/_branches/add_api_documentation/#api
- Pull request for documentation: https://github.com/LibrePCB/librepcb-doc/pull/16