### PR TITLE
Library Editor: Rotate pins, pads and texts with right-click

### DIFF
--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
@@ -190,6 +190,12 @@ bool PackageEditorState_AddPads::processGraphicsSceneLeftMouseButtonPressed(QGra
     return startAddPad(currentPos);
 }
 
+bool PackageEditorState_AddPads::processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent &e) noexcept
+{
+    Q_UNUSED(e);
+    return processRotateCcw();
+}
+
 bool PackageEditorState_AddPads::processRotateCw() noexcept
 {
     if (mCurrentPad) {

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
@@ -73,6 +73,7 @@ class PackageEditorState_AddPads : public PackageEditorState
         // Event Handlers
         virtual bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept override;
         virtual bool processGraphicsSceneLeftMouseButtonPressed(QGraphicsSceneMouseEvent& e) noexcept override;
+        virtual bool processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent &e) noexcept override;
         virtual bool processRotateCw() noexcept override;
         virtual bool processRotateCcw() noexcept override;
 

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -148,6 +148,11 @@ bool PackageEditorState_DrawTextBase::processGraphicsSceneLeftMouseButtonPressed
     return startAddText(currentPos);
 }
 
+bool PackageEditorState_DrawTextBase::processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent &e)  noexcept
+{
+    Q_UNUSED(e);
+    return processRotateCcw();
+}
 bool PackageEditorState_DrawTextBase::processRotateCw() noexcept
 {
     if (mCurrentText) {

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
@@ -72,6 +72,7 @@ class PackageEditorState_DrawTextBase : public PackageEditorState
         // Event Handlers
         bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept override;
         bool processGraphicsSceneLeftMouseButtonPressed(QGraphicsSceneMouseEvent& e) noexcept override;
+        bool processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent &e)  noexcept override;
         bool processRotateCw() noexcept override;
         bool processRotateCcw() noexcept override;
 

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
@@ -140,6 +140,12 @@ bool SymbolEditorState_AddPins::processGraphicsSceneLeftMouseButtonPressed(QGrap
     }
 }
 
+bool SymbolEditorState_AddPins::processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent& e) noexcept
+{
+    Q_UNUSED(e);
+    return processRotateCcw();
+}
+
 bool SymbolEditorState_AddPins::processRotateCw() noexcept
 {
     mEditCmd->rotate(-Angle::deg90(), mCurrentPin->getPosition(), true);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.h
@@ -68,6 +68,7 @@ class SymbolEditorState_AddPins final : public SymbolEditorState
         // Event Handlers
         bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept override;
         bool processGraphicsSceneLeftMouseButtonPressed(QGraphicsSceneMouseEvent& e) noexcept override;
+        bool processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent& e) noexcept override;
         bool processRotateCw() noexcept override;
         bool processRotateCcw() noexcept override;
 

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -150,6 +150,12 @@ bool SymbolEditorState_DrawTextBase::processGraphicsSceneLeftMouseButtonPressed(
     return startAddText(currentPos);
 }
 
+bool SymbolEditorState_DrawTextBase::processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent& e) noexcept
+{
+    Q_UNUSED(e);
+    return processRotateCcw();
+}
+
 bool SymbolEditorState_DrawTextBase::processRotateCw() noexcept
 {
     if (mCurrentText) {

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
@@ -73,6 +73,7 @@ class SymbolEditorState_DrawTextBase : public SymbolEditorState
         // Event Handlers
         bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept override;
         bool processGraphicsSceneLeftMouseButtonPressed(QGraphicsSceneMouseEvent& e) noexcept override;
+        bool processGraphicsSceneRightMouseButtonReleased(QGraphicsSceneMouseEvent& e) noexcept override;
         bool processRotateCw() noexcept override;
         bool processRotateCcw() noexcept override;
 


### PR DESCRIPTION
Fixes #290 