### PR TITLE
Use separate *.sqlite files for each database version

### DIFF
--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -68,6 +68,9 @@ public:
   explicit WorkspaceLibraryDb(Workspace& ws);
   ~WorkspaceLibraryDb() noexcept;
 
+  // Getters: Attributes
+  const FilePath& getFilePath() const noexcept { return mFilePath; }
+
   // Getters: Library Elements by their UUID
   QMultiMap<Version, FilePath> getComponentCategories(const Uuid& uuid) const;
   QMultiMap<Version, FilePath> getPackageCategories(const Uuid& uuid) const;
@@ -153,7 +156,8 @@ private:
 
   // Attributes
   Workspace&                     mWorkspace;
-  QScopedPointer<SQLiteDatabase> mDb;  ///< the SQLite database "cache.sqlite"
+  FilePath                       mFilePath;  ///< path to the SQLite database
+  QScopedPointer<SQLiteDatabase> mDb;        ///< the SQLite database
   QScopedPointer<WorkspaceLibraryScanner> mLibraryScanner;
 
   // Constants

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.cpp
@@ -41,8 +41,9 @@ using namespace library;
  *  Constructors / Destructor
  ******************************************************************************/
 
-WorkspaceLibraryScanner::WorkspaceLibraryScanner(Workspace& ws) noexcept
-  : QThread(nullptr), mWorkspace(ws), mAbort(false) {
+WorkspaceLibraryScanner::WorkspaceLibraryScanner(
+    Workspace& ws, const FilePath& dbFilePath) noexcept
+  : QThread(nullptr), mWorkspace(ws), mDbFilePath(dbFilePath), mAbort(false) {
 }
 
 WorkspaceLibraryScanner::~WorkspaceLibraryScanner() noexcept {
@@ -83,9 +84,7 @@ void WorkspaceLibraryScanner::run() noexcept {
     libraries.append(mWorkspace.getRemoteLibraries().values());
 
     // open SQLite database
-    FilePath dbFilePath =
-        mWorkspace.getLibrariesPath().getPathTo("cache.sqlite");
-    SQLiteDatabase db(dbFilePath);  // can throw
+    SQLiteDatabase db(mDbFilePath);  // can throw
 
     // begin database transaction
     SQLiteDatabase::TransactionScopeGuard transactionGuard(db);  // can throw

--- a/libs/librepcb/workspace/library/workspacelibraryscanner.h
+++ b/libs/librepcb/workspace/library/workspacelibraryscanner.h
@@ -23,7 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/common/exceptions.h>
+#include <librepcb/common/fileio/filepath.h>
 
 #include <QtCore>
 
@@ -67,7 +67,7 @@ class WorkspaceLibraryScanner final : public QThread {
 
 public:
   // Constructors / Destructor
-  explicit WorkspaceLibraryScanner(Workspace& ws) noexcept;
+  WorkspaceLibraryScanner(Workspace& ws, const FilePath& dbFilePath) noexcept;
   WorkspaceLibraryScanner(const WorkspaceLibraryScanner& other) = delete;
   ~WorkspaceLibraryScanner() noexcept;
 
@@ -101,6 +101,7 @@ private:  // Methods
 
 private:  // Data
   Workspace&    mWorkspace;
+  FilePath      mDbFilePath;
   volatile bool mAbort;
 };
 


### PR DESCRIPTION
Until now, the workspace library database is stored in the file
"cache.sqlite" in the workspace. And the database itself contains a
version number which is intended to be incremented if we change the
database layout.

But if you use two different LibrePCB application versions on the same
workspace, this doesn't work well in every case. The newer application
would upgrade the database on the first application start, but the older
application may no longer be able to work with that database version. So
generally we must introduce database format changes only with new major
versions of the application, which decreases our flexibility in minor
releases.

This change puts the database version number into the filename of the
database, i.e. the file "cache.sqlite" will be renamed to
"cache_v1.sqlite" and every future database version will use a separate
file. This way the issue as described above is fixed, and we still have
the flexibility to introduce breaking database changes at any time, even
in minor releases.

Used for #400 as it introduces a new database layout.