### PR TITLE
Length: Reimplement mapNmToGrid() without using floating point

### DIFF
--- a/libs/librepcb/common/units/length.cpp
+++ b/libs/librepcb/common/units/length.cpp
@@ -197,7 +197,7 @@ LengthBase_t Length::mapNmToGrid(LengthBase_t  nanometers,
   }
 
   LengthBaseU_t remainder = nm_abs % grid_interval;
-  if (remainder >= (grid_interval / 2)) {
+  if (remainder > (grid_interval / 2)) {
     // snap away from zero, but it might overflow
     LengthBaseU_t tmp_snapped = nm_abs + (grid_interval - remainder);
     if ((tmp_snapped < nm_abs) || (tmp_snapped > max)) {

--- a/libs/librepcb/common/units/length.cpp
+++ b/libs/librepcb/common/units/length.cpp
@@ -96,7 +96,11 @@ Length Length::abs() const noexcept {
 }
 
 Length& Length::makeAbs() noexcept {
-  mNanometers = qAbs(mNanometers);
+  if (mNanometers == std::numeric_limits<LengthBase_t>::min()) {
+    mNanometers = std::numeric_limits<LengthBase_t>::max();
+  } else {
+    mNanometers = qAbs(mNanometers);
+  }
   return *this;
 }
 
@@ -177,8 +181,7 @@ LengthBase_t Length::mapNmToGrid(LengthBase_t  nanometers,
                                  const Length& gridInterval) noexcept {
   using LengthBaseU_t = std::make_unsigned<LengthBase_t>::type;
 
-  // assume gridInterval >= 0
-  LengthBaseU_t grid_interval = static_cast<LengthBaseU_t>(gridInterval.mNanometers);
+  LengthBaseU_t grid_interval = static_cast<LengthBaseU_t>(gridInterval.abs().mNanometers);
   if (grid_interval == 0)
     return nanometers;
 

--- a/libs/librepcb/common/units/length.cpp
+++ b/libs/librepcb/common/units/length.cpp
@@ -200,7 +200,7 @@ LengthBase_t Length::mapNmToGrid(LengthBase_t  nanometers,
   if (remainder >= (grid_interval / 2)) {
     // snap away from zero, but it might overflow
     LengthBaseU_t tmp_snapped = nm_abs + (grid_interval - remainder);
-    if (tmp_snapped < nm_abs || tmp_snapped > max) {
+    if ((tmp_snapped < nm_abs) || (tmp_snapped > max)) {
       // overflow, snap towards zero
       nm_abs -= remainder;
     } else {

--- a/libs/librepcb/common/units/length.cpp
+++ b/libs/librepcb/common/units/length.cpp
@@ -175,11 +175,43 @@ void Length::setLengthFromFloat(qreal nanometers) {
 
 LengthBase_t Length::mapNmToGrid(LengthBase_t  nanometers,
                                  const Length& gridInterval) noexcept {
-  if (gridInterval.mNanometers != 0)
-    return qRound((qreal)nanometers / gridInterval.mNanometers) *
-           gridInterval.mNanometers;
-  else
+  using LengthBaseU_t = std::make_unsigned<LengthBase_t>::type;
+
+  // assume gridInterval >= 0
+  LengthBaseU_t grid_interval = static_cast<LengthBaseU_t>(gridInterval.mNanometers);
+  if (grid_interval == 0)
     return nanometers;
+
+  LengthBaseU_t nm_abs;
+  LengthBaseU_t max;
+
+  if (nanometers >= 0) {
+    nm_abs = static_cast<LengthBaseU_t>(nanometers);
+    max = static_cast<LengthBaseU_t>(std::numeric_limits<LengthBase_t>::max());
+  } else {
+    nm_abs = -static_cast<LengthBaseU_t>(nanometers);
+    max = static_cast<LengthBaseU_t>(std::numeric_limits<LengthBase_t>::min());
+  }
+
+  LengthBaseU_t remainder = nm_abs % grid_interval;
+  if (remainder >= (grid_interval / 2)) {
+    // snap away from zero, but it might overflow
+    LengthBaseU_t tmp_snapped = nm_abs + (grid_interval - remainder);
+    if (tmp_snapped < nm_abs || tmp_snapped > max) {
+      // overflow, snap towards zero
+      nm_abs -= remainder;
+    } else {
+      nm_abs = tmp_snapped;
+    }
+  } else {
+    // snap towards zero
+    nm_abs -= remainder;
+  }
+
+  if (nanometers >= 0)
+    return static_cast<LengthBase_t>(nm_abs);
+  else
+    return static_cast<LengthBase_t>(-nm_abs);
 }
 
 LengthBase_t Length::mmStringToNm(const QString& millimeters) {

--- a/libs/librepcb/common/units/length.h
+++ b/libs/librepcb/common/units/length.h
@@ -571,10 +571,6 @@ private:
    *
    * @return  The length which is mapped to the grid (always a multiple of
    * gridInterval)
-   *
-   * @todo    does this work correctly with large 64bit integers?!
-   *          and maybe there is a better, integer-based method for this
-   * purpose?
    */
   static LengthBase_t mapNmToGrid(LengthBase_t  nanometers,
                                   const Length& gridInterval) noexcept;

--- a/tests/unittests/common/lengthsnaptest.cpp
+++ b/tests/unittests/common/lengthsnaptest.cpp
@@ -1,0 +1,88 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/common/units/length.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  Length value;
+  Length gridInterval;
+  Length mappedToGrid;
+} LengthSnapTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class LengthSnapTest : public ::testing::TestWithParam<LengthSnapTestData> {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+TEST_P(LengthSnapTest, testSnapToGrid) {
+  const LengthSnapTestData& data = GetParam();
+  EXPECT_EQ(data.value.mappedToGrid(data.gridInterval), data.mappedToGrid);
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(LengthSnapTest, LengthSnapTest, ::testing::Values(
+    LengthSnapTestData({Length(0),   Length(10), Length(0)  }),
+    LengthSnapTestData({Length(10),  Length(0),  Length(10) }),
+    LengthSnapTestData({Length(-10), Length(0),  Length(-10)}),
+    LengthSnapTestData({Length(10),  Length(1),  Length(10) }),
+    LengthSnapTestData({Length(-10), Length(1),  Length(-10)}),
+    LengthSnapTestData({Length(8),   Length(10), Length(10) }),
+    LengthSnapTestData({Length(2),   Length(10), Length(0)  }),
+    LengthSnapTestData({Length(-8),  Length(10), Length(-10)}),
+    LengthSnapTestData({Length(-2),  Length(10), Length(0)  }),
+    LengthSnapTestData({Length(18),  Length(10), Length(20) }),
+    LengthSnapTestData({Length(12),  Length(10), Length(10) }),
+    LengthSnapTestData({Length(-18), Length(10), Length(-20)}),
+    LengthSnapTestData({Length(-12), Length(10), Length(-10)}),
+    LengthSnapTestData({Length(10),  Length(10), Length(10) }),
+    LengthSnapTestData({Length(-10), Length(10), Length(-10)}),
+    LengthSnapTestData({Length(20),  Length(10), Length(20) }),
+    LengthSnapTestData({Length(-20), Length(10), Length(-20)})
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/lengthtest.cpp
+++ b/tests/unittests/common/lengthtest.cpp
@@ -36,11 +36,9 @@ namespace tests {
 
 typedef struct {
   bool    valid;
-  QString orig_str;
+  QString origStr;
   Length  value;
-  QString gen_str;
-  Length grid_interval;
-  Length mapped_to_grid;
+  QString genStr;
 } LengthTestData;
 
 /*******************************************************************************
@@ -56,9 +54,9 @@ TEST_P(LengthTest, testFromMm) {
   const LengthTestData& data = GetParam();
 
   if (data.valid) {
-    EXPECT_EQ(Length::fromMm(data.orig_str), data.value);
+    EXPECT_EQ(Length::fromMm(data.origStr), data.value);
   } else {
-    EXPECT_THROW(Length::fromMm(data.orig_str), RuntimeError);
+    EXPECT_THROW(Length::fromMm(data.origStr), RuntimeError);
   }
 }
 
@@ -66,15 +64,7 @@ TEST_P(LengthTest, testToMmString) {
   const LengthTestData& data = GetParam();
 
   if (data.valid) {
-    EXPECT_EQ(data.value.toMmString(), data.gen_str);
-  }
-}
-
-TEST_P(LengthTest, testSnapToGrid) {
-  const LengthTestData& data = GetParam();
-
-  if (data.valid) {
-    EXPECT_EQ(data.value.mappedToGrid(data.grid_interval), data.mapped_to_grid);
+    EXPECT_EQ(data.value.toMmString(), data.genStr);
   }
 }
 
@@ -85,63 +75,44 @@ TEST_P(LengthTest, testSnapToGrid) {
 // clang-format off
 INSTANTIATE_TEST_CASE_P(LengthTest, LengthTest, ::testing::Values(
     // from/to mm
-    LengthTestData({true,  "0",              Length(0),           "0.0",          Length(0),  Length(0)           }),
-    LengthTestData({true,  "1",              Length(1000000),     "1.0",          Length(0),  Length(1000000)     }),
-    LengthTestData({true,  "-1",             Length(-1000000),    "-1.0",         Length(0),  Length(-1000000)    }),
-    LengthTestData({true,  "0.000001",       Length(1),           "0.000001",     Length(0),  Length(1)           }),
-    LengthTestData({true,  "-0.000001",      Length(-1),          "-0.000001",    Length(0),  Length(-1)          }),
-    LengthTestData({true,  "1e-6",           Length(1),           "0.000001",     Length(0),  Length(1)           }),
-    LengthTestData({true,  "-1e-6",          Length(-1),          "-0.000001",    Length(0),  Length(-1)          }),
-    LengthTestData({true,  "1.000001",       Length(1000001),     "1.000001",     Length(0),  Length(1000001)     }),
-    LengthTestData({true,  "-1.000001",      Length(-1000001),    "-1.000001",    Length(0),  Length(-1000001)    }),
-    LengthTestData({true,  "1e3",            Length(1000000000),  "1000.0",       Length(0),  Length(1000000000)  }),
-    LengthTestData({true,  "-1e3",           Length(-1000000000), "-1000.0",      Length(0),  Length(-1000000000) }),
-    LengthTestData({true,  ".1",             Length(100000),      "0.1",          Length(0),  Length(100000)      }),
-    LengthTestData({true,  "1.",             Length(1000000),     "1.0",          Length(0),  Length(1000000)     }),
-    LengthTestData({true,  "2147483647e-6",  Length(2147483647),  "2147.483647",  Length(0),  Length(2147483647)  }),
-    LengthTestData({true,  "-2147483648e-6", Length(-2147483648), "-2147.483648", Length(0),  Length(-2147483648) }),
-    LengthTestData({true,  "9",              Length(9000000),     "9.0",          Length(0),  Length(9000000)     }),
-    LengthTestData({true,  "9.9",            Length(9900000),     "9.9",          Length(0),  Length(9900000)     }),
-    LengthTestData({true,  "0.9",            Length(900000),      "0.9",          Length(0),  Length(900000)      }),
-    LengthTestData({true,  "0.99",           Length(990000),      "0.99",         Length(0),  Length(990000)      }),
-    LengthTestData({true,  "0.09",           Length(90000),       "0.09",         Length(0),  Length(90000)       }),
-    LengthTestData({true,  "0.099",          Length(99000),       "0.099",        Length(0),  Length(99000)       }),
-    LengthTestData({true,  "0.009",          Length(9000),        "0.009",        Length(0),  Length(9000)        }),
-    LengthTestData({true,  "0.0099",         Length(9900),        "0.0099",       Length(0),  Length(9900)        }),
-    LengthTestData({true,  "0.0009",         Length(900),         "0.0009",       Length(0),  Length(900)         }),
-    LengthTestData({true,  "0.00099",        Length(990),         "0.00099",      Length(0),  Length(990)         }),
-    LengthTestData({true,  "0.00009",        Length(90),          "0.00009",      Length(0),  Length(90)          }),
-    LengthTestData({true,  "0.000099",       Length(99),          "0.000099",     Length(0),  Length(99)          }),
-    LengthTestData({true,  "0.000009",       Length(9),           "0.000009",     Length(0),  Length(9)           }),
-
-    // snap to grid
-    LengthTestData({true,  "0.0",            Length(0),           "0.0",          Length(10), Length(0)           }),
-    LengthTestData({true,  "0.00001",        Length(10),          "0.00001",      Length(0),  Length(10)          }),
-    LengthTestData({true,  "-0.00001",       Length(-10),         "-0.00001",     Length(0),  Length(-10)         }),
-    LengthTestData({true,  "0.00001",        Length(10),          "0.00001",      Length(1),  Length(10)          }),
-    LengthTestData({true,  "-0.00001",       Length(-10),         "-0.00001",     Length(1),  Length(-10)         }),
-    LengthTestData({true,  "0.000008",       Length(8),           "0.000008",     Length(10), Length(10)          }),
-    LengthTestData({true,  "0.000002",       Length(2),           "0.000002",     Length(10), Length(0)           }),
-    LengthTestData({true,  "-0.000008",      Length(-8),          "-0.000008",    Length(10), Length(-10)         }),
-    LengthTestData({true,  "-0.000002",      Length(-2),          "-0.000002",    Length(10), Length(0)           }),
-    LengthTestData({true,  "0.000018",       Length(18),          "0.000018",     Length(10), Length(20)          }),
-    LengthTestData({true,  "0.000012",       Length(12),          "0.000012",     Length(10), Length(10)          }),
-    LengthTestData({true,  "-0.000018",      Length(-18),         "-0.000018",    Length(10), Length(-20)         }),
-    LengthTestData({true,  "-0.000012",      Length(-12),         "-0.000012",    Length(10), Length(-10)         }),
-    LengthTestData({true,  "0.00001",        Length(10),          "0.00001",      Length(10), Length(10)          }),
-    //LengthTestData({true,  "-0.00001",       Length(-10),         "-0.00001",     Length(10), Length(-10)         }),
-    //LengthTestData({true,  "0.00002",        Length(20),          "0.00002",      Length(10), Length(20)          }),
-    //LengthTestData({true,  "-0.00002",       Length(-20),         "-0.00002",     Length(10), Length(-20)         }),
+    LengthTestData({true,  "0",              Length(0),           "0.0"         }),
+    LengthTestData({true,  "1",              Length(1000000),     "1.0"         }),
+    LengthTestData({true,  "-1",             Length(-1000000),    "-1.0",       }),
+    LengthTestData({true,  "0.000001",       Length(1),           "0.000001"    }),
+    LengthTestData({true,  "-0.000001",      Length(-1),          "-0.000001"   }),
+    LengthTestData({true,  "1e-6",           Length(1),           "0.000001"    }),
+    LengthTestData({true,  "-1e-6",          Length(-1),          "-0.000001"   }),
+    LengthTestData({true,  "1.000001",       Length(1000001),     "1.000001"    }),
+    LengthTestData({true,  "-1.000001",      Length(-1000001),    "-1.000001"   }),
+    LengthTestData({true,  "1e3",            Length(1000000000),  "1000.0"      }),
+    LengthTestData({true,  "-1e3",           Length(-1000000000), "-1000.0"     }),
+    LengthTestData({true,  ".1",             Length(100000),      "0.1"         }),
+    LengthTestData({true,  "1.",             Length(1000000),     "1.0"         }),
+    LengthTestData({true,  "2147483647e-6",  Length(2147483647),  "2147.483647" }),
+    LengthTestData({true,  "-2147483648e-6", Length(-2147483648), "-2147.483648"}),
+    LengthTestData({true,  "9",              Length(9000000),     "9.0"         }),
+    LengthTestData({true,  "9.9",            Length(9900000),     "9.9"         }),
+    LengthTestData({true,  "0.9",            Length(900000),      "0.9"         }),
+    LengthTestData({true,  "0.99",           Length(990000),      "0.99"        }),
+    LengthTestData({true,  "0.09",           Length(90000),       "0.09"        }),
+    LengthTestData({true,  "0.099",          Length(99000),       "0.099"       }),
+    LengthTestData({true,  "0.009",          Length(9000),        "0.009"       }),
+    LengthTestData({true,  "0.0099",         Length(9900),        "0.0099"      }),
+    LengthTestData({true,  "0.0009",         Length(900),         "0.0009"      }),
+    LengthTestData({true,  "0.00099",        Length(990),         "0.00099"     }),
+    LengthTestData({true,  "0.00009",        Length(90),          "0.00009"     }),
+    LengthTestData({true,  "0.000099",       Length(99),          "0.000099"    }),
+    LengthTestData({true,  "0.000009",       Length(9),           "0.000009"    }),
 
     // invalid cases
-    LengthTestData({false, "",               Length(),            QString(),      Length(),   Length()            }),
-    LengthTestData({false, ".",              Length(),            QString(),      Length(),   Length()            }),
-    LengthTestData({false, "0e",             Length(),            QString(),      Length(),   Length()            }),
-    LengthTestData({false, "0e+",            Length(),            QString(),      Length(),   Length()            }),
-    LengthTestData({false, "0e-",            Length(),            QString(),      Length(),   Length()            }),
-    LengthTestData({false, "0.0000001",      Length(),            QString(),      Length(),   Length()            }),
-    LengthTestData({false, "1e-7",           Length(),            QString(),      Length(),   Length()            }),
-    LengthTestData({false, "1e1000",         Length(),            QString(),      Length(),   Length()            })
+    LengthTestData({false, "",               Length(),            QString()     }),
+    LengthTestData({false, ".",              Length(),            QString()     }),
+    LengthTestData({false, "0e",             Length(),            QString()     }),
+    LengthTestData({false, "0e+",            Length(),            QString()     }),
+    LengthTestData({false, "0e-",            Length(),            QString()     }),
+    LengthTestData({false, "0.0000001",      Length(),            QString()     }),
+    LengthTestData({false, "1e-7",           Length(),            QString()     }),
+    LengthTestData({false, "1e1000",         Length(),            QString()     })
 ));
 // clang-format on
 

--- a/tests/unittests/common/lengthtest.cpp
+++ b/tests/unittests/common/lengthtest.cpp
@@ -39,6 +39,8 @@ typedef struct {
   QString orig_str;
   Length  value;
   QString gen_str;
+  Length grid_interval;
+  Length mapped_to_grid;
 } LengthTestData;
 
 /*******************************************************************************
@@ -68,24 +70,12 @@ TEST_P(LengthTest, testToMmString) {
   }
 }
 
-TEST(LengthTest, testSnapToGrid) {
-  EXPECT_EQ(Length(0).mappedToGrid(10), Length(0));
-  EXPECT_EQ(Length(10).mappedToGrid(0), Length(10));
-  EXPECT_EQ(Length(-10).mappedToGrid(0), Length(-10));
-  EXPECT_EQ(Length(10).mappedToGrid(1), Length(10));
-  EXPECT_EQ(Length(-10).mappedToGrid(1), Length(-10));
-  EXPECT_EQ(Length(8).mappedToGrid(10), Length(10));
-  EXPECT_EQ(Length(2).mappedToGrid(10), Length(0));
-  EXPECT_EQ(Length(-8).mappedToGrid(10), Length(-10));
-  EXPECT_EQ(Length(-2).mappedToGrid(10), Length(0));
-  EXPECT_EQ(Length(18).mappedToGrid(10), Length(20));
-  EXPECT_EQ(Length(12).mappedToGrid(10), Length(10));
-  EXPECT_EQ(Length(-18).mappedToGrid(10), Length(-20));
-  EXPECT_EQ(Length(-12).mappedToGrid(10), Length(-10));
-  EXPECT_EQ(Length(10).mappedToGrid(10), Length(10));
-  EXPECT_EQ(Length(-10).mappedToGrid(10), Length(-10));
-  EXPECT_EQ(Length(20).mappedToGrid(20), Length(20));
-  EXPECT_EQ(Length(-20).mappedToGrid(20), Length(-20));
+TEST_P(LengthTest, testSnapToGrid) {
+  const LengthTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.value.mappedToGrid(data.grid_interval), data.mapped_to_grid);
+  }
 }
 
 /*******************************************************************************
@@ -94,44 +84,64 @@ TEST(LengthTest, testSnapToGrid) {
 
 // clang-format off
 INSTANTIATE_TEST_CASE_P(LengthTest, LengthTest, ::testing::Values(
-    LengthTestData({true,  "0",              Length(0),           "0.0"         }),
-    LengthTestData({true,  "1",              Length(1000000),     "1.0"         }),
-    LengthTestData({true,  "-1",             Length(-1000000),    "-1.0"        }),
-    LengthTestData({true,  "0.000001",       Length(1),           "0.000001"    }),
-    LengthTestData({true,  "-0.000001",      Length(-1),          "-0.000001"   }),
-    LengthTestData({true,  "1e-6",           Length(1),           "0.000001"    }),
-    LengthTestData({true,  "-1e-6",          Length(-1),          "-0.000001"   }),
-    LengthTestData({true,  "1.000001",       Length(1000001),     "1.000001"    }),
-    LengthTestData({true,  "-1.000001",      Length(-1000001),    "-1.000001"   }),
-    LengthTestData({true,  "1e3",            Length(1000000000),  "1000.0"      }),
-    LengthTestData({true,  "-1e3",           Length(-1000000000), "-1000.0"     }),
-    LengthTestData({true,  ".1",             Length(100000),      "0.1"         }),
-    LengthTestData({true,  "1.",             Length(1000000),     "1.0"         }),
-    LengthTestData({true,  "2147483647e-6",  Length(2147483647),  "2147.483647" }),
-    LengthTestData({true,  "-2147483648e-6", Length(-2147483648), "-2147.483648"}),
-    LengthTestData({true,  "9",              Length(9000000),     "9.0"         }),
-    LengthTestData({true,  "9.9",            Length(9900000),     "9.9"         }),
-    LengthTestData({true,  "0.9",            Length(900000),      "0.9"         }),
-    LengthTestData({true,  "0.99",           Length(990000),      "0.99"        }),
-    LengthTestData({true,  "0.09",           Length(90000),       "0.09"        }),
-    LengthTestData({true,  "0.099",          Length(99000),       "0.099"       }),
-    LengthTestData({true,  "0.009",          Length(9000),        "0.009"       }),
-    LengthTestData({true,  "0.0099",         Length(9900),        "0.0099"      }),
-    LengthTestData({true,  "0.0009",         Length(900),         "0.0009"      }),
-    LengthTestData({true,  "0.00099",        Length(990),         "0.00099"     }),
-    LengthTestData({true,  "0.00009",        Length(90),          "0.00009"     }),
-    LengthTestData({true,  "0.000099",       Length(99),          "0.000099"    }),
-    LengthTestData({true,  "0.000009",       Length(9),           "0.000009"    }),
+    // from/to mm
+    LengthTestData({true,  "0",              Length(0),           "0.0",          Length(0),  Length(0)           }),
+    LengthTestData({true,  "1",              Length(1000000),     "1.0",          Length(0),  Length(1000000)     }),
+    LengthTestData({true,  "-1",             Length(-1000000),    "-1.0",         Length(0),  Length(-1000000)    }),
+    LengthTestData({true,  "0.000001",       Length(1),           "0.000001",     Length(0),  Length(1)           }),
+    LengthTestData({true,  "-0.000001",      Length(-1),          "-0.000001",    Length(0),  Length(-1)          }),
+    LengthTestData({true,  "1e-6",           Length(1),           "0.000001",     Length(0),  Length(1)           }),
+    LengthTestData({true,  "-1e-6",          Length(-1),          "-0.000001",    Length(0),  Length(-1)          }),
+    LengthTestData({true,  "1.000001",       Length(1000001),     "1.000001",     Length(0),  Length(1000001)     }),
+    LengthTestData({true,  "-1.000001",      Length(-1000001),    "-1.000001",    Length(0),  Length(-1000001)    }),
+    LengthTestData({true,  "1e3",            Length(1000000000),  "1000.0",       Length(0),  Length(1000000000)  }),
+    LengthTestData({true,  "-1e3",           Length(-1000000000), "-1000.0",      Length(0),  Length(-1000000000) }),
+    LengthTestData({true,  ".1",             Length(100000),      "0.1",          Length(0),  Length(100000)      }),
+    LengthTestData({true,  "1.",             Length(1000000),     "1.0",          Length(0),  Length(1000000)     }),
+    LengthTestData({true,  "2147483647e-6",  Length(2147483647),  "2147.483647",  Length(0),  Length(2147483647)  }),
+    LengthTestData({true,  "-2147483648e-6", Length(-2147483648), "-2147.483648", Length(0),  Length(-2147483648) }),
+    LengthTestData({true,  "9",              Length(9000000),     "9.0",          Length(0),  Length(9000000)     }),
+    LengthTestData({true,  "9.9",            Length(9900000),     "9.9",          Length(0),  Length(9900000)     }),
+    LengthTestData({true,  "0.9",            Length(900000),      "0.9",          Length(0),  Length(900000)      }),
+    LengthTestData({true,  "0.99",           Length(990000),      "0.99",         Length(0),  Length(990000)      }),
+    LengthTestData({true,  "0.09",           Length(90000),       "0.09",         Length(0),  Length(90000)       }),
+    LengthTestData({true,  "0.099",          Length(99000),       "0.099",        Length(0),  Length(99000)       }),
+    LengthTestData({true,  "0.009",          Length(9000),        "0.009",        Length(0),  Length(9000)        }),
+    LengthTestData({true,  "0.0099",         Length(9900),        "0.0099",       Length(0),  Length(9900)        }),
+    LengthTestData({true,  "0.0009",         Length(900),         "0.0009",       Length(0),  Length(900)         }),
+    LengthTestData({true,  "0.00099",        Length(990),         "0.00099",      Length(0),  Length(990)         }),
+    LengthTestData({true,  "0.00009",        Length(90),          "0.00009",      Length(0),  Length(90)          }),
+    LengthTestData({true,  "0.000099",       Length(99),          "0.000099",     Length(0),  Length(99)          }),
+    LengthTestData({true,  "0.000009",       Length(9),           "0.000009",     Length(0),  Length(9)           }),
+
+    // snap to grid
+    LengthTestData({true,  "0.0",            Length(0),           "0.0",          Length(10), Length(0)           }),
+    LengthTestData({true,  "0.00001",        Length(10),          "0.00001",      Length(0),  Length(10)          }),
+    LengthTestData({true,  "-0.00001",       Length(-10),         "-0.00001",     Length(0),  Length(-10)         }),
+    LengthTestData({true,  "0.00001",        Length(10),          "0.00001",      Length(1),  Length(10)          }),
+    LengthTestData({true,  "-0.00001",       Length(-10),         "-0.00001",     Length(1),  Length(-10)         }),
+    LengthTestData({true,  "0.000008",       Length(8),           "0.000008",     Length(10), Length(10)          }),
+    LengthTestData({true,  "0.000002",       Length(2),           "0.000002",     Length(10), Length(0)           }),
+    LengthTestData({true,  "-0.000008",      Length(-8),          "-0.000008",    Length(10), Length(-10)         }),
+    LengthTestData({true,  "-0.000002",      Length(-2),          "-0.000002",    Length(10), Length(0)           }),
+    LengthTestData({true,  "0.000018",       Length(18),          "0.000018",     Length(10), Length(20)          }),
+    LengthTestData({true,  "0.000012",       Length(12),          "0.000012",     Length(10), Length(10)          }),
+    LengthTestData({true,  "-0.000018",      Length(-18),         "-0.000018",    Length(10), Length(-20)         }),
+    LengthTestData({true,  "-0.000012",      Length(-12),         "-0.000012",    Length(10), Length(-10)         }),
+    LengthTestData({true,  "0.00001",        Length(10),          "0.00001",      Length(10), Length(10)          }),
+    //LengthTestData({true,  "-0.00001",       Length(-10),         "-0.00001",     Length(10), Length(-10)         }),
+    //LengthTestData({true,  "0.00002",        Length(20),          "0.00002",      Length(10), Length(20)          }),
+    //LengthTestData({true,  "-0.00002",       Length(-20),         "-0.00002",     Length(10), Length(-20)         }),
 
     // invalid cases
-    LengthTestData({false, "",               Length(),            QString()     }),
-    LengthTestData({false, ".",              Length(),            QString()     }),
-    LengthTestData({false, "0e",             Length(),            QString()     }),
-    LengthTestData({false, "0e+",            Length(),            QString()     }),
-    LengthTestData({false, "0e-",            Length(),            QString()     }),
-    LengthTestData({false, "0.0000001",      Length(),            QString()     }),
-    LengthTestData({false, "1e-7",           Length(),            QString()     }),
-    LengthTestData({false, "1e1000",         Length(),            QString()     })
+    LengthTestData({false, "",               Length(),            QString(),      Length(),   Length()            }),
+    LengthTestData({false, ".",              Length(),            QString(),      Length(),   Length()            }),
+    LengthTestData({false, "0e",             Length(),            QString(),      Length(),   Length()            }),
+    LengthTestData({false, "0e+",            Length(),            QString(),      Length(),   Length()            }),
+    LengthTestData({false, "0e-",            Length(),            QString(),      Length(),   Length()            }),
+    LengthTestData({false, "0.0000001",      Length(),            QString(),      Length(),   Length()            }),
+    LengthTestData({false, "1e-7",           Length(),            QString(),      Length(),   Length()            }),
+    LengthTestData({false, "1e1000",         Length(),            QString(),      Length(),   Length()            })
 ));
 // clang-format on
 

--- a/tests/unittests/common/lengthtest.cpp
+++ b/tests/unittests/common/lengthtest.cpp
@@ -68,6 +68,17 @@ TEST_P(LengthTest, testToMmString) {
   }
 }
 
+TEST(LengthTest, testSnapToGrid) {
+  EXPECT_EQ(Length(8).mappedToGrid(10), Length(10));
+  EXPECT_EQ(Length(2).mappedToGrid(10), Length(0));
+  EXPECT_EQ(Length(-8).mappedToGrid(10), Length(-10));
+  EXPECT_EQ(Length(-2).mappedToGrid(10), Length(0));
+  EXPECT_EQ(Length(18).mappedToGrid(10), Length(20));
+  EXPECT_EQ(Length(12).mappedToGrid(10), Length(10));
+  EXPECT_EQ(Length(-18).mappedToGrid(10), Length(-20));
+  EXPECT_EQ(Length(-12).mappedToGrid(10), Length(-10));
+}
+
 /*******************************************************************************
  *  Test Data
  ******************************************************************************/
@@ -112,7 +123,6 @@ INSTANTIATE_TEST_CASE_P(LengthTest, LengthTest, ::testing::Values(
     LengthTestData({false, "0.0000001",      Length(),            QString()     }),
     LengthTestData({false, "1e-7",           Length(),            QString()     }),
     LengthTestData({false, "1e1000",         Length(),            QString()     })
-
 ));
 // clang-format on
 

--- a/tests/unittests/common/lengthtest.cpp
+++ b/tests/unittests/common/lengthtest.cpp
@@ -69,6 +69,11 @@ TEST_P(LengthTest, testToMmString) {
 }
 
 TEST(LengthTest, testSnapToGrid) {
+  EXPECT_EQ(Length(0).mappedToGrid(10), Length(0));
+  EXPECT_EQ(Length(10).mappedToGrid(0), Length(10));
+  EXPECT_EQ(Length(-10).mappedToGrid(0), Length(-10));
+  EXPECT_EQ(Length(10).mappedToGrid(1), Length(10));
+  EXPECT_EQ(Length(-10).mappedToGrid(1), Length(-10));
   EXPECT_EQ(Length(8).mappedToGrid(10), Length(10));
   EXPECT_EQ(Length(2).mappedToGrid(10), Length(0));
   EXPECT_EQ(Length(-8).mappedToGrid(10), Length(-10));
@@ -77,6 +82,10 @@ TEST(LengthTest, testSnapToGrid) {
   EXPECT_EQ(Length(12).mappedToGrid(10), Length(10));
   EXPECT_EQ(Length(-18).mappedToGrid(10), Length(-20));
   EXPECT_EQ(Length(-12).mappedToGrid(10), Length(-10));
+  EXPECT_EQ(Length(10).mappedToGrid(10), Length(10));
+  EXPECT_EQ(Length(-10).mappedToGrid(10), Length(-10));
+  EXPECT_EQ(Length(20).mappedToGrid(20), Length(20));
+  EXPECT_EQ(Length(-20).mappedToGrid(20), Length(-20));
 }
 
 /*******************************************************************************

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -68,6 +68,7 @@ SOURCES += \
     common/filedownloadtest.cpp \
     common/fileio/serializableobjectlisttest.cpp \
     common/filepathtest.cpp \
+    common/lengthsnaptest.cpp \
     common/lengthtest.cpp \
     common/networkrequesttest.cpp \
     common/pointtest.cpp \


### PR DESCRIPTION
Maybe its worth defining `LengthBaseU_t` outside the functions?
Regarding tests, I don't know how to pass different test data to different test methods from the same class.