### PR TITLE
AddComponentDialog: Pre-select symbol variant by project norms

### DIFF
--- a/libs/librepcb/library/cmp/component.cpp
+++ b/libs/librepcb/library/cmp/component.cpp
@@ -100,6 +100,19 @@ std::shared_ptr<const ComponentSignal> Component::getSignalOfPin(
   }
 }
 
+int Component::getSymbolVariantIndexByNorm(const QStringList& normOrder) const
+    noexcept {
+  foreach (const QString& norm, normOrder) {
+    for (int i = 0; i < mSymbolVariants.count(); ++i) {
+      std::shared_ptr<const ComponentSymbolVariant> var = mSymbolVariants.at(i);
+      if (cleanNorm(var->getNorm()) == cleanNorm(norm)) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
 std::shared_ptr<ComponentSymbolVariantItem> Component::getSymbVarItem(
     const Uuid& symbVar, const Uuid& item) {
   return mSymbolVariants.get(symbVar)->getSymbolItems().get(item);  // can throw
@@ -131,6 +144,10 @@ void Component::serialize(SExpression& root) const {
   mAttributes.serialize(root);
   mSignals.serialize(root);
   mSymbolVariants.serialize(root);
+}
+
+QString Component::cleanNorm(QString norm) noexcept {
+  return QString(norm.toUpper().remove(QRegularExpression("[^0-9A-Z]")));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/component.h
+++ b/libs/librepcb/library/cmp/component.h
@@ -126,6 +126,7 @@ public:
   std::shared_ptr<const ComponentSignal> getSignalOfPin(const Uuid& symbVar,
                                                         const Uuid& item,
                                                         const Uuid& pin) const;
+  int getSymbolVariantIndexByNorm(const QStringList& normOrder) const noexcept;
   std::shared_ptr<ComponentSymbolVariantItem> getSymbVarItem(
       const Uuid& symbVar, const Uuid& item);
   std::shared_ptr<const ComponentSymbolVariantItem> getSymbVarItem(
@@ -148,6 +149,8 @@ public:
 private:  // Methods
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
+
+  static QString cleanNorm(QString norm) noexcept;
 
 private:                // Data
   bool mSchematicOnly;  ///< if true, this component is schematic-only (no

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -539,9 +539,6 @@
    <property name="toolTip">
     <string>Project Settings</string>
    </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
   </action>
   <action name="actionAbout">
    <property name="icon">

--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.cpp
@@ -397,8 +397,11 @@ void AddComponentDialog::setSelectedComponent(const library::Component* cmp) {
       }
       mUi->cbxSymbVar->addItem(text, symbVar.getUuid().toStr());
     }
-    mUi->cbxSymbVar->setCurrentIndex(cmp->getSymbolVariants().count() > 0 ? 0
-                                                                          : -1);
+    if (!cmp->getSymbolVariants().isEmpty()) {
+      mUi->cbxSymbVar->setCurrentIndex(
+          qMax(0, cmp->getSymbolVariantIndexByNorm(
+                      mProject.getSettings().getNormOrder())));
+    }
   }
 
   mUi->lblSymbVar->setVisible(mUi->cbxSymbVar->count() > 1);

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -643,9 +643,6 @@
    <property name="text">
     <string>&amp;Settings</string>
    </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
   </action>
   <action name="actionToolAddNetLabel">
    <property name="icon">


### PR DESCRIPTION
- Enable project settings menu item in board/schematic editors (I guess they were hidden by accident).
- `AddComponentDialog`: Pre-select symbol variant by project norms

Now you can set your preferred norm in the project settings dialog:
![grafik](https://user-images.githubusercontent.com/5374821/54480471-f6eb0580-4828-11e9-8727-4311a90c1e55.png)


And then the "Add Component"-dialog automatically pre-selects the component symbol variant according the specified norm:
![grafik](https://user-images.githubusercontent.com/5374821/54480467-e6d32600-4828-11e9-9b5b-5e1e2de120d0.png)

Fixes #396