### PR TITLE
Remove submodule "dev/demo-workspace"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "dev/demo-workspace"]
-	path = dev/demo-workspace
-	url = https://github.com/LibrePCB/demo-workspace.git
 [submodule "libs/hoedown"]
 	path = libs/hoedown
 	url = https://github.com/LibrePCB/hoedown.git

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ On a Unix/Linux system, LibrePCB can be installed with `sudo make install`.
 
 At the first startup, LibrePCB asks for a workspace directory where the library
 elements and projects are located. For developers there is a demo workspace
-inclusive some libraries and projects in the submodule
-[`dev/demo-workspace/`](https://github.com/LibrePCB/demo-workspace).
+inclusive some libraries and projects (useful for testing purposes) at
+[LibrePCB/demo-workspace](https://github.com/LibrePCB/demo-workspace).
 
 
 ## Credits

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -11,6 +11,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
 RUN git clone --recursive https://github.com/LibrePCB/LibrePCB.git /opt/LibrePCB \
   && cd /opt/LibrePCB
 
+# checkout demo workspace
+RUN git clone --recursive https://github.com/LibrePCB/demo-workspace.git /librepcb-workspace
+
 # build and install librepcb
 RUN /opt/LibrePCB/dev/docker/make_librepcb.sh
 

--- a/dev/docker/LibrePCB.conf
+++ b/dev/docker/LibrePCB.conf
@@ -1,2 +1,2 @@
 [workspaces]
-most_recently_used=/opt/LibrePCB/dev/demo-workspace
+most_recently_used=/librepcb-workspace


### PR DESCRIPTION
As the file format is getting more and more stable, I think we don't need it anymore as a submodule. If still needed for testing purposes, it could be cloned separately.