### PR TITLE
Allow running clang-format in Docker container

### DIFF
--- a/dev/clang-format/Dockerfile
+++ b/dev/clang-format/Dockerfile
@@ -1,10 +1,4 @@
-# Usage:
-#
-#   $ docker build . -t librepcb/clang-format:6
-#
-# Then from the main directory:
-#
-#   $ docker run --rm -t -i -v $(pwd):/code librepcb/clang-format:6 /bin/bash -c "cd /code && dev/format_code.sh"
+# Container with clang-format 6. Used in the `dev/format_code.sh` script.
 
 FROM ubuntu:bionic
 

--- a/dev/clang-format/Dockerfile
+++ b/dev/clang-format/Dockerfile
@@ -1,15 +1,17 @@
 # Usage:
 #
-# $ docker build . -t librepcb/clang-format:6
+#   $ docker build . -t librepcb/clang-format:6
 #
 # Then from the main directory:
 #
-# $ docker build . -t librepcb/clang-format:6
-# $ docker run --rm -t -i -v $(pwd):/code librepcb/clang-format:6 /bin/bash -c "cd /code && dev/format_code.sh"
+#   $ docker run --rm -t -i -v $(pwd):/code librepcb/clang-format:6 /bin/bash -c "cd /code && dev/format_code.sh"
+
 FROM ubuntu:bionic
 
 RUN apt-get -q update \
  && apt-get -qy install \
-  clang-format \
+  clang-format-6.0 \
   git \
  && apt-get clean
+
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 50

--- a/dev/clang-format/Dockerfile
+++ b/dev/clang-format/Dockerfile
@@ -1,0 +1,15 @@
+# Usage:
+#
+# $ docker build . -t librepcb/clang-format:6
+#
+# Then from the main directory:
+#
+# $ docker build . -t librepcb/clang-format:6
+# $ docker run --rm -t -i -v $(pwd):/code librepcb/clang-format:6 /bin/bash -c "cd /code && dev/format_code.sh"
+FROM ubuntu:bionic
+
+RUN apt-get -q update \
+ && apt-get -qy install \
+  clang-format \
+  git \
+ && apt-get clean

--- a/dev/doxygen/pages/code_style_guide.md
+++ b/dev/doxygen/pages/code_style_guide.md
@@ -18,6 +18,9 @@ This page describes the code style guide for LibrePCB developers.
   script `./dev/format_code.sh` to format all files which are modified compared
   to the `master` branch (this avoids formatting of files other than the ones
   you modified).
+- If your operating system does not ship clang-format version 6, you can also
+  run the formatter in a Docker container by using the `./dev/format_code.sh
+  --docker` command.
 
 
 # General {#doc_code_style_guide_general}

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -11,18 +11,20 @@ set -eo pipefail
 
 echo "Formatting modified files with clang-format..."
 
-DOCKER_IMAGE=librepcb/clang-format:6
 if [ "$1" == "--docker" ]; then
+  DOCKER_IMAGE=librepcb/clang-format:6
+  REPO_ROOT=$(git rev-parse --show-toplevel)
+
   if [ "$(docker images -q $DOCKER_IMAGE | wc -l)" == "0" ]; then
     echo "Building clang-format container..."
-    cd clang-format
+    cd "$REPO_ROOT/dev/clang-format"
     docker build . -t librepcb/clang-format:6
-    cd ..
+    cd -
   fi
 
   echo "[Re-running format_code.sh inside Docker container]"
   docker run --rm -t -i \
-    -v "$(git rev-parse --show-toplevel):/code" \
+    -v "$REPO_ROOT:/code" \
     $DOCKER_IMAGE \
     /bin/bash -c "cd /code && dev/format_code.sh"
 

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -23,7 +23,7 @@ if [ "$1" == "--docker" ]; then
   fi
 
   echo "[Re-running format_code.sh inside Docker container]"
-  docker run --rm -t -i \
+  docker run --rm -t -i --user $(id -u):$(id -g) \
     -v "$REPO_ROOT:/code" \
     $DOCKER_IMAGE \
     /bin/bash -c "cd /code && dev/format_code.sh"


### PR DESCRIPTION
Are you interested in this?

It's a bit of a hack but seems to work nicely. Simply run the formatting script with `--docker`.