### PR TITLE
CLI: Allow to specify custom fabrication output settings

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -303,7 +303,8 @@ bool CommandLineInterface::openProject(const QString& projectFile, bool runErc,
       bool                 filesOverwritten = false;
       foreach (const Board* board, boardList) {
         print("  " % QString(tr("Board '%1':")).arg(*board->getName()));
-        BoardGerberExport grbExport(*board);
+        BoardGerberExport grbExport(*board,
+                                    board->getFabricationOutputSettings());
         grbExport.exportAllLayers();  // can throw
         foreach (const FilePath& fp, grbExport.getWrittenFiles()) {
           filesCounter[fp]++;

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -25,8 +25,10 @@
 #include <librepcb/common/application.h>
 #include <librepcb/common/attributes/attributesubstitutor.h>
 #include <librepcb/common/debug.h>
+#include <librepcb/common/fileio/fileutils.h>
 #include <librepcb/common/fileio/transactionalfilesystem.h>
 #include <librepcb/project/boards/board.h>
+#include <librepcb/project/boards/boardfabricationoutputsettings.h>
 #include <librepcb/project/boards/boardgerberexport.h>
 #include <librepcb/project/erc/ercmsg.h>
 #include <librepcb/project/erc/ercmsglist.h>
@@ -87,6 +89,12 @@ int CommandLineInterface::execute() noexcept {
       tr("Export PCB fabrication data (Gerber/Excellon) according the "
          "fabrication "
          "output settings of boards. Existing files will be overwritten."));
+  QCommandLineOption pcbFabricationSettingsOption(
+      "pcb-fabrication-settings",
+      tr("Override PCB fabrication output settings by providing a *.lp file "
+         "containing custom settings. If not set, the settings from the boards "
+         "will be used instead."),
+      tr("file"));
   QCommandLineOption boardOption("board",
                                  tr("The name of the board(s) to export. Can "
                                     "be given multiple times. If not set, "
@@ -116,6 +124,7 @@ int CommandLineInterface::execute() noexcept {
     parser.addOption(ercOption);
     parser.addOption(exportSchematicsOption);
     parser.addOption(exportPcbFabricationDataOption);
+    parser.addOption(pcbFabricationSettingsOption);
     parser.addOption(boardOption);
     parser.addOption(saveOption);
   } else if (!command.isEmpty()) {
@@ -169,13 +178,13 @@ int CommandLineInterface::execute() noexcept {
       return 1;
     }
     cmdSuccess = openProject(
-        positionalArgs.value(0),                // project filepath
-        parser.isSet(ercOption),                // run ERC
-        parser.values(exportSchematicsOption),  // export schematics
-        parser.isSet(
-            exportPcbFabricationDataOption),  // export PCB fabrication data
-        parser.values(boardOption),           // boards
-        parser.isSet(saveOption)              // save project
+        positionalArgs.value(0),                       // project filepath
+        parser.isSet(ercOption),                       // run ERC
+        parser.values(exportSchematicsOption),         // export schematics
+        parser.isSet(exportPcbFabricationDataOption),  // export PCB fab. data
+        parser.value(pcbFabricationSettingsOption),    // PCB fab. settings
+        parser.values(boardOption),                    // boards
+        parser.isSet(saveOption)                       // save project
     );
   } else {
     printErr(tr("Internal failure."));
@@ -193,11 +202,11 @@ int CommandLineInterface::execute() noexcept {
  *  Private Methods
  ******************************************************************************/
 
-bool CommandLineInterface::openProject(const QString& projectFile, bool runErc,
-                                       const QStringList& exportSchematicsFiles,
-                                       bool exportPcbFabricationData,
-                                       const QStringList& boards,
-                                       bool               save) const noexcept {
+bool CommandLineInterface::openProject(
+    const QString& projectFile, bool runErc,
+    const QStringList& exportSchematicsFiles, bool exportPcbFabricationData,
+    const QString& pcbFabricationSettingsPath, const QStringList& boards,
+    bool save) const noexcept {
   try {
     bool success = true;
 
@@ -299,12 +308,28 @@ bool CommandLineInterface::openProject(const QString& projectFile, bool runErc,
           }
         }
       }
+      tl::optional<BoardFabricationOutputSettings> customSettings;
+      if (!pcbFabricationSettingsPath.isEmpty()) {
+        try {
+          qDebug() << "Load custom fabrication output settings:"
+                   << pcbFabricationSettingsPath;
+          FilePath fp(QFileInfo(pcbFabricationSettingsPath).absoluteFilePath());
+          customSettings = BoardFabricationOutputSettings(
+              SExpression::parse(FileUtils::readFile(fp), fp));  // can throw
+        } catch (const Exception& e) {
+          printErr(QString(tr("ERROR: Failed to load custom settings: %1"))
+                       .arg(e.getMsg()));
+          success = false;
+          boardList.clear();  // avoid exporting any boards
+        }
+      }
       QHash<FilePath, int> filesCounter;
       bool                 filesOverwritten = false;
       foreach (const Board* board, boardList) {
         print("  " % QString(tr("Board '%1':")).arg(*board->getName()));
-        BoardGerberExport grbExport(*board,
-                                    board->getFabricationOutputSettings());
+        BoardGerberExport grbExport(
+            *board, customSettings ? *customSettings
+                                   : board->getFabricationOutputSettings());
         grbExport.exportAllLayers();  // can throw
         foreach (const FilePath& fp, grbExport.getWrittenFiles()) {
           filesCounter[fp]++;

--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -57,8 +57,9 @@ public:
 private:  // Methods
   bool           openProject(const QString& projectFile, bool runErc,
                              const QStringList& exportSchematicsFiles,
-                             bool exportPcbFabricationData, const QStringList& boards,
-                             bool save) const noexcept;
+                             bool               exportPcbFabricationData,
+                             const QString&     pcbFabricationSettingsPath,
+                             const QStringList& boards, bool save) const noexcept;
   static QString prettyPath(const FilePath& path,
                             const QString&  style) noexcept;
   static void    print(const QString& str, int newlines = 1) noexcept;

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -60,8 +60,12 @@ namespace project {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BoardGerberExport::BoardGerberExport(const Board& board) noexcept
-  : mProject(board.getProject()), mBoard(board), mCurrentInnerCopperLayer(0) {
+BoardGerberExport::BoardGerberExport(
+    const Board& board, const BoardFabricationOutputSettings& settings) noexcept
+  : mProject(board.getProject()),
+    mBoard(board),
+    mSettings(new BoardFabricationOutputSettings(settings)),
+    mCurrentInnerCopperLayer(0) {
 }
 
 BoardGerberExport::~BoardGerberExport() noexcept {
@@ -82,7 +86,7 @@ FilePath BoardGerberExport::getOutputDirectory() const noexcept {
 void BoardGerberExport::exportAllLayers() const {
   mWrittenFiles.clear();
 
-  if (mBoard.getFabricationOutputSettings().getMergeDrillFiles()) {
+  if (mSettings->getMergeDrillFiles()) {
     exportDrills();
   } else {
     exportDrillsNpth();
@@ -96,10 +100,10 @@ void BoardGerberExport::exportAllLayers() const {
   exportLayerBottomSolderMask();
   exportLayerTopSilkscreen();
   exportLayerBottomSilkscreen();
-  if (mBoard.getFabricationOutputSettings().getEnableSolderPasteTop()) {
+  if (mSettings->getEnableSolderPasteTop()) {
     exportLayerTopSolderPaste();
   }
-  if (mBoard.getFabricationOutputSettings().getEnableSolderPasteBot()) {
+  if (mSettings->getEnableSolderPasteBot()) {
     exportLayerBottomSolderPaste();
   }
 }
@@ -127,8 +131,7 @@ BoardGerberExport::getAttributeProviderParents() const noexcept {
  ******************************************************************************/
 
 void BoardGerberExport::exportDrills() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixDrills());
+  FilePath          fp = getOutputFilePath(mSettings->getSuffixDrills());
   ExcellonGenerator gen;
   drawPthDrills(gen);
   drawNpthDrills(gen);
@@ -138,8 +141,7 @@ void BoardGerberExport::exportDrills() const {
 }
 
 void BoardGerberExport::exportDrillsNpth() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixDrillsNpth());
+  FilePath          fp = getOutputFilePath(mSettings->getSuffixDrillsNpth());
   ExcellonGenerator gen;
   int               count = drawNpthDrills(gen);
   if (count > 0) {
@@ -154,8 +156,7 @@ void BoardGerberExport::exportDrillsNpth() const {
 }
 
 void BoardGerberExport::exportDrillsPth() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixDrillsPth());
+  FilePath          fp = getOutputFilePath(mSettings->getSuffixDrillsPth());
   ExcellonGenerator gen;
   drawPthDrills(gen);
   gen.generate();
@@ -164,8 +165,7 @@ void BoardGerberExport::exportDrillsPth() const {
 }
 
 void BoardGerberExport::exportLayerBoardOutlines() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixOutlines());
+  FilePath        fp = getOutputFilePath(mSettings->getSuffixOutlines());
   GerberGenerator gen(
       mProject.getMetadata().getName() % " - " % mBoard.getName(),
       mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -176,8 +176,7 @@ void BoardGerberExport::exportLayerBoardOutlines() const {
 }
 
 void BoardGerberExport::exportLayerTopCopper() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixCopperTop());
+  FilePath        fp = getOutputFilePath(mSettings->getSuffixCopperTop());
   GerberGenerator gen(
       mProject.getMetadata().getName() % " - " % mBoard.getName(),
       mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -188,8 +187,7 @@ void BoardGerberExport::exportLayerTopCopper() const {
 }
 
 void BoardGerberExport::exportLayerBottomCopper() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixCopperBot());
+  FilePath        fp = getOutputFilePath(mSettings->getSuffixCopperBot());
   GerberGenerator gen(
       mProject.getMetadata().getName() % " - " % mBoard.getName(),
       mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -202,8 +200,7 @@ void BoardGerberExport::exportLayerBottomCopper() const {
 void BoardGerberExport::exportLayerInnerCopper() const {
   for (int i = 1; i <= mBoard.getLayerStack().getInnerLayerCount(); ++i) {
     mCurrentInnerCopperLayer = i;  // used for attribute provider
-    FilePath fp              = getOutputFilePath(
-        mBoard.getFabricationOutputSettings().getSuffixCopperInner());
+    FilePath        fp = getOutputFilePath(mSettings->getSuffixCopperInner());
     GerberGenerator gen(
         mProject.getMetadata().getName() % " - " % mBoard.getName(),
         mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -216,8 +213,7 @@ void BoardGerberExport::exportLayerInnerCopper() const {
 }
 
 void BoardGerberExport::exportLayerTopSolderMask() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixSolderMaskTop());
+  FilePath        fp = getOutputFilePath(mSettings->getSuffixSolderMaskTop());
   GerberGenerator gen(
       mProject.getMetadata().getName() % " - " % mBoard.getName(),
       mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -228,8 +224,7 @@ void BoardGerberExport::exportLayerTopSolderMask() const {
 }
 
 void BoardGerberExport::exportLayerBottomSolderMask() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixSolderMaskBot());
+  FilePath        fp = getOutputFilePath(mSettings->getSuffixSolderMaskBot());
   GerberGenerator gen(
       mProject.getMetadata().getName() % " - " % mBoard.getName(),
       mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -240,12 +235,10 @@ void BoardGerberExport::exportLayerBottomSolderMask() const {
 }
 
 void BoardGerberExport::exportLayerTopSilkscreen() const {
-  QStringList layers =
-      mBoard.getFabricationOutputSettings().getSilkscreenLayersTop();
+  QStringList layers = mSettings->getSilkscreenLayersTop();
   if (layers.count() >
       0) {  // don't create silkscreen file if no layers selected
-    FilePath fp = getOutputFilePath(
-        mBoard.getFabricationOutputSettings().getSuffixSilkscreenTop());
+    FilePath        fp = getOutputFilePath(mSettings->getSuffixSilkscreenTop());
     GerberGenerator gen(
         mProject.getMetadata().getName() % " - " % mBoard.getName(),
         mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -259,12 +252,10 @@ void BoardGerberExport::exportLayerTopSilkscreen() const {
 }
 
 void BoardGerberExport::exportLayerBottomSilkscreen() const {
-  QStringList layers =
-      mBoard.getFabricationOutputSettings().getSilkscreenLayersBot();
+  QStringList layers = mSettings->getSilkscreenLayersBot();
   if (layers.count() >
       0) {  // don't create silkscreen file if no layers selected
-    FilePath fp = getOutputFilePath(
-        mBoard.getFabricationOutputSettings().getSuffixSilkscreenBot());
+    FilePath        fp = getOutputFilePath(mSettings->getSuffixSilkscreenBot());
     GerberGenerator gen(
         mProject.getMetadata().getName() % " - " % mBoard.getName(),
         mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -278,8 +269,7 @@ void BoardGerberExport::exportLayerBottomSilkscreen() const {
 }
 
 void BoardGerberExport::exportLayerTopSolderPaste() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixSolderPasteTop());
+  FilePath        fp = getOutputFilePath(mSettings->getSuffixSolderPasteTop());
   GerberGenerator gen(
       mProject.getMetadata().getName() % " - " % mBoard.getName(),
       mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -290,8 +280,7 @@ void BoardGerberExport::exportLayerTopSolderPaste() const {
 }
 
 void BoardGerberExport::exportLayerBottomSolderPaste() const {
-  FilePath fp = getOutputFilePath(
-      mBoard.getFabricationOutputSettings().getSuffixSolderPasteBot());
+  FilePath        fp = getOutputFilePath(mSettings->getSuffixSolderPasteBot());
   GerberGenerator gen(
       mProject.getMetadata().getName() % " - " % mBoard.getName(),
       mBoard.getUuid(), mProject.getMetadata().getVersion());
@@ -590,8 +579,7 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator&       gen,
 
 FilePath BoardGerberExport::getOutputFilePath(const QString& suffix) const
     noexcept {
-  QString path =
-      mBoard.getFabricationOutputSettings().getOutputBasePath() + suffix;
+  QString path = mSettings->getOutputBasePath() + suffix;
   path = AttributeSubstitutor::substitute(path, this, [&](const QString& str) {
     return FilePath::cleanFileName(
         str, FilePath::ReplaceSpaces | FilePath::KeepCase);

--- a/libs/librepcb/project/boards/boardgerberexport.h
+++ b/libs/librepcb/project/boards/boardgerberexport.h
@@ -46,6 +46,7 @@ class Board;
 class BI_Via;
 class BI_Footprint;
 class BI_FootprintPad;
+class BoardFabricationOutputSettings;
 
 /*******************************************************************************
  *  Class BoardGerberExport
@@ -64,7 +65,8 @@ public:
   // Constructors / Destructor
   BoardGerberExport()                               = delete;
   BoardGerberExport(const BoardGerberExport& other) = delete;
-  BoardGerberExport(const Board& board) noexcept;
+  BoardGerberExport(const Board&                          board,
+                    const BoardFabricationOutputSettings& settings) noexcept;
   ~BoardGerberExport() noexcept;
 
   // Getters
@@ -131,10 +133,11 @@ private:
   }
 
   // Private Member Variables
-  const Project&            mProject;
-  const Board&              mBoard;
-  mutable int               mCurrentInnerCopperLayer;
-  mutable QVector<FilePath> mWrittenFiles;
+  const Project&                                       mProject;
+  const Board&                                         mBoard;
+  QScopedPointer<const BoardFabricationOutputSettings> mSettings;
+  mutable int                                          mCurrentInnerCopperLayer;
+  mutable QVector<FilePath>                            mWrittenFiles;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.cpp
@@ -171,7 +171,7 @@ void FabricationOutputDialog::on_btnGenerate_clicked() {
     }
 
     // generate files
-    BoardGerberExport grbExport(mBoard);
+    BoardGerberExport grbExport(mBoard, mBoard.getFabricationOutputSettings());
     grbExport.exportAllLayers();
   } catch (Exception& e) {
     QMessageBox::warning(this, tr("Error"), e.getMsg());
@@ -179,7 +179,7 @@ void FabricationOutputDialog::on_btnGenerate_clicked() {
 }
 
 void FabricationOutputDialog::on_btnBrowseOutputDir_clicked() {
-  BoardGerberExport grbExport(mBoard);
+  BoardGerberExport grbExport(mBoard, mBoard.getFabricationOutputSettings());
   FilePath          dir = grbExport.getOutputDirectory();
   if (dir.isExistingDir()) {
     QDesktopServices::openUrl(QUrl::fromLocalFile(dir.toStr()));

--- a/tests/cli/open-project/test_export_pcb_fabrication_data.py
+++ b/tests/cli/open-project/test_export_pcb_fabrication_data.py
@@ -210,3 +210,97 @@ def test_export_project_with_two_conflicting_boards_succeeds_explicit(cli):
     assert stdout[-1] == 'SUCCESS'
     assert os.path.exists(dir)
     assert len(os.listdir(dir)) == 8
+
+
+@pytest.mark.parametrize("project,output_dir", [
+    (PROJECT_PATH_1_LPP, 'data/Empty Project/custom_output'),
+    (PROJECT_PATH_1_LPPZ, 'data/custom_output'),
+], ids=[
+    'EmptyProject.lpp',
+    'EmptyProject.lppz',
+])
+def test_export_with_custom_settings(cli, project, output_dir):
+    settings = """
+      (fabrication_output_settings
+        (base_path "./custom_output/")
+        (outlines (suffix "OUTLINES.gbr"))
+        (copper_top (suffix "COPPER-TOP.gbr"))
+        (copper_inner (suffix "COPPER-IN{{CU_LAYER}}.gbr"))
+        (copper_bot (suffix "COPPER-BOTTOM.gbr"))
+        (soldermask_top (suffix "SOLDERMASK-TOP.gbr"))
+        (soldermask_bot (suffix "SOLDERMASK-BOTTOM.gbr"))
+        (silkscreen_top (suffix "SILKSCREEN-TOP.gbr")
+          (layers top_placement top_names)
+        )
+        (silkscreen_bot (suffix "SILKSCREEN-BOTTOM.gbr")
+          (layers bot_placement bot_names)
+        )
+        (drills (merge true)
+          (suffix_pth "DRILLS-PTH.drl")
+          (suffix_npth "DRILLS-NPTH.drl")
+          (suffix_merged "DRILLS.drl")
+        )
+        (solderpaste_top (create true) (suffix "SOLDERPASTE-TOP.gbr"))
+        (solderpaste_bot (create true) (suffix "SOLDERPASTE-BOTTOM.gbr"))
+      )
+    """
+    with open(cli.abspath('settings.lp'), mode='w') as f:
+        f.write(settings)
+    dir = cli.abspath(output_dir)
+    assert not os.path.exists(dir)
+    code, stdout, stderr = cli.run('open-project',
+                                   '--export-pcb-fabrication-data',
+                                   '--pcb-fabrication-settings=settings.lp',
+                                   project)
+    assert code == 0
+    assert len(stderr) == 0
+    assert len(stdout) > 0
+    assert stdout[-1] == 'SUCCESS'
+    assert os.path.exists(dir)
+    assert len(os.listdir(dir)) == 10
+
+
+@pytest.mark.parametrize("project,output_dir", [
+    (PROJECT_PATH_1_LPP, OUTPUT_DIR_1_LPP),
+    (PROJECT_PATH_2_LPPZ, OUTPUT_DIR_2_LPPZ),
+], ids=[
+    'EmptyProject.lpp',
+    'ProjectWithTwoBoards.lppz',
+])
+def test_if_export_with_nonexistent_settings_fails(cli, project, output_dir):
+    dir = cli.abspath(output_dir)
+    assert not os.path.exists(dir)
+    code, stdout, stderr = cli.run('open-project',
+                                   '--export-pcb-fabrication-data',
+                                   '--pcb-fabrication-settings=nonexistent.lp',
+                                   project)
+    assert code == 1
+    assert len(stderr) == 1
+    assert "Failed to load custom settings:" in stderr[0]
+    assert len(stdout) > 0
+    assert stdout[-1] == 'Finished with errors!'
+    assert not os.path.exists(dir)
+
+
+@pytest.mark.parametrize("project,output_dir", [
+    (PROJECT_PATH_1_LPP, OUTPUT_DIR_1_LPP),
+    (PROJECT_PATH_2_LPPZ, OUTPUT_DIR_2_LPPZ),
+], ids=[
+    'EmptyProject.lpp',
+    'ProjectWithTwoBoards.lppz',
+])
+def test_if_export_with_invalid_settings_fails(cli, project, output_dir):
+    with open(cli.abspath('settings.lp'), mode='w') as f:
+        f.write('foobar')
+    dir = cli.abspath(output_dir)
+    assert not os.path.exists(dir)
+    code, stdout, stderr = cli.run('open-project',
+                                   '--export-pcb-fabrication-data',
+                                   '--pcb-fabrication-settings=settings.lp',
+                                   project)
+    assert code == 1
+    assert len(stderr) > 0
+    assert "Failed to load custom settings: File parse error:" in stderr[0]
+    assert len(stdout) > 0
+    assert stdout[-1] == 'Finished with errors!'
+    assert not os.path.exists(dir)


### PR DESCRIPTION
Adds the CLI argument `--pcb-fabrication-settings=<file>` to specify a *.lp file with custom fabrication output settings, overriding the settings stored in the board itself. This is useful for PCB manufacturers to generate Gerber files from LibrePCB projects with the settings they need ;)