### PR TITLE
Fix inconsistent coding style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,7 +53,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true

--- a/apps/UuidGenerator/main.cpp
+++ b/apps/UuidGenerator/main.cpp
@@ -2,7 +2,7 @@
 
 #include <QApplication>
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   QApplication a(argc, argv);
   MainWindow   w;
   w.show();

--- a/apps/UuidGenerator/mainwindow.cpp
+++ b/apps/UuidGenerator/mainwindow.cpp
@@ -9,7 +9,7 @@
 
 using namespace librepcb;
 
-MainWindow::MainWindow(QWidget *parent)
+MainWindow::MainWindow(QWidget* parent)
   : QMainWindow(parent), ui(new Ui::MainWindow) {
   ui->setupUi(this);
   QSettings s;

--- a/apps/UuidGenerator/mainwindow.h
+++ b/apps/UuidGenerator/mainwindow.h
@@ -11,7 +11,7 @@ class MainWindow : public QMainWindow {
   Q_OBJECT
 
 public:
-  explicit MainWindow(QWidget *parent = 0);
+  explicit MainWindow(QWidget* parent = 0);
   ~MainWindow();
 
 private slots:
@@ -21,8 +21,8 @@ private slots:
   void on_checkBox_toggled(bool checked);
 
 private:
-  Ui::MainWindow *ui;
-  QTimer *        timer;
+  Ui::MainWindow* ui;
+  QTimer*         timer;
 };
 
 #endif  // MAINWINDOW_H

--- a/apps/WorkspaceLibraryUpdater/mainwindow.h
+++ b/apps/WorkspaceLibraryUpdater/mainwindow.h
@@ -24,7 +24,7 @@ class MainWindow : public QMainWindow {
   Q_OBJECT
 
 public:
-  explicit MainWindow(QWidget *parent = 0);
+  explicit MainWindow(QWidget* parent = 0);
   ~MainWindow();
 
 private slots:
@@ -36,10 +36,10 @@ private slots:
 
 private:
   template <typename ElementType>
-  void updateElements(const librepcb::library::Library &lib) noexcept;
+  void updateElements(const librepcb::library::Library& lib) noexcept;
 
   // Attributes
-  Ui::MainWindow *ui;
+  Ui::MainWindow* ui;
   QString         lastDir;
   int             elementCount;
   int             ignoreCount;

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -110,8 +110,9 @@ ControlPanel::ControlPanel(Workspace& workspace)
   connect(mUi->actionQuit, &QAction::triggered, this, &ControlPanel::close);
   connect(mUi->actionOpenWebsite, &QAction::triggered,
           []() { QDesktopServices::openUrl(QUrl("https://librepcb.org")); });
-  connect(mUi->actionOnlineDocumentation, &QAction::triggered,
-          []() { QDesktopServices::openUrl(QUrl("https://docs.librepcb.org")); });
+  connect(mUi->actionOnlineDocumentation, &QAction::triggered, []() {
+    QDesktopServices::openUrl(QUrl("https://docs.librepcb.org"));
+  });
   connect(mUi->actionAbout_Qt, &QAction::triggered, qApp,
           &QApplication::aboutQt);
   connect(mUi->actionAbout, &QAction::triggered, qApp, &Application::about);

--- a/apps/librepcb/firstrunwizard/firstrunwizard.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizard.cpp
@@ -37,7 +37,7 @@ namespace application {
  *  Constructors / Destructor
  ******************************************************************************/
 
-FirstRunWizard::FirstRunWizard(QWidget *parent) noexcept
+FirstRunWizard::FirstRunWizard(QWidget* parent) noexcept
   : QWizard(parent), mUi(new Ui::FirstRunWizard) {
   mUi->setupUi(this);
 

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.cpp
@@ -34,7 +34,7 @@ namespace application {
  *  Constructors / Destructor
  ******************************************************************************/
 
-FirstRunWizardPage_Welcome::FirstRunWizardPage_Welcome(QWidget *parent) noexcept
+FirstRunWizardPage_Welcome::FirstRunWizardPage_Welcome(QWidget* parent) noexcept
   : QWizardPage(parent), mUi(new Ui::FirstRunWizardPage_Welcome) {
   mUi->setupUi(this);
   setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_welcome.h
@@ -51,7 +51,7 @@ class FirstRunWizardPage_Welcome final : public QWizardPage {
 
 public:
   // Constructors / Destructor
-  explicit FirstRunWizardPage_Welcome(QWidget *parent = 0) noexcept;
+  explicit FirstRunWizardPage_Welcome(QWidget* parent = 0) noexcept;
   ~FirstRunWizardPage_Welcome() noexcept;
 
 private:

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.cpp
@@ -39,7 +39,7 @@ namespace application {
  ******************************************************************************/
 
 FirstRunWizardPage_WorkspacePath::FirstRunWizardPage_WorkspacePath(
-    QWidget *parent) noexcept
+    QWidget* parent) noexcept
   : QWizardPage(parent), mUi(new Ui::FirstRunWizardPage_WorkspacePath) {
   mUi->setupUi(this);
   registerField("CreateWorkspace", mUi->rbtnCreateWs);

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacepath.h
@@ -51,7 +51,7 @@ class FirstRunWizardPage_WorkspacePath final : public QWizardPage {
 
 public:
   // Constructors / Destructor
-  explicit FirstRunWizardPage_WorkspacePath(QWidget *parent = 0) noexcept;
+  explicit FirstRunWizardPage_WorkspacePath(QWidget* parent = 0) noexcept;
   ~FirstRunWizardPage_WorkspacePath() noexcept;
 
   // Inherited Methods

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.cpp
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.cpp
@@ -40,7 +40,7 @@ namespace application {
  ******************************************************************************/
 
 FirstRunWizardPage_WorkspaceSettings::FirstRunWizardPage_WorkspaceSettings(
-    QWidget *parent) noexcept
+    QWidget* parent) noexcept
   : QWizardPage(parent), mUi(new Ui::FirstRunWizardPage_WorkspaceSettings) {
   mUi->setupUi(this);
   registerField("NewWorkspaceUserName", mUi->edtUserName);

--- a/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.h
+++ b/apps/librepcb/firstrunwizard/firstrunwizardpage_workspacesettings.h
@@ -48,7 +48,7 @@ class FirstRunWizardPage_WorkspaceSettings final : public QWizardPage {
 
 public:
   // Constructors / Destructor
-  explicit FirstRunWizardPage_WorkspaceSettings(QWidget *parent = 0) noexcept;
+  explicit FirstRunWizardPage_WorkspaceSettings(QWidget* parent = 0) noexcept;
   ~FirstRunWizardPage_WorkspaceSettings() noexcept;
 
   // Inherited Methods

--- a/dev/clang-format/Dockerfile
+++ b/dev/clang-format/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -q update \
  && apt-get -qy install \
   clang-format-6.0 \
   git \
+  python \
  && apt-get clean
 
 RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 50

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Formats files according our coding style with clang-format.
+# Formats files according our coding style with clang-format. And if Python is
+# available, *.pro project files will be sorted with sort_qmake_file_entries.py.
 #
 # Usage:
 #   - Make sure the executables "clang-format" and "git" are available in PATH.
@@ -26,9 +27,10 @@ done
 
 echo "Formatting files with clang-format..."
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
 if [ "$DOCKER" == "--docker" ]; then
   DOCKER_IMAGE=librepcb/clang-format:6
-  REPO_ROOT=$(git rev-parse --show-toplevel)
 
   if [ "$(docker images -q $DOCKER_IMAGE | wc -l)" == "0" ]; then
     echo "Building clang-format container..."
@@ -77,3 +79,8 @@ do
 done
 
 echo "Finished: $COUNTER files modified."
+
+# Also run sort_qmake_file_entries.py if Python is available
+if [ -x "$(command -v python)" ]; then
+  python "$REPO_ROOT/dev/sort_qmake_file_entries.py"
+fi

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -1,17 +1,32 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Formats all files which differ from their state on the master branch with
-# clang-format.
+# Formats files according our coding style with clang-format.
 #
 # Usage:
 #   - Make sure the executables "clang-format" and "git" are available in PATH.
 #   - Run the command "./dev/format_code.sh" in the root of the repository.
 #   - To run clang-format in a docker-container, use the "--docker" parameter.
+#   - To format all files (instead of only modified ones), add the "--all"
+#     parameter. This is intended only for LibrePCB maintainers, don't use it!
 
-echo "Formatting modified files with clang-format..."
+for i in "$@"
+do
+case $i in
+    --docker)
+    DOCKER="--docker"
+    shift
+    ;;
+    --all)
+    ALL="--all"
+    shift
+    ;;
+esac
+done
 
-if [ "$1" == "--docker" ]; then
+echo "Formatting files with clang-format..."
+
+if [ "$DOCKER" == "--docker" ]; then
   DOCKER_IMAGE=librepcb/clang-format:6
   REPO_ROOT=$(git rev-parse --show-toplevel)
 
@@ -26,7 +41,7 @@ if [ "$1" == "--docker" ]; then
   docker run --rm -t -i --user $(id -u):$(id -g) \
     -v "$REPO_ROOT:/code" \
     $DOCKER_IMAGE \
-    /bin/bash -c "cd /code && dev/format_code.sh"
+    /bin/bash -c "cd /code && dev/format_code.sh $ALL"
 
   echo "[Docker done.]"
   exit 0
@@ -36,9 +51,14 @@ COUNTER=0
 
 for dir in apps/ libs/librepcb/ tests/unittests/
 do
-  MODIFIED=`git diff --name-only master -- "${dir}**.cpp" "${dir}**.hpp" "${dir}**.h"`
+  if [ "$ALL" == "--all" ]; then
+    TRACKED=`git ls-files -- "${dir}**.cpp" "${dir}**.hpp" "${dir}**.h"`
+  else
+    # Only files which differ from the master branch
+    TRACKED=`git diff --name-only master -- "${dir}**.cpp" "${dir}**.hpp" "${dir}**.h"`
+  fi
   UNTRACKED=`git ls-files --others --exclude-standard -- "${dir}**.cpp" "${dir}**.hpp" "${dir}**.h"`
-  for file in $MODIFIED $UNTRACKED
+  for file in $TRACKED $UNTRACKED
   do
     # Note: Do NOT use in-place edition of clang-format because this causes
     # "make" to detect the files as changed every time, even if the content was

--- a/libs/librepcb/common/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/common/dialogs/aboutdialog.cpp
@@ -61,7 +61,8 @@ AboutDialog::AboutDialog(QWidget* parent) noexcept
   mUi->textLinks->setText(
       tr("For more information, please check out <a href='%1'>librepcb.org</a> "
          "or our <a href='%2'>GitHub repository</a>.")
-          .arg("https://librepcb.org/", "https://github.com/LibrePCB/LibrePCB"));
+          .arg("https://librepcb.org/",
+               "https://github.com/LibrePCB/LibrePCB"));
   mUi->textContributeFinancially->setText(
       tr("Support sustainable development of LibrePCB by donating financially, "
          "either via <a href='%1'>Patreon</a> or via <a href='%2'>Bitcoin</a>!")

--- a/libs/librepcb/common/dialogs/filedialog.cpp
+++ b/libs/librepcb/common/dialogs/filedialog.cpp
@@ -31,38 +31,38 @@ namespace librepcb {
  *  Public Methods
  ******************************************************************************/
 
-QString FileDialog::getOpenFileName(QWidget *parent, const QString &caption,
-                                    const QString &dir, const QString &filter,
-                                    QString *            selectedFilter,
+QString FileDialog::getOpenFileName(QWidget* parent, const QString& caption,
+                                    const QString& dir, const QString& filter,
+                                    QString*             selectedFilter,
                                     QFileDialog::Options options) {
   patchOptions(options);
   return QFileDialog::getOpenFileName(parent, caption, dir, filter,
                                       selectedFilter, options);
 }
 
-QStringList FileDialog::getOpenFileNames(QWidget *            parent,
-                                         const QString &      caption,
-                                         const QString &      dir,
-                                         const QString &      filter,
-                                         QString *            selectedFilter,
+QStringList FileDialog::getOpenFileNames(QWidget*             parent,
+                                         const QString&       caption,
+                                         const QString&       dir,
+                                         const QString&       filter,
+                                         QString*             selectedFilter,
                                          QFileDialog::Options options) {
   patchOptions(options);
   return QFileDialog::getOpenFileNames(parent, caption, dir, filter,
                                        selectedFilter, options);
 }
 
-QString FileDialog::getSaveFileName(QWidget *parent, const QString &caption,
-                                    const QString &dir, const QString &filter,
-                                    QString *            selectedFilter,
+QString FileDialog::getSaveFileName(QWidget* parent, const QString& caption,
+                                    const QString& dir, const QString& filter,
+                                    QString*             selectedFilter,
                                     QFileDialog::Options options) {
   patchOptions(options);
   return QFileDialog::getSaveFileName(parent, caption, dir, filter,
                                       selectedFilter, options);
 }
 
-QString FileDialog::getExistingDirectory(QWidget *            parent,
-                                         const QString &      caption,
-                                         const QString &      dir,
+QString FileDialog::getExistingDirectory(QWidget*             parent,
+                                         const QString&       caption,
+                                         const QString&       dir,
                                          QFileDialog::Options options) {
   patchOptions(options);
   return QFileDialog::getExistingDirectory(parent, caption, dir, options);
@@ -72,7 +72,7 @@ QString FileDialog::getExistingDirectory(QWidget *            parent,
  *  Private Methods
  ******************************************************************************/
 
-void FileDialog::patchOptions(QFileDialog::Options &options) noexcept {
+void FileDialog::patchOptions(QFileDialog::Options& options) noexcept {
   static const bool noNativeDialogs =
       qgetenv("LIBREPCB_DISABLE_NATIVE_DIALOGS") == "1";
   if (noNativeDialogs) {

--- a/libs/librepcb/common/dialogs/filedialog.h
+++ b/libs/librepcb/common/dialogs/filedialog.h
@@ -46,37 +46,37 @@ class FileDialog final {
 public:
   // Constructors / Destructor
   FileDialog()                        = delete;
-  FileDialog(const FileDialog &other) = delete;
+  FileDialog(const FileDialog& other) = delete;
   ~FileDialog()                       = delete;
 
-  static QString getOpenFileName(QWidget *            parent  = 0,
-                                 const QString &      caption = QString(),
-                                 const QString &      dir     = QString(),
-                                 const QString &      filter  = QString(),
-                                 QString *            selectedFilter = 0,
+  static QString getOpenFileName(QWidget*             parent  = 0,
+                                 const QString&       caption = QString(),
+                                 const QString&       dir     = QString(),
+                                 const QString&       filter  = QString(),
+                                 QString*             selectedFilter = 0,
                                  QFileDialog::Options options        = 0);
 
-  static QStringList getOpenFileNames(QWidget *            parent  = 0,
-                                      const QString &      caption = QString(),
-                                      const QString &      dir     = QString(),
-                                      const QString &      filter  = QString(),
-                                      QString *            selectedFilter = 0,
+  static QStringList getOpenFileNames(QWidget*             parent  = 0,
+                                      const QString&       caption = QString(),
+                                      const QString&       dir     = QString(),
+                                      const QString&       filter  = QString(),
+                                      QString*             selectedFilter = 0,
                                       QFileDialog::Options options        = 0);
 
-  static QString getSaveFileName(QWidget *            parent  = 0,
-                                 const QString &      caption = QString(),
-                                 const QString &      dir     = QString(),
-                                 const QString &      filter  = QString(),
-                                 QString *            selectedFilter = 0,
+  static QString getSaveFileName(QWidget*             parent  = 0,
+                                 const QString&       caption = QString(),
+                                 const QString&       dir     = QString(),
+                                 const QString&       filter  = QString(),
+                                 QString*             selectedFilter = 0,
                                  QFileDialog::Options options        = 0);
 
   static QString getExistingDirectory(
-      QWidget *parent = 0, const QString &caption = QString(),
-      const QString &      dir     = QString(),
+      QWidget* parent = 0, const QString& caption = QString(),
+      const QString&       dir     = QString(),
       QFileDialog::Options options = QFileDialog::ShowDirsOnly);
 
 private:
-  static void patchOptions(QFileDialog::Options &options) noexcept;
+  static void patchOptions(QFileDialog::Options& options) noexcept;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/geometry/path.cpp
+++ b/libs/librepcb/common/geometry/path.cpp
@@ -279,10 +279,11 @@ Path Path::flatArc(const Point& p1, const Point& p2, const Angle& angle,
 
   // calculate how many lines we need to create
   qreal radiusAbsNm = static_cast<qreal>(radiusAbs.toNm());
-  qreal y =
-      qBound(qreal(0.0), static_cast<qreal>(maxTolerance->toNm()), radiusAbsNm / qreal(4));
-  qreal stepsPerRad = qMin(qreal(0.5) / qAcos(1 - y / radiusAbsNm), radiusAbsNm / qreal(2));
-  int   steps       = qCeil(stepsPerRad * angle.abs().toRad());
+  qreal y = qBound(qreal(0.0), static_cast<qreal>(maxTolerance->toNm()),
+                   radiusAbsNm / qreal(4));
+  qreal stepsPerRad =
+      qMin(qreal(0.5) / qAcos(1 - y / radiusAbsNm), radiusAbsNm / qreal(2));
+  int steps = qCeil(stepsPerRad * angle.abs().toRad());
 
   // some other very complex calculations...
   qreal angleDelta = angle.toMicroDeg() / (qreal)steps;

--- a/libs/librepcb/common/toolbox.h
+++ b/libs/librepcb/common/toolbox.h
@@ -25,10 +25,10 @@
  ******************************************************************************/
 #include "units/all_length_units.h"
 
+#include <type_traits>
+
 #include <QtCore>
 #include <QtWidgets>
-
-#include <type_traits>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -148,7 +148,6 @@ public:
                                       const QString& spaceReplacement = " ",
                                       int            maxLength = -1) noexcept;
 
-
   /**
    * @brief Convert a fixed point decimal number from an integer to a QString
    *
@@ -176,16 +175,13 @@ public:
       // pointPos must be > 0 for this to work correctly
       str.insert(str.length() - pointPos, '.');
     } else {
-      for (qint32 i = pointPos - str.length(); i != 0; i--)
-        str.insert(0, '0');
+      for (qint32 i = pointPos - str.length(); i != 0; i--) str.insert(0, '0');
       str.insert(0, "0.");
     }
 
-    while (str.endsWith('0') && !str.endsWith(".0"))
-      str.chop(1);
+    while (str.endsWith('0') && !str.endsWith(".0")) str.chop(1);
 
-    if (value < 0)
-      str.insert(0, '-');
+    if (value < 0) str.insert(0, '-');
 
     return str;
   }
@@ -198,7 +194,7 @@ public:
    *                 decimal digits, this function will throw
    */
   template <typename T>
-  static T decimalFixedPointFromString(const QString &str, qint32 pointPos) {
+  static T decimalFixedPointFromString(const QString& str, qint32 pointPos) {
     using UnsignedT = typename std::make_unsigned<T>::type;
 
     const T         min   = std::numeric_limits<T>::min();
@@ -216,14 +212,14 @@ public:
       EXP_AFTER_SIGN,
       EXP_DIGITS,
     };
-    State state = State::START;
-    UnsignedT valueAbs = 0;
-    bool sign = false;
-    qint32 expOffset = pointPos;
+    State     state     = State::START;
+    UnsignedT valueAbs  = 0;
+    bool      sign      = false;
+    qint32    expOffset = pointPos;
 
-    const quint32 maxExp = std::numeric_limits<quint32>::max();
-    quint32 exp = 0;
-    bool expSign = false;
+    const quint32 maxExp  = std::numeric_limits<quint32>::max();
+    quint32       exp     = 0;
+    bool          expSign = false;
 
     for (QChar c : str) {
       if (state == State::INVALID) {
@@ -231,53 +227,53 @@ public:
         break;
       }
       switch (state) {
-      case State::INVALID:
-        // already checked, but needed to avoid compiler warnings
-        break;
+        case State::INVALID:
+          // already checked, but needed to avoid compiler warnings
+          break;
 
-      case State::START:
-        if (c == '-') {
-          sign = true;
-          state = State::AFTER_SIGN;
-        } else if (c == '+') {
-          state = State::AFTER_SIGN;
-        } else if (c == '.') {
-          state = State::LONELY_DOT;
-        } else if (c.isDigit()) {
+        case State::START:
+          if (c == '-') {
+            sign  = true;
+            state = State::AFTER_SIGN;
+          } else if (c == '+') {
+            state = State::AFTER_SIGN;
+          } else if (c == '.') {
+            state = State::LONELY_DOT;
+          } else if (c.isDigit()) {
             valueAbs = static_cast<UnsignedT>(c.digitValue());
-            state = State::INT_PART;
-        } else {
-          state = State::INVALID;
-        }
-        break;
+            state    = State::INT_PART;
+          } else {
+            state = State::INVALID;
+          }
+          break;
 
-      case State::AFTER_SIGN:
-        if (c == '.') {
-          state = State::LONELY_DOT;
-        } else if (c.isDigit()) {
+        case State::AFTER_SIGN:
+          if (c == '.') {
+            state = State::LONELY_DOT;
+          } else if (c.isDigit()) {
             valueAbs = static_cast<UnsignedT>(c.digitValue());
-            state = State::INT_PART;
-        } else {
-          state = State::INVALID;
-        }
-        break;
+            state    = State::INT_PART;
+          } else {
+            state = State::INVALID;
+          }
+          break;
 
-      case State::LONELY_DOT:
-        if (c.isDigit()) {
+        case State::LONELY_DOT:
+          if (c.isDigit()) {
             valueAbs = static_cast<UnsignedT>(c.digitValue());
             expOffset -= 1;
             state = State::FRAC_PART;
-        } else {
-          state = State::INVALID;
-        }
-        break;
+          } else {
+            state = State::INVALID;
+          }
+          break;
 
-      case State::INT_PART:
-        if (c == '.') {
-          state = State::FRAC_PART;
-        } else if (c == 'e' || c == 'E') {
-          state = State::EXP;
-        } else if (c.isDigit()) {
+        case State::INT_PART:
+          if (c == '.') {
+            state = State::FRAC_PART;
+          } else if (c == 'e' || c == 'E') {
+            state = State::EXP;
+          } else if (c.isDigit()) {
             UnsignedT digit = static_cast<UnsignedT>(c.digitValue());
             if (valueAbs > (max_u / 10)) {
               // Would overflow
@@ -291,15 +287,15 @@ public:
               break;
             }
             valueAbs += digit;
-        } else {
-          state = State::INVALID;
-        }
-        break;
+          } else {
+            state = State::INVALID;
+          }
+          break;
 
-      case State::FRAC_PART:
-        if (c == 'e' || c == 'E') {
-          state = State::EXP;
-        } else if (c.isDigit()) {
+        case State::FRAC_PART:
+          if (c == 'e' || c == 'E') {
+            state = State::EXP;
+          } else if (c.isDigit()) {
             UnsignedT digit = static_cast<UnsignedT>(c.digitValue());
             if (valueAbs > (max_u / 10)) {
               // Would overflow
@@ -314,38 +310,38 @@ public:
             }
             valueAbs += digit;
             expOffset -= 1;
-        } else {
-          state = State::INVALID;
-        }
-        break;
+          } else {
+            state = State::INVALID;
+          }
+          break;
 
-      case State::EXP:
-        if (c == '-') {
-          expSign = true;
-          state = State::EXP_AFTER_SIGN;
-        } else if (c == '+') {
-          state = State::EXP_AFTER_SIGN;
-        } else if (c.isDigit()) {
-          exp = static_cast<quint32>(c.digitValue());
-          state = State::EXP_DIGITS;
-        } else {
-          state = State::INVALID;
-        }
-        break;
+        case State::EXP:
+          if (c == '-') {
+            expSign = true;
+            state   = State::EXP_AFTER_SIGN;
+          } else if (c == '+') {
+            state = State::EXP_AFTER_SIGN;
+          } else if (c.isDigit()) {
+            exp   = static_cast<quint32>(c.digitValue());
+            state = State::EXP_DIGITS;
+          } else {
+            state = State::INVALID;
+          }
+          break;
 
-      case State::EXP_AFTER_SIGN:
-        if (c.isDigit()) {
-          exp = static_cast<quint32>(c.digitValue());
-          state = State::EXP_DIGITS;
-        } else {
-          state = State::INVALID;
-        }
-        break;
+        case State::EXP_AFTER_SIGN:
+          if (c.isDigit()) {
+            exp   = static_cast<quint32>(c.digitValue());
+            state = State::EXP_DIGITS;
+          } else {
+            state = State::INVALID;
+          }
+          break;
 
-      case State::EXP_DIGITS:
-        if (c.isDigit()) {
-          quint32 digit = static_cast<quint32>(c.digitValue());
-          if (exp > (maxExp / 10)) {
+        case State::EXP_DIGITS:
+          if (c.isDigit()) {
+            quint32 digit = static_cast<quint32>(c.digitValue());
+            if (exp > (maxExp / 10)) {
               // Would overflow
               state = State::INVALID;
               break;
@@ -357,27 +353,27 @@ public:
               break;
             }
             exp += digit;
-        } else {
-          state = State::INVALID;
-        }
+          } else {
+            state = State::INVALID;
+          }
       }
     }
 
     bool ok = true;
     switch (state) {
-    case State::INVALID:
-    case State::START:
-    case State::AFTER_SIGN:
-    case State::LONELY_DOT:
-    case State::EXP:
-    case State::EXP_AFTER_SIGN:
-      ok = false;
-      break;
+      case State::INVALID:
+      case State::START:
+      case State::AFTER_SIGN:
+      case State::LONELY_DOT:
+      case State::EXP:
+      case State::EXP_AFTER_SIGN:
+        ok = false;
+        break;
 
-    case State::INT_PART:
-    case State::FRAC_PART:
-    case State::EXP_DIGITS:
-      break;
+      case State::INT_PART:
+      case State::FRAC_PART:
+      case State::EXP_DIGITS:
+        break;
     }
 
     if (ok) {

--- a/libs/librepcb/common/units/angle.cpp
+++ b/libs/librepcb/common/units/angle.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include "angle.h"
+
 #include "../toolbox.h"
 
 #include <QtCore>

--- a/libs/librepcb/common/units/length.cpp
+++ b/libs/librepcb/common/units/length.cpp
@@ -21,12 +21,14 @@
  *  Includes
  ******************************************************************************/
 #include "length.h"
+
 #include "../toolbox.h"
+
+#include <type_traits>
 
 #include <QtCore>
 
 #include <limits>
-#include <type_traits>
 
 /*******************************************************************************
  *  Namespace
@@ -137,9 +139,9 @@ LengthBase_t Length::mapNmToGrid(LengthBase_t  nanometers,
                                  const Length& gridInterval) noexcept {
   using LengthBaseU_t = std::make_unsigned<LengthBase_t>::type;
 
-  LengthBaseU_t grid_interval = static_cast<LengthBaseU_t>(gridInterval.abs().mNanometers);
-  if (grid_interval == 0)
-    return nanometers;
+  LengthBaseU_t grid_interval =
+      static_cast<LengthBaseU_t>(gridInterval.abs().mNanometers);
+  if (grid_interval == 0) return nanometers;
 
   LengthBaseU_t nm_abs;
   LengthBaseU_t max;

--- a/libs/librepcb/common/units/ratio.cpp
+++ b/libs/librepcb/common/units/ratio.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include "ratio.h"
+
 #include "../toolbox.h"
 
 #include <QtCore>

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -131,8 +131,9 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   connect(mUi->actionQuit, &QAction::triggered, this, &BoardEditor::close);
   connect(mUi->actionOpenWebsite, &QAction::triggered,
           []() { QDesktopServices::openUrl(QUrl("https://librepcb.org")); });
-  connect(mUi->actionOnlineDocumentation, &QAction::triggered,
-          []() { QDesktopServices::openUrl(QUrl("https://docs.librepcb.org")); });
+  connect(mUi->actionOnlineDocumentation, &QAction::triggered, []() {
+    QDesktopServices::openUrl(QUrl("https://docs.librepcb.org"));
+  });
   connect(mUi->actionAbout, &QAction::triggered, qApp, &Application::about);
   connect(mUi->actionAboutQt, &QAction::triggered, qApp,
           &QApplication::aboutQt);

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
@@ -39,7 +39,7 @@ namespace editor {
  ******************************************************************************/
 
 NewProjectWizardPage_VersionControl::NewProjectWizardPage_VersionControl(
-    QWidget *parent) noexcept
+    QWidget* parent) noexcept
   : QWizardPage(parent), mUi(new Ui::NewProjectWizardPage_VersionControl) {
   mUi->setupUi(this);
   setPixmap(QWizard::LogoPixmap, QPixmap(":/img/actions/plus_2.png"));

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -106,8 +106,9 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   connect(mUi->actionQuit, &QAction::triggered, this, &SchematicEditor::close);
   connect(mUi->actionOpenWebsite, &QAction::triggered,
           []() { QDesktopServices::openUrl(QUrl("https://librepcb.org")); });
-  connect(mUi->actionOnlineDocumentation, &QAction::triggered,
-          []() { QDesktopServices::openUrl(QUrl("https://docs.librepcb.org")); });
+  connect(mUi->actionOnlineDocumentation, &QAction::triggered, []() {
+    QDesktopServices::openUrl(QUrl("https://docs.librepcb.org"));
+  });
   connect(mUi->actionAbout, &QAction::triggered, qApp, &Application::about);
   connect(mUi->actionAbout_Qt, &QAction::triggered, qApp,
           &QApplication::aboutQt);

--- a/tests/unittests/main.cpp
+++ b/tests/unittests/main.cpp
@@ -36,7 +36,7 @@ using namespace librepcb;
  *  The Unit Testing Program
  ******************************************************************************/
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   // many classes rely on a QApplication instance, so we create it here
   Application app(argc, argv);
   Application::setOrganizationName("LibrePCB");


### PR DESCRIPTION
I noticed inconsistent handling of pointer alignment in #388 which clang-format did not fix. This PR makes clang-format fixing it:

- `.clang-format`: Disable `DerivePointerAlignment` to enforce pointer alignment style for all files.
- Add parameter "--all" to `dev/format_code.sh` to format all files, not only modified ones.
- Also format *.pro files with `dev/format_code.sh` to avoid inconsistent project files.
- Reformat whole code base with clang-format to fix all inconsistencies.

@dbrgn Would be good to merge this before #388, then you can run `dev/format_code.sh` again on your branch to fix the style issues :)