### PR TITLE
Fix GUI issues on Windows

### DIFF
--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -337,7 +337,7 @@ void ComponentSignalListEditorWidget::setTableRowContent(int row, const tl::opti
     mTable->setItem(row, COLUMN_FORCEDNETNAME, new QTableWidgetItem(forcedNetName));
 
     // button
-    int btnSize = requiredCheckBox->sizeHint().height();
+    int btnSize = qMax(requiredCheckBox->sizeHint().height(), 17);
     QToolButton* btnAddRemove = new QToolButton(this);
     btnAddRemove->setProperty("row", row);
     btnAddRemove->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
@@ -75,8 +75,6 @@ AddComponentDialog::AddComponentDialog(workspace::Workspace& workspace, Project&
     mUi->lblCompDescription->hide();
     mUi->lblSymbVar->hide();
     mUi->cbxSymbVar->hide();
-    mUi->lblDeviceName->hide();
-    mUi->viewDevice->hide();
     connect(mUi->edtSearch, &QLineEdit::textChanged,
             this, &AddComponentDialog::searchEditTextChanged);
     connect(mUi->treeComponents, &QTreeWidget::currentItemChanged,
@@ -100,6 +98,9 @@ AddComponentDialog::AddComponentDialog(workspace::Workspace& workspace, Project&
     mUi->treeCategories->setModel(mCategoryTreeModel);
     connect(mUi->treeCategories->selectionModel(), &QItemSelectionModel::currentChanged,
             this, &AddComponentDialog::treeCategories_currentItemChanged);
+
+    // Reset GUI to state of nothing selected
+    setSelectedComponent(nullptr);
 }
 
 AddComponentDialog::~AddComponentDialog() noexcept
@@ -331,10 +332,11 @@ void AddComponentDialog::setSelectedCategory(const tl::optional<Uuid>& categoryU
 
 void AddComponentDialog::setSelectedComponent(const library::Component* cmp)
 {
-    if (cmp == mSelectedComponent) return;
+    if (cmp && (cmp == mSelectedComponent)) return;
 
     mUi->lblCompName->setText(tr("No component selected"));
     mUi->lblCompDescription->clear();
+    mUi->cbxSymbVar->clear();
     setSelectedDevice(nullptr);
     setSelectedSymbVar(nullptr);
     delete mSelectedComponent;
@@ -349,7 +351,6 @@ void AddComponentDialog::setSelectedComponent(const library::Component* cmp)
 
         mSelectedComponent = cmp;
 
-        mUi->cbxSymbVar->clear();
         for (const library::ComponentSymbolVariant& symbVar : cmp->getSymbolVariants()) {
             QString text = *symbVar.getNames().value(localeOrder);
             if (!symbVar.getNorm().isEmpty()) {text += " [" + symbVar.getNorm() + "]";}
@@ -365,7 +366,7 @@ void AddComponentDialog::setSelectedComponent(const library::Component* cmp)
 
 void AddComponentDialog::setSelectedSymbVar(const library::ComponentSymbolVariant* symbVar)
 {
-    if (symbVar == mSelectedSymbVar) return;
+    if (symbVar && (symbVar == mSelectedSymbVar)) return;
     qDeleteAll(mPreviewSymbolGraphicsItems);
     mPreviewSymbolGraphicsItems.clear();
     mSelectedSymbVar = symbVar;
@@ -390,8 +391,9 @@ void AddComponentDialog::setSelectedSymbVar(const library::ComponentSymbolVarian
 
 void AddComponentDialog::setSelectedDevice(const library::Device* dev)
 {
-    if (dev == mSelectedDevice) return;
+    if (dev && (dev == mSelectedDevice)) return;
 
+    mUi->lblDeviceName->setText(tr("No device selected"));
     delete mPreviewFootprintGraphicsItem;   mPreviewFootprintGraphicsItem = nullptr;
     delete mSelectedPackage;                mSelectedPackage = nullptr;
     delete mSelectedDevice;                 mSelectedDevice = nullptr;
@@ -415,10 +417,6 @@ void AddComponentDialog::setSelectedDevice(const library::Device* dev)
             }
         }
     }
-
-    mUi->lblDeviceName->setVisible(dev ? true : false);
-    mUi->viewDevice->setVisible(dev ? true : false);
-    mUi->viewComponent->zoomAll();
 }
 
 void AddComponentDialog::accept() noexcept

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
@@ -6,158 +6,148 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>925</width>
-    <height>510</height>
+    <width>900</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Add Component</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="4,5,4">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0,1,0" columnstretch="4,5,4">
+   <item row="0" column="0" rowspan="4">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QLineEdit" name="edtSearch">
-         <property name="placeholderText">
-          <string>What are you looking for?</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTreeView" name="treeCategories">
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-         <property name="headerHidden">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QTreeWidget" name="treeComponents">
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
+      <widget class="QLineEdit" name="edtSearch">
+       <property name="placeholderText">
+        <string>What are you looking for?</string>
        </property>
-       <property name="editTriggers">
-        <set>QAbstractItemView::NoEditTriggers</set>
-       </property>
-       <property name="verticalScrollMode">
-        <enum>QAbstractItemView::ScrollPerPixel</enum>
-       </property>
-       <property name="headerHidden">
+       <property name="clearButtonEnabled">
         <bool>true</bool>
-       </property>
-       <property name="columnCount">
-        <number>0</number>
        </property>
       </widget>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,1,0,1">
+      <widget class="QTreeView" name="treeCategories">
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="headerHidden">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1" rowspan="4">
+    <widget class="QTreeWidget" name="treeComponents">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
+     <property name="headerHidden">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QLabel" name="lblCompName">
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string notr="true">lblCompName</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblCompDescription">
+       <property name="font">
+        <font>
+         <italic>true</italic>
+        </font>
+       </property>
+       <property name="text">
+        <string notr="true">lblCompDescription</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
        <item>
-        <widget class="QLabel" name="lblCompName">
-         <property name="minimumSize">
-          <size>
-           <width>300</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
+        <widget class="QLabel" name="lblSymbVar">
          <property name="text">
-          <string>No component selected</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          <string>Variant:</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="lblCompDescription">
-         <property name="font">
-          <font>
-           <italic>true</italic>
-          </font>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="lblSymbVar">
-           <property name="text">
-            <string>Variant:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cbxSymbVar"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="GraphicsView" name="viewComponent">
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="lblDeviceName">
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>No device selected</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="GraphicsView" name="viewDevice">
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-        </widget>
+        <widget class="QComboBox" name="cbxSymbVar"/>
        </item>
       </layout>
      </item>
     </layout>
    </item>
-   <item>
+   <item row="1" column="2">
+    <widget class="GraphicsView" name="viewComponent">
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="lblDeviceName">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string notr="true">lblDeviceName</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="GraphicsView" name="viewDevice">
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
- Component Editor: Fix unreadable text in signals list
  - Increasing the minimum row width to 17 pixels seems to fix the unreadable text on Windows.
  - Fixes #304 
- AddComponentDialog: Fix size glitches on Windows
  - Reorganize layout: Replace some HBox/VBoxLayouts by GridLayout.
  - Always show (empty) device/package, even if no device selected.
  - Fixes #307 
