### PR TITLE
Load category tree from database instead of file system

### DIFF
--- a/libs/librepcb/workspace/library/cat/categorytreeitem.h
+++ b/libs/librepcb/workspace/library/cat/categorytreeitem.h
@@ -83,12 +83,12 @@ private:
   QSet<Uuid> getCategoryChilds(const WorkspaceLibraryDb& lib) const;
 
   // Attributes
-  QStringList                 mLocaleOrder;
-  CategoryTreeItem*           mParent;
-  tl::optional<Uuid>          mUuid;
-  QScopedPointer<ElementType> mCategory;
-  unsigned int mDepth;  ///< this is to avoid endless recursion in the
-                        ///< parent-child relationship
+  CategoryTreeItem*  mParent;
+  tl::optional<Uuid> mUuid;
+  QString            mName;
+  QString            mDescription;
+  unsigned int       mDepth;  ///< this is to avoid endless recursion in the
+                              ///< parent-child relationship
   QString          mExceptionMessage;
   QList<ChildType> mChilds;
 };


### PR DESCRIPTION
All the information needed to build category tree views (e.g. in the "Add Component" dialog) is available in the workspace library database, which is much faster than loading the categories from the file system. So let's use the database ;)