### PR TITLE
Add rule check for library elements

### DIFF
--- a/libs/librepcb/common/fileio/serializableobjectlist.h
+++ b/libs/librepcb/common/fileio/serializableobjectlist.h
@@ -222,6 +222,7 @@ public:
   std::shared_ptr<const T> value(int index) const noexcept {
     return std::const_pointer_cast<const T>(mObjects.value(index));
   }
+  std::shared_ptr<T> find(const T* obj) noexcept { return value(indexOf(obj)); }
   std::shared_ptr<T> find(const Uuid& key) noexcept {
     return value(indexOf(key));
   }
@@ -243,7 +244,12 @@ public:
   std::shared_ptr<const T> first() const noexcept { return mObjects.first(); }
   std::shared_ptr<T>&      last() noexcept { return mObjects.last(); }
   std::shared_ptr<const T> last() const noexcept { return mObjects.last(); }
-  std::shared_ptr<T>       get(const Uuid& key) {
+  std::shared_ptr<T>       get(const T* obj) {
+    std::shared_ptr<T> ptr = find(obj);
+    if (!ptr) throw LogicError(__FILE__, __LINE__);
+    return ptr;
+  }
+  std::shared_ptr<T> get(const Uuid& key) {
     std::shared_ptr<T> ptr = find(key);
     if (!ptr) throwKeyNotFoundException(key);
     return ptr;

--- a/libs/librepcb/library/cmp/component.cpp
+++ b/libs/librepcb/library/cmp/component.cpp
@@ -22,6 +22,8 @@
  ******************************************************************************/
 #include "component.h"
 
+#include "componentcheck.h"
+
 #include <librepcb/common/fileio/sexpression.h>
 
 #include <QtCore>
@@ -112,6 +114,15 @@ std::shared_ptr<ComponentSymbolVariantItem> Component::getSymbVarItem(
 std::shared_ptr<const ComponentSymbolVariantItem> Component::getSymbVarItem(
     const Uuid& symbVar, const Uuid& item) const {
   return mSymbolVariants.get(symbVar)->getSymbolItems().get(item);  // can throw
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+LibraryElementCheckMessageList Component::runChecks() const {
+  ComponentCheck check(*this);
+  return check.runChecks();  // can throw
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/component.h
+++ b/libs/librepcb/library/cmp/component.h
@@ -131,6 +131,9 @@ public:
   std::shared_ptr<const ComponentSymbolVariantItem> getSymbVarItem(
       const Uuid& symbVar, const Uuid& item) const;
 
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
+
   // Operator Overloadings
   Component& operator=(const Component& rhs) = delete;
 

--- a/libs/librepcb/library/cmp/componentcheck.cpp
+++ b/libs/librepcb/library/cmp/componentcheck.cpp
@@ -1,0 +1,113 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "componentcheck.h"
+
+#include "component.h"
+#include "msg/msgduplicatesignalname.h"
+#include "msg/msgmissingcomponentdefaultvalue.h"
+#include "msg/msgmissingcomponentprefix.h"
+#include "msg/msgmissingsymbolvariant.h"
+#include "msg/msgmissingsymbolvariantitem.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+ComponentCheck::ComponentCheck(const Component& component) noexcept
+  : LibraryElementCheck(component), mComponent(component) {
+}
+
+ComponentCheck::~ComponentCheck() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+LibraryElementCheckMessageList ComponentCheck::runChecks() const {
+  LibraryElementCheckMessageList msgs = LibraryElementCheck::runChecks();
+  checkMissingPrefix(msgs);
+  checkMissingDefaultValue(msgs);
+  checkDuplicateSignalNames(msgs);
+  checkMissingSymbolVariants(msgs);
+  checkMissingSymbolVariantItems(msgs);
+  return msgs;
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+void ComponentCheck::checkMissingPrefix(MsgList& msgs) const {
+  if (mComponent.getPrefixes().getDefaultValue()->isEmpty()) {
+    msgs.append(std::make_shared<MsgMissingComponentPrefix>());
+  }
+}
+
+void ComponentCheck::checkMissingDefaultValue(MsgList& msgs) const {
+  if (mComponent.getDefaultValue().trimmed().isEmpty()) {
+    msgs.append(std::make_shared<MsgMissingComponentDefaultValue>());
+  }
+}
+
+void ComponentCheck::checkDuplicateSignalNames(MsgList& msgs) const {
+  QSet<CircuitIdentifier> names;
+  for (const ComponentSignal& signal : mComponent.getSignals()) {
+    if (names.contains(signal.getName())) {
+      msgs.append(std::make_shared<MsgDuplicateSignalName>(signal));
+    } else {
+      names.insert(signal.getName());
+    }
+  }
+}
+
+void ComponentCheck::checkMissingSymbolVariants(MsgList& msgs) const {
+  if (mComponent.getSymbolVariants().isEmpty()) {
+    msgs.append(std::make_shared<MsgMissingSymbolVariant>());
+  }
+}
+
+void ComponentCheck::checkMissingSymbolVariantItems(MsgList& msgs) const {
+  for (auto it = mComponent.getSymbolVariants().begin();
+       it != mComponent.getSymbolVariants().end(); ++it) {
+    std::shared_ptr<const ComponentSymbolVariant> symbVar = it.ptr();
+    if (symbVar->getSymbolItems().isEmpty()) {
+      msgs.append(std::make_shared<MsgMissingSymbolVariantItem>(symbVar));
+    }
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/cmp/componentcheck.h
+++ b/libs/librepcb/library/cmp/componentcheck.h
@@ -17,65 +17,55 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_COMPONENTCHECK_H
+#define LIBREPCB_LIBRARY_COMPONENTCHECK_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "libraryelementcheck.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class Component;
 
 /*******************************************************************************
- *  General Methods
+ *  Class ComponentCheck
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The ComponentCheck class
+ */
+class ComponentCheck : public LibraryElementCheck {
+public:
+  // Constructors / Destructor
+  ComponentCheck()                            = delete;
+  ComponentCheck(const ComponentCheck& other) = delete;
+  explicit ComponentCheck(const Component& component) noexcept;
+  virtual ~ComponentCheck() noexcept;
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Operator Overloadings
+  ComponentCheck& operator=(const ComponentCheck& rhs) = delete;
+
+protected:  // Methods
+  void checkMissingPrefix(MsgList& msgs) const;
+  void checkMissingDefaultValue(MsgList& msgs) const;
+  void checkDuplicateSignalNames(MsgList& msgs) const;
+  void checkMissingSymbolVariants(MsgList& msgs) const;
+  void checkMissingSymbolVariantItems(MsgList& msgs) const;
+
+private:  // Data
+  const Component& mComponent;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +73,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_COMPONENTCHECK_H

--- a/libs/librepcb/library/cmp/msg/msgduplicatesignalname.cpp
+++ b/libs/librepcb/library/cmp/msg/msgduplicatesignalname.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgduplicatesignalname.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../componentsignal.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,20 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgDuplicateSignalName::MsgDuplicateSignalName(
+    const ComponentSignal& signal) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        QString(tr("Duplicate signal name: '%1'")).arg(*signal.getName()),
+        tr("All component signals must have unique names, otherwise they "
+           "cannot be distinguished later in the device editor. If your part "
+           "has several pins which are electrically exactly equal (e.g. "
+           "multiple GND pins), you should add only one of these pins as a "
+           "component signal. The assignment to multiple pins should be done "
+           "in the device editor instead.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgDuplicateSignalName::~MsgDuplicateSignalName() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/msg/msgduplicatesignalname.h
+++ b/libs/librepcb/library/cmp/msg/msgduplicatesignalname.h
@@ -17,65 +17,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGDUPLICATESIGNALNAME_H
+#define LIBREPCB_LIBRARY_MSGDUPLICATESIGNALNAME_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class ComponentSignal;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgDuplicateSignalName
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgDuplicateSignalName class
+ */
+class MsgDuplicateSignalName final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgDuplicateSignalName)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgDuplicateSignalName() = delete;
+  explicit MsgDuplicateSignalName(const ComponentSignal& signal) noexcept;
+  MsgDuplicateSignalName(const MsgDuplicateSignalName& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgDuplicateSignalName() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +60,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGDUPLICATESIGNALNAME_H

--- a/libs/librepcb/library/cmp/msg/msgmissingcomponentdefaultvalue.cpp
+++ b/libs/librepcb/library/cmp/msg/msgmissingcomponentdefaultvalue.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingcomponentdefaultvalue.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,23 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingComponentDefaultValue::MsgMissingComponentDefaultValue() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning, tr("No default value set"),
+        QString(tr("Most components should have a default value set. The "
+                   "default value becomes the component's value when adding it "
+                   "to a schematic. It can also contain placeholders which are "
+                   "substituted later in the schematic. Commonly used default "
+                   "values are:\n\n"
+                   "Generic parts (e.g. a diode): %1\n"
+                   "Specific parts (e.g. a microcontroller): %2\n"
+                   "Passive parts: Using an attribute, e.g. %3"))
+            .arg("'{{PARTNUMBER or DEVICE}}'",
+                 "'{{PARTNUMBER or DEVICE or COMPONENT}}'",
+                 "'{{RESISTANCE}}'")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingComponentDefaultValue::~MsgMissingComponentDefaultValue() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/msg/msgmissingcomponentdefaultvalue.h
+++ b/libs/librepcb/library/cmp/msg/msgmissingcomponentdefaultvalue.h
@@ -17,65 +17,41 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGCOMPONENTDEFAULTVALUE_H
+#define LIBREPCB_LIBRARY_MSGMISSINGCOMPONENTDEFAULTVALUE_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingComponentDefaultValue
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingComponentDefaultValue class
+ */
+class MsgMissingComponentDefaultValue final
+  : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingComponentDefaultValue)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingComponentDefaultValue() noexcept;
+  MsgMissingComponentDefaultValue(
+      const MsgMissingComponentDefaultValue& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingComponentDefaultValue() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +59,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGCOMPONENTDEFAULTVALUE_H

--- a/libs/librepcb/library/cmp/msg/msgmissingcomponentprefix.cpp
+++ b/libs/librepcb/library/cmp/msg/msgmissingcomponentprefix.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingcomponentprefix.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,16 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingComponentPrefix::MsgMissingComponentPrefix() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning, tr("No component prefix set"),
+        tr("Most components should have a prefix defined. The prefix is used "
+           "to generate the component's name when adding it to a schematic. "
+           "For example the prefix 'R' (resistor) leads to component names "
+           "'R1', 'R2', 'R3' etc.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingComponentPrefix::~MsgMissingComponentPrefix() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/msg/msgmissingcomponentprefix.h
+++ b/libs/librepcb/library/cmp/msg/msgmissingcomponentprefix.h
@@ -17,65 +17,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGCOMPONENTPREFIX_H
+#define LIBREPCB_LIBRARY_MSGMISSINGCOMPONENTPREFIX_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingComponentPrefix
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingComponentPrefix class
+ */
+class MsgMissingComponentPrefix final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingComponentPrefix)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingComponentPrefix() noexcept;
+  MsgMissingComponentPrefix(const MsgMissingComponentPrefix& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingComponentPrefix() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +57,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGCOMPONENTPREFIX_H

--- a/libs/librepcb/library/cmp/msg/msgmissingsymbolvariant.cpp
+++ b/libs/librepcb/library/cmp/msg/msgmissingsymbolvariant.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingsymbolvariant.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,14 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingSymbolVariant::MsgMissingSymbolVariant() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error, tr("No symbol variant defined"),
+        tr("Every component requires at least one symbol variant, otherwise it "
+           "can't be added to schematics.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingSymbolVariant::~MsgMissingSymbolVariant() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/msg/msgmissingsymbolvariant.h
+++ b/libs/librepcb/library/cmp/msg/msgmissingsymbolvariant.h
@@ -17,65 +17,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGSYMBOLVARIANT_H
+#define LIBREPCB_LIBRARY_MSGMISSINGSYMBOLVARIANT_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingSymbolVariant
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingSymbolVariant class
+ */
+class MsgMissingSymbolVariant final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingSymbolVariant)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingSymbolVariant() noexcept;
+  MsgMissingSymbolVariant(const MsgMissingSymbolVariant& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingSymbolVariant() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +57,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGSYMBOLVARIANT_H

--- a/libs/librepcb/library/cmp/msg/msgmissingsymbolvariantitem.cpp
+++ b/libs/librepcb/library/cmp/msg/msgmissingsymbolvariantitem.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgmissingsymbolvariantitem.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../componentsymbolvariant.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,18 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingSymbolVariantItem::MsgMissingSymbolVariantItem(
+    std::shared_ptr<const ComponentSymbolVariant> symbVar) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        QString(tr("Symbol variant '%1' has no items"))
+            .arg(*symbVar->getNames().getDefaultValue()),
+        tr("Every symbol variant requires at least one symbol item, otherwise "
+           "it can't be added to schematics.")),
+    mSymbVar(symbVar) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingSymbolVariantItem::~MsgMissingSymbolVariantItem() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/msg/msgmissingsymbolvariantitem.h
+++ b/libs/librepcb/library/cmp/msg/msgmissingsymbolvariantitem.h
@@ -17,65 +17,51 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGSYMBOLVARIANTITEM_H
+#define LIBREPCB_LIBRARY_MSGMISSINGSYMBOLVARIANTITEM_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class ComponentSymbolVariant;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgMissingSymbolVariantItem
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgMissingSymbolVariantItem class
+ */
+class MsgMissingSymbolVariantItem final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingSymbolVariantItem)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+public:
+  // Constructors / Destructor
+  MsgMissingSymbolVariantItem() noexcept;
+  explicit MsgMissingSymbolVariantItem(
+      std::shared_ptr<const ComponentSymbolVariant> symbVar) noexcept;
+  MsgMissingSymbolVariantItem(const MsgMissingSymbolVariantItem& other) noexcept
+    : LibraryElementCheckMessage(other), mSymbVar(other.mSymbVar) {}
+  virtual ~MsgMissingSymbolVariantItem() noexcept;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Getters
+  std::shared_ptr<const ComponentSymbolVariant> getSymbVar() const noexcept {
+    return mSymbVar;
+  }
+
+private:
+  std::shared_ptr<const ComponentSymbolVariant> mSymbVar;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +69,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGSYMBOLVARIANTITEM_H

--- a/libs/librepcb/library/library.pro
+++ b/libs/librepcb/library/library.pro
@@ -32,17 +32,29 @@ SOURCES += \
     cmp/cmd/cmdcomponentsymbolvariantedit.cpp \
     cmp/cmpsigpindisplaytype.cpp \
     cmp/component.cpp \
+    cmp/componentcheck.cpp \
     cmp/componentpinsignalmap.cpp \
     cmp/componentsignal.cpp \
     cmp/componentsymbolvariant.cpp \
     cmp/componentsymbolvariantitem.cpp \
+    cmp/msg/msgduplicatesignalname.cpp \
+    cmp/msg/msgmissingcomponentdefaultvalue.cpp \
+    cmp/msg/msgmissingcomponentprefix.cpp \
+    cmp/msg/msgmissingsymbolvariant.cpp \
+    cmp/msg/msgmissingsymbolvariantitem.cpp \
     dev/cmd/cmddeviceedit.cpp \
     dev/cmd/cmddevicepadsignalmapitemedit.cpp \
     dev/device.cpp \
     dev/devicepadsignalmap.cpp \
     library.cpp \
     librarybaseelement.cpp \
+    librarybaseelementcheck.cpp \
     libraryelement.cpp \
+    libraryelementcheck.cpp \
+    msg/libraryelementcheckmessage.cpp \
+    msg/msgmissingauthor.cpp \
+    msg/msgmissingcategories.cpp \
+    msg/msgnamenottitlecase.cpp \
     pkg/cmd/cmdfootprintedit.cpp \
     pkg/cmd/cmdfootprintpadedit.cpp \
     pkg/cmd/cmdpackagepadedit.cpp \
@@ -52,10 +64,24 @@ SOURCES += \
     pkg/footprintpadgraphicsitem.cpp \
     pkg/footprintpadpreviewgraphicsitem.cpp \
     pkg/footprintpreviewgraphicsitem.cpp \
+    pkg/msg/msgduplicatepadname.cpp \
+    pkg/msg/msgmissingfootprint.cpp \
+    pkg/msg/msgmissingfootprintname.cpp \
+    pkg/msg/msgmissingfootprintvalue.cpp \
+    pkg/msg/msgpadoverlapswithplacement.cpp \
+    pkg/msg/msgwrongfootprinttextlayer.cpp \
     pkg/package.cpp \
+    pkg/packagecheck.cpp \
     pkg/packagepad.cpp \
     sym/cmd/cmdsymbolpinedit.cpp \
+    sym/msg/msgduplicatepinname.cpp \
+    sym/msg/msgmissingsymbolname.cpp \
+    sym/msg/msgmissingsymbolvalue.cpp \
+    sym/msg/msgoverlappingsymbolpins.cpp \
+    sym/msg/msgsymbolpinnotongrid.cpp \
+    sym/msg/msgwrongsymboltextlayer.cpp \
     sym/symbol.cpp \
+    sym/symbolcheck.cpp \
     sym/symbolgraphicsitem.cpp \
     sym/symbolpin.cpp \
     sym/symbolpingraphicsitem.cpp \
@@ -75,12 +101,18 @@ HEADERS += \
     cmp/cmd/cmdcomponentsymbolvariantedit.h \
     cmp/cmpsigpindisplaytype.h \
     cmp/component.h \
+    cmp/componentcheck.h \
     cmp/componentpinsignalmap.h \
     cmp/componentprefix.h \
     cmp/componentsignal.h \
     cmp/componentsymbolvariant.h \
     cmp/componentsymbolvariantitem.h \
     cmp/componentsymbolvariantitemsuffix.h \
+    cmp/msg/msgduplicatesignalname.h \
+    cmp/msg/msgmissingcomponentdefaultvalue.h \
+    cmp/msg/msgmissingcomponentprefix.h \
+    cmp/msg/msgmissingsymbolvariant.h \
+    cmp/msg/msgmissingsymbolvariantitem.h \
     dev/cmd/cmddeviceedit.h \
     dev/cmd/cmddevicepadsignalmapitemedit.h \
     dev/device.h \
@@ -88,7 +120,13 @@ HEADERS += \
     elements.h \
     library.h \
     librarybaseelement.h \
+    librarybaseelementcheck.h \
     libraryelement.h \
+    libraryelementcheck.h \
+    msg/libraryelementcheckmessage.h \
+    msg/msgmissingauthor.h \
+    msg/msgmissingcategories.h \
+    msg/msgnamenottitlecase.h \
     pkg/cmd/cmdfootprintedit.h \
     pkg/cmd/cmdfootprintpadedit.h \
     pkg/cmd/cmdpackagepadedit.h \
@@ -98,10 +136,24 @@ HEADERS += \
     pkg/footprintpadgraphicsitem.h \
     pkg/footprintpadpreviewgraphicsitem.h \
     pkg/footprintpreviewgraphicsitem.h \
+    pkg/msg/msgduplicatepadname.h \
+    pkg/msg/msgmissingfootprint.h \
+    pkg/msg/msgmissingfootprintname.h \
+    pkg/msg/msgmissingfootprintvalue.h \
+    pkg/msg/msgpadoverlapswithplacement.h \
+    pkg/msg/msgwrongfootprinttextlayer.h \
     pkg/package.h \
+    pkg/packagecheck.h \
     pkg/packagepad.h \
     sym/cmd/cmdsymbolpinedit.h \
+    sym/msg/msgduplicatepinname.h \
+    sym/msg/msgmissingsymbolname.h \
+    sym/msg/msgmissingsymbolvalue.h \
+    sym/msg/msgoverlappingsymbolpins.h \
+    sym/msg/msgsymbolpinnotongrid.h \
+    sym/msg/msgwrongsymboltextlayer.h \
     sym/symbol.h \
+    sym/symbolcheck.h \
     sym/symbolgraphicsitem.h \
     sym/symbolpin.h \
     sym/symbolpingraphicsitem.h \

--- a/libs/librepcb/library/librarybaseelement.cpp
+++ b/libs/librepcb/library/librarybaseelement.cpp
@@ -22,6 +22,8 @@
  ******************************************************************************/
 #include "librarybaseelement.h"
 
+#include "librarybaseelementcheck.h"
+
 #include <librepcb/common/application.h>
 #include <librepcb/common/fileio/fileutils.h>
 #include <librepcb/common/fileio/sexpression.h>
@@ -174,6 +176,11 @@ QStringList LibraryBaseElement::getAllAvailableLocales() const noexcept {
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+LibraryElementCheckMessageList LibraryBaseElement::runChecks() const {
+  LibraryBaseElementCheck check(*this);
+  return check.runChecks();  // can throw
+}
 
 void LibraryBaseElement::save() {
   if (mOpenedReadOnly) {

--- a/libs/librepcb/library/librarybaseelement.h
+++ b/libs/librepcb/library/librarybaseelement.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "./msg/libraryelementcheckmessage.h"
+
 #include <librepcb/common/fileio/filepath.h>
 #include <librepcb/common/fileio/serializablekeyvaluemap.h>
 #include <librepcb/common/fileio/serializableobject.h>
@@ -101,8 +103,9 @@ public:
   }
 
   // General Methods
-  virtual void save();
-  virtual void saveTo(const FilePath& destination);
+  virtual LibraryElementCheckMessageList runChecks() const;
+  virtual void                           save();
+  virtual void                           saveTo(const FilePath& destination);
   virtual void saveIntoParentDirectory(const FilePath& parentDir);
   virtual void moveTo(const FilePath& destination);
   virtual void moveIntoParentDirectory(const FilePath& parentDir);

--- a/libs/librepcb/library/librarybaseelementcheck.h
+++ b/libs/librepcb/library/librarybaseelementcheck.h
@@ -17,65 +17,54 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_LIBRARYBASEELEMENTCHECK_H
+#define LIBREPCB_LIBRARY_LIBRARYBASEELEMENTCHECK_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "./msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class LibraryBaseElement;
 
 /*******************************************************************************
- *  General Methods
+ *  Class LibraryBaseElementCheck
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The LibraryBaseElementCheck class
+ */
+class LibraryBaseElementCheck {
+public:
+  // Constructors / Destructor
+  LibraryBaseElementCheck()                                     = delete;
+  LibraryBaseElementCheck(const LibraryBaseElementCheck& other) = delete;
+  explicit LibraryBaseElementCheck(const LibraryBaseElement& element) noexcept;
+  virtual ~LibraryBaseElementCheck() noexcept;
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Operator Overloadings
+  LibraryBaseElementCheck& operator=(const LibraryBaseElementCheck& rhs) =
+      delete;
+
+protected:
+  typedef LibraryElementCheckMessageList MsgList;
+  void checkDefaultNameTitleCase(MsgList& msgs) const;
+  void checkMissingAuthor(MsgList& msgs) const;
+
+private:  // Data
+  const LibraryBaseElement& mElement;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +72,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_LIBRARYBASEELEMENTCHECK_H

--- a/libs/librepcb/library/libraryelement.cpp
+++ b/libs/librepcb/library/libraryelement.cpp
@@ -22,6 +22,8 @@
  ******************************************************************************/
 #include "libraryelement.h"
 
+#include "libraryelementcheck.h"
+
 #include <librepcb/common/fileio/sexpression.h>
 #include <librepcb/common/toolbox.h>
 
@@ -60,6 +62,15 @@ LibraryElement::LibraryElement(const FilePath& elementDirectory,
 }
 
 LibraryElement::~LibraryElement() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+LibraryElementCheckMessageList LibraryElement::runChecks() const {
+  LibraryElementCheck check(*this);
+  return check.runChecks();  // can throw
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/libraryelement.h
+++ b/libs/librepcb/library/libraryelement.h
@@ -66,6 +66,9 @@ public:
   // Setters: Attributes
   void setCategories(const QSet<Uuid>& uuids) noexcept { mCategories = uuids; }
 
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
+
   // Operator Overloadings
   LibraryElement& operator=(const LibraryElement& rhs) = delete;
 

--- a/libs/librepcb/library/libraryelementcheck.h
+++ b/libs/librepcb/library/libraryelementcheck.h
@@ -17,65 +17,51 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_LIBRARYELEMENTCHECK_H
+#define LIBREPCB_LIBRARY_LIBRARYELEMENTCHECK_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "librarybaseelementcheck.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class LibraryElement;
 
 /*******************************************************************************
- *  General Methods
+ *  Class LibraryElementCheck
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The LibraryElementCheck class
+ */
+class LibraryElementCheck : public LibraryBaseElementCheck {
+public:
+  // Constructors / Destructor
+  LibraryElementCheck()                                 = delete;
+  LibraryElementCheck(const LibraryElementCheck& other) = delete;
+  explicit LibraryElementCheck(const LibraryElement& element) noexcept;
+  virtual ~LibraryElementCheck() noexcept;
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Operator Overloadings
+  LibraryElementCheck& operator=(const LibraryElementCheck& rhs) = delete;
+
+protected:  // Methods
+  void checkMissingCategories(MsgList& msgs) const;
+
+private:  // Data
+  const LibraryElement& mElement;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +69,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_LIBRARYELEMENTCHECK_H

--- a/libs/librepcb/library/msg/libraryelementcheckmessage.h
+++ b/libs/librepcb/library/msg/libraryelementcheckmessage.h
@@ -1,0 +1,105 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_LIBRARYELEMENTCHECKMESSAGE_H
+#define LIBREPCB_LIBRARY_LIBRARYELEMENTCHECKMESSAGE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Class LibraryElementCheckMessage
+ ******************************************************************************/
+
+/**
+ * @brief The LibraryElementCheckMessage class
+ */
+class LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(LibraryElementCheckMessage)
+
+public:
+  /// Message severity type (higher numer = higher severity)
+  enum class Severity {
+    Hint    = 0,
+    Warning = 1,
+    Error   = 2,
+  };
+
+  // Constructors / Destructor
+  LibraryElementCheckMessage() = delete;
+
+  // Getters
+  Severity       getSeverity() const noexcept { return mSeverity; }
+  const QPixmap& getSeverityPixmap() const noexcept { return mSeverityPixmap; }
+  const QString& getMessage() const noexcept { return mMessage; }
+  const QString& getDescription() const noexcept { return mDescription; }
+
+  // General Methods
+  template <typename T>
+  T* as() noexcept {
+    return dynamic_cast<T*>(this);
+  }
+  template <typename T>
+  const T* as() const noexcept {
+    return dynamic_cast<const T*>(this);
+  }
+
+  // Static Methods
+  static QPixmap getSeverityPixmap(Severity severity) noexcept;
+
+  // Operator Overloads
+  bool operator==(const LibraryElementCheckMessage& rhs) const noexcept;
+  bool operator!=(const LibraryElementCheckMessage& rhs) const noexcept;
+  bool operator<(const LibraryElementCheckMessage& rhs) const noexcept;
+
+protected:  // Methods
+  LibraryElementCheckMessage(const LibraryElementCheckMessage& other) noexcept;
+  LibraryElementCheckMessage(Severity severity, const QString& msg,
+                             const QString& description) noexcept;
+  virtual ~LibraryElementCheckMessage() noexcept;
+
+protected:  // Data
+  Severity mSeverity;
+  QPixmap  mSeverityPixmap;
+  QString  mMessage;
+  QString  mDescription;
+};
+
+typedef QVector<std::shared_ptr<const LibraryElementCheckMessage>>
+    LibraryElementCheckMessageList;
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_LIBRARYELEMENTCHECKMESSAGE_H

--- a/libs/librepcb/library/msg/msgmissingauthor.cpp
+++ b/libs/librepcb/library/msg/msgmissingauthor.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingauthor.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,14 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingAuthor::MsgMissingAuthor() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning, tr("Author not set"),
+        tr("It is recommended to set an author (e.g. full name or nickname), "
+           "although it's not required.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingAuthor::~MsgMissingAuthor() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/msg/msgmissingauthor.h
+++ b/libs/librepcb/library/msg/msgmissingauthor.h
@@ -17,65 +17,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGAUTHOR_H
+#define LIBREPCB_LIBRARY_MSGMISSINGAUTHOR_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingAuthor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingAuthor class
+ */
+class MsgMissingAuthor final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingAuthor)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingAuthor() noexcept;
+  MsgMissingAuthor(const MsgMissingAuthor& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingAuthor() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +57,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGAUTHOR_H

--- a/libs/librepcb/library/msg/msgmissingcategories.cpp
+++ b/libs/librepcb/library/msg/msgmissingcategories.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingcategories.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,16 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingCategories::MsgMissingCategories() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error, tr("No categories set"),
+        tr("It's very important to assign every library element to at least "
+           "one category. Otherwise it will be very hard to find the element "
+           "in the workspace library, so it's highly recommended to fix "
+           "this.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingCategories::~MsgMissingCategories() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/msg/msgmissingcategories.h
+++ b/libs/librepcb/library/msg/msgmissingcategories.h
@@ -17,65 +17,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGCATEGORIES_H
+#define LIBREPCB_LIBRARY_MSGMISSINGCATEGORIES_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingCategories
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingCategories class
+ */
+class MsgMissingCategories final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingCategories)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingCategories() noexcept;
+  MsgMissingCategories(const MsgMissingCategories& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingCategories() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +57,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGCATEGORIES_H

--- a/libs/librepcb/library/msg/msgnamenottitlecase.h
+++ b/libs/librepcb/library/msg/msgnamenottitlecase.h
@@ -17,65 +17,51 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGNAMENOTTITLECASE_H
+#define LIBREPCB_LIBRARY_MSGNAMENOTTITLECASE_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "libraryelementcheckmessage.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include <librepcb/common/elementname.h>
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgNameNotTitleCase
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgNameNotTitleCase class
+ */
+class MsgNameNotTitleCase final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgNameNotTitleCase)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
+public:
+  // Constructors / Destructor
+  MsgNameNotTitleCase() = delete;
+  explicit MsgNameNotTitleCase(const ElementName& name) noexcept;
+  MsgNameNotTitleCase(const MsgNameNotTitleCase& other) noexcept
+    : LibraryElementCheckMessage(other), mName(other.mName) {}
+  virtual ~MsgNameNotTitleCase() noexcept;
 
-  cleanupAfterLoadingElementFromFile();
-}
+  const ElementName& getName() const noexcept { return mName; }
+  ElementName getFixedName() const noexcept { return getFixedName(mName); }
 
-Package::~Package() noexcept {
-}
+  static bool        isTitleCase(const ElementName& name) noexcept;
+  static ElementName getFixedName(const ElementName& name) noexcept;
 
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+private:
+  ElementName mName;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +69,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGNAMENOTTITLECASE_H

--- a/libs/librepcb/library/pkg/msg/msgduplicatepadname.cpp
+++ b/libs/librepcb/library/pkg/msg/msgduplicatepadname.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgduplicatepadname.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../packagepad.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,20 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgDuplicatePadName::MsgDuplicatePadName(const PackagePad& pad) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        QString(tr("Duplicate pad name: '%1'")).arg(*pad.getName()),
+        tr("All package pads must have unique names, otherwise they cannot be "
+           "distinguished later in the device editor. If your part has several "
+           "leads with same functionality (e.g. multiple GND leads), you can "
+           "assign all these pads to the same component signal later in the "
+           "device editor.\n\nFor neutral packages (e.g. SOT23), pads should "
+           "be named only by numbers anyway, not by functionality (e.g. name "
+           "them '1', '2', '3' instead of 'D', 'G', 'S').")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgDuplicatePadName::~MsgDuplicatePadName() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/pkg/msg/msgduplicatepadname.h
+++ b/libs/librepcb/library/pkg/msg/msgduplicatepadname.h
@@ -17,65 +17,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGDUPLICATEPADNAME_H
+#define LIBREPCB_LIBRARY_MSGDUPLICATEPADNAME_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class PackagePad;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgDuplicatePadName
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgDuplicatePadName class
+ */
+class MsgDuplicatePadName final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgDuplicatePadName)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgDuplicatePadName() = delete;
+  explicit MsgDuplicatePadName(const PackagePad& pad) noexcept;
+  MsgDuplicatePadName(const MsgDuplicatePadName& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgDuplicatePadName() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +60,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGDUPLICATEPADNAME_H

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprint.cpp
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprint.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingfootprint.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,14 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingFootprint::MsgMissingFootprint() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error, tr("No footprint defined"),
+        tr("Every package must have at least one footprint, otherwise it can't "
+           "be added to a board.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingFootprint::~MsgMissingFootprint() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprint.h
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprint.h
@@ -17,65 +17,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINT_H
+#define LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINT_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingFootprint
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingFootprint class
+ */
+class MsgMissingFootprint final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingFootprint)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingFootprint() noexcept;
+  MsgMissingFootprint(const MsgMissingFootprint& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingFootprint() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +57,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINT_H

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprintname.cpp
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprintname.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgmissingfootprintname.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,20 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingFootprintName::MsgMissingFootprintName(
+    std::shared_ptr<const Footprint> footprint) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        QString(tr("Missing text '{{NAME}}' in footprint '%1'"))
+            .arg(*footprint->getNames().getDefaultValue()),
+        tr("Most footprints should have a text element for the component's "
+           "name, otherwise you won't see that name on the PCB (e.g. on "
+           "silkscreen). There are only a few exceptions which don't need a "
+           "name (e.g. if the footprint is only a drawing), for those you can "
+           "ignore this message.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingFootprintName::~MsgMissingFootprintName() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprintname.h
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprintname.h
@@ -17,65 +17,43 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINTNAME_H
+#define LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINTNAME_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class Footprint;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgMissingFootprintName
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgMissingFootprintName class
+ */
+class MsgMissingFootprintName final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingFootprintName)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingFootprintName() = delete;
+  explicit MsgMissingFootprintName(
+      std::shared_ptr<const Footprint> footprint) noexcept;
+  MsgMissingFootprintName(const MsgMissingFootprintName& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingFootprintName() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +61,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINTNAME_H

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprintvalue.cpp
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprintvalue.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgmissingfootprintvalue.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,20 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingFootprintValue::MsgMissingFootprintValue(
+    std::shared_ptr<const Footprint> footprint) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        QString(tr("Missing text '{{VALUE}}' in footprint '%1'"))
+            .arg(*footprint->getNames().getDefaultValue()),
+        tr("Most footprints should have a text element for the component's "
+           "value, otherwise you won't see that value on the PCB (e.g. on "
+           "silkscreen). There are only a few exceptions which don't need a "
+           "value (e.g. if the footprint is only a drawing), for those you can "
+           "ignore this message.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingFootprintValue::~MsgMissingFootprintValue() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprintvalue.h
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprintvalue.h
@@ -17,65 +17,43 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINTVALUE_H
+#define LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINTVALUE_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class Footprint;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgMissingFootprintValue
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgMissingFootprintValue class
+ */
+class MsgMissingFootprintValue final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingFootprintValue)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingFootprintValue() = delete;
+  explicit MsgMissingFootprintValue(
+      std::shared_ptr<const Footprint> footprint) noexcept;
+  MsgMissingFootprintValue(const MsgMissingFootprintValue& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingFootprintValue() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +61,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGFOOTPRINTVALUE_H

--- a/libs/librepcb/library/pkg/msg/msgpadoverlapswithplacement.cpp
+++ b/libs/librepcb/library/pkg/msg/msgpadoverlapswithplacement.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgpadoverlapswithplacement.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,23 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgPadOverlapsWithPlacement::MsgPadOverlapsWithPlacement(
+    std::shared_ptr<const Footprint>    footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName,
+    const Length& clearance) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        QString(tr("Clearance of pad '%1' in '%2' to placement layer"))
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        QString(tr("Pads should have at least %1 clearance to the outlines "
+                   "layer because outlines are drawn on silkscreen which will "
+                   "be cropped for Gerber export."))
+            .arg(QString::number(clearance.toMm() * 1000) % "μm")),
+    mFootprint(footprint),
+    mPad(pad) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgPadOverlapsWithPlacement::~MsgPadOverlapsWithPlacement() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/pkg/msg/msgpadoverlapswithplacement.h
+++ b/libs/librepcb/library/pkg/msg/msgpadoverlapswithplacement.h
@@ -17,65 +17,60 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGPADOVERLAPSWITHPLACEMENT_H
+#define LIBREPCB_LIBRARY_MSGPADOVERLAPSWITHPLACEMENT_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "../../msg/libraryelementcheckmessage.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include <librepcb/common/units/length.h>
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class Footprint;
+class FootprintPad;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgPadOverlapsWithPlacement
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgPadOverlapsWithPlacement class
+ */
+class MsgPadOverlapsWithPlacement final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadOverlapsWithPlacement)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+public:
+  // Constructors / Destructor
+  MsgPadOverlapsWithPlacement() = delete;
+  MsgPadOverlapsWithPlacement(std::shared_ptr<const Footprint>    footprint,
+                              std::shared_ptr<const FootprintPad> pad,
+                              const QString&                      pkgPadName,
+                              const Length& clearance) noexcept;
+  MsgPadOverlapsWithPlacement(const MsgPadOverlapsWithPlacement& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mPad(other.mPad) {}
+  virtual ~MsgPadOverlapsWithPlacement() noexcept;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint>    mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +78,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGPADOVERLAPSWITHPLACEMENT_H

--- a/libs/librepcb/library/pkg/msg/msgwrongfootprinttextlayer.cpp
+++ b/libs/librepcb/library/pkg/msg/msgwrongfootprinttextlayer.cpp
@@ -20,13 +20,12 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgwrongfootprinttextlayer.h"
 
-#include "packagecheck.h"
+#include "../footprint.h"
 
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include <librepcb/common/geometry/stroketext.h>
+#include <librepcb/common/graphics/graphicslayer.h>
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +37,24 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgWrongFootprintTextLayer::MsgWrongFootprintTextLayer(
+    std::shared_ptr<const Footprint>  footprint,
+    std::shared_ptr<const StrokeText> text,
+    const QString&                    expectedLayerName) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        QString(tr("Layer of '%1' in '%2' is not '%3'"))
+            .arg(text->getText(), *footprint->getNames().getDefaultValue(),
+                 GraphicsLayer(expectedLayerName).getNameTr()),
+        QString(tr("The text element '%1' should normally be on layer '%2'."))
+            .arg(text->getText(),
+                 GraphicsLayer(expectedLayerName).getNameTr())),
+    mFootprint(footprint),
+    mText(text),
+    mExpectedLayerName(expectedLayerName) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgWrongFootprintTextLayer::~MsgWrongFootprintTextLayer() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/pkg/msg/msgwrongfootprinttextlayer.h
+++ b/libs/librepcb/library/pkg/msg/msgwrongfootprinttextlayer.h
@@ -17,65 +17,62 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGWRONGFOOTPRINTTEXTLAYER_H
+#define LIBREPCB_LIBRARY_MSGWRONGFOOTPRINTTEXTLAYER_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class StrokeText;
+
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class Footprint;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgWrongFootprintTextLayer
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgWrongFootprintTextLayer class
+ */
+class MsgWrongFootprintTextLayer final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgWrongFootprintTextLayer)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+public:
+  // Constructors / Destructor
+  MsgWrongFootprintTextLayer() = delete;
+  MsgWrongFootprintTextLayer(std::shared_ptr<const Footprint>  footprint,
+                             std::shared_ptr<const StrokeText> text,
+                             const QString& expectedLayerName) noexcept;
+  MsgWrongFootprintTextLayer(const MsgWrongFootprintTextLayer& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mText(other.mText),
+      mExpectedLayerName(other.mExpectedLayerName) {}
+  virtual ~MsgWrongFootprintTextLayer() noexcept;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const StrokeText> getText() const noexcept { return mText; }
+  QString getExpectedLayerName() const noexcept { return mExpectedLayerName; }
+
+private:
+  std::shared_ptr<const Footprint>  mFootprint;
+  std::shared_ptr<const StrokeText> mText;
+  QString                           mExpectedLayerName;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +80,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGWRONGFOOTPRINTTEXTLAYER_H

--- a/libs/librepcb/library/pkg/package.h
+++ b/libs/librepcb/library/pkg/package.h
@@ -72,6 +72,9 @@ public:
   FootprintList&        getFootprints() noexcept { return mFootprints; }
   const FootprintList&  getFootprints() const noexcept { return mFootprints; }
 
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
+
   // Operator Overloadings
   Package& operator=(const Package& rhs) = delete;
 

--- a/libs/librepcb/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/library/pkg/packagecheck.cpp
@@ -1,0 +1,181 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "packagecheck.h"
+
+#include "msg/msgduplicatepadname.h"
+#include "msg/msgmissingfootprint.h"
+#include "msg/msgmissingfootprintname.h"
+#include "msg/msgmissingfootprintvalue.h"
+#include "msg/msgpadoverlapswithplacement.h"
+#include "msg/msgwrongfootprinttextlayer.h"
+#include "package.h"
+
+#include <librepcb/common/graphics/graphicslayer.h>
+#include <librepcb/common/toolbox.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PackageCheck::PackageCheck(const Package& package) noexcept
+  : LibraryElementCheck(package), mPackage(package) {
+}
+
+PackageCheck::~PackageCheck() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+LibraryElementCheckMessageList PackageCheck::runChecks() const {
+  LibraryElementCheckMessageList msgs = LibraryElementCheck::runChecks();
+  checkDuplicatePadNames(msgs);
+  checkMissingFootprint(msgs);
+  checkMissingTexts(msgs);
+  checkWrongTextLayers(msgs);
+  checkPadsOverlapWithPlacement(msgs);
+  return msgs;
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+void PackageCheck::checkDuplicatePadNames(MsgList& msgs) const {
+  QSet<CircuitIdentifier> padNames;
+  for (const PackagePad& pad : mPackage.getPads()) {
+    if (padNames.contains(pad.getName())) {
+      msgs.append(std::make_shared<MsgDuplicatePadName>(pad));
+    } else {
+      padNames.insert(pad.getName());
+    }
+  }
+}
+
+void PackageCheck::checkMissingFootprint(MsgList& msgs) const {
+  if (mPackage.getFootprints().isEmpty()) {
+    msgs.append(std::make_shared<MsgMissingFootprint>());
+  }
+}
+
+void PackageCheck::checkMissingTexts(MsgList& msgs) const {
+  for (auto itFtp = mPackage.getFootprints().begin();
+       itFtp != mPackage.getFootprints().end(); ++itFtp) {
+    QHash<QString, QVector<std::shared_ptr<const StrokeText>>> texts;
+    for (auto it = (*itFtp).getStrokeTexts().begin();
+         it != (*itFtp).getStrokeTexts().end(); ++it) {
+      texts[(*it).getText()].append(it.ptr());
+    }
+    if (texts.value("{{NAME}}").isEmpty()) {
+      msgs.append(std::make_shared<MsgMissingFootprintName>(itFtp.ptr()));
+    }
+    if (texts.value("{{VALUE}}").isEmpty()) {
+      msgs.append(std::make_shared<MsgMissingFootprintValue>(itFtp.ptr()));
+    }
+  }
+}
+
+void PackageCheck::checkWrongTextLayers(MsgList& msgs) const {
+  QHash<QString, QString> textLayers = {
+      std::make_pair("{{NAME}}", QString(GraphicsLayer::sTopNames)),
+      std::make_pair("{{VALUE}}", QString(GraphicsLayer::sTopValues)),
+  };
+  for (auto itFtp = mPackage.getFootprints().begin();
+       itFtp != mPackage.getFootprints().end(); ++itFtp) {
+    for (auto it = (*itFtp).getStrokeTexts().begin();
+         it != (*itFtp).getStrokeTexts().end(); ++it) {
+      QString expectedLayer = textLayers.value((*it).getText());
+      if ((!expectedLayer.isEmpty()) &&
+          ((*it).getLayerName() != expectedLayer)) {
+        msgs.append(std::make_shared<MsgWrongFootprintTextLayer>(
+            itFtp.ptr(), it.ptr(), expectedLayer));
+      }
+    }
+  }
+}
+
+void PackageCheck::checkPadsOverlapWithPlacement(MsgList& msgs) const {
+  for (auto itFtp = mPackage.getFootprints().begin();
+       itFtp != mPackage.getFootprints().end(); ++itFtp) {
+    std::shared_ptr<const Footprint> footprint = itFtp.ptr();
+
+    QPainterPath topPlacement;
+    QPainterPath botPlacement;
+    for (const Polygon& polygon : footprint->getPolygons()) {
+      QPen pen(Qt::NoPen);
+      if (polygon.getLineWidth() > 0) {
+        pen.setStyle(Qt::SolidLine);
+        pen.setWidthF(polygon.getLineWidth()->toPx());
+      }
+      QBrush brush(Qt::NoBrush);
+      if (polygon.isFilled()) {
+        brush.setStyle(Qt::SolidPattern);
+      }
+      QPainterPath area = Toolbox::shapeFromPath(
+          polygon.getPath().toQPainterPathPx(), pen, brush);
+      if (polygon.getLayerName() == GraphicsLayer::sTopPlacement) {
+        topPlacement.addPath(area);
+      } else if (polygon.getLayerName() == GraphicsLayer::sBotPlacement) {
+        botPlacement.addPath(area);
+      }
+    }
+
+    for (auto it = (*itFtp).getPads().begin(); it != (*itFtp).getPads().end();
+         ++it) {
+      std::shared_ptr<const FootprintPad> pad = it.ptr();
+      std::shared_ptr<const PackagePad>   pkgPad =
+          mPackage.getPads().find(pad->getUuid());
+      Length clearance(150000);  // 150um
+      Path   stopMaskPath = pad->getOutline(clearance);
+      stopMaskPath.rotate(pad->getRotation()).translate(pad->getPosition());
+      QPainterPath stopMask = stopMaskPath.toQPainterPathPx();
+      if (pad->isOnLayer(GraphicsLayer::sTopCopper) &&
+          stopMask.intersects(topPlacement)) {
+        msgs.append(std::make_shared<MsgPadOverlapsWithPlacement>(
+            footprint, pad, pkgPad ? *pkgPad->getName() : QString(),
+            clearance));
+      } else if (pad->isOnLayer(GraphicsLayer::sBotCopper) &&
+                 stopMask.intersects(botPlacement)) {
+        msgs.append(std::make_shared<MsgPadOverlapsWithPlacement>(
+            footprint, pad, pkgPad ? *pkgPad->getName() : QString(),
+            clearance));
+      }
+    }
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/pkg/packagecheck.h
+++ b/libs/librepcb/library/pkg/packagecheck.h
@@ -17,65 +17,55 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_PACKAGECHECK_H
+#define LIBREPCB_LIBRARY_PACKAGECHECK_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "libraryelementcheck.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class Package;
 
 /*******************************************************************************
- *  General Methods
+ *  Class PackageCheck
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The PackageCheck class
+ */
+class PackageCheck : public LibraryElementCheck {
+public:
+  // Constructors / Destructor
+  PackageCheck()                          = delete;
+  PackageCheck(const PackageCheck& other) = delete;
+  explicit PackageCheck(const Package& package) noexcept;
+  virtual ~PackageCheck() noexcept;
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Operator Overloadings
+  PackageCheck& operator=(const PackageCheck& rhs) = delete;
+
+protected:  // Methods
+  void checkDuplicatePadNames(MsgList& msgs) const;
+  void checkMissingFootprint(MsgList& msgs) const;
+  void checkMissingTexts(MsgList& msgs) const;
+  void checkWrongTextLayers(MsgList& msgs) const;
+  void checkPadsOverlapWithPlacement(MsgList& msgs) const;
+
+private:  // Data
+  const Package& mPackage;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +73,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_PACKAGECHECK_H

--- a/libs/librepcb/library/sym/msg/msgduplicatepinname.cpp
+++ b/libs/librepcb/library/sym/msg/msgduplicatepinname.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgduplicatepinname.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../symbolpin.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,18 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgDuplicatePinName::MsgDuplicatePinName(const SymbolPin& pin) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        QString(tr("Duplicate pin name: '%1'")).arg(*pin.getName()),
+        tr("All symbol pins must have unique names, otherwise they cannot be "
+           "distinguished later in the component editor. If your part has "
+           "several pins with same functionality (e.g. multiple GND pins), you "
+           "should add only one of these pins to the symbol. The assignment to "
+           "multiple leads should be done in the device editor instead.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgDuplicatePinName::~MsgDuplicatePinName() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/sym/msg/msgduplicatepinname.h
+++ b/libs/librepcb/library/sym/msg/msgduplicatepinname.h
@@ -17,65 +17,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGDUPLICATEPINNAME_H
+#define LIBREPCB_LIBRARY_MSGDUPLICATEPINNAME_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class SymbolPin;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgDuplicatePinName
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgDuplicatePinName class
+ */
+class MsgDuplicatePinName final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgDuplicatePinName)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgDuplicatePinName() = delete;
+  explicit MsgDuplicatePinName(const SymbolPin& pin) noexcept;
+  MsgDuplicatePinName(const MsgDuplicatePinName& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgDuplicatePinName() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +60,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGDUPLICATEPINNAME_H

--- a/libs/librepcb/library/sym/msg/msgmissingsymbolname.cpp
+++ b/libs/librepcb/library/sym/msg/msgmissingsymbolname.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingsymbolname.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,16 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingSymbolName::MsgMissingSymbolName() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning, tr("Missing text: '{{NAME}}'"),
+        tr("Most symbols should have a text element for the component's name, "
+           "otherwise you won't see that name in the schematics. There are "
+           "only a few exceptions (e.g. a schematic frame) which don't need a "
+           "name, for those you can ignore this message.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingSymbolName::~MsgMissingSymbolName() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/sym/msg/msgmissingsymbolname.h
+++ b/libs/librepcb/library/sym/msg/msgmissingsymbolname.h
@@ -17,65 +17,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGNAME_H
+#define LIBREPCB_LIBRARY_MSGMISSINGNAME_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingSymbolName
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingSymbolName class
+ */
+class MsgMissingSymbolName final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingSymbolName)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingSymbolName() noexcept;
+  MsgMissingSymbolName(const MsgMissingSymbolName& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingSymbolName() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +57,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGNAME_H

--- a/libs/librepcb/library/sym/msg/msgmissingsymbolvalue.cpp
+++ b/libs/librepcb/library/sym/msg/msgmissingsymbolvalue.cpp
@@ -20,13 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "msgmissingsymbolvalue.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +32,16 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgMissingSymbolValue::MsgMissingSymbolValue() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning, tr("Missing text: '{{VALUE}}'"),
+        tr("Most symbols should have a text element for the component's value, "
+           "otherwise you won't see that value in the schematics. There are "
+           "only a few exceptions (e.g. a schematic frame) which don't need a "
+           "value, for those you can ignore this message.")) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgMissingSymbolValue::~MsgMissingSymbolValue() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/sym/msg/msgmissingsymbolvalue.h
+++ b/libs/librepcb/library/sym/msg/msgmissingsymbolvalue.h
@@ -17,65 +17,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGMISSINGVALUE_H
+#define LIBREPCB_LIBRARY_MSGMISSINGVALUE_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgMissingSymbolValue
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgMissingSymbolValue class
+ */
+class MsgMissingSymbolValue final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMissingSymbolValue)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+public:
+  // Constructors / Destructor
+  MsgMissingSymbolValue() noexcept;
+  MsgMissingSymbolValue(const MsgMissingSymbolValue& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgMissingSymbolValue() noexcept;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +57,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGMISSINGVALUE_H

--- a/libs/librepcb/library/sym/msg/msgoverlappingsymbolpins.h
+++ b/libs/librepcb/library/sym/msg/msgoverlappingsymbolpins.h
@@ -17,65 +17,57 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGOVERLAPPINGSYMBOLPINS_H
+#define LIBREPCB_LIBRARY_MSGOVERLAPPINGSYMBOLPINS_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "../../msg/libraryelementcheckmessage.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include <librepcb/common/units/length.h>
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class SymbolPin;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgOverlappingSymbolPins
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgOverlappingSymbolPins class
+ */
+class MsgOverlappingSymbolPins final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgOverlappingSymbolPins)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+public:
+  // Constructors / Destructor
+  MsgOverlappingSymbolPins() = delete;
+  MsgOverlappingSymbolPins(
+      QVector<std::shared_ptr<const SymbolPin>> pins) noexcept;
+  MsgOverlappingSymbolPins(const MsgOverlappingSymbolPins& other) noexcept
+    : LibraryElementCheckMessage(other), mPins(other.mPins) {}
+  virtual ~MsgOverlappingSymbolPins() noexcept;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Getters
+  const QVector<std::shared_ptr<const SymbolPin>>& getPins() const noexcept {
+    return mPins;
+  }
+
+private:
+  static QString buildMessage(
+      const QVector<std::shared_ptr<const SymbolPin>>& pins) noexcept;
+
+private:  // Data
+  QVector<std::shared_ptr<const SymbolPin>> mPins;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +75,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGOVERLAPPINGSYMBOLPINS_H

--- a/libs/librepcb/library/sym/msg/msgsymbolpinnotongrid.cpp
+++ b/libs/librepcb/library/sym/msg/msgsymbolpinnotongrid.cpp
@@ -20,13 +20,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgsymbolpinnotongrid.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include "../symbolpin.h"
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +34,21 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgSymbolPinNotOnGrid::MsgSymbolPinNotOnGrid(
+    std::shared_ptr<const SymbolPin> pin,
+    const PositiveLength&            gridInterval) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        QString(tr("Pin not on %1mm grid: '%2'"))
+            .arg(gridInterval->toMmString(), *pin->getName()),
+        QString(tr("Every pin must be placed exactly on the %1mm grid, "
+                   "otherwise it cannot be connected in the schematic editor."))
+            .arg(gridInterval->toMmString())),
+    mPin(pin),
+    mGridInterval(gridInterval) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgSymbolPinNotOnGrid::~MsgSymbolPinNotOnGrid() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/sym/msg/msgsymbolpinnotongrid.h
+++ b/libs/librepcb/library/sym/msg/msgsymbolpinnotongrid.h
@@ -17,65 +17,59 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGSYMBOLPINNOTONGRID_H
+#define LIBREPCB_LIBRARY_MSGSYMBOLPINNOTONGRID_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "../../msg/libraryelementcheckmessage.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include <librepcb/common/units/length.h>
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class SymbolPin;
 
 /*******************************************************************************
- *  General Methods
+ *  Class MsgSymbolPinNotOnGrid
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The MsgSymbolPinNotOnGrid class
+ */
+class MsgSymbolPinNotOnGrid final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgSymbolPinNotOnGrid)
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+public:
+  // Constructors / Destructor
+  MsgSymbolPinNotOnGrid() = delete;
+  MsgSymbolPinNotOnGrid(std::shared_ptr<const SymbolPin> pin,
+                        const PositiveLength&            gridInterval) noexcept;
+  MsgSymbolPinNotOnGrid(const MsgSymbolPinNotOnGrid& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mPin(other.mPin),
+      mGridInterval(other.mGridInterval) {}
+  virtual ~MsgSymbolPinNotOnGrid() noexcept;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Getters
+  const std::shared_ptr<const SymbolPin>& getPin() const noexcept {
+    return mPin;
+  }
+  const PositiveLength& getGridInterval() const noexcept {
+    return mGridInterval;
+  }
+
+private:
+  std::shared_ptr<const SymbolPin> mPin;
+  PositiveLength                   mGridInterval;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +77,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGSYMBOLPINNOTONGRID_H

--- a/libs/librepcb/library/sym/msg/msgwrongsymboltextlayer.cpp
+++ b/libs/librepcb/library/sym/msg/msgwrongsymboltextlayer.cpp
@@ -20,13 +20,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
+#include "msgwrongsymboltextlayer.h"
 
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
-
-#include <QtCore>
+#include <librepcb/common/geometry/text.h>
+#include <librepcb/common/graphics/graphicslayer.h>
 
 /*******************************************************************************
  *  Namespace
@@ -38,43 +35,20 @@ namespace library {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
+MsgWrongSymbolTextLayer::MsgWrongSymbolTextLayer(
+    std::shared_ptr<const Text> text, const QString& expectedLayerName) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        QString(tr("Layer of '%1' is not '%2'"))
+            .arg(text->getText(), GraphicsLayer(expectedLayerName).getNameTr()),
+        QString(tr("The text element '%1' should normally be on layer '%2'."))
+            .arg(text->getText(),
+                 GraphicsLayer(expectedLayerName).getNameTr())),
+    mText(text),
+    mExpectedLayerName(expectedLayerName) {
 }
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
+MsgWrongSymbolTextLayer::~MsgWrongSymbolTextLayer() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/sym/msg/msgwrongsymboltextlayer.h
+++ b/libs/librepcb/library/sym/msg/msgwrongsymboltextlayer.h
@@ -17,65 +17,54 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_MSGWRONGSYMBOLNAMELAYER_H
+#define LIBREPCB_LIBRARY_MSGWRONGSYMBOLNAMELAYER_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class Text;
+
 namespace library {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class MsgWrongSymbolTextLayer
  ******************************************************************************/
 
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
+/**
+ * @brief The MsgWrongSymbolTextLayer class
+ */
+class MsgWrongSymbolTextLayer final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgWrongSymbolTextLayer)
 
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
+public:
+  // Constructors / Destructor
+  MsgWrongSymbolTextLayer() = delete;
+  MsgWrongSymbolTextLayer(std::shared_ptr<const Text> text,
+                          const QString& expectedLayerName) noexcept;
+  MsgWrongSymbolTextLayer(const MsgWrongSymbolTextLayer& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mText(other.mText),
+      mExpectedLayerName(other.mExpectedLayerName) {}
+  virtual ~MsgWrongSymbolTextLayer() noexcept;
 
-  cleanupAfterLoadingElementFromFile();
-}
+  // Getters
+  std::shared_ptr<const Text> getText() const noexcept { return mText; }
+  QString getExpectedLayerName() const noexcept { return mExpectedLayerName; }
 
-Package::~Package() noexcept {
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+private:
+  std::shared_ptr<const Text> mText;
+  QString                     mExpectedLayerName;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +72,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGWRONGSYMBOLNAMELAYER_H

--- a/libs/librepcb/library/sym/symbol.cpp
+++ b/libs/librepcb/library/sym/symbol.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "symbol.h"
 
+#include "symbolcheck.h"
 #include "symbolgraphicsitem.h"
 
 #include <librepcb/common/fileio/sexpression.h>
@@ -79,6 +80,11 @@ Symbol::~Symbol() noexcept {
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+LibraryElementCheckMessageList Symbol::runChecks() const {
+  SymbolCheck check(*this);
+  return check.runChecks();  // can throw
+}
 
 void Symbol::registerGraphicsItem(SymbolGraphicsItem& item) noexcept {
   Q_ASSERT(!mRegisteredGraphicsItem);

--- a/libs/librepcb/library/sym/symbol.h
+++ b/libs/librepcb/library/sym/symbol.h
@@ -82,6 +82,7 @@ public:
   const TextList&      getTexts() const noexcept { return mTexts; }
 
   // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
   void registerGraphicsItem(SymbolGraphicsItem& item) noexcept;
   void unregisterGraphicsItem(SymbolGraphicsItem& item) noexcept;
 

--- a/libs/librepcb/library/sym/symbolcheck.cpp
+++ b/libs/librepcb/library/sym/symbolcheck.cpp
@@ -1,0 +1,140 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "symbolcheck.h"
+
+#include "msg/msgduplicatepinname.h"
+#include "msg/msgmissingsymbolname.h"
+#include "msg/msgmissingsymbolvalue.h"
+#include "msg/msgoverlappingsymbolpins.h"
+#include "msg/msgsymbolpinnotongrid.h"
+#include "msg/msgwrongsymboltextlayer.h"
+#include "symbol.h"
+
+#include <librepcb/common/graphics/graphicslayer.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+SymbolCheck::SymbolCheck(const Symbol& symbol) noexcept
+  : LibraryElementCheck(symbol), mSymbol(symbol) {
+}
+
+SymbolCheck::~SymbolCheck() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+LibraryElementCheckMessageList SymbolCheck::runChecks() const {
+  LibraryElementCheckMessageList msgs = LibraryElementCheck::runChecks();
+  checkDuplicatePinNames(msgs);
+  checkOffTheGridPins(msgs);
+  checkOverlappingPins(msgs);
+  checkMissingTexts(msgs);
+  checkWrongTextLayers(msgs);
+  return msgs;
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+void SymbolCheck::checkDuplicatePinNames(MsgList& msgs) const {
+  QSet<CircuitIdentifier> pinNames;
+  for (const SymbolPin& pin : mSymbol.getPins()) {
+    if (pinNames.contains(pin.getName())) {
+      msgs.append(std::make_shared<MsgDuplicatePinName>(pin));
+    } else {
+      pinNames.insert(pin.getName());
+    }
+  }
+}
+
+void SymbolCheck::checkOffTheGridPins(MsgList& msgs) const {
+  for (auto it = mSymbol.getPins().begin(); it != mSymbol.getPins().end();
+       ++it) {
+    PositiveLength grid(2540000);
+    if (((*it).getPosition() % (*grid)) != Point(0, 0)) {
+      msgs.append(std::make_shared<MsgSymbolPinNotOnGrid>(it.ptr(), grid));
+    }
+  }
+}
+
+void SymbolCheck::checkOverlappingPins(MsgList& msgs) const {
+  QHash<Point, QVector<std::shared_ptr<const SymbolPin>>> pinPositions;
+  for (auto it = mSymbol.getPins().begin(); it != mSymbol.getPins().end();
+       ++it) {
+    pinPositions[(*it).getPosition()].append(it.ptr());
+  }
+  foreach (const auto& pins, pinPositions) {
+    if (pins.count() > 1) {
+      msgs.append(std::make_shared<MsgOverlappingSymbolPins>(pins));
+    }
+  }
+}
+
+void SymbolCheck::checkMissingTexts(MsgList& msgs) const {
+  QHash<QString, QVector<std::shared_ptr<const Text>>> texts;
+  for (auto it = mSymbol.getTexts().begin(); it != mSymbol.getTexts().end();
+       ++it) {
+    texts[(*it).getText()].append(it.ptr());
+  }
+  if (texts.value("{{NAME}}").isEmpty()) {
+    msgs.append(std::make_shared<MsgMissingSymbolName>());
+  }
+  if (texts.value("{{VALUE}}").isEmpty()) {
+    msgs.append(std::make_shared<MsgMissingSymbolValue>());
+  }
+}
+
+void SymbolCheck::checkWrongTextLayers(MsgList& msgs) const {
+  QHash<QString, QString> textLayers = {
+      std::make_pair("{{NAME}}", QString(GraphicsLayer::sSymbolNames)),
+      std::make_pair("{{VALUE}}", QString(GraphicsLayer::sSymbolValues)),
+  };
+  for (auto it = mSymbol.getTexts().begin(); it != mSymbol.getTexts().end();
+       ++it) {
+    QString expectedLayer = textLayers.value((*it).getText());
+    if ((!expectedLayer.isEmpty()) && ((*it).getLayerName() != expectedLayer)) {
+      msgs.append(
+          std::make_shared<MsgWrongSymbolTextLayer>(it.ptr(), expectedLayer));
+    }
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/sym/symbolcheck.h
+++ b/libs/librepcb/library/sym/symbolcheck.h
@@ -17,65 +17,55 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef LIBREPCB_LIBRARY_SYMBOLCHECK_H
+#define LIBREPCB_LIBRARY_SYMBOLCHECK_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "package.h"
-
-#include "packagecheck.h"
-
-#include <librepcb/common/fileio/sexpression.h>
+#include "libraryelementcheck.h"
 
 #include <QtCore>
 
 /*******************************************************************************
- *  Namespace
+ *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-/*******************************************************************************
- *  Constructors / Destructor
- ******************************************************************************/
-
-Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
-                 const QString& description_en_US,
-                 const QString& keywords_en_US)
-  : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US) {
-}
-
-Package::Package(const FilePath& elementDirectory, bool readOnly)
-  : LibraryElement(elementDirectory, getShortElementName(),
-                   getLongElementName(), readOnly) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
-
-  cleanupAfterLoadingElementFromFile();
-}
-
-Package::~Package() noexcept {
-}
+class Symbol;
 
 /*******************************************************************************
- *  General Methods
+ *  Class SymbolCheck
  ******************************************************************************/
 
-LibraryElementCheckMessageList Package::runChecks() const {
-  PackageCheck check(*this);
-  return check.runChecks();  // can throw
-}
+/**
+ * @brief The SymbolCheck class
+ */
+class SymbolCheck : public LibraryElementCheck {
+public:
+  // Constructors / Destructor
+  SymbolCheck()                         = delete;
+  SymbolCheck(const SymbolCheck& other) = delete;
+  explicit SymbolCheck(const Symbol& symbol) noexcept;
+  virtual ~SymbolCheck() noexcept;
 
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
 
-void Package::serialize(SExpression& root) const {
-  LibraryElement::serialize(root);
-  mPads.serialize(root);
-  mFootprints.serialize(root);
-}
+  // Operator Overloadings
+  SymbolCheck& operator=(const SymbolCheck& rhs) = delete;
+
+protected:  // Methods
+  void checkDuplicatePinNames(MsgList& msgs) const;
+  void checkOffTheGridPins(MsgList& msgs) const;
+  void checkOverlappingPins(MsgList& msgs) const;
+  void checkMissingTexts(MsgList& msgs) const;
+  void checkWrongTextLayers(MsgList& msgs) const;
+
+private:  // Data
+  const Symbol& mSymbol;
+};
 
 /*******************************************************************************
  *  End of File
@@ -83,3 +73,5 @@ void Package::serialize(SExpression& root) const {
 
 }  // namespace library
 }  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_SYMBOLCHECK_H

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.h
@@ -84,6 +84,15 @@ private:  // Methods
          ComponentSymbolVariant& variant) noexcept override;
   void memorizeComponentInterface() noexcept;
   bool isInterfaceBroken() const noexcept override;
+  bool runChecks(LibraryElementCheckMessageList& msgs) const override;
+  template <typename MessageType>
+  void fixMsg(const MessageType& msg);
+  template <typename MessageType>
+  bool fixMsgHelper(std::shared_ptr<const LibraryElementCheckMessage> msg,
+                    bool                                              applyFix);
+  bool processCheckMessage(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool                                              applyFix) override;
 
 private:  // Data
   QScopedPointer<Ui::ComponentEditorWidget>         mUi;

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>840</width>
-    <height>439</height>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -38,26 +38,14 @@
       </size>
      </property>
     </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="lblWarnAboutMissingCategory">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QLabel {background-color: rgb(255, 255, 127); color: rgb(170, 0, 0);};</string>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WARNING: This component is not assigned to any category! Please choose at least one category, otherwise you can't add it to a schematic.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="margin">
-      <number>10</number>
+  </item>
+  <item>
+    <widget class="QWidget" name="errorNotificationWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
      </property>
     </widget>
    </item>
@@ -339,6 +327,30 @@
          </property>
         </widget>
        </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Messages:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="librepcb::library::editor::LibraryElementCheckListWidget" name="lstMessages" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
@@ -350,6 +362,12 @@
    <class>librepcb::PlainTextEdit</class>
    <extends>QPlainTextEdit</extends>
    <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::library::editor::LibraryElementCheckListWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/libraryeditor/common/libraryelementchecklistwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>librepcb::AttributeListEditorWidget</class>

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
@@ -119,6 +119,15 @@ void ComponentSymbolVariantListWidget::setReferences(
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void ComponentSymbolVariantListWidget::addDefaultSymbolVariant() {
+  if (!allReferencesValid()) return;
+  addVariant("default", "", "");
+}
+
+/*******************************************************************************
  *  Private Slots
  ******************************************************************************/
 

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
@@ -77,6 +77,9 @@ public:
       UndoStack* undoStack, ComponentSymbolVariantList* variants,
       IF_ComponentSymbolVariantEditorProvider* editorProvider) noexcept;
 
+  // General Methods
+  void addDefaultSymbolVariant();
+
   // Operator Overloadings
   ComponentSymbolVariantListWidget& operator       =(
       const ComponentSymbolVariantListWidget& rhs) = delete;

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.h
@@ -75,9 +75,18 @@ private:  // Methods
   void    updateMetadata() noexcept;
   QString commitMetadata() noexcept;
   bool    isInterfaceBroken() const noexcept override { return false; }
-  void    btnChooseParentCategoryClicked() noexcept;
-  void    btnResetParentCategoryClicked() noexcept;
-  void    updateCategoryLabel() noexcept;
+  bool    runChecks(LibraryElementCheckMessageList& msgs) const override;
+  template <typename MessageType>
+  void fixMsg(const MessageType& msg);
+  template <typename MessageType>
+  bool fixMsgHelper(std::shared_ptr<const LibraryElementCheckMessage> msg,
+                    bool                                              applyFix);
+  bool processCheckMessage(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool                                              applyFix) override;
+  void btnChooseParentCategoryClicked() noexcept;
+  void btnResetParentCategoryClicked() noexcept;
+  void updateCategoryLabel() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::ComponentCategoryEditorWidget> mUi;

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
@@ -113,13 +113,6 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -204,6 +197,33 @@
      </item>
     </layout>
    </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Messages:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="librepcb::library::editor::LibraryElementCheckListWidget" name="lstMessages" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -211,6 +231,12 @@
    <class>librepcb::PlainTextEdit</class>
    <extends>QPlainTextEdit</extends>
    <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::library::editor::LibraryElementCheckListWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/libraryeditor/common/libraryelementchecklistwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
@@ -74,6 +74,9 @@ public:
   void setRequiresMinimumOneEntry(bool v) noexcept;
   void setUuids(const QSet<Uuid>& uuids) noexcept;
 
+  // General Methods
+  void openAddCategoryDialog() noexcept { btnAddClicked(); }
+
   // Operator Overloadings
   CategoryListEditorWidgetBase& operator       =(
       const CategoryListEditorWidgetBase& rhs) = delete;

--- a/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.cpp
+++ b/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.cpp
@@ -1,0 +1,150 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "libraryelementchecklistwidget.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+LibraryElementCheckListWidget::LibraryElementCheckListWidget(
+    QWidget* parent) noexcept
+  : QWidget(parent), mListWidget(new QListWidget(this)), mHandler(nullptr) {
+  QVBoxLayout* layout = new QVBoxLayout(this);
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->addWidget(mListWidget.data());
+  connect(mListWidget.data(), &QListWidget::itemDoubleClicked, this,
+          &LibraryElementCheckListWidget::itemDoubleClicked);
+  updateList();  // adds the "looks good" message
+}
+
+LibraryElementCheckListWidget::~LibraryElementCheckListWidget() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void LibraryElementCheckListWidget::setHandler(
+    IF_LibraryElementCheckHandler* handler) noexcept {
+  mHandler = handler;
+}
+
+void LibraryElementCheckListWidget::setMessages(
+    LibraryElementCheckMessageList messages) noexcept {
+  // Sort by severity and message.
+  qSort(messages.begin(), messages.end(),
+        [](std::shared_ptr<const LibraryElementCheckMessage> a,
+           std::shared_ptr<const LibraryElementCheckMessage> b) {
+          return (a && b) ? (*b) < (*a) : false;
+        });
+
+  // Detect if messages have changed.
+  bool isSame = (mMessages.count() == messages.count());
+  if (isSame) {
+    for (int i = 0; i < mMessages.count(); ++i) {
+      auto m1 = mMessages.value(i);
+      auto m2 = messages.value(i);
+      if ((!m1) || (!m2) || (*m1 != *m2)) {
+        isSame = false;
+      }
+    }
+  }
+
+  // Only update if messages have changed (avoid GUI flickering).
+  if (!isSame) {
+    mMessages = messages;
+    updateList();
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void LibraryElementCheckListWidget::updateList() noexcept {
+  mListWidget->clear();
+  foreach (const auto& msg, mMessages) {
+    QListWidgetItem* item = new QListWidgetItem();
+    mListWidget->addItem(item);
+    LibraryElementCheckListItemWidget* widget =
+        new LibraryElementCheckListItemWidget(msg, *this);
+    mListWidget->setItemWidget(item, widget);
+  }
+  if (mListWidget->count() == 0) {
+    mListWidget->setEnabled(false);
+    mListWidget->addItem(tr("Looks good so far :-)"));
+  } else {
+    mListWidget->setEnabled(true);
+  }
+}
+
+void LibraryElementCheckListWidget::itemDoubleClicked(
+    QListWidgetItem* item) noexcept {
+  std::shared_ptr<const LibraryElementCheckMessage> msg =
+      mMessages.value(mListWidget->row(item));
+  if (msg && mHandler) {
+    if (mHandler->libraryElementCheckFixAvailable(msg)) {
+      mHandler->libraryElementCheckFixRequested(msg);
+    } else {
+      mHandler->libraryElementCheckDescriptionRequested(msg);
+    }
+  }
+}
+
+bool LibraryElementCheckListWidget::libraryElementCheckFixAvailable(
+    std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept {
+  if (mHandler) {
+    return mHandler->libraryElementCheckFixAvailable(msg);
+  } else {
+    return false;
+  }
+}
+
+void LibraryElementCheckListWidget::libraryElementCheckFixRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept {
+  if (mHandler) {
+    mHandler->libraryElementCheckFixRequested(msg);
+  }
+}
+
+void LibraryElementCheckListWidget::libraryElementCheckDescriptionRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept {
+  if (mHandler) {
+    mHandler->libraryElementCheckDescriptionRequested(msg);
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.h
+++ b/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.h
@@ -1,0 +1,185 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_EDITOR_LIBRARYELEMENTCHECKLISTWIDGET_H
+#define LIBREPCB_LIBRARY_EDITOR_LIBRARYELEMENTCHECKLISTWIDGET_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/library/msg/libraryelementcheckmessage.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+namespace editor {
+
+/*******************************************************************************
+ *  Interface IF_LibraryElementCheckHandler
+ ******************************************************************************/
+
+class IF_LibraryElementCheckHandler {
+public:
+  virtual bool libraryElementCheckFixAvailable(
+      std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept = 0;
+  virtual void libraryElementCheckFixRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept = 0;
+  virtual void libraryElementCheckDescriptionRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept = 0;
+
+protected:
+  IF_LibraryElementCheckHandler() noexcept {}
+  IF_LibraryElementCheckHandler(const IF_LibraryElementCheckHandler&) noexcept {
+  }
+  virtual ~IF_LibraryElementCheckHandler() noexcept {}
+};
+
+/*******************************************************************************
+ *  Class LibraryElementCheckListItemWidget
+ ******************************************************************************/
+
+/**
+ * @brief The LibraryElementCheckListItemWidget class
+ */
+class LibraryElementCheckListItemWidget final : public QWidget {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit LibraryElementCheckListItemWidget(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      IF_LibraryElementCheckHandler&                    handler,
+      QWidget* parent = nullptr) noexcept
+    : QWidget(parent),
+      mMessage(msg),
+      mHandler(handler),
+      mIconLabel(new QLabel(this)) {
+    if (!msg) return;
+    QHBoxLayout* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(3);
+
+    // severity icon
+    mIconLabel->setScaledContents(true);
+    mIconLabel->setPixmap(msg->getSeverityPixmap());
+    layout->addWidget(mIconLabel.data());
+
+    // message
+    QLabel* lblMsg = new QLabel(msg->getMessage(), this);
+    lblMsg->setToolTip(msg->getMessage());
+    layout->addWidget(lblMsg);
+    layout->setStretch(1, 100);
+
+    // "fix" button
+    if (mHandler.libraryElementCheckFixAvailable(mMessage)) {
+      QToolButton* btnFix = new QToolButton(this);
+      btnFix->setText(tr("Fix"));
+      connect(btnFix, &QToolButton::clicked,
+              [this]() { mHandler.libraryElementCheckFixRequested(mMessage); });
+      layout->addWidget(btnFix);
+    }
+
+    // "details" button
+    QToolButton* btnDetails = new QToolButton(this);
+    btnDetails->setText("?");
+    btnDetails->setToolTip(tr("Details"));
+    connect(btnDetails, &QToolButton::clicked, [this]() {
+      mHandler.libraryElementCheckDescriptionRequested(mMessage);
+    });
+    layout->addWidget(btnDetails);
+  }
+  LibraryElementCheckListItemWidget(
+      const LibraryElementCheckListItemWidget& other) = delete;
+  ~LibraryElementCheckListItemWidget() noexcept {}
+
+  // Operator Overloadings
+  LibraryElementCheckListItemWidget& operator       =(
+      const LibraryElementCheckListItemWidget& rhs) = delete;
+
+private:  // Methods
+  void resizeEvent(QResizeEvent* event) override {
+    QWidget::resizeEvent(event);
+    mIconLabel->setFixedWidth(mIconLabel->height());
+  }
+
+private:  // Data
+  std::shared_ptr<const LibraryElementCheckMessage> mMessage;
+  IF_LibraryElementCheckHandler&                    mHandler;
+  QScopedPointer<QLabel>                            mIconLabel;
+};
+
+/*******************************************************************************
+ *  Class LibraryElementCheckListWidget
+ ******************************************************************************/
+
+/**
+ * @brief The LibraryElementCheckListWidget class
+ */
+class LibraryElementCheckListWidget final
+  : public QWidget,
+    private IF_LibraryElementCheckHandler {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit LibraryElementCheckListWidget(QWidget* parent = nullptr) noexcept;
+  LibraryElementCheckListWidget(const LibraryElementCheckListWidget& other) =
+      delete;
+  ~LibraryElementCheckListWidget() noexcept;
+
+  // Setters
+  void setHandler(IF_LibraryElementCheckHandler* handler) noexcept;
+  void setMessages(LibraryElementCheckMessageList messages) noexcept;
+
+  // Operator Overloadings
+  LibraryElementCheckListWidget& operator       =(
+      const LibraryElementCheckListWidget& rhs) = delete;
+
+private:  // Methods
+  void updateList() noexcept;
+  void itemDoubleClicked(QListWidgetItem* item) noexcept;
+  bool libraryElementCheckFixAvailable(
+      std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept override;
+  void libraryElementCheckFixRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept override;
+  void libraryElementCheckDescriptionRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept override;
+
+private:  // Data
+  QScopedPointer<QListWidget>    mListWidget;
+  IF_LibraryElementCheckHandler* mHandler;
+  LibraryElementCheckMessageList mMessages;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_EDITOR_LIBRARYELEMENTCHECKLISTWIDGET_H

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.h
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.h
@@ -95,6 +95,15 @@ private:  // Methods
   void    updatePackagePreview() noexcept;
   void    memorizeDeviceInterface() noexcept;
   bool    isInterfaceBroken() const noexcept override;
+  bool    runChecks(LibraryElementCheckMessageList& msgs) const override;
+  template <typename MessageType>
+  void fixMsg(const MessageType& msg);
+  template <typename MessageType>
+  bool fixMsgHelper(std::shared_ptr<const LibraryElementCheckMessage> msg,
+                    bool                                              applyFix);
+  bool processCheckMessage(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool                                              applyFix) override;
 
 private:  // Data
   QScopedPointer<Ui::DeviceEditorWidget>            mUi;

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
@@ -38,6 +38,16 @@
       </size>
      </property>
     </widget>
+  </item>
+  <item>
+    <widget class="QWidget" name="errorNotificationWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,0,1">
@@ -381,6 +391,33 @@
          </property>
         </widget>
        </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Messages:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="librepcb::library::editor::LibraryElementCheckListWidget" name="lstMessages" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
@@ -397,6 +434,12 @@
    <class>librepcb::GraphicsView</class>
    <extends>QGraphicsView</extends>
    <header location="global">librepcb/common/graphics/graphicsview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::library::editor::LibraryElementCheckListWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/libraryeditor/common/libraryelementchecklistwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>librepcb::library::editor::PadSignalMapEditorWidget</class>

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -83,7 +83,16 @@ private:  // Methods
   void    updateMetadata() noexcept;
   QString commitMetadata() noexcept;
   bool    isInterfaceBroken() const noexcept override { return false; }
-  void    updateElementLists() noexcept;
+  bool    runChecks(LibraryElementCheckMessageList& msgs) const override;
+  template <typename MessageType>
+  void fixMsg(const MessageType& msg);
+  template <typename MessageType>
+  bool fixMsgHelper(std::shared_ptr<const LibraryElementCheckMessage> msg,
+                    bool                                              applyFix);
+  bool processCheckMessage(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool                                              applyFix) override;
+  void updateElementLists() noexcept;
   template <typename ElementType>
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;
 

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
@@ -420,6 +420,33 @@
          </property>
         </widget>
        </item>
+       <item row="11" column="0" colspan="2">
+        <widget class="Line" name="line_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Messages:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="librepcb::library::editor::LibraryElementCheckListWidget" name="lstMessages" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -431,6 +458,12 @@
    <class>librepcb::PlainTextEdit</class>
    <extends>QPlainTextEdit</extends>
    <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::library::editor::LibraryElementCheckListWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/libraryeditor/common/libraryelementchecklistwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/libs/librepcb/libraryeditor/libraryeditor.pro
+++ b/libs/librepcb/libraryeditor/libraryeditor.pro
@@ -33,6 +33,7 @@ SOURCES += \
     common/categorytreelabeltextbuilder.cpp \
     common/componentchooserdialog.cpp \
     common/editorwidgetbase.cpp \
+    common/libraryelementchecklistwidget.cpp \
     common/packagechooserdialog.cpp \
     common/symbolchooserdialog.cpp \
     dev/deviceeditorwidget.cpp \
@@ -110,6 +111,7 @@ HEADERS += \
     common/categorytreelabeltextbuilder.h \
     common/componentchooserdialog.h \
     common/editorwidgetbase.h \
+    common/libraryelementchecklistwidget.h \
     common/packagechooserdialog.h \
     common/symbolchooserdialog.h \
     dev/deviceeditorwidget.h \

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
@@ -87,6 +87,14 @@ void FootprintListEditorWidget::setReferences(FootprintList& list,
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void FootprintListEditorWidget::addDefaultFootprint() {
+  addFootprint(cleanElementName("default"));  // can throw
+}
+
+/*******************************************************************************
  *  Private Slots
  ******************************************************************************/
 

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
@@ -64,6 +64,9 @@ public:
   // Setters
   void setReferences(FootprintList& list, UndoStack& stack) noexcept;
 
+  // General Methods
+  void addDefaultFootprint();
+
   // Operator Overloadings
   FootprintListEditorWidget& operator=(const FootprintListEditorWidget& rhs) =
       delete;

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
@@ -104,6 +104,15 @@ private:  // Methods
   void currentFootprintChanged(int index) noexcept;
   void memorizePackageInterface() noexcept;
   bool isInterfaceBroken() const noexcept override;
+  bool runChecks(LibraryElementCheckMessageList& msgs) const override;
+  template <typename MessageType>
+  void fixMsg(const MessageType& msg);
+  template <typename MessageType>
+  bool fixMsgHelper(std::shared_ptr<const LibraryElementCheckMessage> msg,
+                    bool                                              applyFix);
+  bool processCheckMessage(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool                                              applyFix) override;
 
 private:  // Data
   QScopedPointer<Ui::PackageEditorWidget>         mUi;

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.ui
@@ -38,6 +38,16 @@
       </size>
      </property>
     </widget>
+  </item>
+  <item>
+    <widget class="QWidget" name="errorNotificationWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="2,0,1">
@@ -245,6 +255,33 @@
          </property>
         </widget>
        </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Messages:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="librepcb::library::editor::LibraryElementCheckListWidget" name="lstMessages" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
@@ -261,6 +298,12 @@
    <class>librepcb::GraphicsView</class>
    <extends>QGraphicsView</extends>
    <header location="global">librepcb/common/graphics/graphicsview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::library::editor::LibraryElementCheckListWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/libraryeditor/common/libraryelementchecklistwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>librepcb::library::editor::PackagePadListEditorWidget</class>

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.h
@@ -75,9 +75,18 @@ private:  // Methods
   void    updateMetadata() noexcept;
   QString commitMetadata() noexcept;
   bool    isInterfaceBroken() const noexcept override { return false; }
-  void    btnChooseParentCategoryClicked() noexcept;
-  void    btnResetParentCategoryClicked() noexcept;
-  void    updateCategoryLabel() noexcept;
+  bool    runChecks(LibraryElementCheckMessageList& msgs) const override;
+  template <typename MessageType>
+  void fixMsg(const MessageType& msg);
+  template <typename MessageType>
+  bool fixMsgHelper(std::shared_ptr<const LibraryElementCheckMessage> msg,
+                    bool                                              applyFix);
+  bool processCheckMessage(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool                                              applyFix) override;
+  void btnChooseParentCategoryClicked() noexcept;
+  void btnResetParentCategoryClicked() noexcept;
+  void updateCategoryLabel() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::PackageCategoryEditorWidget> mUi;

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
@@ -109,21 +109,21 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Parent:</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="6" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>0</number>
@@ -200,6 +200,26 @@
      </item>
     </layout>
    </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Messages:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="librepcb::library::editor::LibraryElementCheckListWidget" name="lstMessages" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -207,6 +227,12 @@
    <class>librepcb::PlainTextEdit</class>
    <extends>QPlainTextEdit</extends>
    <header location="global">librepcb/common/widgets/plaintextedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::library::editor::LibraryElementCheckListWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/libraryeditor/common/libraryelementchecklistwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
@@ -101,6 +101,15 @@ private:  // Methods
   bool graphicsViewEventHandler(QEvent* event) noexcept override;
   bool toolChangeRequested(Tool newTool) noexcept override;
   bool isInterfaceBroken() const noexcept override;
+  bool runChecks(LibraryElementCheckMessageList& msgs) const override;
+  template <typename MessageType>
+  void fixMsg(const MessageType& msg);
+  template <typename MessageType>
+  bool fixMsgHelper(std::shared_ptr<const LibraryElementCheckMessage> msg,
+                    bool                                              applyFix);
+  bool processCheckMessage(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool                                              applyFix) override;
 
 private:  // Data
   QScopedPointer<Ui::SymbolEditorWidget>            mUi;

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.ui
@@ -38,6 +38,16 @@
       </size>
      </property>
     </widget>
+  </item>
+  <item>
+    <widget class="QWidget" name="errorNotificationWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="2,0,1">
@@ -171,6 +181,33 @@
          </property>
         </widget>
        </item>
+       <item row="7" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Messages:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="librepcb::library::editor::LibraryElementCheckListWidget" name="lstMessages" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
@@ -187,6 +224,12 @@
    <class>librepcb::GraphicsView</class>
    <extends>QGraphicsView</extends>
    <header location="global">librepcb/common/graphics/graphicsview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::library::editor::LibraryElementCheckListWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/libraryeditor/common/libraryelementchecklistwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
Like a PCB DRC, but for library elements :smiley: 

![librepcb-library-element-check](https://user-images.githubusercontent.com/5374821/48679644-1fbd0000-eb93-11e8-94ce-2416c811e2f8.gif)
