### PR TITLE
AddComponentDialog: place a component by double-clicking list item

### DIFF
--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
@@ -204,5 +204,21 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>treeComponents</sender>
+   <signal>itemDoubleClicked(QTreeWidgetItem*,int)</signal>
+   <receiver>librepcb::project::editor::AddComponentDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>419</x>
+     <y>301</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>492</x>
+     <y>463</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
 </ui>

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.ui
@@ -52,6 +52,9 @@
      <property name="headerHidden">
       <bool>true</bool>
      </property>
+     <property name="expandsOnDoubleClick">
+      <bool>false</bool>
+     </property>
      <property name="columnCount">
       <number>0</number>
      </property>


### PR DESCRIPTION
To place a symbol from the 'Add Component' dialog, the user currently
has to select the desired symbol from the list and click 'OK'. This
change allows users to place a symbol by double-clicking the symbol in
the list without clicking the 'OK' button.

Fixes #344