### PR TITLE
Library manager: Add "select all" checkbox

### DIFF
--- a/libs/librepcb/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/librarymanager/addlibrarywidget.cpp
@@ -352,6 +352,9 @@ void AddLibraryWidget::repositoryLibraryListReceived(
   foreach (const QJsonValue& libVal, libs) {
     RepositoryLibraryListWidgetItem* widget =
         new RepositoryLibraryListWidgetItem(mWorkspace, libVal.toObject());
+    widget->setChecked(mUi->cbxRepoLibsSelectAll->isChecked());
+    connect(mUi->cbxRepoLibsSelectAll, &QCheckBox::clicked,
+            widget, &RepositoryLibraryListWidgetItem::setChecked);
     connect(widget, &RepositoryLibraryListWidgetItem::checkedChanged, this,
             &AddLibraryWidget::repoLibraryDownloadCheckedChanged);
     QListWidgetItem* item = new QListWidgetItem(mUi->lstRepoLibs);

--- a/libs/librepcb/librarymanager/addlibrarywidget.ui
+++ b/libs/librepcb/librarymanager/addlibrarywidget.ui
@@ -50,11 +50,22 @@
         <widget class="QListWidget" name="lstRepoLibs"/>
        </item>
        <item>
-        <widget class="QPushButton" name="btnRepoLibsDownload">
-         <property name="text">
-          <string>Download and install/update all selected libraries</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+         <item>
+          <widget class="QCheckBox" name="cbxRepoLibsSelectAll">
+           <property name="text">
+            <string>Select all</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnRepoLibsDownload">
+           <property name="text">
+            <string>Download and install/update selected libraries</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
As there are more and more libraries, a "select all" checkbox is handy to save time :)

![grafik](https://user-images.githubusercontent.com/5374821/51806735-dae1d380-227d-11e9-8585-f0a88a079428.png)
