### PR TITLE
Allow dragging symbols by circular grab areas

### DIFF
--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -23,7 +23,6 @@
 #include <QtCore>
 #include <QtWidgets>
 #include <QPrinter>
-#include <QPainterPathStroker>
 #include "sgi_symbol.h"
 #include "../items/si_symbol.h"
 #include "../schematic.h"
@@ -92,7 +91,7 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept
             stroker.setCapStyle(Qt::RoundCap);
             stroker.setJoinStyle(Qt::RoundJoin);
             stroker.setWidth(2 * w);
-            mShape = stroker.createStroke(polygonPath);
+            mShape = mShape.united(stroker.createStroke(polygonPath));
         }
     }
 

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -67,6 +67,7 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept
     prepareGeometryChange();
 
     mBoundingRect = QRectF();
+
     mShape = QPainterPath();
     mShape.setFillRule(Qt::WindingFill);
 
@@ -77,10 +78,34 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept
 
     // polygons
     for (const Polygon& polygon : mLibSymbol.getPolygons()) {
+        // query polygon path and line width
         QPainterPath polygonPath = polygon.getPath().toQPainterPathPx();
         qreal w = polygon.getLineWidth()->toPx() / 2;
+
+        // update bounding rectangle
         mBoundingRect = mBoundingRect.united(polygonPath.boundingRect().adjusted(-w, -w, w, w));
+
+        // update shape
         if (polygon.isGrabArea()) mShape = mShape.united(polygonPath);
+    }
+
+    // circles
+    for (const Circle& circle : mLibSymbol.getCircles()) {
+        // get circle radius, including compensation for the stroke width
+        qreal w = circle.getLineWidth()->toPx() / 2;
+        qreal r = circle.getDiameter()->toPx() / 2 + w;
+
+        // get the bounding rectangle for the circle
+        QPointF center = circle.getCenter().toPxQPointF();
+        QRectF boundingRect = QRectF(QPointF(center.x() - r, center.y() - r), QSizeF(r, r));
+
+        // update bounding rectangle
+        mBoundingRect = mBoundingRect.united(boundingRect);
+
+        // update shape
+        if (circle.isGrabArea()) {
+            mShape.addEllipse(circle.getCenter().toPxQPointF(), r, r);
+        }
     }
 
     // texts

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -91,6 +91,9 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept
             stroker.setCapStyle(Qt::RoundCap);
             stroker.setJoinStyle(Qt::RoundJoin);
             stroker.setWidth(2 * w);
+            // add polygon area
+            mShape = mShape.united(polygonPath);
+            // add stroke area
             mShape = mShape.united(stroker.createStroke(polygonPath));
         }
     }

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -103,7 +103,7 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept
 
         // get the bounding rectangle for the circle
         QPointF center = circle.getCenter().toPxQPointF();
-        QRectF boundingRect = QRectF(QPointF(center.x() - r, center.y() - r), QSizeF(r, r));
+        QRectF boundingRect = QRectF(QPointF(center.x() - r, center.y() - r), QSizeF(r * 2, r * 2));
 
         // update bounding rectangle
         mBoundingRect = mBoundingRect.united(boundingRect);

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -23,6 +23,7 @@
 #include <QtCore>
 #include <QtWidgets>
 #include <QPrinter>
+#include <QPainterPathStroker>
 #include "sgi_symbol.h"
 #include "../items/si_symbol.h"
 #include "../schematic.h"
@@ -86,7 +87,13 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept
         mBoundingRect = mBoundingRect.united(polygonPath.boundingRect().adjusted(-w, -w, w, w));
 
         // update shape
-        if (polygon.isGrabArea()) mShape = mShape.united(polygonPath);
+        if (polygon.isGrabArea()) {
+            QPainterPathStroker stroker;
+            stroker.setCapStyle(Qt::RoundCap);
+            stroker.setJoinStyle(Qt::RoundJoin);
+            stroker.setWidth(2 * w);
+            mShape = stroker.createStroke(polygonPath);
+        }
     }
 
     // circles


### PR DESCRIPTION
I don't really know what I'm doing, but this seems to do the trick.

Fixes #311.

@ubruhin does the `mBoundingRect` need to be updated too? Do you have some high-level documentation on how all this code works, or what it does?