### PR TITLE
Add search field to symbol/package/component chooser dialogs

### DIFF
--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.cpp
@@ -70,6 +70,8 @@ ComponentChooserDialog::ComponentChooserDialog(
           &ComponentChooserDialog::listComponents_currentItemChanged);
   connect(mUi->listComponents, &QListWidget::itemDoubleClicked, this,
           &ComponentChooserDialog::listComponents_itemDoubleClicked);
+  connect(mUi->edtSearch, &QLineEdit::textChanged, this,
+          &ComponentChooserDialog::searchEditTextChanged);
 
   setSelectedComponent(tl::nullopt);
 }
@@ -81,6 +83,21 @@ ComponentChooserDialog::~ComponentChooserDialog() noexcept {
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void ComponentChooserDialog::searchEditTextChanged(
+    const QString& text) noexcept {
+  try {
+    QModelIndex catIndex = mUi->treeCategories->currentIndex();
+    if (text.trimmed().isEmpty() && catIndex.isValid()) {
+      setSelectedCategory(
+          Uuid::tryFromString(catIndex.data(Qt::UserRole).toString()));
+    } else {
+      searchComponents(text.trimmed());
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(this, tr("Error"), e.getMsg());
+  }
+}
 
 void ComponentChooserDialog::treeCategories_currentItemChanged(
     const QModelIndex& current, const QModelIndex& previous) noexcept {
@@ -106,6 +123,27 @@ void ComponentChooserDialog::listComponents_itemDoubleClicked(
     setSelectedComponent(
         Uuid::tryFromString(item->data(Qt::UserRole).toString()));
     accept();
+  }
+}
+
+void ComponentChooserDialog::searchComponents(const QString& input) {
+  setSelectedCategory(tl::nullopt);
+
+  // min. 2 chars to avoid freeze on entering first character due to huge result
+  if (input.length() > 1) {
+    QList<Uuid> components =
+        mWorkspace.getLibraryDb().getElementsBySearchKeyword<Component>(input);
+    foreach (const Uuid& uuid, components) {
+      FilePath fp =
+          mWorkspace.getLibraryDb().getLatestComponent(uuid);  // can throw
+      QString name;
+      mWorkspace.getLibraryDb().getElementTranslations<Component>(
+          fp, localeOrder(),
+          &name);  // can throw
+      QListWidgetItem* item = new QListWidgetItem(name);
+      item->setData(Qt::UserRole, uuid.toStr());
+      mUi->listComponents->addItem(item);
+    }
   }
 }
 
@@ -142,18 +180,16 @@ void ComponentChooserDialog::setSelectedCategory(
 
 void ComponentChooserDialog::setSelectedComponent(
     const tl::optional<Uuid>& uuid) noexcept {
-  QString uuidStr = "00000000-0000-0000-0000-000000000000";
-  QString name, desc;
+  FilePath fp;
+  QString  name = tr("No component selected");
+  QString  desc;
   mSelectedComponentUuid = uuid;
 
   if (uuid) {
     try {
-      uuidStr = uuid->toStr();
-      mComponentFilePath =
-          mWorkspace.getLibraryDb().getLatestComponent(*uuid);  // can throw
-
+      fp = mWorkspace.getLibraryDb().getLatestComponent(*uuid);  // can throw
       mWorkspace.getLibraryDb().getElementTranslations<Component>(
-          mComponentFilePath, localeOrder(), &name, &desc);  // can throw
+          fp, localeOrder(), &name, &desc);  // can throw
     } catch (const Exception& e) {
       QMessageBox::critical(this, tr("Could not load component metadata"),
                             e.getMsg());
@@ -162,19 +198,19 @@ void ComponentChooserDialog::setSelectedComponent(
 
   mUi->lblComponentName->setText(name);
   mUi->lblComponentDescription->setText(desc);
-  updatePreview();
+  updatePreview(fp);
 }
 
-void ComponentChooserDialog::updatePreview() noexcept {
+void ComponentChooserDialog::updatePreview(const FilePath& fp) noexcept {
   mSymbolGraphicsItems.clear();
   mSymbols.clear();
   mComponent.reset();
 
-  if (mComponentFilePath.isValid() && mLayerProvider) {
+  if (fp.isValid() && mLayerProvider) {
     try {
-      mComponent.reset(new Component(std::unique_ptr<TransactionalDirectory>(
-          new TransactionalDirectory(TransactionalFileSystem::openRO(
-              mComponentFilePath)))));  // can throw
+      mComponent.reset(new Component(
+          std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
+              TransactionalFileSystem::openRO(fp)))));  // can throw
       if (mComponent && mComponent->getSymbolVariants().count() > 0) {
         const ComponentSymbolVariant& symbVar =
             *mComponent->getSymbolVariants().first();

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.h
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.h
@@ -86,14 +86,16 @@ public:
   ComponentChooserDialog& operator=(const ComponentChooserDialog& rhs) = delete;
 
 private:  // Methods
+  void searchEditTextChanged(const QString& text) noexcept;
   void treeCategories_currentItemChanged(const QModelIndex& current,
                                          const QModelIndex& previous) noexcept;
   void listComponents_currentItemChanged(QListWidgetItem* current,
                                          QListWidgetItem* previous) noexcept;
   void listComponents_itemDoubleClicked(QListWidgetItem* item) noexcept;
+  void searchComponents(const QString& input);
   void setSelectedCategory(const tl::optional<Uuid>& uuid) noexcept;
   void setSelectedComponent(const tl::optional<Uuid>& uuid) noexcept;
-  void updatePreview() noexcept;
+  void updatePreview(const FilePath& fp) noexcept;
   void accept() noexcept override;
   const QStringList& localeOrder() const noexcept;
 
@@ -106,7 +108,6 @@ private:  // Data
   tl::optional<Uuid>                         mSelectedComponentUuid;
 
   // preview
-  FilePath                                          mComponentFilePath;
   QScopedPointer<Component>                         mComponent;
   QScopedPointer<GraphicsScene>                     mGraphicsScene;
   QList<std::shared_ptr<Symbol>>                    mSymbols;

--- a/libs/librepcb/libraryeditor/common/componentchooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/componentchooserdialog.ui
@@ -21,11 +21,31 @@
   </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0" columnstretch="1,1,1">
    <item row="0" column="0" rowspan="2">
-    <widget class="QTreeView" name="treeCategories">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-    </widget>
+    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+     <item>
+      <widget class="QLineEdit" name="edtSearch">
+       <property name="maxLength">
+        <number>100</number>
+       </property>
+       <property name="placeholderText">
+        <string>What are you looking for?</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QTreeView" name="treeCategories">
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="0" column="1" rowspan="2">
     <widget class="QListWidget" name="listComponents">

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.cpp
@@ -71,6 +71,8 @@ PackageChooserDialog::PackageChooserDialog(
           &PackageChooserDialog::listPackages_currentItemChanged);
   connect(mUi->listPackages, &QListWidget::itemDoubleClicked, this,
           &PackageChooserDialog::listPackages_itemDoubleClicked);
+  connect(mUi->edtSearch, &QLineEdit::textChanged, this,
+          &PackageChooserDialog::searchEditTextChanged);
 
   setSelectedPackage(tl::nullopt);
 }
@@ -82,6 +84,20 @@ PackageChooserDialog::~PackageChooserDialog() noexcept {
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void PackageChooserDialog::searchEditTextChanged(const QString& text) noexcept {
+  try {
+    QModelIndex catIndex = mUi->treeCategories->currentIndex();
+    if (text.trimmed().isEmpty() && catIndex.isValid()) {
+      setSelectedCategory(
+          Uuid::tryFromString(catIndex.data(Qt::UserRole).toString()));
+    } else {
+      searchPackages(text.trimmed());
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(this, tr("Error"), e.getMsg());
+  }
+}
 
 void PackageChooserDialog::treeCategories_currentItemChanged(
     const QModelIndex& current, const QModelIndex& previous) noexcept {
@@ -107,6 +123,27 @@ void PackageChooserDialog::listPackages_itemDoubleClicked(
     setSelectedPackage(
         Uuid::tryFromString(item->data(Qt::UserRole).toString()));
     accept();
+  }
+}
+
+void PackageChooserDialog::searchPackages(const QString& input) {
+  setSelectedCategory(tl::nullopt);
+
+  // min. 2 chars to avoid freeze on entering first character due to huge result
+  if (input.length() > 1) {
+    QList<Uuid> packages =
+        mWorkspace.getLibraryDb().getElementsBySearchKeyword<Package>(input);
+    foreach (const Uuid& uuid, packages) {
+      FilePath fp =
+          mWorkspace.getLibraryDb().getLatestPackage(uuid);  // can throw
+      QString name;
+      mWorkspace.getLibraryDb().getElementTranslations<Package>(
+          fp, localeOrder(),
+          &name);  // can throw
+      QListWidgetItem* item = new QListWidgetItem(name);
+      item->setData(Qt::UserRole, uuid.toStr());
+      mUi->listPackages->addItem(item);
+    }
   }
 }
 
@@ -144,17 +181,16 @@ void PackageChooserDialog::setSelectedCategory(
 
 void PackageChooserDialog::setSelectedPackage(
     const tl::optional<Uuid>& uuid) noexcept {
-  QString uuidStr = "00000000-0000-0000-0000-000000000000";
-  QString name, desc;
+  FilePath fp;
+  QString  name = tr("No package selected");
+  QString  desc;
   mSelectedPackageUuid = uuid;
 
   if (uuid) {
     try {
-      uuidStr = uuid->toStr();
-      mPackageFilePath =
-          mWorkspace.getLibraryDb().getLatestPackage(*uuid);  // can throw
+      fp = mWorkspace.getLibraryDb().getLatestPackage(*uuid);  // can throw
       mWorkspace.getLibraryDb().getElementTranslations<Package>(
-          mPackageFilePath, localeOrder(), &name, &desc);  // can throw
+          fp, localeOrder(), &name, &desc);  // can throw
     } catch (const Exception& e) {
       QMessageBox::critical(this, tr("Could not load package metadata"),
                             e.getMsg());
@@ -163,18 +199,18 @@ void PackageChooserDialog::setSelectedPackage(
 
   mUi->lblPackageName->setText(name);
   mUi->lblPackageDescription->setText(desc);
-  updatePreview();
+  updatePreview(fp);
 }
 
-void PackageChooserDialog::updatePreview() noexcept {
+void PackageChooserDialog::updatePreview(const FilePath& fp) noexcept {
   mGraphicsItem.reset();
   mPackage.reset();
 
-  if (mPackageFilePath.isValid() && mLayerProvider) {
+  if (fp.isValid() && mLayerProvider) {
     try {
-      mPackage.reset(new Package(std::unique_ptr<TransactionalDirectory>(
-          new TransactionalDirectory(TransactionalFileSystem::openRO(
-              mPackageFilePath)))));  // can throw
+      mPackage.reset(new Package(
+          std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
+              TransactionalFileSystem::openRO(fp)))));  // can throw
       if (mPackage->getFootprints().count() > 0) {
         mGraphicsItem.reset(new FootprintPreviewGraphicsItem(
             *mLayerProvider, QStringList(), *mPackage->getFootprints().first(),

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.h
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.h
@@ -83,14 +83,16 @@ public:
   PackageChooserDialog& operator=(const PackageChooserDialog& rhs) = delete;
 
 private:  // Methods
+  void searchEditTextChanged(const QString& text) noexcept;
   void treeCategories_currentItemChanged(const QModelIndex& current,
                                          const QModelIndex& previous) noexcept;
   void listPackages_currentItemChanged(QListWidgetItem* current,
                                        QListWidgetItem* previous) noexcept;
   void listPackages_itemDoubleClicked(QListWidgetItem* item) noexcept;
+  void searchPackages(const QString& input);
   void setSelectedCategory(const tl::optional<Uuid>& uuid) noexcept;
   void setSelectedPackage(const tl::optional<Uuid>& uuid) noexcept;
-  void updatePreview() noexcept;
+  void updatePreview(const FilePath& fp) noexcept;
   void accept() noexcept override;
   const QStringList& localeOrder() const noexcept;
 
@@ -103,7 +105,6 @@ private:  // Data
   tl::optional<Uuid>                       mSelectedPackageUuid;
 
   // preview
-  FilePath                                     mPackageFilePath;
   QScopedPointer<Package>                      mPackage;
   QScopedPointer<GraphicsScene>                mGraphicsScene;
   QScopedPointer<FootprintPreviewGraphicsItem> mGraphicsItem;

--- a/libs/librepcb/libraryeditor/common/packagechooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/packagechooserdialog.ui
@@ -21,11 +21,31 @@
   </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0" columnstretch="1,1,1">
    <item row="0" column="0" rowspan="2">
-    <widget class="QTreeView" name="treeCategories">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-    </widget>
+    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+     <item>
+      <widget class="QLineEdit" name="edtSearch">
+       <property name="maxLength">
+        <number>100</number>
+       </property>
+       <property name="placeholderText">
+        <string>What are you looking for?</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QTreeView" name="treeCategories">
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="0" column="1" rowspan="2">
     <widget class="QListWidget" name="listPackages">

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.h
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.h
@@ -83,11 +83,13 @@ public:
   SymbolChooserDialog& operator=(const SymbolChooserDialog& rhs) = delete;
 
 private:  // Methods
+  void searchEditTextChanged(const QString& text) noexcept;
   void treeCategories_currentItemChanged(const QModelIndex& current,
                                          const QModelIndex& previous) noexcept;
   void listSymbols_currentItemChanged(QListWidgetItem* current,
                                       QListWidgetItem* previous) noexcept;
   void listSymbols_itemDoubleClicked(QListWidgetItem* item) noexcept;
+  void searchSymbols(const QString& input);
   void setSelectedCategory(const tl::optional<Uuid>& uuid) noexcept;
   void setSelectedSymbol(const FilePath& fp) noexcept;
   void accept() noexcept override;

--- a/libs/librepcb/libraryeditor/common/symbolchooserdialog.ui
+++ b/libs/librepcb/libraryeditor/common/symbolchooserdialog.ui
@@ -21,11 +21,31 @@
   </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0" columnstretch="1,1,1">
    <item row="0" column="0" rowspan="2">
-    <widget class="QTreeView" name="treeCategories">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-    </widget>
+    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+     <item>
+      <widget class="QLineEdit" name="edtSearch">
+       <property name="maxLength">
+        <number>100</number>
+       </property>
+       <property name="placeholderText">
+        <string>What are you looking for?</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QTreeView" name="treeCategories">
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="0" column="1" rowspan="2">
     <widget class="QListWidget" name="listSymbols">

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -92,6 +92,11 @@ public:
   FilePath getLatestComponent(const Uuid& uuid) const;
   FilePath getLatestDevice(const Uuid& uuid) const;
 
+  // Getters: Library elements by search keyword
+  template <typename ElementType>
+  QList<Uuid> getElementsBySearchKeyword(const QString& keyword) const;
+  QSet<Uuid>  getComponentsBySearchKeyword(const QString& keyword) const;
+
   // Getters: Library elements of a specified library
   template <typename ElementType>
   QList<FilePath> getLibraryElements(const FilePath& lib) const;
@@ -123,7 +128,6 @@ public:
   QSet<Uuid> getComponentsByCategory(const tl::optional<Uuid>& category) const;
   QSet<Uuid> getDevicesByCategory(const tl::optional<Uuid>& category) const;
   QSet<Uuid> getDevicesOfComponent(const Uuid& component) const;
-  QSet<Uuid> getComponentsBySearchKeyword(const QString& keyword) const;
 
   // General Methods
 
@@ -170,6 +174,9 @@ private:
   QSet<Uuid>         getElementsByCategory(
               const QString& tablename, const QString& idrowname,
               const tl::optional<Uuid>& categoryUuid) const;
+  QList<Uuid>     getElementsBySearchKeyword(const QString& tablename,
+                                             const QString& idrowname,
+                                             const QString& keyword) const;
   int             getLibraryId(const FilePath& lib) const;
   QList<FilePath> getLibraryElements(const FilePath& lib,
                                      const QString&  tablename) const;


### PR DESCRIPTION
In the library editor there are various locations where you need to choose a symbol, package or component with a dialog. This PR adds a search text field to these dialogs to help finding elements, basically just like we already have it in the "Add Component" dialog in the schematic editor.

![grafik](https://user-images.githubusercontent.com/5374821/56322919-9f62f100-616a-11e9-8901-e6c795923fef.png)

