### PR TITLE
Refactor workspace libraries handling

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -94,17 +94,14 @@ ControlPanel::ControlPanel(Workspace& workspace)
       Workspace::getHighestFileFormatVersionOfWorkspace(workspace.getPath());
   mUi->lblWarnForNewerAppVersions->setVisible(highestVersion > actualVersion);
 
-  // decide if we have to show the warning about missing workspace libraries
-  if (mWorkspace.getLocalLibraries().isEmpty() &&
-      mWorkspace.getRemoteLibraries().isEmpty()) {
-    mUi->lblWarnForNoLibraries->setVisible(true);
-    connect(mUi->lblWarnForNoLibraries, &QLabel::linkActivated, this,
-            &ControlPanel::on_actionOpen_Library_Manager_triggered);
-    connect(&mWorkspace, &Workspace::libraryAdded, mUi->lblWarnForNoLibraries,
-            &QLabel::hide);
-  } else {
-    mUi->lblWarnForNoLibraries->setVisible(false);
-  }
+  // hide warning about missing libraries, but update visibility each time the
+  // workspace library was scanned
+  mUi->lblWarnForNoLibraries->setVisible(false);
+  connect(mUi->lblWarnForNoLibraries, &QLabel::linkActivated, this,
+          &ControlPanel::on_actionOpen_Library_Manager_triggered);
+  connect(&mWorkspace.getLibraryDb(),
+          &WorkspaceLibraryDb::scanLibraryListUpdated, this,
+          &ControlPanel::updateNoLibrariesWarningVisibility);
 
   // connect some actions which are created with the Qt Designer
   connect(mUi->actionQuit, &QAction::triggered, this, &ControlPanel::close);
@@ -248,6 +245,16 @@ void ControlPanel::loadSettings() {
   clientSettings.endGroup();
 }
 
+void ControlPanel::updateNoLibrariesWarningVisibility() noexcept {
+  bool showWarning = false;
+  try {
+    showWarning = mWorkspace.getLibraryDb().getLibraries().isEmpty();
+  } catch (const Exception& e) {
+    qCritical() << "Could not get library list:" << e.getMsg();
+  }
+  mUi->lblWarnForNoLibraries->setVisible(showWarning);
+}
+
 void ControlPanel::showProjectReadmeInBrowser(
     const FilePath& projectFilePath) noexcept {
   if (projectFilePath.isValid()) {
@@ -371,16 +378,18 @@ ProjectEditor* ControlPanel::getOpenProject(const FilePath& filepath) const
  *  Library Management
  ******************************************************************************/
 
-void ControlPanel::openLibraryEditor(
-    QSharedPointer<library::Library> lib) noexcept {
+void ControlPanel::openLibraryEditor(const FilePath& libDir) noexcept {
+  using library::Library;
   using library::editor::LibraryEditor;
-  LibraryEditor* editor = mOpenLibraryEditors.value(lib.data());
+  LibraryEditor* editor = mOpenLibraryEditors.value(libDir);
   if (!editor) {
     try {
+      bool remote = libDir.isLocatedInDir(mWorkspace.getRemoteLibrariesPath());
+      QSharedPointer<Library> lib(new Library(libDir, remote));
       editor = new LibraryEditor(mWorkspace, lib);
       connect(editor, &LibraryEditor::destroyed, this,
               &ControlPanel::libraryEditorDestroyed);
-      mOpenLibraryEditors.insert(lib.data(), editor);
+      mOpenLibraryEditors.insert(libDir, editor);
     } catch (const Exception& e) {
       QMessageBox::critical(this, tr("Error"), e.getMsg());
     }
@@ -398,8 +407,8 @@ void ControlPanel::libraryEditorDestroyed() noexcept {
   // static_cast is used instead ;)
   LibraryEditor* editor = static_cast<LibraryEditor*>(QObject::sender());
   Q_ASSERT(editor);
-  library::Library* library = mOpenLibraryEditors.key(editor);
-  Q_ASSERT(library);
+  FilePath library = mOpenLibraryEditors.key(editor);
+  Q_ASSERT(library.isValid());
   mOpenLibraryEditors.remove(library);
 }
 

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -81,7 +81,7 @@ ControlPanel::ControlPanel(Workspace& workspace)
   mUi->statusBar->setProgressBarTextFormat(tr("Scanning libraries (%p%)"));
   connect(&mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanStarted,
           mUi->statusBar, &StatusBar::showProgressBar, Qt::QueuedConnection);
-  connect(&mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanSucceeded,
+  connect(&mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanFinished,
           mUi->statusBar, &StatusBar::hideProgressBar, Qt::QueuedConnection);
   connect(&mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanProgressUpdate,
           mUi->statusBar, &StatusBar::setProgressBarPercent,

--- a/apps/librepcb/controlpanel/controlpanel.h
+++ b/apps/librepcb/controlpanel/controlpanel.h
@@ -130,6 +130,7 @@ private:
   // General private methods
   void saveSettings();
   void loadSettings();
+  void updateNoLibrariesWarningVisibility() noexcept;
   void showProjectReadmeInBrowser(const FilePath& projectFilePath) noexcept;
 
   // Project Management
@@ -206,7 +207,7 @@ private:
       noexcept;
 
   // Library Management
-  void openLibraryEditor(QSharedPointer<library::Library> lib) noexcept;
+  void openLibraryEditor(const FilePath& libDir) noexcept;
   void libraryEditorDestroyed() noexcept;
 
   /**
@@ -220,12 +221,12 @@ private:
   bool closeAllLibraryEditors(bool askForSave) noexcept;
 
   // Attributes
-  workspace::Workspace&                                     mWorkspace;
-  QScopedPointer<Ui::ControlPanel>                          mUi;
-  QScopedPointer<library::manager::LibraryManager>          mLibraryManager;
-  QHash<QString, project::editor::ProjectEditor*>           mOpenProjectEditors;
-  QHash<library::Library*, library::editor::LibraryEditor*> mOpenLibraryEditors;
-  QScopedPointer<ProjectLibraryUpdater> mProjectLibraryUpdater;
+  workspace::Workspace&                            mWorkspace;
+  QScopedPointer<Ui::ControlPanel>                 mUi;
+  QScopedPointer<library::manager::LibraryManager> mLibraryManager;
+  QHash<QString, project::editor::ProjectEditor*>  mOpenProjectEditors;
+  QHash<FilePath, library::editor::LibraryEditor*> mOpenLibraryEditors;
+  QScopedPointer<ProjectLibraryUpdater>            mProjectLibraryUpdater;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
@@ -89,6 +89,7 @@ protected:  // Data
   const workspace::Workspace&                 mWorkspace;
   QScopedPointer<Ui::LibraryListEditorWidget> mUi;
   QSet<Uuid>                                  mUuids;
+  QHash<Uuid, QString>                        mLibNames;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -123,7 +123,7 @@ LibraryOverviewWidget::LibraryOverviewWidget(const Context&          context,
   // Load all library elements.
   updateElementLists();
   connect(&mContext.workspace.getLibraryDb(),
-          &workspace::WorkspaceLibraryDb::scanSucceeded, this,
+          &workspace::WorkspaceLibraryDb::scanFinished, this,
           &LibraryOverviewWidget::updateElementLists);
 }
 

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -123,7 +123,7 @@ LibraryEditor::LibraryEditor(workspace::Workspace&   ws,
           &workspace::WorkspaceLibraryDb::scanStarted, mUi->statusBar,
           &StatusBar::showProgressBar, Qt::QueuedConnection);
   connect(&mWorkspace.getLibraryDb(),
-          &workspace::WorkspaceLibraryDb::scanSucceeded, mUi->statusBar,
+          &workspace::WorkspaceLibraryDb::scanFinished, mUi->statusBar,
           &StatusBar::hideProgressBar, Qt::QueuedConnection);
   connect(&mWorkspace.getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanProgressUpdate, mUi->statusBar,

--- a/libs/librepcb/librarymanager/addlibrarywidget.h
+++ b/libs/librepcb/librarymanager/addlibrarywidget.h
@@ -69,14 +69,12 @@ public:
 
   // General Methods
   void updateRepositoryLibraryList() noexcept;
-  void updateInstalledStatusOfRepositoryLibraries() noexcept;
 
   // Operator Overloadings
   AddLibraryWidget& operator=(const AddLibraryWidget& rhs) = delete;
 
 signals:
-
-  void libraryAdded(const FilePath& libDir, bool select);
+  void libraryAdded(const FilePath& libDir);
 
 private:  // Methods
   void localLibraryNameLineEditTextChanged(QString name) noexcept;

--- a/libs/librepcb/librarymanager/libraryinfowidget.h
+++ b/libs/librepcb/librarymanager/libraryinfowidget.h
@@ -23,7 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/common/exceptions.h>
+#include <librepcb/common/fileio/filepath.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -53,9 +53,6 @@ class LibraryInfoWidget;
 
 /**
  * @brief The LibraryInfoWidget class
- *
- * @author ubruhin
- * @date 2016-08-03
  */
 class LibraryInfoWidget final : public QWidget {
   Q_OBJECT
@@ -64,8 +61,7 @@ public:
   // Constructors / Destructor
   LibraryInfoWidget() noexcept;
   LibraryInfoWidget(const LibraryInfoWidget& other) = delete;
-  LibraryInfoWidget(workspace::Workspace&   ws,
-                    QSharedPointer<Library> lib) noexcept;
+  LibraryInfoWidget(workspace::Workspace& ws, const FilePath& libDir);
   ~LibraryInfoWidget() noexcept;
 
   // Getters
@@ -75,9 +71,7 @@ public:
   LibraryInfoWidget& operator=(const LibraryInfoWidget& rhs) = delete;
 
 signals:
-
-  void libraryRemoved(const FilePath& libDir);
-  void openLibraryEditorTriggered(QSharedPointer<Library> lib);
+  void openLibraryEditorTriggered(const FilePath& libDir);
 
 private:  // Methods
   void btnOpenLibraryEditorClicked() noexcept;
@@ -87,7 +81,7 @@ private:  // Methods
 private:  // Data
   QScopedPointer<Ui::LibraryInfoWidget> mUi;
   workspace::Workspace&                 mWorkspace;
-  QSharedPointer<Library>               mLib;
+  FilePath                              mLibDir;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
@@ -24,8 +24,6 @@
 
 #include "ui_librarylistwidgetitem.h"
 
-#include <librepcb/library/library.h>
-#include <librepcb/workspace/settings/workspacesettings.h>
 #include <librepcb/workspace/workspace.h>
 
 #include <QtCore>
@@ -42,19 +40,20 @@ namespace manager {
  *  Constructors / Destructor
  ******************************************************************************/
 
-LibraryListWidgetItem::LibraryListWidgetItem(
-    workspace::Workspace& ws, QSharedPointer<Library> lib) noexcept
+LibraryListWidgetItem::LibraryListWidgetItem(workspace::Workspace& ws,
+                                             const FilePath&       libDir,
+                                             const QString&        name,
+                                             const QString&        description,
+                                             const QPixmap& icon) noexcept
   : QWidget(nullptr),
     mUi(new Ui::LibraryListWidgetItem),
-    mWorkspace(ws),
-    mLib(lib) {
+    mLibDir(libDir),
+    mIsRemoteLibrary(libDir.isLocatedInDir(ws.getRemoteLibrariesPath())) {
   mUi->setupUi(this);
 
-  if (lib) {
-    const QStringList& localeOrder =
-        ws.getSettings().getLibLocaleOrder().getLocaleOrder();
-    if (!lib->getIconAsPixmap().isNull()) {
-      mUi->lblIcon->setPixmap(lib->getIconAsPixmap());
+  if (mLibDir.isValid()) {
+    if (!icon.isNull()) {
+      mUi->lblIcon->setPixmap(icon);
     }
     if (isRemoteLibrary()) {
       mUi->lblLibraryType->setText(tr("(remote)"));
@@ -63,11 +62,9 @@ LibraryListWidgetItem::LibraryListWidgetItem(
       mUi->lblLibraryType->setText(tr("(local)"));
       mUi->lblLibraryType->setStyleSheet("QLabel { color: blue; }");
     }
-    mUi->lblLibraryName->setText(*lib->getNames().value(localeOrder));
-    mUi->lblLibraryDescription->setText(
-        lib->getDescriptions().value(localeOrder));
-    mUi->lblLibraryUrl->setText(
-        lib->getFilePath().toRelative(ws.getLibrariesPath()));
+    mUi->lblLibraryName->setText(name);
+    mUi->lblLibraryDescription->setText(description);
+    mUi->lblLibraryUrl->setText(libDir.toRelative(ws.getLibrariesPath()));
   } else {
     QPixmap image(":/img/actions/add.png");
     mUi->lblIcon->setPixmap(image.scaled(
@@ -94,17 +91,13 @@ QString LibraryListWidgetItem::getName() const noexcept {
   return mUi->lblLibraryName->text();
 }
 
-bool LibraryListWidgetItem::isRemoteLibrary() const noexcept {
-  return mLib ? mLib->isOpenedReadOnly() : false;
-}
-
 /*******************************************************************************
  *  Inherited from QWidget
  ******************************************************************************/
 
 void LibraryListWidgetItem::mouseDoubleClickEvent(QMouseEvent* e) noexcept {
-  if (mLib) {
-    emit openLibraryEditorTriggered(mLib);
+  if (mLibDir.isValid()) {
+    emit openLibraryEditorTriggered(mLibDir);
     e->accept();
   } else {
     QWidget::mouseDoubleClickEvent(e);

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.h
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.h
@@ -23,7 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/common/exceptions.h>
+#include <librepcb/common/fileio/filepath.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -38,9 +38,6 @@ class Workspace;
 }
 
 namespace library {
-
-class Library;
-
 namespace manager {
 
 namespace Ui {
@@ -64,14 +61,16 @@ public:
   // Constructors / Destructor
   LibraryListWidgetItem() noexcept;
   LibraryListWidgetItem(const LibraryListWidgetItem& other) = delete;
-  LibraryListWidgetItem(workspace::Workspace&   ws,
-                        QSharedPointer<Library> lib) noexcept;
+  LibraryListWidgetItem(workspace::Workspace& ws, const FilePath& libDir,
+                        const QString& name        = "",
+                        const QString& description = "",
+                        const QPixmap& icon        = QPixmap()) noexcept;
   ~LibraryListWidgetItem() noexcept;
 
   // Getters
-  QSharedPointer<Library> getLibrary() const noexcept { return mLib; }
-  QString                 getName() const noexcept;
-  bool                    isRemoteLibrary() const noexcept;
+  const FilePath& getLibraryFilePath() const noexcept { return mLibDir; }
+  QString         getName() const noexcept;
+  bool            isRemoteLibrary() const noexcept { return mIsRemoteLibrary; }
 
   // Operator Overloadings
   LibraryListWidgetItem& operator=(const LibraryListWidgetItem& rhs) = delete;
@@ -80,12 +79,12 @@ protected:  // Methods
   void mouseDoubleClickEvent(QMouseEvent* e) noexcept override;
 
 signals:
-  void openLibraryEditorTriggered(QSharedPointer<Library> lib);
+  void openLibraryEditorTriggered(const FilePath& libDir);
 
 private:  // Data
   QScopedPointer<Ui::LibraryListWidgetItem> mUi;
-  workspace::Workspace&                     mWorkspace;
-  QSharedPointer<Library>                   mLib;
+  FilePath                                  mLibDir;
+  bool                                      mIsRemoteLibrary;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/librarymanager/librarymanager.cpp
+++ b/libs/librepcb/librarymanager/librarymanager.cpp
@@ -51,7 +51,8 @@ LibraryManager::LibraryManager(workspace::Workspace& ws,
   : QMainWindow(parent),
     mWorkspace(ws),
     mUi(new Ui::LibraryManager),
-    mCurrentWidget(nullptr) {
+    mCurrentWidget(nullptr),
+    mSelectedLibrary() {
   mUi->setupUi(this);
   connect(mUi->btnClose, &QPushButton::clicked, this, &QMainWindow::close);
   connect(mUi->lstLibraries, &QListWidget::currentItemChanged, this,
@@ -62,7 +63,10 @@ LibraryManager::LibraryManager(workspace::Workspace& ws,
   connect(mAddLibraryWidget.data(), &AddLibraryWidget::libraryAdded, this,
           &LibraryManager::libraryAddedSlot);
 
-  loadLibraryList();
+  updateLibraryList();
+  connect(&mWorkspace.getLibraryDb(),
+          &workspace::WorkspaceLibraryDb::scanLibraryListUpdated, this,
+          &LibraryManager::updateLibraryList);
 }
 
 LibraryManager::~LibraryManager() noexcept {
@@ -98,37 +102,57 @@ void LibraryManager::clearLibraryList() noexcept {
   Q_ASSERT(mUi->lstLibraries->count() == 0);
 }
 
-void LibraryManager::loadLibraryList() noexcept {
+void LibraryManager::updateLibraryList() noexcept {
+  FilePath selectedLibrary = mSelectedLibrary;
+
+  clearLibraryList();
+
   QList<LibraryListWidgetItem*> widgets;
 
   // add the "Add new library" item
-  widgets.append(new LibraryListWidgetItem(mWorkspace,
-                                           QSharedPointer<library::Library>()));
+  widgets.append(new LibraryListWidgetItem(mWorkspace, FilePath()));
 
   // add all existing libraries
-  QList<QSharedPointer<library::Library>> libraries;
-  libraries.append(mWorkspace.getLocalLibraries().values());
-  libraries.append(mWorkspace.getRemoteLibraries().values());
-  foreach (const QSharedPointer<library::Library>& lib, libraries) {
-    LibraryListWidgetItem* widget = new LibraryListWidgetItem(mWorkspace, lib);
-    connect(widget, &LibraryListWidgetItem::openLibraryEditorTriggered, this,
-            &LibraryManager::openLibraryEditorTriggered);
-    widgets.append(widget);
+  try {
+    QMultiMap<Version, FilePath> libraries =
+        mWorkspace.getLibraryDb().getLibraries();  // can throw
+
+    foreach (const FilePath& libDir, libraries) {
+      QString name, description, keywords;
+      mWorkspace.getLibraryDb().getElementTranslations<Library>(
+          libDir, mWorkspace.getSettings().getLibLocaleOrder().getLocaleOrder(),
+          &name, &description, &keywords);  // can throw
+      QPixmap icon;
+      mWorkspace.getLibraryDb().getLibraryMetadata(libDir, &icon);  // can throw
+
+      LibraryListWidgetItem* widget = new LibraryListWidgetItem(
+          mWorkspace, libDir, name, description, icon);
+      connect(widget, &LibraryListWidgetItem::openLibraryEditorTriggered, this,
+              &LibraryManager::openLibraryEditorTriggered);
+      widgets.append(widget);
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(this, tr("Could not load library list"), e.getMsg());
   }
 
   // sort all list widget items
   qSort(widgets.begin(), widgets.end(), widgetsLessThan);
 
   // populate the list widget
-  foreach (LibraryListWidgetItem* widget, widgets) {
+  int selectedLibraryIndex = 0;
+  for (int i = 0; i < widgets.count(); ++i) {
+    LibraryListWidgetItem* widget = widgets.at(i);
     Q_ASSERT(widget);
     QListWidgetItem* item = new QListWidgetItem(mUi->lstLibraries);
     item->setSizeHint(widget->sizeHint());
     mUi->lstLibraries->setItemWidget(item, widget);
+    if (widget->getLibraryFilePath() == selectedLibrary) {
+      selectedLibraryIndex = i;
+    }
   }
 
-  // select the first item in the list
-  mUi->lstLibraries->setCurrentRow(0);
+  // select the previously selected library
+  mUi->lstLibraries->setCurrentRow(selectedLibraryIndex);
 }
 
 void LibraryManager::currentListItemChanged(
@@ -140,18 +164,23 @@ void LibraryManager::currentListItemChanged(
     mCurrentWidget = nullptr;
   }
 
+  mSelectedLibrary = FilePath();
+
   if (current) {
     LibraryListWidgetItem* item = dynamic_cast<LibraryListWidgetItem*>(
         mUi->lstLibraries->itemWidget(current));
-    if (item && (!item->getLibrary().isNull())) {
-      QSharedPointer<library::Library> lib = item->getLibrary();
-      LibraryInfoWidget* widget = new LibraryInfoWidget(mWorkspace, lib);
-      connect(widget, &LibraryInfoWidget::openLibraryEditorTriggered, this,
-              &LibraryManager::openLibraryEditorTriggered);
-      connect(widget, &LibraryInfoWidget::libraryRemoved, this,
-              &LibraryManager::libraryRemovedSlot);
-      mUi->verticalLayout->insertWidget(0, widget);
-      mCurrentWidget = widget;
+    if (item && item->getLibraryFilePath().isValid()) {
+      try {
+        LibraryInfoWidget* widget = new LibraryInfoWidget(
+            mWorkspace, item->getLibraryFilePath());  // can throw
+        connect(widget, &LibraryInfoWidget::openLibraryEditorTriggered, this,
+                &LibraryManager::openLibraryEditorTriggered);
+        mUi->verticalLayout->insertWidget(0, widget);
+        mCurrentWidget   = widget;
+        mSelectedLibrary = item->getLibraryFilePath();
+      } catch (const Exception& e) {
+        QMessageBox::critical(this, tr("Error"), e.getMsg());
+      }
     }
   } else {
     mCurrentWidget = new QWidget();
@@ -161,33 +190,12 @@ void LibraryManager::currentListItemChanged(
   mAddLibraryWidget->setVisible(mCurrentWidget ? false : true);
 }
 
-void LibraryManager::libraryAddedSlot(const FilePath& libDir,
-                                      bool            select) noexcept {
-  clearLibraryList();
-  loadLibraryList();
-  mAddLibraryWidget->updateInstalledStatusOfRepositoryLibraries();
-
-  if (select) {
-    // select the new item
-    for (int i = 0; i < mUi->lstLibraries->count(); i++) {
-      QListWidgetItem* item = mUi->lstLibraries->item(i);
-      Q_ASSERT(item);
-      LibraryListWidgetItem* widget = dynamic_cast<LibraryListWidgetItem*>(
-          mUi->lstLibraries->itemWidget(item));
-      if (widget && widget->getLibrary() &&
-          widget->getLibrary()->getFilePath() == libDir) {
-        mUi->lstLibraries->setCurrentItem(item);
-        break;
-      }
-    }
-  }
-}
-
-void LibraryManager::libraryRemovedSlot(const FilePath& libDir) noexcept {
-  Q_UNUSED(libDir);
-  clearLibraryList();
-  loadLibraryList();
-  mAddLibraryWidget->updateInstalledStatusOfRepositoryLibraries();
+void LibraryManager::libraryAddedSlot(const FilePath& libDir) noexcept {
+  // Update the selected library and start library scan - the library list will
+  // be updated soon (triggered by the workspace library scanner), then the new
+  // library will be selected as soon as it appears in the list.
+  mSelectedLibrary = libDir;
+  mWorkspace.getLibraryDb().startLibraryRescan();
 }
 
 /*******************************************************************************
@@ -202,9 +210,9 @@ bool LibraryManager::widgetsLessThan(const LibraryListWidgetItem* a,
   } else if (a->isRemoteLibrary() && !b->isRemoteLibrary()) {
     return false;
   } else {
-    if (a->getLibrary().isNull()) {
+    if (!a->getLibraryFilePath().isValid()) {
       return true;
-    } else if (b->getLibrary().isNull()) {
+    } else if (!b->getLibraryFilePath().isValid()) {
       return false;
     } else {
       return a->getName().toLower() < b->getName().toLower();

--- a/libs/librepcb/librarymanager/librarymanager.h
+++ b/libs/librepcb/librarymanager/librarymanager.h
@@ -23,7 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/common/exceptions.h>
+#include <librepcb/common/fileio/filepath.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -79,23 +79,23 @@ public:
 private:  // Methods
   void closeEvent(QCloseEvent* event) noexcept override;
   void clearLibraryList() noexcept;
-  void loadLibraryList() noexcept;
+  void updateLibraryList() noexcept;
   void currentListItemChanged(QListWidgetItem* current,
                               QListWidgetItem* previous) noexcept;
-  void libraryAddedSlot(const FilePath& libDir, bool select) noexcept;
-  void libraryRemovedSlot(const FilePath& libDir) noexcept;
+  void libraryAddedSlot(const FilePath& libDir) noexcept;
 
   static bool widgetsLessThan(const LibraryListWidgetItem* a,
                               const LibraryListWidgetItem* b) noexcept;
 
 signals:
-  void openLibraryEditorTriggered(QSharedPointer<Library> lib);
+  void openLibraryEditorTriggered(const FilePath& libDir);
 
 private:  // Data
   workspace::Workspace&              mWorkspace;
   QScopedPointer<Ui::LibraryManager> mUi;
   QScopedPointer<AddLibraryWidget>   mAddLibraryWidget;
   QWidget*                           mCurrentWidget;
+  FilePath                           mSelectedLibrary;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -27,6 +27,7 @@
 
 #include <librepcb/common/network/networkrequest.h>
 #include <librepcb/library/library.h>
+#include <librepcb/workspace/library/workspacelibrarydb.h>
 #include <librepcb/workspace/workspace.h>
 
 #include <QtCore>
@@ -86,6 +87,9 @@ RepositoryLibraryListWidgetItem::RepositoryLibraryListWidgetItem(
 
   // check if this library is already installed
   updateInstalledStatus();
+  connect(&mWorkspace.getLibraryDb(),
+          &workspace::WorkspaceLibraryDb::scanLibraryListUpdated, this,
+          &RepositoryLibraryListWidgetItem::updateInstalledStatus);
 }
 
 RepositoryLibraryListWidgetItem::~RepositoryLibraryListWidgetItem() noexcept {
@@ -110,41 +114,6 @@ void RepositoryLibraryListWidgetItem::setChecked(bool checked) noexcept {
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
-
-void RepositoryLibraryListWidgetItem::updateInstalledStatus() noexcept {
-  if (mUuid) {
-    QSharedPointer<library::Library> lib =
-        mWorkspace.getLibrary(*mUuid, true, true);
-    if (lib) {
-      mUi->lblInstalledVersion->setText(
-          QString(tr("Installed: v%1")).arg(lib->getVersion().toStr()));
-      mUi->lblInstalledVersion->setVisible(true);
-      if (lib->getVersion() < mVersion) {
-        mUi->lblInstalledVersion->setStyleSheet("QLabel {color: red;}");
-        mUi->cbxDownload->setText(tr("Update"));
-        mUi->cbxDownload->setVisible(true);
-      } else {
-        mUi->lblInstalledVersion->setStyleSheet("QLabel {color: green;}");
-        mUi->cbxDownload->setVisible(false);
-      }
-    } else {
-      if (mIsRecommended) {
-        mUi->lblInstalledVersion->setText(tr("Recommended"));
-        mUi->lblInstalledVersion->setStyleSheet("QLabel {color: blue;}");
-        mUi->lblInstalledVersion->setVisible(true);
-      } else {
-        mUi->lblInstalledVersion->setVisible(false);
-      }
-      mUi->cbxDownload->setText(tr("Install"));
-      mUi->cbxDownload->setVisible(true);
-    }
-  } else {
-    mUi->lblInstalledVersion->setText(tr("Error: Invalid UUID"));
-    mUi->lblInstalledVersion->setStyleSheet("QLabel {color: red;}");
-    mUi->lblInstalledVersion->setVisible(true);
-    mUi->cbxDownload->setVisible(false);
-  }
-}
 
 void RepositoryLibraryListWidgetItem::startDownloadIfSelected() noexcept {
   if (mUuid && mUi->cbxDownload->isVisible() && mUi->cbxDownload->isChecked() &&
@@ -189,23 +158,7 @@ void RepositoryLibraryListWidgetItem::downloadFinished(
     bool success, const QString& errMsg) noexcept {
   Q_ASSERT(mLibraryDownload);
 
-  if (success) {
-    try {
-      // if the library exists already in the workspace, remove it first
-      QString libDirName = mLibraryDownload->getDestinationDir().getFilename();
-      if (mWorkspace.getRemoteLibraries().contains(libDirName)) {
-        mWorkspace.removeRemoteLibrary(libDirName, false);  // can throw
-      }
-
-      // add downloaded library to workspace
-      mWorkspace.addRemoteLibrary(libDirName);  // can throw
-
-      // finish
-      emit libraryAdded(mLibraryDownload->getDestinationDir(), false);
-    } catch (const Exception& e) {
-      QMessageBox::critical(this, tr("Download failed"), e.getMsg());
-    }
-  } else if (!errMsg.isEmpty()) {
+  if ((!success) && (!errMsg.isEmpty())) {
     QMessageBox::critical(this, tr("Download failed"), errMsg);
   }
 
@@ -217,6 +170,9 @@ void RepositoryLibraryListWidgetItem::downloadFinished(
 
   // delete download helper
   mLibraryDownload.reset();
+
+  // start library scanner to index the new library
+  mWorkspace.getLibraryDb().startLibraryRescan();
 }
 
 void RepositoryLibraryListWidgetItem::iconReceived(
@@ -224,6 +180,52 @@ void RepositoryLibraryListWidgetItem::iconReceived(
   QPixmap pixmap;
   pixmap.loadFromData(data);
   mUi->lblIcon->setPixmap(pixmap);
+}
+
+void RepositoryLibraryListWidgetItem::updateInstalledStatus() noexcept {
+  if (mUuid) {
+    tl::optional<Version> installedVersion;
+    try {
+      FilePath fp =
+          mWorkspace.getLibraryDb().getLatestLibrary(*mUuid);  // can throw
+      if (fp.isValid()) {
+        Version v = Version::fromString("0.1");  // only for initialization
+        mWorkspace.getLibraryDb().getElementMetadata<Library>(fp, nullptr,
+                                                              &v);  // can throw
+        installedVersion = v;
+      }
+    } catch (const Exception& e) {
+      qCritical() << "Could not determine if library is installed.";
+    }
+    if (installedVersion) {
+      mUi->lblInstalledVersion->setText(
+          QString(tr("Installed: v%1")).arg(installedVersion->toStr()));
+      mUi->lblInstalledVersion->setVisible(true);
+      if (installedVersion < mVersion) {
+        mUi->lblInstalledVersion->setStyleSheet("QLabel {color: red;}");
+        mUi->cbxDownload->setText(tr("Update"));
+        mUi->cbxDownload->setVisible(true);
+      } else {
+        mUi->lblInstalledVersion->setStyleSheet("QLabel {color: green;}");
+        mUi->cbxDownload->setVisible(false);
+      }
+    } else {
+      if (mIsRecommended) {
+        mUi->lblInstalledVersion->setText(tr("Recommended"));
+        mUi->lblInstalledVersion->setStyleSheet("QLabel {color: blue;}");
+        mUi->lblInstalledVersion->setVisible(true);
+      } else {
+        mUi->lblInstalledVersion->setVisible(false);
+      }
+      mUi->cbxDownload->setText(tr("Install"));
+      mUi->cbxDownload->setVisible(true);
+    }
+  } else {
+    mUi->lblInstalledVersion->setText(tr("Error: Invalid UUID"));
+    mUi->lblInstalledVersion->setStyleSheet("QLabel {color: red;}");
+    mUi->lblInstalledVersion->setVisible(true);
+    mUi->cbxDownload->setVisible(false);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.h
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.h
@@ -80,7 +80,6 @@ public:
   void setChecked(bool checked) noexcept;
 
   // General Methods
-  void updateInstalledStatus() noexcept;
   void startDownloadIfSelected() noexcept;
 
   // Operator Overloadings
@@ -88,13 +87,12 @@ public:
       const RepositoryLibraryListWidgetItem& rhs) = delete;
 
 signals:
-
   void checkedChanged(bool checked);
-  void libraryAdded(const FilePath& libDir, bool select);
 
 private:  // Methods
   void downloadFinished(bool success, const QString& errMsg) noexcept;
   void iconReceived(const QByteArray& data) noexcept;
+  void updateInstalledStatus() noexcept;
 
 private:  // Data
   workspace::Workspace&                               mWorkspace;

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -224,7 +224,7 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
           &workspace::WorkspaceLibraryDb::scanStarted, mUi->statusbar,
           &StatusBar::showProgressBar, Qt::QueuedConnection);
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
-          &workspace::WorkspaceLibraryDb::scanSucceeded, mUi->statusbar,
+          &workspace::WorkspaceLibraryDb::scanFinished, mUi->statusbar,
           &StatusBar::hideProgressBar, Qt::QueuedConnection);
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanProgressUpdate, mUi->statusbar,

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -190,7 +190,7 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
           &workspace::WorkspaceLibraryDb::scanStarted, mUi->statusbar,
           &StatusBar::showProgressBar, Qt::QueuedConnection);
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
-          &workspace::WorkspaceLibraryDb::scanSucceeded, mUi->statusbar,
+          &workspace::WorkspaceLibraryDb::scanFinished, mUi->statusbar,
           &StatusBar::hideProgressBar, Qt::QueuedConnection);
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanProgressUpdate, mUi->statusbar,

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -462,7 +462,7 @@ QSet<Uuid> WorkspaceLibraryDb::getComponentsBySearchKeyword(
  ******************************************************************************/
 
 void WorkspaceLibraryDb::startLibraryRescan() noexcept {
-  mLibraryScanner->start();
+  mLibraryScanner->startScan();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -564,12 +564,14 @@ void WorkspaceLibraryDb::createAllTables() {
       "`id` INTEGER PRIMARY KEY NOT NULL, "
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
-      "`version` TEXT NOT NULL "
+      "`version` TEXT NOT NULL, "
+      "`icon_png` BLOB "
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS libraries_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER REFERENCES libraries(id) NOT NULL, "
+      "`lib_id` INTEGER "
+      "REFERENCES libraries(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
@@ -590,7 +592,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS component_categories_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`cat_id` INTEGER REFERENCES component_categories(id) NOT NULL, "
+      "`cat_id` INTEGER "
+      "REFERENCES component_categories(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
@@ -611,7 +614,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS package_categories_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`cat_id` INTEGER REFERENCES package_categories(id) NOT NULL, "
+      "`cat_id` INTEGER "
+      "REFERENCES package_categories(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
@@ -631,7 +635,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS symbols_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`symbol_id` INTEGER REFERENCES symbols(id) NOT NULL, "
+      "`symbol_id` INTEGER "
+      "REFERENCES symbols(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
@@ -641,7 +646,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS symbols_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`symbol_id` INTEGER REFERENCES symbols(id) NOT NULL, "
+      "`symbol_id` INTEGER "
+      "REFERENCES symbols(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
       "UNIQUE(symbol_id, category_uuid)"
       ")");
@@ -658,7 +664,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS packages_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`package_id` INTEGER REFERENCES packages(id) NOT NULL, "
+      "`package_id` INTEGER "
+      "REFERENCES packages(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
@@ -668,7 +675,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS packages_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`package_id` INTEGER REFERENCES packages(id) NOT NULL, "
+      "`package_id` INTEGER "
+      "REFERENCES packages(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
       "UNIQUE(package_id, category_uuid)"
       ")");
@@ -685,7 +693,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS components_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`component_id` INTEGER REFERENCES components(id) NOT NULL, "
+      "`component_id` INTEGER "
+      "REFERENCES components(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
@@ -695,7 +704,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS components_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`component_id` INTEGER REFERENCES components(id) NOT NULL, "
+      "`component_id` INTEGER "
+      "REFERENCES components(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
       "UNIQUE(component_id, category_uuid)"
       ")");
@@ -714,7 +724,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS devices_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`device_id` INTEGER REFERENCES devices(id) NOT NULL, "
+      "`device_id` INTEGER "
+      "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
@@ -724,7 +735,8 @@ void WorkspaceLibraryDb::createAllTables() {
   queries << QString(
       "CREATE TABLE IF NOT EXISTS devices_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`device_id` INTEGER REFERENCES devices(id) NOT NULL, "
+      "`device_id` INTEGER "
+      "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
       "UNIQUE(device_id, category_uuid)"
       ")");

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -76,14 +76,19 @@ WorkspaceLibraryDb::WorkspaceLibraryDb(Workspace& ws)
 
   // create library scanner object
   mLibraryScanner.reset(new WorkspaceLibraryScanner(mWorkspace, mFilePath));
-  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::started, this,
+  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::scanStarted, this,
           &WorkspaceLibraryDb::scanStarted, Qt::QueuedConnection);
-  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::progressUpdate,
+  connect(mLibraryScanner.data(),
+          &WorkspaceLibraryScanner::scanLibraryListUpdated, this,
+          &WorkspaceLibraryDb::scanLibraryListUpdated, Qt::QueuedConnection);
+  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::scanProgressUpdate,
           this, &WorkspaceLibraryDb::scanProgressUpdate, Qt::QueuedConnection);
-  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::succeeded, this,
+  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::scanSucceeded, this,
           &WorkspaceLibraryDb::scanSucceeded, Qt::QueuedConnection);
-  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::failed, this,
+  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::scanFailed, this,
           &WorkspaceLibraryDb::scanFailed, Qt::QueuedConnection);
+  connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::scanFinished, this,
+          &WorkspaceLibraryDb::scanFinished, Qt::QueuedConnection);
 
   qDebug("Workspace library database successfully loaded!");
 }

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -71,7 +71,11 @@ public:
   // Getters: Attributes
   const FilePath& getFilePath() const noexcept { return mFilePath; }
 
+  // Getters: Libraries
+  QMultiMap<Version, FilePath> getLibraries() const;
+
   // Getters: Library Elements by their UUID
+  QMultiMap<Version, FilePath> getLibraries(const Uuid& uuid) const;
   QMultiMap<Version, FilePath> getComponentCategories(const Uuid& uuid) const;
   QMultiMap<Version, FilePath> getPackageCategories(const Uuid& uuid) const;
   QMultiMap<Version, FilePath> getSymbols(const Uuid& uuid) const;
@@ -80,6 +84,7 @@ public:
   QMultiMap<Version, FilePath> getDevices(const Uuid& uuid) const;
 
   // Getters: Best Match Library Elements by their UUID
+  FilePath getLatestLibrary(const Uuid& uuid) const;
   FilePath getLatestComponentCategory(const Uuid& uuid) const;
   FilePath getLatestPackageCategory(const Uuid& uuid) const;
   FilePath getLatestSymbol(const Uuid& uuid) const;
@@ -97,6 +102,10 @@ public:
                               const QStringList& localeOrder,
                               QString* name = nullptr, QString* desc = nullptr,
                               QString* keywords = nullptr) const;
+  template <typename ElementType>
+  void getElementMetadata(const FilePath elemDir, Uuid* uuid = nullptr,
+                          Version* version = nullptr) const;
+  void getLibraryMetadata(const FilePath libDir, QPixmap* icon = nullptr) const;
   void getDeviceMetadata(const FilePath& devDir, Uuid* pkgUuid = nullptr) const;
 
   // Getters: Special
@@ -134,6 +143,8 @@ private:
                               const FilePath&    elemDir,
                               const QStringList& localeOrder, QString* name,
                               QString* desc, QString* keywords) const;
+  void getElementMetadata(const QString& table, const FilePath elemDir,
+                          Uuid* uuid, Version* version) const;
   QMultiMap<Version, FilePath> getElementFilePathsFromDb(
       const QString& tablename, const Uuid& uuid) const;
   FilePath getLatestVersionFilePath(

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -161,7 +161,7 @@ private:
   QScopedPointer<WorkspaceLibraryScanner> mLibraryScanner;
 
   // Constants
-  static const int sCurrentDbVersion = 1;
+  static const int sCurrentDbVersion = 2;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -133,9 +133,11 @@ public:
 signals:
 
   void scanStarted();
+  void scanLibraryListUpdated(int libraryCount);
   void scanProgressUpdate(int percent);
   void scanSucceeded(int elementCount);
   void scanFailed(QString errorMsg);
+  void scanFinished();
 
 private:
   // Private Methods

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
@@ -43,11 +43,17 @@ using namespace library;
 
 WorkspaceLibraryScanner::WorkspaceLibraryScanner(
     Workspace& ws, const FilePath& dbFilePath) noexcept
-  : QThread(nullptr), mWorkspace(ws), mDbFilePath(dbFilePath), mAbort(false) {
+  : QThread(nullptr),
+    mWorkspace(ws),
+    mDbFilePath(dbFilePath),
+    mSemaphore(0),
+    mAbort(false) {
+  start();
 }
 
 WorkspaceLibraryScanner::~WorkspaceLibraryScanner() noexcept {
   mAbort = true;
+  mSemaphore.release();
   if (!wait(2000)) {
     qWarning() << "Could not abort the library scanner worker thread!";
     terminate();
@@ -55,6 +61,14 @@ WorkspaceLibraryScanner::~WorkspaceLibraryScanner() noexcept {
       qCritical() << "Could not terminate the library scanner worker thread!";
     }
   }
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void WorkspaceLibraryScanner::startScan() noexcept {
+  mSemaphore.release();
 }
 
 /*******************************************************************************
@@ -74,10 +88,24 @@ QVariant WorkspaceLibraryScanner::optionalToVariant(
 }
 
 void WorkspaceLibraryScanner::run() noexcept {
+  qDebug() << "Workspace library scanner thread started.";
+
+  while (true) {
+    mSemaphore.acquire();
+    if (mAbort) {
+      break;
+    } else {
+      scan();
+    }
+  }
+
+  qDebug() << "Workspace library scanner thread stopped.";
+}
+
+void WorkspaceLibraryScanner::scan() noexcept {
   try {
     QElapsedTimer timer;
     timer.start();
-    mAbort = false;
     emit scanStarted();
     emit scanProgressUpdate(0);
     qDebug() << "Workspace library scan started.";
@@ -108,37 +136,37 @@ void WorkspaceLibraryScanner::run() noexcept {
       int                             libId = libIds[fp];
       const std::shared_ptr<Library>& lib   = libraries[fp];
       Q_ASSERT(lib);
-      if (mAbort) break;
+      if (mAbort || (mSemaphore.available() > 0)) break;
       count += addCategoriesToDb<ComponentCategory>(
           db, lib->searchForElements<ComponentCategory>(),
           "component_categories", "cat_id", libId);
       emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
-      if (mAbort) break;
+      if (mAbort || (mSemaphore.available() > 0)) break;
       count += addCategoriesToDb<PackageCategory>(
           db, lib->searchForElements<PackageCategory>(), "package_categories",
           "cat_id", libId);
       emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
-      if (mAbort) break;
+      if (mAbort || (mSemaphore.available() > 0)) break;
       count += addElementsToDb<Symbol>(db, lib->searchForElements<Symbol>(),
                                        "symbols", "symbol_id", libId);
       emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
-      if (mAbort) break;
+      if (mAbort || (mSemaphore.available() > 0)) break;
       count += addElementsToDb<Package>(db, lib->searchForElements<Package>(),
                                         "packages", "package_id", libId);
       emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
-      if (mAbort) break;
+      if (mAbort || (mSemaphore.available() > 0)) break;
       count +=
           addElementsToDb<Component>(db, lib->searchForElements<Component>(),
                                      "components", "component_id", libId);
       emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
-      if (mAbort) break;
+      if (mAbort || (mSemaphore.available() > 0)) break;
       count += addDevicesToDb(db, lib->searchForElements<Device>(), "devices",
                               "device_id", libId);
       emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
     }
 
     // commit transaction
-    if (!mAbort) {
+    if ((!mAbort) && (mSemaphore.available() == 0)) {
       transactionGuard.commit();  // can throw
       qDebug() << "Workspace library scan succeeded:" << count << "elements in"
                << timer.elapsed() << "ms";
@@ -300,7 +328,7 @@ int WorkspaceLibraryScanner::addCategoriesToDb(SQLiteDatabase&        db,
                                                int                    libId) {
   int count = 0;
   foreach (const FilePath& filepath, dirs) {
-    if (mAbort) break;
+    if (mAbort || (mSemaphore.available() > 0)) break;
     try {
       ElementType element(filepath, true);  // can throw
       QSqlQuery   query = db.prepareQuery(
@@ -352,7 +380,7 @@ int WorkspaceLibraryScanner::addElementsToDb(SQLiteDatabase&        db,
                                              int                    libId) {
   int count = 0;
   foreach (const FilePath& filepath, dirs) {
-    if (mAbort) break;
+    if (mAbort || (mSemaphore.available() > 0)) break;
     try {
       ElementType element(filepath, true);  // can throw
       QSqlQuery   query =
@@ -411,7 +439,7 @@ int WorkspaceLibraryScanner::addDevicesToDb(SQLiteDatabase&        db,
                                             int                    libId) {
   int count = 0;
   foreach (const FilePath& filepath, dirs) {
-    if (mAbort) break;
+    if (mAbort || (mSemaphore.available() > 0)) break;
     try {
       Device    element(filepath, true);  // can throw
       QSqlQuery query = db.prepareQuery("INSERT INTO " % table %

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
@@ -75,16 +75,24 @@ QVariant WorkspaceLibraryScanner::optionalToVariant(
 
 void WorkspaceLibraryScanner::run() noexcept {
   try {
+    QElapsedTimer timer;
+    timer.start();
     mAbort = false;
-    emit started();
-
-    // get a list of all available libraries
-    QList<QSharedPointer<library::Library>> libraries;
-    libraries.append(mWorkspace.getLocalLibraries().values());
-    libraries.append(mWorkspace.getRemoteLibraries().values());
+    emit scanStarted();
+    emit scanProgressUpdate(0);
+    qDebug() << "Workspace library scan started.";
 
     // open SQLite database
     SQLiteDatabase db(mDbFilePath);  // can throw
+
+    // update list of libraries
+    QHash<FilePath, std::shared_ptr<Library>> libraries;
+    getLibrariesOfDirectory(mWorkspace.getLocalLibrariesPath(), libraries);
+    getLibrariesOfDirectory(mWorkspace.getRemoteLibrariesPath(), libraries);
+    QHash<FilePath, int> libIds = updateLibraries(db, libraries);  // can throw
+    emit                 scanLibraryListUpdated(libIds.count());
+    qDebug() << "Workspace libraries indexed:" << libIds.count()
+             << "libraries in" << timer.elapsed() << "ms";
 
     // begin database transaction
     SQLiteDatabase::TransactionScopeGuard transactionGuard(db);  // can throw
@@ -95,52 +103,166 @@ void WorkspaceLibraryScanner::run() noexcept {
     // scan all libraries
     int   count   = 0;
     qreal percent = 0;
-    foreach (const QSharedPointer<Library>& lib, libraries) {
-      int libId = addLibraryToDb(db, lib);
+    foreach (const FilePath& fp, libraries.keys()) {
+      Q_ASSERT(libIds.contains(fp));
+      int                             libId = libIds[fp];
+      const std::shared_ptr<Library>& lib   = libraries[fp];
+      Q_ASSERT(lib);
       if (mAbort) break;
       count += addCategoriesToDb<ComponentCategory>(
           db, lib->searchForElements<ComponentCategory>(),
           "component_categories", "cat_id", libId);
-      emit progressUpdate(percent += qreal(100) / (libraries.count() * 6));
+      emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
       if (mAbort) break;
       count += addCategoriesToDb<PackageCategory>(
           db, lib->searchForElements<PackageCategory>(), "package_categories",
           "cat_id", libId);
-      emit progressUpdate(percent += qreal(100) / (libraries.count() * 6));
+      emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
       if (mAbort) break;
       count += addElementsToDb<Symbol>(db, lib->searchForElements<Symbol>(),
                                        "symbols", "symbol_id", libId);
-      emit progressUpdate(percent += qreal(100) / (libraries.count() * 6));
+      emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
       if (mAbort) break;
       count += addElementsToDb<Package>(db, lib->searchForElements<Package>(),
                                         "packages", "package_id", libId);
-      emit progressUpdate(percent += qreal(100) / (libraries.count() * 6));
+      emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
       if (mAbort) break;
       count +=
           addElementsToDb<Component>(db, lib->searchForElements<Component>(),
                                      "components", "component_id", libId);
-      emit progressUpdate(percent += qreal(100) / (libraries.count() * 6));
+      emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
       if (mAbort) break;
       count += addDevicesToDb(db, lib->searchForElements<Device>(), "devices",
                               "device_id", libId);
-      emit progressUpdate(percent += qreal(100) / (libraries.count() * 6));
+      emit scanProgressUpdate(percent += qreal(100) / (libraries.count() * 6));
     }
 
     // commit transaction
     if (!mAbort) {
       transactionGuard.commit();  // can throw
-      emit succeeded(count);
+      qDebug() << "Workspace library scan succeeded:" << count << "elements in"
+               << timer.elapsed() << "ms";
+      emit scanSucceeded(count);
+    } else {
+      qDebug() << "Workspace library scan aborted after" << timer.elapsed()
+               << "ms.";
     }
   } catch (const Exception& e) {
-    emit failed(e.getMsg());
+    qDebug() << "Workspace library scan failed:" << e.getMsg();
+    emit scanFailed(e.getMsg());
+  }
+  emit scanFinished();
+}
+
+void WorkspaceLibraryScanner::getLibrariesOfDirectory(
+    const FilePath&                            dir,
+    QHash<FilePath, std::shared_ptr<Library>>& libs) noexcept {
+  foreach (const QString& name,
+           QDir(dir.toStr()).entryList(QDir::AllDirs | QDir::NoDotAndDotDot)) {
+    FilePath libDirPath = dir.getPathTo(name);
+    if (Library::isValidElementDirectory<Library>(libDirPath)) {
+      try {
+        libs.insert(libDirPath, std::make_shared<Library>(libDirPath, true));
+      } catch (Exception& e) {
+        qCritical() << "Could not open workspace library!";
+        qCritical() << "Library:" << libDirPath.toNative();
+        qCritical() << "Error:" << e.getMsg();
+      }
+    } else {
+      qWarning() << "Directory is not a valid libary:" << libDirPath.toNative();
+    }
   }
 }
 
-void WorkspaceLibraryScanner::clearAllTables(SQLiteDatabase& db) {
-  // libraries
-  db.clearTable("libraries_tr");
-  db.clearTable("libraries");
+QHash<FilePath, int> WorkspaceLibraryScanner::updateLibraries(
+    SQLiteDatabase& db, const QHash<FilePath, std::shared_ptr<Library>>& libs) {
+  SQLiteDatabase::TransactionScopeGuard transactionGuard(db);  // can throw
 
+  // get IDs of libraries in DB
+  QHash<FilePath, int> dbLibIds;
+  QSqlQuery query = db.prepareQuery("SELECT id, filepath FROM libraries");
+  db.exec(query);
+  while (query.next()) {
+    int      id = query.value(0).toInt();
+    FilePath fp(FilePath::fromRelative(mWorkspace.getLibrariesPath(),
+                                       query.value(1).toString()));
+    if (!fp.isValid()) throw LogicError(__FILE__, __LINE__);
+    dbLibIds[fp] = id;
+  }
+
+  // update existing libraries in DB
+  foreach (const FilePath& fp, libs.keys().toSet() & dbLibIds.keys().toSet()) {
+    Q_ASSERT(dbLibIds.contains(fp));
+    std::shared_ptr<Library> lib = libs[fp];
+    Q_ASSERT(lib);
+    query = db.prepareQuery(
+        "UPDATE libraries SET "
+        "filepath = :filepath, "
+        "uuid = :uuid, "
+        "version = :version, "
+        "icon_png = :icon_png "
+        "WHERE id = :id");
+    query.bindValue(":filepath", fp.toRelative(mWorkspace.getLibrariesPath()));
+    query.bindValue(":uuid", lib->getUuid().toStr());
+    query.bindValue(":version", lib->getVersion().toStr());
+    query.bindValue(":icon_png", lib->getIcon());
+    query.bindValue(":id", dbLibIds[fp]);
+    db.exec(query);
+  }
+
+  // add new libraries to DB
+  foreach (const FilePath& fp, libs.keys().toSet() - dbLibIds.keys().toSet()) {
+    Q_ASSERT(!dbLibIds.contains(fp));
+    std::shared_ptr<Library> lib = libs[fp];
+    Q_ASSERT(lib);
+    query = db.prepareQuery(
+        "INSERT INTO libraries "
+        "(filepath, uuid, version, icon_png) VALUES "
+        "(:filepath, :uuid, :version, :icon_png)");
+    query.bindValue(":filepath", fp.toRelative(mWorkspace.getLibrariesPath()));
+    query.bindValue(":uuid", lib->getUuid().toStr());
+    query.bindValue(":version", lib->getVersion().toStr());
+    query.bindValue(":icon_png", lib->getIcon());
+    dbLibIds[fp] = db.insert(query);
+  }
+
+  // remove no longer existing libraries from DB
+  foreach (const FilePath& fp, dbLibIds.keys().toSet() - libs.keys().toSet()) {
+    Q_ASSERT(dbLibIds.contains(fp));
+    query = db.prepareQuery("DELETE FROM libraries WHERE id = :id");
+    query.bindValue(":id", dbLibIds[fp]);
+    db.exec(query);
+    dbLibIds.remove(fp);
+  }
+
+  // update all library translations
+  db.clearTable("libraries_tr");
+  foreach (const FilePath& fp, libs.keys()) {
+    Q_ASSERT(dbLibIds.contains(fp));
+    std::shared_ptr<Library> lib = libs[fp];
+    Q_ASSERT(lib);
+    foreach (const QString& locale, lib->getAllAvailableLocales()) {
+      query = db.prepareQuery(
+          "INSERT INTO libraries_tr "
+          "(lib_id, locale, name, description, keywords) VALUES "
+          "(:lib_id, :locale, :name, :description, :keywords)");
+      query.bindValue(":lib_id", dbLibIds[fp]);
+      query.bindValue(":locale", locale);
+      query.bindValue(":name",
+                      optionalToVariant(lib->getNames().tryGet(locale)));
+      query.bindValue(":description",
+                      optionalToVariant(lib->getDescriptions().tryGet(locale)));
+      query.bindValue(":keywords",
+                      optionalToVariant(lib->getKeywords().tryGet(locale)));
+      db.insert(query);
+    }
+  }
+
+  transactionGuard.commit();  // can throw
+  return dbLibIds;
+}
+
+void WorkspaceLibraryScanner::clearAllTables(SQLiteDatabase& db) {
   // component categories
   db.clearTable("component_categories_tr");
   db.clearTable("component_categories");
@@ -168,34 +290,6 @@ void WorkspaceLibraryScanner::clearAllTables(SQLiteDatabase& db) {
   db.clearTable("devices_tr");
   db.clearTable("devices_cat");
   db.clearTable("devices");
-}
-
-int WorkspaceLibraryScanner::addLibraryToDb(
-    SQLiteDatabase& db, const QSharedPointer<library::Library>& lib) {
-  QSqlQuery query = db.prepareQuery(
-      "INSERT INTO libraries "
-      "(filepath, uuid, version) VALUES "
-      "(:filepath, :uuid, :version)");
-  query.bindValue(":filepath",
-                  lib->getFilePath().toRelative(mWorkspace.getLibrariesPath()));
-  query.bindValue(":uuid", lib->getUuid().toStr());
-  query.bindValue(":version", lib->getVersion().toStr());
-  int id = db.insert(query);
-  foreach (const QString& locale, lib->getAllAvailableLocales()) {
-    QSqlQuery query = db.prepareQuery(
-        "INSERT INTO libraries_tr "
-        "(lib_id, locale, name, description, keywords) VALUES "
-        "(:element_id, :locale, :name, :description, :keywords)");
-    query.bindValue(":element_id", id);
-    query.bindValue(":locale", locale);
-    query.bindValue(":name", optionalToVariant(lib->getNames().tryGet(locale)));
-    query.bindValue(":description",
-                    optionalToVariant(lib->getDescriptions().tryGet(locale)));
-    query.bindValue(":keywords",
-                    optionalToVariant(lib->getKeywords().tryGet(locale)));
-    db.insert(query);
-  }
-  return id;
 }
 
 template <typename ElementType>

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.h
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.h
@@ -65,6 +65,9 @@ public:
   WorkspaceLibraryScanner(const WorkspaceLibraryScanner& other) = delete;
   ~WorkspaceLibraryScanner() noexcept;
 
+  // General Methods
+  void startScan() noexcept;
+
   // Operator Overloadings
   WorkspaceLibraryScanner& operator=(const WorkspaceLibraryScanner& rhs) =
       delete;
@@ -79,6 +82,7 @@ signals:
 
 private:  // Methods
   void                 run() noexcept override;
+  void                 scan() noexcept;
   QHash<FilePath, int> updateLibraries(
       SQLiteDatabase&                                           db,
       const QHash<FilePath, std::shared_ptr<library::Library>>& libs);
@@ -101,6 +105,7 @@ private:  // Methods
 private:  // Data
   Workspace&    mWorkspace;
   FilePath      mDbFilePath;
+  QSemaphore    mSemaphore;
   volatile bool mAbort;
 };
 

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.h
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.h
@@ -27,6 +27,8 @@
 
 #include <QtCore>
 
+#include <memory>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -53,14 +55,6 @@ class Workspace;
  * @warning Be very careful with dependencies to other objects as the #run()
  * method is executed in a separate thread! Keep the number of dependencies as
  * small as possible and consider thread synchronization and object lifetimes.
- *
- * @todo    Don't really sure that the #run() method is 100% thread save ;)
- *          Maybe it would be better to put the whole library scanning code into
- * this class instead of having references to objects from the library and
- * workspace namespaces. This way it would be easier to guarantee thread safety.
- *
- * @author ubruhin
- * @date 2016-09-06
  */
 class WorkspaceLibraryScanner final : public QThread {
   Q_OBJECT
@@ -76,17 +70,22 @@ public:
       delete;
 
 signals:
-
-  void started();
-  void progressUpdate(int percent);
-  void succeeded(int elementCount);
-  void failed(QString errorMsg);
+  void scanStarted();
+  void scanLibraryListUpdated(int libraryCount);
+  void scanProgressUpdate(int percent);
+  void scanSucceeded(int elementCount);
+  void scanFailed(QString errorMsg);
+  void scanFinished();
 
 private:  // Methods
-  void run() noexcept override;
+  void                 run() noexcept override;
+  QHash<FilePath, int> updateLibraries(
+      SQLiteDatabase&                                           db,
+      const QHash<FilePath, std::shared_ptr<library::Library>>& libs);
   void clearAllTables(SQLiteDatabase& db);
-  int  addLibraryToDb(SQLiteDatabase&                         db,
-                      const QSharedPointer<library::Library>& lib);
+  void getLibrariesOfDirectory(
+      const FilePath&                                     dir,
+      QHash<FilePath, std::shared_ptr<library::Library>>& libs) noexcept;
   template <typename ElementType>
   int addCategoriesToDb(SQLiteDatabase& db, const QList<FilePath>& dirs,
                         const QString& table, const QString& idColumn,

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -112,59 +112,8 @@ Workspace::Workspace(const FilePath& wsPath)
   // load workspace settings
   mWorkspaceSettings.reset(new WorkspaceSettings(*this));
 
-  // load local libraries
-  FilePath localLibsDirPath = getLocalLibrariesPath();
-  QDir     localLibsDir(localLibsDirPath.toStr());
-  foreach (const QString& dir,
-           localLibsDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot)) {
-    FilePath libDirPath = localLibsDirPath.getPathTo(dir);
-    if (Library::isValidElementDirectory<Library>(libDirPath)) {
-      qDebug() << "Load local workspace library:" << dir;
-      try {
-        addLocalLibrary(dir);  // can throw
-      } catch (Exception& e) {
-        // @todo do not show a message box here, better use something like a
-        // getLastError() method which is used by the ControlPanel to show
-        // errors
-        QMessageBox::critical(nullptr, tr("Error"),
-                              QString(tr("Could not open local library %1: %2"))
-                                  .arg(dir, e.getMsg()));
-      }
-    } else {
-      qWarning() << "Directory is not a valid libary:" << libDirPath.toNative();
-    }
-  }
-
-  // load remote libraries
-  FilePath remoteLibsDirPath = getRemoteLibrariesPath();
-  QDir     remoteLibsDir(remoteLibsDirPath.toStr());
-  foreach (const QString& dir,
-           remoteLibsDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot)) {
-    FilePath libDirPath = remoteLibsDirPath.getPathTo(dir);
-    if (Library::isValidElementDirectory<Library>(libDirPath)) {
-      qDebug() << "Load remote workspace library:" << dir;
-      try {
-        addRemoteLibrary(dir);  // can throw
-      } catch (Exception& e) {
-        // @todo do not show a message box here, better use something like a
-        // getLastError() method which is used by the ControlPanel to show
-        // errors
-        QMessageBox::critical(
-            nullptr, tr("Error"),
-            QString(tr("Could not open remote library %1: %2"))
-                .arg(dir, e.getMsg()));
-      }
-    } else {
-      qWarning() << "Directory is not a valid libary:" << libDirPath.toNative();
-    }
-  }
-
   // load library database
   mLibraryDb.reset(new WorkspaceLibraryDb(*this));  // can throw
-  connect(this, &Workspace::libraryAdded, mLibraryDb.data(),
-          &WorkspaceLibraryDb::startLibraryRescan);
-  connect(this, &Workspace::libraryRemoved, mLibraryDb.data(),
-          &WorkspaceLibraryDb::startLibraryRescan);
 
   // load project models
   mRecentProjectsModel.reset(new RecentProjectsModel(*this));
@@ -189,79 +138,6 @@ RecentProjectsModel& Workspace::getRecentProjectsModel() const noexcept {
 
 FavoriteProjectsModel& Workspace::getFavoriteProjectsModel() const noexcept {
   return *mFavoriteProjectsModel;
-}
-
-/*******************************************************************************
- *  Library Management
- ******************************************************************************/
-
-QSharedPointer<library::Library> Workspace::getLibrary(const Uuid& uuid,
-                                                       bool        local,
-                                                       bool        remote) const
-    noexcept {
-  QSharedPointer<library::Library> library;
-  if (local) {
-    foreach (const auto& lib, mLocalLibraries) {
-      Q_ASSERT(lib);
-      if ((lib->getUuid() == uuid) &&
-          ((!library) || (library->getVersion() < lib->getVersion()))) {
-        library = lib;
-      }
-    }
-  }
-  if (remote) {
-    foreach (const auto& lib, mRemoteLibraries) {
-      Q_ASSERT(lib);
-      if ((lib->getUuid() == uuid) &&
-          ((!library) || (library->getVersion() < lib->getVersion()))) {
-        library = lib;
-      }
-    }
-  }
-  return library;
-}
-
-void Workspace::addLocalLibrary(const QString& libDirName) {
-  if (!mLocalLibraries.contains(libDirName)) {
-    FilePath libDirPath =
-        mLibrariesPath.getPathTo("local").getPathTo(libDirName);
-    QSharedPointer<Library> library(
-        new Library(libDirPath, false));  // can throw
-    mLocalLibraries.insert(libDirName, library);
-    emit libraryAdded(libDirPath);
-  }
-}
-
-void Workspace::addRemoteLibrary(const QString& libDirName) {
-  if (!mRemoteLibraries.contains(libDirName)) {
-    // remote libraries are always opened read-only!
-    FilePath libDirPath =
-        mLibrariesPath.getPathTo("remote").getPathTo(libDirName);
-    QSharedPointer<Library> library(
-        new Library(libDirPath, true));  // can throw
-    mRemoteLibraries.insert(libDirName, library);
-    emit libraryAdded(libDirPath);
-  }
-}
-
-void Workspace::removeLocalLibrary(const QString& libDirName, bool rmDir) {
-  Library* library = mLocalLibraries.value(libDirName).data();
-  if (library) {
-    FilePath libDirPath = library->getFilePath();
-    mLocalLibraries.remove(libDirName);
-    emit libraryRemoved(libDirPath);
-    if (rmDir) FileUtils::removeDirRecursively(libDirPath);  // can throw
-  }
-}
-
-void Workspace::removeRemoteLibrary(const QString& libDirName, bool rmDir) {
-  Library* library = mRemoteLibraries.value(libDirName).data();
-  if (library) {
-    FilePath libDirPath = library->getFilePath();
-    mRemoteLibraries.remove(libDirName);
-    emit libraryRemoved(libDirPath);
-    if (rmDir) FileUtils::removeDirRecursively(libDirPath);  // can throw
-  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -113,7 +113,7 @@ Workspace::Workspace(const FilePath& wsPath)
   mWorkspaceSettings.reset(new WorkspaceSettings(*this));
 
   // load local libraries
-  FilePath localLibsDirPath = mLibrariesPath.getPathTo("local");
+  FilePath localLibsDirPath = getLocalLibrariesPath();
   QDir     localLibsDir(localLibsDirPath.toStr());
   foreach (const QString& dir,
            localLibsDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot)) {
@@ -136,7 +136,7 @@ Workspace::Workspace(const FilePath& wsPath)
   }
 
   // load remote libraries
-  FilePath remoteLibsDirPath = mLibrariesPath.getPathTo("remote");
+  FilePath remoteLibsDirPath = getRemoteLibrariesPath();
   QDir     remoteLibsDir(remoteLibsDirPath.toStr());
   foreach (const QString& dir,
            remoteLibsDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot)) {

--- a/libs/librepcb/workspace/workspace.h
+++ b/libs/librepcb/workspace/workspace.h
@@ -109,6 +109,20 @@ public:
    */
   const FilePath& getLibrariesPath() const { return mLibrariesPath; }
 
+  /**
+   * @brief Get the filepath to the "v#/libraries/local" directory
+   */
+  FilePath getLocalLibrariesPath() const {
+    return mLibrariesPath.getPathTo("local");
+  }
+
+  /**
+   * @brief Get the filepath to the "v#/libraries/remote" directory
+   */
+  FilePath getRemoteLibrariesPath() const {
+    return mLibrariesPath.getPathTo("remote");
+  }
+
   ProjectTreeModel&      getProjectTreeModel() const noexcept;
   RecentProjectsModel&   getRecentProjectsModel() const noexcept;
   FavoriteProjectsModel& getFavoriteProjectsModel() const noexcept;

--- a/libs/librepcb/workspace/workspace.h
+++ b/libs/librepcb/workspace/workspace.h
@@ -23,9 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/common/exceptions.h>
 #include <librepcb/common/fileio/directorylock.h>
-#include <librepcb/common/uuid.h>
 #include <librepcb/common/version.h>
 
 #include <QtCore>
@@ -133,79 +131,6 @@ public:
   WorkspaceSettings& getSettings() const { return *mWorkspaceSettings; }
 
   // Library Management
-
-  /**
-   * @brief Get the (highest version) library of a given UUID
-   *
-   * @param uuid      The uuid of the library
-   * @param local     If true, local libraries are searched
-   * @param remote    If true, remote libraries are searched
-   *
-   * @return The library with the highest version (nullptr if not installed)
-   */
-  QSharedPointer<library::Library> getLibrary(const Uuid& uuid,
-                                              bool        local  = true,
-                                              bool        remote = true) const
-      noexcept;
-
-  /**
-   * @brief Get all local libraries (located in "workspace/v#/libraries/local")
-   *
-   * @return A list of all local libraries
-   */
-  const QMap<QString, QSharedPointer<library::Library>> getLocalLibraries()
-      const noexcept {
-    return mLocalLibraries;
-  }
-
-  /**
-   * @brief Get all remote libraries (located in
-   * "workspace/v#/libraries/remote")
-   *
-   * @return A list of all remote libraries
-   */
-  const QMap<QString, QSharedPointer<library::Library>> getRemoteLibraries()
-      const noexcept {
-    return mRemoteLibraries;
-  }
-
-  /**
-   * @brief Add a new local library
-   *
-   * @param libDirName    The name of the (existing) local library directory
-   *
-   * @throws Exception on error
-   */
-  void addLocalLibrary(const QString& libDirName);
-
-  /**
-   * @brief Add a new remote library
-   *
-   * @param libDirName    The name of the (existing) remote library directory
-   *
-   * @throws Exception on error
-   */
-  void addRemoteLibrary(const QString& libDirName);
-
-  /**
-   * @brief Remove a local library
-   *
-   * @param libDirName    The name of the (existing) local library directory
-   * @param rmDir         It true, the library's directory will be removed
-   *
-   * @throws Exception on error
-   */
-  void removeLocalLibrary(const QString& libDirName, bool rmDir = true);
-
-  /**
-   * @brief Remove a remote library
-   *
-   * @param libDirName    The name of the (existing) remote library directory
-   * @param rmDir         It true, the library's directory will be removed
-   *
-   * @throws Exception on error
-   */
-  void removeRemoteLibrary(const QString& libDirName, bool rmDir = true);
 
   /**
    * @brief Get the workspace library database
@@ -317,32 +242,36 @@ public:
     return Version::fromString("0.1");
   }
 
-signals:
-
-  void libraryAdded(const FilePath& libDir);
-  void libraryRemoved(const FilePath& libDir);
-
 private:  // Data
-  FilePath
-           mPath;  ///< a FilePath object which represents the workspace directory
-  FilePath mProjectsPath;  ///< the directory "projects"
-  FilePath
-                mMetadataPath;  ///< the subdirectory of the current file format version
-  FilePath      mLibrariesPath;  ///< the directory "v#/libraries"
-  DirectoryLock mLock;  ///< to lock the version directory (#mVersionPath)
-  QScopedPointer<WorkspaceSettings>
-      mWorkspaceSettings;  ///< the WorkspaceSettings object
-  QMap<QString, QSharedPointer<library::Library>>
-      mLocalLibraries;  ///< all local libraries
-  QMap<QString, QSharedPointer<library::Library>>
-                                     mRemoteLibraries;  ///< all remote libraries
-  QScopedPointer<WorkspaceLibraryDb> mLibraryDb;  ///< the library database
-  QScopedPointer<ProjectTreeModel>
-      mProjectTreeModel;  ///< a tree model for the whole projects directory
-  QScopedPointer<RecentProjectsModel>
-      mRecentProjectsModel;  ///< a list model of all recent projects
-  QScopedPointer<FavoriteProjectsModel>
-      mFavoriteProjectsModel;  ///< a list model of all favorite projects
+  /// a FilePath object which represents the workspace directory
+  FilePath mPath;
+
+  /// the directory "projects"
+  FilePath mProjectsPath;
+
+  /// the subdirectory of the current file format version
+  FilePath mMetadataPath;
+
+  /// the directory "v#/libraries"
+  FilePath mLibrariesPath;
+
+  /// to lock the version directory (#mVersionPath)
+  DirectoryLock mLock;
+
+  /// the WorkspaceSettings object
+  QScopedPointer<WorkspaceSettings> mWorkspaceSettings;
+
+  /// the library database
+  QScopedPointer<WorkspaceLibraryDb> mLibraryDb;
+
+  /// a tree model for the whole projects directory
+  QScopedPointer<ProjectTreeModel> mProjectTreeModel;
+
+  /// a list model of all recent projects
+  QScopedPointer<RecentProjectsModel> mRecentProjectsModel;
+
+  /// a list model of all favorite projects
+  QScopedPointer<FavoriteProjectsModel> mFavoriteProjectsModel;
 };
 
 /*******************************************************************************

--- a/tests/funq/librarymanager/test_install_remote_libraries.py
+++ b/tests/funq/librarymanager/test_install_remote_libraries.py
@@ -57,6 +57,11 @@ def test(librepcb, helpers):
         # Install selected libraries
         app.widget('libraryManagerDownloadFromRepoDownloadButton').click()
 
+        # Check if two libraries were added
+        library_count_after = library_count_before + 2
+        helpers.wait_for_model_items_count(library_list, library_count_after,
+                                           library_count_after)
+
         # Wait until progress bars are at 100% and hidden (i.e. installation finished)
         for i in range(0, remote_library_count):
             props = {'value': 100 if i <= 1 else 0, 'visible': False}
@@ -68,8 +73,3 @@ def test(librepcb, helpers):
                 assert statuslabels[i].properties()['text'].startswith('Installed')
             else:
                 assert statuslabels[i].properties()['text'] == 'Recommended'
-
-        # Check if two libraries were added
-        library_count_after = library_count_before + 2
-        helpers.wait_for_model_items_count(library_list, library_count_after,
-                                           library_count_after)


### PR DESCRIPTION
### Update version of workspace library database to v2

- Store PNG icon of libraries in database. Used to get library icons without loading the libraries (useful for the library manager).
- Use "ON DELETE CASCADE" for foreign keys. Required to allow removing single libraries from the database without generating a foreign key error. Used to speed-up scanning of installed libraries.

### WorkspaceLibraryDb: Add more methods to query data

Add support for reading more data from the database, especially library metadata.

### Refactor and improve scanning of workspace libraries

WorkspaceLibraryScanner now also scans which libraries are installed instead of using the libraries loaded by the Workspace object. This allows to add/remove/update workspace libraries without notifying the Workspace object about the exact changes. To get faster feedback of the changes (e.g. to update the widgets of the library manager), the scanner now emits a signal after the library list is updated.

In addition, the scanner now emits a new signal scanFinished() which is used in many classes to get notified even if the scan fails or was aborted.

Also the debug output is now a bit more verbose to see more information about the library scan.

### Restart workspace library scanner when triggered

Until now, the workspace library scanner was not restarted on every trigger, thus triggers while the scan was running were lost, which lead to outdated information in the database. Now the scan is immediately restarted if it is triggered while already running. This avoids outdated information, and is important to keep the list of libraries (especially in the library manager) always up to date when libraries are added or removed.

### LibraryManager: Use library metadata from database

Because now we have more library metadata in the database.

### Workspace: Don't load libraries at startup

Using libraries from the database instead -> Faster startup, and avoids message boxes if libraries can't be loaded.