### PR TITLE
Add command-line tool "librepcb-cli"

### DIFF
--- a/apps/apps.pro
+++ b/apps/apps.pro
@@ -2,6 +2,7 @@ TEMPLATE = subdirs
 
 SUBDIRS = \
     librepcb \
+    librepcb-cli \
     EagleImport \
     UuidGenerator \
     WorkspaceLibraryUpdater

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -1,0 +1,338 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include "commandlineinterface.h"
+#include <librepcb/common/application.h>
+#include <librepcb/common/debug.h>
+#include <librepcb/common/attributes/attributesubstitutor.h>
+#include <librepcb/project/project.h>
+#include <librepcb/project/boards/board.h>
+#include <librepcb/project/boards/boardgerberexport.h>
+#include <librepcb/project/erc/ercmsg.h>
+#include <librepcb/project/erc/ercmsglist.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace cli {
+
+using namespace librepcb::project;
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+CommandLineInterface::CommandLineInterface(const Application& app) noexcept :
+    mApp(app)
+{
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+int CommandLineInterface::execute() noexcept
+{
+    QMap<QString, QPair<QString, QString>> commands = {
+        {
+            "open-project", {
+                tr("Open a project to execute project-related tasks."),
+                tr("open-project [command_options]")
+            }
+        },
+    };
+
+    // Add global options
+    QCommandLineParser parser;
+    parser.setApplicationDescription(tr("LibrePCB Command Line Interface"));
+    const QCommandLineOption helpOption = parser.addHelpOption();
+    const QCommandLineOption versionOption = parser.addVersionOption();
+    QCommandLineOption verboseOption("verbose", tr("Verbose output."));
+    parser.addOption(verboseOption);
+    parser.addPositionalArgument("command", tr("The command to execute."));
+
+    // Define options for "open-project"
+    QCommandLineOption ercOption(
+        "erc",
+        tr("Run the electrical rule check, print all non-approved warnings/errors and "
+           "report failure (exit code = 1) if there are non-approved messages."));
+    QCommandLineOption exportSchematicsOption(
+        "export-schematics",
+        QString(tr("Export schematics to given file(s). Existing files will be "
+                   "overwritten. Supported file extensions: %1")).arg("pdf"),
+        tr("file"));
+    QCommandLineOption exportPcbFabricationDataOption(
+        "export-pcb-fabrication-data",
+        tr("Export PCB fabrication data (Gerber/Excellon) according the fabrication "
+           "output settings of boards. Existing files will be overwritten."));
+    QCommandLineOption boardOption(
+        "board",
+        tr("The name of the board(s) to export. Can be given multiple times. If not set, "
+           "all boards are exported."),
+        tr("name"));
+    QCommandLineOption saveOption(
+        "save",
+        tr("Save project before closing it (useful to upgrade file format)."));
+
+    // First parse to get the supplied command (ignoring errors because the parser does
+    // not yet know the command-dependent options).
+    parser.parse(mApp.arguments());
+
+    // Add command-dependent options
+    QStringList positionalArgs = parser.positionalArguments();
+    QString command = positionalArgs.isEmpty() ? QString() : positionalArgs.first();
+    if (positionalArgs.count() > 0) {
+        positionalArgs.removeFirst(); // command is now stored in separate variable
+    }
+    if (command == "open-project") {
+        parser.clearPositionalArguments();
+        parser.addPositionalArgument(command, commands[command].first, commands[command].second);
+        parser.addPositionalArgument("project", tr("Path to project file (*.lpp)."));
+        parser.addOption(ercOption);
+        parser.addOption(exportSchematicsOption);
+        parser.addOption(exportPcbFabricationDataOption);
+        parser.addOption(boardOption);
+        parser.addOption(saveOption);
+    } else if (!command.isEmpty()) {
+        printErr(QString(tr("Unknown command '%1'.")).arg(command), 2);
+        print(parser.helpText(), 0);
+        return 1;
+    }
+
+    // Parse the actual command line arguments given by the user
+    if (!parser.parse(mApp.arguments())) {
+        printErr(parser.errorText(), 2);
+        print(parser.helpText(), 0);
+        return 1;
+    }
+
+    // --help (also shown if no command supplied)
+    if (parser.isSet(helpOption) || command.isEmpty()) {
+        print(parser.helpText(), 0);
+        if (command.isEmpty()) {
+            print("\n" % tr("Commands:"));
+            for (auto it = commands.constBegin(); it != commands.constEnd(); ++it) {
+                print("  " % it.key().leftJustified(15) % it.value().first);
+            }
+        }
+        return 0;
+    }
+
+    // --version
+    if (parser.isSet(versionOption)) {
+        print(QString(tr("LibrePCB CLI Version %1")).arg(mApp.getAppVersion().toPrettyStr(3)));
+        print(QString(tr("Git Revision %1")).arg(mApp.getGitVersion()));
+        print(QString(tr("Qt Version %1 (compiled against %2)")).arg(qVersion(), QT_VERSION_STR));
+        print(QString(tr("Built at %1")).arg(mApp.getBuildDate().toString(Qt::LocalDate)));
+        return 0;
+    }
+
+    // --verbose
+    if (parser.isSet(verboseOption)) {
+        Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::All);
+    }
+
+    // Execute command
+    bool cmdSuccess = false;
+    if (command == "open-project") {
+        if (positionalArgs.count() != 1) {
+            printErr(tr("Wrong argument count."), 2);
+            print(parser.helpText(), 0);
+            return 1;
+        }
+        cmdSuccess = openProject(
+            positionalArgs.value(0),                      // project filepath
+            parser.isSet(ercOption),                      // run ERC
+            parser.values(exportSchematicsOption),        // export schematics
+            parser.isSet(exportPcbFabricationDataOption), // export PCB fabrication data
+            parser.values(boardOption),                   // boards
+            parser.isSet(saveOption)                      // save project
+        );
+    } else {
+        printErr(tr("Internal failure."));
+    }
+    if (cmdSuccess) {
+        print(tr("SUCCESS"));
+        return 0;
+    } else {
+        print(tr("Finished with errors!"));
+        return 1;
+    }
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+bool CommandLineInterface::openProject(const QString& projectFile, bool runErc,
+    const QStringList& exportSchematicsFiles, bool exportPcbFabricationData,
+    const QStringList& boards, bool save) const noexcept
+{
+    try {
+        bool success = true;
+
+        // Open project
+        FilePath projectFp(QFileInfo(projectFile).absoluteFilePath());
+        print(QString(tr("Open project '%1'...")).arg(prettyPath(projectFp, projectFile)));
+        Project project(projectFp, !save, false); // can throw
+
+        // ERC
+        if (runErc) {
+            print(tr("Run ERC..."));
+            QStringList messages;
+            int approvedMsgCount = 0;
+            foreach (const ErcMsg* msg, project.getErcMsgList().getItems()) {
+                if (!msg->isVisible()) continue;
+                if (msg->isIgnored()) {
+                    ++approvedMsgCount;
+                } else {
+                    QString severity;
+                    switch (msg->getMsgType()) {
+                        case ErcMsg::ErcMsgType_t::CircuitWarning:
+                        case ErcMsg::ErcMsgType_t::SchematicWarning:
+                        case ErcMsg::ErcMsgType_t::BoardWarning:
+                            severity = tr("WARNING");
+                            break;
+                        default:
+                            severity = tr("ERROR");
+                            break;
+                    }
+                    messages.append(QString("    - [%1] %2").arg(severity, msg->getMsg()));
+                }
+            }
+            print("  " % QString(tr("Approved messages: %1")).arg(approvedMsgCount));
+            print("  " % QString(tr("Non-approved messages: %1")).arg(messages.count()));
+            qSort(messages); // increases readability of console output
+            foreach (const QString& msg, messages) {
+                printErr(msg);
+            }
+            if (messages.count() > 0) {
+                success = false;
+            }
+        }
+
+        // Export schematics
+        foreach (const QString& destStr, exportSchematicsFiles) {
+            print(QString(tr("Export schematics to '%1'...")).arg(destStr));
+            QString suffix = destStr.split('.').last().toLower();
+            if (suffix == "pdf") {
+                QString destPathStr = AttributeSubstitutor::substitute(destStr, &project, [&](const QString& str){
+                    return FilePath::cleanFileName(str, FilePath::ReplaceSpaces | FilePath::KeepCase);
+                });
+                FilePath destPath(QFileInfo(destPathStr).absoluteFilePath());
+                project.exportSchematicsAsPdf(destPath); // can throw
+                print(QString("  => '%1'").arg(prettyPath(destPath, destPathStr)));
+            } else {
+                printErr("  " % QString(tr("ERROR: Unknown extension '%1'.")).arg(suffix));
+                success = false;
+            }
+        }
+
+        // Export PCB fabrication data
+        if (exportPcbFabricationData) {
+            print(tr("Export PCB fabrication data..."));
+            QList<Board*> boardList;
+            if (boards.isEmpty()) {
+                // export all boards
+                boardList = project.getBoards();
+            } else {
+                // export specified boards
+                foreach (const QString& boardName, boards) {
+                    Board* board = project.getBoardByName(boardName);
+                    if (board) {
+                        boardList.append(board);
+                    } else {
+                        printErr(QString(tr("ERROR: No board with the name '%1' found."))
+                                 .arg(boardName));
+                        success = false;
+                    }
+                }
+            }
+            QHash<FilePath, int> filesCounter;
+            bool filesOverwritten = false;
+            foreach (const Board* board, boardList) {
+                print("  " % QString(tr("Board '%1':")).arg(*board->getName()));
+                BoardGerberExport grbExport(*board);
+                grbExport.exportAllLayers(); // can throw
+                foreach (const FilePath& fp, grbExport.getWrittenFiles()) {
+                    filesCounter[fp]++;
+                    if (filesCounter[fp] > 1) filesOverwritten = true;
+                    print(QString("    => '%1'").arg(prettyPath(fp, projectFile)));
+                }
+            }
+            if (filesOverwritten) {
+                printErr("  " % tr("ERROR: Some files were written multiple times! "
+                                   "Please make sure that every board uses a different "
+                                   "fabrication output path or specify the board to "
+                                   "export with the '--board' argument."));
+                success = false;
+            }
+        }
+
+        // Save project
+        if (save) {
+            print(tr("Save project..."));
+            // first save to temporary files, then to original files
+            project.save(false); // can throw
+            project.save(true); // can throw
+        }
+
+        return success;
+    } catch (const Exception& e) {
+        printErr(QString(tr("ERROR: %1")).arg(e.getMsg()));
+        return false;
+    }
+}
+
+QString CommandLineInterface::prettyPath(const FilePath& path, const QString& style) noexcept
+{
+    return QFileInfo(style).isRelative()
+            ? path.toRelative(FilePath(QDir::currentPath()))
+            : path.toStr();
+}
+
+void CommandLineInterface::print(const QString& str, int newlines) noexcept
+{
+    QTextStream s(stdout);
+    s << str;
+    for (int i = 0; i < newlines; ++i) {
+        s << endl;
+    }
+}
+
+void CommandLineInterface::printErr(const QString& str, int newlines) noexcept
+{
+    QTextStream s(stderr);
+    s << str;
+    for (int i = 0; i < newlines; ++i) {
+        s << endl;
+    }
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace cli
+} // namespace librepcb

--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -1,0 +1,83 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CLI_COMMANDLINEINTERFACE_H
+#define LIBREPCB_CLI_COMMANDLINEINTERFACE_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+
+class Application;
+class FilePath;
+
+namespace cli {
+
+/*****************************************************************************************
+ *  Class CommandLineInterface
+ ****************************************************************************************/
+
+/**
+ * @brief The CommandLineInterface class
+ */
+class CommandLineInterface final
+{
+        Q_DECLARE_TR_FUNCTIONS(CommandLineInterface);
+
+    public:
+
+        // Constructors / Destructor
+        CommandLineInterface() = delete;
+        explicit CommandLineInterface(const Application& app) noexcept;
+        ~CommandLineInterface() noexcept = default;
+
+        // General Methods
+        int execute() noexcept;
+
+
+    private: // Methods
+        bool openProject(const QString& projectFile,
+                         bool runErc,
+                         const QStringList& exportSchematicsFiles,
+                         bool exportPcbFabricationData,
+                         const QStringList& boards,
+                         bool save) const noexcept;
+        static QString prettyPath(const FilePath& path, const QString& style) noexcept;
+        static void print(const QString& str, int newlines = 1) noexcept;
+        static void printErr(const QString& str, int newlines = 1) noexcept;
+
+
+    private: // Data
+        const Application& mApp;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace cli
+} // namespace librepcb
+
+#endif // LIBREPCB_CLI_COMMANDLINEINTERFACE_H

--- a/apps/librepcb-cli/librepcb-cli.pro
+++ b/apps/librepcb-cli/librepcb-cli.pro
@@ -1,0 +1,78 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2013-02-05T16:47:16
+#
+#-------------------------------------------------
+
+TEMPLATE = app
+TARGET = librepcb-cli
+
+# Use common project definitions
+include(../../common.pri)
+
+QT += core widgets opengl network xml printsupport sql
+
+CONFIG += console
+
+# Files to be installed by "make install"
+target.path = $${PREFIX}/bin
+INSTALLS += target
+
+# Note: The order of the libraries is very important for the linker!
+# Another order could end up in "undefined reference" errors!
+LIBS += \
+    -L$${DESTDIR} \
+    -lhoedown \
+    -llibrepcblibrarymanager \
+    -llibrepcbprojecteditor \
+    -llibrepcblibraryeditor \
+    -llibrepcbworkspace \
+    -llibrepcbproject \
+    -llibrepcblibrary \
+    -llibrepcbcommon \
+    -lsexpresso \
+    -lclipper \
+    -lquazip -lz
+
+INCLUDEPATH += \
+    ../../libs \
+    ../../libs/quazip \
+    ../../libs/type_safe/include \
+    ../../libs/type_safe/external/debug_assert \
+
+DEPENDPATH += \
+    ../../libs/hoedown \
+    ../../libs/librepcb/librarymanager \
+    ../../libs/librepcb/projecteditor \
+    ../../libs/librepcb/libraryeditor \
+    ../../libs/librepcb/workspace \
+    ../../libs/librepcb/project \
+    ../../libs/librepcb/library \
+    ../../libs/librepcb/common \
+    ../../libs/quazip \
+    ../../libs/sexpresso \
+    ../../libs/clipper \
+
+PRE_TARGETDEPS += \
+    $${DESTDIR}/libhoedown.a \
+    $${DESTDIR}/liblibrepcblibrarymanager.a \
+    $${DESTDIR}/liblibrepcbprojecteditor.a \
+    $${DESTDIR}/liblibrepcblibraryeditor.a \
+    $${DESTDIR}/liblibrepcbworkspace.a \
+    $${DESTDIR}/liblibrepcbproject.a \
+    $${DESTDIR}/liblibrepcblibrary.a \
+    $${DESTDIR}/liblibrepcbcommon.a \
+    $${DESTDIR}/libquazip.a \
+    $${DESTDIR}/libsexpresso.a \
+    $${DESTDIR}/libclipper.a \
+
+RESOURCES += \
+    ../../img/images.qrc
+
+SOURCES += \
+    commandlineinterface.cpp \
+    main.cpp \
+
+HEADERS += \
+    commandlineinterface.h \
+

--- a/apps/librepcb-cli/main.cpp
+++ b/apps/librepcb-cli/main.cpp
@@ -1,0 +1,109 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include <QTranslator>
+#include <librepcb/common/application.h>
+#include <librepcb/common/debug.h>
+#include "./commandlineinterface.h"
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+using namespace librepcb;
+
+/*****************************************************************************************
+ *  Function Prototypes
+ ****************************************************************************************/
+
+static void setApplicationMetadata() noexcept;
+static void installTranslations() noexcept;
+
+/*****************************************************************************************
+ *  main()
+ ****************************************************************************************/
+
+int main(int argc, char* argv[])
+{
+    // --------------------------------- INITIALIZATION ----------------------------------
+
+    // Creates the Debug object which installs the message handler. This must be done as
+    // early as possible.
+    Debug::instance();
+
+    // Silence debug output, it's a command line tool
+    Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::Nothing);
+
+    // Create Application instance
+    Application app(argc, argv);
+
+    // Set the organization / application names must be done very early because some other
+    // classes will use these values (for example QSettings, Debug)!
+    setApplicationMetadata();
+
+    // Install translation files. This must be done before any widget is shown.
+    installTranslations();
+
+    // --------------------------------- RUN APPLICATION ---------------------------------
+    cli::CommandLineInterface cli(app);
+    return cli.execute();
+}
+
+/*****************************************************************************************
+ *  setApplicationMetadata()
+ ****************************************************************************************/
+
+static void setApplicationMetadata() noexcept
+{
+    Application::setOrganizationName("LibrePCB");
+    Application::setOrganizationDomain("librepcb.org");
+    Application::setApplicationName("LibrePCB CLI");
+}
+
+/*****************************************************************************************
+ *  installTranslations()
+ ****************************************************************************************/
+
+static void installTranslations() noexcept
+{
+    // Install Qt translations
+    QTranslator* qtTranslator = new QTranslator(qApp);
+    qtTranslator->load("qt_" % QLocale::system().name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    qApp->installTranslator(qtTranslator);
+
+    // Install system language translations (all system languages defined in the system settings, in the defined order)
+    const QString dir = qApp->getResourcesFilePath("i18n").toStr();
+    QTranslator* systemTranslator = new QTranslator(qApp);
+    systemTranslator->load(QLocale::system(), "librepcb", "_", dir);
+    qApp->installTranslator(systemTranslator);
+
+    // Install language translations (like "de" for German)
+    QTranslator* appTranslator1 = new QTranslator(qApp);
+    appTranslator1->load("librepcb_" % QLocale::system().name().split("_").at(0), dir);
+    qApp->installTranslator(appTranslator1);
+
+    // Install language/country translations (like "de_ch" for German/Switzerland)
+    QTranslator* appTranslator2 = new QTranslator(qApp);
+    appTranslator2->load("librepcb_" % QLocale::system().name(), dir);
+    qApp->installTranslator(appTranslator2);
+}

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -298,7 +298,7 @@ ProjectEditor* ControlPanel::openProject(const FilePath& filepath) noexcept
         ProjectEditor* editor = getOpenProject(filepath);
         if (!editor)
         {
-            Project* project = new Project(filepath, false);
+            Project* project = new Project(filepath, false, true);
             editor = new ProjectEditor(mWorkspace, *project);
             connect(editor, &ProjectEditor::projectEditorClosed, this, &ControlPanel::projectEditorClosed);
             connect(editor, &ProjectEditor::showControlPanelClicked, this, &ControlPanel::showControlPanel);

--- a/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
+++ b/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
@@ -111,7 +111,7 @@ void ProjectLibraryUpdater::btnUpdateClicked()
             // check whether project can still be opened of if we broke something
             try {
                 log(QString(tr("Open project %1...")).arg(prettyPath(mProjectFilePath)));
-                project::Project prj(mProjectFilePath, false);
+                project::Project prj(mProjectFilePath, false, false);
                 log(QString(tr("Save project %1...")).arg(prettyPath(mProjectFilePath)));
                 prj.save(true); // force updating library elements file format
             } catch (const Exception& e) {

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -46,27 +46,38 @@ popd
 # Prepare artifacts directory
 mkdir -p ./artifacts/nightly_builds
 
-# Linux: Build AppImage
+# Linux: Build AppImages
 if [ "${TRAVIS_OS_NAME-}" = "linux" ]
 then
+  cp -r "./build/install" "./build/install-cli"
+  mv -f "./build/install-cli/opt/bin/librepcb-cli" "./build/install-cli/opt/bin/librepcb"
+  LD_LIBRARY_PATH="" linuxdeployqt "./build/install-cli/opt/share/applications/librepcb.desktop" -bundle-non-qt-libs -appimage
+  mv ./LibrePCB-x86_64.AppImage ./LibrePCB-CLI-x86_64.AppImage
   LD_LIBRARY_PATH="" linuxdeployqt "./build/install/opt/share/applications/librepcb.desktop" -bundle-non-qt-libs -appimage
   if [ "${DEPLOY_APPIMAGE-}" = "true" ]
   then
     cp ./LibrePCB-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-x86_64.AppImage
+    cp ./LibrePCB-CLI-x86_64.AppImage ./artifacts/nightly_builds/librepcb-cli-nightly-linux-x86_64.AppImage
   fi
 fi
 
-# Mac: Build application bundle
+# Mac: Build application bundles
 if [ "${TRAVIS_OS_NAME-}" = "osx" ]
 then
-  # replace "bin" and "share" directories with the single librepcb.app directory
+  # replace "bin" and "share" directories with the single *.app directory
   mv "./build/install/opt/bin/librepcb.app" "./build/install/opt/librepcb.app"
-  mv "./build/install/opt/share" "./build/install/opt/librepcb.app/Contents/share"
-  rmdir "./build/install/opt/bin"
+  cp -r "./build/install/opt/share" "./build/install/opt/librepcb.app/Contents/"
+  mv "./build/install/opt/bin/librepcb-cli.app" "./build/install/opt/librepcb-cli.app"
+  cp -r "./build/install/opt/share" "./build/install/opt/librepcb-cli.app/Contents/"
+  rm -r "./build/install/opt/bin" "./build/install/opt/share"
   macdeployqt "./build/install/opt/librepcb.app" -dmg
+  mv ./build/install/opt/librepcb.dmg ./librepcb.dmg
+  macdeployqt "./build/install/opt/librepcb-cli.app" -dmg
+  mv ./build/install/opt/librepcb-cli.dmg ./librepcb-cli.dmg
   if [ "${DEPLOY_BUNDLE-}" = "true" ]
   then
-    mv ./build/install/opt/librepcb.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
+    cp ./librepcb.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
+    cp ./librepcb-cli.dmg ./artifacts/nightly_builds/librepcb-cli-nightly-mac-x86_64.dmg
   fi
 fi
 
@@ -78,6 +89,7 @@ then
   cp -v /c/OpenSSL-Win32/bin/*eay*.dll         ./build/install/opt/bin/  # OpenSSL DLLs
   cp -v "`cygpath -u \"$QTDIR\"`"/bin/lib*.dll ./build/install/opt/bin/  # MinGW DLLs
   windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb.exe # Qt DLLs
+  windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb-cli.exe # Qt DLLs
   cp -r ./build/install/opt/. ./artifacts/nightly_builds/librepcb-nightly-windows-x86/
 fi
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -17,3 +17,14 @@ else
   ./build/output/librepcb-unittests.exe
 fi
 
+# check if the CLI works
+if [ "${TRAVIS_OS_NAME-}" = "linux" ]
+then
+  xvfb-run -a ./LibrePCB-CLI-x86_64.AppImage --help
+elif [ "${TRAVIS_OS_NAME-}" = "osx" ]
+then
+  ./build/install/opt/librepcb-cli.app/Contents/MacOS/librepcb-cli --help
+else
+  ./build/install/opt/bin/librepcb-cli.exe --help
+fi
+

--- a/libs/librepcb/project/boards/boardgerberexport.h
+++ b/libs/librepcb/project/boards/boardgerberexport.h
@@ -70,6 +70,7 @@ class BoardGerberExport final : public QObject, public AttributeProvider
 
         // Getters
         FilePath getOutputDirectory() const noexcept;
+        const QVector<FilePath>& getWrittenFiles() const noexcept {return mWrittenFiles;}
 
         // General Methods
         void exportAllLayers() const;
@@ -130,6 +131,7 @@ class BoardGerberExport final : public QObject, public AttributeProvider
         const Project& mProject;
         const Board& mBoard;
         mutable int mCurrentInnerCopperLayer;
+        mutable QVector<FilePath> mWrittenFiles;
 };
 
 /*****************************************************************************************

--- a/libs/librepcb/project/project.h
+++ b/libs/librepcb/project/project.h
@@ -93,11 +93,12 @@ class Project final : public QObject, public AttributeProvider
          *
          * @param filepath      The filepath to the an existing *.lpp project file
          * @param readOnly      It true, the project will be opened in read-only mode
+         * @param interactive   If true, message boxes may be shown.
          *
          * @throw Exception     If the project could not be opened successfully
          */
-        Project(const FilePath& filepath, bool readOnly) :
-            Project(filepath, false, readOnly) {}
+        Project(const FilePath& filepath, bool readOnly, bool interactve) :
+            Project(filepath, false, readOnly, interactve) {}
 
         /**
          * @brief The destructor will close the whole project (without saving!)
@@ -223,7 +224,7 @@ class Project final : public QObject, public AttributeProvider
          *
          * @return A pointer to the specified schematic, or nullptr if name is invalid
          */
-        Schematic* getSchematicByName(const ElementName& name) const noexcept;
+        Schematic* getSchematicByName(const QString& name) const noexcept;
 
         /**
          * @brief Create a new schematic (page)
@@ -315,7 +316,7 @@ class Project final : public QObject, public AttributeProvider
          *
          * @return A pointer to the specified board, or nullptr if name is invalid
          */
-        Board* getBoardByName(const ElementName& name) const noexcept;
+        Board* getBoardByName(const QString& name) const noexcept;
 
         /**
          * @brief Create a new board
@@ -395,7 +396,7 @@ class Project final : public QObject, public AttributeProvider
         // Static Methods
 
         static Project* create(const FilePath& filepath)
-        {return new Project(filepath, true, false);}
+        {return new Project(filepath, true, false, false);}
 
         static bool isFilePathInsideProjectDirectory(const FilePath& fp) noexcept;
         static bool isProjectFile(const FilePath& file) noexcept;
@@ -448,10 +449,13 @@ class Project final : public QObject, public AttributeProvider
          * @param create        True if the specified project does not exist already and
          *                      must be created.
          * @param readOnly      If true, the project will be opened in read-only mode
+         * @param interactive   If true, message boxes may be shown.
          *
          * @throw Exception     If the project could not be created/opened successfully
+         *
+         * @todo Remove interactive message boxes, should be done at a higher layer!
          */
-        explicit Project(const FilePath& filepath, bool create, bool readOnly);
+        explicit Project(const FilePath& filepath, bool create, bool readOnly, bool interactve);
 
         /**
          * @brief Save the project to the harddisc (to temporary or original files)

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -323,6 +323,7 @@ void SchematicEditor::on_actionPDF_Export_triggered()
         if (!filename.endsWith(".pdf")) filename.append(".pdf");
         FilePath filepath(filename);
         mProject.exportSchematicsAsPdf(filepath); // this method can throw an exception
+        QDesktopServices::openUrl(QUrl::fromLocalFile(filepath.toStr()));
     }
     catch (Exception& e)
     {

--- a/tests/unittests/project/boards/boardplanefragmentsbuildertest.cpp
+++ b/tests/unittests/project/boards/boardplanefragmentsbuildertest.cpp
@@ -59,7 +59,7 @@ TEST(BoardPlaneFragmentsBuilderTest, testFragments)
 
     // open project from test data directory
     FilePath projectFp = testDataDir.getPathTo("test_project/test_project.lpp");
-    QScopedPointer<Project> project(new Project(projectFp, true));
+    QScopedPointer<Project> project(new Project(projectFp, true, false));
 
     // force planes rebuild
     Board* board = project->getBoards().first();

--- a/tests/unittests/project/projecttest.cpp
+++ b/tests/unittests/project/projecttest.cpp
@@ -92,7 +92,7 @@ TEST_F(ProjectTest, testCreateCloseOpen)
     EXPECT_TRUE(mProjectDir.getPathTo("circuit/erc.lp").isExistingFile());
 
     // open project again
-    project.reset(new Project(mProjectFile, false));
+    project.reset(new Project(mProjectFile, false, false));
     EXPECT_EQ(mProjectFile, project->getFilepath());
     EXPECT_EQ(mProjectDir, project->getPath());
     EXPECT_FALSE(project->isReadOnly());
@@ -119,7 +119,7 @@ TEST_F(ProjectTest, testSave)
 
     // close and re-open project
     project.reset();
-    project.reset(new Project(mProjectFile, false));
+    project.reset(new Project(mProjectFile, false, false));
 
     // save project
     project->save(false);
@@ -127,7 +127,7 @@ TEST_F(ProjectTest, testSave)
 
     // close and re-open project
     project.reset();
-    project.reset(new Project(mProjectFile, false));
+    project.reset(new Project(mProjectFile, false, false));
 }
 
 TEST_F(ProjectTest, testIfLastModifiedDateTimeIsUpdatedOnSave)
@@ -171,7 +171,7 @@ TEST_F(ProjectTest, testSettersGetters)
 
     // close and re-open project (read-only)
     project.reset();
-    project.reset(new Project(mProjectFile, true));
+    project.reset(new Project(mProjectFile, true, false));
 
     // get properties
     EXPECT_EQ(name, project->getMetadata().getName());


### PR DESCRIPTION
This adds a first version of a `librepcb-cli` application which is intended to automate some frequently used tasks. It's especially useful for Continuous Integration of LibrePCB projects (e.g. with Travis-CI).

Currently it supports to load a project and...
- Report ERC messages (report failure if there are non-approved messages)
- Export schematics as PDF
- Export boards as Gerber/Excellon

For usage instructions see documentation here: https://docs.librepcb.org/_branches/add-cli/#cli