### PR TITLE
Library Editor: Fix possibly outdated information in component signal editor

### DIFF
--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -426,8 +426,8 @@ bool ComponentSignalListEditorWidget::setName(const Uuid&    uuid,
   try {
     ComponentSignal* signal = mSignalList->get(uuid).get();  // can throw
     if (signal->getName() == name) {
-        updateTable();
-        return true;
+      updateTable();
+      return true;
     }
     CircuitIdentifier constrainedName = validateNameOrThrow(name);  // can throw
     if (mUndoStack) {

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -425,7 +425,10 @@ bool ComponentSignalListEditorWidget::setName(const Uuid&    uuid,
                                               const QString& name) noexcept {
   try {
     ComponentSignal* signal = mSignalList->get(uuid).get();  // can throw
-    if (signal->getName() == name) return true;
+    if (signal->getName() == name) {
+        updateTable();
+        return true;
+    }
     CircuitIdentifier constrainedName = validateNameOrThrow(name);  // can throw
     if (mUndoStack) {
       QScopedPointer<CmdComponentSignalEdit> cmd(

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -440,6 +440,7 @@ bool ComponentSignalListEditorWidget::setName(const Uuid&    uuid,
     }
     return true;
   } catch (const Exception& e) {
+    updateTable();
     QMessageBox::critical(this, tr("Could not edit signal"), e.getMsg());
     return false;
   }


### PR DESCRIPTION
componentSignalListedEditorWidget: Fix wrong behaviour when name of
signal contains forbidden characters.

Updating signal table when name and name without forbidden characters are
the same.

Fixes #392