### PR TITLE
Mark many strings as non-translatable

### DIFF
--- a/apps/EagleImport/mainwindow.ui
+++ b/apps/EagleImport/mainwindow.ui
@@ -41,7 +41,7 @@
        </sizepolicy>
       </property>
       <property name="text">
-       <string>...</string>
+       <string notr="true">...</string>
       </property>
      </widget>
     </item>
@@ -136,7 +136,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>+</string>
+         <string notr="true">+</string>
         </property>
        </widget>
       </item>
@@ -149,7 +149,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>+INI</string>
+         <string notr="true">+INI</string>
         </property>
        </widget>
       </item>
@@ -162,7 +162,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>-</string>
+         <string notr="true">-</string>
         </property>
        </widget>
       </item>
@@ -175,7 +175,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>clr</string>
+         <string notr="true">clr</string>
         </property>
        </widget>
       </item>
@@ -268,7 +268,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>
@@ -293,7 +293,7 @@
        </sizepolicy>
       </property>
       <property name="text">
-       <string>...</string>
+       <string notr="true">...</string>
       </property>
      </widget>
     </item>

--- a/apps/WorkspaceLibraryUpdater/mainwindow.ui
+++ b/apps/WorkspaceLibraryUpdater/mainwindow.ui
@@ -70,7 +70,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>+</string>
+         <string notr="true">+</string>
         </property>
        </widget>
       </item>
@@ -83,7 +83,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>-</string>
+         <string notr="true">-</string>
         </property>
        </widget>
       </item>
@@ -96,7 +96,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>clr</string>
+         <string notr="true">clr</string>
         </property>
        </widget>
       </item>
@@ -127,49 +127,49 @@
       <item>
        <widget class="QCheckBox" name="cbx_lplib">
         <property name="text">
-         <string>lplib</string>
+         <string notr="true">lplib</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="cbx_cmpcat">
         <property name="text">
-         <string>cmpcat</string>
+         <string notr="true">cmpcat</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="cbx_pkgcat">
         <property name="text">
-         <string>pkgcat</string>
+         <string notr="true">pkgcat</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="cbx_sym">
         <property name="text">
-         <string>sym</string>
+         <string notr="true">sym</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="cbx_pkg">
         <property name="text">
-         <string>pkg</string>
+         <string notr="true">pkg</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="cbx_cmp">
         <property name="text">
-         <string>cmp</string>
+         <string notr="true">cmp</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="cbx_dev">
         <property name="text">
-         <string>dev</string>
+         <string notr="true">dev</string>
         </property>
        </widget>
       </item>

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.ui
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.ui
@@ -14,7 +14,7 @@
    <string>WizardPage</string>
   </property>
   <property name="title">
-   <string>Select Workspace Path</string>
+   <string>Select Wor&amp;kspace Path</string>
   </property>
   <property name="subTitle">
    <string>Please select a directory to open or create a LibrePCB workspace.</string>
@@ -73,7 +73,7 @@ Workspaces are platform independent, so they can be used across different operat
      <item>
       <widget class="QToolButton" name="btnCreateWsBrowse">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
@@ -89,7 +89,7 @@ Workspaces are platform independent, so they can be used across different operat
    <item>
     <widget class="QRadioButton" name="rbtnOpenWs">
      <property name="text">
-      <string>Open an existing workspace</string>
+      <string>Open an e&amp;xisting workspace</string>
      </property>
     </widget>
    </item>
@@ -121,7 +121,7 @@ Workspaces are platform independent, so they can be used across different operat
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
@@ -178,7 +178,7 @@
        <item row="0" column="1">
         <widget class="QLabel" name="lblUuid">
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">TextLabel</string>
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>317</width>
+    <width>331</width>
     <height>305</height>
    </rect>
   </property>
@@ -36,7 +36,7 @@
    <item row="0" column="1">
     <widget class="QLabel" name="lblUuid">
      <property name="text">
-      <string>TextLabel</string>
+      <string notr="true">TextLabel</string>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.ui
@@ -69,7 +69,7 @@
           </font>
          </property>
          <property name="text">
-          <string>00000000-0000-0000-0000-000000000000</string>
+          <string notr="true">00000000-0000-0000-0000-000000000000</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.ui
@@ -69,7 +69,7 @@
           </font>
          </property>
          <property name="text">
-          <string>00000000-0000-0000-0000-000000000000</string>
+          <string notr="true">00000000-0000-0000-0000-000000000000</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.ui
@@ -69,7 +69,7 @@
           </font>
          </property>
          <property name="text">
-          <string>00000000-0000-0000-0000-000000000000</string>
+          <string notr="true">00000000-0000-0000-0000-000000000000</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
@@ -426,7 +426,6 @@
  </customwidgets>
  <resources>
   <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
@@ -101,7 +101,7 @@
                </font>
               </property>
               <property name="text">
-               <string>TextLabel</string>
+               <string notr="true">TextLabel</string>
               </property>
              </widget>
             </item>
@@ -137,7 +137,7 @@
             <item row="1" column="1">
              <widget class="QLabel" name="lblPackageUuid">
               <property name="text">
-               <string>TextLabel</string>
+               <string notr="true">TextLabel</string>
               </property>
               <property name="textInteractionFlags">
                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -188,14 +188,14 @@
                </font>
               </property>
               <property name="text">
-               <string>TextLabel</string>
+               <string notr="true">TextLabel</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
              <widget class="QLabel" name="lblComponentUuid">
               <property name="text">
-               <string>TextLabel</string>
+               <string notr="true">TextLabel</string>
               </property>
               <property name="textInteractionFlags">
                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -302,7 +302,7 @@
        <item row="0" column="1">
         <widget class="QLabel" name="lblUuid">
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">TextLabel</string>
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>
@@ -425,6 +425,7 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../../../img/images.qrc"/>
   <include location="../../../../img/images.qrc"/>
  </resources>
  <connections/>

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
@@ -313,7 +313,7 @@
        <item row="2" column="1">
         <widget class="QLabel" name="lblUuid">
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">TextLabel</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.ui
@@ -14,7 +14,7 @@
    <string>Device Properties</string>
   </property>
   <property name="title">
-   <string>Device Properties</string>
+   <string>De&amp;vice Properties</string>
   </property>
   <property name="subTitle">
    <string>Set the component and the package of the new device.</string>
@@ -66,14 +66,14 @@
          </font>
         </property>
         <property name="text">
-         <string>TextLabel</string>
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QLabel" name="lblComponentDescription">
         <property name="text">
-         <string>TextLabel</string>
+         <string notr="true">TextLabel</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -142,14 +142,14 @@
          </font>
         </property>
         <property name="text">
-         <string>TextLabel</string>
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QLabel" name="lblPackageDescription">
         <property name="text">
-         <string>TextLabel</string>
+         <string notr="true">TextLabel</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
@@ -74,7 +74,7 @@
    </item>
    <item row="1" column="1">
     <widget class="QPlainTextEdit" name="edtDescription">
-     <property name="placeholderText">
+     <property name="placeholderText" stdset="0">
       <string/>
      </property>
     </widget>

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
@@ -74,7 +74,7 @@
    </item>
    <item row="1" column="1">
     <widget class="QPlainTextEdit" name="edtDescription">
-     <property name="placeholderText" stdset="0">
+     <property name="placeholderText">
       <string/>
      </property>
     </widget>
@@ -136,7 +136,7 @@
    <item row="6" column="1">
     <widget class="QLabel" name="lblCategoryTree">
      <property name="text">
-      <string>TextLabel</string>
+      <string notr="true">TextLabel</string>
      </property>
     </widget>
    </item>

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
@@ -158,7 +158,7 @@
        <item row="0" column="1">
         <widget class="QLabel" name="lblUuid">
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">TextLabel</string>
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>317</width>
+    <width>331</width>
     <height>305</height>
    </rect>
   </property>
@@ -36,7 +36,7 @@
    <item row="0" column="1">
     <widget class="QLabel" name="lblUuid">
      <property name="text">
-      <string>TextLabel</string>
+      <string notr="true">TextLabel</string>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>313</width>
     <height>197</height>
    </rect>
   </property>
@@ -26,7 +26,7 @@
      <item row="0" column="1">
       <widget class="QLabel" name="lblUuid">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
@@ -88,7 +88,7 @@
        <item row="0" column="1">
         <widget class="QLabel" name="lblUuid">
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">TextLabel</string>
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>

--- a/libs/librepcb/librarymanager/libraryinfowidget.ui
+++ b/libs/librepcb/librarymanager/libraryinfowidget.ui
@@ -76,7 +76,7 @@
         </font>
        </property>
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -93,7 +93,7 @@
      <item row="1" column="1">
       <widget class="QLabel" name="lblDescription">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -110,7 +110,7 @@
      <item row="2" column="1">
       <widget class="QLabel" name="lblVersion">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -127,7 +127,7 @@
      <item row="3" column="1">
       <widget class="QLabel" name="lblAuthor">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -144,7 +144,7 @@
      <item row="4" column="1">
       <widget class="QLabel" name="lblUrl">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -167,7 +167,7 @@
      <item row="5" column="1">
       <widget class="QLabel" name="lblCreated">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -184,7 +184,7 @@
      <item row="6" column="1">
       <widget class="QLabel" name="lblDeprecated">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -208,7 +208,7 @@
      <item row="8" column="1">
       <widget class="QLabel" name="lblUuid">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -225,7 +225,7 @@
      <item row="9" column="1">
       <widget class="QLabel" name="lblLibType">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -245,7 +245,7 @@
      <item row="10" column="1">
       <widget class="QLabel" name="lblDependencies">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -262,7 +262,7 @@
      <item row="11" column="1">
       <widget class="QLabel" name="lblDirectory">
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.ui
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.ui
@@ -92,7 +92,7 @@
           </font>
          </property>
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">TextLabel</string>
          </property>
         </widget>
        </item>
@@ -105,7 +105,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">TextLabel</string>
          </property>
         </widget>
        </item>
@@ -125,7 +125,7 @@
         </font>
        </property>
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
       </widget>
      </item>
@@ -144,7 +144,7 @@
         </font>
        </property>
        <property name="text">
-        <string>TextLabel</string>
+        <string notr="true">TextLabel</string>
        </property>
       </widget>
      </item>

--- a/libs/librepcb/projecteditor/boardeditor/boardlayersdock.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayersdock.ui
@@ -20,7 +20,7 @@
    <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
   </property>
   <property name="windowTitle">
-   <string>Layers</string>
+   <string>&amp;Layers</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -53,7 +53,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>TOP</string>
+         <string notr="true">TOP</string>
         </property>
        </widget>
       </item>
@@ -66,7 +66,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>BOT</string>
+         <string notr="true">BOT</string>
         </property>
        </widget>
       </item>
@@ -79,7 +79,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>T+B</string>
+         <string notr="true">T+B</string>
         </property>
        </widget>
       </item>
@@ -92,7 +92,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>ALL</string>
+         <string notr="true">ALL</string>
         </property>
        </widget>
       </item>
@@ -105,7 +105,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>NONE</string>
+         <string notr="true">NONE</string>
         </property>
        </widget>
       </item>

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
@@ -29,7 +29,7 @@
      <item row="0" column="1">
       <widget class="QLabel" name="lblUuid">
        <property name="text">
-        <string>-</string>
+        <string notr="true">-</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>330</width>
+    <width>346</width>
     <height>220</height>
    </rect>
   </property>
@@ -26,7 +26,7 @@
      <item row="0" column="1">
       <widget class="QLabel" name="lblUuid">
        <property name="text">
-        <string>-</string>
+        <string notr="true">-</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -43,7 +43,7 @@
      <item row="1" column="1">
       <widget class="QLabel" name="lblNetSignal">
        <property name="text">
-        <string>-</string>
+        <string notr="true">-</string>
        </property>
       </widget>
      </item>

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
@@ -212,7 +212,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
@@ -234,7 +234,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -247,7 +247,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
@@ -269,7 +269,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -282,7 +282,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
@@ -317,7 +317,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -355,7 +355,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>

--- a/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.ui
@@ -63,7 +63,7 @@
       <item row="3" column="1">
        <widget class="QLabel" name="lblCreatedDateTime">
         <property name="text">
-         <string>TextLabel</string>
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
@@ -77,7 +77,7 @@
       <item row="4" column="1">
        <widget class="QLabel" name="lblLastModifiedDateTime">
         <property name="text">
-         <string>TextLabel</string>
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_initialization.ui
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_initialization.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="title">
-   <string>Initialization</string>
+   <string>Initiali&amp;zation</string>
   </property>
   <property name="subTitle">
    <string>Specify how the project should be initialized.</string>
@@ -20,7 +20,7 @@
    <item>
     <widget class="QGroupBox" name="cbxAddSchematic">
      <property name="title">
-      <string>Add Schematic</string>
+      <string>Add Sche&amp;matic</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -50,7 +50,7 @@
       <item row="1" column="1">
        <widget class="QLabel" name="lblSchematicFileName">
         <property name="text">
-         <string>-</string>
+         <string notr="true">-</string>
         </property>
        </widget>
       </item>
@@ -90,7 +90,7 @@
       <item row="1" column="1">
        <widget class="QLabel" name="lblBoardFileName">
         <property name="text">
-         <string>-</string>
+         <string notr="true">-</string>
         </property>
        </widget>
       </item>

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="title">
-   <string>Project Metadata</string>
+   <string>Project &amp;Metadata</string>
   </property>
   <property name="subTitle">
    <string>Specify some metadata of the project to be created.</string>
@@ -94,7 +94,7 @@
         </size>
        </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
@@ -115,7 +115,7 @@
       </font>
      </property>
      <property name="text">
-      <string>-</string>
+      <string notr="true">-</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -212,6 +212,7 @@
   </layout>
  </widget>
  <resources>
+  <include location="../../../../img/images.qrc"/>
   <include location="../../../../img/images.qrc"/>
  </resources>
  <connections/>

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -213,7 +213,6 @@
  </widget>
  <resources>
   <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -47,7 +47,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -70,7 +70,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -241,7 +241,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
@@ -263,7 +263,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -276,7 +276,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
@@ -298,7 +298,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -311,7 +311,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
@@ -340,7 +340,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -378,7 +378,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>


### PR DESCRIPTION
When creating a new dialog, please make sure to remove the "translatable" checkbox when necessary.