### PR TITLE
Remove backward compatibility to pre-0.1 file format

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -144,19 +144,6 @@ static void setApplicationMetadata() noexcept {
  ******************************************************************************/
 
 static void configureApplicationSettings() noexcept {
-  // Migrate from old platform-dependent settings format to INI
-  // backward compatibility - remove this some time!
-  QSettings::setDefaultFormat(QSettings::NativeFormat);
-  QSettings oldSettings;
-  QSettings::setDefaultFormat(QSettings::IniFormat);
-  QSettings newSettings;
-  if (!FilePath(newSettings.fileName()).isExistingFile()) {
-    qInfo() << "Migrating old settings to" << newSettings.fileName();
-    foreach (const QString& key, oldSettings.allKeys()) {
-      newSettings.setValue(key, oldSettings.value(key));
-    }
-  }
-
   // Make sure the INI format is used for settings on all platforms because:
   // - Consistent storage format on all platforms
   // - Useful for functional testing (control settings by fixtures)

--- a/libs/librepcb/common/attributes/attribute.cpp
+++ b/libs/librepcb/common/attributes/attribute.cpp
@@ -44,21 +44,10 @@ Attribute::Attribute(const Attribute& other) noexcept
 }
 
 Attribute::Attribute(const SExpression& node)
-  : mKey("UNKNOWN"),  // backward compatibility - remove this some time!
+  : mKey(node.getChildByIndex(0).getValue<QString>(true)),
     mType(&AttributeType::fromString(node.getValueByPath<QString>("type"))),
     mValue(node.getValueByPath<QString>("value")),
     mUnit(mType->getUnitFromString(node.getValueByPath<QString>("unit"))) {
-  // backward compatibility - remove this some time!
-  QString key = node.getChildByIndex(0).getValue<QString>(true);
-  key.replace(".", "_");
-  key.replace("-", "_");
-  mKey = key.toUpper();
-
-  // backward compatibility - remove this some time!
-  mValue.replace(QRegularExpression("#([_A-Za-z][_\\|0-9A-Za-z]*)"), "{{\\1}}");
-  mValue.replace(QRegularExpression("\\{\\{(\\w+)\\|(\\w+)\\}\\}"),
-                 "{{ \\1 or \\2 }}");
-
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 }
 

--- a/libs/librepcb/common/attributes/attributekey.h
+++ b/libs/librepcb/common/attributes/attributekey.h
@@ -103,12 +103,7 @@ inline SExpression serializeToSExpression(const AttributeKey& obj) {
 template <>
 inline AttributeKey deserializeFromSExpression(const SExpression& sexpr,
                                                bool throwIfEmpty) {
-  QString str = sexpr.getStringOrToken(throwIfEmpty);
-  // backward compatibility - remove this some time!
-  str = str.toUpper();
-  str.remove(QRegularExpression("[^0-9A-Z_]"));
-  str.truncate(40);
-  return AttributeKey(str);  // can throw
+  return AttributeKey(sexpr.getStringOrToken(throwIfEmpty));  // can throw
 }
 
 inline QDataStream& operator<<(QDataStream& stream, const AttributeKey& obj) {

--- a/libs/librepcb/common/circuitidentifier.h
+++ b/libs/librepcb/common/circuitidentifier.h
@@ -125,11 +125,7 @@ inline SExpression serializeToSExpression(const CircuitIdentifier& obj) {
 template <>
 inline CircuitIdentifier deserializeFromSExpression(const SExpression& sexpr,
                                                     bool throwIfEmpty) {
-  QString str = sexpr.getStringOrToken(throwIfEmpty);
-  // backward compatibility - remove this some time!
-  str.remove(QRegularExpression("[^-a-zA-Z0-9_+/!?@#$]"));
-  str.truncate(32);
-  return CircuitIdentifier(str);  // can throw
+  return CircuitIdentifier(sexpr.getStringOrToken(throwIfEmpty));  // can throw
 }
 
 inline QDataStream& operator<<(QDataStream&             stream,

--- a/libs/librepcb/common/elementname.h
+++ b/libs/librepcb/common/elementname.h
@@ -122,11 +122,7 @@ inline SExpression serializeToSExpression(const ElementName& obj) {
 template <>
 inline ElementName deserializeFromSExpression(const SExpression& sexpr,
                                               bool               throwIfEmpty) {
-  QString str = sexpr.getStringOrToken(throwIfEmpty);
-  // backward compatibility - remove this some time!
-  str = str.trimmed();
-  str.truncate(70);
-  return ElementName(str);  // can throw
+  return ElementName(sexpr.getStringOrToken(throwIfEmpty));  // can throw
 }
 
 inline QDataStream& operator<<(QDataStream& stream, const ElementName& obj) {

--- a/libs/librepcb/common/geometry/circle.cpp
+++ b/libs/librepcb/common/geometry/circle.cpp
@@ -60,41 +60,13 @@ Circle::Circle(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 Circle::Circle(const SExpression& node)
-  : mUuid(Uuid::createRandom()),  // backward compatibility, remove this some
-                                  // time!
+  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mLineWidth(node.getValueByPath<UnsignedLength>("width")),
     mIsFilled(node.getValueByPath<bool>("fill")),
-    mIsGrabArea(false),
-    mCenter(0, 0),
-    mDiameter(1) {
-  if (node.getChildByIndex(0).isString()) {
-    mUuid = node.getChildByIndex(0).getValue<Uuid>();
-  }
-  if (node.tryGetChildByPath("grab_area")) {
-    mIsGrabArea = node.getValueByPath<bool>("grab_area");
-  } else {
-    // backward compatibility, remove this some time!
-    mIsGrabArea = node.getValueByPath<bool>("grab");
-  }
-  if (node.tryGetChildByPath("position")) {
-    mCenter = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mCenter = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("diameter")) {
-    mDiameter = node.getValueByPath<PositiveLength>("diameter");
-  } else if (node.tryGetChildByPath("dia")) {
-    // backward compatibility, remove this some time!
-    mDiameter = node.getValueByPath<PositiveLength>("dia");
-  } else if (node.tryGetChildByPath("size")) {
-    // backward compatibility, remove this some time!
-    mDiameter = Point(node.getChildByPath("size")).getX();
-  } else {
-    // backward compatibility, remove this some time!
-    mDiameter = node.getValueByPath<Length>("rx") * 2;
-  }
+    mIsGrabArea(node.getValueByPath<bool>("grab_area")),
+    mCenter(node.getChildByPath("position")),
+    mDiameter(node.getValueByPath<PositiveLength>("diameter")) {
 }
 
 Circle::~Circle() noexcept {

--- a/libs/librepcb/common/geometry/hole.cpp
+++ b/libs/librepcb/common/geometry/hole.cpp
@@ -47,25 +47,9 @@ Hole::Hole(const Uuid& uuid, const Point& position,
 }
 
 Hole::Hole(const SExpression& node)
-  : mUuid(Uuid::createRandom()),  // backward compatibility, remove this some
-                                  // time!
-    mPosition(0, 0),
-    mDiameter(1) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("diameter")) {
-    mDiameter = node.getValueByPath<PositiveLength>("diameter");
-  } else {
-    // backward compatibility, remove this some time!
-    mDiameter = node.getValueByPath<PositiveLength>("dia");
-  }
-  if (node.getChildByIndex(0).isString()) {
-    mUuid = node.getChildByIndex(0).getValue<Uuid>();
-  }
+  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+    mPosition(node.getChildByPath("position")),
+    mDiameter(node.getValueByPath<PositiveLength>("diameter")) {
 }
 
 Hole::~Hole() noexcept {

--- a/libs/librepcb/common/geometry/polygon.cpp
+++ b/libs/librepcb/common/geometry/polygon.cpp
@@ -61,35 +61,12 @@ Polygon::Polygon(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 Polygon::Polygon(const SExpression& node)
-  : mUuid(Uuid::createRandom()),  // backward compatibility, remove this some
-                                  // time!
+  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mLineWidth(node.getValueByPath<UnsignedLength>("width")),
     mIsFilled(node.getValueByPath<bool>("fill")),
-    mIsGrabArea(false),
-    mPath() {
-  if (node.getChildByIndex(0).isString()) {
-    mUuid = node.getChildByIndex(0).getValue<Uuid>();
-  }
-  if (node.tryGetChildByPath("grab_area")) {
-    mIsGrabArea = node.getValueByPath<bool>("grab_area");
-  } else {
-    // backward compatibility, remove this some time!
-    mIsGrabArea = node.getValueByPath<bool>("grab");
-  }
-
-  // load vertices
-  if ((!node.tryGetChildByPath("pos")) &&
-      (!node.tryGetChildByPath("position"))) {
-    mPath = Path(node);  // can throw
-  } else {
-    // backward compatibility, remove this some time!
-    mPath.addVertex(Point(node.getChildByPath("pos")));
-    foreach (const SExpression& child, node.getChildren("segment")) {
-      mPath.getVertices().last().setAngle(child.getValueByPath<Angle>("angle"));
-      mPath.addVertex(Point(child.getChildByPath("pos")));
-    }
-  }
+    mIsGrabArea(node.getValueByPath<bool>("grab_area")),
+    mPath(node) {
 }
 
 Polygon::~Polygon() noexcept {

--- a/libs/librepcb/common/geometry/stroketext.cpp
+++ b/libs/librepcb/common/geometry/stroketext.cpp
@@ -83,68 +83,20 @@ StrokeText::StrokeText(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 StrokeText::StrokeText(const SExpression& node)
-  : mUuid(Uuid::createRandom()),  // backward compatibility, remove this some
-                                  // time!
+  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
-    mText(),
-    mPosition(0, 0),
-    mRotation(0),
+    mText(node.getValueByPath<QString>("value")),
+    mPosition(node.getChildByPath("position")),
+    mRotation(node.getValueByPath<Angle>("rotation")),
     mHeight(node.getValueByPath<PositiveLength>("height")),
-    mStrokeWidth(200000),  // backward compatibility, remove this some time!
-    mLetterSpacing(),      // backward compatibility, remove this some time!
-    mLineSpacing(),        // backward compatibility, remove this some time!
+    mStrokeWidth(node.getValueByPath<UnsignedLength>("stroke_width")),
+    mLetterSpacing(node.getValueByPath<StrokeTextSpacing>("letter_spacing")),
+    mLineSpacing(node.getValueByPath<StrokeTextSpacing>("line_spacing")),
     mAlign(node.getChildByPath("align")),
-    mMirrored(false),   // backward compatibility, remove this some time!
-    mAutoRotate(true),  // backward compatibility, remove this some time!
+    mMirrored(node.getValueByPath<bool>("mirror")),
+    mAutoRotate(node.getValueByPath<bool>("auto_rotate")),
     mAttributeProvider(nullptr),
     mFont(nullptr) {
-  if (Uuid::isValid(node.getChildByIndex(0).getValue<QString>())) {
-    mUuid = node.getChildByIndex(0).getValue<Uuid>();
-    mText = node.getValueByPath<QString>("value");
-  } else {
-    // backward compatibility, remove this some time!
-    mText = node.getChildByIndex(0).getValue<QString>();
-  }
-
-  // load geometry attributes
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mRotation = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mRotation = node.getValueByPath<Angle>("rot");
-  }
-  if (const SExpression* child = node.tryGetChildByPath("stroke_width")) {
-    mStrokeWidth = child->getValueOfFirstChild<UnsignedLength>();
-  }
-  if (const SExpression* child = node.tryGetChildByPath("letter_spacing")) {
-    mLetterSpacing = child->getValueOfFirstChild<StrokeTextSpacing>();
-  }
-  if (const SExpression* child = node.tryGetChildByPath("line_spacing")) {
-    mLineSpacing = child->getValueOfFirstChild<StrokeTextSpacing>();
-  }
-  if (const SExpression* child = node.tryGetChildByPath("mirror")) {
-    mMirrored = child->getValueOfFirstChild<bool>();
-  }
-  if (const SExpression* child = node.tryGetChildByPath("auto_rotate")) {
-    mAutoRotate = child->getValueOfFirstChild<bool>();
-  }
-
-  // backward compatibility, remove this some time!
-  if ((node.getName() == "text") &&
-      ((mText == "#NAME") || (mText == "#VALUE"))) {
-    mHeight = PositiveLength(1000000);
-  }
-
-  // backward compatibility - remove this some time!
-  mText.replace(QRegularExpression("#([_A-Za-z][_\\|0-9A-Za-z]*)"), "{{\\1}}");
-  mText.replace(QRegularExpression("\\{\\{(\\w+)\\|(\\w+)\\}\\}"),
-                "{{ \\1 or \\2 }}");
 }
 
 StrokeText::~StrokeText() noexcept {

--- a/libs/librepcb/common/geometry/text.cpp
+++ b/libs/librepcb/common/geometry/text.cpp
@@ -60,38 +60,13 @@ Text::Text(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 Text::Text(const SExpression& node)
-  : mUuid(Uuid::createRandom()),  // backward compatibility, remove this some
-                                  // time!
+  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
-    mText(),
-    mPosition(0, 0),
-    mRotation(0),
+    mText(node.getValueByPath<QString>("value")),
+    mPosition(node.getChildByPath("position")),
+    mRotation(node.getValueByPath<Angle>("rotation")),
     mHeight(node.getValueByPath<PositiveLength>("height")),
     mAlign(node.getChildByPath("align")) {
-  if (Uuid::isValid(node.getChildByIndex(0).getValue<QString>())) {
-    mUuid = node.getChildByIndex(0).getValue<Uuid>();
-    mText = node.getValueByPath<QString>("value");
-  } else {
-    // backward compatibility, remove this some time!
-    mText = node.getChildByIndex(0).getValue<QString>();
-  }
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mRotation = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mRotation = node.getValueByPath<Angle>("rot");
-  }
-
-  // backward compatibility - remove this some time!
-  mText.replace(QRegularExpression("#([_A-Za-z][_\\|0-9A-Za-z]*)"), "{{\\1}}");
-  mText.replace(QRegularExpression("\\{\\{(\\w+)\\|(\\w+)\\}\\}"),
-                "{{ \\1 or \\2 }}");
 }
 
 Text::~Text() noexcept {

--- a/libs/librepcb/common/geometry/vertex.cpp
+++ b/libs/librepcb/common/geometry/vertex.cpp
@@ -35,12 +35,7 @@ namespace librepcb {
 
 Vertex::Vertex(const SExpression& node) {
   try {
-    if (node.tryGetChildByPath("position")) {
-      mPos = Point(node.getChildByPath("position"));
-    } else {
-      // backward compatibility, remove this some time!
-      mPos = Point(node.getChildByPath("pos"));
-    }
+    mPos   = Point(node.getChildByPath("position"));
     mAngle = node.getValueByPath<Angle>("angle");
   } catch (const Exception& e) {
     throw FileParseError(__FILE__, __LINE__, node.getFilePath(), -1, -1,

--- a/libs/librepcb/common/uuid.h
+++ b/libs/librepcb/common/uuid.h
@@ -172,8 +172,7 @@ inline SExpression serializeToSExpression(const Uuid& obj) {
 template <>
 inline Uuid deserializeFromSExpression(const SExpression& sexpr,
                                        bool               throwIfEmpty) {
-  QString str = sexpr.getStringOrToken(throwIfEmpty);
-  return Uuid::fromString(str);
+  return Uuid::fromString(sexpr.getStringOrToken(throwIfEmpty));
 }
 
 template <>
@@ -189,8 +188,7 @@ template <>
 inline tl::optional<Uuid> deserializeFromSExpression(const SExpression& sexpr,
                                                      bool throwIfEmpty) {
   QString str = sexpr.getStringOrToken(throwIfEmpty);
-  // "null" for backward compatibility - remove this some time!
-  if (str == "none" || str == "null") {
+  if (str == "none") {
     return tl::nullopt;
   } else {
     return deserializeFromSExpression<Uuid>(sexpr, throwIfEmpty);  // can throw

--- a/libs/librepcb/library/cmp/component.cpp
+++ b/libs/librepcb/library/cmp/component.cpp
@@ -63,12 +63,6 @@ Component::Component(const FilePath& elementDirectory, bool readOnly)
   mSignals.loadFromDomElement(mLoadingFileDocument);
   mSymbolVariants.loadFromDomElement(mLoadingFileDocument);
 
-  // backward compatibility - remove this some time!
-  mDefaultValue.replace(QRegularExpression("#([_A-Za-z][_\\|0-9A-Za-z]*)"),
-                        "{{\\1}}");
-  mDefaultValue.replace(QRegularExpression("\\{\\{(\\w+)\\|(\\w+)\\}\\}"),
-                        "{{ \\1 or \\2 }}");
-
   cleanupAfterLoadingElementFromFile();
 }
 

--- a/libs/librepcb/library/cmp/componentpinsignalmap.cpp
+++ b/libs/librepcb/library/cmp/componentpinsignalmap.cpp
@@ -49,24 +49,9 @@ ComponentPinSignalMapItem::ComponentPinSignalMapItem(
 
 ComponentPinSignalMapItem::ComponentPinSignalMapItem(const SExpression& node)
   : mPinUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mSignalUuid(Uuid::createRandom()),  // backward compatibility, remove this
-                                        // some time!
-    mDisplayType(CmpSigPinDisplayType::componentSignal()) {
-  if (node.tryGetChildByPath("signal")) {
-    mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("signal");
-  } else {
-    // backward compatibility, remove this some time!
-    mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("sig");
-  }
-
-  if (node.tryGetChildByPath("text")) {
-    mDisplayType =
-        CmpSigPinDisplayType::fromString(node.getValueByPath<QString>("text"));
-  } else {
-    // backward compatibility, remove this some time!
-    mDisplayType =
-        CmpSigPinDisplayType::fromString(node.getValueByPath<QString>("disp"));
-  }
+    mSignalUuid(node.getValueByPath<tl::optional<Uuid>>("signal")),
+    mDisplayType(CmpSigPinDisplayType::fromString(
+        node.getValueByPath<QString>("text"))) {
 }
 
 ComponentPinSignalMapItem::~ComponentPinSignalMapItem() noexcept {

--- a/libs/librepcb/library/cmp/componentprefix.h
+++ b/libs/librepcb/library/cmp/componentprefix.h
@@ -112,9 +112,6 @@ template <>
 inline library::ComponentPrefix deserializeFromSExpression(
     const SExpression& sexpr, bool throwIfEmpty) {
   QString str = sexpr.getStringOrToken(throwIfEmpty);
-  // backward compatibility - remove this some time!
-  str.remove(QRegularExpression("[^a-zA-Z_]"));
-  str.truncate(16);
   return library::ComponentPrefix(str);  // can throw
 }
 

--- a/libs/librepcb/library/cmp/componentsignal.cpp
+++ b/libs/librepcb/library/cmp/componentsignal.cpp
@@ -69,11 +69,6 @@ ComponentSignal::ComponentSignal(const SExpression& node)
     mIsRequired(node.getValueByPath<bool>("required")),
     mIsNegated(node.getValueByPath<bool>("negated")),
     mIsClock(node.getValueByPath<bool>("clock")) {
-  // backward compatibility - remove this some time!
-  mForcedNetName.replace(QRegularExpression("#([_A-Za-z][_\\|0-9A-Za-z]*)"),
-                         "{{\\1}}");
-  mForcedNetName.replace(QRegularExpression("\\{\\{(\\w+)\\|(\\w+)\\}\\}"),
-                         "{{ \\1 or \\2 }}");
 }
 
 ComponentSignal::~ComponentSignal() noexcept {

--- a/libs/librepcb/library/cmp/componentsymbolvariant.cpp
+++ b/libs/librepcb/library/cmp/componentsymbolvariant.cpp
@@ -64,11 +64,6 @@ ComponentSymbolVariant::ComponentSymbolVariant(const SExpression& node)
     mNames(node),
     mDescriptions(node),
     mSymbolItems(node, this) {
-  // backward compatibility, remove this some time!
-  foreach (const SExpression& node, node.getChildren("item")) {
-    mSymbolItems.append(
-        std::make_shared<ComponentSymbolVariantItem>(node));  // can throw
-  }
 }
 
 ComponentSymbolVariant::~ComponentSymbolVariant() noexcept {

--- a/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
@@ -64,23 +64,11 @@ ComponentSymbolVariantItem::ComponentSymbolVariantItem(
 ComponentSymbolVariantItem::ComponentSymbolVariantItem(const SExpression& node)
   : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mSymbolUuid(node.getValueByPath<Uuid>("symbol")),
-    mSymbolPos(0, 0),
-    mSymbolRot(0),
+    mSymbolPos(node.getChildByPath("position")),
+    mSymbolRot(node.getValueByPath<Angle>("rotation")),
     mIsRequired(node.getValueByPath<bool>("required")),
     mSuffix(node.getValueByPath<ComponentSymbolVariantItemSuffix>("suffix")),
     mPinSignalMap(node) {
-  if (node.tryGetChildByPath("position")) {
-    mSymbolPos = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mSymbolPos = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mSymbolRot = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mSymbolRot = node.getValueByPath<Angle>("rot");
-  }
 }
 
 ComponentSymbolVariantItem::~ComponentSymbolVariantItem() noexcept {

--- a/libs/librepcb/library/cmp/componentsymbolvariantitemsuffix.h
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitemsuffix.h
@@ -118,9 +118,6 @@ template <>
 inline library::ComponentSymbolVariantItemSuffix deserializeFromSExpression(
     const SExpression& sexpr, bool throwIfEmpty) {
   QString str = sexpr.getStringOrToken(throwIfEmpty);
-  // backward compatibility - remove this some time!
-  str.remove(QRegularExpression("[^0-9a-zA-Z_]"));
-  str.truncate(16);
   return library::ComponentSymbolVariantItemSuffix(str);  // can throw
 }
 

--- a/libs/librepcb/library/dev/devicepadsignalmap.cpp
+++ b/libs/librepcb/library/dev/devicepadsignalmap.cpp
@@ -47,15 +47,7 @@ DevicePadSignalMapItem::DevicePadSignalMapItem(
 DevicePadSignalMapItem::DevicePadSignalMapItem(const SExpression& node)
   : QObject(nullptr),
     mPadUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mSignalUuid(Uuid::createRandom())  // backward compatibility, remove this
-                                       // some time!
-{
-  if (node.tryGetChildByPath("signal")) {
-    mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("signal");
-  } else {
-    // backward compatibility, remove this some time!
-    mSignalUuid = node.getValueByPath<tl::optional<Uuid>>("sig");
-  }
+    mSignalUuid(node.getValueByPath<tl::optional<Uuid>>("signal")) {
 }
 
 DevicePadSignalMapItem::~DevicePadSignalMapItem() noexcept {

--- a/libs/librepcb/library/librarybaseelement.cpp
+++ b/libs/librepcb/library/librarybaseelement.cpp
@@ -123,12 +123,7 @@ LibraryBaseElement::LibraryBaseElement(const FilePath& elementDirectory,
   mLoadingFileDocument = sexprFile.parseFileAndBuildDomTree();
 
   // read attributes
-  if (mLoadingFileDocument.getChildByIndex(0).isString()) {
-    mUuid = mLoadingFileDocument.getChildByIndex(0).getValue<Uuid>();
-  } else {
-    // backward compatibility, remove this some time!
-    mUuid = mLoadingFileDocument.getValueByPath<Uuid>("uuid");
-  }
+  mUuid         = mLoadingFileDocument.getChildByIndex(0).getValue<Uuid>();
   mVersion      = mLoadingFileDocument.getValueByPath<Version>("version");
   mAuthor       = mLoadingFileDocument.getValueByPath<QString>("author");
   mCreated      = mLoadingFileDocument.getValueByPath<QDateTime>("created");

--- a/libs/librepcb/library/pkg/footprint.cpp
+++ b/libs/librepcb/library/pkg/footprint.cpp
@@ -75,14 +75,6 @@ Footprint::Footprint(const SExpression& node)
     mHoles(node, this),
     mStrokeFont(nullptr),
     mRegisteredGraphicsItem(nullptr) {
-  // backward compatibility, remove this some time!
-  foreach (const SExpression& child, node.getChildren("text")) {
-    mStrokeTexts.append(std::make_shared<StrokeText>(child));
-  }
-  // backward compatibility, remove this some time!
-  foreach (const SExpression& child, node.getChildren("ellipse")) {
-    mCircles.append(std::make_shared<Circle>(child));
-  }
 }
 
 Footprint::~Footprint() noexcept {

--- a/libs/librepcb/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/library/pkg/footprintpad.cpp
@@ -69,26 +69,14 @@ FootprintPad::FootprintPad(const Uuid& padUuid, const Point& pos,
 
 FootprintPad::FootprintPad(const SExpression& node)
   : mPackagePadUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(0, 0),
-    mRotation(0),
+    mPosition(node.getChildByPath("position")),
+    mRotation(node.getValueByPath<Angle>("rotation")),
     mShape(node.getValueByPath<Shape>("shape")),
     mWidth(Point(node.getChildByPath("size")).getX()),
     mHeight(Point(node.getChildByPath("size")).getY()),
     mDrillDiameter(node.getValueByPath<UnsignedLength>("drill")),
     mBoardSide(node.getValueByPath<BoardSide>("side")),
     mRegisteredGraphicsItem(nullptr) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mRotation = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mRotation = node.getValueByPath<Angle>("rot");
-  }
 }
 
 FootprintPad::~FootprintPad() noexcept {

--- a/libs/librepcb/library/sym/symbol.cpp
+++ b/libs/librepcb/library/sym/symbol.cpp
@@ -63,13 +63,6 @@ Symbol::Symbol(const FilePath& elementDirectory, bool readOnly)
   mPolygons.loadFromDomElement(mLoadingFileDocument);  // can throw
   mCircles.loadFromDomElement(mLoadingFileDocument);   // can throw
   mTexts.loadFromDomElement(mLoadingFileDocument);     // can throw
-
-  // backward compatibility, remove this some time!
-  foreach (const SExpression& child,
-           mLoadingFileDocument.getChildren("ellipse")) {
-    mCircles.append(std::make_shared<Circle>(child));
-  }
-
   cleanupAfterLoadingElementFromFile();
 }
 

--- a/libs/librepcb/library/sym/symbolpin.cpp
+++ b/libs/librepcb/library/sym/symbolpin.cpp
@@ -59,22 +59,10 @@ SymbolPin::SymbolPin(const Uuid& uuid, const CircuitIdentifier& name,
 SymbolPin::SymbolPin(const SExpression& node)
   : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mName(node.getValueByPath<CircuitIdentifier>("name", true)),
-    mPosition(0, 0),
+    mPosition(node.getChildByPath("position")),
     mLength(node.getValueByPath<UnsignedLength>("length")),
-    mRotation(0),
+    mRotation(node.getValueByPath<Angle>("rotation")),
     mRegisteredGraphicsItem(nullptr) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mRotation = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mRotation = node.getValueByPath<Angle>("rot");
-  }
 }
 
 SymbolPin::~SymbolPin() noexcept {

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -236,12 +236,7 @@ Board::Board(Project& project, const FilePath& filepath, bool restore,
       // the board seems to be ready to open, so we will create all needed
       // objects
 
-      if (root.getChildByIndex(0).isString()) {
-        mUuid = root.getChildByIndex(0).getValue<Uuid>();
-      } else {
-        // backward compatibility, remove this some time!
-        mUuid = root.getValueByPath<Uuid>("uuid");
-      }
+      mUuid = root.getChildByIndex(0).getValue<Uuid>();
       mName = root.getValueByPath<ElementName>("name");
       if (const SExpression* child = root.tryGetChildByPath("default_font")) {
         mDefaultFontFileName = child->getValueOfFirstChild<QString>(true);
@@ -261,14 +256,8 @@ Board::Board(Project& project, const FilePath& filepath, bool restore,
           new BoardDesignRules(root.getChildByPath("design_rules")));
 
       // load fabrication output settings
-      if (const SExpression* child =
-              root.tryGetChildByPath("fabrication_output_settings")) {
-        mFabricationOutputSettings.reset(
-            new BoardFabricationOutputSettings(*child));
-      } else {
-        // backward compatibility - remove this some time!
-        mFabricationOutputSettings.reset(new BoardFabricationOutputSettings());
-      }
+      mFabricationOutputSettings.reset(new BoardFabricationOutputSettings(
+          root.getChildByPath("fabrication_output_settings")));
 
       // load user settings
       mUserSettings.reset(
@@ -323,24 +312,6 @@ Board::Board(Project& project, const FilePath& filepath, bool restore,
         BI_Hole* hole = new BI_Hole(*this, node);
         mHoles.append(hole);
       }
-
-      //////////////////////////////////////////////////////////////////////////////
-      // TODO: Backward compatibility, remove this some time!
-      int strokeTextCount = mStrokeTexts.count();
-      foreach (const BI_Device* device, mDeviceInstances) {
-        foreach (const BI_StrokeText* text,
-                 device->getFootprint().getStrokeTexts()) {
-          Q_UNUSED(text);
-          ++strokeTextCount;
-        }
-      }
-      if (strokeTextCount == 0) {
-        foreach (const BI_Device* device, mDeviceInstances) {
-          device->getFootprint()
-              .resetStrokeTextsToLibraryFootprint();  // can throw
-        }
-      }
-      //////////////////////////////////////////////////////////////////////////////
     }
 
     rebuildAllPlanes();

--- a/libs/librepcb/project/boards/items/bi_device.cpp
+++ b/libs/librepcb/project/boards/items/bi_device.cpp
@@ -84,18 +84,8 @@ BI_Device::BI_Device(Board& board, const SExpression& node)
   initDeviceAndPackageAndFootprint(deviceUuid, footprintUuid);
 
   // get position, rotation and mirrored
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mRotation = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mRotation = node.getValueByPath<Angle>("rot");
-  }
+  mPosition   = Point(node.getChildByPath("position"));
+  mRotation   = node.getValueByPath<Angle>("rotation");
   mIsMirrored = node.getValueByPath<bool>("mirror");
 
   // load attributes

--- a/libs/librepcb/project/boards/items/bi_netline.h
+++ b/libs/librepcb/project/boards/items/bi_netline.h
@@ -80,9 +80,7 @@ public:
   BI_NetLine(const BI_NetLine& other) = delete;
   BI_NetLine(BI_NetSegment& segment, const BI_NetLine& other,
              BI_NetLineAnchor& startPoint, BI_NetLineAnchor& endPoint);
-  BI_NetLine(BI_NetSegment& segment, const SExpression& node,
-             const QHash<Uuid, QString>&           netpointLayerMap,
-             const QHash<Uuid, BI_NetLineAnchor*>& netPointAnchorMap);
+  BI_NetLine(BI_NetSegment& segment, const SExpression& node);
   BI_NetLine(BI_NetSegment& segment, BI_NetLineAnchor& startPoint,
              BI_NetLineAnchor& endPoint, GraphicsLayer& layer,
              const PositiveLength& width);
@@ -125,10 +123,8 @@ public:
 
 private:
   void              init();
-  BI_NetLineAnchor* deserializeAnchor(
-      const SExpression& root, const QString& oldKey, const QString& newKey,
-      const QHash<Uuid, BI_NetLineAnchor*>& netPointAnchorMap,
-      Uuid&                                 oldPointUuid) const;
+  BI_NetLineAnchor* deserializeAnchor(const SExpression& root,
+                                      const QString&     key) const;
   void serializeAnchor(SExpression& root, BI_NetLineAnchor* anchor) const;
 
   // General

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -50,14 +50,7 @@ BI_NetPoint::BI_NetPoint(BI_NetSegment& segment, const SExpression& node)
   : BI_Base(segment.getBoard()),
     mNetSegment(segment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(0, 0) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-
+    mPosition(node.getChildByPath("position")) {
   init();
 }
 

--- a/libs/librepcb/project/boards/items/bi_via.cpp
+++ b/libs/librepcb/project/boards/items/bi_via.cpp
@@ -53,17 +53,10 @@ BI_Via::BI_Via(BI_NetSegment& netsegment, const SExpression& node)
   : BI_Base(netsegment.getBoard()),
     mNetSegment(netsegment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(0, 0),
+    mPosition(node.getChildByPath("position")),
     mShape(node.getValueByPath<Shape>("shape")),
     mSize(node.getValueByPath<PositiveLength>("size")),
     mDrillDiameter(node.getValueByPath<PositiveLength>("drill")) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-
   init();
 }
 

--- a/libs/librepcb/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/project/circuit/componentinstance.cpp
@@ -99,11 +99,6 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node)
             .arg(mLibComponent->getUuid().toStr()));
   }
 
-  // backward compatibility - remove this some time!
-  mValue.replace(QRegularExpression("#([_A-Za-z][_\\|0-9A-Za-z]*)"), "{{\\1}}");
-  mValue.replace(QRegularExpression("\\{\\{(\\w+)\\|(\\w+)\\}\\}"),
-                 "{{ \\1 or \\2 }}");
-
   init();
 }
 

--- a/libs/librepcb/project/metadata/projectmetadata.cpp
+++ b/libs/librepcb/project/metadata/projectmetadata.cpp
@@ -64,10 +64,7 @@ ProjectMetadata::ProjectMetadata(Project& project, bool restore, bool readOnly,
     mFile.reset(new SmartSExprFile(mFilepath, restore, readOnly));
     SExpression root = mFile->parseFileAndBuildDomTree();
 
-    if (root.getChildByIndex(0)
-            .isString()) {  // backward compatibility, remove this some time!
-      mUuid = root.getChildByIndex(0).getValue<Uuid>();
-    }
+    mUuid    = root.getChildByIndex(0).getValue<Uuid>();
     mName    = root.getValueByPath<ElementName>("name");
     mAuthor  = root.getValueByPath<QString>("author");
     mVersion = root.getValueByPath<QString>("version");

--- a/libs/librepcb/project/schematics/items/si_netlabel.cpp
+++ b/libs/librepcb/project/schematics/items/si_netlabel.cpp
@@ -47,21 +47,8 @@ SI_NetLabel::SI_NetLabel(SI_NetSegment& segment, const SExpression& node)
   : SI_Base(segment.getSchematic()),
     mNetSegment(segment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(0, 0),
-    mRotation(0) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mRotation = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mRotation = node.getValueByPath<Angle>("rot");
-  }
-
+    mPosition(node.getChildByPath("position")),
+    mRotation(node.getValueByPath<Angle>("rotation")) {
   init();
 }
 

--- a/libs/librepcb/project/schematics/items/si_netline.h
+++ b/libs/librepcb/project/schematics/items/si_netline.h
@@ -68,8 +68,7 @@ public:
   // Constructors / Destructor
   SI_NetLine()                        = delete;
   SI_NetLine(const SI_NetLine& other) = delete;
-  SI_NetLine(SI_NetSegment& segment, const SExpression& node,
-             const QHash<Uuid, SI_NetLineAnchor*>& netPointAnchorMap);
+  SI_NetLine(SI_NetSegment& segment, const SExpression& node);
   SI_NetLine(SI_NetSegment& segment, SI_NetLineAnchor& startPoint,
              SI_NetLineAnchor& endPoint, const UnsignedLength& width);
   ~SI_NetLine() noexcept;
@@ -106,9 +105,8 @@ public:
 
 private:
   void              init();
-  SI_NetLineAnchor* deserializeAnchor(
-      const SExpression& root, const QString& oldKey, const QString& newKey,
-      const QHash<Uuid, SI_NetLineAnchor*>& netPointAnchorMap) const;
+  SI_NetLineAnchor* deserializeAnchor(const SExpression& root,
+                                      const QString&     key) const;
   void serializeAnchor(SExpression& root, SI_NetLineAnchor* anchor) const;
 
   // General

--- a/libs/librepcb/project/schematics/items/si_netpoint.cpp
+++ b/libs/librepcb/project/schematics/items/si_netpoint.cpp
@@ -42,14 +42,7 @@ SI_NetPoint::SI_NetPoint(SI_NetSegment& segment, const SExpression& node)
   : SI_Base(segment.getSchematic()),
     mNetSegment(segment),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(0, 0) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-
+    mPosition(node.getChildByPath("position")) {
   init();
 }
 

--- a/libs/librepcb/project/schematics/items/si_netsegment.cpp
+++ b/libs/librepcb/project/schematics/items/si_netsegment.cpp
@@ -63,34 +63,21 @@ SI_NetSegment::SI_NetSegment(Schematic& schematic, const SExpression& node)
     }
 
     // Load all netpoints
-    QHash<Uuid, SI_NetLineAnchor*>
-        netPointAnchorMap;  // backward compatibility, remove this some time!
-    foreach (const SExpression& child,
-             node.getChildren("netpoint") + node.getChildren("junction")) {
-      if (const SExpression* symNode = child.tryGetChildByPath("sym")) {
-        Uuid       netpointUuid = child.getValueOfFirstChild<Uuid>();
-        Uuid       symbolUuid   = symNode->getValueOfFirstChild<Uuid>();
-        Uuid       pinUuid      = child.getValueByPath<Uuid>("pin");
-        SI_Symbol* symbol       = mSchematic.getSymbolByUuid(symbolUuid);
-        Q_ASSERT(symbol);
-        SI_SymbolPin* pin = symbol->getPin(pinUuid);
-        netPointAnchorMap.insert(netpointUuid, pin);
-      } else {
-        SI_NetPoint* netpoint = new SI_NetPoint(*this, child);
-        if (getNetPointByUuid(netpoint->getUuid())) {
-          throw RuntimeError(
-              __FILE__, __LINE__,
-              QString(tr("There is already a netpoint with the UUID \"%1\"!"))
-                  .arg(netpoint->getUuid().toStr()));
-        }
-        mNetPoints.append(netpoint);
+    foreach (const SExpression& child, node.getChildren("junction")) {
+      SI_NetPoint* netpoint = new SI_NetPoint(*this, child);
+      if (getNetPointByUuid(netpoint->getUuid())) {
+        throw RuntimeError(
+            __FILE__, __LINE__,
+            QString(tr("There is already a netpoint with the UUID \"%1\"!"))
+                .arg(netpoint->getUuid().toStr()));
       }
+      mNetPoints.append(netpoint);
     }
 
     // Load all netlines
     foreach (const SExpression& child,
              node.getChildren("netline") + node.getChildren("line")) {
-      SI_NetLine* netline = new SI_NetLine(*this, child, netPointAnchorMap);
+      SI_NetLine* netline = new SI_NetLine(*this, child);
       if (getNetLineByUuid(netline->getUuid())) {
         throw RuntimeError(
             __FILE__, __LINE__,

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -52,28 +52,9 @@ SI_Symbol::SI_Symbol(Schematic& schematic, const SExpression& node)
     mSymbVarItem(nullptr),
     mSymbol(nullptr),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(0, 0),
-    mRotation(0),
-    mMirrored(false) {
-  if (node.tryGetChildByPath("position")) {
-    mPosition = Point(node.getChildByPath("position"));
-  } else {
-    // backward compatibility, remove this some time!
-    mPosition = Point(node.getChildByPath("pos"));
-  }
-  if (node.tryGetChildByPath("rotation")) {
-    mRotation = node.getValueByPath<Angle>("rotation");
-  } else {
-    // backward compatibility, remove this some time!
-    mRotation = node.getValueByPath<Angle>("rot");
-  }
-  if (node.tryGetChildByPath("mirror")) {
-    mMirrored = node.getValueByPath<bool>("mirror");
-  } else {
-    // backward compatibility, remove this some time!
-    mMirrored = false;
-  }
-
+    mPosition(node.getChildByPath("position")),
+    mRotation(node.getValueByPath<Angle>("rotation")),
+    mMirrored(node.getValueByPath<bool>("mirror")) {
   Uuid gcUuid = node.getValueByPath<Uuid>("component");
   mComponentInstance =
       schematic.getProject().getCircuit().getComponentInstanceByUuid(gcUuid);
@@ -83,14 +64,7 @@ SI_Symbol::SI_Symbol(Schematic& schematic, const SExpression& node)
         QString(tr("No component with the UUID \"%1\" found in the circuit!"))
             .arg(gcUuid.toStr()));
   }
-  Uuid symbVarItemUuid =
-      Uuid::createRandom();  // only initialization, will be overwritten
-  if (node.tryGetChildByPath("lib_gate")) {
-    symbVarItemUuid = node.getValueByPath<Uuid>("lib_gate");
-  } else {
-    // backward compatibility, remove this some time!
-    symbVarItemUuid = node.getValueByPath<Uuid>("lib_item");
-  }
+  Uuid symbVarItemUuid = node.getValueByPath<Uuid>("lib_gate");
   init(symbVarItemUuid);
 }
 

--- a/libs/librepcb/project/schematics/schematic.cpp
+++ b/libs/librepcb/project/schematics/schematic.cpp
@@ -80,12 +80,7 @@ Schematic::Schematic(Project& project, const FilePath& filepath, bool restore,
       // the schematic seems to be ready to open, so we will create all needed
       // objects
 
-      if (root.getChildByIndex(0).isString()) {
-        mUuid = root.getChildByIndex(0).getValue<Uuid>();
-      } else {
-        // backward compatibility, remove this some time!
-        mUuid = root.getValueByPath<Uuid>("uuid");
-      }
+      mUuid = root.getChildByIndex(0).getValue<Uuid>();
       mName = root.getValueByPath<ElementName>("name");
 
       // Load grid properties


### PR DESCRIPTION
Remove a lot of backward compatibility code for the (rolling) file format before the 0.1.0 release. So from now on we only support file format 0.1, which is used by 0.1.x releases.

If someone still has libraries or projects with an older file format, one can just use the 0.1.0 release to upgrade the file format to 0.1. Afterwards those files will be loadable with all future releases of LibrePCB.

This is the last open task of #340.