### PR TITLE
Update URL to website (http -> https)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ This project welcomes non-code contributions, too! The following types of contri
   [Transifex](https://www.transifex.com/librepcb/librepcb-application/dashboard/).
   Follow [this guide](https://docs.transifex.com/getting-started/translators) to
   get started.
-- **Website**: Improve our [website](http://librepcb.org) which is hosted in the repository [LibrePCB/LibrePCB.github.io](https://github.com/LibrePCB/LibrePCB.github.io).
+- **Website**: Improve our [website](https://librepcb.org) which is hosted in the repository [LibrePCB/LibrePCB.github.io](https://github.com/LibrePCB/LibrePCB.github.io).
 - **Sharing**: Speak about LibrePCB with your friends and colleagues, or write about it in the internet!
 - **Donations**: [Become a Patron](https://www.patreon.com/librepcb)
   or donate to the LibrePCB developers with Bitcoin:

--- a/apps/EagleImport/main.cpp
+++ b/apps/EagleImport/main.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/EagleImport/polygonsimplifier.cpp
+++ b/apps/EagleImport/polygonsimplifier.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/EagleImport/polygonsimplifier.h
+++ b/apps/EagleImport/polygonsimplifier.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/WorkspaceLibraryUpdater/main.cpp
+++ b/apps/WorkspaceLibraryUpdater/main.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb-cli/main.cpp
+++ b/apps/librepcb-cli/main.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/controlpanel/controlpanel.h
+++ b/apps/librepcb/controlpanel/controlpanel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizard.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizard.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizard.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizard.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.ui
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.ui
@@ -40,7 +40,7 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Website: &lt;a href=&quot;http://librepcb.org&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://librepcb.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;GitHub Project: &lt;a href=&quot;https://github.com/LibrePCB&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/LibrePCB&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;LibrePCB is published under the &lt;a href=&quot;http://www.gnu.org/licenses/gpl-3.0.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GNU GPLv3&lt;/span&gt;&lt;/a&gt; License.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Website: &lt;a href=&quot;https://librepcb.org&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://librepcb.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;GitHub Project: &lt;a href=&quot;https://github.com/LibrePCB&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/LibrePCB&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;LibrePCB is published under the &lt;a href=&quot;http://www.gnu.org/licenses/gpl-3.0.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GNU GPLv3&lt;/span&gt;&lt;/a&gt; License.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/markdown/markdownconverter.cpp
+++ b/apps/librepcb/markdown/markdownconverter.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/markdown/markdownconverter.h
+++ b/apps/librepcb/markdown/markdownconverter.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
+++ b/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/librepcb/projectlibraryupdater/projectlibraryupdater.h
+++ b/apps/librepcb/projectlibraryupdater/projectlibraryupdater.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/dev/doxygen/pages/release_workflow.md
+++ b/dev/doxygen/pages/release_workflow.md
@@ -120,7 +120,7 @@ Instead, we use the [GitHub Releases] page to list the changes of every release
 
 Releases built by ourselves (Windows builds, installers, AppImage etc.) are
 published at https://download.librepcb.org, inclusive GPG signature. The website
-http://librepcb.org contains direct download links to the corresponding files.
+https://librepcb.org contains direct download links to the corresponding files.
 
 Packages of package managers (e.g. APT, Flatpak, homebrew, ...) are updated by
 the corresponding package maintainers. Typically they clone the tag we released

--- a/dev/license_header_template.txt
+++ b/dev/license_header_template.txt
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/dist/installer/config/config.xml
+++ b/dist/installer/config/config.xml
@@ -4,7 +4,7 @@
   <Version>1.0.0</Version><!-- the installer version is static -->
   <Title>LibrePCB</Title>
   <Publisher>LibrePCB</Publisher>
-  <ProductUrl>http://librepcb.org/</ProductUrl>
+  <ProductUrl>https://librepcb.org/</ProductUrl>
   <Logo>48x48.png</Logo>
   <MaintenanceToolName>librepcb-maintenance</MaintenanceToolName>
   <MaintenanceToolIniFile>librepcb-maintenance.ini</MaintenanceToolIniFile>

--- a/libs/librepcb/common/alignment.cpp
+++ b/libs/librepcb/common/alignment.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/alignment.h
+++ b/libs/librepcb/common/alignment.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/application.cpp
+++ b/libs/librepcb/common/application.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/application.h
+++ b/libs/librepcb/common/application.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attribute.cpp
+++ b/libs/librepcb/common/attributes/attribute.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attribute.h
+++ b/libs/librepcb/common/attributes/attribute.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributekey.h
+++ b/libs/librepcb/common/attributes/attributekey.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributeprovider.cpp
+++ b/libs/librepcb/common/attributes/attributeprovider.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributeprovider.h
+++ b/libs/librepcb/common/attributes/attributeprovider.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributesubstitutor.cpp
+++ b/libs/librepcb/common/attributes/attributesubstitutor.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributesubstitutor.h
+++ b/libs/librepcb/common/attributes/attributesubstitutor.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributetype.cpp
+++ b/libs/librepcb/common/attributes/attributetype.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributetype.h
+++ b/libs/librepcb/common/attributes/attributetype.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributeunit.cpp
+++ b/libs/librepcb/common/attributes/attributeunit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attributeunit.h
+++ b/libs/librepcb/common/attributes/attributeunit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypecapacitance.cpp
+++ b/libs/librepcb/common/attributes/attrtypecapacitance.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypecapacitance.h
+++ b/libs/librepcb/common/attributes/attrtypecapacitance.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypefrequency.cpp
+++ b/libs/librepcb/common/attributes/attrtypefrequency.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypefrequency.h
+++ b/libs/librepcb/common/attributes/attrtypefrequency.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypeinductance.cpp
+++ b/libs/librepcb/common/attributes/attrtypeinductance.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypeinductance.h
+++ b/libs/librepcb/common/attributes/attrtypeinductance.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtyperesistance.cpp
+++ b/libs/librepcb/common/attributes/attrtyperesistance.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtyperesistance.h
+++ b/libs/librepcb/common/attributes/attrtyperesistance.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypestring.cpp
+++ b/libs/librepcb/common/attributes/attrtypestring.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypestring.h
+++ b/libs/librepcb/common/attributes/attrtypestring.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypevoltage.cpp
+++ b/libs/librepcb/common/attributes/attrtypevoltage.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/attributes/attrtypevoltage.h
+++ b/libs/librepcb/common/attributes/attrtypevoltage.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/boarddesignrules.cpp
+++ b/libs/librepcb/common/boarddesignrules.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/boarddesignrules.h
+++ b/libs/librepcb/common/boarddesignrules.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/cam/excellongenerator.cpp
+++ b/libs/librepcb/common/cam/excellongenerator.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/cam/excellongenerator.h
+++ b/libs/librepcb/common/cam/excellongenerator.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/cam/gerberaperturelist.cpp
+++ b/libs/librepcb/common/cam/gerberaperturelist.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/cam/gerberaperturelist.h
+++ b/libs/librepcb/common/cam/gerberaperturelist.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/cam/gerbergenerator.cpp
+++ b/libs/librepcb/common/cam/gerbergenerator.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/cam/gerbergenerator.h
+++ b/libs/librepcb/common/cam/gerbergenerator.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/circuitidentifier.h
+++ b/libs/librepcb/common/circuitidentifier.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/debug.cpp
+++ b/libs/librepcb/common/debug.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/debug.h
+++ b/libs/librepcb/common/debug.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/common/dialogs/aboutdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2018 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -61,7 +61,7 @@ AboutDialog::AboutDialog(QWidget* parent) noexcept
   mUi->textLinks->setText(
       tr("For more information, please check out <a href='%1'>librepcb.org</a> "
          "or our <a href='%2'>GitHub repository</a>.")
-          .arg("http://librepcb.org/", "https://github.com/LibrePCB/LibrePCB"));
+          .arg("https://librepcb.org/", "https://github.com/LibrePCB/LibrePCB"));
   mUi->textContributeFinancially->setText(
       tr("Support sustainable development of LibrePCB by donating financially, "
          "either via <a href='%1'>Patreon</a> or via <a href='%2'>Bitcoin</a>!")

--- a/libs/librepcb/common/dialogs/aboutdialog.h
+++ b/libs/librepcb/common/dialogs/aboutdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2018 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.h
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/filedialog.cpp
+++ b/libs/librepcb/common/dialogs/filedialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/filedialog.h
+++ b/libs/librepcb/common/dialogs/filedialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/gridsettingsdialog.cpp
+++ b/libs/librepcb/common/dialogs/gridsettingsdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/gridsettingsdialog.h
+++ b/libs/librepcb/common/dialogs/gridsettingsdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/elementname.h
+++ b/libs/librepcb/common/elementname.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/exceptions.cpp
+++ b/libs/librepcb/common/exceptions.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/exceptions.h
+++ b/libs/librepcb/common/exceptions.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementinsert.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementinsert.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementremove.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementsswap.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementsswap.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/directorylock.cpp
+++ b/libs/librepcb/common/fileio/directorylock.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/directorylock.h
+++ b/libs/librepcb/common/fileio/directorylock.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/filepath.cpp
+++ b/libs/librepcb/common/fileio/filepath.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/filepath.h
+++ b/libs/librepcb/common/fileio/filepath.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/fileutils.cpp
+++ b/libs/librepcb/common/fileio/fileutils.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/fileutils.h
+++ b/libs/librepcb/common/fileio/fileutils.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/serializablekeyvaluemap.h
+++ b/libs/librepcb/common/fileio/serializablekeyvaluemap.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/serializableobject.h
+++ b/libs/librepcb/common/fileio/serializableobject.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/serializableobjectlist.h
+++ b/libs/librepcb/common/fileio/serializableobjectlist.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/sexpression.cpp
+++ b/libs/librepcb/common/fileio/sexpression.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/sexpression.h
+++ b/libs/librepcb/common/fileio/sexpression.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smartfile.cpp
+++ b/libs/librepcb/common/fileio/smartfile.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smartfile.h
+++ b/libs/librepcb/common/fileio/smartfile.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smartsexprfile.cpp
+++ b/libs/librepcb/common/fileio/smartsexprfile.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smartsexprfile.h
+++ b/libs/librepcb/common/fileio/smartsexprfile.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smarttextfile.cpp
+++ b/libs/librepcb/common/fileio/smarttextfile.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smarttextfile.h
+++ b/libs/librepcb/common/fileio/smarttextfile.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smartversionfile.cpp
+++ b/libs/librepcb/common/fileio/smartversionfile.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/fileio/smartversionfile.h
+++ b/libs/librepcb/common/fileio/smartversionfile.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/font/strokefont.cpp
+++ b/libs/librepcb/common/font/strokefont.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/font/strokefont.h
+++ b/libs/librepcb/common/font/strokefont.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/font/strokefontpool.cpp
+++ b/libs/librepcb/common/font/strokefontpool.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/font/strokefontpool.h
+++ b/libs/librepcb/common/font/strokefontpool.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/circle.cpp
+++ b/libs/librepcb/common/geometry/circle.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/circle.h
+++ b/libs/librepcb/common/geometry/circle.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdcircleedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdcircleedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdcircleedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdcircleedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdholeedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdholeedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdholeedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdholeedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdpolygonedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdpolygonedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdpolygonedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdpolygonedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdstroketextedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdstroketextedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdstroketextedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdstroketextedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdtextedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdtextedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/cmd/cmdtextedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdtextedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/hole.cpp
+++ b/libs/librepcb/common/geometry/hole.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/hole.h
+++ b/libs/librepcb/common/geometry/hole.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/path.cpp
+++ b/libs/librepcb/common/geometry/path.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/path.h
+++ b/libs/librepcb/common/geometry/path.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/polygon.cpp
+++ b/libs/librepcb/common/geometry/polygon.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/polygon.h
+++ b/libs/librepcb/common/geometry/polygon.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/stroketext.cpp
+++ b/libs/librepcb/common/geometry/stroketext.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/stroketext.h
+++ b/libs/librepcb/common/geometry/stroketext.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/text.cpp
+++ b/libs/librepcb/common/geometry/text.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/text.h
+++ b/libs/librepcb/common/geometry/text.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/vertex.cpp
+++ b/libs/librepcb/common/geometry/vertex.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/geometry/vertex.h
+++ b/libs/librepcb/common/geometry/vertex.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/circlegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/circlegraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/circlegraphicsitem.h
+++ b/libs/librepcb/common/graphics/circlegraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/defaultgraphicslayerprovider.cpp
+++ b/libs/librepcb/common/graphics/defaultgraphicslayerprovider.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/defaultgraphicslayerprovider.h
+++ b/libs/librepcb/common/graphics/defaultgraphicslayerprovider.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/graphicslayer.cpp
+++ b/libs/librepcb/common/graphics/graphicslayer.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/graphicslayer.h
+++ b/libs/librepcb/common/graphics/graphicslayer.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/graphicslayername.h
+++ b/libs/librepcb/common/graphics/graphicslayername.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/graphicsscene.cpp
+++ b/libs/librepcb/common/graphics/graphicsscene.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/graphicsscene.h
+++ b/libs/librepcb/common/graphics/graphicsscene.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/graphicsview.cpp
+++ b/libs/librepcb/common/graphics/graphicsview.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/graphicsview.h
+++ b/libs/librepcb/common/graphics/graphicsview.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/holegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/holegraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/holegraphicsitem.h
+++ b/libs/librepcb/common/graphics/holegraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/if_graphicsvieweventhandler.h
+++ b/libs/librepcb/common/graphics/if_graphicsvieweventhandler.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/linegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/linegraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/linegraphicsitem.h
+++ b/libs/librepcb/common/graphics/linegraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/origincrossgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/origincrossgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/origincrossgraphicsitem.h
+++ b/libs/librepcb/common/graphics/origincrossgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/polygongraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/polygongraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/polygongraphicsitem.h
+++ b/libs/librepcb/common/graphics/polygongraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/primitivecirclegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivecirclegraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/primitivecirclegraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitivecirclegraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivepathgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/primitivepathgraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitivepathgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivetextgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/primitivetextgraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitivetextgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/stroketextgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/stroketextgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/stroketextgraphicsitem.h
+++ b/libs/librepcb/common/graphics/stroketextgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/textgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/textgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/graphics/textgraphicsitem.h
+++ b/libs/librepcb/common/graphics/textgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/gridproperties.cpp
+++ b/libs/librepcb/common/gridproperties.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/gridproperties.h
+++ b/libs/librepcb/common/gridproperties.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/filedownload.cpp
+++ b/libs/librepcb/common/network/filedownload.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/filedownload.h
+++ b/libs/librepcb/common/network/filedownload.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/networkaccessmanager.cpp
+++ b/libs/librepcb/common/network/networkaccessmanager.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/networkaccessmanager.h
+++ b/libs/librepcb/common/network/networkaccessmanager.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/networkrequest.cpp
+++ b/libs/librepcb/common/network/networkrequest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/networkrequest.h
+++ b/libs/librepcb/common/network/networkrequest.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/networkrequestbase.cpp
+++ b/libs/librepcb/common/network/networkrequestbase.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/networkrequestbase.h
+++ b/libs/librepcb/common/network/networkrequestbase.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/repository.cpp
+++ b/libs/librepcb/common/network/repository.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/network/repository.h
+++ b/libs/librepcb/common/network/repository.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/scopeguard.h
+++ b/libs/librepcb/common/scopeguard.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2016 The LibrePCB developers
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/scopeguardlist.h
+++ b/libs/librepcb/common/scopeguardlist.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2016 The LibrePCB developers
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/signalrole.cpp
+++ b/libs/librepcb/common/signalrole.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/signalrole.h
+++ b/libs/librepcb/common/signalrole.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/sqlitedatabase.cpp
+++ b/libs/librepcb/common/sqlitedatabase.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/sqlitedatabase.h
+++ b/libs/librepcb/common/sqlitedatabase.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/systeminfo.cpp
+++ b/libs/librepcb/common/systeminfo.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/systeminfo.h
+++ b/libs/librepcb/common/systeminfo.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/toolbox.cpp
+++ b/libs/librepcb/common/toolbox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/toolbox.h
+++ b/libs/librepcb/common/toolbox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/undocommand.cpp
+++ b/libs/librepcb/common/undocommand.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/undocommand.h
+++ b/libs/librepcb/common/undocommand.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/undocommandgroup.cpp
+++ b/libs/librepcb/common/undocommandgroup.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/undocommandgroup.h
+++ b/libs/librepcb/common/undocommandgroup.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/undostack.cpp
+++ b/libs/librepcb/common/undostack.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/undostack.h
+++ b/libs/librepcb/common/undostack.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/angle.cpp
+++ b/libs/librepcb/common/units/angle.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/angle.h
+++ b/libs/librepcb/common/units/angle.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/length.cpp
+++ b/libs/librepcb/common/units/length.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/length.h
+++ b/libs/librepcb/common/units/length.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/lengthunit.cpp
+++ b/libs/librepcb/common/units/lengthunit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/lengthunit.h
+++ b/libs/librepcb/common/units/lengthunit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/point.cpp
+++ b/libs/librepcb/common/units/point.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/point.h
+++ b/libs/librepcb/common/units/point.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/ratio.cpp
+++ b/libs/librepcb/common/units/ratio.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/units/ratio.h
+++ b/libs/librepcb/common/units/ratio.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/clipperhelpers.cpp
+++ b/libs/librepcb/common/utils/clipperhelpers.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/clipperhelpers.h
+++ b/libs/librepcb/common/utils/clipperhelpers.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/exclusiveactiongroup.cpp
+++ b/libs/librepcb/common/utils/exclusiveactiongroup.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/exclusiveactiongroup.h
+++ b/libs/librepcb/common/utils/exclusiveactiongroup.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/graphicslayerstackappearancesettings.cpp
+++ b/libs/librepcb/common/utils/graphicslayerstackappearancesettings.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/graphicslayerstackappearancesettings.h
+++ b/libs/librepcb/common/utils/graphicslayerstackappearancesettings.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/toolbarproxy.cpp
+++ b/libs/librepcb/common/utils/toolbarproxy.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/toolbarproxy.h
+++ b/libs/librepcb/common/utils/toolbarproxy.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/undostackactiongroup.cpp
+++ b/libs/librepcb/common/utils/undostackactiongroup.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/utils/undostackactiongroup.h
+++ b/libs/librepcb/common/utils/undostackactiongroup.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/uuid.cpp
+++ b/libs/librepcb/common/uuid.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/uuid.h
+++ b/libs/librepcb/common/uuid.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/version.cpp
+++ b/libs/librepcb/common/version.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/version.h
+++ b/libs/librepcb/common/version.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/alignmentselector.cpp
+++ b/libs/librepcb/common/widgets/alignmentselector.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/alignmentselector.h
+++ b/libs/librepcb/common/widgets/alignmentselector.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/attributelisteditorwidget.cpp
+++ b/libs/librepcb/common/widgets/attributelisteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/attributelisteditorwidget.h
+++ b/libs/librepcb/common/widgets/attributelisteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/attributetypecombobox.cpp
+++ b/libs/librepcb/common/widgets/attributetypecombobox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/attributetypecombobox.h
+++ b/libs/librepcb/common/widgets/attributetypecombobox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/attributeunitcombobox.cpp
+++ b/libs/librepcb/common/widgets/attributeunitcombobox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/attributeunitcombobox.h
+++ b/libs/librepcb/common/widgets/attributeunitcombobox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/centeredcheckbox.cpp
+++ b/libs/librepcb/common/widgets/centeredcheckbox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/centeredcheckbox.h
+++ b/libs/librepcb/common/widgets/centeredcheckbox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/graphicslayercombobox.cpp
+++ b/libs/librepcb/common/widgets/graphicslayercombobox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/graphicslayercombobox.h
+++ b/libs/librepcb/common/widgets/graphicslayercombobox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/patheditorwidget.cpp
+++ b/libs/librepcb/common/widgets/patheditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/patheditorwidget.h
+++ b/libs/librepcb/common/widgets/patheditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/signalrolecombobox.cpp
+++ b/libs/librepcb/common/widgets/signalrolecombobox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/signalrolecombobox.h
+++ b/libs/librepcb/common/widgets/signalrolecombobox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/statusbar.cpp
+++ b/libs/librepcb/common/widgets/statusbar.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/common/widgets/statusbar.h
+++ b/libs/librepcb/common/widgets/statusbar.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/converterdb.cpp
+++ b/libs/librepcb/eagleimport/converterdb.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/converterdb.h
+++ b/libs/librepcb/eagleimport/converterdb.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/deviceconverter.cpp
+++ b/libs/librepcb/eagleimport/deviceconverter.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/deviceconverter.h
+++ b/libs/librepcb/eagleimport/deviceconverter.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/devicesetconverter.cpp
+++ b/libs/librepcb/eagleimport/devicesetconverter.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/devicesetconverter.h
+++ b/libs/librepcb/eagleimport/devicesetconverter.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/packageconverter.cpp
+++ b/libs/librepcb/eagleimport/packageconverter.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/packageconverter.h
+++ b/libs/librepcb/eagleimport/packageconverter.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/symbolconverter.cpp
+++ b/libs/librepcb/eagleimport/symbolconverter.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/eagleimport/symbolconverter.h
+++ b/libs/librepcb/eagleimport/symbolconverter.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cat/componentcategory.cpp
+++ b/libs/librepcb/library/cat/componentcategory.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cat/componentcategory.h
+++ b/libs/librepcb/library/cat/componentcategory.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cat/librarycategory.cpp
+++ b/libs/librepcb/library/cat/librarycategory.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cat/librarycategory.h
+++ b/libs/librepcb/library/cat/librarycategory.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cat/packagecategory.cpp
+++ b/libs/librepcb/library/cat/packagecategory.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cat/packagecategory.h
+++ b/libs/librepcb/library/cat/packagecategory.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/cmd/cmdcomponentsignaledit.cpp
+++ b/libs/librepcb/library/cmp/cmd/cmdcomponentsignaledit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/cmd/cmdcomponentsignaledit.h
+++ b/libs/librepcb/library/cmp/cmd/cmdcomponentsignaledit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/cmd/cmdcomponentsymbolvariantedit.cpp
+++ b/libs/librepcb/library/cmp/cmd/cmdcomponentsymbolvariantedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/cmd/cmdcomponentsymbolvariantedit.h
+++ b/libs/librepcb/library/cmp/cmd/cmdcomponentsymbolvariantedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/cmpsigpindisplaytype.cpp
+++ b/libs/librepcb/library/cmp/cmpsigpindisplaytype.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/cmpsigpindisplaytype.h
+++ b/libs/librepcb/library/cmp/cmpsigpindisplaytype.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/component.cpp
+++ b/libs/librepcb/library/cmp/component.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/component.h
+++ b/libs/librepcb/library/cmp/component.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentpinsignalmap.cpp
+++ b/libs/librepcb/library/cmp/componentpinsignalmap.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentpinsignalmap.h
+++ b/libs/librepcb/library/cmp/componentpinsignalmap.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentprefix.h
+++ b/libs/librepcb/library/cmp/componentprefix.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentsignal.cpp
+++ b/libs/librepcb/library/cmp/componentsignal.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentsignal.h
+++ b/libs/librepcb/library/cmp/componentsignal.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentsymbolvariant.cpp
+++ b/libs/librepcb/library/cmp/componentsymbolvariant.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentsymbolvariant.h
+++ b/libs/librepcb/library/cmp/componentsymbolvariant.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentsymbolvariantitem.h
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/cmp/componentsymbolvariantitemsuffix.h
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitemsuffix.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/cmd/cmddeviceedit.cpp
+++ b/libs/librepcb/library/dev/cmd/cmddeviceedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/cmd/cmddeviceedit.h
+++ b/libs/librepcb/library/dev/cmd/cmddeviceedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/cmd/cmddevicepadsignalmapitemedit.cpp
+++ b/libs/librepcb/library/dev/cmd/cmddevicepadsignalmapitemedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/cmd/cmddevicepadsignalmapitemedit.h
+++ b/libs/librepcb/library/dev/cmd/cmddevicepadsignalmapitemedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/device.cpp
+++ b/libs/librepcb/library/dev/device.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/device.h
+++ b/libs/librepcb/library/dev/device.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/devicepadsignalmap.cpp
+++ b/libs/librepcb/library/dev/devicepadsignalmap.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/dev/devicepadsignalmap.h
+++ b/libs/librepcb/library/dev/devicepadsignalmap.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/library.cpp
+++ b/libs/librepcb/library/library.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/library.h
+++ b/libs/librepcb/library/library.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/librarybaseelement.cpp
+++ b/libs/librepcb/library/librarybaseelement.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/librarybaseelement.h
+++ b/libs/librepcb/library/librarybaseelement.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/libraryelement.cpp
+++ b/libs/librepcb/library/libraryelement.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/libraryelement.h
+++ b/libs/librepcb/library/libraryelement.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintedit.cpp
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintedit.h
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/cmd/cmdpackagepadedit.cpp
+++ b/libs/librepcb/library/pkg/cmd/cmdpackagepadedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/cmd/cmdpackagepadedit.h
+++ b/libs/librepcb/library/pkg/cmd/cmdpackagepadedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprint.cpp
+++ b/libs/librepcb/library/pkg/footprint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprint.h
+++ b/libs/librepcb/library/pkg/footprint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintgraphicsitem.h
+++ b/libs/librepcb/library/pkg/footprintgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/library/pkg/footprintpad.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpad.h
+++ b/libs/librepcb/library/pkg/footprintpad.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpadgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpadgraphicsitem.h
+++ b/libs/librepcb/library/pkg/footprintpadgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.h
+++ b/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.h
+++ b/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/package.cpp
+++ b/libs/librepcb/library/pkg/package.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/package.h
+++ b/libs/librepcb/library/pkg/package.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/packagepad.cpp
+++ b/libs/librepcb/library/pkg/packagepad.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/pkg/packagepad.h
+++ b/libs/librepcb/library/pkg/packagepad.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.cpp
+++ b/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.h
+++ b/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbol.cpp
+++ b/libs/librepcb/library/sym/symbol.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbol.h
+++ b/libs/librepcb/library/sym/symbol.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolgraphicsitem.cpp
+++ b/libs/librepcb/library/sym/symbolgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolgraphicsitem.h
+++ b/libs/librepcb/library/sym/symbolgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpin.cpp
+++ b/libs/librepcb/library/sym/symbolpin.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpin.h
+++ b/libs/librepcb/library/sym/symbolpin.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpingraphicsitem.cpp
+++ b/libs/librepcb/library/sym/symbolpingraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpingraphicsitem.h
+++ b/libs/librepcb/library/sym/symbolpingraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.h
+++ b/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/sym/symbolpreviewgraphicsitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/library/sym/symbolpreviewgraphicsitem.h
+++ b/libs/librepcb/library/sym/symbolpreviewgraphicsitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/cmpsigpindisplaytypecombobox.cpp
+++ b/libs/librepcb/libraryeditor/cmp/cmpsigpindisplaytypecombobox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/cmpsigpindisplaytypecombobox.h
+++ b/libs/librepcb/libraryeditor/cmp/cmpsigpindisplaytypecombobox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmp/if_componentsymbolvarianteditorprovider.h
+++ b/libs/librepcb/libraryeditor/cmp/if_componentsymbolvarianteditorprovider.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/categorychooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/categorychooserdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/categorychooserdialog.h
+++ b/libs/librepcb/libraryeditor/common/categorychooserdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/categorylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/common/categorylisteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/categorytreelabeltextbuilder.cpp
+++ b/libs/librepcb/libraryeditor/common/categorytreelabeltextbuilder.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/categorytreelabeltextbuilder.h
+++ b/libs/librepcb/libraryeditor/common/categorytreelabeltextbuilder.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.h
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.h
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.h
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.h
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.h
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/libraryeditor.h
+++ b/libs/librepcb/libraryeditor/libraryeditor.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentpinsignalmap.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentpinsignalmap.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentpinsignalmap.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentpinsignalmap.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentproperties.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentproperties.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentproperties.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentproperties.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsignals.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsignals.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsignals.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsignals.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsymbols.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsymbols.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsymbols.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsymbols.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_packagepads.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_packagepads.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_packagepads.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_packagepads.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdmoveselectedfootprintitems.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdmoveselectedfootprintitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdmoveselectedfootprintitems.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdmoveselectedfootprintitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdremoveselectedfootprintitems.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdremoveselectedfootprintitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdremoveselectedfootprintitems.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdremoveselectedfootprintitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdrotateselectedfootprintitems.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdrotateselectedfootprintitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdrotateselectedfootprintitems.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmdrotateselectedfootprintitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addnames.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addnames.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addnames.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addnames.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addvalues.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addvalues.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addvalues.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addvalues.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawline.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawline.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawline.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawline.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygon.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygon.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygon.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygon.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawrect.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawrect.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawrect.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawrect.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtext.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtext.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtext.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtext.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/widgets/boardsideselectorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/widgets/boardsideselectorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/widgets/boardsideselectorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/widgets/boardsideselectorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/widgets/footprintpadshapeselectorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/widgets/footprintpadshapeselectorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/widgets/footprintpadshapeselectorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/widgets/footprintpadshapeselectorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/widgets/packagepadcombobox.cpp
+++ b/libs/librepcb/libraryeditor/pkg/widgets/packagepadcombobox.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkg/widgets/packagepadcombobox.h
+++ b/libs/librepcb/libraryeditor/pkg/widgets/packagepadcombobox.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.h
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdmoveselectedsymbolitems.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdmoveselectedsymbolitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdmoveselectedsymbolitems.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdmoveselectedsymbolitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdremoveselectedsymbolitems.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdremoveselectedsymbolitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdremoveselectedsymbolitems.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdremoveselectedsymbolitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdrotateselectedsymbolitems.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdrotateselectedsymbolitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdrotateselectedsymbolitems.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/cmd/cmdrotateselectedsymbolitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addnames.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addnames.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addnames.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addnames.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addvalues.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addvalues.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addvalues.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addvalues.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawline.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawline.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawline.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawline.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygon.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygon.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygon.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygon.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawrect.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawrect.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawrect.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawrect.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtext.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtext.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtext.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtext.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/librarymanager/addlibrarywidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/addlibrarywidget.h
+++ b/libs/librepcb/librarymanager/addlibrarywidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/librarydownload.cpp
+++ b/libs/librepcb/librarymanager/librarydownload.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/librarydownload.h
+++ b/libs/librepcb/librarymanager/librarydownload.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/libraryinfowidget.cpp
+++ b/libs/librepcb/librarymanager/libraryinfowidget.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/libraryinfowidget.h
+++ b/libs/librepcb/librarymanager/libraryinfowidget.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.h
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/librarymanager.cpp
+++ b/libs/librepcb/librarymanager/librarymanager.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/librarymanager.h
+++ b/libs/librepcb/librarymanager/librarymanager.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.h
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardairwiresbuilder.cpp
+++ b/libs/librepcb/project/boards/boardairwiresbuilder.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardairwiresbuilder.h
+++ b/libs/librepcb/project/boards/boardairwiresbuilder.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardfabricationoutputsettings.cpp
+++ b/libs/librepcb/project/boards/boardfabricationoutputsettings.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardfabricationoutputsettings.h
+++ b/libs/librepcb/project/boards/boardfabricationoutputsettings.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardgerberexport.h
+++ b/libs/librepcb/project/boards/boardgerberexport.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardlayerstack.cpp
+++ b/libs/librepcb/project/boards/boardlayerstack.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardlayerstack.h
+++ b/libs/librepcb/project/boards/boardlayerstack.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/project/boards/boardplanefragmentsbuilder.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardselectionquery.cpp
+++ b/libs/librepcb/project/boards/boardselectionquery.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardselectionquery.h
+++ b/libs/librepcb/project/boards/boardselectionquery.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardusersettings.cpp
+++ b/libs/librepcb/project/boards/boardusersettings.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/boardusersettings.h
+++ b/libs/librepcb/project/boards/boardusersettings.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboarddesignrulesmodify.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboarddesignrulesmodify.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboarddesignrulesmodify.h
+++ b/libs/librepcb/project/boards/cmd/cmdboarddesignrulesmodify.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardholeadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardholeadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardholeremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardholeremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardholeremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardlayerstackedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardlayerstackedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardlayerstackedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardlayerstackedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetlineedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetlineedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetlineedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetlineedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetpointedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetpointedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetpointedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetpointedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremoveelements.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremoveelements.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremoveelements.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentremoveelements.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardplaneremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardplaneremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardpolygonadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardpolygonadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardpolygonadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardpolygonadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardpolygonremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardpolygonremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardpolygonremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardpolygonremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardstroketextadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardstroketextadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardstroketextadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardstroketextadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardstroketextremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardstroketextremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardstroketextremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardstroketextremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardviaedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardviaedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdboardviaedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardviaedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceadd.h
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceedit.h
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.cpp
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.h
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceremove.h
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdfootprintstroketextadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdfootprintstroketextadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdfootprintstroketextadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdfootprintstroketextadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdfootprintstroketextremove.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdfootprintstroketextremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdfootprintstroketextremove.h
+++ b/libs/librepcb/project/boards/cmd/cmdfootprintstroketextremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdfootprintstroketextsreset.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdfootprintstroketextsreset.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/cmd/cmdfootprintstroketextsreset.h
+++ b/libs/librepcb/project/boards/cmd/cmdfootprintstroketextsreset.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_airwire.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_airwire.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_airwire.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_airwire.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_base.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_base.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_base.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_base.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprint.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprint.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netline.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netline.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netline.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netline.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_plane.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_plane.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_plane.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_plane.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/graphicsitems/bgi_via.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_via.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_airwire.cpp
+++ b/libs/librepcb/project/boards/items/bi_airwire.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_airwire.h
+++ b/libs/librepcb/project/boards/items/bi_airwire.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_base.cpp
+++ b/libs/librepcb/project/boards/items/bi_base.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_base.h
+++ b/libs/librepcb/project/boards/items/bi_base.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_device.cpp
+++ b/libs/librepcb/project/boards/items/bi_device.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_device.h
+++ b/libs/librepcb/project/boards/items/bi_device.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_footprint.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_footprint.h
+++ b/libs/librepcb/project/boards/items/bi_footprint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_footprintpad.h
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_hole.cpp
+++ b/libs/librepcb/project/boards/items/bi_hole.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_hole.h
+++ b/libs/librepcb/project/boards/items/bi_hole.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_netline.cpp
+++ b/libs/librepcb/project/boards/items/bi_netline.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_netline.h
+++ b/libs/librepcb/project/boards/items/bi_netline.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_netpoint.h
+++ b/libs/librepcb/project/boards/items/bi_netpoint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_netsegment.cpp
+++ b/libs/librepcb/project/boards/items/bi_netsegment.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_netsegment.h
+++ b/libs/librepcb/project/boards/items/bi_netsegment.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_plane.cpp
+++ b/libs/librepcb/project/boards/items/bi_plane.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_plane.h
+++ b/libs/librepcb/project/boards/items/bi_plane.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_polygon.cpp
+++ b/libs/librepcb/project/boards/items/bi_polygon.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_polygon.h
+++ b/libs/librepcb/project/boards/items/bi_polygon.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_stroketext.cpp
+++ b/libs/librepcb/project/boards/items/bi_stroketext.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_stroketext.h
+++ b/libs/librepcb/project/boards/items/bi_stroketext.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_via.cpp
+++ b/libs/librepcb/project/boards/items/bi_via.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/boards/items/bi_via.h
+++ b/libs/librepcb/project/boards/items/bi_via.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/circuit.cpp
+++ b/libs/librepcb/project/circuit/circuit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/circuit.h
+++ b/libs/librepcb/project/circuit/circuit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.h
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.h
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceremove.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceremove.h
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.h
+++ b/libs/librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetclassadd.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdnetclassadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetclassadd.h
+++ b/libs/librepcb/project/circuit/cmd/cmdnetclassadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetclassedit.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdnetclassedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetclassedit.h
+++ b/libs/librepcb/project/circuit/cmd/cmdnetclassedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetclassremove.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdnetclassremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetclassremove.h
+++ b/libs/librepcb/project/circuit/cmd/cmdnetclassremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetsignaladd.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdnetsignaladd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetsignaladd.h
+++ b/libs/librepcb/project/circuit/cmd/cmdnetsignaladd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetsignaledit.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdnetsignaledit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetsignaledit.h
+++ b/libs/librepcb/project/circuit/cmd/cmdnetsignaledit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetsignalremove.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdnetsignalremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/cmd/cmdnetsignalremove.h
+++ b/libs/librepcb/project/circuit/cmd/cmdnetsignalremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/project/circuit/componentinstance.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/componentinstance.h
+++ b/libs/librepcb/project/circuit/componentinstance.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/componentsignalinstance.cpp
+++ b/libs/librepcb/project/circuit/componentsignalinstance.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/componentsignalinstance.h
+++ b/libs/librepcb/project/circuit/componentsignalinstance.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/netclass.cpp
+++ b/libs/librepcb/project/circuit/netclass.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/netclass.h
+++ b/libs/librepcb/project/circuit/netclass.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/netsignal.cpp
+++ b/libs/librepcb/project/circuit/netsignal.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/circuit/netsignal.h
+++ b/libs/librepcb/project/circuit/netsignal.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/erc/ercmsg.cpp
+++ b/libs/librepcb/project/erc/ercmsg.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/erc/ercmsg.h
+++ b/libs/librepcb/project/erc/ercmsg.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/erc/ercmsglist.cpp
+++ b/libs/librepcb/project/erc/ercmsglist.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/erc/ercmsglist.h
+++ b/libs/librepcb/project/erc/ercmsglist.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/erc/if_ercmsgprovider.h
+++ b/libs/librepcb/project/erc/if_ercmsgprovider.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/library/cmd/cmdprojectlibraryaddelement.cpp
+++ b/libs/librepcb/project/library/cmd/cmdprojectlibraryaddelement.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/library/cmd/cmdprojectlibraryaddelement.h
+++ b/libs/librepcb/project/library/cmd/cmdprojectlibraryaddelement.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/library/cmd/cmdprojectlibraryremoveelement.cpp
+++ b/libs/librepcb/project/library/cmd/cmdprojectlibraryremoveelement.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/library/cmd/cmdprojectlibraryremoveelement.h
+++ b/libs/librepcb/project/library/cmd/cmdprojectlibraryremoveelement.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/library/projectlibrary.cpp
+++ b/libs/librepcb/project/library/projectlibrary.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/library/projectlibrary.h
+++ b/libs/librepcb/project/library/projectlibrary.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/metadata/cmd/cmdprojectmetadataedit.cpp
+++ b/libs/librepcb/project/metadata/cmd/cmdprojectmetadataedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/metadata/cmd/cmdprojectmetadataedit.h
+++ b/libs/librepcb/project/metadata/cmd/cmdprojectmetadataedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/metadata/projectmetadata.cpp
+++ b/libs/librepcb/project/metadata/projectmetadata.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/metadata/projectmetadata.h
+++ b/libs/librepcb/project/metadata/projectmetadata.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/project.cpp
+++ b/libs/librepcb/project/project.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/project.h
+++ b/libs/librepcb/project/project.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicadd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicadd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelremove.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelremove.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabelremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetpointedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicremove.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdschematicremove.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceadd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceadd.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceadd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceadd.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceedit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceremove.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceremove.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceremove.h
+++ b/libs/librepcb/project/schematics/cmd/cmdsymbolinstanceremove.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_base.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_base.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_base.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_base.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netline.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netline.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netline.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netline.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_base.cpp
+++ b/libs/librepcb/project/schematics/items/si_base.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_base.h
+++ b/libs/librepcb/project/schematics/items/si_base.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netlabel.cpp
+++ b/libs/librepcb/project/schematics/items/si_netlabel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netlabel.h
+++ b/libs/librepcb/project/schematics/items/si_netlabel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netline.cpp
+++ b/libs/librepcb/project/schematics/items/si_netline.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netline.h
+++ b/libs/librepcb/project/schematics/items/si_netline.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netpoint.cpp
+++ b/libs/librepcb/project/schematics/items/si_netpoint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netpoint.h
+++ b/libs/librepcb/project/schematics/items/si_netpoint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netsegment.cpp
+++ b/libs/librepcb/project/schematics/items/si_netsegment.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_netsegment.h
+++ b/libs/librepcb/project/schematics/items/si_netsegment.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_symbol.h
+++ b/libs/librepcb/project/schematics/items/si_symbol.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/items/si_symbolpin.h
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/schematic.cpp
+++ b/libs/librepcb/project/schematics/schematic.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/schematic.h
+++ b/libs/librepcb/project/schematics/schematic.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/schematiclayerprovider.cpp
+++ b/libs/librepcb/project/schematics/schematiclayerprovider.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/schematiclayerprovider.h
+++ b/libs/librepcb/project/schematics/schematiclayerprovider.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/schematicselectionquery.cpp
+++ b/libs/librepcb/project/schematics/schematicselectionquery.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/schematics/schematicselectionquery.h
+++ b/libs/librepcb/project/schematics/schematicselectionquery.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/settings/cmd/cmdprojectsettingschange.cpp
+++ b/libs/librepcb/project/settings/cmd/cmdprojectsettingschange.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/settings/cmd/cmdprojectsettingschange.h
+++ b/libs/librepcb/project/settings/cmd/cmdprojectsettingschange.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/settings/projectsettings.cpp
+++ b/libs/librepcb/project/settings/projectsettings.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/project/settings/projectsettings.h
+++ b/libs/librepcb/project/settings/projectsettings.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardlayersdock.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayersdock.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardlayersdock.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayersdock.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardlayerstacksetupdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayerstacksetupdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardlayerstacksetupdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayerstacksetupdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_adddevice.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_adddevice.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_adddevice.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_adddevice.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_fsm.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorevent.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorevent.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorevent.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorevent.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.h
+++ b/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.h
+++ b/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdadddevicetoboard.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdadddevicetoboard.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdadddevicetoboard.h
+++ b/libs/librepcb/projecteditor/cmd/cmdadddevicetoboard.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdaddsymboltoschematic.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdaddsymboltoschematic.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdaddsymboltoschematic.h
+++ b/libs/librepcb/projecteditor/cmd/cmdaddsymboltoschematic.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.h
+++ b/libs/librepcb/projecteditor/cmd/cmdchangenetsignalofschematicnetsegment.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombineallnetsignalsunderschematicnetpoint.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineallnetsignalsunderschematicnetpoint.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombineallnetsignalsunderschematicnetpoint.h
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineallnetsignalsunderschematicnetpoint.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.h
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombinenetsignals.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombinenetsignals.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombinenetsignals.h
+++ b/libs/librepcb/projecteditor/cmd/cmdcombinenetsignals.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.h
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdflipselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdflipselectedboarditems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdflipselectedboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdflipselectedboarditems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdmoveselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmoveselectedboarditems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdmoveselectedboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdmoveselectedboarditems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdmoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmoveselectedschematicitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdmoveselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdmoveselectedschematicitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveunusedlibraryelements.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveunusedlibraryelements.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveunusedlibraryelements.h
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveunusedlibraryelements.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveunusednetsignals.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveunusednetsignals.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdremoveunusednetsignals.h
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveunusednetsignals.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdreplacedevice.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdreplacedevice.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdreplacedevice.h
+++ b/libs/librepcb/projecteditor/cmd/cmdreplacedevice.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdrotateselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdrotateselectedboarditems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdrotateselectedboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdrotateselectedboarditems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdrotateselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdrotateselectedschematicitems.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/cmd/cmdrotateselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdrotateselectedschematicitems.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/editnetclassesdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/editnetclassesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/editnetclassesdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/editnetclassesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.h
+++ b/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/docks/ercmsgdock.cpp
+++ b/libs/librepcb/projecteditor/docks/ercmsgdock.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/docks/ercmsgdock.h
+++ b/libs/librepcb/projecteditor/docks/ercmsgdock.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizard.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizard.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizard.h
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizard.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_initialization.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_initialization.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_initialization.h
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_initialization.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.h
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.h
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/projecteditor.cpp
+++ b/libs/librepcb/projecteditor/projecteditor.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/projecteditor.h
+++ b/libs/librepcb/projecteditor/projecteditor.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorevent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorevent.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorevent.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorevent.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_fsm.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_fsm.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_fsm.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_fsm.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/schematicclipboard.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicclipboard.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/schematicclipboard.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicclipboard.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/favoriteprojectsmodel.cpp
+++ b/libs/librepcb/workspace/favoriteprojectsmodel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/favoriteprojectsmodel.h
+++ b/libs/librepcb/workspace/favoriteprojectsmodel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/fileiconprovider.cpp
+++ b/libs/librepcb/workspace/fileiconprovider.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/fileiconprovider.h
+++ b/libs/librepcb/workspace/fileiconprovider.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/cat/categorytreeitem.cpp
+++ b/libs/librepcb/workspace/library/cat/categorytreeitem.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/cat/categorytreeitem.h
+++ b/libs/librepcb/workspace/library/cat/categorytreeitem.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/cat/categorytreemodel.cpp
+++ b/libs/librepcb/workspace/library/cat/categorytreemodel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/cat/categorytreemodel.h
+++ b/libs/librepcb/workspace/library/cat/categorytreemodel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.h
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/projecttreemodel.cpp
+++ b/libs/librepcb/workspace/projecttreemodel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/projecttreemodel.h
+++ b/libs/librepcb/workspace/projecttreemodel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/recentprojectsmodel.cpp
+++ b/libs/librepcb/workspace/recentprojectsmodel.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/recentprojectsmodel.h
+++ b/libs/librepcb/workspace/recentprojectsmodel.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_appdefaultmeasurementunits.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_appdefaultmeasurementunits.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_appdefaultmeasurementunits.h
+++ b/libs/librepcb/workspace/settings/items/wsi_appdefaultmeasurementunits.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_appearance.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_appearance.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_appearance.h
+++ b/libs/librepcb/workspace/settings/items/wsi_appearance.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_applocale.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_applocale.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_applocale.h
+++ b/libs/librepcb/workspace/settings/items/wsi_applocale.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_base.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_base.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_base.h
+++ b/libs/librepcb/workspace/settings/items/wsi_base.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_debugtools.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_debugtools.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_debugtools.h
+++ b/libs/librepcb/workspace/settings/items/wsi_debugtools.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_librarylocaleorder.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_librarylocaleorder.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_librarylocaleorder.h
+++ b/libs/librepcb/workspace/settings/items/wsi_librarylocaleorder.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_librarynormorder.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_librarynormorder.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_librarynormorder.h
+++ b/libs/librepcb/workspace/settings/items/wsi_librarynormorder.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_projectautosaveinterval.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_projectautosaveinterval.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_projectautosaveinterval.h
+++ b/libs/librepcb/workspace/settings/items/wsi_projectautosaveinterval.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_repositories.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_repositories.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_repositories.h
+++ b/libs/librepcb/workspace/settings/items/wsi_repositories.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_user.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_user.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/items/wsi_user.h
+++ b/libs/librepcb/workspace/settings/items/wsi_user.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/workspacesettings.cpp
+++ b/libs/librepcb/workspace/settings/workspacesettings.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/workspacesettings.h
+++ b/libs/librepcb/workspace/settings/workspacesettings.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/workspacesettingsdialog.cpp
+++ b/libs/librepcb/workspace/settings/workspacesettingsdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/settings/workspacesettingsdialog.h
+++ b/libs/librepcb/workspace/settings/workspacesettingsdialog.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/librepcb/workspace/workspace.h
+++ b/libs/librepcb/workspace/workspace.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/librepcb/library/readme_template
+++ b/share/librepcb/library/readme_template
@@ -2,7 +2,7 @@
 
 ## Description
 
-This is a [LibrePCB](http://librepcb.org) library!
+This is a [LibrePCB](https://librepcb.org) library!
 Just edit this file to add a description about it.
 
 ## License

--- a/share/librepcb/project/readme_template
+++ b/share/librepcb/project/readme_template
@@ -2,7 +2,7 @@
 
 ## Description
 
-This is a [LibrePCB](http://librepcb.org) project!
+This is a [LibrePCB](https://librepcb.org) project!
 Just edit this file to add a description about it.
 
 ## License

--- a/share/metainfo/org.librepcb.LibrePCB.appdata.xml
+++ b/share/metainfo/org.librepcb.LibrePCB.appdata.xml
@@ -35,27 +35,27 @@
     </screenshot>
     <screenshot>
       <caption>Control panel</caption>
-      <image>http://librepcb.org/img/control_panel.png</image>
+      <image>https://librepcb.org/img/control_panel.png</image>
     </screenshot>
     <screenshot>
       <caption>Schematic Editor</caption>
-      <image>http://librepcb.org/img/schematic_editor.png</image>
+      <image>https://librepcb.org/img/schematic_editor.png</image>
     </screenshot>
     <screenshot>
       <caption>Board editor</caption>
-      <image>http://librepcb.org/img/board_editor.png</image>
+      <image>https://librepcb.org/img/board_editor.png</image>
     </screenshot>
     <screenshot>
       <caption>Library browser</caption>
-      <image>http://librepcb.org/img/thumbs/add_component_dialog.png</image>
+      <image>https://librepcb.org/img/thumbs/add_component_dialog.png</image>
     </screenshot>
     <screenshot>
       <caption>Library manager</caption>
-      <image>http://librepcb.org/img/library_manager.png</image>
+      <image>https://librepcb.org/img/library_manager.png</image>
     </screenshot>
   </screenshots>
 
-  <url type="homepage">http://librepcb.org</url>
+  <url type="homepage">https://librepcb.org</url>
   <url type="bugtracker">https://github.com/LibrePCB/LibrePCB/issues</url>
   <url type="help">https://docs.librepcb.org/</url>
   

--- a/tests/unittests/common/applicationtest.cpp
+++ b/tests/unittests/common/applicationtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/attributes/attributeproviderdummy.h
+++ b/tests/unittests/common/attributes/attributeproviderdummy.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/attributes/attributesubstitutortest.cpp
+++ b/tests/unittests/common/attributes/attributesubstitutortest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/directorylocktest.cpp
+++ b/tests/unittests/common/directorylocktest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/filedownloadtest.cpp
+++ b/tests/unittests/common/filedownloadtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/fileio/serializableobjectlisttest.cpp
+++ b/tests/unittests/common/fileio/serializableobjectlisttest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/fileio/serializableobjectmock.h
+++ b/tests/unittests/common/fileio/serializableobjectmock.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/filepathtest.cpp
+++ b/tests/unittests/common/filepathtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/networkrequestbasesignalreceiver.h
+++ b/tests/unittests/common/networkrequestbasesignalreceiver.h
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/networkrequesttest.cpp
+++ b/tests/unittests/common/networkrequesttest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/pointtest.cpp
+++ b/tests/unittests/common/pointtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/ratiotest.cpp
+++ b/tests/unittests/common/ratiotest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/scopeguardtest.cpp
+++ b/tests/unittests/common/scopeguardtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2016 The LibrePCB developers
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/sqlitedatabasetest.cpp
+++ b/tests/unittests/common/sqlitedatabasetest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/systeminfotest.cpp
+++ b/tests/unittests/common/systeminfotest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/toolboxtest.cpp
+++ b/tests/unittests/common/toolboxtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2017 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/uuidtest.cpp
+++ b/tests/unittests/common/uuidtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/common/versiontest.cpp
+++ b/tests/unittests/common/versiontest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/eagleimport/deviceconvertertest.cpp
+++ b/tests/unittests/eagleimport/deviceconvertertest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/eagleimport/devicesetconvertertest.cpp
+++ b/tests/unittests/eagleimport/devicesetconvertertest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/eagleimport/packageconvertertest.cpp
+++ b/tests/unittests/eagleimport/packageconvertertest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/eagleimport/symbolconvertertest.cpp
+++ b/tests/unittests/eagleimport/symbolconvertertest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/library/librarybaseelementtest.cpp
+++ b/tests/unittests/library/librarybaseelementtest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/main.cpp
+++ b/tests/unittests/main.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/project/boards/boardplanefragmentsbuildertest.cpp
+++ b/tests/unittests/project/boards/boardplanefragmentsbuildertest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/project/library/projectlibrarytest.cpp
+++ b/tests/unittests/project/library/projectlibrarytest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/project/projecttest.cpp
+++ b/tests/unittests/project/projecttest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unittests/workspace/workspacetest.cpp
+++ b/tests/unittests/workspace/workspacetest.cpp
@@ -1,7 +1,7 @@
 /*
  * LibrePCB - Professional EDA for everyone!
  * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
- * http://librepcb.org/
+ * https://librepcb.org/
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Our website now supports TLS, so all URLs should be changed fro http://librepcb.org to https://librepcb.org.