### PR TITLE
Bundle fonts used in schematics together with LibrePCB

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "libs/delaunay-triangulation"]
 	path = libs/delaunay-triangulation
 	url = https://github.com/LibrePCB/delaunay-triangulation.git
+[submodule "share/librepcb/fonts"]
+	path = share/librepcb/fonts
+	url = https://github.com/LibrePCB/librepcb-fonts.git

--- a/libs/librepcb/common/application.cpp
+++ b/libs/librepcb/common/application.cpp
@@ -75,6 +75,28 @@ Application::Application(int& argc, char** argv) noexcept :
 #endif
     Q_ASSERT(mResourcesDir.isValid());
 
+    // load all bundled TrueType/OpenType fonts
+    QDir fontsDir(getResourcesFilePath("fonts").toStr());
+    fontsDir.setFilter(QDir::Files);
+    fontsDir.setNameFilters({"*.ttf", "*.otf"});
+    foreach (const QFileInfo& info, fontsDir.entryInfoList()) {
+        QString fp = info.absoluteFilePath();
+        int id = QFontDatabase::addApplicationFont(fp);
+        if (id < 0) {
+            qCritical() << "Failed to load font" << fp;
+        }
+    }
+
+    // set default sans serif font
+    mSansSerifFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
+    mSansSerifFont.setStyleHint(QFont::SansSerif);
+    mSansSerifFont.setFamily("Noto Sans");
+
+    // set default monospace font
+    mMonospaceFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
+    mMonospaceFont.setStyleHint(QFont::TypeWriter);
+    mMonospaceFont.setFamily("Noto Sans Mono");
+
     // load all stroke fonts
     mStrokeFontPool.reset(new StrokeFontPool(getResourcesFilePath("fontobene")));
     getDefaultStrokeFont(); // ensure that the default font is available (aborts if not)

--- a/libs/librepcb/common/application.h
+++ b/libs/librepcb/common/application.h
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <QApplication>
+#include <QFont>
 #include "version.h"
 #include "fileio/filepath.h"
 
@@ -73,6 +74,8 @@ class Application final : public QApplication
         const Version& getFileFormatVersion() const noexcept {return mFileFormatVersion;}
         const FilePath& getResourcesDir() const noexcept {return mResourcesDir;}
         FilePath getResourcesFilePath(const QString& filepath) const noexcept;
+        const QFont& getDefaultSansSerifFont() const noexcept {return mSansSerifFont;}
+        const QFont& getDefaultMonospaceFont() const noexcept {return mMonospaceFont;}
         const StrokeFontPool& getStrokeFonts() const noexcept {return *mStrokeFontPool;}
         QString getDefaultStrokeFontName() const noexcept {return "newstroke.bene";}
         const StrokeFont& getDefaultStrokeFont() const noexcept;
@@ -93,6 +96,8 @@ class Application final : public QApplication
         Version mFileFormatVersion;
         FilePath mResourcesDir;
         QScopedPointer<StrokeFontPool> mStrokeFontPool; ///< all application stroke fonts
+        QFont mSansSerifFont;
+        QFont mMonospaceFont;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/common/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivetextgraphicsitem.cpp
@@ -23,6 +23,7 @@
 #include <QtCore>
 #include <QtWidgets>
 #include "primitivetextgraphicsitem.h"
+#include "../application.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -37,9 +38,7 @@ PrimitiveTextGraphicsItem::PrimitiveTextGraphicsItem(QGraphicsItem* parent) noex
     QGraphicsItem(parent), mLayer(nullptr), mAlignment(HAlign::left(), VAlign::bottom()),
     mTextFlags(0)
 {
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Nimbus Sans L");
+    mFont = qApp->getDefaultSansSerifFont();
     mFont.setPixelSize(1);
 
     updateBoundingRectAndShape();
@@ -86,23 +85,17 @@ void PrimitiveTextGraphicsItem::setAlignment(const Alignment& align) noexcept
 
 void PrimitiveTextGraphicsItem::setFont(Font font) noexcept
 {
+    int size = mFont.pixelSize(); // memorize size
     switch (font) {
-        case Font::SansSerif: {
-            mFont.setStyleHint(QFont::SansSerif);
-            mFont.setFamily("Nimbus Sans L");
-            break;
-        }
-        case Font::Monospace: {
-            mFont.setStyleHint(QFont::TypeWriter);
-            mFont.setFamily("Monospace");
-            break;
-        }
+        case Font::SansSerif: mFont = qApp->getDefaultSansSerifFont(); break;
+        case Font::Monospace: mFont = qApp->getDefaultMonospaceFont(); break;
         default: {
             Q_ASSERT(false);
             qCritical() << "Unknown font:" << static_cast<int>(font);
             break;
         }
     }
+    mFont.setPixelSize(size);
     updateBoundingRectAndShape();
 }
 

--- a/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.cpp
@@ -26,6 +26,7 @@
 #include "footprintpadpreviewgraphicsitem.h"
 #include "packagepad.h"
 #include "footprintpad.h"
+#include <librepcb/common/application.h>
 #include <librepcb/common/graphics/graphicslayer.h>
 
 /*****************************************************************************************
@@ -42,9 +43,7 @@ FootprintPadPreviewGraphicsItem::FootprintPadPreviewGraphicsItem(const IF_Graphi
         const PackagePad* pkgPad) noexcept :
     QGraphicsItem(), mFootprintPad(fptPad), mPackagePad(pkgPad), mDrawBoundingRect(false)
 {
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Helvetica");
+    mFont = qApp->getDefaultSansSerifFont();
     mFont.setPixelSize(2);
 
     if (mPackagePad)

--- a/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.cpp
@@ -26,6 +26,7 @@
 #include "symbolpinpreviewgraphicsitem.h"
 #include "symbolpin.h"
 #include "../cmp/component.h"
+#include <librepcb/common/application.h>
 #include <librepcb/common/graphics/graphicslayer.h>
 
 /*****************************************************************************************
@@ -59,9 +60,7 @@ SymbolPinPreviewGraphicsItem::SymbolPinPreviewGraphicsItem(const IF_GraphicsLaye
     mStaticText.setTextFormat(Qt::PlainText);
     mStaticText.setPerformanceHint(QStaticText::AggressiveCaching);
 
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Nimbus Sans L");
+    mFont = qApp->getDefaultSansSerifFont();
     mFont.setPixelSize(5);
 
     mRadiusPx = Length(600000).toPx();

--- a/libs/librepcb/library/sym/symbolpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/sym/symbolpreviewgraphicsitem.cpp
@@ -25,6 +25,7 @@
 #include <QPrinter>
 #include "symbolpreviewgraphicsitem.h"
 #include "symbol.h"
+#include <librepcb/common/application.h>
 #include <librepcb/common/attributes/attributesubstitutor.h>
 #include <librepcb/common/graphics/graphicslayer.h>
 #include "symbolpinpreviewgraphicsitem.h"
@@ -50,9 +51,7 @@ SymbolPreviewGraphicsItem::SymbolPreviewGraphicsItem(const IF_GraphicsLayerProvi
     QGraphicsItem(), mLayerProvider(layerProvider), mSymbol(symbol), mComponent(cmp),
     mSymbVarItem(nullptr), mDrawBoundingRect(false), mLocaleOrder(localeOrder)
 {
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Nimbus Sans L");
+    mFont = qApp->getDefaultSansSerifFont();
 
     try {
         if (mComponent) {

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.cpp
@@ -28,6 +28,7 @@
 #include "../items/bi_footprint.h"
 #include "../board.h"
 #include "../../project.h"
+#include <librepcb/common/application.h>
 #include <librepcb/common/boarddesignrules.h>
 #include <librepcb/library/pkg/footprint.h>
 #include "../../settings/projectsettings.h"
@@ -53,9 +54,7 @@ BGI_FootprintPad::BGI_FootprintPad(BI_FootprintPad& pad) noexcept :
 {
     setToolTip(mPad.getDisplayText());
 
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Helvetica");
+    mFont = qApp->getDefaultSansSerifFont();
     mFont.setPixelSize(1);
 
     updateCacheAndRepaint();

--- a/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
@@ -29,6 +29,7 @@
 #include "../../project.h"
 #include "../boardlayerstack.h"
 #include "../../circuit/netsignal.h"
+#include <librepcb/common/application.h>
 #include <librepcb/common/boarddesignrules.h>
 
 /*****************************************************************************************
@@ -47,9 +48,7 @@ BGI_Via::BGI_Via(BI_Via& via) noexcept :
 {
     setZValue(Board::ZValue_Vias);
 
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Helvetica");
+    mFont = qApp->getDefaultSansSerifFont();
     mFont.setPixelSize(1);
 
     updateCacheAndRepaint();

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -88,7 +88,7 @@ void SGI_NetLabel::updateCacheAndRepaint() noexcept
     mStaticText.setText(mNetLabel.getNetSignalOfNetSegment().getName());
     mStaticText.prepare(QTransform(), mFont);
     mTextOrigin.setX(mRotate180 ? -mStaticText.size().width() : 0);
-    mTextOrigin.setY(mRotate180 ? 0 : -0.5-mStaticText.size().height());
+    mTextOrigin.setY(mRotate180 ? 0 : -mStaticText.size().height());
     mStaticText.prepare(QTransform().rotate(mRotate180 ? 180 : 0)
                               .translate(mTextOrigin.x(), mTextOrigin.y()), mFont);
 

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -30,6 +30,7 @@
 #include "../schematiclayerprovider.h"
 #include "../../project.h"
 #include "../../circuit/netsignal.h"
+#include <librepcb/common/application.h>
 #include <librepcb/common/graphics/linegraphicsitem.h>
 
 /*****************************************************************************************
@@ -52,9 +53,7 @@ SGI_NetLabel::SGI_NetLabel(SI_NetLabel& netlabel) noexcept :
     mStaticText.setTextFormat(Qt::PlainText);
     mStaticText.setPerformanceHint(QStaticText::AggressiveCaching);
 
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::TypeWriter);
-    mFont.setFamily("Monospace");
+    mFont = qApp->getDefaultMonospaceFont();
     mFont.setPixelSize(4);
 
     if (sOriginCrossLines.isEmpty())

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netline.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netline.cpp
@@ -30,6 +30,7 @@
 #include "../schematiclayerprovider.h"
 #include "../../project.h"
 #include "../../circuit/netsignal.h"
+#include <librepcb/common/application.h>
 
 /*****************************************************************************************
  *  Namespace
@@ -105,10 +106,7 @@ void SGI_NetLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* optio
     if (layer->isVisible())
     {
         // draw net signal name
-        QFont font;
-        font.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-        font.setStyleHint(QFont::TypeWriter);
-        font.setFamily("Monospace");
+        QFont font = qApp->getDefaultMonospaceFont();
         font.setPixelSize(3);
         painter->setFont(font);
         painter->setPen(QPen(layer->getColor(highlight), 0));

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -29,6 +29,7 @@
 #include "../schematiclayerprovider.h"
 #include "../../project.h"
 #include "../../circuit/componentinstance.h"
+#include <librepcb/common/application.h>
 #include <librepcb/common/attributes/attributesubstitutor.h>
 #include <librepcb/library/sym/symbol.h>
 #include <librepcb/library/cmp/component.h>
@@ -48,9 +49,7 @@ SGI_Symbol::SGI_Symbol(SI_Symbol& symbol) noexcept :
 {
     setZValue(Schematic::ZValue_Symbols);
 
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Nimbus Sans L");
+    mFont = qApp->getDefaultSansSerifFont();
 
     updateCacheAndRepaint();
 }

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.cpp
@@ -32,6 +32,7 @@
 #include "../../circuit/netsignal.h"
 #include "../../circuit/componentinstance.h"
 #include "../../circuit/componentsignalinstance.h"
+#include <librepcb/common/application.h>
 #include <librepcb/library/sym/symbolpin.h>
 #include <librepcb/library/cmp/component.h>
 #include "../../settings/projectsettings.h"
@@ -55,9 +56,7 @@ SGI_SymbolPin::SGI_SymbolPin(SI_SymbolPin& pin) noexcept :
     mStaticText.setTextFormat(Qt::PlainText);
     mStaticText.setPerformanceHint(QStaticText::AggressiveCaching);
 
-    mFont.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-    mFont.setStyleHint(QFont::SansSerif);
-    mFont.setFamily("Nimbus Sans L");
+    mFont = qApp->getDefaultSansSerifFont();
     mFont.setPixelSize(5);
 
     mRadiusPx = Length(600000).toPx();
@@ -172,10 +171,7 @@ void SGI_SymbolPin::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
     if ((layer->isVisible()) && (netsignal))
     {
         // draw net signal name
-        QFont font;
-        font.setStyleStrategy(QFont::StyleStrategy(QFont::OpenGLCompatible | QFont::PreferQuality));
-        font.setStyleHint(QFont::TypeWriter);
-        font.setFamily("Monospace");
+        QFont font = qApp->getDefaultMonospaceFont();
         font.setPixelSize(3);
         painter->setFont(font);
         painter->setPen(QPen(layer->getColor(highlight), 0));


### PR DESCRIPTION
This makes LibrePCB using [Noto Fonts](https://www.google.com/get/noto/) for schematics. To ensure consistent look over all platforms, the fonts are bundled together with LibrePCB. So the look of schematics no longer depends on the available system fonts.

Preview:
![auswahl_004](https://user-images.githubusercontent.com/5374821/41819573-dd024dc2-77c2-11e8-995e-5b4aeb05c590.png)

Fixes #153.