### PR TITLE
Filter all category trees to show only relevant entries

### DIFF
--- a/libs/librepcb/common/sqlitedatabase.cpp
+++ b/libs/librepcb/common/sqlitedatabase.cpp
@@ -160,6 +160,21 @@ QSqlQuery SQLiteDatabase::prepareQuery(const QString& query) const {
   return q;
 }
 
+int SQLiteDatabase::count(QSqlQuery& query) {
+  exec(query);  // can throw
+
+  int  count   = 0;
+  bool success = query.next() && query.value(0).isValid();
+  if (success) {
+    count = query.value(0).toInt(&success);
+  }
+  if (success) {
+    return count;
+  } else {
+    throw LogicError(__FILE__, __LINE__);
+  }
+}
+
 int SQLiteDatabase::insert(QSqlQuery& query) {
   exec(query);  // can throw
 

--- a/libs/librepcb/common/sqlitedatabase.h
+++ b/libs/librepcb/common/sqlitedatabase.h
@@ -77,6 +77,7 @@ public:
 
   // General Methods
   QSqlQuery prepareQuery(const QString& query) const;
+  int       count(QSqlQuery& query);
   int       insert(QSqlQuery& query);
   void      exec(QSqlQuery& query);
   void      exec(const QString& query);

--- a/libs/librepcb/libraryeditor/common/categorychooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/categorychooserdialog.cpp
@@ -50,8 +50,8 @@ CategoryChooserDialog<ElementType>::CategoryChooserDialog(
           &CategoryChooserDialog<ElementType>::accept);
 
   mModel.reset(new workspace::CategoryTreeModel<ElementType>(
-      ws.getLibraryDb(),
-      ws.getSettings().getLibLocaleOrder().getLocaleOrder()));
+      ws.getLibraryDb(), ws.getSettings().getLibLocaleOrder().getLocaleOrder(),
+      workspace::CategoryTreeFilter::ALL));
   mUi->treeView->setModel(mModel.data());
   mUi->treeView->setRootIndex(QModelIndex());
 }

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
@@ -60,7 +60,8 @@ ComponentChooserDialog::ComponentChooserDialog(
   mUi->graphicsView->setScene(mGraphicsScene.data());
 
   mCategoryTreeModel.reset(new workspace::ComponentCategoryTreeModel(
-      mWorkspace.getLibraryDb(), localeOrder()));
+      mWorkspace.getLibraryDb(), localeOrder(),
+      workspace::CategoryTreeFilter::COMPONENTS));
   mUi->treeCategories->setModel(mCategoryTreeModel.data());
   connect(mUi->treeCategories->selectionModel(),
           &QItemSelectionModel::currentChanged, this,

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
@@ -61,7 +61,8 @@ PackageChooserDialog::PackageChooserDialog(
   mUi->graphicsView->setScene(mGraphicsScene.data());
 
   mCategoryTreeModel.reset(new workspace::PackageCategoryTreeModel(
-      mWorkspace.getLibraryDb(), localeOrder()));
+      mWorkspace.getLibraryDb(), localeOrder(),
+      workspace::CategoryTreeFilter::PACKAGES));
   mUi->treeCategories->setModel(mCategoryTreeModel.data());
   connect(mUi->treeCategories->selectionModel(),
           &QItemSelectionModel::currentChanged, this,

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.cpp
@@ -60,7 +60,8 @@ SymbolChooserDialog::SymbolChooserDialog(
   mUi->graphicsView->setOriginCrossVisible(false);
 
   mCategoryTreeModel.reset(new workspace::ComponentCategoryTreeModel(
-      mWorkspace.getLibraryDb(), localeOrder()));
+      mWorkspace.getLibraryDb(), localeOrder(),
+      workspace::CategoryTreeFilter::SYMBOLS));
   mUi->treeCategories->setModel(mCategoryTreeModel.data());
   connect(mUi->treeCategories->selectionModel(),
           &QItemSelectionModel::currentChanged, this,

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_copyfrom.cpp
@@ -247,22 +247,42 @@ void NewElementWizardPage_CopyFrom::initializePage() noexcept {
   setSelectedElement(FilePath());
   mIsCategoryElement = false;
   switch (mContext.mElementType) {
-    case NewElementWizardContext::ElementType::ComponentCategory:
+    case NewElementWizardContext::ElementType::ComponentCategory: {
       mIsCategoryElement = true;
-    case NewElementWizardContext::ElementType::Symbol:
-    case NewElementWizardContext::ElementType::Component:
-    case NewElementWizardContext::ElementType::Device: {
       setCategoryTreeModel(new workspace::ComponentCategoryTreeModel(
-          mContext.getWorkspace().getLibraryDb(),
-          mContext.getLibLocaleOrder()));
+          mContext.getWorkspace().getLibraryDb(), mContext.getLibLocaleOrder(),
+          workspace::CategoryTreeFilter::ALL));
       break;
     }
-    case NewElementWizardContext::ElementType::PackageCategory:
+    case NewElementWizardContext::ElementType::Symbol: {
+      setCategoryTreeModel(new workspace::ComponentCategoryTreeModel(
+          mContext.getWorkspace().getLibraryDb(), mContext.getLibLocaleOrder(),
+          workspace::CategoryTreeFilter::SYMBOLS));
+      break;
+    }
+    case NewElementWizardContext::ElementType::Component: {
+      setCategoryTreeModel(new workspace::ComponentCategoryTreeModel(
+          mContext.getWorkspace().getLibraryDb(), mContext.getLibLocaleOrder(),
+          workspace::CategoryTreeFilter::COMPONENTS));
+      break;
+    }
+    case NewElementWizardContext::ElementType::Device: {
+      setCategoryTreeModel(new workspace::ComponentCategoryTreeModel(
+          mContext.getWorkspace().getLibraryDb(), mContext.getLibLocaleOrder(),
+          workspace::CategoryTreeFilter::DEVICES));
+      break;
+    }
+    case NewElementWizardContext::ElementType::PackageCategory: {
       mIsCategoryElement = true;
+      setCategoryTreeModel(new workspace::PackageCategoryTreeModel(
+          mContext.getWorkspace().getLibraryDb(), mContext.getLibLocaleOrder(),
+          workspace::CategoryTreeFilter::ALL));
+      break;
+    }
     case NewElementWizardContext::ElementType::Package: {
       setCategoryTreeModel(new workspace::PackageCategoryTreeModel(
-          mContext.getWorkspace().getLibraryDb(),
-          mContext.getLibLocaleOrder()));
+          mContext.getWorkspace().getLibraryDb(), mContext.getLibLocaleOrder(),
+          workspace::CategoryTreeFilter::PACKAGES));
       break;
     }
     default: {

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
@@ -105,7 +105,8 @@ AddComponentDialog::AddComponentDialog(workspace::Workspace& workspace,
 
   const QStringList& localeOrder = mProject.getSettings().getLocaleOrder();
   mCategoryTreeModel             = new workspace::ComponentCategoryTreeModel(
-      mWorkspace.getLibraryDb(), localeOrder);
+      mWorkspace.getLibraryDb(), localeOrder,
+      workspace::CategoryTreeFilter::COMPONENTS);
   mUi->treeCategories->setModel(mCategoryTreeModel);
   connect(mUi->treeCategories->selectionModel(),
           &QItemSelectionModel::currentChanged, this,

--- a/libs/librepcb/workspace/library/cat/categorytreeitem.h
+++ b/libs/librepcb/workspace/library/cat/categorytreeitem.h
@@ -42,6 +42,21 @@ namespace workspace {
 class WorkspaceLibraryDb;
 
 /*******************************************************************************
+ *  Class CategoryTreeFilter
+ ******************************************************************************/
+
+struct CategoryTreeFilter {
+  enum Flag {
+    SYMBOLS    = 1 << 0,  ///< Show items containing symbols
+    PACKAGES   = 1 << 1,  ///< Show items containing packages
+    COMPONENTS = 1 << 2,  ///< Show items containing components
+    DEVICES    = 1 << 3,  ///< Show items containing devices
+    ALL        = 1 << 4,  ///< Show all items, even empty ones
+  };
+  Q_DECLARE_FLAGS(Flags, Flag)
+};
+
+/*******************************************************************************
  *  Class CategoryTreeItem
  ******************************************************************************/
 
@@ -56,7 +71,8 @@ public:
   CategoryTreeItem(const CategoryTreeItem& other) = delete;
   CategoryTreeItem(const WorkspaceLibraryDb& library,
                    const QStringList localeOrder, CategoryTreeItem* parent,
-                   const tl::optional<Uuid>& uuid) noexcept;
+                   const tl::optional<Uuid>& uuid,
+                   CategoryTreeFilter::Flags filter) noexcept;
   ~CategoryTreeItem() noexcept;
 
   // Getters
@@ -70,6 +86,7 @@ public:
   int      getChildCount() const noexcept { return mChilds.count(); }
   int      getChildNumber() const noexcept;
   QVariant data(int role) const noexcept;
+  bool     isVisible() const noexcept { return mIsVisible; }
 
   // Operator Overloadings
   CategoryTreeItem& operator=(const CategoryTreeItem& rhs) = delete;
@@ -81,6 +98,8 @@ private:
   // Methods
   FilePath   getLatestCategory(const WorkspaceLibraryDb& lib) const;
   QSet<Uuid> getCategoryChilds(const WorkspaceLibraryDb& lib) const;
+  bool       matchesFilter(const WorkspaceLibraryDb& lib,
+                           CategoryTreeFilter::Flags filter) const;
 
   // Attributes
   CategoryTreeItem*  mParent;
@@ -90,6 +109,7 @@ private:
   unsigned int       mDepth;  ///< this is to avoid endless recursion in the
                               ///< parent-child relationship
   QString          mExceptionMessage;
+  bool             mIsVisible;
   QList<ChildType> mChilds;
 };
 
@@ -102,5 +122,7 @@ typedef CategoryTreeItem<library::PackageCategory>   PackageCategoryTreeItem;
 
 }  // namespace workspace
 }  // namespace librepcb
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(librepcb::workspace::CategoryTreeFilter::Flags)
 
 #endif  // LIBREPCB_LIBRARY_CATEGORYTREEITEM_H

--- a/libs/librepcb/workspace/library/cat/categorytreemodel.cpp
+++ b/libs/librepcb/workspace/library/cat/categorytreemodel.cpp
@@ -40,10 +40,11 @@ namespace workspace {
 
 template <typename ElementType>
 CategoryTreeModel<ElementType>::CategoryTreeModel(
-    const WorkspaceLibraryDb& library, const QStringList& localeOrder) noexcept
+    const WorkspaceLibraryDb& library, const QStringList& localeOrder,
+    CategoryTreeFilter::Flags filter) noexcept
   : QAbstractItemModel(nullptr) {
-  mRootItem.reset(new CategoryTreeItem<ElementType>(library, localeOrder,
-                                                    nullptr, tl::nullopt));
+  mRootItem.reset(new CategoryTreeItem<ElementType>(
+      library, localeOrder, nullptr, tl::nullopt, filter));
 }
 
 template <typename ElementType>

--- a/libs/librepcb/workspace/library/cat/categorytreemodel.h
+++ b/libs/librepcb/workspace/library/cat/categorytreemodel.h
@@ -49,7 +49,8 @@ public:
   CategoryTreeModel()                               = delete;
   CategoryTreeModel(const CategoryTreeModel& other) = delete;
   explicit CategoryTreeModel(const WorkspaceLibraryDb& library,
-                             const QStringList&        localeOrder) noexcept;
+                             const QStringList&        localeOrder,
+                             CategoryTreeFilter::Flags filter) noexcept;
   ~CategoryTreeModel() noexcept;
 
   // Getters

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -113,12 +113,17 @@ public:
   QSet<Uuid> getPackageCategoryChilds(const tl::optional<Uuid>& parent) const;
   QList<Uuid> getComponentCategoryParents(const Uuid& category) const;
   QList<Uuid> getPackageCategoryParents(const Uuid& category) const;
-  QSet<Uuid>  getSymbolsByCategory(const tl::optional<Uuid>& category) const;
-  QSet<Uuid>  getPackagesByCategory(const tl::optional<Uuid>& category) const;
-  QSet<Uuid>  getComponentsByCategory(const tl::optional<Uuid>& category) const;
-  QSet<Uuid>  getDevicesByCategory(const tl::optional<Uuid>& category) const;
-  QSet<Uuid>  getDevicesOfComponent(const Uuid& component) const;
-  QSet<Uuid>  getComponentsBySearchKeyword(const QString& keyword) const;
+  void getComponentCategoryElementCount(const tl::optional<Uuid>& category,
+                                        int* categories, int* symbols,
+                                        int* components, int* devices) const;
+  void getPackageCategoryElementCount(const tl::optional<Uuid>& category,
+                                      int* categories, int* packages) const;
+  QSet<Uuid> getSymbolsByCategory(const tl::optional<Uuid>& category) const;
+  QSet<Uuid> getPackagesByCategory(const tl::optional<Uuid>& category) const;
+  QSet<Uuid> getComponentsByCategory(const tl::optional<Uuid>& category) const;
+  QSet<Uuid> getDevicesByCategory(const tl::optional<Uuid>& category) const;
+  QSet<Uuid> getDevicesOfComponent(const Uuid& component) const;
+  QSet<Uuid> getComponentsBySearchKeyword(const QString& keyword) const;
 
   // General Methods
 
@@ -157,6 +162,11 @@ private:
                                         const Uuid&    category) const;
   tl::optional<Uuid> getCategoryParent(const QString& tablename,
                                        const Uuid&    category) const;
+  int                getCategoryChildCount(const QString&            tablename,
+                                           const tl::optional<Uuid>& category) const;
+  int                getCategoryElementCount(const QString&            tablename,
+                                             const QString&            idrowname,
+                                             const tl::optional<Uuid>& category) const;
   QSet<Uuid>         getElementsByCategory(
               const QString& tablename, const QString& idrowname,
               const tl::optional<Uuid>& categoryUuid) const;

--- a/tests/funq/libraryeditor/test_copy_package.py
+++ b/tests/funq/libraryeditor/test_copy_package.py
@@ -24,7 +24,7 @@ def test(library_editor, helpers):
     # Choose category
     category_tree = le.widget('libraryEditorNewElementWizardCopyFromCategoriesTree')
     helpers.wait_for_model_items_count(category_tree, 2)
-    category = category_tree.model().items().items[1]
+    category = category_tree.model().items().items[0]
     category_tree.select_item(category)
 
     # Choose element


### PR DESCRIPTION
See #378. In addition to the "Add component"-dialog in the schematic editor, empty categories are also hidden in the library editor, depending on the use-case of the category tree. For example when selecting a device, you will now only see categories which actually contain devices.

Fixes #378.