### PR TITLE
Add initial setup for automated functional tests

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -22,7 +22,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <QtWidgets>
-#include <QFileDialog>
 #include "controlpanel.h"
 #include "ui_controlpanel.h"
 #include <librepcb/workspace/workspace.h>
@@ -40,6 +39,7 @@
 #include <librepcb/common/application.h>
 #include <librepcb/common/dialogs/aboutdialog.h>
 #include <librepcb/common/fileio/fileutils.h>
+#include <librepcb/common/dialogs/filedialog.h>
 #include "../markdown/markdownconverter.h"
 #include "projectlibraryupdater/projectlibraryupdater.h"
 
@@ -436,8 +436,8 @@ void ControlPanel::on_actionOpen_Project_triggered()
     QString lastOpenedFile = settings.value("controlpanel/last_open_project",
                              mWorkspace.getPath().toStr()).toString();
 
-    FilePath filepath(QFileDialog::getOpenFileName(this, tr("Open Project"), lastOpenedFile,
-                                    tr("LibrePCB project files (%1)").arg("*.lpp")));
+    FilePath filepath(FileDialog::getOpenFileName(this, tr("Open Project"), lastOpenedFile,
+                      tr("LibrePCB project files (%1)").arg("*.lpp")));
 
     if (!filepath.isValid())
         return;

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
@@ -20,10 +20,10 @@
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
-#include <QFileDialog>
 #include "firstrunwizardpage_workspacepath.h"
 #include "ui_firstrunwizardpage_workspacepath.h"
 #include <librepcb/common/fileio/filepath.h>
+#include <librepcb/common/dialogs/filedialog.h>
 #include <librepcb/workspace/workspace.h>
 
 /*****************************************************************************************
@@ -115,14 +115,14 @@ void FirstRunWizardPage_WorkspacePath::on_rbtnOpenWs_toggled(bool checked)
 
 void FirstRunWizardPage_WorkspacePath::on_btnCreateWsBrowse_clicked()
 {
-    QString filepath = QFileDialog::getExistingDirectory(0, tr("Select Empty Directory"));
+    QString filepath = FileDialog::getExistingDirectory(0, tr("Select Empty Directory"));
     if (filepath.isEmpty()) return;
     mUi->edtCreateWsPath->setText(filepath);
 }
 
 void FirstRunWizardPage_WorkspacePath::on_btnOpenWsBrowse_clicked()
 {
-    QString filepath = QFileDialog::getExistingDirectory(0, tr("Select Workspace Directory"));
+    QString filepath = FileDialog::getExistingDirectory(0, tr("Select Workspace Directory"));
     if (filepath.isEmpty()) return;
     mUi->edtOpenWsPath->setText(filepath);
 }

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -17,13 +17,14 @@ then
     source "/opt/${QT_BASE}/bin/${QT_BASE}-env.sh"
   else
     sudo apt-get update -qq
-    sudo apt-get install -qq qt5-default qttools5-dev-tools
+    sudo apt-get install -qq qt5-default qttools5-dev-tools qtdeclarative5-dev qtdeclarative5-qtquick2-plugin
   fi
   sudo apt-get install -qq libc++-dev libglu1-mesa-dev zlib1g zlib1g-dev openssl xvfb doxygen graphviz
 
   # python packages
-  pip install --user future
+  pip install --user future flake8
   pip install --user -r ./tests/cli/requirements.txt
+  pip install --user -r ./tests/funq/requirements.txt
 
   # linuxdeployqt
   sudo wget -cq "$LINUXDEPLOYQT_URL" -O /usr/local/bin/linuxdeployqt
@@ -47,8 +48,9 @@ then
   export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
   # python packages
-  pip2 install --user future
+  pip2 install --user future flake8
   pip2 install --user -r ./tests/cli/requirements.txt
+  pip2 install --user -r ./tests/funq/requirements.txt
   export PATH="$PATH:`python2 -m site --user-base`/bin"
 
   # Qt Installer Framework
@@ -71,7 +73,8 @@ then
   ccache -s
 
   # python packages
-  pip install future
+  pip install future flake8
   pip install -r ./tests/cli/requirements.txt
+  pip install -r ./tests/funq/requirements.txt
 
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -27,3 +27,17 @@ then
 else
   pytest -v --librepcb-executable="build/install/opt/bin/librepcb-cli.exe" ./tests/cli
 fi
+
+# run functional tests
+if [ "${TRAVIS_OS_NAME-}" = "linux" ]
+then
+  xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -v --librepcb-executable="LibrePCB-x86_64.AppImage" ./tests/funq
+elif [ "${TRAVIS_OS_NAME-}" = "osx" ]
+then
+  pytest -v --librepcb-executable="build/install/opt/librepcb.app/Contents/MacOS/librepcb" ./tests/funq
+else
+  pytest -v --librepcb-executable="build/install/opt/bin/librepcb.exe" ./tests/funq
+fi
+
+# run python style checks
+flake8 --ignore=E501 tests

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -49,6 +49,7 @@ SOURCES += \
     dialogs/aboutdialog.cpp \
     dialogs/boarddesignrulesdialog.cpp \
     dialogs/circlepropertiesdialog.cpp \
+    dialogs/filedialog.cpp \
     dialogs/gridsettingsdialog.cpp \
     dialogs/holepropertiesdialog.cpp \
     dialogs/polygonpropertiesdialog.cpp \
@@ -150,6 +151,7 @@ HEADERS += \
     dialogs/aboutdialog.h \
     dialogs/boarddesignrulesdialog.h \
     dialogs/circlepropertiesdialog.h \
+    dialogs/filedialog.h \
     dialogs/gridsettingsdialog.h \
     dialogs/holepropertiesdialog.h \
     dialogs/polygonpropertiesdialog.h \

--- a/libs/librepcb/common/dialogs/filedialog.cpp
+++ b/libs/librepcb/common/dialogs/filedialog.cpp
@@ -1,0 +1,81 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include "filedialog.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Public Methods
+ ****************************************************************************************/
+
+QString FileDialog::getOpenFileName(QWidget *parent, const QString &caption,
+                                    const QString &dir, const QString &filter,
+                                    QString *selectedFilter, QFileDialog::Options options)
+{
+    patchOptions(options);
+    return QFileDialog::getOpenFileName(parent, caption, dir, filter, selectedFilter, options);
+}
+
+QStringList FileDialog::getOpenFileNames(QWidget *parent, const QString &caption,
+                                         const QString &dir, const QString &filter,
+                                         QString *selectedFilter, QFileDialog::Options options)
+{
+    patchOptions(options);
+    return QFileDialog::getOpenFileNames(parent, caption, dir, filter, selectedFilter, options);
+}
+
+QString FileDialog::getSaveFileName(QWidget *parent, const QString &caption,
+                                    const QString &dir, const QString &filter,
+                                    QString *selectedFilter, QFileDialog::Options options)
+{
+    patchOptions(options);
+    return QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options);
+}
+
+QString FileDialog::getExistingDirectory(QWidget *parent, const QString &caption,
+                                         const QString &dir, QFileDialog::Options options)
+{
+    patchOptions(options);
+    return QFileDialog::getExistingDirectory(parent, caption, dir, options);
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void FileDialog::patchOptions(QFileDialog::Options& options) noexcept
+{
+    static const bool noNativeDialogs = qgetenv("LIBREPCB_DISABLE_NATIVE_DIALOGS") == "1";
+    if (noNativeDialogs) {
+        options |= QFileDialog::DontUseNativeDialog;
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb

--- a/libs/librepcb/common/dialogs/filedialog.h
+++ b/libs/librepcb/common/dialogs/filedialog.h
@@ -1,0 +1,90 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_FILEDIALOG_H
+#define LIBREPCB_FILEDIALOG_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+/*****************************************************************************************
+ *  Class FileDialog
+ ****************************************************************************************/
+
+/**
+ * @brief Wrapper around QFileDialog to slightly change its behaviour
+ *
+ * Using these methods ensures that no native file dialogs are used if the environment
+ * variable `LIBREPCB_DISABLE_NATIVE_DIALOGS` is set to "1". This is needed for automatic
+ * functional testing, as native dialogs are hard to test.
+ */
+class FileDialog final
+{
+    public:
+
+        // Constructors / Destructor
+        FileDialog() = delete;
+        FileDialog(const FileDialog& other) = delete;
+        ~FileDialog() = delete;
+
+        static QString getOpenFileName(QWidget *parent = 0,
+                                       const QString &caption = QString(),
+                                       const QString &dir = QString(),
+                                       const QString &filter = QString(),
+                                       QString *selectedFilter = 0,
+                                       QFileDialog::Options options = 0);
+
+        static QStringList getOpenFileNames(QWidget *parent = 0,
+                                            const QString &caption = QString(),
+                                            const QString &dir = QString(),
+                                            const QString &filter = QString(),
+                                            QString *selectedFilter = 0,
+                                            QFileDialog::Options options = 0);
+
+        static QString getSaveFileName(QWidget *parent = 0,
+                                       const QString &caption = QString(),
+                                       const QString &dir = QString(),
+                                       const QString &filter = QString(),
+                                       QString *selectedFilter = 0,
+                                       QFileDialog::Options options = 0);
+
+        static QString getExistingDirectory(QWidget *parent = 0,
+                                            const QString &caption = QString(),
+                                            const QString &dir = QString(),
+                                            QFileDialog::Options options = QFileDialog::ShowDirsOnly);
+
+    private:
+        static void patchOptions(QFileDialog::Options& options) noexcept;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace librepcb
+
+#endif // LIBREPCB_FILEDIALOG_H

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -24,6 +24,7 @@
 #include <QtWidgets>
 #include "libraryoverviewwidget.h"
 #include "ui_libraryoverviewwidget.h"
+#include <librepcb/common/dialogs/filedialog.h>
 #include <librepcb/library/elements.h>
 #include <librepcb/workspace/workspace.h>
 #include <librepcb/workspace/library/workspacelibrarydb.h>
@@ -208,7 +209,7 @@ void LibraryOverviewWidget::updateElementList(QListWidget& listWidget, const QIc
 
 void LibraryOverviewWidget::btnIconClicked() noexcept
 {
-    QString fp = QFileDialog::getOpenFileName(this, tr("Choose library icon"),
+    QString fp = FileDialog::getOpenFileName(this, tr("Choose library icon"),
         mLibrary->getIconFilePath().toNative(), tr("Portable Network Graphics (*.png)"));
     if (!fp.isEmpty()) {
         mLibrary->setIconFilePath(FilePath(fp));

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -38,6 +38,7 @@
 #include <librepcb/common/dialogs/aboutdialog.h>
 #include <librepcb/common/dialogs/gridsettingsdialog.h>
 #include <librepcb/common/dialogs/boarddesignrulesdialog.h>
+#include <librepcb/common/dialogs/filedialog.h>
 #include "../dialogs/projectpropertieseditordialog.h"
 #include <librepcb/project/settings/projectsettings.h>
 #include <librepcb/common/graphics/graphicsview.h>
@@ -423,8 +424,8 @@ void BoardEditor::on_actionExportAsPdf_triggered()
 {
     try
     {
-        QString filename = QFileDialog::getSaveFileName(this, tr("PDF Export"),
-                                                        QDir::homePath(), "*.pdf");
+        QString filename = FileDialog::getSaveFileName(this, tr("PDF Export"),
+                                                       QDir::homePath(), "*.pdf");
         if (filename.isEmpty()) return;
         if (!filename.endsWith(".pdf")) filename.append(".pdf");
         //FilePath filepath(filename);

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -25,6 +25,7 @@
 #include "newprojectwizardpage_metadata.h"
 #include "ui_newprojectwizardpage_metadata.h"
 #include <librepcb/common/application.h>
+#include <librepcb/common/dialogs/filedialog.h>
 #include <librepcb/workspace/workspace.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
 
@@ -136,7 +137,7 @@ void NewProjectWizardPage_Metadata::locationChanged(const QString& dir) noexcept
 
 void NewProjectWizardPage_Metadata::chooseLocationClicked() noexcept
 {
-    QString dir = QFileDialog::getExistingDirectory(this,
+    QString dir = FileDialog::getExistingDirectory(this,
         tr("Project's parent directory"), mUi->edtLocation->text());
     if (!dir.isEmpty()) {
         mUi->edtLocation->setText(FilePath(dir).toNative());

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -44,6 +44,7 @@
 #include <librepcb/project/settings/projectsettings.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/gridproperties.h>
+#include <librepcb/common/dialogs/filedialog.h>
 #include <librepcb/project/schematics/cmd/cmdschematicadd.h>
 #include "../projecteditor.h"
 
@@ -317,8 +318,8 @@ void SchematicEditor::on_actionPDF_Export_triggered()
                                .arg(projectVersion, projectName);
         FilePath defaultFilePath = mProject.getPath().getPathTo(relativePath);
         QDir().mkpath(defaultFilePath.getParentDir().toStr());
-        QString filename = QFileDialog::getSaveFileName(this, tr("PDF Export"),
-                                                        defaultFilePath.toNative(), "*.pdf");
+        QString filename = FileDialog::getSaveFileName(this, tr("PDF Export"),
+                                                       defaultFilePath.toNative(), "*.pdf");
         if (filename.isEmpty()) return;
         if (!filename.endsWith(".pdf")) filename.append(".pdf");
         FilePath filepath(filename);

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -21,12 +21,12 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
-#include <QFileDialog>
 #include "workspace.h"
 #include <librepcb/common/exceptions.h>
 #include <librepcb/common/fileio/filepath.h>
 #include <librepcb/common/fileio/fileutils.h>
 #include <librepcb/common/fileio/smartversionfile.h>
+#include <librepcb/common/dialogs/filedialog.h>
 #include <librepcb/common/application.h>
 #include <librepcb/libraryeditor/libraryeditor.h>
 #include <librepcb/project/project.h>
@@ -331,7 +331,7 @@ void Workspace::setMostRecentlyUsedWorkspacePath(const FilePath& path) noexcept
 
 FilePath Workspace::chooseWorkspacePath() noexcept
 {
-    FilePath path(QFileDialog::getExistingDirectory(0, tr("Select Workspace Path")));
+    FilePath path(FileDialog::getExistingDirectory(0, tr("Select Workspace Path")));
 
     if ((path.isValid()) && (!isValidWorkspacePath(path))) {
         int answer = QMessageBox::question(0, tr("Create new workspace?"),

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,4 +4,5 @@ This directory contains tests for LibrePCB. Purpose of subdirectories:
 
 - `data`: Data files (for example LibrePCB projects) used for the tests.
 - `unittests`: Unit/integration tests for all static libraries of LibrePCB.
+- `funq`: Functional tests (i.e. GUI tests) for LibrePCB.
 - `cli`: System tests for the LibrePCB CLI.

--- a/tests/funq/.gitignore
+++ b/tests/funq/.gitignore
@@ -1,0 +1,3 @@
+pytest.ini
+gitems.json
+widgets_list.json

--- a/tests/funq/README.md
+++ b/tests/funq/README.md
@@ -1,0 +1,21 @@
+# Functional Tests
+
+This directory contains functional tests (simulating user input) using
+[funq](https://github.com/parkouss/funq) and [pytest](https://docs.pytest.org).
+
+## Create Virtualenv
+
+    mkvirtualenv -p `which python3` librepcb-funq
+
+## Install Requirements
+
+    pip install -r requirements.txt
+
+## Run Tests
+
+    pytest -v --librepcb-executable=/path/to/librepcb
+
+## Links
+
+- [Documentation of `funq`](http://funq.readthedocs.io/en/latest/)
+- [Documentation of `pytest`](https://docs.pytest.org/en/latest/contents.html)

--- a/tests/funq/aliases
+++ b/tests/funq/aliases
@@ -1,0 +1,145 @@
+################################################################################
+# Control Panel
+################################################################################
+
+# Main window
+controlPanel = librepcb__application__ControlPanel
+controlPanelWidget = {controlPanel}::centralWidget
+
+# Menu
+controlPanelMenuBar = {controlPanel}::menuBar
+controlPanelMenuExtras = {controlPanelMenuBar}::menuExtras
+
+# Labels at top
+controlPanelWarnForNoLibrariesLabel = {controlPanelWidget}::lblWarnForNoLibraries
+
+# Buttons in the top right frame
+controlPanelButtonsFrame = {controlPanelWidget}::splitter_h::layoutWidget1::frame
+controlPanelNewProjectButton = {controlPanelButtonsFrame}::newProjectButton
+controlPanelOpenProjectButton = {controlPanelButtonsFrame}::openProjectButton
+controlPanelOpenLibraryManagerButton = {controlPanelButtonsFrame}::openLibraryManagerButton
+
+# Open project dialog
+controlPanelOpenProjectDialog = {controlPanel}::{QT_FILE_DIALOG}
+controlPanelOpenProjectDialogFileNameEdit = {controlPanel}::{QT_FILE_DIALOG_LINE_EDIT}
+controlPanelOpenProjectDialogOkButton = {controlPanel}::{QT_FILE_DIALOG_BTN_OK}
+
+# New project wizard
+controlPanelNewProjectWizard = {controlPanel}::librepcb__project__editor__NewProjectWizard
+controlPanelNewProjectWizardWidget = {controlPanelNewProjectWizard}::QWidget
+controlPanelNewProjectWizardNextButton = {controlPanelNewProjectWizardWidget}::__qt__passive_wizardbutton1
+controlPanelNewProjectWizardFinishButton = {controlPanelNewProjectWizardWidget}::qt_wizard_finish
+controlPanelNewProjectWizardFrame = {controlPanelNewProjectWizardWidget}::QFrame
+controlPanelNewProjectWizardMetadataPage = {controlPanelNewProjectWizardFrame}::librepcb__project__editor__NewProjectWizardPage_Metadata
+controlPanelNewProjectWizardMetadataNameEdit = {controlPanelNewProjectWizardMetadataPage}::edtName
+controlPanelNewProjectWizardMetadataPathLabel = {controlPanelNewProjectWizardMetadataPage}::lblFullFilePath
+
+
+################################################################################
+# Library Manager
+################################################################################
+
+# Main window
+libraryManager = {controlPanel}::librepcb__library__manager__LibraryManager
+libraryManagerWidget = {libraryManager}::centralwidget
+
+# Installed libraries list
+libraryManagerInstalledLibrariesList = {libraryManagerWidget}::lstLibraries
+libraryManagerInstalledLibrariesListViewport = {libraryManagerInstalledLibrariesList}::qt_scrollarea_viewport
+
+# Add library widget
+libraryManagerAddLibraryWidget = {libraryManagerWidget}::librepcb__library__manager____AddLibraryWidget
+libraryManagerAddLibraryTabWidget = {libraryManagerAddLibraryWidget}::tabWidget
+libraryManagerAddLibraryTabBar = {libraryManagerAddLibraryTabWidget}::qt_tabwidget_tabbar
+libraryManagerAddLibraryStackedWidget = {libraryManagerAddLibraryTabWidget}::qt_tabwidget_stackedwidget
+
+# Remote libraries tab
+libraryManagerDownloadFromRepoTab = {libraryManagerAddLibraryStackedWidget}::tabDownloadFromRepo
+libraryManagerDownloadFromRepoLibraryList = {libraryManagerDownloadFromRepoTab}::lstRepoLibs
+libraryManagerDownloadFromRepoLibraryListViewport = {libraryManagerDownloadFromRepoLibraryList}::qt_scrollarea_viewport
+libraryManagerDownloadFromRepoLibraryListItem = {libraryManagerDownloadFromRepoLibraryListViewport}::librepcb__library__manager__RepositoryLibraryListWidgetItem
+libraryManagerDownloadFromRepoDownloadButton = {libraryManagerDownloadFromRepoTab}::btnRepoLibsDownload
+
+# Create local library tab
+libraryManagerCreateLocalLibraryTab = {libraryManagerAddLibraryStackedWidget}::tabCreateLocal
+libraryManagerCreateLocalLibraryNameEdit = {libraryManagerCreateLocalLibraryTab}::edtLocalName
+libraryManagerCreateLocalLibraryDescriptionEdit = {libraryManagerCreateLocalLibraryTab}::edtLocalDescription
+libraryManagerCreateLocalLibraryAuthorEdit = {libraryManagerCreateLocalLibraryTab}::edtLocalAuthor
+libraryManagerCreateLocalLibraryUrlEdit = {libraryManagerCreateLocalLibraryTab}::edtLocalUrl
+libraryManagerCreateLocalLibraryVersionEdit = {libraryManagerCreateLocalLibraryTab}::edtLocalVersion
+libraryManagerCreateLocalLibraryCc0LicenseCheckbox = {libraryManagerCreateLocalLibraryTab}::cbxLocalCc0License
+libraryManagerCreateLocalLibraryDirectoryEdit = {libraryManagerCreateLocalLibraryTab}::edtLocalDirectory
+libraryManagerCreateLocalLibraryCreateButton = {libraryManagerCreateLocalLibraryTab}::btnLocalCreate
+
+# Library info widget
+libraryManagerLibraryInfoWidget = {libraryManagerWidget}::librepcb__library__manager__LibraryInfoWidget
+libraryManagerLibraryInfoWidgetOpenEditorButton = {libraryManagerLibraryInfoWidget}::btnOpenLibraryEditor
+
+
+################################################################################
+# Library Editor
+################################################################################
+
+# Main window
+libraryEditor = librepcb__library__editor__LibraryEditor
+libraryEditorWidget = {libraryEditor}::centralWidget
+
+# Tab widget
+libraryEditorTabWidget = {libraryEditorWidget}::tabWidget
+libraryEditorStackedWidget = {libraryEditorTabWidget}::qt_tabwidget_stackedwidget
+
+# Library overview widget
+libraryEditorOverviewWidget = {libraryEditorStackedWidget}::librepcb__library__editor__LibraryOverviewWidget
+libraryEditorOverviewMetadataWidget = {libraryEditorOverviewWidget}::splitter::layoutWidget
+libraryEditorOverviewNameEdit = {libraryEditorOverviewMetadataWidget}::edtName
+libraryEditorOverviewDescriptionEdit = {libraryEditorOverviewMetadataWidget}::edtDescription
+libraryEditorOverviewKeywordsEdit = {libraryEditorOverviewMetadataWidget}::edtKeywords
+libraryEditorOverviewAuthorEdit = {libraryEditorOverviewMetadataWidget}::edtAuthor
+libraryEditorOverviewVersionEdit = {libraryEditorOverviewMetadataWidget}::edtVersion
+libraryEditorOverviewDeprecatedCheckbox = {libraryEditorOverviewMetadataWidget}::cbxDeprecated
+libraryEditorOverviewUrlEdit = {libraryEditorOverviewMetadataWidget}::edtUrl
+
+# New element wizard
+libraryEditorNewElementWizard = librepcb__library__editor__NewElementWizard
+libraryEditorNewElementWizardWidget = {libraryEditorNewElementWizard}::centralWidget
+libraryEditorNewElementWizardNextButton = {libraryEditorNewElementWizardWidget}::__qt__passive_wizardbutton1
+libraryEditorNewElementWizardFinishButton = {libraryEditorNewElementWizardWidget}::qt_wizard_finish
+libraryEditorNewElementWizardFrame = {libraryEditorNewElementWizard}::QFrame
+libraryEditorNewElementWizardChooseTypePage = {libraryEditorNewElementWizardFrame}::librepcb__library__editor__NewElementWizardPage_ChooseType
+libraryEditorNewElementWizardChooseTypeCmpCatButton = {libraryEditorNewElementWizardChooseTypePage}::btnComponentCategory
+libraryEditorNewElementWizardChooseTypePkgCatButton = {libraryEditorNewElementWizardChooseTypePage}::btnPackageCategory
+libraryEditorNewElementWizardChooseTypeSymbolButton = {libraryEditorNewElementWizardChooseTypePage}::btnSymbol
+libraryEditorNewElementWizardChooseTypePackageButton = {libraryEditorNewElementWizardChooseTypePage}::btnPackage
+libraryEditorNewElementWizardChooseTypeComponentButton = {libraryEditorNewElementWizardChooseTypePage}::btnComponent
+libraryEditorNewElementWizardChooseTypeDeviceButton = {libraryEditorNewElementWizardChooseTypePage}::btnDevice
+libraryEditorNewElementWizardMetadataPage = {libraryEditorNewElementWizardFrame}::librepcb__library__editor__NewElementWizardPage_EnterMetadata
+libraryEditorNewElementWizardMetadataNameEdit = {libraryEditorNewElementWizardMetadataPage}::edtName
+libraryEditorNewElementWizardMetadataDescriptionEdit = {libraryEditorNewElementWizardMetadataPage}::edtDescription
+libraryEditorNewElementWizardMetadataKeywordsEdit = {libraryEditorNewElementWizardMetadataPage}::edtKeywords
+libraryEditorNewElementWizardMetadataAuthorEdit = {libraryEditorNewElementWizardMetadataPage}::edtAuthor
+libraryEditorNewElementWizardMetadataVersionEdit = {libraryEditorNewElementWizardMetadataPage}::edtVersion
+libraryEditorNewElementWizardMetadataCategoryEdit = {libraryEditorNewElementWizardMetadataPage}::edtCategory
+libraryEditorNewElementWizardMetadataCategoryLabel = {libraryEditorNewElementWizardMetadataPage}::lblCategoryTree
+libraryEditorNewElementWizardMetadataCategoryButton = {libraryEditorNewElementWizardMetadataPage}::btnChooseCategory
+
+
+################################################################################
+# Schematic Editor
+################################################################################
+
+# Main window
+schematicEditor = librepcb__project__editor__SchematicEditor
+schematicEditorWidget = {schematicEditor}::centralWidget
+
+# Graphics view
+schematicEditorGraphicsView = {schematicEditor}::librepcb:_:GraphicsView
+schematicEditorGraphicsViewWidget = {schematicEditorGraphicsView}::QWidget
+
+
+################################################################################
+# Board Editor
+################################################################################
+
+# Main window
+boardEditor = librepcb__project__editor__BoardEditor
+boardEditorWidget = {boardEditor}::centralWidget

--- a/tests/funq/conftest.py
+++ b/tests/funq/conftest.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import platform
+import shutil
+import pytest
+import funq
+from funq.client import ApplicationContext, ApplicationConfig
+
+
+FUNQ_DIR = os.path.dirname(__file__)
+TESTS_DIR = os.path.dirname(FUNQ_DIR)
+REPO_DIR = os.path.dirname(TESTS_DIR)
+DATA_DIR = os.path.join(TESTS_DIR, 'data')
+FUNQ_DATA_DIR = os.path.join(DATA_DIR, 'funq')
+FIXTURES_DATA_DIR = os.path.join(FUNQ_DATA_DIR, 'fixtures')
+
+
+def pytest_addoption(parser):
+    parser.addoption("--librepcb-executable",
+                     action="store",
+                     help="Path to librepcb executable to test")
+
+
+class GlobalOptions:
+    def __init__(self):
+        self.funq_conf = 'funq.conf'
+        self.funq_attach_exe = funq.tools.which('funq')
+        self.funq_gkit = 'default'
+        self.funq_gkit_file = os.path.join(os.path.dirname(os.path.realpath(funq.client.__file__)), 'aliases-gkits.conf')
+
+
+class Application(object):
+    def __init__(self, executable, env=None, args=()):
+        super(Application, self).__init__()
+        cfg = ApplicationConfig(executable=executable, args=args, cwd=os.getcwd(), env=env,
+                                aliases=os.path.join(FUNQ_DIR, 'aliases'), global_options=GlobalOptions())
+        self._context = ApplicationContext(cfg)
+
+    def __enter__(self):
+        return self._context.funq
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        del self._context
+
+
+class LibrePcbFixture(object):
+    def __init__(self, config, tmpdir):
+        super(LibrePcbFixture, self).__init__()
+        self.executable = os.path.abspath(config.getoption('--librepcb-executable'))
+        if not os.path.exists(self.executable):
+            raise Exception("Executable '{}' not found. Please pass it with "
+                            "'--librepcb-executable'.".format(self.executable))
+        self.tmpdir = tmpdir
+        # Copy test data to temporary directory to avoid modifications in original data
+        self.data_dir = os.path.join(self.tmpdir, 'data')
+        shutil.copytree(FUNQ_DATA_DIR, self.data_dir)
+        # Init members to default values
+        self.workspace_path = os.path.join(self.data_dir, 'fixtures', 'Empty Workspace')
+        self.project_path = None
+
+    def abspath(self, relpath):
+        return os.path.join(self.tmpdir, relpath)
+
+    def set_workspace(self, path):
+        if not os.path.isabs(path):
+            path = self.abspath(path)
+        self.workspace_path = path
+
+    def set_project(self, path):
+        if not os.path.isabs(path):
+            path = self.abspath(path)
+        self.project_path = path
+
+    def add_local_library_to_workspace(self, path='data/fixtures/Empty Library.lplib'):
+        if not os.path.isabs(path):
+            path = self.abspath(path)
+        dest = os.path.join(self.workspace_path, 'v0.1', 'libraries', 'local')
+        dest = os.path.join(dest, os.path.basename(path))
+        shutil.copytree(path, dest)
+
+    def open(self):
+        self._create_application_config_file()
+        return Application(self.executable, env=self._env(), args=self._args())
+
+    def _create_application_config_file(self):
+        org_dir = 'LibrePCB.org' if platform.system() == 'Darwin' else 'LibrePCB'
+        config_dir = os.path.join(self.tmpdir, 'config', org_dir)
+        config_ini = os.path.join(config_dir, 'LibrePCB.ini')
+        if not os.path.exists(config_dir):
+            os.makedirs(config_dir)
+        with open(config_ini, 'w') as f:
+            if self.workspace_path:
+                f.write("[workspaces]\n")
+                f.write("most_recently_used=\"{}\"\n".format(self.workspace_path.replace('\\', '/')))
+
+    def _args(self):
+        args = []
+        if self.project_path:
+            args.append(self.project_path)
+        return args
+
+    def _env(self):
+        env = os.environ
+        # Make GUI independent from the system's language
+        env['LC_ALL'] = 'C'
+        # Override configuration location to make tests independent of existing configs
+        env['LIBREPCB_CONFIG_DIR'] = os.path.join(self.tmpdir, 'config')
+        # Use a neutral username
+        env['USERNAME'] = 'testuser'
+        # Force LibrePCB to use Qt-style file dialogs because native dialogs don't work
+        env['LIBREPCB_DISABLE_NATIVE_DIALOGS'] = '1'
+        return env
+
+
+@pytest.fixture(scope="session")
+def librepcb_server():
+    """
+    Fixture which provides a HTTP server at localhost:8080
+
+    All tests should use this server instead of the official LibrePCB API server
+    or GitHub for downloading libraries.
+    """
+    import time
+    import threading
+    import socket
+    import socketserver
+    import http.server
+
+    class Handler(http.server.SimpleHTTPRequestHandler, object):
+        def translate_path(self, path):
+            path = super(Handler, self).translate_path(path)
+            relpath = os.path.relpath(path, os.curdir)
+            return os.path.join(FIXTURES_DATA_DIR, 'server', relpath)
+
+    # Set SO_REUSEADDR option to avoid "port already in use" errors
+    httpd = socketserver.TCPServer(("", 50080), Handler, bind_and_activate=False)
+    httpd.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    httpd.server_bind()
+    httpd.server_activate()
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    time.sleep(0.2)  # wait a bit to make sure the server is ready
+
+
+@pytest.fixture
+def create_librepcb(request, tmpdir, librepcb_server):
+    """
+    Fixture allowing to create multiple application instances
+    """
+    def _create():
+        return LibrePcbFixture(request.config, str(tmpdir))
+    return _create
+
+
+@pytest.fixture
+def librepcb(create_librepcb):
+    """
+    Fixture allowing to create one application instance
+    """
+    yield create_librepcb()

--- a/tests/funq/controlpanel/test_create_project.py
+++ b/tests/funq/controlpanel/test_create_project.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test creating projects
+"""
+
+import os
+
+
+def test_new_project_wizard(librepcb):
+    """
+    Create project using the wizard from the control panel
+    """
+    with librepcb.open() as app:
+        # Open new project wizard
+        app.widget('controlPanelNewProjectButton').click()
+        assert app.widget('controlPanelNewProjectWizard').properties()['visible'] is True
+        # Enter metadata
+        name = 'New Project'
+        app.widget('controlPanelNewProjectWizardMetadataNameEdit').set_property('text', name)
+        path = app.widget('controlPanelNewProjectWizardMetadataPathLabel').properties()['text']
+        app.widget('controlPanelNewProjectWizardNextButton').click()
+        # Setup schematic/board
+        app.widget('controlPanelNewProjectWizardFinishButton').click()
+        # Verify if editors are opened and project file exists
+        assert app.widget('schematicEditor').properties()['visible'] is True
+        assert app.widget('boardEditor').properties()['visible'] is True
+        assert os.path.exists(path)
+
+    # Open project again to see if it was saved properly
+    librepcb.set_project(path)
+    with librepcb.open() as app:
+        assert app.widget('schematicEditor').properties()['visible'] is True
+        assert app.widget('boardEditor').properties()['visible'] is True

--- a/tests/funq/controlpanel/test_open_librarymanager.py
+++ b/tests/funq/controlpanel/test_open_librarymanager.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test opening the library manager
+"""
+
+
+def test_using_button(librepcb):
+    """
+    Open library manager with the button in the control panel
+    """
+    with librepcb.open() as app:
+        app.widget('controlPanelOpenLibraryManagerButton').click()
+        assert app.widget('libraryManager').properties()['visible'] is True
+
+
+# TODO: How to emulate clicks on QMenuBar/QMenu/QAction?
+# def test_using_menu(librepcb):
+#     """
+#     Open library manager with the menu item in the control panel
+#     """
+#     with librepcb.open() as app:
+#         app.widget('controlPanelMenuExtras', wait_active=False).set_property('visible', True)
+#         assert app.widget('libraryManager').properties()['visible'] is True
+
+
+# TODO: How to emulate a click on the hyperlink in a QLabel?
+# def test_using_no_libraries_warning(librepcb):
+#     """
+#     Open library manager with the link in the "no libraries installed" warning
+#     """
+#     with librepcb.open() as app:
+#         label = app.widget('controlPanelWarnForNoLibrariesLabel')
+#         assert app.widget('libraryManager').properties()['visible'] is True

--- a/tests/funq/controlpanel/test_open_project.py
+++ b/tests/funq/controlpanel/test_open_project.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test opening projects
+"""
+
+project = 'data/fixtures/Empty Project/Empty Project.lpp'
+
+
+def test_command_line_argument(librepcb):
+    """
+    Open project by command line argument
+    """
+    librepcb.set_project(project)
+    with librepcb.open() as app:
+        assert app.widget('schematicEditor').properties()['visible'] is True
+        assert app.widget('boardEditor').properties()['visible'] is True
+
+
+def test_open_dialog(librepcb):
+    """
+    Open project by open dialog in control panel
+    """
+    with librepcb.open() as app:
+        path = librepcb.abspath(project)
+        app.widget('controlPanelOpenProjectButton').click()
+        app.widget('controlPanelOpenProjectDialogFileNameEdit').set_property('text', path)
+        app.widget('controlPanelOpenProjectDialogOkButton').click()
+        assert app.widget('schematicEditor').properties()['visible'] is True
+        assert app.widget('boardEditor').properties()['visible'] is True

--- a/tests/funq/libraryeditor/conftest.py
+++ b/tests/funq/libraryeditor/conftest.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+
+@pytest.fixture
+def library_editor(librepcb):
+    """
+    Fixture opening the library editor with an empty library
+    """
+    librepcb.add_local_library_to_workspace()
+    with librepcb.open() as app:
+        # Open library manager
+        app.widget('controlPanelOpenLibraryManagerButton').click()
+        assert app.widget('libraryManager').properties()['visible'] is True
+
+        # Select the empty library in library list
+        library_list = app.widget('libraryManagerInstalledLibrariesList')
+        assert len(library_list.model_items().items) == 2
+        library_item = library_list.model_items().items[1]
+        library_item.select()
+
+        # Open library editor of empty library
+        app.widget('libraryManagerLibraryInfoWidgetOpenEditorButton').click()
+        assert app.widget('libraryEditor').properties()['visible'] is True
+
+        # Start the actual test
+        yield app

--- a/tests/funq/libraryeditor/test_open.py
+++ b/tests/funq/libraryeditor/test_open.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test opening the library editor
+"""
+
+
+def test_metadata(library_editor):
+    """
+    Just open the library editor and check some metadata
+    """
+    le = library_editor
+    assert le.widget('libraryEditorOverviewNameEdit').properties()['text'] == 'Empty Library'
+    assert le.widget('libraryEditorOverviewDescriptionEdit').properties()['plainText'] == ''
+    assert le.widget('libraryEditorOverviewKeywordsEdit').properties()['text'] == ''
+    assert le.widget('libraryEditorOverviewAuthorEdit').properties()['text'] == 'test'
+    assert le.widget('libraryEditorOverviewVersionEdit').properties()['text'] == '0.1'

--- a/tests/funq/librarymanager/test_create_local_library.py
+++ b/tests/funq/librarymanager/test_create_local_library.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import time
+
+"""
+Test creating local libraries with the library manager
+"""
+
+
+def test(librepcb):
+    """
+    Create new local library
+    """
+    with librepcb.open() as app:
+
+        # Open library manager
+        app.widget('controlPanelOpenLibraryManagerButton').click()
+        assert app.widget('libraryManager').properties()['visible'] is True
+
+        # Make sure there is only one entry ("New Library") in the libraries list
+        library_list = app.widget('libraryManagerInstalledLibrariesList')
+        library_count_before = len(library_list.model_items().items)
+        assert library_count_before == 1
+
+        # Create new library
+        app.widget('libraryManagerAddLibraryTabBar').set_current_tab(1)
+        widget_properties = {
+            ('NameEdit', 'text'): 'Local Library',
+            ('DescriptionEdit', 'text'): 'Foo Bar',
+            ('AuthorEdit', 'text'): 'Functional Test',
+            ('UrlEdit', 'text'): '',
+            ('VersionEdit', 'text'): '1.2.3',
+            ('Cc0LicenseCheckbox', 'checked'): True,
+        }
+        for (widget, property), value in widget_properties.items():
+            app.widget('libraryManagerCreateLocalLibrary' + widget).set_property(property, value)
+        time.sleep(0.5)  # Workaround for https://github.com/parkouss/funq/issues/39
+        app.widget('libraryManagerCreateLocalLibraryCreateButton').click()
+
+        # Check if one library is added
+        library_count_after = len(library_list.model_items().items)
+        assert library_count_after == library_count_before + 1
+
+        # Open the new library to check if everything is OK
+        app.widget('libraryManagerLibraryInfoWidgetOpenEditorButton').click()
+        assert app.widget('libraryEditor').properties()['visible'] is True

--- a/tests/funq/librarymanager/test_install_remote_libraries.py
+++ b/tests/funq/librarymanager/test_install_remote_libraries.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test installing remote libraries with the library manager
+"""
+
+
+def test(librepcb):
+    """
+    Install some remote libraries
+    """
+    with librepcb.open() as app:
+
+        # Open library manager
+        app.widget('controlPanelOpenLibraryManagerButton').click()
+        assert app.widget('libraryManager').properties()['visible'] is True
+
+        # Make sure there is only one entry ("New Library") in the libraries list
+        library_list = app.widget('libraryManagerInstalledLibrariesList')
+        library_count_before = len(library_list.model_items().items)
+        assert library_count_before == 1
+
+        # TODO: Wait until all libraries are fetched and check the count of them
+        remote_library_count = 3  # The dummy API provides 3 libraries
+
+        # Get the required widgets of all libraries and check their initial state
+        statuslabels = list()
+        checkboxes = list()
+        progressbars = list()
+        for i in range(0, remote_library_count):
+            suffix = "-{}".format(i) if i > 0 else ''
+            item_path = app.aliases['libraryManagerDownloadFromRepoLibraryListItem'] + suffix
+            statuslabel = app.widget(path=item_path + '::lblInstalledVersion')
+            assert statuslabel.properties()['text'] == 'Recommended'
+            statuslabels.append(statuslabel)
+            checkbox = app.widget(path=item_path + '::cbxDownload')
+            assert checkbox.properties()['checked'] is False
+            checkboxes.append(checkbox)
+            progressbar = app.widget(path=item_path + '::prgProgress', wait_active=False)
+            assert progressbar.properties()['value'] == 0
+            progressbars.append(progressbar)
+
+        # Select second library to install -> this must also check the first
+        # library because it's a dependency!
+        checkboxes[1].set_property('checked', True)
+
+        # Verify checked state of all libraries
+        for i in range(0, remote_library_count):
+            assert checkboxes[i].properties()['checked'] is (True if i <= 1 else False)
+
+        # Install selected libraries
+        app.widget('libraryManagerDownloadFromRepoDownloadButton').click()
+
+        # Wait until progress bars are at 100% and hidden (i.e. installation finished)
+        for i in range(0, remote_library_count):
+            props = {'value': 100 if i <= 1 else 0, 'visible': False}
+            progressbars[i].wait_for_properties(props=props)
+
+        # Check installed status of libraries in remote library list
+        for i in range(0, remote_library_count):
+            if i <= 1:
+                assert statuslabels[i].properties()['text'].startswith('Installed')
+            else:
+                assert statuslabels[i].properties()['text'] == 'Recommended'
+
+        # Check if exactly two libraries were added to the library list
+        library_count_after = len(library_list.model_items().items)
+        assert library_count_after == library_count_before + 2

--- a/tests/funq/requirements.txt
+++ b/tests/funq/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/parkouss/funq.git@6da9961f8aa44083e1943dcbd882704ed4f3e55e#egg=funq-server&subdirectory=server
+git+https://github.com/parkouss/funq.git@6da9961f8aa44083e1943dcbd882704ed4f3e55e#egg=funq&subdirectory=client
+pytest~=3.6.3

--- a/tests/funq/setup.cfg
+++ b/tests/funq/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+addopts = -v --librepcb-executable=../../build/output/librepcb


### PR DESCRIPTION
This adds an initial setup to perform automated functional tests ("GUI tests") using [funq](https://github.com/parkouss/funq) and [pytest](https://docs.pytest.org/en/latest/index.html). I think such tests are very useful to keep the quality and stability of LibrePCB as high as possible. So it would be great to add more and more tests in future.

![peek 2018-07-10 22-42](https://user-images.githubusercontent.com/5374821/42537197-76572564-8494-11e8-90d1-676fae760235.gif)

### Other Changes

There were some small changes required in the source code of LibrePCB to make `funq` working properly:

#### Use INI for application settings on all platforms

Tests require to control local application settings (`~/.config/LibrePCB/` on Linux). On Windows, Qt uses the Registry for these settings, but this is a mess for testing. I think the Registry is bullshit anyway, so let's use INI instead. Now settings have the same format on all platforms.

#### Slightly delay opening projects passed as arguments

This is required to make `libFunq` initializing as early as possible (it injects a TCP server into the application, which then communicates with the tests written in Python).

#### Wrap `QFileDialog` to allow disabling native file dialogs

Add new common class `FileDialog` as a wrapper for `QFileDialog`. It allows to disable native file dialogs with the environment variable `LIBREPCB_DISABLE_NATIVE_DIALOGS`. This is used for automated functional tests because native dialogs cannot be tested.

#### Move unit tests from ./tests to ./tests/unittests

To clearly distinguish between unit tests and functional tests.

#### Rename tests executable from `tests` to `librepcb-unittests`

Just to be more expressive.