### PR TITLE
Stop using abbreviations in S-Expression files

### DIFF
--- a/libs/librepcb/common/geometry/circle.cpp
+++ b/libs/librepcb/common/geometry/circle.cpp
@@ -61,14 +61,29 @@ Circle::Circle(const SExpression& node) :
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mLineWidth(node.getValueByPath<UnsignedLength>("width")),
     mIsFilled(node.getValueByPath<bool>("fill")),
-    mIsGrabArea(node.getValueByPath<bool>("grab")),
-    mCenter(node.getChildByPath("pos")),
+    mIsGrabArea(false),
+    mCenter(0, 0),
     mDiameter(1)
 {
     if (node.getChildByIndex(0).isString()) {
         mUuid = node.getChildByIndex(0).getValue<Uuid>();
     }
-    if (node.tryGetChildByPath("dia")) {
+    if (node.tryGetChildByPath("grab_area")) {
+        mIsGrabArea = node.getValueByPath<bool>("grab_area");
+    } else {
+        // backward compatibility, remove this some time!
+        mIsGrabArea = node.getValueByPath<bool>("grab");
+    }
+    if (node.tryGetChildByPath("position")) {
+        mCenter = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mCenter = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("diameter")) {
+        mDiameter = node.getValueByPath<PositiveLength>("diameter");
+    } else if (node.tryGetChildByPath("dia")) {
+        // backward compatibility, remove this some time!
         mDiameter = node.getValueByPath<PositiveLength>("dia");
     } else if (node.tryGetChildByPath("size")) {
         // backward compatibility, remove this some time!
@@ -171,9 +186,9 @@ void Circle::serialize(SExpression& root) const
     root.appendChild("layer", mLayerName, false);
     root.appendChild("width", mLineWidth, true);
     root.appendChild("fill", mIsFilled, false);
-    root.appendChild("grab", mIsGrabArea, false);
-    root.appendChild("dia", mDiameter, false);
-    root.appendChild(mCenter.serializeToDomElement("pos"), false);
+    root.appendChild("grab_area", mIsGrabArea, false);
+    root.appendChild("diameter", mDiameter, false);
+    root.appendChild(mCenter.serializeToDomElement("position"), false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/geometry/hole.cpp
+++ b/libs/librepcb/common/geometry/hole.cpp
@@ -52,9 +52,21 @@ Hole::Hole(const Uuid& uuid, const Point& position, const PositiveLength& diamet
 
 Hole::Hole(const SExpression& node) :
     mUuid(Uuid::createRandom()), // backward compatibility, remove this some time!
-    mPosition(node.getChildByPath("pos")),
-    mDiameter(node.getValueByPath<PositiveLength>("dia"))
+    mPosition(0, 0),
+    mDiameter(1)
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("diameter")) {
+        mDiameter = node.getValueByPath<PositiveLength>("diameter");
+    } else {
+        // backward compatibility, remove this some time!
+        mDiameter = node.getValueByPath<PositiveLength>("dia");
+    }
     if (node.getChildByIndex(0).isString()) {
         mUuid = node.getChildByIndex(0).getValue<Uuid>();
     }
@@ -104,8 +116,8 @@ void Hole::unregisterObserver(IF_HoleObserver& object) const noexcept
 void Hole::serialize(SExpression& root) const
 {
     root.appendChild(mUuid);
-    root.appendChild("dia", mDiameter, false);
-    root.appendChild(mPosition.serializeToDomElement("pos"), false);
+    root.appendChild("diameter", mDiameter, false);
+    root.appendChild(mPosition.serializeToDomElement("position"), false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/geometry/polygon.cpp
+++ b/libs/librepcb/common/geometry/polygon.cpp
@@ -62,15 +62,21 @@ Polygon::Polygon(const SExpression& node) :
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mLineWidth(node.getValueByPath<UnsignedLength>("width")),
     mIsFilled(node.getValueByPath<bool>("fill")),
-    mIsGrabArea(node.getValueByPath<bool>("grab")),
+    mIsGrabArea(false),
     mPath()
 {
     if (node.getChildByIndex(0).isString()) {
         mUuid = node.getChildByIndex(0).getValue<Uuid>();
     }
+    if (node.tryGetChildByPath("grab_area")) {
+        mIsGrabArea = node.getValueByPath<bool>("grab_area");
+    } else {
+        // backward compatibility, remove this some time!
+        mIsGrabArea = node.getValueByPath<bool>("grab");
+    }
 
     // load vertices
-    if (!node.tryGetChildByPath("pos")) {
+    if ((!node.tryGetChildByPath("pos")) && (!node.tryGetChildByPath("position"))) {
         mPath = Path(node); // can throw
     } else {
         // backward compatibility, remove this some time!
@@ -155,7 +161,7 @@ void Polygon::serialize(SExpression& root) const
     root.appendChild("layer", mLayerName, false);
     root.appendChild("width", mLineWidth, true);
     root.appendChild("fill", mIsFilled, false);
-    root.appendChild("grab", mIsGrabArea, false);
+    root.appendChild("grab_area", mIsGrabArea, false);
     mPath.serialize(root);
 }
 

--- a/libs/librepcb/common/geometry/stroketext.cpp
+++ b/libs/librepcb/common/geometry/stroketext.cpp
@@ -74,8 +74,8 @@ StrokeText::StrokeText(const SExpression& node) :
     mUuid(Uuid::createRandom()), // backward compatibility, remove this some time!
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mText(),
-    mPosition(node.getChildByPath("pos")),
-    mRotation(node.getValueByPath<Angle>("rot")),
+    mPosition(0, 0),
+    mRotation(0),
     mHeight(node.getValueByPath<PositiveLength>("height")),
     mStrokeWidth(200000), // backward compatibility, remove this some time!
     mLetterSpacing(), // backward compatibility, remove this some time!
@@ -95,6 +95,18 @@ StrokeText::StrokeText(const SExpression& node) :
     }
 
     // load geometry attributes
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mRotation = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mRotation = node.getValueByPath<Angle>("rot");
+    }
     if (const SExpression* child = node.tryGetChildByPath("stroke_width")) {
         mStrokeWidth = child->getValueOfFirstChild<UnsignedLength>();
     }
@@ -358,10 +370,10 @@ void StrokeText::serialize(SExpression& root) const
     root.appendChild("letter_spacing", mLetterSpacing, false);
     root.appendChild("line_spacing", mLineSpacing, false);
     root.appendChild(mAlign.serializeToDomElement("align"), true);
-    root.appendChild(mPosition.serializeToDomElement("pos"), false);
-    root.appendChild("rot", mRotation, false);
-    root.appendChild("auto_rotate", mAutoRotate, false);
-    root.appendChild("mirror", mMirrored, true);
+    root.appendChild(mPosition.serializeToDomElement("position"), false);
+    root.appendChild("rotation", mRotation, false);
+    root.appendChild("auto_rotate", mAutoRotate, true);
+    root.appendChild("mirror", mMirrored, false);
     root.appendChild("value", mText, false);
 }
 

--- a/libs/librepcb/common/geometry/text.cpp
+++ b/libs/librepcb/common/geometry/text.cpp
@@ -61,8 +61,8 @@ Text::Text(const SExpression& node) :
     mUuid(Uuid::createRandom()), // backward compatibility, remove this some time!
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mText(),
-    mPosition(node.getChildByPath("pos")),
-    mRotation(node.getValueByPath<Angle>("rot")),
+    mPosition(0, 0),
+    mRotation(0),
     mHeight(node.getValueByPath<PositiveLength>("height")),
     mAlign(node.getChildByPath("align"))
 {
@@ -72,6 +72,18 @@ Text::Text(const SExpression& node) :
     } else {
         // backward compatibility, remove this some time!
         mText = node.getChildByIndex(0).getValue<QString>();
+    }
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mRotation = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mRotation = node.getValueByPath<Angle>("rot");
     }
 
     // backward compatibility - remove this some time!
@@ -162,8 +174,8 @@ void Text::serialize(SExpression& root) const
     root.appendChild("value", mText, false);
     root.appendChild(mAlign.serializeToDomElement("align"), true);
     root.appendChild("height", mHeight, false);
-    root.appendChild(mPosition.serializeToDomElement("pos"), false);
-    root.appendChild("rot", mRotation, false);
+    root.appendChild(mPosition.serializeToDomElement("position"), false);
+    root.appendChild("rotation", mRotation, false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/common/geometry/vertex.cpp
+++ b/libs/librepcb/common/geometry/vertex.cpp
@@ -35,7 +35,12 @@ namespace librepcb {
 Vertex::Vertex(const SExpression& node)
 {
     try {
-        mPos = Point(node.getChildByPath("pos"));
+        if (node.tryGetChildByPath("position")) {
+            mPos = Point(node.getChildByPath("position"));
+        } else {
+            // backward compatibility, remove this some time!
+            mPos = Point(node.getChildByPath("pos"));
+        }
         mAngle = node.getValueByPath<Angle>("angle");
     } catch (const Exception& e) {
         throw FileParseError(__FILE__, __LINE__, node.getFilePath(), -1, -1,
@@ -49,7 +54,7 @@ Vertex::Vertex(const SExpression& node)
 
 void Vertex::serialize(SExpression& root) const
 {
-    root.appendChild(mPos.serializeToDomElement("pos"), false);
+    root.appendChild(mPos.serializeToDomElement("position"), false);
     root.appendChild("angle", mAngle, false);
 }
 

--- a/libs/librepcb/library/cmp/componentpinsignalmap.cpp
+++ b/libs/librepcb/library/cmp/componentpinsignalmap.cpp
@@ -48,9 +48,22 @@ ComponentPinSignalMapItem::ComponentPinSignalMapItem(const Uuid& pin,
 
 ComponentPinSignalMapItem::ComponentPinSignalMapItem(const SExpression& node) :
     mPinUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mSignalUuid(node.getValueByPath<tl::optional<Uuid>>("sig")),
-    mDisplayType(CmpSigPinDisplayType::fromString(node.getValueByPath<QString>("disp")))
+    mSignalUuid(Uuid::createRandom()), // backward compatibility, remove this some time!
+    mDisplayType(CmpSigPinDisplayType::componentSignal())
 {
+    if (node.tryGetChildByPath("signal")) {
+        mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("signal");
+    } else {
+        // backward compatibility, remove this some time!
+        mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("sig");
+    }
+
+    if (node.tryGetChildByPath("text")) {
+        mDisplayType = CmpSigPinDisplayType::fromString(node.getValueByPath<QString>("text"));
+    } else {
+        // backward compatibility, remove this some time!
+        mDisplayType = CmpSigPinDisplayType::fromString(node.getValueByPath<QString>("disp"));
+    }
 }
 
 ComponentPinSignalMapItem::~ComponentPinSignalMapItem() noexcept
@@ -64,8 +77,8 @@ ComponentPinSignalMapItem::~ComponentPinSignalMapItem() noexcept
 void ComponentPinSignalMapItem::serialize(SExpression& root) const
 {
     root.appendChild(mPinUuid);
-    root.appendChild("sig", mSignalUuid, false);
-    root.appendChild("disp", mDisplayType, false);
+    root.appendChild("signal", mSignalUuid, false);
+    root.appendChild("text", mDisplayType, false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
@@ -57,12 +57,24 @@ ComponentSymbolVariantItem::ComponentSymbolVariantItem(const Uuid& uuid,
 ComponentSymbolVariantItem::ComponentSymbolVariantItem(const SExpression& node) :
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mSymbolUuid(node.getValueByPath<Uuid>("symbol")),
-    mSymbolPos(node.getChildByPath("pos")),
-    mSymbolRot(node.getValueByPath<Angle>("rot")),
+    mSymbolPos(0, 0),
+    mSymbolRot(0),
     mIsRequired(node.getValueByPath<bool>("required")),
     mSuffix(node.getValueByPath<ComponentSymbolVariantItemSuffix>("suffix")),
     mPinSignalMap(node)
 {
+    if (node.tryGetChildByPath("position")) {
+        mSymbolPos = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mSymbolPos = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mSymbolRot = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mSymbolRot = node.getValueByPath<Angle>("rot");
+    }
 }
 
 ComponentSymbolVariantItem::~ComponentSymbolVariantItem() noexcept
@@ -77,8 +89,8 @@ void ComponentSymbolVariantItem::serialize(SExpression& root) const
 {
     root.appendChild(mUuid);
     root.appendChild("symbol", mSymbolUuid, true);
-    root.appendChild(mSymbolPos.serializeToDomElement("pos"), true);
-    root.appendChild("rot", mSymbolRot, false);
+    root.appendChild(mSymbolPos.serializeToDomElement("position"), true);
+    root.appendChild("rotation", mSymbolRot, false);
     root.appendChild("required", mIsRequired, false);
     root.appendChild("suffix", mSuffix, false);
     mPinSignalMap.sortedByUuid().serialize(root);

--- a/libs/librepcb/library/dev/devicepadsignalmap.cpp
+++ b/libs/librepcb/library/dev/devicepadsignalmap.cpp
@@ -48,8 +48,14 @@ DevicePadSignalMapItem::DevicePadSignalMapItem(const Uuid& pad, const tl::option
 DevicePadSignalMapItem::DevicePadSignalMapItem(const SExpression& node) :
     QObject(nullptr),
     mPadUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mSignalUuid(node.getValueByPath<tl::optional<Uuid>>("sig"))
+    mSignalUuid(Uuid::createRandom()) // backward compatibility, remove this some time!
 {
+    if (node.tryGetChildByPath("signal")) {
+        mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("signal");
+    } else {
+        // backward compatibility, remove this some time!
+        mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("sig");
+    }
 }
 
 DevicePadSignalMapItem::~DevicePadSignalMapItem() noexcept
@@ -74,7 +80,7 @@ void DevicePadSignalMapItem::setSignalUuid(const tl::optional<Uuid>& uuid) noexc
 void DevicePadSignalMapItem::serialize(SExpression& root) const
 {
     root.appendChild(mPadUuid);
-    root.appendChild("sig", mSignalUuid, false);
+    root.appendChild("signal", mSignalUuid, false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/library/pkg/footprintpad.cpp
@@ -59,8 +59,8 @@ FootprintPad::FootprintPad(const Uuid& padUuid, const Point& pos, const Angle& r
 
 FootprintPad::FootprintPad(const SExpression& node) :
     mPackagePadUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(node.getChildByPath("pos")),
-    mRotation(node.getValueByPath<Angle>("rot")),
+    mPosition(0, 0),
+    mRotation(0),
     mShape(node.getValueByPath<Shape>("shape")),
     mWidth(Point(node.getChildByPath("size")).getX()),
     mHeight(Point(node.getChildByPath("size")).getY()),
@@ -68,6 +68,18 @@ FootprintPad::FootprintPad(const SExpression& node) :
     mBoardSide(node.getValueByPath<BoardSide>("side")),
     mRegisteredGraphicsItem(nullptr)
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mRotation = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mRotation = node.getValueByPath<Angle>("rot");
+    }
 }
 
 FootprintPad::~FootprintPad() noexcept
@@ -197,8 +209,8 @@ void FootprintPad::serialize(SExpression& root) const
     root.appendChild(mPackagePadUuid);
     root.appendChild("side", mBoardSide, false);
     root.appendChild("shape", mShape, false);
-    root.appendChild(mPosition.serializeToDomElement("pos"), true);
-    root.appendChild("rot", mRotation, false);
+    root.appendChild(mPosition.serializeToDomElement("position"), true);
+    root.appendChild("rotation", mRotation, false);
     root.appendChild(Point(*mWidth, *mHeight).serializeToDomElement("size"), false);
     root.appendChild("drill", mDrillDiameter, false);
 }

--- a/libs/librepcb/library/sym/symbolpin.cpp
+++ b/libs/librepcb/library/sym/symbolpin.cpp
@@ -54,11 +54,23 @@ SymbolPin::SymbolPin(const Uuid& uuid, const CircuitIdentifier& name, const Poin
 SymbolPin::SymbolPin(const SExpression& node) :
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mName(node.getValueByPath<CircuitIdentifier>("name", true)),
-    mPosition(node.getChildByPath("pos")),
+    mPosition(0, 0),
     mLength(node.getValueByPath<UnsignedLength>("length")),
-    mRotation(node.getValueByPath<Angle>("rot")),
+    mRotation(0),
     mRegisteredGraphicsItem(nullptr)
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mRotation = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mRotation = node.getValueByPath<Angle>("rot");
+    }
 }
 
 SymbolPin::~SymbolPin() noexcept
@@ -114,8 +126,8 @@ void SymbolPin::serialize(SExpression& root) const
 {
     root.appendChild(mUuid);
     root.appendChild("name", mName, false);
-    root.appendChild(mPosition.serializeToDomElement("pos"), true);
-    root.appendChild("rot", mRotation, false);
+    root.appendChild(mPosition.serializeToDomElement("position"), true);
+    root.appendChild("rotation", mRotation, false);
     root.appendChild("length", mLength, false);
 }
 

--- a/libs/librepcb/project/boards/items/bi_device.cpp
+++ b/libs/librepcb/project/boards/items/bi_device.cpp
@@ -72,8 +72,18 @@ BI_Device::BI_Device(Board& board, const SExpression& node) :
     initDeviceAndPackageAndFootprint(deviceUuid, footprintUuid);
 
     // get position, rotation and mirrored
-    mPosition = Point(node.getChildByPath("pos"));
-    mRotation = node.getValueByPath<Angle>("rot");
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mRotation = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mRotation = node.getValueByPath<Angle>("rot");
+    }
     mIsMirrored = node.getValueByPath<bool>("mirror");
 
     // load attributes
@@ -233,8 +243,8 @@ void BI_Device::serialize(SExpression& root) const
     root.appendChild(mCompInstance->getUuid());
     root.appendChild("lib_device", mLibDevice->getUuid(), true);
     root.appendChild("lib_footprint", mLibFootprint->getUuid(), true);
-    root.appendChild(mPosition.serializeToDomElement("pos"), true);
-    root.appendChild("rot", mRotation, false);
+    root.appendChild(mPosition.serializeToDomElement("position"), true);
+    root.appendChild("rotation", mRotation, false);
     root.appendChild("mirror", mIsMirrored, false);
     mAttributes.serialize(root);
     mFootprint->serialize(root);

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -46,8 +46,15 @@ BI_NetPoint::BI_NetPoint(BI_NetSegment& segment, const BI_NetPoint& other) :
 BI_NetPoint::BI_NetPoint(BI_NetSegment& segment, const SExpression& node) :
     BI_Base(segment.getBoard()), mNetSegment(segment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(node.getChildByPath("pos"))
+    mPosition(0, 0)
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+
     init();
 }
 
@@ -163,7 +170,7 @@ void BI_NetPoint::unregisterNetLine(BI_NetLine& netline)
 void BI_NetPoint::serialize(SExpression& root) const
 {
     root.appendChild(mUuid);
-    root.appendChild(mPosition.serializeToDomElement("pos"), false);
+    root.appendChild(mPosition.serializeToDomElement("position"), false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/boards/items/bi_via.cpp
+++ b/libs/librepcb/project/boards/items/bi_via.cpp
@@ -48,11 +48,18 @@ BI_Via::BI_Via(BI_NetSegment& netsegment, const SExpression& node) :
     BI_Base(netsegment.getBoard()),
     mNetSegment(netsegment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(node.getChildByPath("pos")),
+    mPosition(0, 0),
     mShape(node.getValueByPath<Shape>("shape")),
     mSize(node.getValueByPath<PositiveLength>("size")),
     mDrillDiameter(node.getValueByPath<PositiveLength>("drill"))
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+
     init();
 }
 
@@ -213,7 +220,7 @@ void BI_Via::unregisterNetLine(BI_NetLine& netline)
 void BI_Via::serialize(SExpression& root) const
 {
     root.appendChild(mUuid);
-    root.appendChild(mPosition.serializeToDomElement("pos"), true);
+    root.appendChild(mPosition.serializeToDomElement("position"), true);
     root.appendChild("size", mSize, false);
     root.appendChild("drill", mDrillDiameter, false);
     root.appendChild("shape", mShape, false);

--- a/libs/librepcb/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/project/circuit/componentinstance.cpp
@@ -68,7 +68,7 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node) 
     mAttributes.reset(new AttributeList(node)); // can throw
 
     // load all signal instances
-    foreach (const SExpression& node, node.getChildren("sig")) {
+    foreach (const SExpression& node, node.getChildren("sig") + node.getChildren("signal")) {
         ComponentSignalInstance* signal = new ComponentSignalInstance(mCircuit, *this, node);
         if (mSignals.contains(signal->getCompSignal().getUuid())) {
             throw RuntimeError(__FILE__, __LINE__,
@@ -340,7 +340,7 @@ void ComponentInstance::serialize(SExpression& root) const
     root.appendChild("name", mName, true);
     root.appendChild("value", mValue, false);
     mAttributes->serialize(root);
-    serializePointerContainer(root, mSignals, "sig");
+    serializePointerContainer(root, mSignals, "signal");
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/items/si_netlabel.cpp
+++ b/libs/librepcb/project/schematics/items/si_netlabel.cpp
@@ -43,9 +43,22 @@ namespace project {
 SI_NetLabel::SI_NetLabel(SI_NetSegment& segment, const SExpression& node) :
     SI_Base(segment.getSchematic()), mNetSegment(segment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(node.getChildByPath("pos")),
-    mRotation(node.getValueByPath<Angle>("rot"))
+    mPosition(0, 0),
+    mRotation(0)
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mRotation = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mRotation = node.getValueByPath<Angle>("rot");
+    }
+
     init();
 }
 
@@ -139,8 +152,8 @@ void SI_NetLabel::removeFromSchematic()
 void SI_NetLabel::serialize(SExpression& root) const
 {
     root.appendChild(mUuid);
-    root.appendChild(mPosition.serializeToDomElement("pos"), true);
-    root.appendChild("rot", mRotation, false);
+    root.appendChild(mPosition.serializeToDomElement("position"), true);
+    root.appendChild("rotation", mRotation, false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/items/si_netpoint.cpp
+++ b/libs/librepcb/project/schematics/items/si_netpoint.cpp
@@ -39,8 +39,15 @@ namespace project {
 SI_NetPoint::SI_NetPoint(SI_NetSegment& segment, const SExpression& node) :
     SI_Base(segment.getSchematic()), mNetSegment(segment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(node.getChildByPath("pos"))
+    mPosition(0, 0)
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+
     init();
 }
 
@@ -156,7 +163,7 @@ void SI_NetPoint::unregisterNetLine(SI_NetLine& netline)
 void SI_NetPoint::serialize(SExpression& root) const
 {
     root.appendChild(mUuid);
-    root.appendChild(mPosition.serializeToDomElement("pos"), false);
+    root.appendChild(mPosition.serializeToDomElement("position"), false);
 }
 
 /*****************************************************************************************

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -46,9 +46,22 @@ namespace project {
 SI_Symbol::SI_Symbol(Schematic& schematic, const SExpression& node) :
     SI_Base(schematic), mComponentInstance(nullptr), mSymbVarItem(nullptr), mSymbol(nullptr),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(node.getChildByPath("pos")),
-    mRotation(node.getValueByPath<Angle>("rot"))
+    mPosition(0, 0),
+    mRotation(0)
 {
+    if (node.tryGetChildByPath("position")) {
+        mPosition = Point(node.getChildByPath("position"));
+    } else {
+        // backward compatibility, remove this some time!
+        mPosition = Point(node.getChildByPath("pos"));
+    }
+    if (node.tryGetChildByPath("rotation")) {
+        mRotation = node.getValueByPath<Angle>("rotation");
+    } else {
+        // backward compatibility, remove this some time!
+        mRotation = node.getValueByPath<Angle>("rot");
+    }
+
     Uuid gcUuid = node.getValueByPath<Uuid>("component");
     mComponentInstance = schematic.getProject().getCircuit().getComponentInstanceByUuid(gcUuid);
     if (!mComponentInstance) {
@@ -200,8 +213,8 @@ void SI_Symbol::serialize(SExpression& root) const
     root.appendChild(mUuid);
     root.appendChild("component", mComponentInstance->getUuid(), true);
     root.appendChild("lib_gate", mSymbVarItem->getUuid(), true);
-    root.appendChild(mPosition.serializeToDomElement("pos"), true);
-    root.appendChild("rot", mRotation, false);
+    root.appendChild(mPosition.serializeToDomElement("position"), true);
+    root.appendChild("rotation", mRotation, false);
 }
 
 /*****************************************************************************************


### PR DESCRIPTION
Some nodes in our S-Expression files were written as abbreviations (e.g. "pos" instead of "position"), while most aren't. For consistency and readability, these abbreviations are now also replaced with their long names.

Here is the corresponding diff on the demo workspace: https://github.com/LibrePCB/demo-workspace/commit/f25e364b975ca3a70bf34d60a1874531ff8a40cc