### PR TITLE
Package editor: Change default line width to 0.2mm

### DIFF
--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -54,7 +54,7 @@ PackageEditorState_DrawPolygonBase::PackageEditorState_DrawPolygonBase(
     mCurrentPolygon(nullptr),
     mCurrentGraphicsItem(nullptr),
     mLastLayerName(GraphicsLayer::sTopPlacement),
-    mLastLineWidth(254000),
+    mLastLineWidth(200000),
     mLastAngle(0),
     mLastFill(false),
     mLastGrabArea(mode != Mode::LINE) {


### PR DESCRIPTION
As per https://github.com/LibrePCB/librepcb-doc/pull/35