### PR TITLE
LibraryManager: Various small layout improvements

### DIFF
--- a/libs/librepcb/librarymanager/addlibrarywidget.ui
+++ b/libs/librepcb/librarymanager/addlibrarywidget.ui
@@ -66,7 +66,10 @@
        <item row="0" column="0" colspan="2">
         <widget class="QLabel" name="label_8">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Creates a new local library in the currently opened workspace. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Note: Please specify all attributes in the english language (locale 'en_US').&lt;br&gt;Support for other languages will be added in a later release of LibrePCB.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;p&gt;Creates a new local library in the currently opened workspace.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Note: Please specify all attributes in the english language (locale 'en_US'). Support for other languages will be added in a later release of LibrePCB.&lt;/span&gt;&lt;/p&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -165,15 +168,26 @@
         </widget>
        </item>
        <item row="7" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0">
          <property name="spacing">
           <number>0</number>
          </property>
          <item>
-          <widget class="QCheckBox" name="cbxLocalCc0License">
+          <widget class="QCheckBox" name="cbxLocalCc0License"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblLicenseDescription">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
-            <string>Put library under the Public Domain License (CC0-1.0).
-Note: This is mandatory to publish the library on librepcb.org!</string>
+            <string>Put library under the Public Domain License CC0-1.0 (mandatory to publish it on librepcb.org).</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -231,7 +245,10 @@ Note: This is mandatory to publish the library on librepcb.org!</string>
        <item row="0" column="0" colspan="2">
         <widget class="QLabel" name="label_10">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Downloads a zipped library from the internet and saves it as a local library. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Note: Libraries which are downloaded this way cannot be updated automatically.&lt;br/&gt;It's highly recommended to use &amp;quot;Download from repository&amp;quot; whenever possible. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;p&gt;Downloads a zipped library from the internet and saves it as a local library. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Note: Libraries which are downloaded this way cannot be updated automatically. It's highly recommended to use &amp;quot;Download from repository&amp;quot; whenever possible. &lt;/span&gt;&lt;/p&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.cpp
@@ -55,21 +55,16 @@ LibraryListWidgetItem::LibraryListWidgetItem(workspace::Workspace& ws,
     if (!icon.isNull()) {
       mUi->lblIcon->setPixmap(icon);
     }
-    if (isRemoteLibrary()) {
-      mUi->lblLibraryType->setText(tr("(remote)"));
-      mUi->lblLibraryType->setStyleSheet("QLabel { color: red; }");
-    } else {
-      mUi->lblLibraryType->setText(tr("(local)"));
-      mUi->lblLibraryType->setStyleSheet("QLabel { color: blue; }");
-    }
     mUi->lblLibraryName->setText(name);
     mUi->lblLibraryDescription->setText(description);
-    mUi->lblLibraryUrl->setText(libDir.toRelative(ws.getLibrariesPath()));
+    QString path = libDir.toRelative(ws.getLibrariesPath());
+    path.replace("local/", "<font color=\"blue\">local</font>/");
+    path.replace("remote/", "<font color=\"red\">remote</font>/");
+    mUi->lblLibraryUrl->setText(path);
   } else {
     QPixmap image(":/img/actions/add.png");
     mUi->lblIcon->setPixmap(image.scaled(
         mUi->lblIcon->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
-    mUi->lblLibraryType->setVisible(false);
     mUi->lblLibraryName->setText(tr("Add a new library"));
     mUi->lblLibraryDescription->setText(tr("Click here to add a new library."));
     mUi->lblLibraryUrl->setText("");

--- a/libs/librepcb/librarymanager/librarylistwidgetitem.ui
+++ b/libs/librepcb/librarymanager/librarylistwidgetitem.ui
@@ -72,49 +72,29 @@
       <number>1</number>
      </property>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="rightMargin">
-        <number>6</number>
+      <widget class="QLabel" name="lblLibraryName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <item>
-        <widget class="QLabel" name="lblLibraryName">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="lblLibraryType">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string notr="true">TextLabel</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="lblLibraryDescription">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -132,7 +112,7 @@
      <item>
       <widget class="QLabel" name="lblLibraryUrl">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>

--- a/libs/librepcb/librarymanager/librarymanager.cpp
+++ b/libs/librepcb/librarymanager/librarymanager.cpp
@@ -67,9 +67,21 @@ LibraryManager::LibraryManager(workspace::Workspace& ws,
   connect(&mWorkspace.getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanLibraryListUpdated, this,
           &LibraryManager::updateLibraryList);
+
+  // Restore Window Geometry
+  QSettings clientSettings;
+  restoreGeometry(
+      clientSettings.value("library_manager/window_geometry").toByteArray());
+  restoreState(
+      clientSettings.value("library_manager/window_state").toByteArray());
 }
 
 LibraryManager::~LibraryManager() noexcept {
+  // Save Window Geometry
+  QSettings clientSettings;
+  clientSettings.setValue("library_manager/window_geometry", saveGeometry());
+  clientSettings.setValue("library_manager/window_state", saveState());
+
   clearLibraryList();
   mAddLibraryWidget.reset();
   mUi.reset();

--- a/libs/librepcb/librarymanager/librarymanager.ui
+++ b/libs/librepcb/librarymanager/librarymanager.ui
@@ -17,7 +17,7 @@
    <string>Workspace Library Manager</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QHBoxLayout" name="horizontalLayout">
+   <layout class="QHBoxLayout" name="horizontalLayout" stretch="4,5">
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -29,9 +29,15 @@
     </property>
     <item>
      <widget class="QListWidget" name="lstLibraries">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>0</height>
+       </size>
+      </property>
       <property name="maximumSize">
        <size>
-        <width>400</width>
+        <width>600</width>
         <height>16777215</height>
        </size>
       </property>

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.ui
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.ui
@@ -13,10 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,0">
-   <property name="spacing">
-    <number>0</number>
-   </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_4">
    <property name="leftMargin">
     <number>3</number>
    </property>
@@ -24,7 +21,7 @@
     <number>1</number>
    </property>
    <property name="rightMargin">
-    <number>1</number>
+    <number>3</number>
    </property>
    <property name="bottomMargin">
     <number>1</number>
@@ -65,131 +62,161 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <property name="leftMargin">
-      <number>5</number>
-     </property>
      <item>
-      <widget class="QLabel" name="lblName">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>500</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>10</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Name + Version</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="lblName">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>500</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Name + Version</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblInstalledVersion">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::RightToLeft</enum>
+         </property>
+         <property name="text">
+          <string>Installed Version</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
-      <widget class="QLabel" name="lblDescription">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>500</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Description</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="lblDescription">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>500</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Description</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QProgressBar" name="prgProgress">
+         <property name="maximum">
+          <number>120</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbxDownload">
+         <property name="layoutDirection">
+          <enum>Qt::RightToLeft</enum>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
-      <widget class="QLabel" name="lblAuthor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>500</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Author</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>5</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="lblInstalledVersion">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::RightToLeft</enum>
-       </property>
-       <property name="text">
-        <string>Installed Version</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="cbxDownload">
-       <property name="layoutDirection">
-        <enum>Qt::RightToLeft</enum>
-       </property>
-       <property name="text">
-        <string>Install</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QProgressBar" name="prgProgress">
-       <property name="maximum">
-        <number>120</number>
-       </property>
-       <property name="value">
-        <number>0</number>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="lblAuthor">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>500</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Author</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/tests/funq/librarymanager/test_install_remote_libraries.py
+++ b/tests/funq/librarymanager/test_install_remote_libraries.py
@@ -70,6 +70,8 @@ def test(librepcb, helpers):
         # Check installed status of libraries in remote library list
         for i in range(0, remote_library_count):
             if i <= 1:
-                assert statuslabels[i].properties()['text'].startswith('Installed')
+                # The downloaded libraries are outdated, thus the installed
+                # version number is displayed.
+                assert statuslabels[i].properties()['text'].startswith('v')
             else:
                 assert statuslabels[i].properties()['text'] == 'Recommended'


### PR DESCRIPTION
- Make it better usable on small screens (required to create nice looking screenshots for website and documentation :wink:)
- Crop long texts to avoid strange looking layouts by ignoring widget
  size hint and/or enabling word wrap in labels
- Various other small improvements
- Save/restore window position and size

Before:
![grafik](https://user-images.githubusercontent.com/5374821/50714779-6b136b00-107a-11e9-8937-d6a3531355af.png)

After:
![grafik](https://user-images.githubusercontent.com/5374821/50714801-82525880-107a-11e9-8a77-fa55215aeaf1.png)
