### PR TITLE
Store default author name in workspace settings

### DIFF
--- a/apps/librepcb/firstrunwizard/firstrunwizard.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizard.cpp
@@ -24,6 +24,7 @@
 #include "ui_firstrunwizard.h"
 #include "firstrunwizardpage_welcome.h"
 #include "firstrunwizardpage_workspacepath.h"
+#include "firstrunwizardpage_workspacesettings.h"
 
 /*****************************************************************************************
  *  Namespace
@@ -41,8 +42,9 @@ FirstRunWizard::FirstRunWizard(QWidget *parent) noexcept :
     mUi->setupUi(this);
 
     // add pages
-    addPage(new FirstRunWizardPage_Welcome());
-    addPage(new FirstRunWizardPage_WorkspacePath());
+    setPage(Page_Welcome, new FirstRunWizardPage_Welcome());
+    setPage(Page_WorkspacePath, new FirstRunWizardPage_WorkspacePath());
+    setPage(Page_WorkspaceSettings, new FirstRunWizardPage_WorkspaceSettings());
 
     // set header logo
     setPixmap(WizardPixmap::LogoPixmap, QPixmap(":/img/logo/48x48.png"));
@@ -67,6 +69,33 @@ FilePath FirstRunWizard::getWorkspaceFilePath() const noexcept
         return FilePath(field("CreateWorkspacePath").toString());
     else
         return FilePath(field("OpenWorkspacePath").toString());
+}
+
+QString FirstRunWizard::getNewWorkspaceUserName() const noexcept
+{
+    return field("NewWorkspaceUserName").toString();
+}
+
+/*****************************************************************************************
+ *  Inherited from QWizard
+ ****************************************************************************************/
+
+int FirstRunWizard::nextId() const
+{
+    switch (currentId()) {
+        case Page_Welcome: {
+            return Page_WorkspacePath;
+        }
+        case Page_WorkspacePath: {
+            return getCreateNewWorkspace() ? Page_WorkspaceSettings : -1;
+        }
+        case Page_WorkspaceSettings: {
+            return -1;
+        }
+        default: {
+            return -1;
+        }
+    }
 }
 
 /*****************************************************************************************

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
@@ -102,6 +102,7 @@ void FirstRunWizardPage_WorkspacePath::on_rbtnCreateWs_toggled(bool checked)
     mUi->lblCreateWs->setEnabled(checked);
     mUi->edtCreateWsPath->setEnabled(checked);
     mUi->btnCreateWsBrowse->setEnabled(checked);
+    setFinalPage(!checked); // force updating page order
 }
 
 void FirstRunWizardPage_WorkspacePath::on_rbtnOpenWs_toggled(bool checked)
@@ -109,6 +110,7 @@ void FirstRunWizardPage_WorkspacePath::on_rbtnOpenWs_toggled(bool checked)
     mUi->lblOpenWs->setEnabled(checked);
     mUi->edtOpenWsPath->setEnabled(checked);
     mUi->btnOpenWsBrowse->setEnabled(checked);
+    setFinalPage(checked); // force updating page order
 }
 
 void FirstRunWizardPage_WorkspacePath::on_btnCreateWsBrowse_clicked()

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.cpp
@@ -17,69 +17,47 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_FIRSTRUNWIZARD_H
-#define LIBREPCB_FIRSTRUNWIZARD_H
-
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
-#include <QtCore>
-#include <QtWidgets>
-#include <librepcb/common/fileio/filepath.h>
+#include <QFileDialog>
+#include "firstrunwizardpage_workspacesettings.h"
+#include "ui_firstrunwizardpage_workspacesettings.h"
+#include <librepcb/common/systeminfo.h>
+#include <librepcb/workspace/workspace.h>
 
 /*****************************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ****************************************************************************************/
 namespace librepcb {
 namespace application {
 
-namespace Ui {
-class FirstRunWizard;
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+FirstRunWizardPage_WorkspaceSettings::FirstRunWizardPage_WorkspaceSettings(QWidget *parent) noexcept :
+    QWizardPage(parent), mUi(new Ui::FirstRunWizardPage_WorkspaceSettings)
+{
+    mUi->setupUi(this);
+    registerField("NewWorkspaceUserName", mUi->edtUserName);
+
+    // Initialize user name with the system's username.
+    mUi->edtUserName->setText(SystemInfo::getFullUsername());
+}
+
+FirstRunWizardPage_WorkspaceSettings::~FirstRunWizardPage_WorkspaceSettings() noexcept
+{
 }
 
 /*****************************************************************************************
- *  Class FirstRunWizard
+ *  Inherited Methods
  ****************************************************************************************/
 
-/**
- * @brief The FirstRunWizard class
- *
- * @author ubruhin
- * @date 2015-09-22
- */
-class FirstRunWizard final : public QWizard
+bool FirstRunWizardPage_WorkspaceSettings::validatePage() noexcept
 {
-        Q_OBJECT
-
-        enum PageId {
-            Page_Welcome,
-            Page_WorkspacePath,
-            Page_WorkspaceSettings,
-        };
-
-    public:
-
-        // Constructors / Destructor
-        explicit FirstRunWizard(QWidget* parent = 0) noexcept;
-        ~FirstRunWizard() noexcept;
-
-        // Getters
-        bool getCreateNewWorkspace() const noexcept;
-        FilePath getWorkspaceFilePath() const noexcept;
-        QString getNewWorkspaceUserName() const noexcept;
-
-        // Inherited from QWizard
-        int nextId() const override;
-
-
-    private:
-
-        // Private Methods
-        Q_DISABLE_COPY(FirstRunWizard)
-
-        // Private Membervariables
-        QScopedPointer<Ui::FirstRunWizard> mUi;
-};
+    return true; // Any user name is valid
+}
 
 /*****************************************************************************************
  *  End of File
@@ -87,5 +65,3 @@ class FirstRunWizard final : public QWizard
 
 } // namespace application
 } // namespace librepcb
-
-#endif // LIBREPCB_FIRSTRUNWIZARD_H

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.h
@@ -17,15 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_FIRSTRUNWIZARD_H
-#define LIBREPCB_FIRSTRUNWIZARD_H
+#ifndef LIBREPCB_APPLICATION_FIRSTRUNWIZARDPAGE_WORKSPACESETTINGS_H
+#define LIBREPCB_APPLICATION_FIRSTRUNWIZARDPAGE_WORKSPACESETTINGS_H
 
 /*****************************************************************************************
  *  Includes
  ****************************************************************************************/
 #include <QtCore>
 #include <QtWidgets>
-#include <librepcb/common/fileio/filepath.h>
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -34,51 +33,36 @@ namespace librepcb {
 namespace application {
 
 namespace Ui {
-class FirstRunWizard;
+class FirstRunWizardPage_WorkspaceSettings;
 }
 
 /*****************************************************************************************
- *  Class FirstRunWizard
+ *  Class FirstRunWizardPage_WorkspaceSettings
  ****************************************************************************************/
 
 /**
- * @brief The FirstRunWizard class
- *
- * @author ubruhin
- * @date 2015-09-22
+ * @brief The FirstRunWizardPage_WorkspaceSettings class
  */
-class FirstRunWizard final : public QWizard
+class FirstRunWizardPage_WorkspaceSettings final : public QWizardPage
 {
         Q_OBJECT
-
-        enum PageId {
-            Page_Welcome,
-            Page_WorkspacePath,
-            Page_WorkspaceSettings,
-        };
 
     public:
 
         // Constructors / Destructor
-        explicit FirstRunWizard(QWidget* parent = 0) noexcept;
-        ~FirstRunWizard() noexcept;
+        explicit FirstRunWizardPage_WorkspaceSettings(QWidget *parent = 0) noexcept;
+        ~FirstRunWizardPage_WorkspaceSettings() noexcept;
 
-        // Getters
-        bool getCreateNewWorkspace() const noexcept;
-        FilePath getWorkspaceFilePath() const noexcept;
-        QString getNewWorkspaceUserName() const noexcept;
-
-        // Inherited from QWizard
-        int nextId() const override;
+        // Inherited Methods
+        bool validatePage() noexcept override;
 
 
-    private:
+    private: // Methods
+        Q_DISABLE_COPY(FirstRunWizardPage_WorkspaceSettings)
 
-        // Private Methods
-        Q_DISABLE_COPY(FirstRunWizard)
 
-        // Private Membervariables
-        QScopedPointer<Ui::FirstRunWizard> mUi;
+    private: // Data
+        QScopedPointer<Ui::FirstRunWizardPage_WorkspaceSettings> mUi;
 };
 
 /*****************************************************************************************
@@ -88,4 +72,4 @@ class FirstRunWizard final : public QWizard
 } // namespace application
 } // namespace librepcb
 
-#endif // LIBREPCB_FIRSTRUNWIZARD_H
+#endif // LIBREPCB_APPLICATION_FIRSTRUNWIZARDPAGE_WORKSPACESETTINGS_H

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.ui
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.ui
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::application::FirstRunWizardPage_WorkspaceSettings</class>
+ <widget class="QWizardPage" name="librepcb::application::FirstRunWizardPage_WorkspaceSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>501</width>
+    <height>66</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">WizardPage</string>
+  </property>
+  <property name="title">
+   <string>Workspace Settings</string>
+  </property>
+  <property name="subTitle">
+   <string>Set the most important workspace settings (of course they can still be changed later).</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>User Name:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="edtUserName">
+     <property name="maxLength">
+      <number>100</number>
+     </property>
+     <property name="placeholderText">
+      <string>e.g. &quot;John Doe&quot;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>This name will be used as author when creating new projects or libraries.</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -88,6 +88,7 @@ SOURCES += \
     firstrunwizard/firstrunwizard.cpp \
     firstrunwizard/firstrunwizardpage_welcome.cpp \
     firstrunwizard/firstrunwizardpage_workspacepath.cpp \
+    firstrunwizard/firstrunwizardpage_workspacesettings.cpp \
     main.cpp \
     markdown/markdownconverter.cpp \
     projectlibraryupdater/projectlibraryupdater.cpp \
@@ -97,6 +98,7 @@ HEADERS += \
     firstrunwizard/firstrunwizard.h \
     firstrunwizard/firstrunwizardpage_welcome.h \
     firstrunwizard/firstrunwizardpage_workspacepath.h \
+    firstrunwizard/firstrunwizardpage_workspacesettings.h \
     markdown/markdownconverter.h \
     projectlibraryupdater/projectlibraryupdater.h \
 
@@ -105,6 +107,7 @@ FORMS += \
     firstrunwizard/firstrunwizard.ui \
     firstrunwizard/firstrunwizardpage_welcome.ui \
     firstrunwizard/firstrunwizardpage_workspacepath.ui \
+    firstrunwizard/firstrunwizardpage_workspacesettings.ui \
     projectlibraryupdater/projectlibraryupdater.ui \
 
 # Custom compiler "lrelease" for qm generation

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -28,6 +28,7 @@
 #include <librepcb/common/exceptions.h>
 #include <librepcb/common/network/networkaccessmanager.h>
 #include <librepcb/workspace/workspace.h>
+#include <librepcb/workspace/settings/workspacesettings.h>
 #include "firstrunwizard/firstrunwizard.h"
 #include "controlpanel/controlpanel.h"
 
@@ -238,7 +239,13 @@ static FilePath determineWorkspacePath() noexcept
             wsPath = wizard.getWorkspaceFilePath();
             if (wizard.getCreateNewWorkspace()) {
                 try {
+                    // create new workspace
                     Workspace::createNewWorkspace(wsPath); // can throw
+
+                    // open workspace and apply settings
+                    Workspace ws(wsPath);
+                    ws.getSettings().getUser().setName(wizard.getNewWorkspaceUserName());
+                    ws.getSettings().applyAll(); // can throw
                 } catch (const Exception& e) {
                     QMessageBox::critical(0, Application::translate("Workspace", "Error"),
                                           e.getMsg());

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
@@ -21,7 +21,6 @@
  *  Includes
  ****************************************************************************************/
 #include "newelementwizardcontext.h"
-#include <librepcb/common/systeminfo.h>
 #include <librepcb/library/elements.h>
 #include <librepcb/workspace/workspace.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
@@ -69,7 +68,7 @@ void NewElementWizardContext::reset() noexcept
     mElementName = tl::nullopt;
     mElementDescription.clear();
     mElementKeywords.clear();
-    mElementAuthor = SystemInfo::getFullUsername();
+    mElementAuthor = mWorkspace.getSettings().getUser().getName();
     mElementVersion = Version::fromString("0.1");
     mElementCategoryUuid = tl::nullopt;
 

--- a/libs/librepcb/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/librarymanager/addlibrarywidget.cpp
@@ -25,7 +25,6 @@
 #include "addlibrarywidget.h"
 #include "ui_addlibrarywidget.h"
 #include <librepcb/common/application.h>
-#include <librepcb/common/systeminfo.h>
 #include <librepcb/common/fileio/fileutils.h>
 #include <librepcb/common/network/repository.h>
 #include <librepcb/library/library.h>
@@ -62,7 +61,7 @@ AddLibraryWidget::AddLibraryWidget(workspace::Workspace& ws) noexcept :
 
     // tab "create local library": set placeholder texts
     mUi->edtLocalName->setPlaceholderText("My Library");
-    mUi->edtLocalAuthor->setPlaceholderText(SystemInfo::getFullUsername());
+    mUi->edtLocalAuthor->setPlaceholderText(mWorkspace.getSettings().getUser().getName());
     mUi->edtLocalVersion->setPlaceholderText("0.1");
     mUi->edtLocalUrl->setPlaceholderText(tr("e.g. the URL to the Git repository (optional)"));
     localLibraryNameLineEditTextChanged(mUi->edtLocalName->text());

--- a/libs/librepcb/project/metadata/projectmetadata.cpp
+++ b/libs/librepcb/project/metadata/projectmetadata.cpp
@@ -22,7 +22,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include "projectmetadata.h"
-#include <librepcb/common/systeminfo.h>
 #include <librepcb/common/fileio/smartsexprfile.h>
 #include <librepcb/common/fileio/sexpression.h>
 #include "../project.h"
@@ -53,7 +52,7 @@ ProjectMetadata::ProjectMetadata(Project& project, bool restore, bool readOnly, 
         } catch (const Exception&) {
             // fall back to default name
         }
-        mAuthor = SystemInfo::getFullUsername();
+        mAuthor = tr("Unknown");
         mVersion = "v1";
         mCreated = QDateTime::currentDateTime();
     } else {

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizard.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizard.cpp
@@ -52,7 +52,7 @@ NewProjectWizard::NewProjectWizard(const workspace::Workspace& ws, QWidget* pare
 {
     mUi->setupUi(this);
 
-    addPage(mPageMetadata = new NewProjectWizardPage_Metadata(this));
+    addPage(mPageMetadata = new NewProjectWizardPage_Metadata(mWorkspace, this));
     addPage(mPageInitialization = new NewProjectWizardPage_Initialization(this));
     //addPage(mPageVersionControl = new NewProjectWizardPage_VersionControl(this));
 }

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -25,7 +25,8 @@
 #include "newprojectwizardpage_metadata.h"
 #include "ui_newprojectwizardpage_metadata.h"
 #include <librepcb/common/application.h>
-#include <librepcb/common/systeminfo.h>
+#include <librepcb/workspace/workspace.h>
+#include <librepcb/workspace/settings/workspacesettings.h>
 
 /*****************************************************************************************
  *  Namespace
@@ -38,7 +39,7 @@ namespace editor {
  *  Constructors / Destructor
  ****************************************************************************************/
 
-NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(QWidget *parent) noexcept :
+NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(const workspace::Workspace& ws, QWidget *parent) noexcept :
     QWizardPage(parent), mUi(new Ui::NewProjectWizardPage_Metadata)
 {
     mUi->setupUi(this);
@@ -54,7 +55,7 @@ NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(QWidget *parent) no
             this, &NewProjectWizardPage_Metadata::chooseLocationClicked);
 
     // insert values
-    mUi->edtAuthor->setText(SystemInfo::getFullUsername());
+    mUi->edtAuthor->setText(ws.getSettings().getUser().getName());
     mUi->cbxLicense->addItem(QString("No License (not recommended)"),
                              QString());
     mUi->cbxLicense->addItem(tr("CC0-1.0 (no restrictions, recommended for open hardware projects)"),

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.h
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.h
@@ -32,6 +32,11 @@
  ****************************************************************************************/
 
 namespace librepcb {
+
+namespace workspace {
+class Workspace;
+}
+
 namespace project {
 namespace editor {
 
@@ -56,7 +61,8 @@ class NewProjectWizardPage_Metadata final : public QWizardPage
     public:
 
         // Constructors / Destructor
-        explicit NewProjectWizardPage_Metadata(QWidget* parent = nullptr) noexcept;
+        explicit NewProjectWizardPage_Metadata(const workspace::Workspace& ws,
+                                               QWidget* parent = nullptr) noexcept;
         NewProjectWizardPage_Metadata(const NewProjectWizardPage_Metadata& other) = delete;
         ~NewProjectWizardPage_Metadata() noexcept;
 

--- a/libs/librepcb/workspace/settings/items/wsi_user.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_user.cpp
@@ -1,0 +1,108 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+#include "wsi_user.h"
+#include <librepcb/common/systeminfo.h>
+
+/*****************************************************************************************
+ *  Namespace
+ ****************************************************************************************/
+namespace librepcb {
+namespace workspace {
+
+/*****************************************************************************************
+ *  Constructors / Destructor
+ ****************************************************************************************/
+
+WSI_User::WSI_User(const SExpression& node) :
+    WSI_Base()
+{
+    if (const SExpression* child = node.tryGetChildByPath("user")) {
+        mName = child->getValueOfFirstChild<QString>();
+    } else {
+        // Fallback to system's username if no user name defined. This should actually
+        // only happen once when upgrading older workspace settings.
+        mName = SystemInfo::getFullUsername();
+    }
+
+    // create widget
+    mWidget.reset(new QWidget());
+    QVBoxLayout* layout = new QVBoxLayout(mWidget.data());
+    layout->setContentsMargins(0, 0, 0, 0);
+    mNameEdit.reset(new QLineEdit(mName));
+    mNameEdit->setMaxLength(100);
+    mNameEdit->setPlaceholderText(tr("e.g. \"John Doe\""));
+    layout->addWidget(mNameEdit.data());
+    layout->addWidget(new QLabel(tr("This name will be used as author when creating new "
+                                    "projects or libraries.")));
+}
+
+WSI_User::~WSI_User() noexcept
+{
+}
+
+/*****************************************************************************************
+ * Direct Access
+ ****************************************************************************************/
+
+void WSI_User::setName(const QString& name) noexcept
+{
+    mName = name;
+    mNameEdit->setText(name);
+}
+
+/*****************************************************************************************
+ *  General Methods
+ ****************************************************************************************/
+
+void WSI_User::restoreDefault() noexcept
+{
+    mNameEdit->setText(SystemInfo::getFullUsername());
+}
+
+void WSI_User::apply() noexcept
+{
+    mName = mNameEdit->text();
+}
+
+void WSI_User::revert() noexcept
+{
+    mNameEdit->setText(mName);
+}
+
+/*****************************************************************************************
+ *  Private Methods
+ ****************************************************************************************/
+
+void WSI_User::serialize(SExpression& root) const
+{
+    root.appendChild("user", mName, true);
+}
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace workspace
+} // namespace librepcb

--- a/libs/librepcb/workspace/settings/items/wsi_user.h
+++ b/libs/librepcb/workspace/settings/items/wsi_user.h
@@ -1,0 +1,88 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * http://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_WORKSPACE_WSI_USER_H
+#define LIBREPCB_WORKSPACE_WSI_USER_H
+
+/*****************************************************************************************
+ *  Includes
+ ****************************************************************************************/
+#include "wsi_base.h"
+
+/*****************************************************************************************
+ *  Namespace / Forward Declarations
+ ****************************************************************************************/
+namespace librepcb {
+namespace workspace {
+
+/*****************************************************************************************
+ *  Class WSI_User
+ ****************************************************************************************/
+
+/**
+ * @brief The WSI_User class contains the default author used for projects and libraries
+ */
+class WSI_User final : public WSI_Base
+{
+        Q_OBJECT
+
+    public:
+
+        // Constructors / Destructor
+        WSI_User() = delete;
+        WSI_User(const WSI_User& other) = delete;
+        explicit WSI_User(const SExpression& node);
+        ~WSI_User() noexcept;
+
+        // Direct Access
+        void setName(const QString& name) noexcept;
+        const QString& getName() const noexcept {return mName;}
+
+        // Getters: Widgets
+        QString getLabelText() const noexcept {return tr("User Name:");}
+        QWidget* getWidget() const noexcept {return mWidget.data();}
+
+        // General Methods
+        void restoreDefault() noexcept override;
+        void apply() noexcept override;
+        void revert() noexcept override;
+
+        /// @copydoc librepcb::SerializableObject::serialize()
+        void serialize(SExpression& root) const override;
+
+        // Operator Overloadings
+        WSI_User& operator=(const WSI_User& rhs) = delete;
+
+
+    private: // Data
+        QString mName;
+
+        // Widgets
+        QScopedPointer<QWidget> mWidget;
+        QScopedPointer<QLineEdit> mNameEdit;
+};
+
+/*****************************************************************************************
+ *  End of File
+ ****************************************************************************************/
+
+} // namespace workspace
+} // namespace librepcb
+
+#endif // LIBREPCB_WORKSPACE_WSI_USER_H

--- a/libs/librepcb/workspace/settings/workspacesettings.cpp
+++ b/libs/librepcb/workspace/settings/workspacesettings.cpp
@@ -53,6 +53,7 @@ WorkspaceSettings::WorkspaceSettings(const Workspace& workspace) :
     }
 
     // load all settings
+    loadSettingsItem(mUser,                     root);
     loadSettingsItem(mAppLocale,                root);
     loadSettingsItem(mAppDefMeasUnits,          root);
     loadSettingsItem(mProjectAutosaveInterval,  root);

--- a/libs/librepcb/workspace/settings/workspacesettings.h
+++ b/libs/librepcb/workspace/settings/workspacesettings.h
@@ -36,6 +36,7 @@
 #include "items/wsi_debugtools.h"
 #include "items/wsi_appearance.h"
 #include "items/wsi_repositories.h"
+#include "items/wsi_user.h"
 
 /*****************************************************************************************
  *  Namespace / Forward Declarations
@@ -78,6 +79,7 @@ class WorkspaceSettings final : public QObject, public SerializableObject
 
 
         // Getters: Settings Items
+        WSI_User& getUser() const noexcept {return *mUser;}
         WSI_AppLocale& getAppLocale() const noexcept {return *mAppLocale;}
         WSI_AppDefaultMeasurementUnits& getAppDefMeasUnits() const noexcept {return *mAppDefMeasUnits;}
         WSI_ProjectAutosaveInterval& getProjectAutosaveInterval() const noexcept {return *mProjectAutosaveInterval;}
@@ -125,6 +127,7 @@ class WorkspaceSettings final : public QObject, public SerializableObject
 
         // Settings Items
         QList<WSI_Base*> mItems; ///< contains all settings items
+        QScopedPointer<WSI_User> mUser;
         QScopedPointer<WSI_AppLocale> mAppLocale;
         QScopedPointer<WSI_AppDefaultMeasurementUnits> mAppDefMeasUnits;
         QScopedPointer<WSI_ProjectAutosaveInterval> mProjectAutosaveInterval;

--- a/libs/librepcb/workspace/settings/workspacesettingsdialog.cpp
+++ b/libs/librepcb/workspace/settings/workspacesettingsdialog.cpp
@@ -45,6 +45,8 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(WorkspaceSettings& settings) :
     // Add all settings widgets
 
     // tab: general
+    mUi->generalLayout->addRow(mSettings.getUser().getLabelText(),
+                               mSettings.getUser().getWidget());
     mUi->generalLayout->addRow(mSettings.getAppLocale().getLabelText(),
                                mSettings.getAppLocale().getWidget());
     mUi->generalLayout->addRow(mSettings.getAppDefMeasUnits().getLengthUnitLabelText(),
@@ -85,6 +87,7 @@ WorkspaceSettingsDialog::~WorkspaceSettingsDialog()
     // Remove all settings widgets from the dialog (important for memory management!)
 
     // tab: general
+    mSettings.getUser().getWidget()->setParent(0);
     mSettings.getAppLocale().getWidget()->setParent(0);
     mSettings.getAppDefMeasUnits().getLengthUnitComboBox()->setParent(0);
     mSettings.getProjectAutosaveInterval().getWidget()->setParent(0);

--- a/libs/librepcb/workspace/workspace.pro
+++ b/libs/librepcb/workspace/workspace.pro
@@ -37,6 +37,7 @@ SOURCES += \
     settings/items/wsi_librarynormorder.cpp \
     settings/items/wsi_projectautosaveinterval.cpp \
     settings/items/wsi_repositories.cpp \
+    settings/items/wsi_user.cpp \
     settings/workspacesettings.cpp \
     settings/workspacesettingsdialog.cpp \
     workspace.cpp \
@@ -59,6 +60,7 @@ HEADERS += \
     settings/items/wsi_librarynormorder.h \
     settings/items/wsi_projectautosaveinterval.h \
     settings/items/wsi_repositories.h \
+    settings/items/wsi_user.h \
     settings/workspacesettings.h \
     settings/workspacesettingsdialog.h \
     workspace.h \

--- a/tests/unittests/project/projecttest.cpp
+++ b/tests/unittests/project/projecttest.cpp
@@ -22,7 +22,6 @@
  ****************************************************************************************/
 #include <QtCore>
 #include <gtest/gtest.h>
-#include <librepcb/common/systeminfo.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/metadata/projectmetadata.h>
 
@@ -69,7 +68,7 @@ TEST_F(ProjectTest, testCreateCloseOpen)
     EXPECT_FALSE(project->isReadOnly());
     EXPECT_FALSE(project->isRestored());
     EXPECT_EQ(mProjectFile.getCompleteBasename(), project->getMetadata().getName());
-    EXPECT_EQ(SystemInfo::getFullUsername(), project->getMetadata().getAuthor());
+    EXPECT_EQ("Unknown", project->getMetadata().getAuthor());
     EXPECT_EQ(QString("v1"), project->getMetadata().getVersion());
     EXPECT_NEAR(datetime.toMSecsSinceEpoch(),
                 project->getMetadata().getCreated().toMSecsSinceEpoch(), 5000);
@@ -98,7 +97,7 @@ TEST_F(ProjectTest, testCreateCloseOpen)
     EXPECT_FALSE(project->isReadOnly());
     EXPECT_FALSE(project->isRestored());
     EXPECT_EQ(mProjectFile.getCompleteBasename(), project->getMetadata().getName());
-    EXPECT_EQ(SystemInfo::getFullUsername(), project->getMetadata().getAuthor());
+    EXPECT_EQ("Unknown", project->getMetadata().getAuthor());
     EXPECT_EQ(QString("v1"), project->getMetadata().getVersion());
     EXPECT_NEAR(datetime.toMSecsSinceEpoch(),
                 project->getMetadata().getCreated().toMSecsSinceEpoch(), 5000);


### PR DESCRIPTION
See #322 and https://github.com/LibrePCB/librepcb-rfcs/issues/22.

New page in first run wizard:
![grafik](https://user-images.githubusercontent.com/5374821/45156729-48159f00-b1df-11e8-8ae2-c355858a20ca.png)

New entry in workspace settings dialog:
![grafik](https://user-images.githubusercontent.com/5374821/45156770-6b404e80-b1df-11e8-94c3-a70588223be2.png)

Fixes #322.