### PR TITLE
Library Editor: Extend functionality of overview lists

### DIFF
--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -153,6 +153,17 @@ bool LibraryOverviewWidget::save() noexcept {
   }
 }
 
+bool LibraryOverviewWidget::remove() noexcept {
+  if (QListWidget* list = dynamic_cast<QListWidget*>(focusWidget())) {
+    QHash<QListWidgetItem*, FilePath> selectedItemPaths =
+        getElementListItemFilePaths(list->selectedItems());
+    removeItems(selectedItemPaths);
+    return true;
+  } else {
+    return false;
+  }
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
@@ -311,23 +322,29 @@ void LibraryOverviewWidget::updateElementList(QListWidget& listWidget,
   }
 }
 
+QHash<QListWidgetItem*, FilePath>
+LibraryOverviewWidget::getElementListItemFilePaths(
+    const QList<QListWidgetItem*>& items) const noexcept {
+  QHash<QListWidgetItem*, FilePath> itemPaths;
+  foreach (QListWidgetItem* item, items) {
+    FilePath fp = FilePath(item->data(Qt::UserRole).toString());
+    if (fp.isValid()) {
+      itemPaths.insert(item, fp);
+    } else {
+      qWarning() << "File path for item is not valid";
+    }
+  }
+  return itemPaths;
+}
+
 void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   Q_UNUSED(pos);
 
-  // Get list widget
+  // Get list widget item file paths
   QListWidget* list = dynamic_cast<QListWidget*>(sender());
   Q_ASSERT(list);
-
-  // Get item texts and validated file paths
-  QHash<QListWidgetItem*, FilePath> selectedItemPaths;
-  foreach (QListWidgetItem* item, list->selectedItems()) {
-    FilePath fp = FilePath(item->data(Qt::UserRole).toString());
-    if (fp.isValid()) {
-      selectedItemPaths.insert(item, fp);
-    } else {
-      qWarning() << "File path for selected item is not valid";
-    }
-  }
+  QHash<QListWidgetItem*, FilePath> selectedItemPaths =
+      getElementListItemFilePaths(list->selectedItems());
 
   // Build the context menu
   QMenu    menu;

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -333,6 +333,8 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   QMenu    menu;
   QAction* aEdit = menu.addAction(QIcon(":/img/actions/edit.png"), tr("Edit"));
   aEdit->setVisible(!selectedItemPaths.isEmpty());
+  QAction* aCopy = menu.addAction(QIcon(":/img/actions/copy.png"), tr("Copy"));
+  aCopy->setVisible(selectedItemPaths.count() == 1);
   QAction* aRemove =
       menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
   aRemove->setVisible(!selectedItemPaths.isEmpty());
@@ -345,9 +347,33 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   // Show context menu, handle action
   QAction* action = menu.exec(QCursor::pos());
   if (action == aEdit) {
+    Q_ASSERT(selectedItemPaths.count() > 0);
     foreach (const FilePath& fp, selectedItemPaths) { editItem(list, fp); }
+  } else if (action == aCopy) {
+    Q_ASSERT(selectedItemPaths.count() == 1);
+    copyItem(list, selectedItemPaths.values().first());
   } else if (action == aRemove) {
+    Q_ASSERT(selectedItemPaths.count() > 0);
     removeItems(selectedItemPaths);
+  }
+}
+
+void LibraryOverviewWidget::copyItem(QListWidget*    list,
+                                     const FilePath& fp) noexcept {
+  if (list == mUi->lstCmpCat) {
+    emit copyComponentCategoryTriggered(fp);
+  } else if (list == mUi->lstPkgCat) {
+    emit copyPackageCategoryTriggered(fp);
+  } else if (list == mUi->lstSym) {
+    emit copySymbolTriggered(fp);
+  } else if (list == mUi->lstPkg) {
+    emit copyPackageTriggered(fp);
+  } else if (list == mUi->lstCmp) {
+    emit copyComponentTriggered(fp);
+  } else if (list == mUi->lstDev) {
+    emit copyDeviceTriggered(fp);
+  } else if (list) {
+    qCritical() << "Unknown list widget!";
   }
 }
 

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -58,17 +58,17 @@ LibraryOverviewWidget::LibraryOverviewWidget(const Context&  context,
   connect(mUi->btnIcon, &QPushButton::clicked, this,
           &LibraryOverviewWidget::btnIconClicked);
   connect(mUi->lstCmpCat, &QListWidget::doubleClicked, this,
-          &LibraryOverviewWidget::lstCmpCatDoubleClicked);
+          &LibraryOverviewWidget::lstDoubleClicked);
   connect(mUi->lstPkgCat, &QListWidget::doubleClicked, this,
-          &LibraryOverviewWidget::lstPkgCatDoubleClicked);
+          &LibraryOverviewWidget::lstDoubleClicked);
   connect(mUi->lstSym, &QListWidget::doubleClicked, this,
-          &LibraryOverviewWidget::lstSymDoubleClicked);
+          &LibraryOverviewWidget::lstDoubleClicked);
   connect(mUi->lstPkg, &QListWidget::doubleClicked, this,
-          &LibraryOverviewWidget::lstPkgDoubleClicked);
+          &LibraryOverviewWidget::lstDoubleClicked);
   connect(mUi->lstCmp, &QListWidget::doubleClicked, this,
-          &LibraryOverviewWidget::lstCmpDoubleClicked);
+          &LibraryOverviewWidget::lstDoubleClicked);
   connect(mUi->lstDev, &QListWidget::doubleClicked, this,
-          &LibraryOverviewWidget::lstDevDoubleClicked);
+          &LibraryOverviewWidget::lstDoubleClicked);
 
   // Insert dependencies editor widget.
   mDependenciesEditorWidget.reset(
@@ -331,14 +331,42 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
 
   // Build the context menu
   QMenu    menu;
+  QAction* aEdit = menu.addAction(QIcon(":/img/actions/edit.png"), tr("Edit"));
+  aEdit->setVisible(!selectedItemPaths.isEmpty());
   QAction* aRemove =
       menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
   aRemove->setVisible(!selectedItemPaths.isEmpty());
 
+  // Set default action
+  if (!selectedItemPaths.isEmpty()) {
+    menu.setDefaultAction(aEdit);
+  }
+
   // Show context menu, handle action
   QAction* action = menu.exec(QCursor::pos());
-  if (action == aRemove) {
+  if (action == aEdit) {
+    foreach (const FilePath& fp, selectedItemPaths) { editItem(list, fp); }
+  } else if (action == aRemove) {
     removeItems(selectedItemPaths);
+  }
+}
+
+void LibraryOverviewWidget::editItem(QListWidget*    list,
+                                     const FilePath& fp) noexcept {
+  if (list == mUi->lstCmpCat) {
+    emit editComponentCategoryTriggered(fp);
+  } else if (list == mUi->lstPkgCat) {
+    emit editPackageCategoryTriggered(fp);
+  } else if (list == mUi->lstSym) {
+    emit editSymbolTriggered(fp);
+  } else if (list == mUi->lstPkg) {
+    emit editPackageTriggered(fp);
+  } else if (list == mUi->lstCmp) {
+    emit editComponentTriggered(fp);
+  } else if (list == mUi->lstDev) {
+    emit editDeviceTriggered(fp);
+  } else if (list) {
+    qCritical() << "Unknown list widget!";
   }
 }
 
@@ -401,63 +429,16 @@ void LibraryOverviewWidget::btnIconClicked() noexcept {
   }
 }
 
-void LibraryOverviewWidget::lstCmpCatDoubleClicked(
+void LibraryOverviewWidget::lstDoubleClicked(
     const QModelIndex& index) noexcept {
-  QListWidgetItem* item = mUi->lstCmpCat->item(index.row());
+  // Get list widget
+  QListWidget* list = dynamic_cast<QListWidget*>(sender());
+  Q_ASSERT(list);
+  QListWidgetItem* item = list->item(index.row());
   FilePath         fp =
       item ? FilePath(item->data(Qt::UserRole).toString()) : FilePath();
   if (fp.isValid()) {
-    emit editComponentCategoryTriggered(fp);
-  }
-}
-
-void LibraryOverviewWidget::lstPkgCatDoubleClicked(
-    const QModelIndex& index) noexcept {
-  QListWidgetItem* item = mUi->lstPkgCat->item(index.row());
-  FilePath         fp =
-      item ? FilePath(item->data(Qt::UserRole).toString()) : FilePath();
-  if (fp.isValid()) {
-    emit editPackageCategoryTriggered(fp);
-  }
-}
-
-void LibraryOverviewWidget::lstSymDoubleClicked(
-    const QModelIndex& index) noexcept {
-  QListWidgetItem* item = mUi->lstSym->item(index.row());
-  FilePath         fp =
-      item ? FilePath(item->data(Qt::UserRole).toString()) : FilePath();
-  if (fp.isValid()) {
-    emit editSymbolTriggered(fp);
-  }
-}
-
-void LibraryOverviewWidget::lstPkgDoubleClicked(
-    const QModelIndex& index) noexcept {
-  QListWidgetItem* item = mUi->lstPkg->item(index.row());
-  FilePath         fp =
-      item ? FilePath(item->data(Qt::UserRole).toString()) : FilePath();
-  if (fp.isValid()) {
-    emit editPackageTriggered(fp);
-  }
-}
-
-void LibraryOverviewWidget::lstCmpDoubleClicked(
-    const QModelIndex& index) noexcept {
-  QListWidgetItem* item = mUi->lstCmp->item(index.row());
-  FilePath         fp =
-      item ? FilePath(item->data(Qt::UserRole).toString()) : FilePath();
-  if (fp.isValid()) {
-    emit editComponentTriggered(fp);
-  }
-}
-
-void LibraryOverviewWidget::lstDevDoubleClicked(
-    const QModelIndex& index) noexcept {
-  QListWidgetItem* item = mUi->lstDev->item(index.row());
-  FilePath         fp =
-      item ? FilePath(item->data(Qt::UserRole).toString()) : FilePath();
-  if (fp.isValid()) {
-    emit editDeviceTriggered(fp);
+    editItem(list, fp);
   }
 }
 

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -355,9 +355,13 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   QAction* aRemove =
       menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
   aRemove->setVisible(!selectedItemPaths.isEmpty());
+  QAction* aNew = menu.addAction(QIcon(":/img/actions/new.png"), tr("New"));
+  aNew->setVisible(selectedItemPaths.count() <= 1);
 
   // Set default action
-  if (!selectedItemPaths.isEmpty()) {
+  if (selectedItemPaths.isEmpty()) {
+    menu.setDefaultAction(aNew);
+  } else {
     menu.setDefaultAction(aEdit);
   }
 
@@ -372,6 +376,26 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   } else if (action == aRemove) {
     Q_ASSERT(selectedItemPaths.count() > 0);
     removeItems(selectedItemPaths);
+  } else if (action == aNew) {
+    newItem(list);
+  }
+}
+
+void LibraryOverviewWidget::newItem(QListWidget* list) noexcept {
+  if (list == mUi->lstCmpCat) {
+    emit newComponentCategoryTriggered();
+  } else if (list == mUi->lstPkgCat) {
+    emit newPackageCategoryTriggered();
+  } else if (list == mUi->lstSym) {
+    emit newSymbolTriggered();
+  } else if (list == mUi->lstPkg) {
+    emit newPackageTriggered();
+  } else if (list == mUi->lstCmp) {
+    emit newComponentTriggered();
+  } else if (list == mUi->lstDev) {
+    emit newDeviceTriggered();
+  } else if (list) {
+    qCritical() << "Unknown list widget!";
   }
 }
 

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -100,8 +100,8 @@ private:  // Methods
   template <typename ElementType>
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;
   void openContextMenuAtPos(const QPoint& pos) noexcept;
-  bool removeSelectedItem(const QString&  itemName,
-                          const FilePath& itemPath) noexcept;
+  void removeItems(
+      const QHash<QListWidgetItem*, FilePath>& selectedItemPaths) noexcept;
 
   // Event Handlers
   void btnIconClicked() noexcept;

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -76,6 +76,12 @@ public slots:
   bool remove() noexcept override;
 
 signals:
+  void newComponentCategoryTriggered();
+  void newPackageCategoryTriggered();
+  void newSymbolTriggered();
+  void newPackageTriggered();
+  void newComponentTriggered();
+  void newDeviceTriggered();
   void editComponentCategoryTriggered(const FilePath& fp);
   void editPackageCategoryTriggered(const FilePath& fp);
   void editSymbolTriggered(const FilePath& fp);
@@ -109,6 +115,7 @@ private:  // Methods
   QHash<QListWidgetItem*, FilePath> getElementListItemFilePaths(
       const QList<QListWidgetItem*>& items) const noexcept;
   void openContextMenuAtPos(const QPoint& pos) noexcept;
+  void newItem(QListWidget* list) noexcept;
   void editItem(QListWidget* list, const FilePath& fp) noexcept;
   void copyItem(QListWidget* list, const FilePath& fp) noexcept;
   void removeItems(

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -73,6 +73,7 @@ public:
 
 public slots:
   bool save() noexcept override;
+  bool remove() noexcept override;
 
 signals:
   void editComponentCategoryTriggered(const FilePath& fp);
@@ -105,6 +106,8 @@ private:  // Methods
   void updateElementLists() noexcept;
   template <typename ElementType>
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;
+  QHash<QListWidgetItem*, FilePath> getElementListItemFilePaths(
+      const QList<QListWidgetItem*>& items) const noexcept;
   void openContextMenuAtPos(const QPoint& pos) noexcept;
   void editItem(QListWidget* list, const FilePath& fp) noexcept;
   void copyItem(QListWidget* list, const FilePath& fp) noexcept;

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -81,6 +81,12 @@ signals:
   void editPackageTriggered(const FilePath& fp);
   void editComponentTriggered(const FilePath& fp);
   void editDeviceTriggered(const FilePath& fp);
+  void copyComponentCategoryTriggered(const FilePath& fp);
+  void copyPackageCategoryTriggered(const FilePath& fp);
+  void copySymbolTriggered(const FilePath& fp);
+  void copyPackageTriggered(const FilePath& fp);
+  void copyComponentTriggered(const FilePath& fp);
+  void copyDeviceTriggered(const FilePath& fp);
   void removeElementTriggered(const FilePath& fp);
 
 private:  // Methods
@@ -101,6 +107,7 @@ private:  // Methods
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;
   void openContextMenuAtPos(const QPoint& pos) noexcept;
   void editItem(QListWidget* list, const FilePath& fp) noexcept;
+  void copyItem(QListWidget* list, const FilePath& fp) noexcept;
   void removeItems(
       const QHash<QListWidgetItem*, FilePath>& selectedItemPaths) noexcept;
 

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -100,17 +100,13 @@ private:  // Methods
   template <typename ElementType>
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;
   void openContextMenuAtPos(const QPoint& pos) noexcept;
+  void editItem(QListWidget* list, const FilePath& fp) noexcept;
   void removeItems(
       const QHash<QListWidgetItem*, FilePath>& selectedItemPaths) noexcept;
 
   // Event Handlers
   void btnIconClicked() noexcept;
-  void lstCmpCatDoubleClicked(const QModelIndex& index) noexcept;
-  void lstPkgCatDoubleClicked(const QModelIndex& index) noexcept;
-  void lstSymDoubleClicked(const QModelIndex& index) noexcept;
-  void lstPkgDoubleClicked(const QModelIndex& index) noexcept;
-  void lstCmpDoubleClicked(const QModelIndex& index) noexcept;
-  void lstDevDoubleClicked(const QModelIndex& index) noexcept;
+  void lstDoubleClicked(const QModelIndex& index) noexcept;
 
 private:  // Data
   QScopedPointer<Ui::LibraryOverviewWidget> mUi;

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.ui
@@ -65,6 +65,9 @@
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
             </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
             <property name="uniformItemSizes">
              <bool>true</bool>
             </property>
@@ -101,6 +104,9 @@
            <widget class="QListWidget" name="lstSym">
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
             </property>
             <property name="uniformItemSizes">
              <bool>true</bool>
@@ -139,6 +145,9 @@
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
             </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
             <property name="uniformItemSizes">
              <bool>true</bool>
             </property>
@@ -175,6 +184,9 @@
            <widget class="QListWidget" name="lstPkg">
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
             </property>
             <property name="uniformItemSizes">
              <bool>true</bool>
@@ -213,6 +225,9 @@
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
             </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
             <property name="uniformItemSizes">
              <bool>true</bool>
             </property>
@@ -249,6 +264,9 @@
            <widget class="QListWidget" name="lstDev">
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
             </property>
             <property name="uniformItemSizes">
              <bool>true</bool>

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -557,6 +557,7 @@ void LibraryEditor::cursorPositionChanged(const Point& pos) noexcept {
 
 void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
   bool hasGraphicalEditor = false;
+  bool isOverviewTab = dynamic_cast<LibraryOverviewWidget*>(widget) != nullptr;
   if (mCurrentEditorWidget) {
     mCurrentEditorWidget->setUndoStackActionGroup(nullptr);
     mCurrentEditorWidget->setToolsActionGroup(nullptr);
@@ -571,6 +572,9 @@ void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
   }
   foreach (QAction* action, mUi->editToolbar->actions()) {
     action->setEnabled(hasGraphicalEditor);
+  }
+  if (isOverviewTab) {
+    mUi->actionRemove->setEnabled(true);
   }
   foreach (QAction* action, mUi->viewToolbar->actions()) {
     action->setEnabled(hasGraphicalEditor);

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -246,6 +246,18 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, const FilePath& libFp,
 #endif
 
   // Edit element signals
+  connect(overviewWidget, &LibraryOverviewWidget::newComponentCategoryTriggered,
+          this, &LibraryEditor::newComponentCategoryTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::newPackageCategoryTriggered,
+          this, &LibraryEditor::newPackageCategoryTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::newSymbolTriggered, this,
+          &LibraryEditor::newSymbolTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::newPackageTriggered, this,
+          &LibraryEditor::newPackageTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::newComponentTriggered, this,
+          &LibraryEditor::newComponentTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::newDeviceTriggered, this,
+          &LibraryEditor::newDeviceTriggered);
   connect(overviewWidget,
           &LibraryOverviewWidget::editComponentCategoryTriggered, this,
           &LibraryEditor::editComponentCategoryTriggered);
@@ -401,6 +413,30 @@ void LibraryEditor::zoomAllTriggered() noexcept {
 
 void LibraryEditor::editGridPropertiesTriggered() noexcept {
   if (mCurrentEditorWidget) mCurrentEditorWidget->editGridProperties();
+}
+
+void LibraryEditor::newComponentCategoryTriggered() noexcept {
+  newLibraryElement(NewElementWizardContext::ElementType::ComponentCategory);
+}
+
+void LibraryEditor::newPackageCategoryTriggered() noexcept {
+  newLibraryElement(NewElementWizardContext::ElementType::PackageCategory);
+}
+
+void LibraryEditor::newSymbolTriggered() noexcept {
+  newLibraryElement(NewElementWizardContext::ElementType::Symbol);
+}
+
+void LibraryEditor::newPackageTriggered() noexcept {
+  newLibraryElement(NewElementWizardContext::ElementType::Package);
+}
+
+void LibraryEditor::newComponentTriggered() noexcept {
+  newLibraryElement(NewElementWizardContext::ElementType::Component);
+}
+
+void LibraryEditor::newDeviceTriggered() noexcept {
+  newLibraryElement(NewElementWizardContext::ElementType::Device);
 }
 
 void LibraryEditor::editComponentCategoryTriggered(
@@ -582,6 +618,17 @@ void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
   mUi->commandToolbar->setEnabled(hasGraphicalEditor);
   mUi->statusBar->setField(StatusBar::AbsolutePosition, hasGraphicalEditor);
   updateTabTitles();  // force updating the "Save" action title
+}
+
+void LibraryEditor::newLibraryElement(
+    NewElementWizardContext::ElementType type) {
+  NewElementWizard wizard(mWorkspace, *mLibrary, *this, this);
+  wizard.setNewElementType(type);
+  if (wizard.exec() == QDialog::Accepted) {
+    FilePath fp = wizard.getContext().getOutputDirectory();
+    editNewLibraryElement(wizard.getContext().mElementType, fp);
+    mWorkspace.getLibraryDb().startLibraryRescan();
+  }
 }
 
 void LibraryEditor::copyLibraryElement(

--- a/libs/librepcb/libraryeditor/libraryeditor.h
+++ b/libs/librepcb/libraryeditor/libraryeditor.h
@@ -141,6 +141,12 @@ private:  // GUI Event Handlers
   void zoomOutTriggered() noexcept;
   void zoomAllTriggered() noexcept;
   void editGridPropertiesTriggered() noexcept;
+  void newComponentCategoryTriggered() noexcept;
+  void newPackageCategoryTriggered() noexcept;
+  void newSymbolTriggered() noexcept;
+  void newPackageTriggered() noexcept;
+  void newComponentTriggered() noexcept;
+  void newDeviceTriggered() noexcept;
   void editComponentCategoryTriggered(const FilePath& fp) noexcept;
   void editPackageCategoryTriggered(const FilePath& fp) noexcept;
   void editSymbolTriggered(const FilePath& fp) noexcept;
@@ -164,6 +170,7 @@ private:  // GUI Event Handlers
 
 private:  // Methods
   void setActiveEditorWidget(EditorWidgetBase* widget);
+  void newLibraryElement(NewElementWizardContext::ElementType type);
   void copyLibraryElement(NewElementWizardContext::ElementType type,
                           const FilePath&                      fp);
   void editNewLibraryElement(NewElementWizardContext::ElementType type,

--- a/libs/librepcb/libraryeditor/libraryeditor.h
+++ b/libs/librepcb/libraryeditor/libraryeditor.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "newelementwizard/newelementwizard.h"
+
 #include <librepcb/common/exceptions.h>
 #include <librepcb/common/fileio/directorylock.h>
 #include <librepcb/common/graphics/graphicslayer.h>
@@ -145,8 +147,14 @@ private:  // GUI Event Handlers
   void editPackageTriggered(const FilePath& fp) noexcept;
   void editComponentTriggered(const FilePath& fp) noexcept;
   void editDeviceTriggered(const FilePath& fp) noexcept;
+  void copyComponentCategoryTriggered(const FilePath& fp) noexcept;
+  void copyPackageCategoryTriggered(const FilePath& fp) noexcept;
+  void copySymbolTriggered(const FilePath& fp) noexcept;
+  void copyPackageTriggered(const FilePath& fp) noexcept;
+  void copyComponentTriggered(const FilePath& fp) noexcept;
+  void copyDeviceTriggered(const FilePath& fp) noexcept;
   void closeTabIfOpen(const FilePath& fp) noexcept;
-  template <typename ElementType, typename EditWidgetType>
+  template <typename EditWidgetType>
   void editLibraryElementTriggered(const FilePath& fp,
                                    bool            isNewElement) noexcept;
   void currentTabChanged(int index) noexcept;
@@ -156,6 +164,10 @@ private:  // GUI Event Handlers
 
 private:  // Methods
   void setActiveEditorWidget(EditorWidgetBase* widget);
+  void copyLibraryElement(NewElementWizardContext::ElementType type,
+                          const FilePath&                      fp);
+  void editNewLibraryElement(NewElementWizardContext::ElementType type,
+                             const FilePath&                      fp);
   void updateTabTitles() noexcept;
   void closeEvent(QCloseEvent* event) noexcept override;
   void addLayer(const QString& name, bool forceVisible = false) noexcept;

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.cpp
@@ -85,6 +85,12 @@ NewElementWizard::~NewElementWizard() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void NewElementWizard::setNewElementType(
+    NewElementWizardContext::ElementType type) noexcept {
+  mContext->reset(type);
+  setStartId(NewElementWizardContext::ID_EnterMetadata);
+}
+
 void NewElementWizard::setElementToCopy(
     NewElementWizardContext::ElementType type, const FilePath& fp) noexcept {
   try {

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.cpp
@@ -85,6 +85,18 @@ NewElementWizard::~NewElementWizard() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void NewElementWizard::setElementToCopy(
+    NewElementWizardContext::ElementType type, const FilePath& fp) noexcept {
+  try {
+    mContext->reset(type);
+    mContext->copyElement(type, fp);  // can throw
+    setStartId(NewElementWizardContext::ID_EnterMetadata);
+  } catch (const Exception& e) {
+    QMessageBox::critical(this, tr("Could not copy element"), e.getMsg());
+    setStartId(NewElementWizardContext::ID_ChooseType);
+  }
+}
+
 bool NewElementWizard::validateCurrentPage() noexcept {
   if (currentPage() && (!currentPage()->validatePage())) {
     return false;

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.h
@@ -79,6 +79,7 @@ public:
   }
 
   // General Methods
+  void setNewElementType(NewElementWizardContext::ElementType type) noexcept;
   void setElementToCopy(NewElementWizardContext::ElementType type,
                         const FilePath&                      fp) noexcept;
   bool validateCurrentPage() noexcept override;

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.h
@@ -79,6 +79,8 @@ public:
   }
 
   // General Methods
+  void setElementToCopy(NewElementWizardContext::ElementType type,
+                        const FilePath&                      fp) noexcept;
   bool validateCurrentPage() noexcept override;
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.h
@@ -110,7 +110,8 @@ public:
   const QStringList& getLibLocaleOrder() const noexcept;
 
   // General Methods
-  void reset() noexcept;
+  void reset(ElementType newType = ElementType::None) noexcept;
+  void copyElement(ElementType type, const FilePath& fp);
   void createLibraryElement();
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.cpp
@@ -117,8 +117,7 @@ void NewElementWizardPage_ChooseType::cleanupPage() noexcept {
 
 void NewElementWizardPage_ChooseType::setElementType(
     NewElementWizardContext::ElementType type) noexcept {
-  mContext.reset();
-  mContext.mElementType = type;
+  mContext.reset(type);
   emit completeChanged();
   if (isComplete()) {
     wizard()->next();

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.h
@@ -98,7 +98,7 @@ private:  // Data
   QScopedPointer<QAbstractItemModel>                mCategoryTreeModel;
   bool                                              mIsCategoryElement;
   tl::optional<Uuid>                                mSelectedCategoryUuid;
-  QScopedPointer<LibraryBaseElement>                mSelectedElement;
+  bool                                              mIsComplete;
 };
 
 /*******************************************************************************

--- a/tests/funq/aliases
+++ b/tests/funq/aliases
@@ -96,9 +96,11 @@ libraryEditorWidget = {libraryEditor}::centralWidget
 
 # Actions
 libraryEditorActionNewElement = {libraryEditor}::actionNew
+libraryEditorActionRemove = {libraryEditor}::actionRemove
 
 # Tab widget
 libraryEditorTabWidget = {libraryEditorWidget}::tabWidget
+libraryEditorTabBar = {libraryEditorTabWidget}::qt_tabwidget_tabbar
 libraryEditorStackedWidget = {libraryEditorTabWidget}::qt_tabwidget_stackedwidget
 
 # Library overview widget
@@ -111,6 +113,15 @@ libraryEditorOverviewAuthorEdit = {libraryEditorOverviewMetadataWidget}::edtAuth
 libraryEditorOverviewVersionEdit = {libraryEditorOverviewMetadataWidget}::edtVersion
 libraryEditorOverviewDeprecatedCheckbox = {libraryEditorOverviewMetadataWidget}::cbxDeprecated
 libraryEditorOverviewUrlEdit = {libraryEditorOverviewMetadataWidget}::edtUrl
+libraryEditorOverviewCmpCatList = {libraryEditorOverviewWidget}::splitter::gridLayoutWidget::groupBox_2::lstCmpCat
+libraryEditorOverviewPkgCatList = {libraryEditorOverviewWidget}::splitter::gridLayoutWidget::groupBox_3::lstPkgCat
+libraryEditorOverviewSymList = {libraryEditorOverviewWidget}::splitter::gridLayoutWidget::groupBox_4::lstSym
+libraryEditorOverviewPkgList = {libraryEditorOverviewWidget}::splitter::gridLayoutWidget::groupBox_7::lstPkg
+libraryEditorOverviewCmpList = {libraryEditorOverviewWidget}::splitter::gridLayoutWidget::groupBox_5::lstCmp
+libraryEditorOverviewDevList = {libraryEditorOverviewWidget}::splitter::gridLayoutWidget::groupBox_6::lstDev
+libraryEditorOverviewMsgBox = {libraryEditorOverviewWidget}::QMessageBox
+libraryEditorOverviewMsgBoxBtnYes = {libraryEditorOverviewMsgBox}::qt_msgbox_buttonbox::QPushButton
+libraryEditorOverviewMsgBoxBtnCancel = {libraryEditorOverviewMsgBox}::qt_msgbox_buttonbox::QPushButton-1
 
 # Component category editor widget
 libraryEditorCmpCatWidget = {libraryEditorStackedWidget}::librepcb__library__editor__ComponentCategoryEditorWidget

--- a/tests/funq/libraryeditor/test_overview_tab.py
+++ b/tests/funq/libraryeditor/test_overview_tab.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test the overview tab in the library editor
+"""
+
+
+def list_dclick_helper(le, widget_name, number):
+    # Double click on the list must do nothing
+    widget = le.widget(widget_name)
+    widget.dclick()
+    assert le.widget('libraryEditorStackedWidget').properties()['count'] == number
+    assert le.widget('libraryEditorStackedWidget').properties()['currentIndex'] == 0
+
+    # Double click on an item must open the element in a new tab
+    widget.dclick_item(widget.model().items().items[0])
+    assert le.widget('libraryEditorStackedWidget').properties()['count'] == number + 1
+    assert le.widget('libraryEditorStackedWidget').properties()['currentIndex'] == number
+
+    # Switch back to overview tab
+    le.widget('libraryEditorTabBar').set_current_tab(0)
+
+
+def test_edit_with_doubleclick(library_editor, helpers):
+    """
+    Open editor tabs with doubleclick in the elements list
+    """
+    list_dclick_helper(library_editor, 'libraryEditorOverviewCmpCatList', 1)
+    list_dclick_helper(library_editor, 'libraryEditorOverviewPkgCatList', 2)
+    list_dclick_helper(library_editor, 'libraryEditorOverviewSymList', 3)
+    list_dclick_helper(library_editor, 'libraryEditorOverviewPkgList', 4)
+    list_dclick_helper(library_editor, 'libraryEditorOverviewCmpList', 5)
+    list_dclick_helper(library_editor, 'libraryEditorOverviewDevList', 6)
+
+
+def delete_action_helper(le, widget_name, valid, tabs):
+    widget = le.widget(widget_name)
+    widget.activate_focus()
+    le.action('libraryEditorActionRemove').trigger(blocking=False)
+    if valid:
+        le.widget('libraryEditorOverviewMsgBoxBtnCancel').click()
+        assert le.widget('libraryEditorStackedWidget').properties()['count'] == tabs + 1
+        assert le.widget('libraryEditorStackedWidget').properties()['currentIndex'] == 0
+    le.action('libraryEditorActionRemove').trigger(blocking=False)
+    if valid:
+        le.widget('libraryEditorOverviewMsgBoxBtnYes').click()
+    assert le.widget('libraryEditorStackedWidget').properties()['count'] == tabs
+    assert le.widget('libraryEditorStackedWidget').properties()['currentIndex'] == 0
+
+
+def test_delete_action(library_editor, helpers):
+    """
+    Create removing library elements with the "delete" action
+    """
+    le = library_editor
+
+    # Open some tabs first
+    test_edit_with_doubleclick(library_editor, helpers)
+    assert le.widget('libraryEditorStackedWidget').properties()['count'] == 7
+
+    # Press delete while the focus is not in a list widget
+    delete_action_helper(le, 'libraryEditorOverviewNameEdit', False, 7)
+
+    # Delete all selected elements
+    delete_action_helper(le, 'libraryEditorOverviewCmpCatList', True, 6)
+    delete_action_helper(le, 'libraryEditorOverviewPkgCatList', True, 5)
+    delete_action_helper(le, 'libraryEditorOverviewSymList', True, 4)
+    delete_action_helper(le, 'libraryEditorOverviewPkgList', True, 3)
+    delete_action_helper(le, 'libraryEditorOverviewCmpList', True, 2)
+    delete_action_helper(le, 'libraryEditorOverviewDevList', True, 1)


### PR DESCRIPTION
- Allow multi selection in lists (to edit or remove multiple elements at once)
- Enable "delete" shortcut to remove elements with the keyboard shortcut
- Add new context menu items to the library editor overview tab:
  - "Edit": Same as double click
  - "Copy": To open the "New Library Element" dialog, prefilled with the values of the selected element (disabled if multiple elements are selected)
- Add some more functional tests

![grafik](https://user-images.githubusercontent.com/5374821/54071614-4c467600-426f-11e9-9269-806d89cb108a.png)

Fixes #347 