### PR TITLE
AddComponentDialog: Refactor and improve search

### DIFF
--- a/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/addcomponentdialog.h
@@ -79,6 +79,22 @@ class AddComponentDialog;
 class AddComponentDialog final : public QDialog {
   Q_OBJECT
 
+  // Types
+  struct SearchResultDevice {
+    QString  name;
+    FilePath pkgFp;
+    QString  pkgName;
+    bool     match = false;
+  };
+
+  struct SearchResultComponent {
+    QString                             name;
+    QHash<FilePath, SearchResultDevice> devices;
+    bool                                match = false;
+  };
+
+  typedef QHash<FilePath, SearchResultComponent> SearchResult;
+
 public:
   // Constructors / Destructor
   explicit AddComponentDialog(workspace::Workspace& workspace, Project& project,
@@ -102,9 +118,10 @@ private slots:
 
 private:
   // Private Methods
-  void searchComponents(const QString& input);
-  void setSelectedCategory(const tl::optional<Uuid>& categoryUuid);
-  void setSelectedComponent(const library::Component* cmp);
+  void         searchComponents(const QString& input);
+  SearchResult searchComponentsAndDevices(const QString& input);
+  void         setSelectedCategory(const tl::optional<Uuid>& categoryUuid);
+  void         setSelectedComponent(const library::Component* cmp);
   void setSelectedSymbVar(const library::ComponentSymbolVariant* symbVar);
   void setSelectedDevice(const library::Device* dev);
   void accept() noexcept;

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -237,28 +237,6 @@ QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<Device>(
   return getElementsBySearchKeyword("devices", "device_id", keyword);
 }
 
-QSet<Uuid> WorkspaceLibraryDb::getComponentsBySearchKeyword(
-    const QString& keyword) const {
-  QSqlQuery query = mDb->prepareQuery(
-      "SELECT components.uuid FROM components, components_tr, devices, "
-      "devices_tr "
-      "ON components.id=components_tr.component_id "
-      "AND devices.id=devices_tr.device_id "
-      "AND devices.component_uuid=components.uuid "
-      "WHERE components_tr.name LIKE :keyword "
-      "OR components_tr.keywords LIKE :keyword "
-      "OR devices_tr.name LIKE :keyword "
-      "OR devices_tr.keywords LIKE :keyword ");
-  query.bindValue(":keyword", "%" + keyword + "%");
-  mDb->exec(query);
-
-  QSet<Uuid> elements;
-  while (query.next()) {
-    elements.insert(Uuid::fromString(query.value(0).toString()));  // can throw
-  }
-  return elements;
-}
-
 /*******************************************************************************
  *  Getters: Library elements of a specified library
  ******************************************************************************/

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -426,9 +426,10 @@ void WorkspaceLibraryDb::getLibraryMetadata(const FilePath libDir,
 }
 
 void WorkspaceLibraryDb::getDeviceMetadata(const FilePath& devDir,
-                                           Uuid*           pkgUuid) const {
+                                           Uuid* pkgUuid, Uuid* cmpUuid) const {
   QSqlQuery query = mDb->prepareQuery(
-      "SELECT package_uuid FROM devices WHERE filepath = :filepath");
+      "SELECT package_uuid, component_uuid "
+      "FROM devices WHERE filepath = :filepath");
   query.bindValue(":filepath",
                   devDir.toRelative(mWorkspace.getLibrariesPath()));
   mDb->exec(query);
@@ -436,6 +437,8 @@ void WorkspaceLibraryDb::getDeviceMetadata(const FilePath& devDir,
   if (query.first()) {
     Uuid uuid = Uuid::fromString(query.value(0).toString());  // can throw
     if (pkgUuid) *pkgUuid = uuid;
+    uuid = Uuid::fromString(query.value(1).toString());  // can throw
+    if (cmpUuid) *cmpUuid = uuid;
   } else {
     throw RuntimeError(
         __FILE__, __LINE__,

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -111,7 +111,8 @@ public:
   void getElementMetadata(const FilePath elemDir, Uuid* uuid = nullptr,
                           Version* version = nullptr) const;
   void getLibraryMetadata(const FilePath libDir, QPixmap* icon = nullptr) const;
-  void getDeviceMetadata(const FilePath& devDir, Uuid* pkgUuid = nullptr) const;
+  void getDeviceMetadata(const FilePath& devDir, Uuid* pkgUuid = nullptr,
+                         Uuid* cmpUuid = nullptr) const;
 
   // Getters: Special
   QSet<Uuid> getComponentCategoryChilds(const tl::optional<Uuid>& parent) const;

--- a/libs/librepcb/workspace/library/workspacelibrarydb.h
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.h
@@ -95,7 +95,6 @@ public:
   // Getters: Library elements by search keyword
   template <typename ElementType>
   QList<Uuid> getElementsBySearchKeyword(const QString& keyword) const;
-  QSet<Uuid>  getComponentsBySearchKeyword(const QString& keyword) const;
 
   // Getters: Library elements of a specified library
   template <typename ElementType>


### PR DESCRIPTION
Makes the search function in the "Add Component" dialog of the schematic editor much more powerful:

- Also find components which do not have devices (previously such components were not found).
- If the component doesn't match the search term:
  - Only show its devices which match the term (previously, all devices were shown).
  - Expand the tree item to directly show the matched devices (previously all tree items were collapsed)