### PR TITLE
Refactor ProjectLibrary to fix several issues

### DIFF
--- a/libs/librepcb/library/librarybaseelement.cpp
+++ b/libs/librepcb/library/librarybaseelement.cpp
@@ -220,10 +220,21 @@ void LibraryBaseElement::copyTo(const FilePath& destination, bool removeSource)
                 .arg(destination.getFilename()));
         }
 
+        // Unfortunately empty directories are sometimes not removed properly, for example
+        // some Git operations remove the contained files but not the parent directories.
+        // But if the destination directory exists already, FileUtils::copyDirRecursively()
+        // would throw an exception because it requires that the destination does not
+        // exist yet. To avoid this issue, we remove the destination first if it's an
+        // empty directory. If it's not empty, we accept that an exception is thrown
+        // because this would likely be a serious error.
+        if (destination.isEmptyDir()) {
+            FileUtils::removeDirRecursively(destination);
+        }
+
         // check if destination directory exists already
         if (destination.isExistingDir() || destination.isExistingFile()) {
             throw RuntimeError(__FILE__, __LINE__, QString(tr("Could not copy "
-                "library element \"%1\" to \"%2\" because the directory exists already."))
+                "library element \"%1\" to \"%2\" because the destination exists already."))
                 .arg(mDirectory.toNative(), destination.toNative()));
         }
 

--- a/libs/librepcb/project/library/projectlibrary.h
+++ b/libs/librepcb/project/library/projectlibrary.h
@@ -112,10 +112,11 @@ class ProjectLibrary final : public QObject
         template <typename ElementType>
         void removeElement(ElementType& element,
                            QHash<Uuid, ElementType*>& elementList);
-        void cleanupElements() noexcept;
 
         // General
         FilePath mLibraryPath; ///< the "library" directory of the project
+        FilePath mBackupPath; ///< same as #mLibraryPath, but with trailing "~"
+        FilePath mTmpDir; ///< path to a temporary directory
 
         // The currently added library elements
         QHash<Uuid, library::Symbol*> mSymbols;
@@ -123,8 +124,10 @@ class ProjectLibrary final : public QObject
         QHash<Uuid, library::Component*> mComponents;
         QHash<Uuid, library::Device*> mDevices;
 
-        enum class State {Loaded, Removed, SavedToTemporary, SavedToOriginal};
-        QHash<library::LibraryBaseElement*, State> mElementsState;
+        QSet<library::LibraryBaseElement*> mAllElements;
+        QSet<library::LibraryBaseElement*> mLoadedElements;
+        QSet<library::LibraryBaseElement*> mSavedToTemporary;
+        QSet<library::LibraryBaseElement*> mSavedToOriginal;
 };
 
 /*****************************************************************************************

--- a/tests/unittests/library/librarybaseelementtest.cpp
+++ b/tests/unittests/library/librarybaseelementtest.cpp
@@ -1,0 +1,103 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <gtest/gtest.h>
+#include <librepcb/common/fileio/fileutils.h>
+#include <librepcb/library/librarybaseelement.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace library {
+namespace tests {
+
+/*****************************************************************************************
+ *  Test Class
+ ****************************************************************************************/
+
+class LibraryBaseElementTest : public ::testing::Test
+{
+    protected:
+        FilePath mTempDir;
+        QScopedPointer<LibraryBaseElement> mNewElement;
+
+        LibraryBaseElementTest() {
+            mTempDir = FilePath::getRandomTempPath();
+
+            mNewElement.reset(new LibraryBaseElement(true, "sym", "symbol",
+                                                     Uuid::createRandom(),
+                                                     Version::fromString("1.0"), "test",
+                                                     ElementName("Test"), "", ""));
+        }
+
+        virtual ~LibraryBaseElementTest() {
+            QDir(mTempDir.toStr()).removeRecursively();
+        }
+};
+
+/*****************************************************************************************
+ *  Test Methods
+ ****************************************************************************************/
+
+TEST_F(LibraryBaseElementTest, testSave)
+{
+    mNewElement->save();
+}
+
+TEST_F(LibraryBaseElementTest, testSaveToNonExistingDirectory)
+{
+    FilePath dest = mTempDir.getPathTo(mNewElement->getUuid().toStr());
+    mNewElement->saveTo(dest);
+    EXPECT_TRUE(dest.getPathTo("symbol.lp").isExistingFile());
+}
+
+TEST_F(LibraryBaseElementTest, testSaveToEmptyDirectory)
+{
+    // Saving into empty destination directory must work because empty directories are
+    // sometimes created "accidentally" (for example by Git operations which remove files,
+    // but not their parent directories). So we handle empty directories like they are not
+    // existent...
+    FilePath dest = mTempDir.getPathTo(mNewElement->getUuid().toStr());
+    FileUtils::makePath(dest);
+    ASSERT_TRUE(dest.isExistingDir());
+    mNewElement->saveTo(dest);
+    EXPECT_TRUE(dest.getPathTo("symbol.lp").isExistingFile());
+}
+
+TEST_F(LibraryBaseElementTest, testSaveToNonEmptyDirectory)
+{
+    // Saving into non-empty destination directory must fail because we may accidentally
+    // overwrite existing files!
+    FilePath dest = mTempDir.getPathTo(mNewElement->getUuid().toStr());
+    FileUtils::writeFile(dest.getPathTo("some file"), "some content");
+    EXPECT_THROW(mNewElement->saveTo(dest), RuntimeError);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace tests
+} // namespace library
+} // namespace librepcb

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -81,6 +81,7 @@ SOURCES += \
     eagleimport/devicesetconvertertest.cpp \
     eagleimport/packageconvertertest.cpp \
     eagleimport/symbolconvertertest.cpp \
+    library/librarybaseelementtest.cpp \
     main.cpp \
     project/boards/boardplanefragmentsbuildertest.cpp \
     project/library/projectlibrarytest.cpp \


### PR DESCRIPTION
- Add support for saving project libraries to backup directory "library~" instead of "library". Now the backup/restore feature of projects should also work properly for the project library. Fixes #47.
- Fix possible error when saving the project library after replacing a library element (remove element and add another one with same UUID). Fixes #312.
- Allow library elements to be saved into empty directories. Sometimes empty directories are not cleaned up properly (for example by Git), so we should handle empty directories just like non-existing directories to avoid possible failures.
- Added some unit tests to avoid regression.