### PR TITLE
AppVeyor: Use ccache to speed up builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,19 @@ deploy: off
 
 environment:
   global:
+    CC: "ccache gcc"
+    CXX: "ccache g++"
     MINGW: C:/Qt/Tools/mingw530_32
     QTDIR: C:/Qt/5.9/mingw53_32
     QTIFWDIR: C:/Qt/QtIFW-3.0.1
     VCRT_DIR: 'C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/Redist/x86/Microsoft.VC120.CRT'
     DEPLOY_INSTALLER: true
 
+cache:
+  - C:/msys64/home/appveyor/.ccache
+
 init:
-  - set PATH=%QTDIR%/bin;%MINGW%/bin;C:/Qt/Tools/QtCreator/bin;%QTIFWDIR%/bin;C:/msys64/bin;C:/msys64/usr/bin;%PATH%
+  - set PATH=%QTDIR%/bin;%MINGW%/bin;C:/Qt/Tools/QtCreator/bin;%QTIFWDIR%/bin;C:/msys64/bin;C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
 
 install:
   - git submodule update --init --recursive

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -66,7 +66,9 @@ then
 elif [ -n "${APPVEYOR-}" ]
 then
 
-  pacman -Sy --noconfirm --needed openssl
+  # MSYS2 packages
+  pacman -Sy --noconfirm --needed openssl mingw-w64-x86_64-ccache
+  ccache -s
 
   # python packages
   pip install future


### PR DESCRIPTION
Unfortunately there are no official `ccache` binaries available, and building from source fails on Windows. Anyone interested in providing trustworthy binaries? If not, I'll use some random, unofficial binaries ;)

`ccache` reduces our AppVeyor build time from ~30min to ~10min!