### PR TITLE
LibraryEditor: Support undo/redo also for library element metadata

### DIFF
--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -126,6 +126,7 @@ SOURCES += \
     widgets/centeredcheckbox.cpp \
     widgets/graphicslayercombobox.cpp \
     widgets/patheditorwidget.cpp \
+    widgets/plaintextedit.cpp \
     widgets/signalrolecombobox.cpp \
     widgets/statusbar.cpp \
 
@@ -242,6 +243,7 @@ HEADERS += \
     widgets/centeredcheckbox.h \
     widgets/graphicslayercombobox.h \
     widgets/patheditorwidget.h \
+    widgets/plaintextedit.h \
     widgets/signalrolecombobox.h \
     widgets/statusbar.h \
 

--- a/libs/librepcb/common/undocommandgroup.cpp
+++ b/libs/librepcb/common/undocommandgroup.cpp
@@ -76,14 +76,17 @@ void UndoCommandGroup::appendChild(UndoCommand* cmd) {
  ******************************************************************************/
 
 bool UndoCommandGroup::performExecute() {
+  bool           modified = false;
   ScopeGuardList sgl(mChilds.count());
   for (int i = 0; i < mChilds.count(); ++i) {  // from bottom to top
     UndoCommand* cmd = mChilds.at(i);
-    cmd->execute();
+    if (cmd->execute()) {
+      modified = true;
+    }
     sgl.add([cmd]() { cmd->undo(); });
   }
   sgl.dismiss();
-  return (mChilds.count() > 0);
+  return modified;
 }
 
 void UndoCommandGroup::performUndo() {

--- a/libs/librepcb/common/widgets/plaintextedit.cpp
+++ b/libs/librepcb/common/widgets/plaintextedit.cpp
@@ -1,0 +1,61 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "plaintextedit.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PlainTextEdit::PlainTextEdit(QWidget* parent) noexcept
+  : QPlainTextEdit(parent) {
+}
+
+PlainTextEdit::~PlainTextEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void PlainTextEdit::focusInEvent(QFocusEvent* e) noexcept {
+  QPlainTextEdit::focusInEvent(e);
+  mPlainTextBeforeGettingFocus = toPlainText();
+}
+void PlainTextEdit::focusOutEvent(QFocusEvent* e) noexcept {
+  QPlainTextEdit::focusOutEvent(e);
+  if (toPlainText() != mPlainTextBeforeGettingFocus) {
+    mPlainTextBeforeGettingFocus = toPlainText();
+    emit editingFinished();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/plaintextedit.h
+++ b/libs/librepcb/common/widgets/plaintextedit.h
@@ -1,0 +1,73 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PLAINTEXTEDIT_H
+#define LIBREPCB_PLAINTEXTEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class PlainTextEdit
+ ******************************************************************************/
+
+/**
+ * @brief The PlainTextEdit class is a customized QPlainTextEdit
+ *
+ * Differences compared to QPlainTextEdit:
+ *   - New signal editingFinished() (equivalent of QLineEdit::editingFinished())
+ */
+class PlainTextEdit final : public QPlainTextEdit {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit PlainTextEdit(QWidget* parent = nullptr) noexcept;
+  PlainTextEdit(const PlainTextEdit& other) = delete;
+  ~PlainTextEdit() noexcept;
+
+  // Operator Overloadings
+  PlainTextEdit& operator=(const PlainTextEdit& rhs) = delete;
+
+signals:
+  void editingFinished();
+
+private:  // Methods
+  void focusInEvent(QFocusEvent* e) noexcept override;
+  void focusOutEvent(QFocusEvent* e) noexcept override;
+
+private:  // Data
+  QString mPlainTextBeforeGettingFocus;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_PLAINTEXTEDIT_H

--- a/libs/librepcb/eagleimport/devicesetconverter.cpp
+++ b/libs/librepcb/eagleimport/devicesetconverter.cpp
@@ -59,8 +59,8 @@ std::unique_ptr<library::Component> DeviceSetConverter::generate() const {
       ""));  // can throw
 
   // properties
-  component->getPrefixes().setDefaultValue(
-      library::ComponentPrefix(mDeviceSet.getPrefix()));  // can throw
+  component->setPrefixes(library::NormDependentPrefixMap(
+      library::ComponentPrefix(mDeviceSet.getPrefix())));  // can throw
 
   // symbol variant
   std::shared_ptr<library::ComponentSymbolVariant> symbolVariant(

--- a/libs/librepcb/library/cat/cmd/cmdlibrarycategoryedit.cpp
+++ b/libs/librepcb/library/cat/cmd/cmdlibrarycategoryedit.cpp
@@ -1,0 +1,83 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdlibrarycategoryedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdLibraryCategoryEdit::CmdLibraryCategoryEdit(
+    LibraryCategory& category) noexcept
+  : CmdLibraryBaseElementEdit(category, tr("Edit category metadata")),
+    mCategory(category),
+    mOldParentUuid(category.getParentUuid()),
+    mNewParentUuid(mOldParentUuid) {
+}
+
+CmdLibraryCategoryEdit::~CmdLibraryCategoryEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CmdLibraryCategoryEdit::setParentUuid(
+    const tl::optional<Uuid>& parentUuid) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewParentUuid = parentUuid;
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdLibraryCategoryEdit::performExecute() {
+  if (CmdLibraryBaseElementEdit::performExecute()) return true;  // can throw
+  if (mNewParentUuid != mOldParentUuid) return true;
+  return false;
+}
+
+void CmdLibraryCategoryEdit::performUndo() {
+  CmdLibraryBaseElementEdit::performUndo();  // can throw
+  mCategory.setParentUuid(mOldParentUuid);
+}
+
+void CmdLibraryCategoryEdit::performRedo() {
+  CmdLibraryBaseElementEdit::performRedo();  // can throw
+  mCategory.setParentUuid(mNewParentUuid);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/cat/cmd/cmdlibrarycategoryedit.h
+++ b/libs/librepcb/library/cat/cmd/cmdlibrarycategoryedit.h
@@ -1,0 +1,82 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_CMDLIBRARYCATEGORYEDIT_H
+#define LIBREPCB_LIBRARY_CMDLIBRARYCATEGORYEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../cmd/cmdlibrarybaseelementedit.h"
+#include "../librarycategory.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Class CmdLibraryCategoryEdit
+ ******************************************************************************/
+
+/**
+ * @brief The CmdLibraryCategoryEdit class
+ */
+class CmdLibraryCategoryEdit : public CmdLibraryBaseElementEdit {
+public:
+  // Constructors / Destructor
+  CmdLibraryCategoryEdit()                                    = delete;
+  CmdLibraryCategoryEdit(const CmdLibraryCategoryEdit& other) = delete;
+  explicit CmdLibraryCategoryEdit(LibraryCategory& category) noexcept;
+  virtual ~CmdLibraryCategoryEdit() noexcept;
+
+  // Setters
+  void setParentUuid(const tl::optional<Uuid>& parentUuid) noexcept;
+
+  // Operator Overloadings
+  CmdLibraryCategoryEdit& operator=(const CmdLibraryCategoryEdit& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  virtual bool performExecute() override;
+
+  /// @copydoc UndoCommand::performUndo()
+  virtual void performUndo() override;
+
+  /// @copydoc UndoCommand::performRedo()
+  virtual void performRedo() override;
+
+private:  // Data
+  LibraryCategory& mCategory;
+
+  tl::optional<Uuid> mOldParentUuid;
+  tl::optional<Uuid> mNewParentUuid;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_CMDLIBRARYCATEGORYEDIT_H

--- a/libs/librepcb/library/cmd/cmdlibrarybaseelementedit.cpp
+++ b/libs/librepcb/library/cmd/cmdlibrarybaseelementedit.cpp
@@ -1,0 +1,152 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdlibrarybaseelementedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdLibraryBaseElementEdit::CmdLibraryBaseElementEdit(
+    LibraryBaseElement& element, const QString& text) noexcept
+  : UndoCommand(text),
+    mElement(element),
+    mOldNames(element.getNames()),
+    mNewNames(mOldNames),
+    mOldDescriptions(element.getDescriptions()),
+    mNewDescriptions(mOldDescriptions),
+    mOldKeywords(element.getKeywords()),
+    mNewKeywords(mOldKeywords),
+    mOldVersion(element.getVersion()),
+    mNewVersion(mOldVersion),
+    mOldAuthor(element.getAuthor()),
+    mNewAuthor(mOldAuthor),
+    mOldDeprecated(element.isDeprecated()),
+    mNewDeprecated(mOldDeprecated) {
+}
+
+CmdLibraryBaseElementEdit::~CmdLibraryBaseElementEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CmdLibraryBaseElementEdit::setName(const QString&     locale,
+                                        const ElementName& name) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewNames.insert(locale, name);
+}
+
+void CmdLibraryBaseElementEdit::setNames(
+    const LocalizedNameMap& names) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewNames = names;
+}
+
+void CmdLibraryBaseElementEdit::setDescription(const QString& locale,
+                                               const QString& desc) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewDescriptions.insert(locale, desc);
+}
+
+void CmdLibraryBaseElementEdit::setDescriptions(
+    const LocalizedDescriptionMap& descriptions) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewDescriptions = descriptions;
+}
+
+void CmdLibraryBaseElementEdit::setKeywords(const QString& locale,
+                                            const QString& keywords) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewKeywords.insert(locale, keywords);
+}
+
+void CmdLibraryBaseElementEdit::setKeywords(
+    const LocalizedKeywordsMap& keywords) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewKeywords = keywords;
+}
+
+void CmdLibraryBaseElementEdit::setVersion(const Version& version) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewVersion = version;
+}
+
+void CmdLibraryBaseElementEdit::setAuthor(const QString& author) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewAuthor = author;
+}
+
+void CmdLibraryBaseElementEdit::setDeprecated(bool deprecated) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewDeprecated = deprecated;
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdLibraryBaseElementEdit::performExecute() {
+  performRedo();  // can throw
+
+  if (mNewNames != mOldNames) return true;
+  if (mNewDescriptions != mOldDescriptions) return true;
+  if (mNewKeywords != mOldKeywords) return true;
+  if (mNewVersion != mOldVersion) return true;
+  if (mNewAuthor != mOldAuthor) return true;
+  if (mNewDeprecated != mOldDeprecated) return true;
+  return false;
+}
+
+void CmdLibraryBaseElementEdit::performUndo() {
+  mElement.setNames(mOldNames);
+  mElement.setDescriptions(mOldDescriptions);
+  mElement.setKeywords(mOldKeywords);
+  mElement.setVersion(mOldVersion);
+  mElement.setAuthor(mOldAuthor);
+  mElement.setDeprecated(mOldDeprecated);
+}
+
+void CmdLibraryBaseElementEdit::performRedo() {
+  mElement.setNames(mNewNames);
+  mElement.setDescriptions(mNewDescriptions);
+  mElement.setKeywords(mNewKeywords);
+  mElement.setVersion(mNewVersion);
+  mElement.setAuthor(mNewAuthor);
+  mElement.setDeprecated(mNewDeprecated);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/cmd/cmdlibrarybaseelementedit.h
+++ b/libs/librepcb/library/cmd/cmdlibrarybaseelementedit.h
@@ -1,0 +1,103 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_CMDLIBRARYBASEELEMENTEDIT_H
+#define LIBREPCB_LIBRARY_CMDLIBRARYBASEELEMENTEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../librarybaseelement.h"
+
+#include <librepcb/common/undocommand.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Class CmdLibraryBaseElementEdit
+ ******************************************************************************/
+
+/**
+ * @brief The CmdLibraryBaseElementEdit class
+ */
+class CmdLibraryBaseElementEdit : public UndoCommand {
+public:
+  // Constructors / Destructor
+  CmdLibraryBaseElementEdit()                                       = delete;
+  CmdLibraryBaseElementEdit(const CmdLibraryBaseElementEdit& other) = delete;
+  explicit CmdLibraryBaseElementEdit(LibraryBaseElement& element,
+                                     const QString&      text) noexcept;
+  virtual ~CmdLibraryBaseElementEdit() noexcept;
+
+  // Setters
+  void setName(const QString& locale, const ElementName& name) noexcept;
+  void setNames(const LocalizedNameMap& names) noexcept;
+  void setDescription(const QString& locale, const QString& desc) noexcept;
+  void setDescriptions(const LocalizedDescriptionMap& descriptions) noexcept;
+  void setKeywords(const QString& locale, const QString& keywords) noexcept;
+  void setKeywords(const LocalizedKeywordsMap& keywords) noexcept;
+  void setVersion(const Version& version) noexcept;
+  void setAuthor(const QString& author) noexcept;
+  void setDeprecated(bool deprecated) noexcept;
+
+  // Operator Overloadings
+  CmdLibraryBaseElementEdit& operator=(const CmdLibraryBaseElementEdit& rhs) =
+      delete;
+
+protected:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  virtual bool performExecute() override;
+
+  /// @copydoc UndoCommand::performUndo()
+  virtual void performUndo() override;
+
+  /// @copydoc UndoCommand::performRedo()
+  virtual void performRedo() override;
+
+private:  // Data
+  LibraryBaseElement& mElement;
+
+  LocalizedNameMap        mOldNames;
+  LocalizedNameMap        mNewNames;
+  LocalizedDescriptionMap mOldDescriptions;
+  LocalizedDescriptionMap mNewDescriptions;
+  LocalizedKeywordsMap    mOldKeywords;
+  LocalizedKeywordsMap    mNewKeywords;
+  Version                 mOldVersion;
+  Version                 mNewVersion;
+  QString                 mOldAuthor;
+  QString                 mNewAuthor;
+  bool                    mOldDeprecated;
+  bool                    mNewDeprecated;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_CMDLIBRARYBASEELEMENTEDIT_H

--- a/libs/librepcb/library/cmd/cmdlibraryedit.cpp
+++ b/libs/librepcb/library/cmd/cmdlibraryedit.cpp
@@ -1,0 +1,101 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdlibraryedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdLibraryEdit::CmdLibraryEdit(Library& library) noexcept
+  : CmdLibraryBaseElementEdit(library, tr("Edit library metadata")),
+    mLibrary(library),
+    mOldUrl(library.getUrl()),
+    mNewUrl(mOldUrl),
+    mOldDependencies(library.getDependencies()),
+    mNewDependencies(mOldDependencies),
+    mOldIcon(library.getIcon()),
+    mNewIcon(mOldIcon) {
+}
+
+CmdLibraryEdit::~CmdLibraryEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CmdLibraryEdit::setUrl(const QUrl& url) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewUrl = url;
+}
+
+void CmdLibraryEdit::setDependencies(const QSet<Uuid>& deps) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewDependencies = deps;
+}
+
+void CmdLibraryEdit::setIcon(const QByteArray& png) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewIcon = png;
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdLibraryEdit::performExecute() {
+  if (CmdLibraryBaseElementEdit::performExecute()) return true;  // can throw
+  if (mNewUrl != mOldUrl) return true;
+  if (mNewDependencies != mOldDependencies) return true;
+  if (mNewIcon != mOldIcon) return true;
+  return false;
+}
+
+void CmdLibraryEdit::performUndo() {
+  CmdLibraryBaseElementEdit::performUndo();  // can throw
+  mLibrary.setUrl(mOldUrl);
+  mLibrary.setDependencies(mOldDependencies);
+  mLibrary.setIcon(mOldIcon);
+}
+
+void CmdLibraryEdit::performRedo() {
+  CmdLibraryBaseElementEdit::performRedo();  // can throw
+  mLibrary.setUrl(mNewUrl);
+  mLibrary.setDependencies(mNewDependencies);
+  mLibrary.setIcon(mNewIcon);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/cmd/cmdlibraryedit.h
+++ b/libs/librepcb/library/cmd/cmdlibraryedit.h
@@ -1,0 +1,88 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_CMDLIBRARYEDIT_H
+#define LIBREPCB_LIBRARY_CMDLIBRARYEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../library.h"
+#include "cmdlibrarybaseelementedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Class CmdLibraryEdit
+ ******************************************************************************/
+
+/**
+ * @brief The CmdLibraryEdit class
+ */
+class CmdLibraryEdit : public CmdLibraryBaseElementEdit {
+public:
+  // Constructors / Destructor
+  CmdLibraryEdit()                            = delete;
+  CmdLibraryEdit(const CmdLibraryEdit& other) = delete;
+  explicit CmdLibraryEdit(Library& library) noexcept;
+  virtual ~CmdLibraryEdit() noexcept;
+
+  // Setters
+  void setUrl(const QUrl& url) noexcept;
+  void setDependencies(const QSet<Uuid>& deps) noexcept;
+  void setIcon(const QByteArray& png) noexcept;
+
+  // Operator Overloadings
+  CmdLibraryEdit& operator=(const CmdLibraryEdit& rhs) = delete;
+
+protected:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  virtual bool performExecute() override;
+
+  /// @copydoc UndoCommand::performUndo()
+  virtual void performUndo() override;
+
+  /// @copydoc UndoCommand::performRedo()
+  virtual void performRedo() override;
+
+private:  // Data
+  Library& mLibrary;
+
+  QUrl       mOldUrl;
+  QUrl       mNewUrl;
+  QSet<Uuid> mOldDependencies;
+  QSet<Uuid> mNewDependencies;
+  QByteArray mOldIcon;
+  QByteArray mNewIcon;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_CMDLIBRARYEDIT_H

--- a/libs/librepcb/library/cmd/cmdlibraryelementedit.cpp
+++ b/libs/librepcb/library/cmd/cmdlibraryelementedit.cpp
@@ -1,0 +1,82 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdlibraryelementedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdLibraryElementEdit::CmdLibraryElementEdit(LibraryElement& element,
+                                             const QString&  text) noexcept
+  : CmdLibraryBaseElementEdit(element, text),
+    mElement(element),
+    mOldCategories(element.getCategories()),
+    mNewCategories(mOldCategories) {
+}
+
+CmdLibraryElementEdit::~CmdLibraryElementEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CmdLibraryElementEdit::setCategories(const QSet<Uuid>& uuids) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewCategories = uuids;
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdLibraryElementEdit::performExecute() {
+  if (CmdLibraryBaseElementEdit::performExecute()) return true;  // can throw
+  if (mNewCategories != mOldCategories) return true;
+  return false;
+}
+
+void CmdLibraryElementEdit::performUndo() {
+  CmdLibraryBaseElementEdit::performUndo();  // can throw
+  mElement.setCategories(mOldCategories);
+}
+
+void CmdLibraryElementEdit::performRedo() {
+  CmdLibraryBaseElementEdit::performRedo();  // can throw
+  mElement.setCategories(mNewCategories);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/cmd/cmdlibraryelementedit.h
+++ b/libs/librepcb/library/cmd/cmdlibraryelementedit.h
@@ -1,0 +1,83 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_CMDLIBRARYELEMENTEDIT_H
+#define LIBREPCB_LIBRARY_CMDLIBRARYELEMENTEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../libraryelement.h"
+#include "cmdlibrarybaseelementedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Class CmdLibraryElementEdit
+ ******************************************************************************/
+
+/**
+ * @brief The CmdLibraryElementEdit class
+ */
+class CmdLibraryElementEdit : public CmdLibraryBaseElementEdit {
+public:
+  // Constructors / Destructor
+  CmdLibraryElementEdit()                                   = delete;
+  CmdLibraryElementEdit(const CmdLibraryElementEdit& other) = delete;
+  explicit CmdLibraryElementEdit(LibraryElement& element,
+                                 const QString&  text) noexcept;
+  virtual ~CmdLibraryElementEdit() noexcept;
+
+  // Setters
+  void setCategories(const QSet<Uuid>& uuids) noexcept;
+
+  // Operator Overloadings
+  CmdLibraryElementEdit& operator=(const CmdLibraryElementEdit& rhs) = delete;
+
+protected:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  virtual bool performExecute() override;
+
+  /// @copydoc UndoCommand::performUndo()
+  virtual void performUndo() override;
+
+  /// @copydoc UndoCommand::performRedo()
+  virtual void performRedo() override;
+
+private:  // Data
+  LibraryElement& mElement;
+
+  QSet<Uuid> mOldCategories;
+  QSet<Uuid> mNewCategories;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_CMDLIBRARYELEMENTEDIT_H

--- a/libs/librepcb/library/cmp/cmd/cmdcomponentedit.cpp
+++ b/libs/librepcb/library/cmp/cmd/cmdcomponentedit.cpp
@@ -1,0 +1,118 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdcomponentedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdComponentEdit::CmdComponentEdit(Component& component) noexcept
+  : CmdLibraryElementEdit(component, tr("Edit component metadata")),
+    mComponent(component),
+    mOldSchematicOnly(component.isSchematicOnly()),
+    mNewSchematicOnly(mOldSchematicOnly),
+    mOldDefaultValue(component.getDefaultValue()),
+    mNewDefaultValue(mOldDefaultValue),
+    mOldPrefixes(component.getPrefixes()),
+    mNewPrefixes(mOldPrefixes),
+    mOldAttributes(component.getAttributes()),
+    mNewAttributes(mOldAttributes) {
+}
+
+CmdComponentEdit::~CmdComponentEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CmdComponentEdit::setIsSchematicOnly(bool schematicOnly) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewSchematicOnly = schematicOnly;
+}
+
+void CmdComponentEdit::setDefaultValue(const QString& value) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewDefaultValue = value;
+}
+
+void CmdComponentEdit::setPrefix(const QString&         norm,
+                                 const ComponentPrefix& prefix) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewPrefixes.insert(norm, prefix);
+}
+
+void CmdComponentEdit::setPrefixes(
+    const NormDependentPrefixMap& prefixes) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewPrefixes = prefixes;
+}
+
+void CmdComponentEdit::setAttributes(const AttributeList& attributes) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewAttributes = attributes;
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdComponentEdit::performExecute() {
+  if (CmdLibraryElementEdit::performExecute()) return true;  // can throw
+  if (mNewSchematicOnly != mOldSchematicOnly) return true;
+  if (mNewDefaultValue != mOldDefaultValue) return true;
+  if (mNewPrefixes != mOldPrefixes) return true;
+  if (mNewAttributes != mOldAttributes) return true;
+  return false;
+}
+
+void CmdComponentEdit::performUndo() {
+  CmdLibraryElementEdit::performUndo();  // can throw
+  mComponent.setIsSchematicOnly(mOldSchematicOnly);
+  mComponent.setDefaultValue(mOldDefaultValue);
+  mComponent.setPrefixes(mOldPrefixes);
+  mComponent.setAttributes(mOldAttributes);
+}
+
+void CmdComponentEdit::performRedo() {
+  CmdLibraryElementEdit::performRedo();  // can throw
+  mComponent.setIsSchematicOnly(mNewSchematicOnly);
+  mComponent.setDefaultValue(mNewDefaultValue);
+  mComponent.setPrefixes(mNewPrefixes);
+  mComponent.setAttributes(mNewAttributes);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/cmp/cmd/cmdcomponentedit.h
+++ b/libs/librepcb/library/cmp/cmd/cmdcomponentedit.h
@@ -1,0 +1,92 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_CMDCOMPONENTEDIT_H
+#define LIBREPCB_LIBRARY_CMDCOMPONENTEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../cmd/cmdlibraryelementedit.h"
+#include "../component.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Class CmdComponentEdit
+ ******************************************************************************/
+
+/**
+ * @brief The CmdComponentEdit class
+ */
+class CmdComponentEdit : public CmdLibraryElementEdit {
+public:
+  // Constructors / Destructor
+  CmdComponentEdit()                              = delete;
+  CmdComponentEdit(const CmdComponentEdit& other) = delete;
+  explicit CmdComponentEdit(Component& component) noexcept;
+  virtual ~CmdComponentEdit() noexcept;
+
+  // Setters
+  void setIsSchematicOnly(bool schematicOnly) noexcept;
+  void setDefaultValue(const QString& value) noexcept;
+  void setPrefix(const QString& norm, const ComponentPrefix& prefix) noexcept;
+  void setPrefixes(const NormDependentPrefixMap& prefixes) noexcept;
+  void setAttributes(const AttributeList& attributes) noexcept;
+
+  // Operator Overloadings
+  CmdComponentEdit& operator=(const CmdComponentEdit& rhs) = delete;
+
+protected:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  virtual bool performExecute() override;
+
+  /// @copydoc UndoCommand::performUndo()
+  virtual void performUndo() override;
+
+  /// @copydoc UndoCommand::performRedo()
+  virtual void performRedo() override;
+
+private:  // Data
+  Component& mComponent;
+
+  bool                   mOldSchematicOnly;
+  bool                   mNewSchematicOnly;
+  QString                mOldDefaultValue;
+  QString                mNewDefaultValue;
+  NormDependentPrefixMap mOldPrefixes;
+  NormDependentPrefixMap mNewPrefixes;
+  AttributeList          mOldAttributes;
+  AttributeList          mNewAttributes;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_CMDCOMPONENTEDIT_H

--- a/libs/librepcb/library/cmp/component.h
+++ b/libs/librepcb/library/cmp/component.h
@@ -90,17 +90,21 @@ public:
   }
 
   // Attribute Methods
-  AttributeList&       getAttributes() noexcept { return mAttributes; }
   const AttributeList& getAttributes() const noexcept { return mAttributes; }
+  void                 setAttributes(const AttributeList& attributes) noexcept {
+    mAttributes = attributes;
+  }
 
   // Default Value Methods
   const QString& getDefaultValue() const noexcept { return mDefaultValue; }
   void setDefaultValue(const QString& value) noexcept { mDefaultValue = value; }
 
   // Prefix Methods
-  NormDependentPrefixMap&       getPrefixes() noexcept { return mPrefixes; }
   const NormDependentPrefixMap& getPrefixes() const noexcept {
     return mPrefixes;
+  }
+  void setPrefixes(const NormDependentPrefixMap& prefixes) noexcept {
+    mPrefixes = prefixes;
   }
 
   // Signal Methods

--- a/libs/librepcb/library/library.h
+++ b/libs/librepcb/library/library.h
@@ -65,18 +65,18 @@ public:
   const QUrl&       getUrl() const noexcept { return mUrl; }
   const QSet<Uuid>& getDependencies() const noexcept { return mDependencies; }
   FilePath          getIconFilePath() const noexcept;
-  const QPixmap&    getIcon() const noexcept { return mIcon; }
+  const QByteArray& getIcon() const noexcept { return mIcon; }
+  QPixmap           getIconAsPixmap() const noexcept;
 
   // Setters
   void setUrl(const QUrl& url) noexcept { mUrl = url; }
   void setDependencies(const QSet<Uuid>& deps) noexcept {
     mDependencies = deps;
   }
-  void setIconFilePath(const FilePath& png) noexcept;
+  void setIcon(const QByteArray& png) noexcept { mIcon = png; }
 
   // General Methods
-  void addDependency(const Uuid& uuid) noexcept;
-  void removeDependency(const Uuid& uuid) noexcept;
+  virtual void save() override;
   template <typename ElementType>
   QList<FilePath> searchForElements() const noexcept;
 
@@ -100,7 +100,7 @@ private:  // Methods
 private:  // Data
   QUrl       mUrl;
   QSet<Uuid> mDependencies;
-  QPixmap    mIcon;
+  QByteArray mIcon;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/library/library.pro
+++ b/libs/librepcb/library/library.pro
@@ -20,9 +20,14 @@ INCLUDEPATH += \
     ../../type_safe/external/debug_assert \
 
 SOURCES += \
+    cat/cmd/cmdlibrarycategoryedit.cpp \
     cat/componentcategory.cpp \
     cat/librarycategory.cpp \
     cat/packagecategory.cpp \
+    cmd/cmdlibrarybaseelementedit.cpp \
+    cmd/cmdlibraryedit.cpp \
+    cmd/cmdlibraryelementedit.cpp \
+    cmp/cmd/cmdcomponentedit.cpp \
     cmp/cmd/cmdcomponentsignaledit.cpp \
     cmp/cmd/cmdcomponentsymbolvariantedit.cpp \
     cmp/cmpsigpindisplaytype.cpp \
@@ -58,9 +63,14 @@ SOURCES += \
     sym/symbolpreviewgraphicsitem.cpp \
 
 HEADERS += \
+    cat/cmd/cmdlibrarycategoryedit.h \
     cat/componentcategory.h \
     cat/librarycategory.h \
     cat/packagecategory.h \
+    cmd/cmdlibrarybaseelementedit.h \
+    cmd/cmdlibraryedit.h \
+    cmd/cmdlibraryelementedit.h \
+    cmp/cmd/cmdcomponentedit.h \
     cmp/cmd/cmdcomponentsignaledit.h \
     cmp/cmd/cmdcomponentsymbolvariantedit.h \
     cmp/cmpsigpindisplaytype.h \

--- a/libs/librepcb/library/librarybaseelement.h
+++ b/libs/librepcb/library/librarybaseelement.h
@@ -92,14 +92,12 @@ public:
   void setVersion(const Version& version) noexcept { mVersion = version; }
   void setAuthor(const QString& author) noexcept { mAuthor = author; }
   void setDeprecated(bool deprecated) noexcept { mIsDeprecated = deprecated; }
-  void setName(const QString& locale, const ElementName& name) noexcept {
-    mNames.insert(locale, name);
+  void setNames(const LocalizedNameMap& names) noexcept { mNames = names; }
+  void setDescriptions(const LocalizedDescriptionMap& descriptions) noexcept {
+    mDescriptions = descriptions;
   }
-  void setDescription(const QString& locale, const QString& desc) noexcept {
-    mDescriptions.insert(locale, desc);
-  }
-  void setKeywords(const QString& locale, const QString& keywords) noexcept {
-    mKeywords.insert(locale, keywords);
+  void setKeywords(const LocalizedKeywordsMap& keywords) noexcept {
+    mKeywords = keywords;
   }
 
   // General Methods

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.h
@@ -27,8 +27,6 @@
 #include "../common/editorwidgetbase.h"
 #include "if_componentsymbolvarianteditorprovider.h"
 
-#include <librepcb/common/exceptions.h>
-#include <librepcb/common/fileio/filepath.h>
 #include <librepcb/library/cmp/componentsymbolvariant.h>
 
 #include <QtCore>
@@ -80,11 +78,12 @@ public slots:
   bool save() noexcept override;
 
 private:  // Methods
-  bool openComponentSymbolVariantEditor(
-      ComponentSymbolVariant& variant) noexcept override;
+  void    updateMetadata() noexcept;
+  QString commitMetadata() noexcept;
+  bool    openComponentSymbolVariantEditor(
+         ComponentSymbolVariant& variant) noexcept override;
   void memorizeComponentInterface() noexcept;
   bool isInterfaceBroken() const noexcept override;
-  void categoriesUpdated() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::ComponentEditorWidget>         mUi;

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
@@ -215,7 +215,11 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QPlainTextEdit" name="edtDescription"/>
+        <widget class="librepcb::PlainTextEdit" name="edtDescription">
+         <property name="tabChangesFocus">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_6">
@@ -329,7 +333,11 @@
         </widget>
        </item>
        <item row="10" column="1">
-        <widget class="QPlainTextEdit" name="edtDefaultValue"/>
+        <widget class="librepcb::PlainTextEdit" name="edtDefaultValue">
+         <property name="tabChangesFocus">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>
@@ -338,6 +346,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>librepcb::PlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
   <customwidget>
    <class>librepcb::AttributeListEditorWidget</class>
    <extends>QWidget</extends>

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
@@ -25,8 +25,6 @@
  ******************************************************************************/
 #include "../common/editorwidgetbase.h"
 
-#include <librepcb/common/exceptions.h>
-#include <librepcb/common/fileio/filepath.h>
 #include <librepcb/common/uuid.h>
 #include <optional/tl/optional.hpp>
 
@@ -53,9 +51,6 @@ class ComponentCategoryEditorWidget;
 
 /**
  * @brief The ComponentCategoryEditorWidget class
- *
- * @author ubruhin
- * @date 2016-10-16
  */
 class ComponentCategoryEditorWidget final : public EditorWidgetBase {
   Q_OBJECT
@@ -74,15 +69,15 @@ public:
       const ComponentCategoryEditorWidget& rhs) = delete;
 
 public slots:
-
   bool save() noexcept override;
 
 private:  // Methods
-  bool isInterfaceBroken() const noexcept override { return false; }
-  void btnChooseParentCategoryClicked() noexcept;
-  void btnResetParentCategoryClicked() noexcept;
-  void edtnameTextChanged(const QString& text) noexcept;
-  void updateCategoryLabel() noexcept;
+  void    updateMetadata() noexcept;
+  QString commitMetadata() noexcept;
+  bool    isInterfaceBroken() const noexcept override { return false; }
+  void    btnChooseParentCategoryClicked() noexcept;
+  void    btnResetParentCategoryClicked() noexcept;
+  void    updateCategoryLabel() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::ComponentCategoryEditorWidget> mUi;

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
@@ -51,7 +51,11 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QPlainTextEdit" name="edtDescription"/>
+    <widget class="librepcb::PlainTextEdit" name="edtDescription">
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_6">
@@ -202,7 +206,15 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::PlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
+  <include location="../../../../img/images.qrc"/>
   <include location="../../../../img/images.qrc"/>
  </resources>
  <connections/>

--- a/libs/librepcb/libraryeditor/common/categorylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/common/categorylisteditorwidget.cpp
@@ -84,6 +84,7 @@ void CategoryListEditorWidgetBase::btnAddClicked() noexcept {
     mUuids.insert(*uuid);
     addItem(*uuid);
     emit categoryAdded(*uuid);
+    emit edited();
   }
 }
 
@@ -94,9 +95,12 @@ void CategoryListEditorWidgetBase::btnRemoveClicked() noexcept {
            : tl::nullopt;
   if (item && uuid) {
     mUuids.remove(*uuid);
-    emit categoryRemoved(*uuid);
     delete item;
     updateColor();
+    // Emit signals *after* removing the item to avoid critical issues if a
+    // signal handler modifies the UUID list befor removing was finished.
+    emit categoryRemoved(*uuid);
+    emit edited();
   }
 }
 

--- a/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
@@ -95,6 +95,7 @@ private:
   void updateColor() noexcept;
 
 signals:
+  void edited();
   void categoryAdded(const Uuid& category);
   void categoryRemoved(const Uuid& category);
 

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
@@ -50,7 +50,6 @@ EditorWidgetBase::EditorWidgetBase(const Context& context, const FilePath& fp,
     mFilePath(fp),
     mUndoStackActionGroup(nullptr),
     mToolsActionGroup(nullptr),
-    mIsDirty(false),
     mIsInterfaceBroken(false) {
   mUndoStack.reset(new UndoStack());
   connect(mUndoStack.data(), &UndoStack::cleanChanged, this,
@@ -62,14 +61,6 @@ EditorWidgetBase::EditorWidgetBase(const Context& context, const FilePath& fp,
 }
 
 EditorWidgetBase::~EditorWidgetBase() noexcept {
-}
-
-/*******************************************************************************
- *  Getters
- ******************************************************************************/
-
-bool EditorWidgetBase::isDirty() const noexcept {
-  return (!mUndoStack->isClean() || mIsDirty);
 }
 
 /*******************************************************************************
@@ -115,7 +106,6 @@ void EditorWidgetBase::setCommandToolBar(QToolBar* toolbar) noexcept {
  ******************************************************************************/
 
 bool EditorWidgetBase::save() noexcept {
-  mIsDirty           = false;
   mIsInterfaceBroken = false;
   mUndoStack->setClean();
   emit dirtyChanged(false);
@@ -148,13 +138,6 @@ void EditorWidgetBase::setupInterfaceBrokenWarningWidget(
   layout->addWidget(label);
   connect(this, &EditorWidgetBase::interfaceBrokenChanged, &widget,
           &QWidget::setVisible);
-}
-
-void EditorWidgetBase::setDirty() noexcept {
-  if (!mIsDirty) {
-    mIsDirty = true;
-    emit dirtyChanged(true);
-  }
 }
 
 void EditorWidgetBase::undoStackStateModified() noexcept {

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.h
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.h
@@ -98,7 +98,7 @@ public:
 
   // Getters
   const FilePath& getFilePath() const noexcept { return mFilePath; }
-  bool            isDirty() const noexcept;
+  bool            isDirty() const noexcept { return !mUndoStack->isClean(); }
   virtual bool    hasGraphicalEditor() const noexcept { return false; }
 
   // Setters
@@ -127,7 +127,6 @@ protected:  // Methods
     Q_UNUSED(newTool);
     return false;
   }
-  void               setDirty() noexcept;
   void               undoStackStateModified() noexcept;
   const QStringList& getLibLocaleOrder() const noexcept;
 
@@ -148,7 +147,6 @@ protected:  // Data
   UndoStackActionGroup*        mUndoStackActionGroup;
   ExclusiveActionGroup*        mToolsActionGroup;
   QScopedPointer<ToolBarProxy> mCommandToolBarProxy;
-  bool                         mIsDirty;
   bool                         mIsInterfaceBroken;
 };
 

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.h
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.h
@@ -26,8 +26,6 @@
 #include "../common/categorylisteditorwidget.h"
 #include "../common/editorwidgetbase.h"
 
-#include <librepcb/common/exceptions.h>
-#include <librepcb/common/fileio/filepath.h>
 #include <librepcb/library/dev/devicepadsignalmap.h>
 
 #include <QtCore>
@@ -87,14 +85,16 @@ public slots:
   bool zoomAll() noexcept override;
 
 private:  // Methods
-  void btnChooseComponentClicked() noexcept;
-  void btnChoosePackageClicked() noexcept;
-  void updateDeviceComponentUuid(const Uuid& uuid) noexcept;
-  void updateComponentPreview() noexcept;
-  void updateDevicePackageUuid(const Uuid& uuid) noexcept;
-  void updatePackagePreview() noexcept;
-  void memorizeDeviceInterface() noexcept;
-  bool isInterfaceBroken() const noexcept override;
+  void    updateMetadata() noexcept;
+  QString commitMetadata() noexcept;
+  void    btnChooseComponentClicked() noexcept;
+  void    btnChoosePackageClicked() noexcept;
+  void    updateDeviceComponentUuid(const Uuid& uuid) noexcept;
+  void    updateComponentPreview() noexcept;
+  void    updateDevicePackageUuid(const Uuid& uuid) noexcept;
+  void    updatePackagePreview() noexcept;
+  void    memorizeDeviceInterface() noexcept;
+  bool    isInterfaceBroken() const noexcept override;
 
 private:  // Data
   QScopedPointer<Ui::DeviceEditorWidget>            mUi;

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
@@ -309,7 +309,11 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QPlainTextEdit" name="edtDescription"/>
+        <widget class="librepcb::PlainTextEdit" name="edtDescription">
+         <property name="tabChangesFocus">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_6">
@@ -385,6 +389,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>librepcb::PlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+  <customwidget>
    <class>librepcb::GraphicsView</class>
    <extends>QGraphicsView</extends>
    <header location="global">librepcb/common/graphics/graphicsview.h</header>
@@ -397,6 +406,7 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../../../img/images.qrc"/>
   <include location="../../../../img/images.qrc"/>
  </resources>
  <connections/>

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
@@ -58,7 +58,8 @@ LibraryListEditorWidget::LibraryListEditorWidget(const workspace::Workspace& ws,
   libs.append(mWorkspace.getRemoteLibraries().values());
   mUi->comboBox->addItem(tr("Choose library..."));
   foreach (const QSharedPointer<library::Library>& lib, libs) {
-    mUi->comboBox->addItem(lib->getIcon(), *lib->getNames().value(localeOrder),
+    mUi->comboBox->addItem(lib->getIconAsPixmap(),
+                           *lib->getNames().value(localeOrder),
                            lib->getUuid().toStr());
   }
 }

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
@@ -96,6 +96,7 @@ void LibraryListEditorWidget::btnAddClicked() noexcept {
     mUuids.insert(*uuid);
     addItem(*uuid);
     emit libraryAdded(*uuid);
+    emit edited();
   }
 }
 
@@ -106,8 +107,11 @@ void LibraryListEditorWidget::btnRemoveClicked() noexcept {
            : tl::nullopt;
   if (item && uuid) {
     mUuids.remove(*uuid);
-    emit libraryRemoved(*uuid);
     delete item;
+    // Emit signals *after* removing the item to avoid critical issues if a
+    // signal handler modifies the UUID list befor removing was finished.
+    emit libraryRemoved(*uuid);
+    emit edited();
   }
 }
 

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
@@ -81,6 +81,7 @@ private:
   void addItem(const Uuid& library) noexcept;
 
 signals:
+  void edited();
   void libraryAdded(const Uuid& lib);
   void libraryRemoved(const Uuid& lib);
 

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -25,8 +25,6 @@
  ******************************************************************************/
 #include "../common/editorwidgetbase.h"
 
-#include <librepcb/common/exceptions.h>
-
 #include <QtCore>
 #include <QtWidgets>
 
@@ -82,9 +80,10 @@ signals:
   void editDeviceTriggered(const FilePath& fp);
 
 private:  // Methods
-  bool isInterfaceBroken() const noexcept override { return false; }
-  void updateIcon() noexcept;
-  void updateElementLists() noexcept;
+  void    updateMetadata() noexcept;
+  QString commitMetadata() noexcept;
+  bool    isInterfaceBroken() const noexcept override { return false; }
+  void    updateElementLists() noexcept;
   template <typename ElementType>
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;
 
@@ -101,6 +100,7 @@ private:  // Data
   QSharedPointer<Library>                   mLibrary;
   QScopedPointer<Ui::LibraryOverviewWidget> mUi;
   QScopedPointer<LibraryListEditorWidget>   mDependenciesEditorWidget;
+  QByteArray                                mIcon;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
@@ -282,6 +282,9 @@
          <property name="cursor">
           <cursorShape>PointingHandCursor</cursorShape>
          </property>
+         <property name="toolTip">
+          <string>Click here to choose an icon (PNG, 256x256px).</string>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -328,7 +331,7 @@
         </widget>
        </item>
        <item row="3" column="1">
-        <widget class="QPlainTextEdit" name="edtDescription"/>
+        <widget class="librepcb::PlainTextEdit" name="edtDescription"/>
        </item>
        <item row="4" column="0">
         <widget class="QLabel" name="label_4">
@@ -423,6 +426,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::PlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -115,7 +115,7 @@ LibraryEditor::LibraryEditor(workspace::Workspace&   ws,
   QString libName = *mLibrary->getNames().value(localeOrder);
   if (mLibrary->isOpenedReadOnly()) libName.append(tr(" [Read-Only]"));
   setWindowTitle(QString(tr("%1 - LibrePCB Library Editor")).arg(libName));
-  setWindowIcon(mLibrary->getIcon());
+  setWindowIcon(mLibrary->getIconAsPixmap());
 
   // setup status bar
   mUi->statusBar->setFields(StatusBar::ProgressBar);

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
@@ -158,9 +158,9 @@ void NewElementWizardContext::createLibraryElement() {
                         *mElementName, mElementDescription, mElementKeywords);
       element.setCategories(categories);
       element.setIsSchematicOnly(mComponentSchematicOnly);
-      element.getAttributes() = mComponentAttributes;
+      element.setAttributes(mComponentAttributes);
       element.setDefaultValue(mComponentDefaultValue);
-      element.getPrefixes()       = mComponentPrefixes;
+      element.setPrefixes(mComponentPrefixes);
       element.getSignals()        = mComponentSignals;
       element.getSymbolVariants() = mComponentSymbolVariants;
       element.saveIntoParentDirectory(

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
@@ -26,8 +26,6 @@
 #include "../common/categorylisteditorwidget.h"
 #include "../common/editorwidgetbase.h"
 
-#include <librepcb/common/exceptions.h>
-#include <librepcb/common/fileio/filepath.h>
 #include <librepcb/common/graphics/if_graphicsvieweventhandler.h>
 #include <librepcb/library/pkg/footprint.h>
 
@@ -98,6 +96,8 @@ public slots:
   bool editGridProperties() noexcept override;
 
 private:  // Methods
+  void    updateMetadata() noexcept;
+  QString commitMetadata() noexcept;
   /// @copydoc librepcb::IF_GraphicsViewEventHandler::graphicsViewEventHandler()
   bool graphicsViewEventHandler(QEvent* event) noexcept override;
   bool toolChangeRequested(Tool newTool) noexcept override;

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
@@ -173,7 +173,11 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QPlainTextEdit" name="edtDescription"/>
+        <widget class="librepcb::PlainTextEdit" name="edtDescription">
+         <property name="tabChangesFocus">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_6">
@@ -248,6 +252,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>librepcb::PlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
   <customwidget>
    <class>librepcb::GraphicsView</class>
    <extends>QGraphicsView</extends>

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
@@ -25,8 +25,6 @@
  ******************************************************************************/
 #include "../common/editorwidgetbase.h"
 
-#include <librepcb/common/exceptions.h>
-#include <librepcb/common/fileio/filepath.h>
 #include <librepcb/common/uuid.h>
 #include <optional/tl/optional.hpp>
 
@@ -53,9 +51,6 @@ class PackageCategoryEditorWidget;
 
 /**
  * @brief The PackageCategoryEditorWidget class
- *
- * @author ubruhin
- * @date 2016-10-16
  */
 class PackageCategoryEditorWidget final : public EditorWidgetBase {
   Q_OBJECT
@@ -74,15 +69,15 @@ public:
       const PackageCategoryEditorWidget& rhs) = delete;
 
 public slots:
-
   bool save() noexcept override;
 
 private:  // Methods
-  bool isInterfaceBroken() const noexcept override { return false; }
-  void btnChooseParentCategoryClicked() noexcept;
-  void btnResetParentCategoryClicked() noexcept;
-  void edtnameTextChanged(const QString& text) noexcept;
-  void updateCategoryLabel() noexcept;
+  void    updateMetadata() noexcept;
+  QString commitMetadata() noexcept;
+  bool    isInterfaceBroken() const noexcept override { return false; }
+  void    btnChooseParentCategoryClicked() noexcept;
+  void    btnResetParentCategoryClicked() noexcept;
+  void    updateCategoryLabel() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::PackageCategoryEditorWidget> mUi;

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
@@ -51,7 +51,7 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QPlainTextEdit" name="edtDescription"/>
+    <widget class="librepcb::PlainTextEdit" name="edtDescription"/>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_6">
@@ -202,7 +202,15 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::PlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
+  <include location="../../../../img/images.qrc"/>
   <include location="../../../../img/images.qrc"/>
  </resources>
  <connections/>

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
@@ -26,8 +26,6 @@
 #include "../common/categorylisteditorwidget.h"
 #include "../common/editorwidgetbase.h"
 
-#include <librepcb/common/exceptions.h>
-#include <librepcb/common/fileio/filepath.h>
 #include <librepcb/common/graphics/if_graphicsvieweventhandler.h>
 
 #include <QtCore>
@@ -86,7 +84,6 @@ public:
   SymbolEditorWidget& operator=(const SymbolEditorWidget& rhs) = delete;
 
 public slots:
-
   bool save() noexcept override;
   bool rotateCw() noexcept override;
   bool rotateCcw() noexcept override;
@@ -98,6 +95,8 @@ public slots:
   bool editGridProperties() noexcept override;
 
 private:  // Methods
+  void    updateMetadata() noexcept;
+  QString commitMetadata() noexcept;
   /// @copydoc librepcb::IF_GraphicsViewEventHandler::graphicsViewEventHandler()
   bool graphicsViewEventHandler(QEvent* event) noexcept override;
   bool toolChangeRequested(Tool newTool) noexcept override;

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
@@ -103,7 +103,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QPlainTextEdit" name="edtDescription"/>
+        <widget class="librepcb::PlainTextEdit" name="edtDescription"/>
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_6">
@@ -178,6 +178,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>librepcb::PlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
   <customwidget>
    <class>librepcb::GraphicsView</class>
    <extends>QGraphicsView</extends>

--- a/libs/librepcb/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/librarymanager/addlibrarywidget.cpp
@@ -207,8 +207,12 @@ void AddLibraryWidget::createLocalLibraryButtonClicked() noexcept {
                                             author, ElementName(name), desc,
                                             QString("")));  // can throw
     lib->setUrl(url);
-    lib->setIconFilePath(
-        qApp->getResourcesDir().getPathTo("library/default_image.png"));
+    try {
+      lib->setIcon(FileUtils::readFile(
+          qApp->getResourcesDir().getPathTo("library/default_image.png")));
+    } catch (const Exception& e) {
+      qCritical() << "Could not open the library image:" << e.getMsg();
+    }
     lib->saveTo(directory);  // can throw
 
     // copy license file

--- a/libs/librepcb/librarymanager/libraryinfowidget.cpp
+++ b/libs/librepcb/librarymanager/libraryinfowidget.cpp
@@ -58,8 +58,8 @@ LibraryInfoWidget::LibraryInfoWidget(workspace::Workspace&   ws,
       ws.getSettings().getLibLocaleOrder().getLocaleOrder();
 
   // image
-  if (!lib->getIcon().isNull()) {
-    mUi->lblIcon->setPixmap(lib->getIcon().scaled(
+  if (!lib->getIconAsPixmap().isNull()) {
+    mUi->lblIcon->setPixmap(lib->getIconAsPixmap().scaled(
         mUi->lblIcon->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
   } else {
     mUi->lblIcon->setVisible(false);

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
@@ -53,8 +53,8 @@ LibraryListWidgetItem::LibraryListWidgetItem(
   if (lib) {
     const QStringList& localeOrder =
         ws.getSettings().getLibLocaleOrder().getLocaleOrder();
-    if (!lib->getIcon().isNull()) {
-      mUi->lblIcon->setPixmap(lib->getIcon());
+    if (!lib->getIconAsPixmap().isNull()) {
+      mUi->lblIcon->setPixmap(lib->getIconAsPixmap());
     }
     if (isRemoteLibrary()) {
       mUi->lblLibraryType->setText(tr("(remote)"));


### PR DESCRIPTION
Until now, library element metadata was not tracked with the undo system. Now every change of every library element metadata is added to the undo stack and thus can be undone/redone.

This is needed for my next pull request :grin: 