### PR TITLE
Mark many strings as nontranslatable

### DIFF
--- a/libs/librepcb/common/attributes/attrtypecapacitance.cpp
+++ b/libs/librepcb/common/attributes/attrtypecapacitance.cpp
@@ -37,13 +37,13 @@ namespace librepcb {
 
 AttrTypeCapacitance::AttrTypeCapacitance() noexcept
   : AttributeType(Type_t::Capacitance, "capacitance", tr("Capacitance")) {
-  mDefaultUnit = new AttributeUnit("microfarad", tr("μF"));
+  mDefaultUnit = new AttributeUnit("microfarad", "μF");
 
-  mAvailableUnits.append(new AttributeUnit("picofarad", tr("pF")));
-  mAvailableUnits.append(new AttributeUnit("nanofarad", tr("nF")));
+  mAvailableUnits.append(new AttributeUnit("picofarad", "pF"));
+  mAvailableUnits.append(new AttributeUnit("nanofarad", "nF"));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("millifarad", tr("mF")));
-  mAvailableUnits.append(new AttributeUnit("farad", tr("F")));
+  mAvailableUnits.append(new AttributeUnit("millifarad", "mF"));
+  mAvailableUnits.append(new AttributeUnit("farad", "F"));
 }
 
 AttrTypeCapacitance::~AttrTypeCapacitance() noexcept {

--- a/libs/librepcb/common/attributes/attrtypecapacitance.cpp
+++ b/libs/librepcb/common/attributes/attrtypecapacitance.cpp
@@ -74,7 +74,7 @@ QString AttrTypeCapacitance::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
+    return QLocale().toString(v) % unit->getSymbolTr();
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtypecapacitance.cpp
+++ b/libs/librepcb/common/attributes/attrtypecapacitance.cpp
@@ -74,7 +74,7 @@ QString AttrTypeCapacitance::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString(tr("%1%2")).arg(QLocale().toString(v), unit->getSymbolTr());
+    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtypefrequency.cpp
+++ b/libs/librepcb/common/attributes/attrtypefrequency.cpp
@@ -75,7 +75,7 @@ QString AttrTypeFrequency::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
+    return QLocale().toString(v) % unit->getSymbolTr();
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtypefrequency.cpp
+++ b/libs/librepcb/common/attributes/attrtypefrequency.cpp
@@ -37,14 +37,14 @@ namespace librepcb {
 
 AttrTypeFrequency::AttrTypeFrequency() noexcept
   : AttributeType(Type_t::Frequency, "frequency", tr("Frequency")) {
-  mDefaultUnit = new AttributeUnit("hertz", tr("Hz"));
+  mDefaultUnit = new AttributeUnit("hertz", "Hz");
 
-  mAvailableUnits.append(new AttributeUnit("microhertz", tr("μHz")));
-  mAvailableUnits.append(new AttributeUnit("millihertz", tr("mHz")));
+  mAvailableUnits.append(new AttributeUnit("microhertz", "μHz"));
+  mAvailableUnits.append(new AttributeUnit("millihertz", "mHz"));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kilohertz", tr("kHz")));
-  mAvailableUnits.append(new AttributeUnit("megahertz", tr("MHz")));
-  mAvailableUnits.append(new AttributeUnit("gigahertz", tr("GHz")));
+  mAvailableUnits.append(new AttributeUnit("kilohertz", "kHz"));
+  mAvailableUnits.append(new AttributeUnit("megahertz", "MHz"));
+  mAvailableUnits.append(new AttributeUnit("gigahertz", "GHz"));
 }
 
 AttrTypeFrequency::~AttrTypeFrequency() noexcept {

--- a/libs/librepcb/common/attributes/attrtypefrequency.cpp
+++ b/libs/librepcb/common/attributes/attrtypefrequency.cpp
@@ -75,7 +75,7 @@ QString AttrTypeFrequency::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString(tr("%1%2")).arg(QLocale().toString(v), unit->getSymbolTr());
+    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtypeinductance.cpp
+++ b/libs/librepcb/common/attributes/attrtypeinductance.cpp
@@ -37,12 +37,12 @@ namespace librepcb {
 
 AttrTypeInductance::AttrTypeInductance() noexcept
   : AttributeType(Type_t::Inductance, "inductance", tr("Inductance")) {
-  mDefaultUnit = new AttributeUnit("millihenry", tr("mH"));
+  mDefaultUnit = new AttributeUnit("millihenry", "mH");
 
-  mAvailableUnits.append(new AttributeUnit("nanohenry", tr("nH")));
-  mAvailableUnits.append(new AttributeUnit("microhenry", tr("μH")));
+  mAvailableUnits.append(new AttributeUnit("nanohenry", "nH"));
+  mAvailableUnits.append(new AttributeUnit("microhenry", "μH"));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("henry", tr("H")));
+  mAvailableUnits.append(new AttributeUnit("henry", "H"));
 }
 
 AttrTypeInductance::~AttrTypeInductance() noexcept {

--- a/libs/librepcb/common/attributes/attrtypeinductance.cpp
+++ b/libs/librepcb/common/attributes/attrtypeinductance.cpp
@@ -73,7 +73,7 @@ QString AttrTypeInductance::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
+    return QLocale().toString(v) % unit->getSymbolTr();
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtypeinductance.cpp
+++ b/libs/librepcb/common/attributes/attrtypeinductance.cpp
@@ -73,7 +73,7 @@ QString AttrTypeInductance::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString(tr("%1%2")).arg(QLocale().toString(v), unit->getSymbolTr());
+    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtyperesistance.cpp
+++ b/libs/librepcb/common/attributes/attrtyperesistance.cpp
@@ -37,13 +37,13 @@ namespace librepcb {
 
 AttrTypeResistance::AttrTypeResistance() noexcept
   : AttributeType(Type_t::Resistance, "resistance", tr("Resistance")) {
-  mDefaultUnit = new AttributeUnit("ohm", tr("Ω"));
+  mDefaultUnit = new AttributeUnit("ohm", "Ω");
 
-  mAvailableUnits.append(new AttributeUnit("microohm", tr("μΩ")));
-  mAvailableUnits.append(new AttributeUnit("milliohm", tr("mΩ")));
+  mAvailableUnits.append(new AttributeUnit("microohm", "μΩ"));
+  mAvailableUnits.append(new AttributeUnit("milliohm", "mΩ"));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kiloohm", tr("kΩ")));
-  mAvailableUnits.append(new AttributeUnit("megaohm", tr("MΩ")));
+  mAvailableUnits.append(new AttributeUnit("kiloohm", "kΩ"));
+  mAvailableUnits.append(new AttributeUnit("megaohm", "MΩ"));
 }
 
 AttrTypeResistance::~AttrTypeResistance() noexcept {

--- a/libs/librepcb/common/attributes/attrtyperesistance.cpp
+++ b/libs/librepcb/common/attributes/attrtyperesistance.cpp
@@ -74,7 +74,7 @@ QString AttrTypeResistance::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
+    return QLocale().toString(v) % unit->getSymbolTr();
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtyperesistance.cpp
+++ b/libs/librepcb/common/attributes/attrtyperesistance.cpp
@@ -74,7 +74,7 @@ QString AttrTypeResistance::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString(tr("%1%2")).arg(QLocale().toString(v), unit->getSymbolTr());
+    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtypevoltage.cpp
+++ b/libs/librepcb/common/attributes/attrtypevoltage.cpp
@@ -37,14 +37,14 @@ namespace librepcb {
 
 AttrTypeVoltage::AttrTypeVoltage() noexcept
   : AttributeType(Type_t::Voltage, "voltage", tr("Voltage")) {
-  mDefaultUnit = new AttributeUnit("volt", tr("V"));
+  mDefaultUnit = new AttributeUnit("volt", "V");
 
-  mAvailableUnits.append(new AttributeUnit("nanovolt", tr("nV")));
-  mAvailableUnits.append(new AttributeUnit("microvolt", tr("μV")));
-  mAvailableUnits.append(new AttributeUnit("millivolt", tr("mV")));
+  mAvailableUnits.append(new AttributeUnit("nanovolt", "nV"));
+  mAvailableUnits.append(new AttributeUnit("microvolt", "μV"));
+  mAvailableUnits.append(new AttributeUnit("millivolt", "mV"));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kilovolt", tr("kV")));
-  mAvailableUnits.append(new AttributeUnit("megavolt", tr("MV")));
+  mAvailableUnits.append(new AttributeUnit("kilovolt", "kV"));
+  mAvailableUnits.append(new AttributeUnit("megavolt", "MV"));
 }
 
 AttrTypeVoltage::~AttrTypeVoltage() noexcept {

--- a/libs/librepcb/common/attributes/attrtypevoltage.cpp
+++ b/libs/librepcb/common/attributes/attrtypevoltage.cpp
@@ -75,7 +75,7 @@ QString AttrTypeVoltage::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
+    return QLocale().toString(v) % unit->getSymbolTr();
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/attributes/attrtypevoltage.cpp
+++ b/libs/librepcb/common/attributes/attrtypevoltage.cpp
@@ -75,7 +75,7 @@ QString AttrTypeVoltage::printableValueTr(const QString&       value,
   bool  ok = false;
   float v  = value.toFloat(&ok);
   if (ok && unit)
-    return QString(tr("%1%2")).arg(QLocale().toString(v), unit->getSymbolTr());
+    return QString("%1%2").arg(QLocale().toString(v), unit->getSymbolTr());
   else if (ok)
     return QLocale().toString(v);
   else

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.ui
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.ui
@@ -59,7 +59,7 @@
    <item row="3" column="3">
     <widget class="QDoubleSpinBox" name="spbxStopMaskMaxViaDia">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -82,7 +82,7 @@
    <item row="4" column="1">
     <widget class="QDoubleSpinBox" name="spbxStopMaskClrMin">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -98,7 +98,7 @@
    <item row="4" column="2">
     <widget class="QDoubleSpinBox" name="spbxStopMaskClrRatio">
      <property name="suffix">
-      <string>%</string>
+      <string notr="true">%</string>
      </property>
      <property name="decimals">
       <number>2</number>
@@ -114,7 +114,7 @@
    <item row="4" column="3">
     <widget class="QDoubleSpinBox" name="spbxStopMaskClrMax">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -137,7 +137,7 @@
    <item row="5" column="1">
     <widget class="QDoubleSpinBox" name="spbxCreamMaskClrMin">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -153,7 +153,7 @@
    <item row="5" column="2">
     <widget class="QDoubleSpinBox" name="spbxCreamMaskClrRatio">
      <property name="suffix">
-      <string>%</string>
+      <string notr="true">%</string>
      </property>
      <property name="decimals">
       <number>2</number>
@@ -169,7 +169,7 @@
    <item row="5" column="3">
     <widget class="QDoubleSpinBox" name="spbxCreamMaskClrMax">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -192,7 +192,7 @@
    <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="spbxRestringPadsMin">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -208,7 +208,7 @@
    <item row="6" column="2">
     <widget class="QDoubleSpinBox" name="spbxRestringPadsRatio">
      <property name="suffix">
-      <string>%</string>
+      <string notr="true">%</string>
      </property>
      <property name="decimals">
       <number>2</number>
@@ -224,7 +224,7 @@
    <item row="6" column="3">
     <widget class="QDoubleSpinBox" name="spbxRestringPadsMax">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -247,7 +247,7 @@
    <item row="7" column="1">
     <widget class="QDoubleSpinBox" name="spbxRestringViasMin">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>
@@ -263,7 +263,7 @@
    <item row="7" column="2">
     <widget class="QDoubleSpinBox" name="spbxRestringViasRatio">
      <property name="suffix">
-      <string>%</string>
+      <string notr="true">%</string>
      </property>
      <property name="decimals">
       <number>2</number>
@@ -279,7 +279,7 @@
    <item row="7" column="3">
     <widget class="QDoubleSpinBox" name="spbxRestringViasMax">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
      <property name="decimals">
       <number>3</number>

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>324</width>
+    <width>328</width>
     <height>388</height>
    </rect>
   </property>
@@ -62,7 +62,7 @@
      <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="spbHeight">
        <property name="suffix">
-        <string>mm</string>
+        <string notr="true">mm</string>
        </property>
        <property name="decimals">
         <number>6</number>
@@ -157,7 +157,7 @@
      <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="spbxStrokeWidth">
        <property name="suffix">
-        <string>mm</string>
+        <string notr="true">mm</string>
        </property>
        <property name="decimals">
         <number>6</number>
@@ -200,7 +200,7 @@
        <item>
         <widget class="QDoubleSpinBox" name="spbxLineSpacingRatio">
          <property name="suffix">
-          <string>%</string>
+          <string notr="true">%</string>
          </property>
          <property name="decimals">
           <number>4</number>
@@ -244,7 +244,7 @@
        <item>
         <widget class="QDoubleSpinBox" name="spbxLetterSpacingRatio">
          <property name="suffix">
-          <string>%</string>
+          <string notr="true">%</string>
          </property>
          <property name="decimals">
           <number>4</number>

--- a/libs/librepcb/common/units/lengthunit.cpp
+++ b/libs/librepcb/common/units/lengthunit.cpp
@@ -79,15 +79,15 @@ QString LengthUnit::toStringTr() const noexcept {
 QString LengthUnit::toShortStringTr() const noexcept {
   switch (mUnit) {
     case LengthUnit_t::Millimeters:
-      return tr("mm");
+      return "mm";
     case LengthUnit_t::Micrometers:
-      return tr("μm");
+      return "μm";
     case LengthUnit_t::Nanometers:
-      return tr("nm");
+      return "nm";
     case LengthUnit_t::Inches:
-      return tr("″");
+      return "″";
     case LengthUnit_t::Mils:
-      return tr("mils");
+      return "mils";
     default:
       qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
       Q_ASSERT(false);

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
@@ -67,7 +67,7 @@
           <enum>QAbstractSpinBox::UpDownArrows</enum>
          </property>
          <property name="suffix">
-          <string>mm</string>
+          <string notr="true">mm</string>
          </property>
          <property name="decimals">
           <number>6</number>
@@ -101,7 +101,7 @@
           <enum>QAbstractSpinBox::UpDownArrows</enum>
          </property>
          <property name="suffix">
-          <string>mm</string>
+          <string notr="true">mm</string>
          </property>
          <property name="decimals">
           <number>6</number>
@@ -129,7 +129,7 @@
      <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="spbxSize">
        <property name="suffix">
-        <string>mm</string>
+        <string notr="true">mm</string>
        </property>
        <property name="minimum">
         <double>0.010000000000000</double>
@@ -149,7 +149,7 @@
      <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="spbxDrillDiameter">
        <property name="suffix">
-        <string>mm</string>
+        <string notr="true">mm</string>
        </property>
        <property name="minimum">
         <double>0.010000000000000</double>

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
@@ -56,7 +56,7 @@
            <enum>QAbstractSpinBox::UpDownArrows</enum>
           </property>
           <property name="suffix">
-           <string>mm</string>
+           <string notr="true">mm</string>
           </property>
           <property name="decimals">
            <number>6</number>
@@ -94,7 +94,7 @@
            </size>
           </property>
           <property name="suffix">
-           <string>mm</string>
+           <string notr="true">mm</string>
           </property>
           <property name="decimals">
            <number>6</number>
@@ -132,7 +132,7 @@
            </size>
           </property>
           <property name="suffix">
-           <string>°</string>
+           <string notr="true">°</string>
           </property>
           <property name="decimals">
            <number>6</number>

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -76,7 +76,7 @@
            <enum>QAbstractSpinBox::UpDownArrows</enum>
           </property>
           <property name="suffix">
-           <string>mm</string>
+           <string notr="true">mm</string>
           </property>
           <property name="decimals">
            <number>6</number>
@@ -114,7 +114,7 @@
            </size>
           </property>
           <property name="suffix">
-           <string>mm</string>
+           <string notr="true">mm</string>
           </property>
           <property name="decimals">
            <number>6</number>
@@ -152,7 +152,7 @@
            </size>
           </property>
           <property name="suffix">
-           <string>°</string>
+           <string notr="true">°</string>
           </property>
           <property name="decimals">
            <number>6</number>


### PR DESCRIPTION
Please remove the "translatable" flag for units and unit-suffixes when creating new dialogs - saves time for the translators :slightly_smiling_face: 