### PR TITLE
Improve context menu entries of board editor and schematic editor

### DIFF
--- a/libs/librepcb/common/geometry/cmd/cmdpolygonedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdpolygonedit.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
+#include <librepcb/common/graphics/graphicslayer.h>
 #include "cmdpolygonedit.h"
 
 /*****************************************************************************************
@@ -96,6 +97,12 @@ void CmdPolygonEdit::setDeltaToStartPos(const Point& deltaPos, bool immediate) n
 void CmdPolygonEdit::rotate(const Angle& angle, const Point& center, bool immediate) noexcept
 {
     setPath(mNewPath.rotated(angle, center), immediate);
+}
+
+void CmdPolygonEdit::mirror(const Point& center, Qt::Orientation orientation, bool immediate) noexcept
+{
+    setLayerName(GraphicsLayerName(GraphicsLayer::getMirroredLayerName(*mNewLayerName)), immediate);
+    setPath(mNewPath.mirrored(orientation, center), immediate);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/geometry/cmd/cmdpolygonedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdpolygonedit.h
@@ -57,6 +57,7 @@ class CmdPolygonEdit final : public UndoCommand
         void setPath(const Path& path, bool immediate) noexcept;
         void setDeltaToStartPos(const Point& deltaPos, bool immediate) noexcept;
         void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
+        void mirror(const Point& center, Qt::Orientation orientation, bool immediate) noexcept;
 
         // Operator Overloadings
         CmdPolygonEdit& operator=(const CmdPolygonEdit& rhs) = delete;

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneedit.cpp
@@ -22,6 +22,7 @@
  ****************************************************************************************/
 #include <QtCore>
 #include "cmdboardplaneedit.h"
+#include <librepcb/common/graphics/graphicslayer.h>
 #include "../board.h"
 
 /*****************************************************************************************
@@ -71,6 +72,12 @@ void CmdBoardPlaneEdit::rotate(const Angle& angle, const Point& center, bool imm
     Q_ASSERT(!wasEverExecuted());
     mNewOutline = mOldOutline.rotated(angle, center);
     if (immediate) mPlane.setOutline(mNewOutline);
+}
+
+void CmdBoardPlaneEdit::mirror(const Point& center, Qt::Orientation orientation, bool immediate) noexcept
+{
+    setLayerName(GraphicsLayerName(GraphicsLayer::getMirroredLayerName(*mNewLayerName)), immediate);
+    setOutline(mNewOutline.mirrored(orientation, center), immediate);
 }
 
 void CmdBoardPlaneEdit::setOutline(const Path& outline, bool immediate) noexcept

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneedit.h
@@ -54,6 +54,7 @@ class CmdBoardPlaneEdit final : public UndoCommand
         // Setters
         void setDeltaToStartPos(const Point& deltaPos, bool immediate) noexcept;
         void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
+        void mirror(const Point& center, Qt::Orientation orientation, bool immediate) noexcept;
         void setOutline(const Path& outline, bool immediate) noexcept;
         void setLayerName(const GraphicsLayerName& layerName, bool immediate) noexcept;
         void setNetSignal(NetSignal& netsignal) noexcept;

--- a/libs/librepcb/project/boards/items/bi_netsegment.cpp
+++ b/libs/librepcb/project/boards/items/bi_netsegment.cpp
@@ -492,6 +492,12 @@ bool BI_NetSegment::isSelected() const noexcept
 
 void BI_NetSegment::setSelected(bool selected) noexcept
 {
+    foreach (BI_Via* via, mVias)
+        via->setSelected(selected);
+    foreach (BI_NetPoint* netpoint, mNetPoints)
+        netpoint->setSelected(selected);
+    foreach (BI_NetLine* netline, mNetLines)
+        netline->setSelected(selected);
     BI_Base::setSelected(selected);
 }
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.h
@@ -34,6 +34,10 @@ namespace librepcb {
 class UndoCommandGroup;
 
 namespace project {
+
+class SI_Symbol;
+class SI_NetLabel;
+
 namespace editor {
 
 class CmdMoveSelectedSchematicItems;
@@ -78,9 +82,8 @@ class SES_Select final : public SES_Base
         bool startMovingSelectedItems(Schematic& schematic, const Point& startPos) noexcept;
         bool rotateSelectedItems(const Angle& angle) noexcept;
         bool removeSelectedItems() noexcept;
-        bool cutSelectedItems() noexcept;
-        bool copySelectedItems() noexcept;
-        bool pasteItems() noexcept;
+        void openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept;
+        void openNetLabelPropertiesDialog(SI_NetLabel& netlabel) noexcept;
 
 
         // Types


### PR DESCRIPTION
- Board Editor:
  - Add support for flipping polygons and planes
  - Add context menu entries to remove/rotate/select/edit netlines/vias/planes/polygons
  - Add context menu entries to select/remove whole net segments
- Schematic Editor:
  - Implement rotate/remove/properties for symbols and netlabels
  - Remove menu entries which are not implemented yet

Fixes #306 