### PR TITLE
Doxygen: Add translation guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ This project welcomes non-code contributions, too! The following types of contri
 - **Translations**: Add/improve translations for LibrePCB using
   [Transifex](https://www.transifex.com/librepcb/librepcb-application/dashboard/).
   Follow [this guide](https://docs.transifex.com/getting-started/translators) to
-  get started.
+  get started. Please also observe our [translation guidelines](https://developers.librepcb.org/db/d3b/doc_translations.html).
 - **Website**: Improve our [website](http://librepcb.org) which is hosted in the repository [LibrePCB/LibrePCB.github.io](https://github.com/LibrePCB/LibrePCB.github.io).
 - **Sharing**: Speak about LibrePCB with your friends and colleagues, or write about it in the internet!
 - **Donations**: [Become a Patron](https://www.patreon.com/librepcb)

--- a/dev/doxygen/pages/mainpage.md
+++ b/dev/doxygen/pages/mainpage.md
@@ -15,6 +15,7 @@ LibrePCB Developers Documentation {#mainpage}
 - @ref doc_project
 - @ref doc_repository
 - @ref doc_server_api
+- @ref doc_translations
 
 
 # Related Pages {#doc_main_related_pages}

--- a/dev/doxygen/pages/translations.md
+++ b/dev/doxygen/pages/translations.md
@@ -1,9 +1,9 @@
 Translation Guidelines {#doc_translations}
-========================================
+==========================================
 
 [TOC]
 
-# Key Terms {#doc_versioning_file}
+# Key Terms {#doc_translations_terms}
 
 For consistent translations, certain LibrePCB specific terms (like "package" or
 "device") should always be translated in the same way.
@@ -15,8 +15,8 @@ For consistent translations, certain LibrePCB specific terms (like "package" or
 - Symbol Variant: Symbol-Variante
 - Signal: Signal
 - Component: Komponente
-- Device: ??
-- Part: ??
+- Device: Bauteil
+- Part: Typ
 - Package: Gehäuse
 - Pad: Pad
 - Footprint: Footprint

--- a/dev/doxygen/pages/translations.md
+++ b/dev/doxygen/pages/translations.md
@@ -1,0 +1,22 @@
+Translation Guidelines {#doc_translations}
+========================================
+
+[TOC]
+
+# Key Terms {#doc_versioning_file}
+
+For consistent translations, certain LibrePCB specific terms (like "package" or
+"device") should always be translated in the same way.
+
+## DE
+
+- Pin: Pin
+- Symbol: Symbol
+- Symbol Variant: Symbol-Variante
+- Signal: Signal
+- Component: Komponente
+- Device: ??
+- Part: ??
+- Package: Gehäuse
+- Pad: Pad
+- Footprint: Footprint

--- a/dev/doxygen/pages/translations.md
+++ b/dev/doxygen/pages/translations.md
@@ -8,15 +8,14 @@ Translation Guidelines {#doc_translations}
 For consistent translations, certain LibrePCB specific terms (like "package" or
 "device") should always be translated in the same way.
 
-## DE
-
-- Pin: Pin
-- Symbol: Symbol
-- Symbol Variant: Symbol-Variante
-- Signal: Signal
-- Component: Komponente
-- Device: Bauteil
-- Part: Typ
-- Package: Gehäuse
-- Pad: Pad
-- Footprint: Footprint
+| **EN** | DE |
+|--------|----|
+| **Pin** | Pin |
+| **Symbol** | Symbol |
+| **Symbol Variant** | Symbol-Variante |
+| **Component** | Komponente |
+| **Device** | Bauteil |
+| **Part** | Typ |
+| **Package** | Gehäuse |
+| **Pad** | Pad |
+| **Footprint** | Footprint |

--- a/dev/doxygen/pages/translations.md
+++ b/dev/doxygen/pages/translations.md
@@ -19,3 +19,9 @@ For consistent translations, certain LibrePCB specific terms (like "package" or
 | **Package** | Gehäuse |
 | **Pad** | Pad |
 | **Footprint** | Footprint |
+| **Workspace** | Workspace |
+| **Project** | Projekt |
+| **Library** | Library |
+| **Schematic** | Schema |
+| **Board** | Board |
+| **Attribute** | Attribut |


### PR DESCRIPTION
We need some kind of translation guidelines, especially for translating key terms.

I added such a page (still very basic), with a suggestion of some terms in German. I haven't found a word for all of them, and left some in English (since that seems to be how the words are being used).

PS: There are still a few links in CONTRIBUTING.md that need their URL updated to the new `developers` subdomain.