### PR TITLE
Hide UUIDs in many windows and dialogs

### DIFF
--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.cpp
@@ -64,10 +64,6 @@ ComponentEditorWidget::ComponentEditorWidget(const Context&  context,
   // load component
   mComponent.reset(new Component(fp, false));  // can throw
   setWindowTitle(*mComponent->getNames().value(getLibLocaleOrder()));
-  mUi->lblUuid->setText(QString("<a href=\"%1\">%2</a>")
-                            .arg(mComponent->getFilePath().toQUrl().toString(),
-                                 mComponent->getUuid().toStr()));
-  mUi->lblUuid->setToolTip(mComponent->getFilePath().toNative());
   mUi->edtName->setText(*mComponent->getNames().value(getLibLocaleOrder()));
   mUi->edtDescription->setPlainText(
       mComponent->getDescriptions().value(getLibLocaleOrder()));

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
@@ -191,40 +191,20 @@
         <number>9</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>UUID:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="lblUuid">
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Name:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="0" column="1">
         <widget class="QLineEdit" name="edtName">
          <property name="maxLength">
           <number>50</number>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Description:</string>
@@ -234,66 +214,66 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="1" column="1">
         <widget class="QPlainTextEdit" name="edtDescription"/>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Keywords:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="edtKeywords">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Author:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QLineEdit" name="edtAuthor">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Version:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="edtVersion">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Deprecated:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <widget class="QCheckBox" name="cbxDeprecated">
          <property name="text">
           <string>Component should no longer be used.</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="lblCategories">
          <property name="text">
           <string>Categories:</string>
@@ -303,42 +283,42 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0" colspan="2">
+       <item row="7" column="0" colspan="2">
         <widget class="Line" name="line">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Schematic-Only:</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="8" column="1">
         <widget class="QCheckBox" name="cbxSchematicOnly">
          <property name="text">
           <string>Component cannot be used in devices.</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_11">
          <property name="text">
           <string>Prefix:</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="9" column="1">
         <widget class="QLineEdit" name="edtPrefix">
          <property name="maxLength">
           <number>10</number>
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Default Value:</string>
@@ -348,7 +328,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="10" column="1">
         <widget class="QPlainTextEdit" name="edtDefaultValue"/>
        </item>
       </layout>

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
@@ -27,6 +27,8 @@
 
 #include <librepcb/common/exceptions.h>
 #include <librepcb/common/fileio/filepath.h>
+#include <librepcb/common/uuid.h>
+#include <optional/tl/optional.hpp>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -78,12 +80,14 @@ public slots:
 private:  // Methods
   bool isInterfaceBroken() const noexcept override { return false; }
   void btnChooseParentCategoryClicked() noexcept;
+  void btnResetParentCategoryClicked() noexcept;
   void edtnameTextChanged(const QString& text) noexcept;
-  void edtParentTextChanged(const QString& text) noexcept;
+  void updateCategoryLabel() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::ComponentCategoryEditorWidget> mUi;
   QScopedPointer<ComponentCategory>                 mCategory;
+  tl::optional<Uuid>                                mParentUuid;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
@@ -27,40 +27,20 @@
     <number>3</number>
    </property>
    <item row="0" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>UUID:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="lblUuid">
-     <property name="text">
-      <string notr="true">TextLabel</string>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Name:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="0" column="1">
     <widget class="QLineEdit" name="edtName">
      <property name="maxLength">
       <number>50</number>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Description:</string>
@@ -70,89 +50,102 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="1" column="1">
     <widget class="QPlainTextEdit" name="edtDescription"/>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
       <string>Keywords:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="2" column="1">
     <widget class="QLineEdit" name="edtKeywords">
      <property name="maxLength">
       <number>100</number>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Author:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="3" column="1">
     <widget class="QLineEdit" name="edtAuthor">
      <property name="maxLength">
       <number>100</number>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>Version:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="4" column="1">
     <widget class="QLineEdit" name="edtVersion">
      <property name="maxLength">
       <number>100</number>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label_10">
      <property name="text">
       <string>Deprecated:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="5" column="1">
     <widget class="QCheckBox" name="cbxDeprecated">
      <property name="text">
       <string>Category should no longer be used.</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="6" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Parent:</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>0</number>
      </property>
      <item>
-      <widget class="QLineEdit" name="edtParent">
-       <property name="maxLength">
-        <number>100</number>
+      <widget class="QLabel" name="lblParentCategories">
+       <property name="text">
+        <string notr="true">Parent Tree...</string>
        </property>
-       <property name="clearButtonEnabled">
+       <property name="wordWrap">
         <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="btnChooseParentCategory">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>25</width>
@@ -162,38 +155,55 @@
        <property name="maximumSize">
         <size>
          <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Choose category</string>
+       </property>
+       <property name="text">
+        <string notr="true">...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnResetParentCategory">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
          <height>25</height>
         </size>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Reset</string>
+       </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../img/images.qrc">
+         <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="9" column="1">
-    <widget class="QLabel" name="lblParentCategories">
-     <property name="text">
-      <string>Parent Tree...</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../../img/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
@@ -158,7 +158,6 @@ void ComponentChooserDialog::setSelectedComponent(
     }
   }
 
-  mUi->lblComponentUuid->setText(uuidStr);
   mUi->lblComponentName->setText(name);
   mUi->lblComponentDescription->setText(desc);
   updatePreview();

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.ui
@@ -57,29 +57,14 @@
           </font>
          </property>
          <property name="text">
-          <string>Name</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="lblComponentUuid">
-         <property name="font">
-          <font>
-           <family>Liberation Mono</family>
-          </font>
-         </property>
-         <property name="text">
-          <string notr="true">00000000-0000-0000-0000-000000000000</string>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          <string notr="true">Name</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLabel" name="lblComponentDescription">
          <property name="text">
-          <string>Description</string>
+          <string notr="true">Description</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
@@ -159,7 +159,6 @@ void PackageChooserDialog::setSelectedPackage(
     }
   }
 
-  mUi->lblPackageUuid->setText(uuidStr);
   mUi->lblPackageName->setText(name);
   mUi->lblPackageDescription->setText(desc);
   updatePreview();

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.ui
@@ -57,29 +57,14 @@
           </font>
          </property>
          <property name="text">
-          <string>Name</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="lblPackageUuid">
-         <property name="font">
-          <font>
-           <family>Liberation Mono</family>
-          </font>
-         </property>
-         <property name="text">
-          <string notr="true">00000000-0000-0000-0000-000000000000</string>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          <string notr="true">Name</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLabel" name="lblPackageDescription">
          <property name="text">
-          <string>Description</string>
+          <string notr="true">Description</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.cpp
@@ -159,7 +159,6 @@ void SymbolChooserDialog::setSelectedCategory(
 void SymbolChooserDialog::setSelectedSymbol(const FilePath& fp) noexcept {
   if (mSelectedSymbol && (mSelectedSymbol->getFilePath() == fp)) return;
 
-  mUi->lblSymbolUuid->setText("00000000-0000-0000-0000-000000000000");
   mUi->lblSymbolName->setText(tr("No symbol selected"));
   mUi->lblSymbolDescription->setText("");
   mGraphicsItem.reset();
@@ -168,7 +167,6 @@ void SymbolChooserDialog::setSelectedSymbol(const FilePath& fp) noexcept {
   if (fp.isValid()) {
     try {
       mSelectedSymbol.reset(new Symbol(fp, true));  // can throw
-      mUi->lblSymbolUuid->setText(mSelectedSymbol->getUuid().toStr());
       mUi->lblSymbolName->setText(
           *mSelectedSymbol->getNames().value(localeOrder()));
       mUi->lblSymbolDescription->setText(

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.ui
@@ -57,29 +57,14 @@
           </font>
          </property>
          <property name="text">
-          <string>Name</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="lblSymbolUuid">
-         <property name="font">
-          <font>
-           <family>Liberation Mono</family>
-          </font>
-         </property>
-         <property name="text">
-          <string notr="true">00000000-0000-0000-0000-000000000000</string>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          <string notr="true">Name</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLabel" name="lblSymbolDescription">
          <property name="text">
-          <string>Description</string>
+          <string notr="true">Description</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.cpp
@@ -80,10 +80,6 @@ DeviceEditorWidget::DeviceEditorWidget(const Context&  context,
 
   mDevice.reset(new Device(fp, false));  // can throw
   setWindowTitle(*mDevice->getNames().value(getLibLocaleOrder()));
-  mUi->lblUuid->setText(QString("<a href=\"%1\">%2</a>")
-                            .arg(mDevice->getFilePath().toQUrl().toString(),
-                                 mDevice->getUuid().toStr()));
-  mUi->lblUuid->setToolTip(mDevice->getFilePath().toNative());
   mUi->edtName->setText(*mDevice->getNames().value(getLibLocaleOrder()));
   mUi->edtDescription->setPlainText(
       mDevice->getDescriptions().value(getLibLocaleOrder()));
@@ -267,7 +263,6 @@ void DeviceEditorWidget::btnChoosePackageClicked() noexcept {
 void DeviceEditorWidget::updateDeviceComponentUuid(const Uuid& uuid) noexcept {
   mSymbolGraphicsItems.clear();
   mSymbols.clear();
-  mUi->lblComponentUuid->setText(uuid.toStr());
   try {
     FilePath fp = mContext.workspace.getLibraryDb().getLatestComponent(
         uuid);  // can throw
@@ -278,11 +273,14 @@ void DeviceEditorWidget::updateDeviceComponentUuid(const Uuid& uuid) noexcept {
     mUi->padSignalMapEditorWidget->setSignalList(mComponent->getSignals());
     mUi->lblComponentName->setText(
         *mComponent->getNames().value(getLibLocaleOrder()));
+    mUi->lblComponentName->setToolTip(
+        mComponent->getDescriptions().value(getLibLocaleOrder()));
     mUi->lblComponentName->setStyleSheet("");
     updateComponentPreview();
   } catch (const Exception& e) {
     mUi->padSignalMapEditorWidget->setSignalList(ComponentSignalList());
     mUi->lblComponentName->setText(e.getMsg());
+    mUi->lblComponentName->setToolTip(QString());
     mUi->lblComponentName->setStyleSheet("color: red;");
   }
 }
@@ -316,7 +314,6 @@ void DeviceEditorWidget::updateComponentPreview() noexcept {
 
 void DeviceEditorWidget::updateDevicePackageUuid(const Uuid& uuid) noexcept {
   mFootprintGraphicsItem.reset();
-  mUi->lblPackageUuid->setText(uuid.toStr());
   try {
     FilePath fp =
         mContext.workspace.getLibraryDb().getLatestPackage(uuid);  // can throw
@@ -327,11 +324,14 @@ void DeviceEditorWidget::updateDevicePackageUuid(const Uuid& uuid) noexcept {
     mUi->padSignalMapEditorWidget->setPadList(mPackage->getPads());
     mUi->lblPackageName->setText(
         *mPackage->getNames().value(getLibLocaleOrder()));
+    mUi->lblPackageName->setToolTip(
+        mPackage->getDescriptions().value(getLibLocaleOrder()));
     mUi->lblPackageName->setStyleSheet("");
     updatePackagePreview();
   } catch (const Exception& e) {
     mUi->padSignalMapEditorWidget->setPadList(PackagePadList());
     mUi->lblPackageName->setText(e.getMsg());
+    mUi->lblPackageName->setToolTip(QString());
     mUi->lblPackageName->setStyleSheet("color: red;");
   }
 }

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
@@ -91,32 +91,24 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="lblPackageName">
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string notr="true">TextLabel</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="0" rowspan="2">
              <widget class="QToolButton" name="btnChoosePackage">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
               <property name="minimumSize">
                <size>
-                <width>30</width>
-                <height>0</height>
+                <width>28</width>
+                <height>28</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>25</width>
+                <height>25</height>
                </size>
               </property>
               <property name="text">
@@ -128,19 +120,23 @@
               </property>
               <property name="iconSize">
                <size>
-                <width>32</width>
-                <height>32</height>
+                <width>25</width>
+                <height>25</height>
                </size>
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="lblPackageUuid">
+            <item row="0" column="1" rowspan="2">
+             <widget class="QLabel" name="lblPackageName">
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
               <property name="text">
                <string notr="true">TextLabel</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -178,42 +174,24 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="lblComponentName">
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string notr="true">TextLabel</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="lblComponentUuid">
-              <property name="text">
-               <string notr="true">TextLabel</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="0" rowspan="2">
              <widget class="QToolButton" name="btnChooseComponent">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
               <property name="minimumSize">
                <size>
-                <width>30</width>
-                <height>0</height>
+                <width>28</width>
+                <height>28</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>25</width>
+                <height>25</height>
                </size>
               </property>
               <property name="text">
@@ -225,9 +203,23 @@
               </property>
               <property name="iconSize">
                <size>
-                <width>32</width>
-                <height>32</height>
+                <width>25</width>
+                <height>25</height>
                </size>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1" rowspan="2">
+             <widget class="QLabel" name="lblComponentName">
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string notr="true">TextLabel</string>
               </property>
              </widget>
             </item>
@@ -293,40 +285,20 @@
         <number>9</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>UUID:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="lblUuid">
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Name:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="0" column="1">
         <widget class="QLineEdit" name="edtName">
          <property name="maxLength">
           <number>50</number>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Description:</string>
@@ -336,66 +308,66 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="1" column="1">
         <widget class="QPlainTextEdit" name="edtDescription"/>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Keywords:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="edtKeywords">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Author:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QLineEdit" name="edtAuthor">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Version:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="edtVersion">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Deprecated:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <widget class="QCheckBox" name="cbxDeprecated">
          <property name="text">
           <string>Device should no longer be used.</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="lblCategories">
          <property name="text">
           <string>Categories:</string>

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
@@ -56,7 +56,7 @@ LibraryListEditorWidget::LibraryListEditorWidget(const workspace::Workspace& ws,
   QList<QSharedPointer<library::Library>> libs;
   libs.append(mWorkspace.getLocalLibraries().values());
   libs.append(mWorkspace.getRemoteLibraries().values());
-  mUi->comboBox->addItem(tr("Enter Library UUID..."));
+  mUi->comboBox->addItem(tr("Choose library..."));
   foreach (const QSharedPointer<library::Library>& lib, libs) {
     mUi->comboBox->addItem(lib->getIcon(), *lib->getNames().value(localeOrder),
                            lib->getUuid().toStr());

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -64,7 +64,6 @@ LibraryOverviewWidget::LibraryOverviewWidget(const Context&          context,
   mUi->formLayout->setWidget(row, QFormLayout::FieldRole,
                              mDependenciesEditorWidget.data());
 
-  mUi->lblUuid->setText(mLibrary->getUuid().toStr());
   mUi->edtName->setText(*mLibrary->getNames().value(getLibLocaleOrder()));
   mUi->edtDescription->setPlainText(
       mLibrary->getDescriptions().value(getLibLocaleOrder()));

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
@@ -304,37 +304,20 @@
         </widget>
        </item>
        <item row="2" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>UUID:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLabel" name="lblUuid">
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Name:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="edtName">
          <property name="maxLength">
           <number>50</number>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Description:</string>
@@ -344,87 +327,87 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QPlainTextEdit" name="edtDescription"/>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Keywords:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="edtKeywords">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Author:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <widget class="QLineEdit" name="edtAuthor">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Version:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="6" column="1">
         <widget class="QLineEdit" name="edtVersion">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Deprecated:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="7" column="1">
         <widget class="QCheckBox" name="cbxDeprecated">
          <property name="text">
           <string>Library should no longer be used.</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="0" colspan="2">
+       <item row="8" column="0" colspan="2">
         <widget class="Line" name="line_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>URL:</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="9" column="1">
         <widget class="QLineEdit" name="edtUrl">
          <property name="maxLength">
           <number>255</number>
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="lblDependencies">
          <property name="text">
           <string>Dependencies:</string>

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -73,6 +73,8 @@ LibraryEditor::LibraryEditor(workspace::Workspace&   ws,
           &LibraryEditor::saveTriggered);
   connect(mUi->actionRemoveElement, &QAction::triggered, this,
           &LibraryEditor::removeElementTriggered);
+  connect(mUi->actionShowElementInFileManager, &QAction::triggered, this,
+          &LibraryEditor::showElementInFileExplorerTriggered);
   connect(mUi->actionUpdateLibraryDb, &QAction::triggered,
           &mWorkspace.getLibraryDb(),
           &workspace::WorkspaceLibraryDb::startLibraryRescan);
@@ -375,6 +377,12 @@ void LibraryEditor::removeElementTriggered() noexcept {
     }
     mWorkspace.getLibraryDb().startLibraryRescan();
   }
+}
+
+void LibraryEditor::showElementInFileExplorerTriggered() noexcept {
+  if (!mCurrentEditorWidget) return;
+  FilePath fp = mCurrentEditorWidget->getFilePath();
+  QDesktopServices::openUrl(fp.toQUrl());
 }
 
 void LibraryEditor::rotateCwTriggered() noexcept {

--- a/libs/librepcb/libraryeditor/libraryeditor.h
+++ b/libs/librepcb/libraryeditor/libraryeditor.h
@@ -130,6 +130,7 @@ private:  // GUI Event Handlers
   void newElementTriggered() noexcept;
   void saveTriggered() noexcept;
   void removeElementTriggered() noexcept;
+  void showElementInFileExplorerTriggered() noexcept;
   void rotateCwTriggered() noexcept;
   void rotateCcwTriggered() noexcept;
   void removeTriggered() noexcept;

--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -86,6 +86,7 @@
     <addaction name="actionNew"/>
     <addaction name="actionSave"/>
     <addaction name="actionRemoveElement"/>
+    <addaction name="actionShowElementInFileManager"/>
     <addaction name="separator"/>
     <addaction name="actionUpdateLibraryDb"/>
     <addaction name="separator"/>
@@ -592,6 +593,15 @@
    </property>
    <property name="text">
     <string>Add Value</string>
+   </property>
+  </action>
+  <action name="actionShowElementInFileManager">
+   <property name="icon">
+    <iconset resource="../../../img/images.qrc">
+     <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
+   </property>
+   <property name="text">
+    <string>Show element in file manager</string>
    </property>
   </action>
  </widget>

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.cpp
@@ -47,10 +47,6 @@ NewElementWizardPage_DeviceProperties::NewElementWizardPage_DeviceProperties(
     mContext(context),
     mUi(new Ui::NewElementWizardPage_DeviceProperties) {
   mUi->setupUi(this);
-  connect(mUi->edtComponentUuid, &QLineEdit::textChanged, this,
-          &NewElementWizardPage_DeviceProperties::edtComponentUuidTextChanged);
-  connect(mUi->edtPackageUuid, &QLineEdit::textChanged, this,
-          &NewElementWizardPage_DeviceProperties::edtPackageUuidTextChanged);
   connect(mUi->btnChooseComponent, &QToolButton::clicked, this,
           &NewElementWizardPage_DeviceProperties::btnChooseComponentClicked);
   connect(mUi->btnChoosePackage, &QToolButton::clicked, this,
@@ -79,23 +75,13 @@ int NewElementWizardPage_DeviceProperties::nextId() const noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void NewElementWizardPage_DeviceProperties::edtComponentUuidTextChanged(
-    const QString& text) noexcept {
-  setComponent(Uuid::tryFromString(text.trimmed()));
-}
-
-void NewElementWizardPage_DeviceProperties::edtPackageUuidTextChanged(
-    const QString& text) noexcept {
-  setPackage(Uuid::tryFromString(text.trimmed()));
-}
-
 void NewElementWizardPage_DeviceProperties::
     btnChooseComponentClicked() noexcept {
   ComponentChooserDialog dialog(mContext.getWorkspace(),
                                 &mContext.getLayerProvider(), this);
   if (dialog.exec() == QDialog::Accepted) {
     tl::optional<Uuid> uuid = dialog.getSelectedComponentUuid();
-    mUi->edtComponentUuid->setText(uuid ? uuid->toStr() : QString());
+    setComponent(uuid);
   }
 }
 
@@ -104,7 +90,7 @@ void NewElementWizardPage_DeviceProperties::btnChoosePackageClicked() noexcept {
                               &mContext.getLayerProvider(), this);
   if (dialog.exec() == QDialog::Accepted) {
     tl::optional<Uuid> uuid = dialog.getSelectedPackageUuid();
-    mUi->edtPackageUuid->setText(uuid ? uuid->toStr() : QString());
+    setPackage(uuid);
   }
 }
 
@@ -159,12 +145,6 @@ void NewElementWizardPage_DeviceProperties::setPackage(
 
 void NewElementWizardPage_DeviceProperties::initializePage() noexcept {
   QWizardPage::initializePage();
-  mUi->edtComponentUuid->setText(mContext.mDeviceComponentUuid
-                                     ? mContext.mDeviceComponentUuid->toStr()
-                                     : QString());
-  mUi->edtPackageUuid->setText(mContext.mDevicePackageUuid
-                                   ? mContext.mDevicePackageUuid->toStr()
-                                   : QString());
   setComponent(mContext.mDeviceComponentUuid);
   setPackage(mContext.mDevicePackageUuid);
 }

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.h
@@ -70,8 +70,6 @@ public:
       const NewElementWizardPage_DeviceProperties& rhs) = delete;
 
 private:  // Methods
-  void edtComponentUuidTextChanged(const QString& text) noexcept;
-  void edtPackageUuidTextChanged(const QString& text) noexcept;
   void btnChooseComponentClicked() noexcept;
   void btnChoosePackageClicked() noexcept;
   void setComponent(const tl::optional<Uuid>& uuid) noexcept;

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>360</width>
-    <height>277</height>
+    <height>210</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,14 +30,21 @@
        <number>3</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
         <property name="spacing">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLineEdit" name="edtComponentUuid">
-          <property name="maxLength">
-           <number>50</number>
+         <widget class="QLabel" name="lblComponentName">
+          <property name="font">
+           <font>
+            <pointsize>11</pointsize>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -55,20 +62,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item>
-       <widget class="QLabel" name="lblComponentName">
-        <property name="font">
-         <font>
-          <pointsize>11</pointsize>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
       </item>
       <item>
        <widget class="QLabel" name="lblComponentDescription">
@@ -106,14 +99,21 @@
        <number>3</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
         <property name="spacing">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLineEdit" name="edtPackageUuid">
-          <property name="maxLength">
-           <number>50</number>
+         <widget class="QLabel" name="lblPackageName">
+          <property name="font">
+           <font>
+            <pointsize>11</pointsize>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>
@@ -131,20 +131,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item>
-       <widget class="QLabel" name="lblPackageName">
-        <property name="font">
-         <font>
-          <pointsize>11</pointsize>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
       </item>
       <item>
        <widget class="QLabel" name="lblPackageDescription">

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.cpp
@@ -56,10 +56,10 @@ NewElementWizardPage_EnterMetadata::NewElementWizardPage_EnterMetadata(
           &NewElementWizardPage_EnterMetadata::edtAuthorTextChanged);
   connect(mUi->edtVersion, &QLineEdit::textChanged, this,
           &NewElementWizardPage_EnterMetadata::edtVersionTextChanged);
-  connect(mUi->edtCategory, &QLineEdit::textChanged, this,
-          &NewElementWizardPage_EnterMetadata::edtCategoryTextChanged);
   connect(mUi->btnChooseCategory, &QToolButton::clicked, this,
           &NewElementWizardPage_EnterMetadata::btnChooseCategoryClicked);
+  connect(mUi->btnResetCategory, &QToolButton::clicked, this,
+          &NewElementWizardPage_EnterMetadata::btnResetCategoryClicked);
 }
 
 NewElementWizardPage_EnterMetadata::
@@ -73,8 +73,6 @@ NewElementWizardPage_EnterMetadata::
 bool NewElementWizardPage_EnterMetadata::isComplete() const noexcept {
   if (!mContext.mElementName) return false;
   if (!mContext.mElementVersion) return false;
-  QString category = mUi->edtCategory->text().trimmed();
-  if (!mContext.mElementCategoryUuid && !category.isEmpty()) return false;
   return true;
 }
 
@@ -129,13 +127,6 @@ void NewElementWizardPage_EnterMetadata::edtVersionTextChanged(
   emit completeChanged();
 }
 
-void NewElementWizardPage_EnterMetadata::edtCategoryTextChanged(
-    const QString& text) noexcept {
-  mContext.mElementCategoryUuid = Uuid::tryFromString(text.trimmed());
-  updateCategoryTreeLabel();
-  emit completeChanged();
-}
-
 void NewElementWizardPage_EnterMetadata::btnChooseCategoryClicked() noexcept {
   tl::optional<Uuid> categoryUuid;
   switch (mContext.mElementType) {
@@ -161,7 +152,13 @@ void NewElementWizardPage_EnterMetadata::btnChooseCategoryClicked() noexcept {
       return;
     }
   }
-  mUi->edtCategory->setText(categoryUuid ? categoryUuid->toStr() : QString());
+  mContext.mElementCategoryUuid = categoryUuid;
+  updateCategoryTreeLabel();
+}
+
+void NewElementWizardPage_EnterMetadata::btnResetCategoryClicked() noexcept {
+  mContext.mElementCategoryUuid = tl::nullopt;
+  updateCategoryTreeLabel();
 }
 
 void NewElementWizardPage_EnterMetadata::updateCategoryTreeLabel() noexcept {
@@ -212,9 +209,6 @@ void NewElementWizardPage_EnterMetadata::initializePage() noexcept {
   mUi->edtAuthor->setText(mContext.mElementAuthor);
   mUi->edtVersion->setText(
       mContext.mElementVersion ? mContext.mElementVersion->toStr() : QString());
-  mUi->edtCategory->setText(mContext.mElementCategoryUuid
-                                ? mContext.mElementCategoryUuid->toStr()
-                                : QString());
   updateCategoryTreeLabel();
 }
 

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.h
@@ -75,8 +75,8 @@ private:  // Methods
   void edtKeywordsTextChanged(const QString& text) noexcept;
   void edtAuthorTextChanged(const QString& text) noexcept;
   void edtVersionTextChanged(const QString& text) noexcept;
-  void edtCategoryTextChanged(const QString& text) noexcept;
   void btnChooseCategoryClicked() noexcept;
+  void btnResetCategoryClicked() noexcept;
   void updateCategoryTreeLabel() noexcept;
   void initializePage() noexcept override;
   void cleanupPage() noexcept override;

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
@@ -115,33 +115,66 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QLineEdit" name="edtCategory">
-       <property name="maxLength">
-        <number>50</number>
-       </property>
-       <property name="placeholderText">
-        <string>Parent category of the new element (empty = root)</string>
+      <widget class="QLabel" name="lblCategoryTree">
+       <property name="text">
+        <string notr="true">TextLabel</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="btnChooseCategory">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Choose category</string>
+       </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnResetCategory">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Reset</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../img/images.qrc">
+         <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="6" column="1">
-    <widget class="QLabel" name="lblCategoryTree">
-     <property name="text">
-      <string notr="true">TextLabel</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../../img/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
@@ -78,10 +78,6 @@ PackageEditorWidget::PackageEditorWidget(const Context&  context,
   // load package
   mPackage.reset(new Package(fp, false));  // can throw
   setWindowTitle(*mPackage->getNames().value(getLibLocaleOrder()));
-  mUi->lblUuid->setText(QString("<a href=\"%1\">%2</a>")
-                            .arg(mPackage->getFilePath().toQUrl().toString(),
-                                 mPackage->getUuid().toStr()));
-  mUi->lblUuid->setToolTip(mPackage->getFilePath().toNative());
   mUi->edtName->setText(*mPackage->getNames().value(getLibLocaleOrder()));
   mUi->edtDescription->setPlainText(
       mPackage->getDescriptions().value(getLibLocaleOrder()));

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
@@ -149,40 +149,20 @@
         <number>9</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>UUID:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="lblUuid">
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Name:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="0" column="1">
         <widget class="QLineEdit" name="edtName">
          <property name="maxLength">
           <number>50</number>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Description:</string>
@@ -192,66 +172,66 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="1" column="1">
         <widget class="QPlainTextEdit" name="edtDescription"/>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Keywords:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="edtKeywords">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Author:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QLineEdit" name="edtAuthor">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Version:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="edtVersion">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Deprecated:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <widget class="QCheckBox" name="cbxDeprecated">
          <property name="text">
           <string>Package should no longer be used.</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="lblCategories">
          <property name="text">
           <string>Categories:</string>

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
@@ -27,6 +27,8 @@
 
 #include <librepcb/common/exceptions.h>
 #include <librepcb/common/fileio/filepath.h>
+#include <librepcb/common/uuid.h>
+#include <optional/tl/optional.hpp>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -78,12 +80,14 @@ public slots:
 private:  // Methods
   bool isInterfaceBroken() const noexcept override { return false; }
   void btnChooseParentCategoryClicked() noexcept;
+  void btnResetParentCategoryClicked() noexcept;
   void edtnameTextChanged(const QString& text) noexcept;
-  void edtParentTextChanged(const QString& text) noexcept;
+  void updateCategoryLabel() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::PackageCategoryEditorWidget> mUi;
   QSharedPointer<PackageCategory>                 mCategory;
+  tl::optional<Uuid>                              mParentUuid;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
@@ -27,40 +27,20 @@
     <number>3</number>
    </property>
    <item row="0" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>UUID:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="lblUuid">
-     <property name="text">
-      <string notr="true">TextLabel</string>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Name:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="0" column="1">
     <widget class="QLineEdit" name="edtName">
      <property name="maxLength">
       <number>50</number>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Description:</string>
@@ -70,72 +50,102 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="1" column="1">
+    <widget class="QPlainTextEdit" name="edtDescription"/>
+   </item>
+   <item row="2" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
       <string>Keywords:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="2" column="1">
     <widget class="QLineEdit" name="edtKeywords">
      <property name="maxLength">
       <number>100</number>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Author:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="3" column="1">
     <widget class="QLineEdit" name="edtAuthor">
      <property name="maxLength">
       <number>100</number>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>Version:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="4" column="1">
     <widget class="QLineEdit" name="edtVersion">
      <property name="maxLength">
       <number>100</number>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Deprecated:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="cbxDeprecated">
+     <property name="text">
+      <string>Category should no longer be used.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Parent:</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>0</number>
      </property>
      <item>
-      <widget class="QLineEdit" name="edtParent">
-       <property name="maxLength">
-        <number>100</number>
+      <widget class="QLabel" name="lblParentCategories">
+       <property name="text">
+        <string notr="true">Parent Tree...</string>
        </property>
-       <property name="clearButtonEnabled">
+       <property name="wordWrap">
         <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="btnChooseParentCategory">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>25</width>
@@ -145,55 +155,55 @@
        <property name="maximumSize">
         <size>
          <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Choose category</string>
+       </property>
+       <property name="text">
+        <string notr="true">...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnResetParentCategory">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
          <height>25</height>
         </size>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Reset</string>
+       </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../img/images.qrc">
+         <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="9" column="1">
-    <widget class="QLabel" name="lblParentCategories">
-     <property name="text">
-      <string>Parent Tree...</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QPlainTextEdit" name="edtDescription"/>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Deprecated:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QCheckBox" name="cbxDeprecated">
-     <property name="text">
-      <string>Category should no longer be used.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../../img/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -50,7 +50,6 @@ SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(SymbolPin& pin,
           &SymbolPinPropertiesDialog::on_buttonBox_clicked);
 
   // load pin attributes
-  mUi->lblUuid->setText(mSymbolPin.getUuid().toStr());
   mUi->edtName->setText(*mSymbolPin.getName());
   mUi->spbPosX->setValue(mSymbolPin.getPosition().getX().toMm());
   mUi->spbPosY->setValue(mSymbolPin.getPosition().getY().toMm());

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>313</width>
-    <height>197</height>
+    <height>174</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,44 +17,27 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>UUID:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="lblUuid">
-       <property name="text">
-        <string notr="true">TextLabel</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Name:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="0" column="1">
       <widget class="QLineEdit" name="edtName">
        <property name="maxLength">
         <number>20</number>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
         <string>Length:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <widget class="QDoubleSpinBox" name="spbLength">
        <property name="decimals">
         <number>6</number>
@@ -67,14 +50,14 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Position:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="2" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QDoubleSpinBox" name="spbPosX">
@@ -110,14 +93,14 @@
        </item>
       </layout>
      </item>
-     <item row="4" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Rotation:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="spbRotation">
        <property name="decimals">
         <number>6</number>

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
@@ -79,10 +79,6 @@ SymbolEditorWidget::SymbolEditorWidget(const Context&  context,
   // load symbol
   mSymbol.reset(new Symbol(fp, false));  // can throw
   setWindowTitle(*mSymbol->getNames().value(getLibLocaleOrder()));
-  mUi->lblUuid->setText(QString("<a href=\"%1\">%2</a>")
-                            .arg(mSymbol->getFilePath().toQUrl().toString(),
-                                 mSymbol->getUuid().toStr()));
-  mUi->lblUuid->setToolTip(mSymbol->getFilePath().toNative());
   mUi->edtName->setText(*mSymbol->getNames().value(getLibLocaleOrder()));
   mUi->edtDescription->setPlainText(
       mSymbol->getDescriptions().value(getLibLocaleOrder()));

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
@@ -79,40 +79,20 @@
         <number>9</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>UUID:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="lblUuid">
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Name:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="0" column="1">
         <widget class="QLineEdit" name="edtName">
          <property name="maxLength">
           <number>50</number>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Description:</string>
@@ -122,63 +102,66 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="1" column="1">
+        <widget class="QPlainTextEdit" name="edtDescription"/>
+       </item>
+       <item row="2" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Keywords:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="edtKeywords">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Author:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QLineEdit" name="edtAuthor">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Version:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="edtVersion">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Deprecated:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <widget class="QCheckBox" name="cbxDeprecated">
          <property name="text">
           <string>Symbol should no longer be used.</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="lblCategories">
          <property name="text">
           <string>Categories:</string>
@@ -187,9 +170,6 @@
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
         </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QPlainTextEdit" name="edtDescription"/>
        </item>
       </layout>
      </item>

--- a/libs/librepcb/librarymanager/libraryinfowidget.cpp
+++ b/libs/librepcb/librarymanager/libraryinfowidget.cpp
@@ -80,15 +80,15 @@ LibraryInfoWidget::LibraryInfoWidget(workspace::Workspace&   ws,
                           : tr("No"));
 
   // extended attributes
-  mUi->lblUuid->setText(lib->getUuid().toStr());
   mUi->lblLibType->setText(isRemoteLibrary() ? tr("Remote") : tr("Local"));
   QString dependencies;
   foreach (const Uuid& uuid, lib->getDependencies()) {
-    tl::optional<Version> installedVersion =
-        mWorkspace.getVersionOfLibrary(uuid, true, true);
+    QSharedPointer<library::Library> installedLib =
+        mWorkspace.getLibrary(uuid, true, true);
     QString line = dependencies.isEmpty() ? "" : "<br>";
-    if (installedVersion) {
-      line += QString(" <font color=\"green\">%1 ✔</font>").arg(uuid.toStr());
+    if (installedLib) {
+      line += QString(" <font color=\"green\">%1 ✔</font>")
+                  .arg(*installedLib->getNames().value(localeOrder));
     } else {
       line += QString(" <font color=\"red\">%1 ✖</font>").arg(uuid.toStr());
     }

--- a/libs/librepcb/librarymanager/libraryinfowidget.ui
+++ b/libs/librepcb/librarymanager/libraryinfowidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>315</width>
-    <height>447</height>
+    <height>401</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -199,30 +199,13 @@
       </widget>
      </item>
      <item row="8" column="0">
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>UUID:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QLabel" name="lblUuid">
-       <property name="text">
-        <string notr="true">TextLabel</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
       <widget class="QLabel" name="label_12">
        <property name="text">
         <string>Library Type:</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="8" column="1">
       <widget class="QLabel" name="lblLibType">
        <property name="text">
         <string notr="true">TextLabel</string>
@@ -232,7 +215,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="label_10">
        <property name="text">
         <string>Dependencies:</string>
@@ -242,7 +225,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="9" column="1">
       <widget class="QLabel" name="lblDependencies">
        <property name="text">
         <string notr="true">TextLabel</string>
@@ -252,14 +235,14 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="label_11">
        <property name="text">
         <string>Directory:</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
+     <item row="10" column="1">
       <widget class="QLabel" name="lblDirectory">
        <property name="text">
         <string notr="true">TextLabel</string>
@@ -275,21 +258,21 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="0" colspan="2">
+     <item row="11" column="0" colspan="2">
       <widget class="Line" name="line_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>
-     <item row="13" column="0" colspan="2">
+     <item row="12" column="0" colspan="2">
       <widget class="QPushButton" name="btnOpenLibraryEditor">
        <property name="text">
         <string>Open Library Editor</string>
        </property>
       </widget>
      </item>
-     <item row="14" column="0" colspan="2">
+     <item row="13" column="0" colspan="2">
       <widget class="QPushButton" name="btnRemove">
        <property name="text">
         <string>Remove this Library</string>

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -26,6 +26,7 @@
 #include "ui_repositorylibrarylistwidgetitem.h"
 
 #include <librepcb/common/network/networkrequest.h>
+#include <librepcb/library/library.h>
 #include <librepcb/workspace/workspace.h>
 
 #include <QtCore>
@@ -112,13 +113,13 @@ void RepositoryLibraryListWidgetItem::setChecked(bool checked) noexcept {
 
 void RepositoryLibraryListWidgetItem::updateInstalledStatus() noexcept {
   if (mUuid) {
-    tl::optional<Version> installedVersion =
-        mWorkspace.getVersionOfLibrary(*mUuid, true, true);
-    if (installedVersion) {
+    QSharedPointer<library::Library> lib =
+        mWorkspace.getLibrary(*mUuid, true, true);
+    if (lib) {
       mUi->lblInstalledVersion->setText(
-          QString(tr("Installed: v%1")).arg(installedVersion->toStr()));
+          QString(tr("Installed: v%1")).arg(lib->getVersion().toStr()));
       mUi->lblInstalledVersion->setVisible(true);
-      if (installedVersion < mVersion) {
+      if (lib->getVersion() < mVersion) {
         mUi->lblInstalledVersion->setStyleSheet("QLabel {color: red;}");
         mUi->cbxDownload->setText(tr("Update"));
         mUi->cbxDownload->setVisible(true);

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
@@ -59,9 +59,6 @@ BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(Project&   project,
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &BoardPlanePropertiesDialog::buttonBoxClicked);
 
-  // UUID label
-  mUi->lblUuid->setText(mPlane.getUuid().toStr());
-
   // net signal combobox
   foreach (NetSignal* netsignal, mPlane.getCircuit().getNetSignals()) {
     mUi->cbxNetSignal->addItem(*netsignal->getName(),

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>270</width>
-    <height>514</height>
+    <height>478</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,50 +20,33 @@
       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
      </property>
      <item row="0" column="0">
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>UUID:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="lblUuid">
-       <property name="text">
-        <string notr="true">-</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Net Signal:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="0" column="1">
       <widget class="QComboBox" name="cbxNetSignal"/>
      </item>
-     <item row="2" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Layer:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <widget class="QComboBox" name="cbxLayer"/>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_7">
        <property name="text">
         <string>Min. Width:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="2" column="1">
       <widget class="QDoubleSpinBox" name="spbMinWidth">
        <property name="decimals">
         <number>6</number>
@@ -76,14 +59,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Min. Clearance:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="spbMinClearance">
        <property name="decimals">
         <number>6</number>
@@ -96,27 +79,34 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Priority:</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="1">
       <widget class="QSpinBox" name="spbPriority"/>
      </item>
-     <item row="6" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Connect Style:</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="5" column="1">
       <widget class="QComboBox" name="cbxConnectStyle"/>
      </item>
-     <item row="7" column="1">
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Options:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
       <widget class="QCheckBox" name="cbKeepOrphans">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -126,13 +116,6 @@
        </property>
        <property name="text">
         <string>Keep Orphans</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Options:</string>
        </property>
       </widget>
      </item>

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
@@ -54,9 +54,6 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(Project&   project,
     mUndoStack(undoStack) {
   mUi->setupUi(this);
 
-  // UUID label
-  mUi->lblUuid->setText(mVia.getUuid().toStr());
-
   // shape combobox
   mUi->cbxShape->addItem(tr("Round"), static_cast<int>(BI_Via::Shape::Round));
   mUi->cbxShape->addItem(tr("Square"), static_cast<int>(BI_Via::Shape::Square));

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>346</width>
-    <height>220</height>
+    <height>197</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,54 +17,37 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>UUID:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="lblUuid">
-       <property name="text">
-        <string notr="true">-</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Net Signal:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="0" column="1">
       <widget class="QLabel" name="lblNetSignal">
        <property name="text">
         <string notr="true">-</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Shape:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <widget class="QComboBox" name="cbxShape"/>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Position:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="2" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QDoubleSpinBox" name="spbxPosX">
@@ -136,14 +119,14 @@
        </item>
       </layout>
      </item>
-     <item row="4" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Outer Size:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="spbxSize">
        <property name="suffix">
         <string>mm</string>
@@ -156,14 +139,14 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Drill Diameter:</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="spbxDrillDiameter">
        <property name="suffix">
         <string>mm</string>

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -64,7 +64,6 @@ DeviceInstancePropertiesDialog::DeviceInstancePropertiesDialog(
 
   // Component Instance Attributes
   ComponentInstance& cmp = mDevice.getComponentInstance();
-  mUi->lblCompInstUuid->setText(cmp.getUuid().toStr());
   mUi->edtCompInstName->setText(*cmp.getName());
   mUi->edtCompInstValue->setText(cmp.getValue());
   mUi->attributeListEditorWidget->setAttributeList(cmp.getAttributes());
@@ -73,28 +72,20 @@ DeviceInstancePropertiesDialog::DeviceInstancePropertiesDialog(
 
   // Library Element Information
   QString htmlLink("<a href=\"%1\">%2<a>");
-  mUi->lblLibDeviceUuid->setText(
-      htmlLink.arg(mDevice.getLibDevice().getFilePath().toQUrl().toString(),
-                   mDevice.getLibDevice().getUuid().toStr()));
-  mUi->lblLibDeviceUuid->setToolTip(
-      mDevice.getLibDevice().getFilePath().toNative());
   mUi->lblLibDeviceName->setText(
-      *mDevice.getLibDevice().getNames().value(localeOrder));
+      htmlLink.arg(mDevice.getLibDevice().getFilePath().toQUrl().toString(),
+                   *mDevice.getLibDevice().getNames().value(localeOrder)));
   mUi->lblLibDeviceName->setToolTip(
-      mDevice.getLibDevice().getDescriptions().value(localeOrder));
+      mDevice.getLibDevice().getDescriptions().value(localeOrder) + "<p>" +
+      mDevice.getLibDevice().getFilePath().toNative());
 
-  mUi->lblLibPackageUuid->setText(
-      htmlLink.arg(mDevice.getLibPackage().getFilePath().toQUrl().toString(),
-                   mDevice.getLibPackage().getUuid().toStr()));
-  mUi->lblLibPackageUuid->setToolTip(
-      mDevice.getLibPackage().getFilePath().toNative());
   mUi->lblLibPackageName->setText(
-      *mDevice.getLibPackage().getNames().value(localeOrder));
+      htmlLink.arg(mDevice.getLibPackage().getFilePath().toQUrl().toString(),
+                   *mDevice.getLibPackage().getNames().value(localeOrder)));
   mUi->lblLibPackageName->setToolTip(
-      mDevice.getLibPackage().getDescriptions().value(localeOrder));
+      mDevice.getLibPackage().getDescriptions().value(localeOrder) + "<p>" +
+      mDevice.getLibPackage().getFilePath().toNative());
 
-  mUi->lblLibFootprintUuid->setText(
-      mDevice.getLibFootprint().getUuid().toStr());
   mUi->lblLibFootprintName->setText(
       *mDevice.getLibFootprint().getNames().value(localeOrder));
   mUi->lblLibFootprintName->setToolTip(

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>560</width>
-    <height>538</height>
+    <width>615</width>
+    <height>511</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -176,20 +176,7 @@
        <property name="title">
         <string>Library Elements</string>
        </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Package:</string>
-          </property>
-         </widget>
-        </item>
+       <layout class="QFormLayout" name="formLayout_3">
         <item row="0" column="0">
          <widget class="QLabel" name="label_10">
           <property name="sizePolicy">
@@ -200,28 +187,6 @@
           </property>
           <property name="text">
            <string>Device:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="lblLibDeviceUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::RichText</enum>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::TextBrowserInteraction</set>
           </property>
          </widget>
         </item>
@@ -236,19 +201,6 @@
           <property name="text">
            <string notr="true">TextLabel</string>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="lblLibFootprintUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
           </property>
@@ -256,12 +208,25 @@
            <bool>true</bool>
           </property>
           <property name="textInteractionFlags">
-           <set>Qt::TextBrowserInteraction</set>
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="lblLibFootprintName">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_18">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Package:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="lblLibPackageName">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -271,19 +236,6 @@
           <property name="text">
            <string notr="true">TextLabel</string>
           </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="lblLibPackageUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
           </property>
@@ -291,7 +243,7 @@
            <bool>true</bool>
           </property>
           <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
          </widget>
         </item>
@@ -308,8 +260,8 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="lblLibPackageName">
+        <item row="2" column="1">
+         <widget class="QLabel" name="lblLibFootprintName">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -318,6 +270,15 @@
           </property>
           <property name="text">
            <string notr="true">TextLabel</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::RichText</enum>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
          </widget>
         </item>
@@ -340,46 +301,23 @@
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
         <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>UUID:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="lblCompInstUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
            <string>Name:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="0" column="1">
          <widget class="QLineEdit" name="edtCompInstName"/>
         </item>
-        <item row="2" column="0">
+        <item row="1" column="0">
          <widget class="QLabel" name="label_4">
           <property name="text">
            <string>Value:</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="1" column="1">
          <widget class="QTextEdit" name="edtCompInstValue">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Maximum">

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -64,7 +64,6 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
   setWindowTitle(QString(tr("Properties of %1")).arg(mSymbol.getName()));
 
   // Component Instance Attributes
-  mUi->lblCompInstUuid->setText(mComponentInstance.getUuid().toStr());
   mUi->edtCompInstName->setText(*mComponentInstance.getName());
   mUi->edtCompInstValue->setText(mComponentInstance.getValue());
   mUi->attributeListEditorWidget->setAttributeList(
@@ -74,18 +73,13 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
 
   // Component Library Element Attributes
   QString htmlLink("<a href=\"%1\">%2<a>");
-  mUi->lblCompLibUuid->setText(htmlLink.arg(
+  mUi->lblCompLibName->setText(htmlLink.arg(
       mComponentInstance.getLibComponent().getFilePath().toQUrl().toString(),
-      mComponentInstance.getLibComponent().getUuid().toStr()));
-  mUi->lblCompLibUuid->setToolTip(
-      mComponentInstance.getLibComponent().getFilePath().toNative());
-  mUi->lblCompLibName->setText(
-      *mComponentInstance.getLibComponent().getNames().value(localeOrder));
+      *mComponentInstance.getLibComponent().getNames().value(localeOrder)));
   mUi->lblCompLibName->setToolTip(
       mComponentInstance.getLibComponent().getDescriptions().value(
-          localeOrder));
-  mUi->lblSymbVarUuid->setText(
-      mComponentInstance.getSymbolVariant().getUuid().toStr());
+          localeOrder) +
+      "<p>" + mComponentInstance.getLibComponent().getFilePath().toNative());
   mUi->lblSymbVarName->setText(
       *mComponentInstance.getSymbolVariant().getNames().value(localeOrder));
   mUi->lblSymbVarName->setToolTip(
@@ -93,7 +87,6 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
           localeOrder));
 
   // Symbol Instance Attributes
-  mUi->lblSymbInstUuid->setText(mSymbol.getUuid().toStr());
   mUi->lblSymbInstName->setText(mSymbol.getName());
   mUi->spbxSymbInstPosX->setValue(mSymbol.getPosition().getX().toMm());
   mUi->spbxSymbInstPosY->setValue(mSymbol.getPosition().getY().toMm());
@@ -101,15 +94,12 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
   mUi->cbxMirror->setChecked(mSymbol.getMirrored());
 
   // Symbol Library Element Attributes
-  mUi->lblSymbLibUuid->setText(
-      htmlLink.arg(mSymbol.getLibSymbol().getFilePath().toQUrl().toString(),
-                   mSymbol.getLibSymbol().getUuid().toStr()));
-  mUi->lblSymbLibUuid->setToolTip(
-      mSymbol.getLibSymbol().getFilePath().toNative());
   mUi->lblSymbLibName->setText(
-      *mSymbol.getLibSymbol().getNames().value(localeOrder));
+      htmlLink.arg(mSymbol.getLibSymbol().getFilePath().toQUrl().toString(),
+                   *mSymbol.getLibSymbol().getNames().value(localeOrder)));
   mUi->lblSymbLibName->setToolTip(
-      mSymbol.getLibSymbol().getDescriptions().value(localeOrder));
+      mSymbol.getLibSymbol().getDescriptions().value(localeOrder) + "<p>" +
+      mSymbol.getLibSymbol().getFilePath().toNative());
 
   // set focus to component instance name
   mUi->edtCompInstName->selectAll();

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -32,36 +32,13 @@
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
         <item row="0" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>UUID:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="lblSymbInstUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
          <widget class="QLabel" name="label_19">
           <property name="text">
            <string>Name:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="0" column="1">
          <widget class="QLabel" name="lblSymbInstName">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -74,14 +51,14 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="1" column="0">
          <widget class="QLabel" name="label_6">
           <property name="text">
            <string>Pos. X:</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="1" column="1">
          <widget class="QDoubleSpinBox" name="spbxSymbInstPosX">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -115,14 +92,14 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="label_7">
           <property name="text">
            <string>Pos. Y:</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="2" column="1">
          <widget class="QDoubleSpinBox" name="spbxSymbInstPosY">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -153,14 +130,14 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="label_8">
           <property name="text">
            <string>Rotation:</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="3" column="1">
          <widget class="QDoubleSpinBox" name="spbxSymbInstAngle">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -191,14 +168,14 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="label_5">
           <property name="text">
            <string>Mirror:</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="4" column="1">
          <widget class="QCheckBox" name="cbxMirror">
           <property name="text">
            <string/>
@@ -219,20 +196,7 @@
        <property name="title">
         <string>Library Elements</string>
        </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Symbol Variant:</string>
-          </property>
-         </widget>
-        </item>
+       <layout class="QFormLayout" name="formLayout_3">
         <item row="0" column="0">
          <widget class="QLabel" name="label_10">
           <property name="sizePolicy">
@@ -243,28 +207,6 @@
           </property>
           <property name="text">
            <string>Component:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="lblCompLibUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::RichText</enum>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::TextBrowserInteraction</set>
           </property>
          </widget>
         </item>
@@ -279,12 +221,34 @@
           <property name="text">
            <string notr="true">TextLabel</string>
           </property>
+          <property name="textFormat">
+           <enum>Qt::RichText</enum>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
+          </property>
          </widget>
         </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="lblSymbLibUuid">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_18">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Symbol Variant:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="lblSymbVarName">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -299,36 +263,7 @@
            <bool>true</bool>
           </property>
           <property name="textInteractionFlags">
-           <set>Qt::TextBrowserInteraction</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="lblSymbLibName">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="lblSymbVarUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
          </widget>
         </item>
@@ -345,8 +280,8 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="lblSymbVarName">
+        <item row="2" column="1">
+         <widget class="QLabel" name="lblSymbLibName">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -355,6 +290,15 @@
           </property>
           <property name="text">
            <string notr="true">TextLabel</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::RichText</enum>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
          </widget>
         </item>
@@ -377,46 +321,23 @@
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
         <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>UUID:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="lblCompInstUuid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
            <string>Name:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="0" column="1">
          <widget class="QLineEdit" name="edtCompInstName"/>
         </item>
-        <item row="2" column="0">
+        <item row="1" column="0">
          <widget class="QLabel" name="label_4">
           <property name="text">
            <string>Value:</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="1" column="1">
          <widget class="QTextEdit" name="edtCompInstValue">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Maximum">

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -195,17 +195,17 @@ FavoriteProjectsModel& Workspace::getFavoriteProjectsModel() const noexcept {
  *  Library Management
  ******************************************************************************/
 
-tl::optional<Version> Workspace::getVersionOfLibrary(const Uuid& uuid,
-                                                     bool        local,
-                                                     bool        remote) const
+QSharedPointer<library::Library> Workspace::getLibrary(const Uuid& uuid,
+                                                       bool        local,
+                                                       bool        remote) const
     noexcept {
-  tl::optional<Version> version;
+  QSharedPointer<library::Library> library;
   if (local) {
     foreach (const auto& lib, mLocalLibraries) {
       Q_ASSERT(lib);
       if ((lib->getUuid() == uuid) &&
-          ((!version) || (version < lib->getVersion()))) {
-        version = lib->getVersion();
+          ((!library) || (library->getVersion() < lib->getVersion()))) {
+        library = lib;
       }
     }
   }
@@ -213,12 +213,12 @@ tl::optional<Version> Workspace::getVersionOfLibrary(const Uuid& uuid,
     foreach (const auto& lib, mRemoteLibraries) {
       Q_ASSERT(lib);
       if ((lib->getUuid() == uuid) &&
-          ((!version) || (version < lib->getVersion()))) {
-        version = lib->getVersion();
+          ((!library) || (library->getVersion() < lib->getVersion()))) {
+        library = lib;
       }
     }
   }
-  return version;
+  return library;
 }
 
 void Workspace::addLocalLibrary(const QString& libDirName) {

--- a/libs/librepcb/workspace/workspace.h
+++ b/libs/librepcb/workspace/workspace.h
@@ -121,17 +121,18 @@ public:
   // Library Management
 
   /**
-   * @brief Get the (highest) version of a specific library
+   * @brief Get the (highest version) library of a given UUID
    *
    * @param uuid      The uuid of the library
    * @param local     If true, local libraries are searched
    * @param remote    If true, remote libraries are searched
    *
-   * @return The highest version of the library (tl::nullopt if library not
-   * installed)
+   * @return The library with the highest version (nullptr if not installed)
    */
-  tl::optional<Version> getVersionOfLibrary(const Uuid& uuid, bool local = true,
-                                            bool remote = true) const noexcept;
+  QSharedPointer<library::Library> getLibrary(const Uuid& uuid,
+                                              bool        local  = true,
+                                              bool        remote = true) const
+      noexcept;
 
   /**
    * @brief Get all local libraries (located in "workspace/v#/libraries/local")


### PR DESCRIPTION
UUIDs are confusing for users, and were originally added only for debugging purposes anyway, so I removed them now from many windows and dialogs. In the library editor I added a menu item "File -> Show element in file manager" instead, so it's still easy to find the corresponding files in the file system if needed.