### PR TITLE
Library Editor: Display element name in "save" action

### DIFF
--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -564,6 +564,7 @@ void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
   }
   mUi->commandToolbar->setEnabled(hasGraphicalEditor);
   mUi->statusBar->setField(StatusBar::AbsolutePosition, hasGraphicalEditor);
+  updateTabTitles();  // force updating the "Save" action title
 }
 
 void LibraryEditor::updateTabTitles() noexcept {
@@ -580,6 +581,14 @@ void LibraryEditor::updateTabTitles() noexcept {
     } else {
       qWarning() << "Tab widget is not a subclass of EditorWidgetBase!";
     }
+  }
+
+  if (mCurrentEditorWidget) {
+    mUi->actionSave->setEnabled(true);
+    mUi->actionSave->setText(
+        QString(tr("&Save '%1'")).arg(mCurrentEditorWidget->windowTitle()));
+  } else {
+    mUi->actionSave->setEnabled(false);
   }
 }
 

--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -284,7 +284,7 @@
      <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Save Element</string>
+    <string notr="true">&amp;Save</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>


### PR DESCRIPTION
Instead of always naming the action "Save element", show the actual element name in the action's title, e.g. "Save 'NE555'".

This is the last change needed to close #384.

Fixes #384.