### PR TITLE
Add tolerance to placement clearance check

### DIFF
--- a/libs/librepcb/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/library/pkg/packagecheck.cpp
@@ -154,8 +154,9 @@ void PackageCheck::checkPadsOverlapWithPlacement(MsgList& msgs) const {
       std::shared_ptr<const FootprintPad> pad = it.ptr();
       std::shared_ptr<const PackagePad>   pkgPad =
           mPackage.getPads().find(pad->getUuid());
-      Length clearance(150000);  // 150um
-      Path   stopMaskPath = pad->getOutline(clearance);
+      Length clearance(150000);  // 150 µm
+      Length tolerance(000100); // 0.1 µm, to avoid rounding issues
+      Path   stopMaskPath = pad->getOutline(clearance - tolerance);
       stopMaskPath.rotate(pad->getRotation()).translate(pad->getPosition());
       QPainterPath stopMask = stopMaskPath.toQPainterPathPx();
       if (pad->isOnLayer(GraphicsLayer::sTopCopper) &&


### PR DESCRIPTION
This gets rid of error messages due to rounding errors that occur if there is exactly 150 µm of clearance.

Seems to resolve #403.