### PR TITLE
Schematic editor: Fix unreadable text in ERC dock with Qt 5.12

### DIFF
--- a/libs/librepcb/projecteditor/docks/ercmsgdock.ui
+++ b/libs/librepcb/projecteditor/docks/ercmsgdock.ui
@@ -60,7 +60,7 @@
        <bool>true</bool>
       </property>
       <property name="wordWrap">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
       <property name="headerHidden">
        <bool>true</bool>


### PR DESCRIPTION
With Qt 5.12 the text in the ERC dock widget gets wrapped, but the height is not adjusted accordingly, thus the text is unreadable. Disabling word wrap fixes this.

Fixes #436 