### PR TITLE
Library editor overview: Rename "copy" to "duplicate"

### DIFF
--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -350,8 +350,9 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   QMenu    menu;
   QAction* aEdit = menu.addAction(QIcon(":/img/actions/edit.png"), tr("Edit"));
   aEdit->setVisible(!selectedItemPaths.isEmpty());
-  QAction* aCopy = menu.addAction(QIcon(":/img/actions/copy.png"), tr("Copy"));
-  aCopy->setVisible(selectedItemPaths.count() == 1);
+  QAction* aDuplicate =
+      menu.addAction(QIcon(":/img/actions/copy.png"), tr("Duplicate"));
+  aDuplicate->setVisible(selectedItemPaths.count() == 1);
   QAction* aRemove =
       menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
   aRemove->setVisible(!selectedItemPaths.isEmpty());
@@ -370,9 +371,9 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   if (action == aEdit) {
     Q_ASSERT(selectedItemPaths.count() > 0);
     foreach (const FilePath& fp, selectedItemPaths) { editItem(list, fp); }
-  } else if (action == aCopy) {
+  } else if (action == aDuplicate) {
     Q_ASSERT(selectedItemPaths.count() == 1);
-    copyItem(list, selectedItemPaths.values().first());
+    duplicateItem(list, selectedItemPaths.values().first());
   } else if (action == aRemove) {
     Q_ASSERT(selectedItemPaths.count() > 0);
     removeItems(selectedItemPaths);
@@ -399,20 +400,20 @@ void LibraryOverviewWidget::newItem(QListWidget* list) noexcept {
   }
 }
 
-void LibraryOverviewWidget::copyItem(QListWidget*    list,
-                                     const FilePath& fp) noexcept {
+void LibraryOverviewWidget::duplicateItem(QListWidget*    list,
+                                          const FilePath& fp) noexcept {
   if (list == mUi->lstCmpCat) {
-    emit copyComponentCategoryTriggered(fp);
+    emit duplicateComponentCategoryTriggered(fp);
   } else if (list == mUi->lstPkgCat) {
-    emit copyPackageCategoryTriggered(fp);
+    emit duplicatePackageCategoryTriggered(fp);
   } else if (list == mUi->lstSym) {
-    emit copySymbolTriggered(fp);
+    emit duplicateSymbolTriggered(fp);
   } else if (list == mUi->lstPkg) {
-    emit copyPackageTriggered(fp);
+    emit duplicatePackageTriggered(fp);
   } else if (list == mUi->lstCmp) {
-    emit copyComponentTriggered(fp);
+    emit duplicateComponentTriggered(fp);
   } else if (list == mUi->lstDev) {
-    emit copyDeviceTriggered(fp);
+    emit duplicateDeviceTriggered(fp);
   } else if (list) {
     qCritical() << "Unknown list widget!";
   }

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -88,12 +88,12 @@ signals:
   void editPackageTriggered(const FilePath& fp);
   void editComponentTriggered(const FilePath& fp);
   void editDeviceTriggered(const FilePath& fp);
-  void copyComponentCategoryTriggered(const FilePath& fp);
-  void copyPackageCategoryTriggered(const FilePath& fp);
-  void copySymbolTriggered(const FilePath& fp);
-  void copyPackageTriggered(const FilePath& fp);
-  void copyComponentTriggered(const FilePath& fp);
-  void copyDeviceTriggered(const FilePath& fp);
+  void duplicateComponentCategoryTriggered(const FilePath& fp);
+  void duplicatePackageCategoryTriggered(const FilePath& fp);
+  void duplicateSymbolTriggered(const FilePath& fp);
+  void duplicatePackageTriggered(const FilePath& fp);
+  void duplicateComponentTriggered(const FilePath& fp);
+  void duplicateDeviceTriggered(const FilePath& fp);
   void removeElementTriggered(const FilePath& fp);
 
 private:  // Methods
@@ -117,7 +117,7 @@ private:  // Methods
   void openContextMenuAtPos(const QPoint& pos) noexcept;
   void newItem(QListWidget* list) noexcept;
   void editItem(QListWidget* list, const FilePath& fp) noexcept;
-  void copyItem(QListWidget* list, const FilePath& fp) noexcept;
+  void duplicateItem(QListWidget* list, const FilePath& fp) noexcept;
   void removeItems(
       const QHash<QListWidgetItem*, FilePath>& selectedItemPaths) noexcept;
 

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -272,18 +272,19 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, const FilePath& libFp,
   connect(overviewWidget, &LibraryOverviewWidget::editDeviceTriggered, this,
           &LibraryEditor::editDeviceTriggered);
   connect(overviewWidget,
-          &LibraryOverviewWidget::copyComponentCategoryTriggered, this,
-          &LibraryEditor::copyComponentCategoryTriggered);
-  connect(overviewWidget, &LibraryOverviewWidget::copyPackageCategoryTriggered,
-          this, &LibraryEditor::copyPackageCategoryTriggered);
-  connect(overviewWidget, &LibraryOverviewWidget::copySymbolTriggered, this,
-          &LibraryEditor::copySymbolTriggered);
-  connect(overviewWidget, &LibraryOverviewWidget::copyPackageTriggered, this,
-          &LibraryEditor::copyPackageTriggered);
-  connect(overviewWidget, &LibraryOverviewWidget::copyComponentTriggered, this,
-          &LibraryEditor::copyComponentTriggered);
-  connect(overviewWidget, &LibraryOverviewWidget::copyDeviceTriggered, this,
-          &LibraryEditor::copyDeviceTriggered);
+          &LibraryOverviewWidget::duplicateComponentCategoryTriggered, this,
+          &LibraryEditor::duplicateComponentCategoryTriggered);
+  connect(overviewWidget,
+          &LibraryOverviewWidget::duplicatePackageCategoryTriggered, this,
+          &LibraryEditor::duplicatePackageCategoryTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::duplicateSymbolTriggered,
+          this, &LibraryEditor::duplicateSymbolTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::duplicatePackageTriggered,
+          this, &LibraryEditor::duplicatePackageTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::duplicateComponentTriggered,
+          this, &LibraryEditor::duplicateComponentTriggered);
+  connect(overviewWidget, &LibraryOverviewWidget::duplicateDeviceTriggered,
+          this, &LibraryEditor::duplicateDeviceTriggered);
   connect(overviewWidget, &LibraryOverviewWidget::removeElementTriggered, this,
           &LibraryEditor::closeTabIfOpen);
 
@@ -476,30 +477,32 @@ void LibraryEditor::editDeviceTriggered(const FilePath& fp) noexcept {
   editLibraryElementTriggered<DeviceEditorWidget>(fp, false);
 }
 
-void LibraryEditor::copyComponentCategoryTriggered(
+void LibraryEditor::duplicateComponentCategoryTriggered(
     const FilePath& fp) noexcept {
-  copyLibraryElement(NewElementWizardContext::ElementType::ComponentCategory,
-                     fp);
+  duplicateLibraryElement(
+      NewElementWizardContext::ElementType::ComponentCategory, fp);
 }
 
-void LibraryEditor::copyPackageCategoryTriggered(const FilePath& fp) noexcept {
-  copyLibraryElement(NewElementWizardContext::ElementType::PackageCategory, fp);
+void LibraryEditor::duplicatePackageCategoryTriggered(
+    const FilePath& fp) noexcept {
+  duplicateLibraryElement(NewElementWizardContext::ElementType::PackageCategory,
+                          fp);
 }
 
-void LibraryEditor::copySymbolTriggered(const FilePath& fp) noexcept {
-  copyLibraryElement(NewElementWizardContext::ElementType::Symbol, fp);
+void LibraryEditor::duplicateSymbolTriggered(const FilePath& fp) noexcept {
+  duplicateLibraryElement(NewElementWizardContext::ElementType::Symbol, fp);
 }
 
-void LibraryEditor::copyPackageTriggered(const FilePath& fp) noexcept {
-  copyLibraryElement(NewElementWizardContext::ElementType::Package, fp);
+void LibraryEditor::duplicatePackageTriggered(const FilePath& fp) noexcept {
+  duplicateLibraryElement(NewElementWizardContext::ElementType::Package, fp);
 }
 
-void LibraryEditor::copyComponentTriggered(const FilePath& fp) noexcept {
-  copyLibraryElement(NewElementWizardContext::ElementType::Component, fp);
+void LibraryEditor::duplicateComponentTriggered(const FilePath& fp) noexcept {
+  duplicateLibraryElement(NewElementWizardContext::ElementType::Component, fp);
 }
 
-void LibraryEditor::copyDeviceTriggered(const FilePath& fp) noexcept {
-  copyLibraryElement(NewElementWizardContext::ElementType::Device, fp);
+void LibraryEditor::duplicateDeviceTriggered(const FilePath& fp) noexcept {
+  duplicateLibraryElement(NewElementWizardContext::ElementType::Device, fp);
 }
 
 template <typename EditWidgetType>
@@ -643,7 +646,7 @@ void LibraryEditor::newLibraryElement(
   }
 }
 
-void LibraryEditor::copyLibraryElement(
+void LibraryEditor::duplicateLibraryElement(
     NewElementWizardContext::ElementType type, const FilePath& fp) {
   NewElementWizard wizard(mWorkspace, *mLibrary, *this, this);
   wizard.setElementToCopy(type, fp);

--- a/libs/librepcb/libraryeditor/libraryeditor.h
+++ b/libs/librepcb/libraryeditor/libraryeditor.h
@@ -156,12 +156,12 @@ private:  // GUI Event Handlers
   void editPackageTriggered(const FilePath& fp) noexcept;
   void editComponentTriggered(const FilePath& fp) noexcept;
   void editDeviceTriggered(const FilePath& fp) noexcept;
-  void copyComponentCategoryTriggered(const FilePath& fp) noexcept;
-  void copyPackageCategoryTriggered(const FilePath& fp) noexcept;
-  void copySymbolTriggered(const FilePath& fp) noexcept;
-  void copyPackageTriggered(const FilePath& fp) noexcept;
-  void copyComponentTriggered(const FilePath& fp) noexcept;
-  void copyDeviceTriggered(const FilePath& fp) noexcept;
+  void duplicateComponentCategoryTriggered(const FilePath& fp) noexcept;
+  void duplicatePackageCategoryTriggered(const FilePath& fp) noexcept;
+  void duplicateSymbolTriggered(const FilePath& fp) noexcept;
+  void duplicatePackageTriggered(const FilePath& fp) noexcept;
+  void duplicateComponentTriggered(const FilePath& fp) noexcept;
+  void duplicateDeviceTriggered(const FilePath& fp) noexcept;
   void closeTabIfOpen(const FilePath& fp) noexcept;
   template <typename EditWidgetType>
   void editLibraryElementTriggered(const FilePath& fp,
@@ -174,8 +174,8 @@ private:  // GUI Event Handlers
 private:  // Methods
   void setActiveEditorWidget(EditorWidgetBase* widget);
   void newLibraryElement(NewElementWizardContext::ElementType type);
-  void copyLibraryElement(NewElementWizardContext::ElementType type,
-                          const FilePath&                      fp);
+  void duplicateLibraryElement(NewElementWizardContext::ElementType type,
+                               const FilePath&                      fp);
   void editNewLibraryElement(NewElementWizardContext::ElementType type,
                              const FilePath&                      fp);
   void updateTabTitles() noexcept;


### PR DESCRIPTION
The "copy" context menu action implies that there's a paste action.
However, there is no such thing. What really happens is a duplication, a
new library element is created from the current element.