### PR TITLE
Refactor implementation of observer pattern in low-level classes

### DIFF
--- a/libs/librepcb/common/attributes/attribute.h
+++ b/libs/librepcb/common/attributes/attribute.h
@@ -50,6 +50,14 @@ class Attribute final : public SerializableObject {
   Q_DECLARE_TR_FUNCTIONS(Attribute)
 
 public:
+  // Signals
+  enum class Event {
+    KeyChanged,
+    TypeValueUnitChanged,
+  };
+  Signal<Attribute, Event>       onEdited;
+  typedef Slot<Attribute, Event> OnEditedSlot;
+
   // Constructors / Destructor
   Attribute() = delete;
   Attribute(const Attribute& other) noexcept;
@@ -69,8 +77,8 @@ public:
   QString              getValueTr(bool showUnit) const noexcept;
 
   // Setters
-  void setKey(const AttributeKey& key) noexcept { mKey = key; }
-  void setTypeValueUnit(const AttributeType& type, const QString& value,
+  bool setKey(const AttributeKey& key) noexcept;
+  bool setTypeValueUnit(const AttributeType& type, const QString& value,
                         const AttributeUnit* unit);
 
   // General Methods
@@ -103,13 +111,16 @@ struct AttributeListNameProvider {
   static constexpr const char* tagname = "attribute";
 };
 using AttributeList =
-    SerializableObjectList<Attribute, AttributeListNameProvider>;
+    SerializableObjectList<Attribute, AttributeListNameProvider,
+                           Attribute::Event>;
 using CmdAttributeInsert =
-    CmdListElementInsert<Attribute, AttributeListNameProvider>;
+    CmdListElementInsert<Attribute, AttributeListNameProvider,
+                         Attribute::Event>;
 using CmdAttributeRemove =
-    CmdListElementRemove<Attribute, AttributeListNameProvider>;
+    CmdListElementRemove<Attribute, AttributeListNameProvider,
+                         Attribute::Event>;
 using CmdAttributesSwap =
-    CmdListElementsSwap<Attribute, AttributeListNameProvider>;
+    CmdListElementsSwap<Attribute, AttributeListNameProvider, Attribute::Event>;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -217,6 +217,7 @@ HEADERS += \
     scopeguard.h \
     scopeguardlist.h \
     signalrole.h \
+    signalslot.h \
     sqlitedatabase.h \
     systeminfo.h \
     toolbox.h \

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementinsert.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementinsert.h
@@ -40,15 +40,15 @@ namespace librepcb {
 /**
  * @brief The CmdListElementInsert class
  */
-template <typename T, typename P>
+template <typename T, typename P, typename... OnEditedArgs>
 class CmdListElementInsert final : public UndoCommand {
 public:
   // Constructors / Destructor
   CmdListElementInsert()                                  = delete;
   CmdListElementInsert(const CmdListElementInsert& other) = delete;
-  CmdListElementInsert(SerializableObjectList<T, P>& list,
-                       const std::shared_ptr<T>&     element,
-                       int                           index = -1) noexcept
+  CmdListElementInsert(SerializableObjectList<T, P, OnEditedArgs...>& list,
+                       const std::shared_ptr<T>&                      element,
+                       int index = -1) noexcept
     : UndoCommand(QString(tr("Add %1")).arg(P::tagname)),
       mList(list),
       mElement(element),
@@ -73,9 +73,9 @@ private:  // Methods
   void performRedo() override { mIndex = mList.insert(mIndex, mElement); }
 
 private:  // Data
-  SerializableObjectList<T, P>& mList;
-  std::shared_ptr<T>            mElement;
-  int                           mIndex;
+  SerializableObjectList<T, P, OnEditedArgs...>& mList;
+  std::shared_ptr<T>                             mElement;
+  int                                            mIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementremove.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementremove.h
@@ -40,14 +40,14 @@ namespace librepcb {
 /**
  * @brief The CmdListElementRemove class
  */
-template <typename T, typename P>
+template <typename T, typename P, typename... OnEditedArgs>
 class CmdListElementRemove final : public UndoCommand {
 public:
   // Constructors / Destructor
   CmdListElementRemove()                                  = delete;
   CmdListElementRemove(const CmdListElementRemove& other) = delete;
-  CmdListElementRemove(SerializableObjectList<T, P>& list,
-                       const T*                      element) noexcept
+  CmdListElementRemove(SerializableObjectList<T, P, OnEditedArgs...>& list,
+                       const T* element) noexcept
     : UndoCommand(QString(tr("Remove %1")).arg(P::tagname)),
       mList(list),
       mElement(element),
@@ -76,10 +76,10 @@ private:  // Methods
   }
 
 private:  // Data
-  SerializableObjectList<T, P>& mList;
-  const T*                      mElement;
-  std::shared_ptr<T>            mMemorizedElement;
-  int                           mIndex;
+  SerializableObjectList<T, P, OnEditedArgs...>& mList;
+  const T*                                       mElement;
+  std::shared_ptr<T>                             mMemorizedElement;
+  int                                            mIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementsswap.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementsswap.h
@@ -40,13 +40,14 @@ namespace librepcb {
 /**
  * @brief The CmdListElementsSwap class
  */
-template <typename T, typename P>
+template <typename T, typename P, typename... OnEditedArgs>
 class CmdListElementsSwap final : public UndoCommand {
 public:
   // Constructors / Destructor
   CmdListElementsSwap()                                 = delete;
   CmdListElementsSwap(const CmdListElementsSwap& other) = delete;
-  CmdListElementsSwap(SerializableObjectList<T, P>& list, int i, int j) noexcept
+  CmdListElementsSwap(SerializableObjectList<T, P, OnEditedArgs...>& list,
+                      int i, int j) noexcept
     : UndoCommand(QString(tr("Move %1")).arg(P::tagname)),
       mList(list),
       mI(i),
@@ -70,9 +71,9 @@ private:  // Methods
   void performRedo() override { mList.swap(mI, mJ); }
 
 private:  // Data
-  SerializableObjectList<T, P>& mList;
-  int                           mI;
-  int                           mJ;
+  SerializableObjectList<T, P, OnEditedArgs...>& mList;
+  int                                            mI;
+  int                                            mJ;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/geometry/circle.cpp
+++ b/libs/librepcb/common/geometry/circle.cpp
@@ -34,7 +34,8 @@ namespace librepcb {
  ******************************************************************************/
 
 Circle::Circle(const Circle& other) noexcept
-  : mUuid(other.mUuid),
+  : onEdited(*this),
+    mUuid(other.mUuid),
     mLayerName(other.mLayerName),
     mLineWidth(other.mLineWidth),
     mIsFilled(other.mIsFilled),
@@ -50,7 +51,8 @@ Circle::Circle(const Uuid& uuid, const Circle& other) noexcept : Circle(other) {
 Circle::Circle(const Uuid& uuid, const GraphicsLayerName& layerName,
                const UnsignedLength& lineWidth, bool fill, bool isGrabArea,
                const Point& center, const PositiveLength& diameter) noexcept
-  : mUuid(uuid),
+  : onEdited(*this),
+    mUuid(uuid),
     mLayerName(layerName),
     mLineWidth(lineWidth),
     mIsFilled(fill),
@@ -60,7 +62,8 @@ Circle::Circle(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 Circle::Circle(const SExpression& node)
-  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mLineWidth(node.getValueByPath<UnsignedLength>("width")),
     mIsFilled(node.getValueByPath<bool>("fill")),
@@ -76,74 +79,69 @@ Circle::~Circle() noexcept {
  *  Setters
  ******************************************************************************/
 
-void Circle::setLayerName(const GraphicsLayerName& name) noexcept {
-  if (name == mLayerName) return;
+bool Circle::setLayerName(const GraphicsLayerName& name) noexcept {
+  if (name == mLayerName) {
+    return false;
+  }
+
   mLayerName = name;
-  foreach (IF_CircleObserver* object, mObservers) {
-    object->circleLayerNameChanged(mLayerName);
-  }
+  onEdited.notify(Event::LayerNameChanged);
+  return true;
 }
 
-void Circle::setLineWidth(const UnsignedLength& width) noexcept {
-  if (width == mLineWidth) return;
+bool Circle::setLineWidth(const UnsignedLength& width) noexcept {
+  if (width == mLineWidth) {
+    return false;
+  }
+
   mLineWidth = width;
-  foreach (IF_CircleObserver* object, mObservers) {
-    object->circleLineWidthChanged(mLineWidth);
-  }
+  onEdited.notify(Event::LineWidthChanged);
+  return true;
 }
 
-void Circle::setIsFilled(bool isFilled) noexcept {
-  if (isFilled == mIsFilled) return;
+bool Circle::setIsFilled(bool isFilled) noexcept {
+  if (isFilled == mIsFilled) {
+    return false;
+  }
+
   mIsFilled = isFilled;
-  foreach (IF_CircleObserver* object, mObservers) {
-    object->circleIsFilledChanged(mIsFilled);
-  }
+  onEdited.notify(Event::IsFilledChanged);
+  return true;
 }
 
-void Circle::setIsGrabArea(bool isGrabArea) noexcept {
-  if (isGrabArea == mIsGrabArea) return;
+bool Circle::setIsGrabArea(bool isGrabArea) noexcept {
+  if (isGrabArea == mIsGrabArea) {
+    return false;
+  }
+
   mIsGrabArea = isGrabArea;
-  foreach (IF_CircleObserver* object, mObservers) {
-    object->circleIsGrabAreaChanged(mIsGrabArea);
-  }
+  onEdited.notify(Event::IsGrabAreaChanged);
+  return true;
 }
 
-void Circle::setCenter(const Point& center) noexcept {
-  if (center == mCenter) return;
+bool Circle::setCenter(const Point& center) noexcept {
+  if (center == mCenter) {
+    return false;
+  }
+
   mCenter = center;
-  foreach (IF_CircleObserver* object, mObservers) {
-    object->circleCenterChanged(mCenter);
-  }
+  onEdited.notify(Event::CenterChanged);
+  return true;
 }
 
-void Circle::setDiameter(const PositiveLength& dia) noexcept {
-  if (dia == mDiameter) return;
+bool Circle::setDiameter(const PositiveLength& dia) noexcept {
+  if (dia == mDiameter) {
+    return false;
+  }
+
   mDiameter = dia;
-  foreach (IF_CircleObserver* object, mObservers) {
-    object->circleDiameterChanged(mDiameter);
-  }
-}
-
-/*******************************************************************************
- *  Transformations
- ******************************************************************************/
-
-Circle& Circle::translate(const Point& offset) noexcept {
-  mCenter += offset;
-  return *this;
+  onEdited.notify(Event::DiameterChanged);
+  return true;
 }
 
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
-
-void Circle::registerObserver(IF_CircleObserver& object) const noexcept {
-  mObservers.insert(&object);
-}
-
-void Circle::unregisterObserver(IF_CircleObserver& object) const noexcept {
-  mObservers.remove(&object);
-}
 
 void Circle::serialize(SExpression& root) const {
   root.appendChild(mUuid);
@@ -171,13 +169,16 @@ bool Circle::operator==(const Circle& rhs) const noexcept {
 }
 
 Circle& Circle::operator=(const Circle& rhs) noexcept {
-  mUuid       = rhs.mUuid;
-  mLayerName  = rhs.mLayerName;
-  mLineWidth  = rhs.mLineWidth;
-  mIsFilled   = rhs.mIsFilled;
-  mIsGrabArea = rhs.mIsGrabArea;
-  mCenter     = rhs.mCenter;
-  mDiameter   = rhs.mDiameter;
+  if (mUuid != rhs.mUuid) {
+    mUuid = rhs.mUuid;
+    onEdited.notify(Event::UuidChanged);
+  }
+  setLayerName(rhs.mLayerName);
+  setLineWidth(rhs.mLineWidth);
+  setIsFilled(rhs.mIsFilled);
+  setIsGrabArea(rhs.mIsGrabArea);
+  setCenter(rhs.mCenter);
+  setDiameter(rhs.mDiameter);
   return *this;
 }
 

--- a/libs/librepcb/common/geometry/circle.h
+++ b/libs/librepcb/common/geometry/circle.h
@@ -38,35 +38,6 @@
 namespace librepcb {
 
 /*******************************************************************************
- *  Interface IF_CircleObserver
- ******************************************************************************/
-
-/**
- * @brief The IF_CircleObserver class
- *
- * @author ubruhin
- * @date 2017-01-01
- */
-class IF_CircleObserver {
-public:
-  virtual void circleLayerNameChanged(
-      const GraphicsLayerName& newLayerName) noexcept = 0;
-  virtual void circleLineWidthChanged(
-      const UnsignedLength& newLineWidth) noexcept                  = 0;
-  virtual void circleIsFilledChanged(bool newIsFilled) noexcept     = 0;
-  virtual void circleIsGrabAreaChanged(bool newIsGrabArea) noexcept = 0;
-  virtual void circleCenterChanged(const Point& newCenter) noexcept = 0;
-  virtual void circleDiameterChanged(
-      const PositiveLength& newDiameter) noexcept = 0;
-
-protected:
-  IF_CircleObserver() noexcept {}
-  explicit IF_CircleObserver(const IF_CircleObserver& other) = delete;
-  virtual ~IF_CircleObserver() noexcept {}
-  IF_CircleObserver& operator=(const IF_CircleObserver& rhs) = delete;
-};
-
-/*******************************************************************************
  *  Class Circle
  ******************************************************************************/
 
@@ -77,6 +48,19 @@ class Circle : public SerializableObject {
   Q_DECLARE_TR_FUNCTIONS(Circle)
 
 public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    LayerNameChanged,
+    LineWidthChanged,
+    IsFilledChanged,
+    IsGrabAreaChanged,
+    CenterChanged,
+    DiameterChanged,
+  };
+  Signal<Circle, Event>       onEdited;
+  typedef Slot<Circle, Event> OnEditedSlot;
+
   // Constructors / Destructor
   Circle() = delete;
   Circle(const Circle& other) noexcept;
@@ -97,19 +81,12 @@ public:
   const PositiveLength&    getDiameter() const noexcept { return mDiameter; }
 
   // Setters
-  void setLayerName(const GraphicsLayerName& name) noexcept;
-  void setLineWidth(const UnsignedLength& width) noexcept;
-  void setIsFilled(bool isFilled) noexcept;
-  void setIsGrabArea(bool isGrabArea) noexcept;
-  void setCenter(const Point& center) noexcept;
-  void setDiameter(const PositiveLength& dia) noexcept;
-
-  // Transformations
-  Circle& translate(const Point& offset) noexcept;
-
-  // General Methods
-  void registerObserver(IF_CircleObserver& object) const noexcept;
-  void unregisterObserver(IF_CircleObserver& object) const noexcept;
+  bool setLayerName(const GraphicsLayerName& name) noexcept;
+  bool setLineWidth(const UnsignedLength& width) noexcept;
+  bool setIsFilled(bool isFilled) noexcept;
+  bool setIsGrabArea(bool isGrabArea) noexcept;
+  bool setCenter(const Point& center) noexcept;
+  bool setDiameter(const PositiveLength& dia) noexcept;
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -127,10 +104,6 @@ private:  // Data
   bool              mIsGrabArea;
   Point             mCenter;
   PositiveLength    mDiameter;
-
-  // Misc
-  mutable QSet<IF_CircleObserver*>
-      mObservers;  ///< A list of all observer objects
 };
 
 /*******************************************************************************
@@ -140,10 +113,14 @@ private:  // Data
 struct CircleListNameProvider {
   static constexpr const char* tagname = "circle";
 };
-using CircleList      = SerializableObjectList<Circle, CircleListNameProvider>;
-using CmdCircleInsert = CmdListElementInsert<Circle, CircleListNameProvider>;
-using CmdCircleRemove = CmdListElementRemove<Circle, CircleListNameProvider>;
-using CmdCirclesSwap  = CmdListElementsSwap<Circle, CircleListNameProvider>;
+using CircleList =
+    SerializableObjectList<Circle, CircleListNameProvider, Circle::Event>;
+using CmdCircleInsert =
+    CmdListElementInsert<Circle, CircleListNameProvider, Circle::Event>;
+using CmdCircleRemove =
+    CmdListElementRemove<Circle, CircleListNameProvider, Circle::Event>;
+using CmdCirclesSwap =
+    CmdListElementsSwap<Circle, CircleListNameProvider, Circle::Event>;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/common/geometry/hole.cpp
+++ b/libs/librepcb/common/geometry/hole.cpp
@@ -34,7 +34,10 @@ namespace librepcb {
  ******************************************************************************/
 
 Hole::Hole(const Hole& other) noexcept
-  : mUuid(other.mUuid), mPosition(other.mPosition), mDiameter(other.mDiameter) {
+  : onEdited(*this),
+    mUuid(other.mUuid),
+    mPosition(other.mPosition),
+    mDiameter(other.mDiameter) {
 }
 
 Hole::Hole(const Uuid& uuid, const Hole& other) noexcept : Hole(other) {
@@ -43,50 +46,46 @@ Hole::Hole(const Uuid& uuid, const Hole& other) noexcept : Hole(other) {
 
 Hole::Hole(const Uuid& uuid, const Point& position,
            const PositiveLength& diameter) noexcept
-  : mUuid(uuid), mPosition(position), mDiameter(diameter) {
+  : onEdited(*this), mUuid(uuid), mPosition(position), mDiameter(diameter) {
 }
 
 Hole::Hole(const SExpression& node)
-  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mPosition(node.getChildByPath("position")),
     mDiameter(node.getValueByPath<PositiveLength>("diameter")) {
 }
 
 Hole::~Hole() noexcept {
-  Q_ASSERT(mObservers.isEmpty());
 }
 
 /*******************************************************************************
  *  Setters
  ******************************************************************************/
 
-void Hole::setPosition(const Point& position) noexcept {
-  if (position == mPosition) return;
-  mPosition = position;
-  foreach (IF_HoleObserver* object, mObservers) {
-    object->holePositionChanged(mPosition);
+bool Hole::setPosition(const Point& position) noexcept {
+  if (position == mPosition) {
+    return false;
   }
+
+  mPosition = position;
+  onEdited.notify(Event::PositionChanged);
+  return true;
 }
 
-void Hole::setDiameter(const PositiveLength& diameter) noexcept {
-  if (diameter == mDiameter) return;
-  mDiameter = diameter;
-  foreach (IF_HoleObserver* object, mObservers) {
-    object->holeDiameterChanged(mDiameter);
+bool Hole::setDiameter(const PositiveLength& diameter) noexcept {
+  if (diameter == mDiameter) {
+    return false;
   }
+
+  mDiameter = diameter;
+  onEdited.notify(Event::DiameterChanged);
+  return true;
 }
 
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
-
-void Hole::registerObserver(IF_HoleObserver& object) const noexcept {
-  mObservers.insert(&object);
-}
-
-void Hole::unregisterObserver(IF_HoleObserver& object) const noexcept {
-  mObservers.remove(&object);
-}
 
 void Hole::serialize(SExpression& root) const {
   root.appendChild(mUuid);
@@ -106,9 +105,12 @@ bool Hole::operator==(const Hole& rhs) const noexcept {
 }
 
 Hole& Hole::operator=(const Hole& rhs) noexcept {
-  mUuid     = rhs.mUuid;
-  mPosition = rhs.mPosition;
-  mDiameter = rhs.mDiameter;
+  if (mUuid != rhs.mUuid) {
+    mUuid = rhs.mUuid;
+    onEdited.notify(Event::UuidChanged);
+  }
+  setPosition(rhs.mPosition);
+  setDiameter(mDiameter = rhs.mDiameter);
   return *this;
 }
 

--- a/libs/librepcb/common/geometry/polygon.cpp
+++ b/libs/librepcb/common/geometry/polygon.cpp
@@ -36,7 +36,8 @@ namespace librepcb {
  ******************************************************************************/
 
 Polygon::Polygon(const Polygon& other) noexcept
-  : mUuid(other.mUuid),
+  : onEdited(*this),
+    mUuid(other.mUuid),
     mLayerName(other.mLayerName),
     mLineWidth(other.mLineWidth),
     mIsFilled(other.mIsFilled),
@@ -52,7 +53,8 @@ Polygon::Polygon(const Uuid& uuid, const Polygon& other) noexcept
 Polygon::Polygon(const Uuid& uuid, const GraphicsLayerName& layerName,
                  const UnsignedLength& lineWidth, bool fill, bool isGrabArea,
                  const Path& path) noexcept
-  : mUuid(uuid),
+  : onEdited(*this),
+    mUuid(uuid),
     mLayerName(layerName),
     mLineWidth(lineWidth),
     mIsFilled(fill),
@@ -61,7 +63,8 @@ Polygon::Polygon(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 Polygon::Polygon(const SExpression& node)
-  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mLineWidth(node.getValueByPath<UnsignedLength>("width")),
     mIsFilled(node.getValueByPath<bool>("fill")),
@@ -76,57 +79,59 @@ Polygon::~Polygon() noexcept {
  *  Setters
  ******************************************************************************/
 
-void Polygon::setLayerName(const GraphicsLayerName& name) noexcept {
-  if (name == mLayerName) return;
+bool Polygon::setLayerName(const GraphicsLayerName& name) noexcept {
+  if (name == mLayerName) {
+    return false;
+  }
+
   mLayerName = name;
-  foreach (IF_PolygonObserver* object, mObservers) {
-    object->polygonLayerNameChanged(mLayerName);
-  }
+  onEdited.notify(Event::LayerNameChanged);
+  return true;
 }
 
-void Polygon::setLineWidth(const UnsignedLength& width) noexcept {
-  if (width == mLineWidth) return;
+bool Polygon::setLineWidth(const UnsignedLength& width) noexcept {
+  if (width == mLineWidth) {
+    return false;
+  }
+
   mLineWidth = width;
-  foreach (IF_PolygonObserver* object, mObservers) {
-    object->polygonLineWidthChanged(mLineWidth);
-  }
+  onEdited.notify(Event::LineWidthChanged);
+  return true;
 }
 
-void Polygon::setIsFilled(bool isFilled) noexcept {
-  if (isFilled == mIsFilled) return;
+bool Polygon::setIsFilled(bool isFilled) noexcept {
+  if (isFilled == mIsFilled) {
+    return false;
+  }
+
   mIsFilled = isFilled;
-  foreach (IF_PolygonObserver* object, mObservers) {
-    object->polygonIsFilledChanged(mIsFilled);
-  }
+  onEdited.notify(Event::IsFilledChanged);
+  return true;
 }
 
-void Polygon::setIsGrabArea(bool isGrabArea) noexcept {
-  if (isGrabArea == mIsGrabArea) return;
+bool Polygon::setIsGrabArea(bool isGrabArea) noexcept {
+  if (isGrabArea == mIsGrabArea) {
+    return false;
+  }
+
   mIsGrabArea = isGrabArea;
-  foreach (IF_PolygonObserver* object, mObservers) {
-    object->polygonIsGrabAreaChanged(mIsGrabArea);
-  }
+  onEdited.notify(Event::IsGrabAreaChanged);
+  return true;
 }
 
-void Polygon::setPath(const Path& path) noexcept {
-  if (path == mPath) return;
-  mPath = path;
-  foreach (IF_PolygonObserver* object, mObservers) {
-    object->polygonPathChanged(mPath);
+bool Polygon::setPath(const Path& path) noexcept {
+  if (path == mPath) {
+    return false;
   }
+
+  mPath = path;
+  onEdited.notify(Event::PathChanged);
+  return true;
 }
 
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
-
-void Polygon::registerObserver(IF_PolygonObserver& object) const noexcept {
-  mObservers.insert(&object);
-}
-
-void Polygon::unregisterObserver(IF_PolygonObserver& object) const noexcept {
-  mObservers.remove(&object);
-}
 
 void Polygon::serialize(SExpression& root) const {
   root.appendChild(mUuid);
@@ -152,12 +157,15 @@ bool Polygon::operator==(const Polygon& rhs) const noexcept {
 }
 
 Polygon& Polygon::operator=(const Polygon& rhs) noexcept {
-  mUuid       = rhs.mUuid;
-  mLayerName  = rhs.mLayerName;
-  mLineWidth  = rhs.mLineWidth;
-  mIsFilled   = rhs.mIsFilled;
-  mIsGrabArea = rhs.mIsGrabArea;
-  mPath       = rhs.mPath;
+  if (mUuid != rhs.mUuid) {
+    mUuid = rhs.mUuid;
+    onEdited.notify(Event::UuidChanged);
+  }
+  setLayerName(rhs.mLayerName);
+  setLineWidth(rhs.mLineWidth);
+  setIsFilled(rhs.mIsFilled);
+  setIsGrabArea(rhs.mIsGrabArea);
+  setPath(rhs.mPath);
   return *this;
 }
 

--- a/libs/librepcb/common/geometry/stroketext.cpp
+++ b/libs/librepcb/common/geometry/stroketext.cpp
@@ -37,7 +37,8 @@ namespace librepcb {
  ******************************************************************************/
 
 StrokeText::StrokeText(const StrokeText& other) noexcept
-  : mUuid(other.mUuid),
+  : onEdited(*this),
+    mUuid(other.mUuid),
     mLayerName(other.mLayerName),
     mText(other.mText),
     mPosition(other.mPosition),
@@ -66,7 +67,8 @@ StrokeText::StrokeText(const Uuid& uuid, const GraphicsLayerName& layerName,
                        const StrokeTextSpacing& lineSpacing,
                        const Alignment& align, bool mirrored,
                        bool autoRotate) noexcept
-  : mUuid(uuid),
+  : onEdited(*this),
+    mUuid(uuid),
     mLayerName(layerName),
     mText(text),
     mPosition(pos),
@@ -83,7 +85,8 @@ StrokeText::StrokeText(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 StrokeText::StrokeText(const SExpression& node)
-  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mText(node.getValueByPath<QString>("value")),
     mPosition(node.getChildByPath("position")),
@@ -149,116 +152,132 @@ Length StrokeText::calcLineSpacing() const noexcept {
  *  Setters
  ******************************************************************************/
 
-void StrokeText::setLayerName(const GraphicsLayerName& name) noexcept {
-  if (name == mLayerName) return;
+bool StrokeText::setLayerName(const GraphicsLayerName& name) noexcept {
+  if (name == mLayerName) {
+    return false;
+  }
+
   mLayerName = name;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextLayerNameChanged(mLayerName);
-  }
+  onEdited.notify(Event::LayerNameChanged);
+  return true;
 }
 
-void StrokeText::setText(const QString& text) noexcept {
-  if (text == mText) return;
+bool StrokeText::setText(const QString& text) noexcept {
+  if (text == mText) {
+    return false;
+  }
+
   mText = text;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextTextChanged(mText);
-  }
   updatePaths();  // because text has changed
+  onEdited.notify(Event::TextChanged);
+  return true;
 }
 
-void StrokeText::setPosition(const Point& pos) noexcept {
-  if (pos == mPosition) return;
-  mPosition = pos;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextPositionChanged(mPosition);
+bool StrokeText::setPosition(const Point& pos) noexcept {
+  if (pos == mPosition) {
+    return false;
   }
+
+  mPosition = pos;
+  onEdited.notify(Event::PositionChanged);
+  return true;
 }
 
-void StrokeText::setRotation(const Angle& rotation) noexcept {
-  if (rotation == mRotation) return;
+bool StrokeText::setRotation(const Angle& rotation) noexcept {
+  if (rotation == mRotation) {
+    return false;
+  }
+
   bool needsRotation = needsAutoRotation();
   mRotation          = rotation;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextRotationChanged(mRotation);
-  }
+  onEdited.notify(Event::RotationChanged);
   if (needsRotation != needsAutoRotation()) {
-    foreach (IF_StrokeTextObserver* object, mObservers) {
-      object->strokeTextPathsChanged(getPaths());
-    }
+    onEdited.notify(Event::PathsChanged);
   }
+  return true;
 }
 
-void StrokeText::setHeight(const PositiveLength& height) noexcept {
-  if (height == mHeight) return;
+bool StrokeText::setHeight(const PositiveLength& height) noexcept {
+  if (height == mHeight) {
+    return false;
+  }
+
   mHeight = height;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextHeightChanged(mHeight);
-  }
   updatePaths();  // because height has changed
+  onEdited.notify(Event::HeightChanged);
+  return true;
 }
 
-void StrokeText::setStrokeWidth(const UnsignedLength& strokeWidth) noexcept {
-  if (strokeWidth == mStrokeWidth) return;
+bool StrokeText::setStrokeWidth(const UnsignedLength& strokeWidth) noexcept {
+  if (strokeWidth == mStrokeWidth) {
+    return false;
+  }
+
   mStrokeWidth = strokeWidth;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextStrokeWidthChanged(mStrokeWidth);
-  }
   updatePaths();  // because stroke width has changed
+  onEdited.notify(Event::StrokeWidthChanged);
+  return true;
 }
 
-void StrokeText::setLetterSpacing(const StrokeTextSpacing& spacing) noexcept {
-  if (spacing == mLetterSpacing) return;
+bool StrokeText::setLetterSpacing(const StrokeTextSpacing& spacing) noexcept {
+  if (spacing == mLetterSpacing) {
+    return false;
+  }
+
   mLetterSpacing = spacing;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextLetterSpacingChanged(mLetterSpacing);
-  }
   updatePaths();  // because letter spacing has changed
+  onEdited.notify(Event::LetterSpacingChanged);
+  return true;
 }
 
-void StrokeText::setLineSpacing(const StrokeTextSpacing& spacing) noexcept {
-  if (spacing == mLineSpacing) return;
+bool StrokeText::setLineSpacing(const StrokeTextSpacing& spacing) noexcept {
+  if (spacing == mLineSpacing) {
+    return false;
+  }
+
   mLineSpacing = spacing;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextLineSpacingChanged(mLineSpacing);
-  }
   updatePaths();  // because line spacing has changed
+  onEdited.notify(Event::LineSpacingChanged);
+  return true;
 }
 
-void StrokeText::setAlign(const Alignment& align) noexcept {
-  if (align == mAlign) return;
-  mAlign = align;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextAlignChanged(mAlign);
+bool StrokeText::setAlign(const Alignment& align) noexcept {
+  if (align == mAlign) {
+    return false;
   }
+
+  mAlign = align;
   updatePaths();  // because alignment has changed
+  onEdited.notify(Event::AlignChanged);
+  return true;
 }
 
-void StrokeText::setMirrored(bool mirrored) noexcept {
-  if (mirrored == mMirrored) return;
+bool StrokeText::setMirrored(bool mirrored) noexcept {
+  if (mirrored == mMirrored) {
+    return false;
+  }
+
   bool needsRotation = needsAutoRotation();
   mMirrored          = mirrored;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextMirroredChanged(mMirrored);
-  }
+  onEdited.notify(Event::MirroredChanged);
   if (needsRotation != needsAutoRotation()) {
-    foreach (IF_StrokeTextObserver* object, mObservers) {
-      object->strokeTextPathsChanged(getPaths());
-    }
+    onEdited.notify(Event::PathsChanged);
   }
+  return true;
 }
 
-void StrokeText::setAutoRotate(bool autoRotate) noexcept {
-  if (autoRotate == mAutoRotate) return;
+bool StrokeText::setAutoRotate(bool autoRotate) noexcept {
+  if (autoRotate == mAutoRotate) {
+    return false;
+  }
+
   bool needsRotation = needsAutoRotation();
   mAutoRotate        = autoRotate;
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextAutoRotateChanged(mAutoRotate);
-  }
+  onEdited.notify(Event::AutoRotateChanged);
   if (needsRotation != needsAutoRotation()) {
-    foreach (IF_StrokeTextObserver* object, mObservers) {
-      object->strokeTextPathsChanged(getPaths());
-    }
+    onEdited.notify(Event::PathsChanged);
   }
+  return true;
 }
 
 /*******************************************************************************
@@ -300,19 +319,7 @@ void StrokeText::updatePaths() noexcept {
     p.rotate(Angle::deg180(), center);
   }
 
-  foreach (IF_StrokeTextObserver* object, mObservers) {
-    object->strokeTextPathsChanged(getPaths());
-  }
-}
-
-void StrokeText::registerObserver(IF_StrokeTextObserver& object) const
-    noexcept {
-  mObservers.insert(&object);
-}
-
-void StrokeText::unregisterObserver(IF_StrokeTextObserver& object) const
-    noexcept {
-  mObservers.remove(&object);
+  onEdited.notify(Event::PathsChanged);
 }
 
 void StrokeText::serialize(SExpression& root) const {
@@ -351,18 +358,21 @@ bool StrokeText::operator==(const StrokeText& rhs) const noexcept {
 }
 
 StrokeText& StrokeText::operator=(const StrokeText& rhs) noexcept {
-  mUuid          = rhs.mUuid;
-  mLayerName     = rhs.mLayerName;
-  mText          = rhs.mText;
-  mPosition      = rhs.mPosition;
-  mRotation      = rhs.mRotation;
-  mHeight        = rhs.mHeight;
-  mStrokeWidth   = rhs.mStrokeWidth;
-  mLetterSpacing = rhs.mLetterSpacing;
-  mLineSpacing   = rhs.mLineSpacing;
-  mAlign         = rhs.mAlign;
-  mMirrored      = rhs.mMirrored;
-  mAutoRotate    = rhs.mAutoRotate;
+  if (mUuid != rhs.mUuid) {
+    mUuid = rhs.mUuid;
+    onEdited.notify(Event::UuidChanged);
+  }
+  setLayerName(rhs.mLayerName);
+  setText(rhs.mText);
+  setPosition(rhs.mPosition);
+  setRotation(rhs.mRotation);
+  setHeight(rhs.mHeight);
+  setStrokeWidth(rhs.mStrokeWidth);
+  setLetterSpacing(rhs.mLetterSpacing);
+  setLineSpacing(rhs.mLineSpacing);
+  setAlign(rhs.mAlign);
+  setMirrored(rhs.mMirrored);
+  setAutoRotate(rhs.mAutoRotate);
   return *this;
 }
 

--- a/libs/librepcb/common/geometry/stroketext.h
+++ b/libs/librepcb/common/geometry/stroketext.h
@@ -110,40 +110,6 @@ inline StrokeTextSpacing deserializeFromSExpression(const SExpression& sexpr,
 }
 
 /*******************************************************************************
- *  Interface IF_StrokeTextObserver
- ******************************************************************************/
-
-/**
- * @brief The IF_StrokeTextObserver class
- */
-class IF_StrokeTextObserver {
-public:
-  virtual void strokeTextLayerNameChanged(
-      const GraphicsLayerName& newLayerName) noexcept                  = 0;
-  virtual void strokeTextTextChanged(const QString& newText) noexcept  = 0;
-  virtual void strokeTextPositionChanged(const Point& newPos) noexcept = 0;
-  virtual void strokeTextRotationChanged(const Angle& newRot) noexcept = 0;
-  virtual void strokeTextHeightChanged(
-      const PositiveLength& newHeight) noexcept = 0;
-  virtual void strokeTextStrokeWidthChanged(
-      const UnsignedLength& newWidth) noexcept = 0;
-  virtual void strokeTextLetterSpacingChanged(
-      const StrokeTextSpacing& spacing) noexcept = 0;
-  virtual void strokeTextLineSpacingChanged(
-      const StrokeTextSpacing& spacing) noexcept                           = 0;
-  virtual void strokeTextAlignChanged(const Alignment& newAlign) noexcept  = 0;
-  virtual void strokeTextMirroredChanged(bool newMirrored) noexcept        = 0;
-  virtual void strokeTextAutoRotateChanged(bool newAutoRotate) noexcept    = 0;
-  virtual void strokeTextPathsChanged(const QVector<Path>& paths) noexcept = 0;
-
-protected:
-  IF_StrokeTextObserver() noexcept {}
-  explicit IF_StrokeTextObserver(const IF_StrokeTextObserver& other) = delete;
-  virtual ~IF_StrokeTextObserver() noexcept {}
-  IF_StrokeTextObserver& operator=(const IF_StrokeTextObserver& rhs) = delete;
-};
-
-/*******************************************************************************
  *  Class StrokeText
  ******************************************************************************/
 
@@ -154,6 +120,25 @@ class StrokeText final : public SerializableObject {
   Q_DECLARE_TR_FUNCTIONS(StrokeText)
 
 public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    LayerNameChanged,
+    TextChanged,
+    PositionChanged,
+    RotationChanged,
+    HeightChanged,
+    StrokeWidthChanged,
+    LetterSpacingChanged,
+    LineSpacingChanged,
+    AlignChanged,
+    MirroredChanged,
+    AutoRotateChanged,
+    PathsChanged,
+  };
+  Signal<StrokeText, Event>       onEdited;
+  typedef Slot<StrokeText, Event> OnEditedSlot;
+
   // Constructors / Destructor
   StrokeText() = delete;
   StrokeText(const StrokeText& other) noexcept;
@@ -190,25 +175,23 @@ public:
   Length               calcLineSpacing() const noexcept;
 
   // Setters
-  void setLayerName(const GraphicsLayerName& name) noexcept;
-  void setText(const QString& text) noexcept;
-  void setPosition(const Point& pos) noexcept;
-  void setRotation(const Angle& rotation) noexcept;
-  void setHeight(const PositiveLength& height) noexcept;
-  void setStrokeWidth(const UnsignedLength& strokeWidth) noexcept;
-  void setLetterSpacing(const StrokeTextSpacing& spacing) noexcept;
-  void setLineSpacing(const StrokeTextSpacing& spacing) noexcept;
-  void setAlign(const Alignment& align) noexcept;
-  void setMirrored(bool mirrored) noexcept;
-  void setAutoRotate(bool autoRotate) noexcept;
+  bool setLayerName(const GraphicsLayerName& name) noexcept;
+  bool setText(const QString& text) noexcept;
+  bool setPosition(const Point& pos) noexcept;
+  bool setRotation(const Angle& rotation) noexcept;
+  bool setHeight(const PositiveLength& height) noexcept;
+  bool setStrokeWidth(const UnsignedLength& strokeWidth) noexcept;
+  bool setLetterSpacing(const StrokeTextSpacing& spacing) noexcept;
+  bool setLineSpacing(const StrokeTextSpacing& spacing) noexcept;
+  bool setAlign(const Alignment& align) noexcept;
+  bool setMirrored(bool mirrored) noexcept;
+  bool setAutoRotate(bool autoRotate) noexcept;
 
   // General Methods
   void setAttributeProvider(const AttributeProvider* provider) noexcept;
   void setFont(const StrokeFont* font) noexcept;
   const StrokeFont* getCurrentFont() const noexcept { return mFont; }
   void              updatePaths() noexcept;
-  void registerObserver(IF_StrokeTextObserver& object) const noexcept;
-  void unregisterObserver(IF_StrokeTextObserver& object) const noexcept;
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -235,8 +218,6 @@ private:  // Data
   bool              mAutoRotate;
 
   // Misc
-  mutable QSet<IF_StrokeTextObserver*>
-      mObservers;  ///< A list of all observer objects
   const AttributeProvider*
                     mAttributeProvider;  ///< for substituting placeholders in text
   const StrokeFont* mFont;               ///< font used for calculating paths
@@ -253,13 +234,17 @@ struct StrokeTextListNameProvider {
   static constexpr const char* tagname = "stroke_text";
 };
 using StrokeTextList =
-    SerializableObjectList<StrokeText, StrokeTextListNameProvider>;
+    SerializableObjectList<StrokeText, StrokeTextListNameProvider,
+                           StrokeText::Event>;
 using CmdStrokeTextInsert =
-    CmdListElementInsert<StrokeText, StrokeTextListNameProvider>;
+    CmdListElementInsert<StrokeText, StrokeTextListNameProvider,
+                         StrokeText::Event>;
 using CmdStrokeTextRemove =
-    CmdListElementRemove<StrokeText, StrokeTextListNameProvider>;
+    CmdListElementRemove<StrokeText, StrokeTextListNameProvider,
+                         StrokeText::Event>;
 using CmdStrokeTextsSwap =
-    CmdListElementsSwap<StrokeText, StrokeTextListNameProvider>;
+    CmdListElementsSwap<StrokeText, StrokeTextListNameProvider,
+                        StrokeText::Event>;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/common/geometry/text.cpp
+++ b/libs/librepcb/common/geometry/text.cpp
@@ -34,7 +34,8 @@ namespace librepcb {
  ******************************************************************************/
 
 Text::Text(const Text& other) noexcept
-  : mUuid(other.mUuid),
+  : onEdited(*this),
+    mUuid(other.mUuid),
     mLayerName(other.mLayerName),
     mText(other.mText),
     mPosition(other.mPosition),
@@ -50,7 +51,8 @@ Text::Text(const Uuid& uuid, const Text& other) noexcept : Text(other) {
 Text::Text(const Uuid& uuid, const GraphicsLayerName& layerName,
            const QString& text, const Point& pos, const Angle& rotation,
            const PositiveLength& height, const Alignment& align) noexcept
-  : mUuid(uuid),
+  : onEdited(*this),
+    mUuid(uuid),
     mLayerName(layerName),
     mText(text),
     mPosition(pos),
@@ -60,7 +62,8 @@ Text::Text(const Uuid& uuid, const GraphicsLayerName& layerName,
 }
 
 Text::Text(const SExpression& node)
-  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mLayerName(node.getValueByPath<GraphicsLayerName>("layer", true)),
     mText(node.getValueByPath<QString>("value")),
     mPosition(node.getChildByPath("position")),
@@ -76,65 +79,69 @@ Text::~Text() noexcept {
  *  Setters
  ******************************************************************************/
 
-void Text::setLayerName(const GraphicsLayerName& name) noexcept {
-  if (name == mLayerName) return;
+bool Text::setLayerName(const GraphicsLayerName& name) noexcept {
+  if (name == mLayerName) {
+    return false;
+  }
+
   mLayerName = name;
-  foreach (IF_TextObserver* object, mObservers) {
-    object->textLayerNameChanged(mLayerName);
-  }
+  onEdited.notify(Event::LayerNameChanged);
+  return true;
 }
 
-void Text::setText(const QString& text) noexcept {
-  if (text == mText) return;
+bool Text::setText(const QString& text) noexcept {
+  if (text == mText) {
+    return false;
+  }
+
   mText = text;
-  foreach (IF_TextObserver* object, mObservers) {
-    object->textTextChanged(mText);
-  }
+  onEdited.notify(Event::TextChanged);
+  return true;
 }
 
-void Text::setPosition(const Point& pos) noexcept {
-  if (pos == mPosition) return;
+bool Text::setPosition(const Point& pos) noexcept {
+  if (pos == mPosition) {
+    return false;
+  }
+
   mPosition = pos;
-  foreach (IF_TextObserver* object, mObservers) {
-    object->textPositionChanged(mPosition);
-  }
+  onEdited.notify(Event::PositionChanged);
+  return true;
 }
 
-void Text::setRotation(const Angle& rotation) noexcept {
-  if (rotation == mRotation) return;
+bool Text::setRotation(const Angle& rotation) noexcept {
+  if (rotation == mRotation) {
+    return false;
+  }
+
   mRotation = rotation;
-  foreach (IF_TextObserver* object, mObservers) {
-    object->textRotationChanged(mRotation);
-  }
+  onEdited.notify(Event::RotationChanged);
+  return true;
 }
 
-void Text::setHeight(const PositiveLength& height) noexcept {
-  if (height == mHeight) return;
+bool Text::setHeight(const PositiveLength& height) noexcept {
+  if (height == mHeight) {
+    return false;
+  }
+
   mHeight = height;
-  foreach (IF_TextObserver* object, mObservers) {
-    object->textHeightChanged(mHeight);
-  }
+  onEdited.notify(Event::HeightChanged);
+  return true;
 }
 
-void Text::setAlign(const Alignment& align) noexcept {
-  if (align == mAlign) return;
-  mAlign = align;
-  foreach (IF_TextObserver* object, mObservers) {
-    object->textAlignChanged(mAlign);
+bool Text::setAlign(const Alignment& align) noexcept {
+  if (align == mAlign) {
+    return false;
   }
+
+  mAlign = align;
+  onEdited.notify(Event::AlignChanged);
+  return true;
 }
 
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
-
-void Text::registerObserver(IF_TextObserver& object) const noexcept {
-  mObservers.insert(&object);
-}
-
-void Text::unregisterObserver(IF_TextObserver& object) const noexcept {
-  mObservers.remove(&object);
-}
 
 void Text::serialize(SExpression& root) const {
   root.appendChild(mUuid);
@@ -162,13 +169,16 @@ bool Text::operator==(const Text& rhs) const noexcept {
 }
 
 Text& Text::operator=(const Text& rhs) noexcept {
-  mUuid      = rhs.mUuid;
-  mLayerName = rhs.mLayerName;
-  mText      = rhs.mText;
-  mPosition  = rhs.mPosition;
-  mRotation  = rhs.mRotation;
-  mHeight    = rhs.mHeight;
-  mAlign     = rhs.mAlign;
+  if (mUuid != rhs.mUuid) {
+    mUuid = rhs.mUuid;
+    onEdited.notify(Event::UuidChanged);
+  }
+  setLayerName(rhs.mLayerName);
+  setText(rhs.mText);
+  setPosition(rhs.mPosition);
+  setRotation(rhs.mRotation);
+  setHeight(rhs.mHeight);
+  setAlign(rhs.mAlign);
   return *this;
 }
 

--- a/libs/librepcb/common/graphics/circlegraphicsitem.h
+++ b/libs/librepcb/common/graphics/circlegraphicsitem.h
@@ -42,12 +42,8 @@ class IF_GraphicsLayerProvider;
 
 /**
  * @brief The CircleGraphicsItem class
- *
- * @author ubruhin
- * @date 2017-05-28
  */
-class CircleGraphicsItem final : public PrimitiveCircleGraphicsItem,
-                                 public IF_CircleObserver {
+class CircleGraphicsItem final : public PrimitiveCircleGraphicsItem {
 public:
   // Constructors / Destructor
   CircleGraphicsItem()                                = delete;
@@ -63,20 +59,15 @@ public:
   CircleGraphicsItem& operator=(const CircleGraphicsItem& rhs) = delete;
 
 private:  // Methods
-  void circleLayerNameChanged(
-      const GraphicsLayerName& newLayerName) noexcept override;
-  void circleLineWidthChanged(
-      const UnsignedLength& newLineWidth) noexcept override;
-  void circleIsFilledChanged(bool newIsFilled) noexcept override;
-  void circleIsGrabAreaChanged(bool newIsGrabArea) noexcept override;
-  void circleCenterChanged(const Point& newCenter) noexcept override;
-  void circleDiameterChanged(
-      const PositiveLength& newDiameter) noexcept override;
+  void circleEdited(const Circle& circle, Circle::Event event) noexcept;
   void updateFillLayer() noexcept;
 
 private:  // Data
   Circle&                         mCircle;
   const IF_GraphicsLayerProvider& mLayerProvider;
+
+  // Slots
+  Circle::OnEditedSlot mEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/graphicslayer.h
+++ b/libs/librepcb/common/graphics/graphicslayer.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../signalslot.h"
 #include "graphicslayername.h"
 
 #include <QtCore>
@@ -35,8 +36,6 @@
  ******************************************************************************/
 namespace librepcb {
 
-class IF_GraphicsLayerObserver;
-
 /*******************************************************************************
  *  Class GraphicsLayer
  ******************************************************************************/
@@ -47,9 +46,6 @@ class IF_GraphicsLayerObserver;
  *
  * These layers are used in graphics items (QGraphicsItem) to determine their
  * visibility and colors.
- *
- * @author ubruhin
- * @date 2016-11-04
  */
 class GraphicsLayer : public QObject {
   Q_OBJECT
@@ -140,6 +136,17 @@ public:
 
   // clang-format on
 
+  // Signals
+  enum class Event {
+    ColorChanged,
+    HighlightColorChanged,
+    VisibleChanged,
+    EnabledChanged,
+    Destroyed,
+  };
+  Signal<GraphicsLayer, Event>       onEdited;
+  typedef Slot<GraphicsLayer, Event> OnEditedSlot;
+
   // Constructors / Destructor
   GraphicsLayer() = delete;
   GraphicsLayer(const GraphicsLayer& other) noexcept;
@@ -175,10 +182,6 @@ public:
   void setVisible(bool visible) noexcept;
   void setEnabled(bool enable) noexcept;
 
-  // General Methods
-  void registerObserver(IF_GraphicsLayerObserver& object) const noexcept;
-  void unregisterObserver(IF_GraphicsLayerObserver& object) const noexcept;
-
   // Operator Overloadings
   GraphicsLayer& operator=(const GraphicsLayer& rhs) = delete;
 
@@ -211,32 +214,6 @@ protected:          // Data
                               ///< layer
   bool mIsVisible;            ///< Visibility of graphics items on that layer
   bool mIsEnabled;            ///< Visibility/availability of the layer itself
-  mutable QSet<IF_GraphicsLayerObserver*>
-      mObservers;  ///< A list of all observer objects
-};
-
-/*******************************************************************************
- *  Interface IF_GraphicsLayerObserver
- ******************************************************************************/
-
-/**
- * @brief The IF_GraphicsLayerOblayerHighlightColorChangedserver class defines
- * an interface for classes which can receive updates from graphics layer
- * attributes
- */
-class IF_GraphicsLayerObserver {
-public:
-  virtual ~IF_GraphicsLayerObserver() {}
-
-  virtual void layerColorChanged(const GraphicsLayer& layer,
-                                 const QColor&        newColor) noexcept          = 0;
-  virtual void layerHighlightColorChanged(const GraphicsLayer& layer,
-                                          const QColor& newColor) noexcept = 0;
-  virtual void layerVisibleChanged(const GraphicsLayer& layer,
-                                   bool newVisible) noexcept               = 0;
-  virtual void layerEnabledChanged(const GraphicsLayer& layer,
-                                   bool newEnabled) noexcept               = 0;
-  virtual void layerDestroyed(const GraphicsLayer& layer) noexcept         = 0;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/holegraphicsitem.h
+++ b/libs/librepcb/common/graphics/holegraphicsitem.h
@@ -43,13 +43,9 @@ class IF_GraphicsLayerProvider;
 
 /**
  * @brief The HoleGraphicsItem class is the graphical representation of a
- * librepcb::Text
- *
- * @author ubruhin
- * @date 2017-05-30
+ *        librepcb::Hole
  */
-class HoleGraphicsItem final : public PrimitiveCircleGraphicsItem,
-                               public IF_HoleObserver {
+class HoleGraphicsItem final : public PrimitiveCircleGraphicsItem {
 public:
   // Constructors / Destructor
   HoleGraphicsItem()                              = delete;
@@ -68,8 +64,7 @@ public:
   HoleGraphicsItem& operator=(const HoleGraphicsItem& rhs) = delete;
 
 private:  // Methods
-  void holePositionChanged(const Point& newPos) noexcept override;
-  void holeDiameterChanged(const PositiveLength& newDiameter) noexcept override;
+  void     holeEdited(const Hole& hole, Hole::Event event) noexcept;
   QVariant itemChange(GraphicsItemChange change,
                       const QVariant&    value) noexcept override;
 
@@ -77,6 +72,9 @@ private:  // Data
   Hole&                                   mHole;
   const IF_GraphicsLayerProvider&         mLayerProvider;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
+
+  // Slots
+  Hole::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/linegraphicsitem.h
+++ b/libs/librepcb/common/graphics/linegraphicsitem.h
@@ -40,12 +40,8 @@ namespace librepcb {
 
 /**
  * @brief The LineGraphicsItem class
- *
- * @author ubruhin
- * @date 2016-11-06
  */
-class LineGraphicsItem final : public QGraphicsItem,
-                               public IF_GraphicsLayerObserver {
+class LineGraphicsItem final : public QGraphicsItem {
 public:
   // Constructors / Destructor
   // LineGraphicsItem() = delete;
@@ -60,17 +56,6 @@ public:
   void setLineWidth(const UnsignedLength& width) noexcept;
   void setLayer(const GraphicsLayer* layer) noexcept;
 
-  // Inherited from IF_LayerObserver
-  void layerColorChanged(const GraphicsLayer& layer,
-                         const QColor&        newColor) noexcept override;
-  void layerHighlightColorChanged(const GraphicsLayer& layer,
-                                  const QColor& newColor) noexcept override;
-  void layerVisibleChanged(const GraphicsLayer& layer,
-                           bool                 newVisible) noexcept override;
-  void layerEnabledChanged(const GraphicsLayer& layer,
-                           bool                 newEnabled) noexcept override;
-  void layerDestroyed(const GraphicsLayer& layer) noexcept override;
-
   // Inherited from QGraphicsItem
   QRectF       boundingRect() const noexcept override { return mBoundingRect; }
   QPainterPath shape() const noexcept override { return mShape; }
@@ -81,6 +66,8 @@ public:
   LineGraphicsItem& operator=(const LineGraphicsItem& rhs) = delete;
 
 private:  // Methods
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
   void updateBoundingRectAndShape() noexcept;
 
 private:  // Data
@@ -90,6 +77,9 @@ private:  // Data
   QLineF               mLine;
   QRectF               mBoundingRect;
   QPainterPath         mShape;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/origincrossgraphicsitem.h
+++ b/libs/librepcb/common/graphics/origincrossgraphicsitem.h
@@ -40,12 +40,8 @@ namespace librepcb {
 
 /**
  * @brief The OriginCrossGraphicsItem class
- *
- * @author ubruhin
- * @date 2016-11-13
  */
-class OriginCrossGraphicsItem final : public QGraphicsItem,
-                                      public IF_GraphicsLayerObserver {
+class OriginCrossGraphicsItem final : public QGraphicsItem {
 public:
   // Constructors / Destructor
   // OriginCrossGraphicsItem() = delete;
@@ -59,17 +55,6 @@ public:
   void setSize(const UnsignedLength& size) noexcept;
   void setLayer(const GraphicsLayer* layer) noexcept;
 
-  // Inherited from IF_LayerObserver
-  void layerColorChanged(const GraphicsLayer& layer,
-                         const QColor&        newColor) noexcept override;
-  void layerHighlightColorChanged(const GraphicsLayer& layer,
-                                  const QColor& newColor) noexcept override;
-  void layerVisibleChanged(const GraphicsLayer& layer,
-                           bool                 newVisible) noexcept override;
-  void layerEnabledChanged(const GraphicsLayer& layer,
-                           bool                 newEnabled) noexcept override;
-  void layerDestroyed(const GraphicsLayer& layer) noexcept override;
-
   // Inherited from QGraphicsItem
   QRectF       boundingRect() const noexcept override { return mBoundingRect; }
   QPainterPath shape() const noexcept override { return mShape; }
@@ -81,6 +66,8 @@ public:
       delete;
 
 private:  // Methods
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
   void updateBoundingRectAndShape() noexcept;
 
 private:  // Data
@@ -92,6 +79,9 @@ private:  // Data
   QLineF               mLineV;
   QRectF               mBoundingRect;
   QPainterPath         mShape;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/polygongraphicsitem.h
+++ b/libs/librepcb/common/graphics/polygongraphicsitem.h
@@ -42,12 +42,8 @@ class IF_GraphicsLayerProvider;
 
 /**
  * @brief The PolygonGraphicsItem class
- *
- * @author ubruhin
- * @date 2017-05-28
  */
-class PolygonGraphicsItem final : public PrimitivePathGraphicsItem,
-                                  public IF_PolygonObserver {
+class PolygonGraphicsItem final : public PrimitivePathGraphicsItem {
 public:
   // Constructors / Destructor
   PolygonGraphicsItem()                                 = delete;
@@ -63,18 +59,15 @@ public:
   PolygonGraphicsItem& operator=(const PolygonGraphicsItem& rhs) = delete;
 
 private:  // Methods
-  void polygonLayerNameChanged(
-      const GraphicsLayerName& newLayerName) noexcept override;
-  void polygonLineWidthChanged(
-      const UnsignedLength& newLineWidth) noexcept override;
-  void polygonIsFilledChanged(bool newIsFilled) noexcept override;
-  void polygonIsGrabAreaChanged(bool newIsGrabArea) noexcept override;
-  void polygonPathChanged(const Path& newPath) noexcept override;
+  void polygonEdited(const Polygon& polygon, Polygon::Event event) noexcept;
   void updateFillLayer() noexcept;
 
 private:  // Data
   Polygon&                        mPolygon;
   const IF_GraphicsLayerProvider& mLayerProvider;
+
+  // Slots
+  Polygon::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/primitivecirclegraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitivecirclegraphicsitem.h
@@ -40,12 +40,8 @@ namespace librepcb {
 
 /**
  * @brief The PrimitiveCircleGraphicsItem class
- *
- * @author ubruhin
- * @date 2017-05-28
  */
-class PrimitiveCircleGraphicsItem : public QGraphicsItem,
-                                    public IF_GraphicsLayerObserver {
+class PrimitiveCircleGraphicsItem : public QGraphicsItem {
 public:
   // Constructors / Destructor
   // PrimitiveCircleGraphicsItem() = delete;
@@ -62,17 +58,6 @@ public:
   void setLineLayer(const GraphicsLayer* layer) noexcept;
   void setFillLayer(const GraphicsLayer* layer) noexcept;
 
-  // Inherited from IF_LayerObserver
-  void layerColorChanged(const GraphicsLayer& layer,
-                         const QColor&        newColor) noexcept override;
-  void layerHighlightColorChanged(const GraphicsLayer& layer,
-                                  const QColor& newColor) noexcept override;
-  void layerVisibleChanged(const GraphicsLayer& layer,
-                           bool                 newVisible) noexcept override;
-  void layerEnabledChanged(const GraphicsLayer& layer,
-                           bool                 newEnabled) noexcept override;
-  void layerDestroyed(const GraphicsLayer& layer) noexcept override;
-
   // Inherited from QGraphicsItem
   virtual QRectF boundingRect() const noexcept override {
     return mBoundingRect;
@@ -86,6 +71,8 @@ public:
       const PrimitiveCircleGraphicsItem& rhs) = delete;
 
 private:  // Methods
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
   void updateColors() noexcept;
   void updateBoundingRectAndShape() noexcept;
   void updateVisibility() noexcept;
@@ -100,6 +87,9 @@ private:  // Data
   QRectF               mCircleRect;
   QRectF               mBoundingRect;
   QPainterPath         mShape;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/primitivepathgraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitivepathgraphicsitem.h
@@ -40,12 +40,8 @@ namespace librepcb {
 
 /**
  * @brief The PrimitivePathGraphicsItem class
- *
- * @author ubruhin
- * @date 2017-05-28
  */
-class PrimitivePathGraphicsItem : public QGraphicsItem,
-                                  public IF_GraphicsLayerObserver {
+class PrimitivePathGraphicsItem : public QGraphicsItem {
 public:
   // Constructors / Destructor
   // PrimitivePathGraphicsItem() = delete;
@@ -61,17 +57,6 @@ public:
   void setLineLayer(const GraphicsLayer* layer) noexcept;
   void setFillLayer(const GraphicsLayer* layer) noexcept;
 
-  // Inherited from IF_LayerObserver
-  void layerColorChanged(const GraphicsLayer& layer,
-                         const QColor&        newColor) noexcept override;
-  void layerHighlightColorChanged(const GraphicsLayer& layer,
-                                  const QColor& newColor) noexcept override;
-  void layerVisibleChanged(const GraphicsLayer& layer,
-                           bool                 newVisible) noexcept override;
-  void layerEnabledChanged(const GraphicsLayer& layer,
-                           bool                 newEnabled) noexcept override;
-  void layerDestroyed(const GraphicsLayer& layer) noexcept override;
-
   // Inherited from QGraphicsItem
   QRectF       boundingRect() const noexcept override { return mBoundingRect; }
   QPainterPath shape() const noexcept override { return mShape; }
@@ -83,6 +68,8 @@ public:
       delete;
 
 private:  // Methods
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
   void updateColors() noexcept;
   void updateBoundingRectAndShape() noexcept;
   void updateVisibility() noexcept;
@@ -97,6 +84,9 @@ private:  // Data
   QPainterPath         mPainterPath;
   QRectF               mBoundingRect;
   QPainterPath         mShape;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/primitivetextgraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitivetextgraphicsitem.h
@@ -44,12 +44,8 @@ namespace librepcb {
  * a text
  *
  * @todo Would QStaticText improve the performance?
- *
- * @author ubruhin
- * @date 2017-05-28
  */
-class PrimitiveTextGraphicsItem : public QGraphicsItem,
-                                  public IF_GraphicsLayerObserver {
+class PrimitiveTextGraphicsItem : public QGraphicsItem {
 public:
   // Types
   enum class Font { SansSerif, Monospace };
@@ -69,17 +65,6 @@ public:
   void setFont(Font font) noexcept;
   void setLayer(const GraphicsLayer* layer) noexcept;
 
-  // Inherited from IF_LayerObserver
-  void layerColorChanged(const GraphicsLayer& layer,
-                         const QColor&        newColor) noexcept override;
-  void layerHighlightColorChanged(const GraphicsLayer& layer,
-                                  const QColor& newColor) noexcept override;
-  void layerVisibleChanged(const GraphicsLayer& layer,
-                           bool                 newVisible) noexcept override;
-  void layerEnabledChanged(const GraphicsLayer& layer,
-                           bool                 newEnabled) noexcept override;
-  void layerDestroyed(const GraphicsLayer& layer) noexcept override;
-
   // Inherited from QGraphicsItem
   QRectF       boundingRect() const noexcept override { return mBoundingRect; }
   QPainterPath shape() const noexcept override { return mShape; }
@@ -91,6 +76,8 @@ public:
       delete;
 
 private:  // Methods
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
   void updateBoundingRectAndShape() noexcept;
 
 private:  // Data
@@ -103,6 +90,9 @@ private:  // Data
   int                  mTextFlags;
   QRectF               mBoundingRect;
   QPainterPath         mShape;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/stroketextgraphicsitem.h
+++ b/libs/librepcb/common/graphics/stroketextgraphicsitem.h
@@ -45,8 +45,7 @@ class IF_GraphicsLayerProvider;
  * @brief The StrokeTextGraphicsItem class is the graphical representation of a
  *        librepcb::StrokeText
  */
-class StrokeTextGraphicsItem final : public PrimitivePathGraphicsItem,
-                                     public IF_StrokeTextObserver {
+class StrokeTextGraphicsItem final : public PrimitivePathGraphicsItem {
 public:
   // Constructors / Destructor
   StrokeTextGraphicsItem()                                    = delete;
@@ -65,23 +64,8 @@ public:
   StrokeTextGraphicsItem& operator=(const StrokeTextGraphicsItem& rhs) = delete;
 
 private:  // Methods
-  void strokeTextLayerNameChanged(
-      const GraphicsLayerName& newLayerName) noexcept override;
-  void strokeTextTextChanged(const QString& newText) noexcept override;
-  void strokeTextPositionChanged(const Point& newPos) noexcept override;
-  void strokeTextRotationChanged(const Angle& newRot) noexcept override;
-  void strokeTextHeightChanged(
-      const PositiveLength& newHeight) noexcept override;
-  void strokeTextStrokeWidthChanged(
-      const UnsignedLength& newStrokeWidth) noexcept override;
-  void strokeTextLetterSpacingChanged(
-      const StrokeTextSpacing& spacing) noexcept override;
-  void strokeTextLineSpacingChanged(
-      const StrokeTextSpacing& spacing) noexcept override;
-  void     strokeTextAlignChanged(const Alignment& newAlign) noexcept override;
-  void     strokeTextMirroredChanged(bool mirrored) noexcept override;
-  void     strokeTextAutoRotateChanged(bool newAutoRotate) noexcept override;
-  void     strokeTextPathsChanged(const QVector<Path>& paths) noexcept override;
+  void     strokeTextEdited(const StrokeText& text,
+                            StrokeText::Event event) noexcept;
   void     updateLayer(const GraphicsLayerName& layerName) noexcept;
   void     updateTransform() noexcept;
   QVariant itemChange(GraphicsItemChange change,
@@ -91,6 +75,9 @@ private:  // Data
   StrokeText&                             mText;
   const IF_GraphicsLayerProvider&         mLayerProvider;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
+
+  // Slots
+  StrokeText::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/textgraphicsitem.h
+++ b/libs/librepcb/common/graphics/textgraphicsitem.h
@@ -43,13 +43,9 @@ class IF_GraphicsLayerProvider;
 
 /**
  * @brief The TextGraphicsItem class is the graphical representation of a
- * librepcb::Text
- *
- * @author ubruhin
- * @date 2017-05-28
+ *        librepcb::Text
  */
-class TextGraphicsItem final : public PrimitiveTextGraphicsItem,
-                               public IF_TextObserver {
+class TextGraphicsItem final : public PrimitiveTextGraphicsItem {
 public:
   // Constructors / Destructor
   TextGraphicsItem()                              = delete;
@@ -65,18 +61,15 @@ public:
   TextGraphicsItem& operator=(const TextGraphicsItem& rhs) = delete;
 
 private:  // Methods
-  void textLayerNameChanged(
-      const GraphicsLayerName& newLayerName) noexcept override;
-  void textTextChanged(const QString& newText) noexcept override;
-  void textPositionChanged(const Point& newPos) noexcept override;
-  void textRotationChanged(const Angle& newRot) noexcept override;
-  void textHeightChanged(const PositiveLength& newHeight) noexcept override;
-  void textAlignChanged(const Alignment& newAlign) noexcept override;
+  void textEdited(const Text& text, Text::Event event) noexcept;
 
 private:  // Data
   Text&                                   mText;
   const IF_GraphicsLayerProvider&         mLayerProvider;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
+
+  // Slots
+  Text::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/signalslot.h
+++ b/libs/librepcb/common/signalslot.h
@@ -1,0 +1,219 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_SIGNALSLOT_H
+#define LIBREPCB_SIGNALSLOT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <functional>
+#include <set>
+#include <vector>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+template <typename Tsender, typename... Args>
+class Slot;
+
+/*******************************************************************************
+ *  Class Signal
+ ******************************************************************************/
+
+/**
+ * @brief The Signal class is used to emit signals on non-QObject derived
+ *        classes
+ *
+ * The classes ::librepcb::Signal and ::librepcb::Slot are similar to Qt's
+ * signal/slot concept. The main difference is that senders and receivers of
+ * signals do not need to be derived from QObject, thus our own signal/slot
+ * mechanism is better suited for low-level classes.
+ *
+ * This gives the advantage of avoiding QObject overhead, but has several
+ * drawbacks:
+ *
+ *   - No thread-safety
+ *   - Always synchronous, no queued connections are possible
+ *   - No endless loop detection
+ *
+ * @see ::librepcb::Slot
+ *
+ * @tparam Tsender  Type of the sender object
+ * @tparam Args     Arguments passed from ::librepcb::Signal::notify() to the
+ *                  callbacks
+ */
+template <typename Tsender, typename... Args>
+class Signal {
+  friend class Slot<Tsender, Args...>;
+
+public:
+  // Constructors / Destructor
+  Signal()                    = delete;
+  Signal(const Signal& other) = delete;
+
+  /**
+   * @brief Constructor
+   *
+   * @param sender  Reference to the sender object of the signal
+   */
+  explicit Signal(const Tsender& sender) noexcept : mSender(sender) {}
+
+  /**
+   * @brief Destructor
+   *
+   * Automatically disconnects from all slots.
+   */
+  ~Signal() noexcept {
+    for (auto slot : mSlots) {
+      slot->mSignals.erase(this);
+    }
+  }
+
+  /**
+   * @brief Attach a slot
+   *
+   * @param slot  Reference to the slot to attach
+   */
+  void attach(Slot<Tsender, Args...>& slot) const noexcept {
+    slot.mSignals.insert(this);
+    mSlots.insert(&slot);
+  }
+
+  /**
+   * @brief Detach a slot
+   *
+   * @param slot  Reference to the slot to detach
+   */
+  void detach(Slot<Tsender, Args...>& slot) const noexcept {
+    slot.mSignals.erase(this);
+    mSlots.erase(&slot);
+  }
+
+  /**
+   * @brief Notify all attached slots
+   *
+   * @param args  Arguments passed to the slots
+   */
+  void notify(Args... args) noexcept {
+    for (auto slot : mSlots) {
+      slot->mCallback(mSender, args...);
+    }
+  }
+
+  // Operator Overloadings
+  Signal& operator=(Signal const& other) = delete;
+
+private:
+  const Tsender& mSender;  ///< Reference to the sender object
+  mutable std::set<Slot<Tsender, Args...>*> mSlots;  ///< All attached slots
+};
+
+/*******************************************************************************
+ *  Class Slot
+ ******************************************************************************/
+
+/**
+ * @brief The Slot class is used to receive signals from non-QObject derived
+ *        classes
+ *
+ * Instances of this class allow to connect ::librepcb::Signal objects to
+ * callback functions. Instead of connecting signals directly to callbacks,
+ * this indirection allows to automatically disconnect connections if either
+ * the sender or the receiver object is destroyed. This avoids potential
+ * segfaults due to dereferencing dangling pointers.
+ *
+ * A slot can be connected to multiple signals if they have the same signature.
+ *
+ * @tparam Tsender  Type of the sender object
+ * @tparam Args     Arguments passed from ::librepcb::Signal::notify() to the
+ *                  callbacks
+ *
+ * @see ::librepcb::Signal
+ */
+template <typename Tsender, typename... Args>
+class Slot {
+  friend class Signal<Tsender, Args...>;
+
+public:
+  // Constructors / Destructor
+  Slot()                  = delete;
+  Slot(const Slot& other) = delete;
+
+  /**
+   * @brief Constructor
+   *
+   * @param callback  The callback to be called if the signal is emitted
+   *
+   * @warning The function must never throw an exception!!!
+   */
+  explicit Slot(std::function<void(const Tsender&, Args...)>& callback) noexcept
+    : mCallback(callback) {}
+
+  /**
+   * @brief Constructor
+   *
+   * @param obj   The object to be called if the signal is emitted
+   * @param func  The member function to be called if the signal is emitted
+   *
+   * @warning The function must never throw an exception!!!
+   */
+  template <typename T>
+  explicit Slot(T& obj, void (T::*func)(const Tsender&, Args...)) noexcept
+    : mCallback([=, &obj](const Tsender& s, Args... args) {
+        (obj.*func)(s, args...);
+      }) {}
+
+  /**
+   * @brief Destructor
+   *
+   * Automatically disconnects from all signals.
+   */
+  ~Slot() noexcept { detachAll(); }
+
+  /**
+   * @brief Detach from all signals
+   */
+  void detachAll() noexcept {
+    for (auto signal : mSignals) {
+      signal->mSlots.erase(this);
+    }
+    mSignals.clear();
+  }
+
+  // Operator Overloadings
+  Slot& operator=(Slot const& other) = delete;
+
+private:
+  /// All signals this slot is attached to
+  std::set<const Signal<Tsender, Args...>*> mSignals;
+
+  /// The registered callback function
+  std::function<void(const Tsender&, Args...)> mCallback;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_SIGNALSLOT_H

--- a/libs/librepcb/common/widgets/attributelisteditorwidget.cpp
+++ b/libs/librepcb/common/widgets/attributelisteditorwidget.cpp
@@ -364,7 +364,7 @@ void AttributeListEditorWidget::moveAttributeUp(int index) noexcept {
 
 void AttributeListEditorWidget::moveAttributeDown(int index) noexcept {
   Q_ASSERT(index >= 0 && index < mAttributeList.count() - 1);
-  mAttributeList.swap(index, index + 1);
+  mAttributeList.swap(index + 1, index);
   updateTable(mSelectedAttribute);
   emit edited(mAttributeList);
 }

--- a/libs/librepcb/library/cmp/component.cpp
+++ b/libs/librepcb/library/cmp/component.cpp
@@ -57,11 +57,11 @@ Component::Component(std::unique_ptr<TransactionalDirectory> directory)
     mPrefixes(ComponentPrefix("")) {
   // Load all properties
   mSchematicOnly = mLoadingFileDocument.getValueByPath<bool>("schematic_only");
-  mAttributes.loadFromDomElement(mLoadingFileDocument);  // can throw
+  mAttributes.loadFromSExpression(mLoadingFileDocument);  // can throw
   mDefaultValue = mLoadingFileDocument.getValueByPath<QString>("default_value");
   mPrefixes     = NormDependentPrefixMap(mLoadingFileDocument);
-  mSignals.loadFromDomElement(mLoadingFileDocument);
-  mSymbolVariants.loadFromDomElement(mLoadingFileDocument);
+  mSignals.loadFromSExpression(mLoadingFileDocument);
+  mSymbolVariants.loadFromSExpression(mLoadingFileDocument);
 
   cleanupAfterLoadingElementFromFile();
 }

--- a/libs/librepcb/library/cmp/componentpinsignalmap.h
+++ b/libs/librepcb/library/cmp/componentpinsignalmap.h
@@ -56,6 +56,15 @@ class ComponentPinSignalMapItem final : public SerializableObject {
   Q_DECLARE_TR_FUNCTIONS(ComponentPinSignalMapItem)
 
 public:
+  // Signals
+  enum class Event {
+    PinUuidChanged,
+    SignalUuidChanged,
+    DisplayTypeChanged,
+  };
+  Signal<ComponentPinSignalMapItem, Event>       onEdited;
+  typedef Slot<ComponentPinSignalMapItem, Event> OnEditedSlot;
+
   // Constructors / Destructor
   ComponentPinSignalMapItem() = delete;
   ComponentPinSignalMapItem(const ComponentPinSignalMapItem& other) noexcept;
@@ -77,12 +86,8 @@ public:
   }
 
   // Setters
-  void setSignalUuid(const tl::optional<Uuid>& uuid) noexcept {
-    mSignalUuid = uuid;
-  }
-  void setDisplayType(const CmpSigPinDisplayType& type) noexcept {
-    mDisplayType = type;
-  }
+  bool setSignalUuid(const tl::optional<Uuid>& uuid) noexcept;
+  bool setDisplayType(const CmpSigPinDisplayType& type) noexcept;
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -110,16 +115,20 @@ struct ComponentPinSignalMapNameProvider {
 };
 using ComponentPinSignalMap =
     SerializableObjectList<ComponentPinSignalMapItem,
-                           ComponentPinSignalMapNameProvider>;
+                           ComponentPinSignalMapNameProvider,
+                           ComponentPinSignalMapItem::Event>;
 using CmdComponentPinSignalMapItemInsert =
     CmdListElementInsert<ComponentPinSignalMapItem,
-                         ComponentPinSignalMapNameProvider>;
+                         ComponentPinSignalMapNameProvider,
+                         ComponentPinSignalMapItem::Event>;
 using CmdComponentPinSignalMapItemRemove =
     CmdListElementRemove<ComponentPinSignalMapItem,
-                         ComponentPinSignalMapNameProvider>;
+                         ComponentPinSignalMapNameProvider,
+                         ComponentPinSignalMapItem::Event>;
 using CmdComponentPinSignalMapItemsSwap =
     CmdListElementsSwap<ComponentPinSignalMapItem,
-                        ComponentPinSignalMapNameProvider>;
+                        ComponentPinSignalMapNameProvider,
+                        ComponentPinSignalMapItem::Event>;
 
 /*******************************************************************************
  *  Class ComponentPinSignalMapHelpers

--- a/libs/librepcb/library/cmp/componentsignal.cpp
+++ b/libs/librepcb/library/cmp/componentsignal.cpp
@@ -35,7 +35,7 @@ namespace library {
  ******************************************************************************/
 
 ComponentSignal::ComponentSignal(const ComponentSignal& other) noexcept
-  : QObject(nullptr),
+  : onEdited(*this),
     mUuid(other.mUuid),
     mName(other.mName),
     mRole(other.mRole),
@@ -50,7 +50,7 @@ ComponentSignal::ComponentSignal(const Uuid&              uuid,
                                  const SignalRole&        role,
                                  const QString& forcedNetName, bool isRequired,
                                  bool isNegated, bool isClock) noexcept
-  : QObject(nullptr),
+  : onEdited(*this),
     mUuid(uuid),
     mName(name),
     mRole(role),
@@ -61,7 +61,7 @@ ComponentSignal::ComponentSignal(const Uuid&              uuid,
 }
 
 ComponentSignal::ComponentSignal(const SExpression& node)
-  : QObject(nullptr),
+  : onEdited(*this),
     mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mName(node.getValueByPath<CircuitIdentifier>("name", true)),
     mRole(node.getValueByPath<SignalRole>("role")),
@@ -78,46 +78,64 @@ ComponentSignal::~ComponentSignal() noexcept {
  *  Setters
  ******************************************************************************/
 
-void ComponentSignal::setName(const CircuitIdentifier& name) noexcept {
-  if (name == mName) return;
+bool ComponentSignal::setName(const CircuitIdentifier& name) noexcept {
+  if (name == mName) {
+    return false;
+  }
+
   mName = name;
-  emit nameChanged(mName);
-  emit edited();
+  onEdited.notify(Event::NameChanged);
+  return true;
 }
 
-void ComponentSignal::setRole(const SignalRole& role) noexcept {
-  if (role == mRole) return;
+bool ComponentSignal::setRole(const SignalRole& role) noexcept {
+  if (role == mRole) {
+    return false;
+  }
+
   mRole = role;
-  emit roleChanged(mRole);
-  emit edited();
+  onEdited.notify(Event::RoleChanged);
+  return true;
 }
 
-void ComponentSignal::setForcedNetName(const QString& name) noexcept {
-  if (name == mForcedNetName) return;
+bool ComponentSignal::setForcedNetName(const QString& name) noexcept {
+  if (name == mForcedNetName) {
+    return false;
+  }
+
   mForcedNetName = name;
-  emit forcedNetNameChanged(mForcedNetName);
-  emit edited();
+  onEdited.notify(Event::ForcedNetNameChanged);
+  return true;
 }
 
-void ComponentSignal::setIsRequired(bool required) noexcept {
-  if (required == mIsRequired) return;
+bool ComponentSignal::setIsRequired(bool required) noexcept {
+  if (required == mIsRequired) {
+    return false;
+  }
+
   mIsRequired = required;
-  emit isRequiredChanged(mIsRequired);
-  emit edited();
+  onEdited.notify(Event::IsRequiredChanged);
+  return true;
 }
 
-void ComponentSignal::setIsNegated(bool negated) noexcept {
-  if (negated == mIsNegated) return;
+bool ComponentSignal::setIsNegated(bool negated) noexcept {
+  if (negated == mIsNegated) {
+    return false;
+  }
+
   mIsNegated = negated;
-  emit isNegatedChanged(mIsNegated);
-  emit edited();
+  onEdited.notify(Event::IsNegatedChanged);
+  return true;
 }
 
-void ComponentSignal::setIsClock(bool clock) noexcept {
-  if (clock == mIsClock) return;
+bool ComponentSignal::setIsClock(bool clock) noexcept {
+  if (clock == mIsClock) {
+    return false;
+  }
+
   mIsClock = clock;
-  emit isClockChanged(mIsClock);
-  emit edited();
+  onEdited.notify(Event::IsClockChanged);
+  return true;
 }
 
 /*******************************************************************************
@@ -153,7 +171,7 @@ ComponentSignal& ComponentSignal::operator=(
     const ComponentSignal& rhs) noexcept {
   if (mUuid != rhs.mUuid) {
     mUuid = rhs.mUuid;
-    emit edited();
+    onEdited.notify(Event::UuidChanged);
   }
   setName(rhs.mName);
   setRole(rhs.mRole);

--- a/libs/librepcb/library/cmp/componentsignal.h
+++ b/libs/librepcb/library/cmp/componentsignal.h
@@ -46,10 +46,21 @@ namespace library {
 /**
  * @brief The ComponentSignal class represents one signal of a component
  */
-class ComponentSignal final : public QObject, public SerializableObject {
-  Q_OBJECT
-
+class ComponentSignal final : public SerializableObject {
 public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    NameChanged,
+    RoleChanged,
+    ForcedNetNameChanged,
+    IsRequiredChanged,
+    IsNegatedChanged,
+    IsClockChanged,
+  };
+  Signal<ComponentSignal, Event>       onEdited;
+  typedef Slot<ComponentSignal, Event> OnEditedSlot;
+
   // Constructors / Destructor
   ComponentSignal() = delete;
   ComponentSignal(const ComponentSignal& other) noexcept;
@@ -72,12 +83,12 @@ public:
   }
 
   // Setters
-  void setName(const CircuitIdentifier& name) noexcept;
-  void setRole(const SignalRole& role) noexcept;
-  void setForcedNetName(const QString& name) noexcept;
-  void setIsRequired(bool required) noexcept;
-  void setIsNegated(bool negated) noexcept;
-  void setIsClock(bool clock) noexcept;
+  bool setName(const CircuitIdentifier& name) noexcept;
+  bool setRole(const SignalRole& role) noexcept;
+  bool setForcedNetName(const QString& name) noexcept;
+  bool setIsRequired(bool required) noexcept;
+  bool setIsNegated(bool negated) noexcept;
+  bool setIsClock(bool clock) noexcept;
 
   // General Methods
 
@@ -90,15 +101,6 @@ public:
     return !(*this == rhs);
   }
   ComponentSignal& operator=(const ComponentSignal& rhs) noexcept;
-
-signals:
-  void edited();
-  void nameChanged(const CircuitIdentifier& name);
-  void roleChanged(const SignalRole& role);
-  void forcedNetNameChanged(const QString& name);
-  void isRequiredChanged(bool required);
-  void isNegatedChanged(bool negated);
-  void isClockChanged(bool clock);
 
 private:  // Data
   Uuid              mUuid;
@@ -118,13 +120,17 @@ struct ComponentSignalListNameProvider {
   static constexpr const char* tagname = "signal";
 };
 using ComponentSignalList =
-    SerializableObjectList<ComponentSignal, ComponentSignalListNameProvider>;
+    SerializableObjectList<ComponentSignal, ComponentSignalListNameProvider,
+                           ComponentSignal::Event>;
 using CmdComponentSignalInsert =
-    CmdListElementInsert<ComponentSignal, ComponentSignalListNameProvider>;
+    CmdListElementInsert<ComponentSignal, ComponentSignalListNameProvider,
+                         ComponentSignal::Event>;
 using CmdComponentSignalRemove =
-    CmdListElementRemove<ComponentSignal, ComponentSignalListNameProvider>;
+    CmdListElementRemove<ComponentSignal, ComponentSignalListNameProvider,
+                         ComponentSignal::Event>;
 using CmdComponentSignalsSwap =
-    CmdListElementsSwap<ComponentSignal, ComponentSignalListNameProvider>;
+    CmdListElementsSwap<ComponentSignal, ComponentSignalListNameProvider,
+                        ComponentSignal::Event>;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitem.cpp
@@ -40,38 +40,105 @@ namespace library {
 
 ComponentSymbolVariantItem::ComponentSymbolVariantItem(
     const ComponentSymbolVariantItem& other) noexcept
-  : mUuid(other.mUuid),
+  : onEdited(*this),
+    mUuid(other.mUuid),
     mSymbolUuid(other.mSymbolUuid),
     mSymbolPos(other.mSymbolPos),
     mSymbolRot(other.mSymbolRot),
     mIsRequired(other.mIsRequired),
     mSuffix(other.mSuffix),
-    mPinSignalMap(other.mPinSignalMap) {
+    mPinSignalMap(other.mPinSignalMap),
+    mOnPinSignalMapEditedSlot(*this,
+                              &ComponentSymbolVariantItem::pinSignalMapEdited) {
+  mPinSignalMap.onEdited.attach(mOnPinSignalMapEditedSlot);
 }
 
 ComponentSymbolVariantItem::ComponentSymbolVariantItem(
     const Uuid& uuid, const Uuid& symbolUuid, const Point& symbolPos,
     const Angle& symbolRotation, bool isRequired,
     const ComponentSymbolVariantItemSuffix& suffix) noexcept
-  : mUuid(uuid),
+  : onEdited(*this),
+    mUuid(uuid),
     mSymbolUuid(symbolUuid),
     mSymbolPos(symbolPos),
     mSymbolRot(symbolRotation),
     mIsRequired(isRequired),
-    mSuffix(suffix) {
+    mSuffix(suffix),
+    mOnPinSignalMapEditedSlot(*this,
+                              &ComponentSymbolVariantItem::pinSignalMapEdited) {
+  mPinSignalMap.onEdited.attach(mOnPinSignalMapEditedSlot);
 }
 
 ComponentSymbolVariantItem::ComponentSymbolVariantItem(const SExpression& node)
-  : mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mSymbolUuid(node.getValueByPath<Uuid>("symbol")),
     mSymbolPos(node.getChildByPath("position")),
     mSymbolRot(node.getValueByPath<Angle>("rotation")),
     mIsRequired(node.getValueByPath<bool>("required")),
     mSuffix(node.getValueByPath<ComponentSymbolVariantItemSuffix>("suffix")),
-    mPinSignalMap(node) {
+    mPinSignalMap(node),
+    mOnPinSignalMapEditedSlot(*this,
+                              &ComponentSymbolVariantItem::pinSignalMapEdited) {
+  mPinSignalMap.onEdited.attach(mOnPinSignalMapEditedSlot);
 }
 
 ComponentSymbolVariantItem::~ComponentSymbolVariantItem() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+bool ComponentSymbolVariantItem::setSymbolUuid(const Uuid& uuid) noexcept {
+  if (uuid == mSymbolUuid) {
+    return false;
+  }
+
+  mSymbolUuid = uuid;
+  onEdited.notify(Event::SymbolUuidChanged);
+  return true;
+}
+
+bool ComponentSymbolVariantItem::setSymbolPosition(const Point& pos) noexcept {
+  if (pos == mSymbolPos) {
+    return false;
+  }
+
+  mSymbolPos = pos;
+  onEdited.notify(Event::SymbolPositionChanged);
+  return true;
+}
+
+bool ComponentSymbolVariantItem::setSymbolRotation(const Angle& rot) noexcept {
+  if (rot == mSymbolRot) {
+    return false;
+  }
+
+  mSymbolRot = rot;
+  onEdited.notify(Event::SymbolRotationChanged);
+  return true;
+}
+
+bool ComponentSymbolVariantItem::setIsRequired(bool required) noexcept {
+  if (required == mIsRequired) {
+    return false;
+  }
+
+  mIsRequired = required;
+  onEdited.notify(Event::IsRequiredChanged);
+  return true;
+}
+
+bool ComponentSymbolVariantItem::setSuffix(
+    const ComponentSymbolVariantItemSuffix& suffix) noexcept {
+  if (suffix == mSuffix) {
+    return false;
+  }
+
+  mSuffix = suffix;
+  onEdited.notify(Event::SuffixChanged);
+  return true;
 }
 
 /*******************************************************************************
@@ -106,14 +173,32 @@ bool ComponentSymbolVariantItem::operator==(
 
 ComponentSymbolVariantItem& ComponentSymbolVariantItem::operator=(
     const ComponentSymbolVariantItem& rhs) noexcept {
-  mUuid         = rhs.mUuid;
-  mSymbolUuid   = rhs.mSymbolUuid;
-  mSymbolPos    = rhs.mSymbolPos;
-  mSymbolRot    = rhs.mSymbolRot;
-  mIsRequired   = rhs.mIsRequired;
-  mSuffix       = rhs.mSuffix;
+  if (mUuid != rhs.mUuid) {
+    mUuid = rhs.mUuid;
+    onEdited.notify(Event::UuidChanged);
+  }
+  setSymbolUuid(rhs.mSymbolUuid);
+  setSymbolPosition(rhs.mSymbolPos);
+  setSymbolRotation(rhs.mSymbolRot);
+  setIsRequired(rhs.mIsRequired);
+  setSuffix(rhs.mSuffix);
   mPinSignalMap = rhs.mPinSignalMap;
   return *this;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void ComponentSymbolVariantItem::pinSignalMapEdited(
+    const ComponentPinSignalMap& map, int index,
+    const std::shared_ptr<const ComponentPinSignalMapItem>& item,
+    ComponentPinSignalMap::Event                            event) noexcept {
+  Q_UNUSED(map);
+  Q_UNUSED(index);
+  Q_UNUSED(item);
+  Q_UNUSED(event);
+  onEdited.notify(Event::PinSignalMapEdited);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/cmp/componentsymbolvariantitem.h
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitem.h
@@ -62,6 +62,19 @@ class ComponentSymbolVariantItem final : public SerializableObject {
   Q_DECLARE_TR_FUNCTIONS(ComponentSymbolVariantItem)
 
 public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    SymbolUuidChanged,
+    SymbolPositionChanged,
+    SymbolRotationChanged,
+    IsRequiredChanged,
+    SuffixChanged,
+    PinSignalMapEdited,
+  };
+  Signal<ComponentSymbolVariantItem, Event>       onEdited;
+  typedef Slot<ComponentSymbolVariantItem, Event> OnEditedSlot;
+
   // Constructors / Destructor
   ComponentSymbolVariantItem() = delete;
   ComponentSymbolVariantItem(const ComponentSymbolVariantItem& other) noexcept;
@@ -83,13 +96,11 @@ public:
   }
 
   // Setters: Attributes
-  void setSymbolUuid(const Uuid& uuid) noexcept { mSymbolUuid = uuid; }
-  void setSymbolPosition(const Point& pos) noexcept { mSymbolPos = pos; }
-  void setSymbolRotation(const Angle& rot) noexcept { mSymbolRot = rot; }
-  void setIsRequired(bool required) noexcept { mIsRequired = required; }
-  void setSuffix(const ComponentSymbolVariantItemSuffix& suffix) noexcept {
-    mSuffix = suffix;
-  }
+  bool setSymbolUuid(const Uuid& uuid) noexcept;
+  bool setSymbolPosition(const Point& pos) noexcept;
+  bool setSymbolRotation(const Angle& rot) noexcept;
+  bool setIsRequired(bool required) noexcept;
+  bool setSuffix(const ComponentSymbolVariantItemSuffix& suffix) noexcept;
 
   // Pin-Signal-Map Methods
   ComponentPinSignalMap& getPinSignalMap() noexcept { return mPinSignalMap; }
@@ -108,6 +119,12 @@ public:
   ComponentSymbolVariantItem& operator=(
       const ComponentSymbolVariantItem& rhs) noexcept;
 
+private:  // Methods
+  void pinSignalMapEdited(
+      const ComponentPinSignalMap& map, int index,
+      const std::shared_ptr<const ComponentPinSignalMapItem>& item,
+      ComponentPinSignalMap::Event                            event) noexcept;
+
 private:  // Data
   Uuid                             mUuid;
   Uuid                             mSymbolUuid;
@@ -116,6 +133,9 @@ private:  // Data
   bool                             mIsRequired;
   ComponentSymbolVariantItemSuffix mSuffix;
   ComponentPinSignalMap            mPinSignalMap;
+
+  // Slots
+  ComponentPinSignalMap::OnEditedSlot mOnPinSignalMapEditedSlot;
 };
 
 /*******************************************************************************
@@ -127,16 +147,20 @@ struct ComponentSymbolVariantItemListNameProvider {
 };
 using ComponentSymbolVariantItemList =
     SerializableObjectList<ComponentSymbolVariantItem,
-                           ComponentSymbolVariantItemListNameProvider>;
+                           ComponentSymbolVariantItemListNameProvider,
+                           ComponentSymbolVariantItem::Event>;
 using CmdComponentSymbolVariantItemInsert =
     CmdListElementInsert<ComponentSymbolVariantItem,
-                         ComponentSymbolVariantItemListNameProvider>;
+                         ComponentSymbolVariantItemListNameProvider,
+                         ComponentSymbolVariantItem::Event>;
 using CmdComponentSymbolVariantItemRemove =
     CmdListElementRemove<ComponentSymbolVariantItem,
-                         ComponentSymbolVariantItemListNameProvider>;
+                         ComponentSymbolVariantItemListNameProvider,
+                         ComponentSymbolVariantItem::Event>;
 using CmdComponentSymbolVariantItemsSwap =
     CmdListElementsSwap<ComponentSymbolVariantItem,
-                        ComponentSymbolVariantItemListNameProvider>;
+                        ComponentSymbolVariantItemListNameProvider,
+                        ComponentSymbolVariantItem::Event>;
 
 /*******************************************************************************
  *  Class ComponentSymbolVariantItemListHelpers

--- a/libs/librepcb/library/dev/devicepadsignalmap.h
+++ b/libs/librepcb/library/dev/devicepadsignalmap.h
@@ -43,10 +43,16 @@ namespace library {
 /**
  * @brief The DevicePadSignalMapItem class
  */
-class DevicePadSignalMapItem final : public QObject, public SerializableObject {
-  Q_OBJECT
-
+class DevicePadSignalMapItem final : public SerializableObject {
 public:
+  // Signals
+  enum class Event {
+    PadUuidChanged,
+    SignalUuidChanged,
+  };
+  Signal<DevicePadSignalMapItem, Event>       onEdited;
+  typedef Slot<DevicePadSignalMapItem, Event> OnEditedSlot;
+
   // Constructors / Destructor
   DevicePadSignalMapItem() = delete;
   DevicePadSignalMapItem(const DevicePadSignalMapItem& other) noexcept;
@@ -65,7 +71,7 @@ public:
   }
 
   // Setters
-  void setSignalUuid(const tl::optional<Uuid>& uuid) noexcept;
+  bool setSignalUuid(const tl::optional<Uuid>& uuid) noexcept;
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -76,9 +82,6 @@ public:
     return !(*this == rhs);
   }
   DevicePadSignalMapItem& operator=(const DevicePadSignalMapItem& rhs) noexcept;
-
-signals:
-  void signalUuidChanged(const tl::optional<Uuid>& uuid);
 
 private:                           // Data
   Uuid               mPadUuid;     ///< must be valid
@@ -94,15 +97,17 @@ struct DevicePadSignalMapNameProvider {
 };
 using DevicePadSignalMap =
     SerializableObjectList<DevicePadSignalMapItem,
-                           DevicePadSignalMapNameProvider>;
+                           DevicePadSignalMapNameProvider,
+                           DevicePadSignalMapItem::Event>;
 using CmdDevicePadSignalMapItemInsert =
-    CmdListElementInsert<DevicePadSignalMapItem,
-                         DevicePadSignalMapNameProvider>;
+    CmdListElementInsert<DevicePadSignalMapItem, DevicePadSignalMapNameProvider,
+                         DevicePadSignalMapItem::Event>;
 using CmdDevicePadSignalMapItemRemove =
-    CmdListElementRemove<DevicePadSignalMapItem,
-                         DevicePadSignalMapNameProvider>;
+    CmdListElementRemove<DevicePadSignalMapItem, DevicePadSignalMapNameProvider,
+                         DevicePadSignalMapItem::Event>;
 using CmdDevicePadSignalMapItemsSwap =
-    CmdListElementsSwap<DevicePadSignalMapItem, DevicePadSignalMapNameProvider>;
+    CmdListElementsSwap<DevicePadSignalMapItem, DevicePadSignalMapNameProvider,
+                        DevicePadSignalMapItem::Event>;
 
 /*******************************************************************************
  *  Class DevicePadSignalMapHelpers

--- a/libs/librepcb/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/library/pkg/footprintpad.cpp
@@ -39,7 +39,8 @@ namespace library {
  ******************************************************************************/
 
 FootprintPad::FootprintPad(const FootprintPad& other) noexcept
-  : mPackagePadUuid(other.mPackagePadUuid),
+  : onEdited(*this),
+    mPackagePadUuid(other.mPackagePadUuid),
     mPosition(other.mPosition),
     mRotation(other.mRotation),
     mShape(other.mShape),
@@ -56,7 +57,8 @@ FootprintPad::FootprintPad(const Uuid& padUuid, const Point& pos,
                            const PositiveLength& height,
                            const UnsignedLength& drillDiameter,
                            BoardSide             side) noexcept
-  : mPackagePadUuid(padUuid),
+  : onEdited(*this),
+    mPackagePadUuid(padUuid),
     mPosition(pos),
     mRotation(rot),
     mShape(shape),
@@ -68,7 +70,8 @@ FootprintPad::FootprintPad(const Uuid& padUuid, const Point& pos,
 }
 
 FootprintPad::FootprintPad(const SExpression& node)
-  : mPackagePadUuid(node.getChildByIndex(0).getValue<Uuid>()),
+  : onEdited(*this),
+    mPackagePadUuid(node.getChildByIndex(0).getValue<Uuid>()),
     mPosition(node.getChildByPath("position")),
     mRotation(node.getValueByPath<Angle>("rotation")),
     mShape(node.getValueByPath<Shape>("shape")),
@@ -144,50 +147,98 @@ QPainterPath FootprintPad::toQPainterPathPx(const Length& expansion) const
 /*******************************************************************************
  *  Setters
  ******************************************************************************/
-void FootprintPad::setPosition(const Point& pos) noexcept {
+bool FootprintPad::setPosition(const Point& pos) noexcept {
+  if (pos == mPosition) {
+    return false;
+  }
+
   mPosition = pos;
   if (mRegisteredGraphicsItem) mRegisteredGraphicsItem->setPosition(mPosition);
+  onEdited.notify(Event::PositionChanged);
+  return true;
 }
 
-void FootprintPad::setPackagePadUuid(const Uuid& pad) noexcept {
+bool FootprintPad::setPackagePadUuid(const Uuid& pad) noexcept {
+  if (pad == mPackagePadUuid) {
+    return false;
+  }
+
   mPackagePadUuid = pad;
+  onEdited.notify(Event::PackagePadUuidChanged);
+  return true;
 }
 
-void FootprintPad::setRotation(const Angle& rot) noexcept {
+bool FootprintPad::setRotation(const Angle& rot) noexcept {
+  if (rot == mRotation) {
+    return false;
+  }
+
   mRotation = rot;
   if (mRegisteredGraphicsItem) mRegisteredGraphicsItem->setRotation(mRotation);
+  onEdited.notify(Event::RotationChanged);
+  return true;
 }
 
-void FootprintPad::setShape(Shape shape) noexcept {
+bool FootprintPad::setShape(Shape shape) noexcept {
+  if (shape == mShape) {
+    return false;
+  }
+
   mShape = shape;
   if (mRegisteredGraphicsItem)
     mRegisteredGraphicsItem->setShape(toQPainterPathPx());
+  onEdited.notify(Event::ShapeChanged);
+  return true;
 }
 
-void FootprintPad::setWidth(const PositiveLength& width) noexcept {
+bool FootprintPad::setWidth(const PositiveLength& width) noexcept {
+  if (width == mWidth) {
+    return false;
+  }
+
   mWidth = width;
   if (mRegisteredGraphicsItem)
     mRegisteredGraphicsItem->setShape(toQPainterPathPx());
+  onEdited.notify(Event::WidthChanged);
+  return true;
 }
 
-void FootprintPad::setHeight(const PositiveLength& height) noexcept {
+bool FootprintPad::setHeight(const PositiveLength& height) noexcept {
+  if (height == mHeight) {
+    return false;
+  }
+
   mHeight = height;
   if (mRegisteredGraphicsItem)
     mRegisteredGraphicsItem->setShape(toQPainterPathPx());
+  onEdited.notify(Event::HeightChanged);
+  return true;
 }
 
-void FootprintPad::setDrillDiameter(const UnsignedLength& diameter) noexcept {
+bool FootprintPad::setDrillDiameter(const UnsignedLength& diameter) noexcept {
+  if (diameter == mDrillDiameter) {
+    return false;
+  }
+
   mDrillDiameter = diameter;
   if (mRegisteredGraphicsItem)
     mRegisteredGraphicsItem->setShape(toQPainterPathPx());
+  onEdited.notify(Event::DrillDiameterChanged);
+  return true;
 }
 
-void FootprintPad::setBoardSide(BoardSide side) noexcept {
+bool FootprintPad::setBoardSide(BoardSide side) noexcept {
+  if (side == mBoardSide) {
+    return false;
+  }
+
   mBoardSide = side;
   if (mRegisteredGraphicsItem)
     mRegisteredGraphicsItem->setLayerName(getLayerName());
   if (mRegisteredGraphicsItem)
     mRegisteredGraphicsItem->setShape(toQPainterPathPx());
+  onEdited.notify(Event::BoardSideChanged);
+  return true;
 }
 
 /*******************************************************************************
@@ -234,14 +285,14 @@ bool FootprintPad::operator==(const FootprintPad& rhs) const noexcept {
 }
 
 FootprintPad& FootprintPad::operator=(const FootprintPad& rhs) noexcept {
-  mPackagePadUuid = rhs.mPackagePadUuid;
-  mPosition       = rhs.mPosition;
-  mRotation       = rhs.mRotation;
-  mShape          = rhs.mShape;
-  mWidth          = rhs.mWidth;
-  mHeight         = rhs.mHeight;
-  mDrillDiameter  = rhs.mDrillDiameter;
-  mBoardSide      = rhs.mBoardSide;
+  setPackagePadUuid(rhs.mPackagePadUuid);
+  setPosition(rhs.mPosition);
+  setRotation(rhs.mRotation);
+  setShape(rhs.mShape);
+  setWidth(rhs.mWidth);
+  setHeight(rhs.mHeight);
+  setDrillDiameter(rhs.mDrillDiameter);
+  setBoardSide(rhs.mBoardSide);
   return *this;
 }
 

--- a/libs/librepcb/library/pkg/footprintpad.h
+++ b/libs/librepcb/library/pkg/footprintpad.h
@@ -57,6 +57,20 @@ public:
   enum class Shape { ROUND, RECT, OCTAGON };
   enum class BoardSide { TOP, BOTTOM, THT };
 
+  // Signals
+  enum class Event {
+    PackagePadUuidChanged,
+    PositionChanged,
+    RotationChanged,
+    ShapeChanged,
+    WidthChanged,
+    HeightChanged,
+    DrillDiameterChanged,
+    BoardSideChanged,
+  };
+  Signal<FootprintPad, Event>       onEdited;
+  typedef Slot<FootprintPad, Event> OnEditedSlot;
+
   // Constructors / Destructor
   FootprintPad() = delete;
   FootprintPad(const FootprintPad& other) noexcept;
@@ -88,14 +102,14 @@ public:
       noexcept;
 
   // Setters
-  void setPackagePadUuid(const Uuid& pad) noexcept;
-  void setPosition(const Point& pos) noexcept;
-  void setRotation(const Angle& rot) noexcept;
-  void setShape(Shape shape) noexcept;
-  void setWidth(const PositiveLength& width) noexcept;
-  void setHeight(const PositiveLength& height) noexcept;
-  void setDrillDiameter(const UnsignedLength& diameter) noexcept;
-  void setBoardSide(BoardSide side) noexcept;
+  bool setPackagePadUuid(const Uuid& pad) noexcept;
+  bool setPosition(const Point& pos) noexcept;
+  bool setRotation(const Angle& rot) noexcept;
+  bool setShape(Shape shape) noexcept;
+  bool setWidth(const PositiveLength& width) noexcept;
+  bool setHeight(const PositiveLength& height) noexcept;
+  bool setDrillDiameter(const UnsignedLength& diameter) noexcept;
+  bool setBoardSide(BoardSide side) noexcept;
 
   // General Methods
   void registerGraphicsItem(FootprintPadGraphicsItem& item) noexcept;
@@ -131,13 +145,17 @@ struct FootprintPadListNameProvider {
   static constexpr const char* tagname = "pad";
 };
 using FootprintPadList =
-    SerializableObjectList<FootprintPad, FootprintPadListNameProvider>;
+    SerializableObjectList<FootprintPad, FootprintPadListNameProvider,
+                           FootprintPad::Event>;
 using CmdFootprintPadInsert =
-    CmdListElementInsert<FootprintPad, FootprintPadListNameProvider>;
+    CmdListElementInsert<FootprintPad, FootprintPadListNameProvider,
+                         FootprintPad::Event>;
 using CmdFootprintPadRemove =
-    CmdListElementRemove<FootprintPad, FootprintPadListNameProvider>;
+    CmdListElementRemove<FootprintPad, FootprintPadListNameProvider,
+                         FootprintPad::Event>;
 using CmdFootprintPadsSwap =
-    CmdListElementsSwap<FootprintPad, FootprintPadListNameProvider>;
+    CmdListElementsSwap<FootprintPad, FootprintPadListNameProvider,
+                        FootprintPad::Event>;
 
 /*******************************************************************************
  *  Non-Member Functions

--- a/libs/librepcb/library/pkg/package.cpp
+++ b/libs/librepcb/library/pkg/package.cpp
@@ -49,8 +49,8 @@ Package::Package(const Uuid& uuid, const Version& version,
 Package::Package(std::unique_ptr<TransactionalDirectory> directory)
   : LibraryElement(std::move(directory), getShortElementName(),
                    getLongElementName()) {
-  mPads.loadFromDomElement(mLoadingFileDocument);
-  mFootprints.loadFromDomElement(mLoadingFileDocument);
+  mPads.loadFromSExpression(mLoadingFileDocument);
+  mFootprints.loadFromSExpression(mLoadingFileDocument);
 
   cleanupAfterLoadingElementFromFile();
 }

--- a/libs/librepcb/library/pkg/packagepad.h
+++ b/libs/librepcb/library/pkg/packagepad.h
@@ -52,6 +52,14 @@ class PackagePad final : public SerializableObject {
   Q_DECLARE_TR_FUNCTIONS(PackagePad)
 
 public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    NameChanged,
+  };
+  Signal<PackagePad, Event>       onEdited;
+  typedef Slot<PackagePad, Event> OnEditedSlot;
+
   // Constructors / Destructor
   PackagePad() = delete;
   PackagePad(const PackagePad& other) noexcept;
@@ -64,7 +72,7 @@ public:
   CircuitIdentifier getName() const noexcept { return mName; }
 
   // Setters
-  void setName(const CircuitIdentifier& name) noexcept;
+  bool setName(const CircuitIdentifier& name) noexcept;
 
   // General Methods
 
@@ -91,13 +99,17 @@ struct PackagePadListNameProvider {
   static constexpr const char* tagname = "pad";
 };
 using PackagePadList =
-    SerializableObjectList<PackagePad, PackagePadListNameProvider>;
+    SerializableObjectList<PackagePad, PackagePadListNameProvider,
+                           PackagePad::Event>;
 using CmdPackagePadInsert =
-    CmdListElementInsert<PackagePad, PackagePadListNameProvider>;
+    CmdListElementInsert<PackagePad, PackagePadListNameProvider,
+                         PackagePad::Event>;
 using CmdPackagePadRemove =
-    CmdListElementRemove<PackagePad, PackagePadListNameProvider>;
+    CmdListElementRemove<PackagePad, PackagePadListNameProvider,
+                         PackagePad::Event>;
 using CmdPackagePadsSwap =
-    CmdListElementsSwap<PackagePad, PackagePadListNameProvider>;
+    CmdListElementsSwap<PackagePad, PackagePadListNameProvider,
+                        PackagePad::Event>;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/library/sym/symbol.h
+++ b/libs/librepcb/library/sym/symbol.h
@@ -54,14 +54,20 @@ class SymbolGraphicsItem;
  *  - Pins (neither adding nor removing pins is allowed)
  *    - UUID
  */
-class Symbol final : public LibraryElement,
-                     private SymbolPinList::IF_Observer,
-                     private PolygonList::IF_Observer,
-                     private CircleList::IF_Observer,
-                     private TextList::IF_Observer {
+class Symbol final : public LibraryElement {
   Q_OBJECT
 
 public:
+  // Signals
+  enum class Event {
+    PinsEdited,
+    PolygonsEdited,
+    CirclesEdited,
+    TextsEdited,
+  };
+  Signal<Symbol, Event>       onEdited;
+  typedef Slot<Symbol, Event> OnEditedSlot;
+
   // Constructors / Destructor
   Symbol()                    = delete;
   Symbol(const Symbol& other) = delete;
@@ -98,23 +104,18 @@ public:
   }
 
 private:  // Methods
-  void listObjectAdded(const SymbolPinList& list, int newIndex,
-                       const std::shared_ptr<SymbolPin>& ptr) noexcept override;
-  void listObjectAdded(const PolygonList& list, int newIndex,
-                       const std::shared_ptr<Polygon>& ptr) noexcept override;
-  void listObjectAdded(const CircleList& list, int newIndex,
-                       const std::shared_ptr<Circle>& ptr) noexcept override;
-  void listObjectAdded(const TextList& list, int newIndex,
-                       const std::shared_ptr<Text>& ptr) noexcept override;
-  void listObjectRemoved(
-      const SymbolPinList& list, int oldIndex,
-      const std::shared_ptr<SymbolPin>& ptr) noexcept override;
-  void listObjectRemoved(const PolygonList& list, int oldIndex,
-                         const std::shared_ptr<Polygon>& ptr) noexcept override;
-  void listObjectRemoved(const CircleList& list, int oldIndex,
-                         const std::shared_ptr<Circle>& ptr) noexcept override;
-  void listObjectRemoved(const TextList& list, int oldIndex,
-                         const std::shared_ptr<Text>& ptr) noexcept override;
+  void pinsEdited(const SymbolPinList& list, int index,
+                  const std::shared_ptr<const SymbolPin>& pin,
+                  SymbolPinList::Event                    event) noexcept;
+  void polygonsEdited(const PolygonList& list, int index,
+                      const std::shared_ptr<const Polygon>& polygon,
+                      PolygonList::Event                    event) noexcept;
+  void circlesEdited(const CircleList& list, int index,
+                     const std::shared_ptr<const Circle>& circle,
+                     CircleList::Event                    event) noexcept;
+  void textsEdited(const TextList& list, int index,
+                   const std::shared_ptr<const Text>& text,
+                   TextList::Event                    event) noexcept;
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
 
@@ -125,6 +126,12 @@ private:  // Data
   TextList      mTexts;
 
   SymbolGraphicsItem* mRegisteredGraphicsItem;
+
+  // Slots
+  SymbolPinList::OnEditedSlot mPinsEditedSlot;
+  PolygonList::OnEditedSlot   mPolygonsEditedSlot;
+  CircleList::OnEditedSlot    mCirclesEditedSlot;
+  TextList::OnEditedSlot      mTextsEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/library/sym/symbolpin.h
+++ b/libs/librepcb/library/sym/symbolpin.h
@@ -55,6 +55,17 @@ class SymbolPin final : public SerializableObject {
   Q_DECLARE_TR_FUNCTIONS(SymbolPin)
 
 public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    NameChanged,
+    PositionChanged,
+    LengthChanged,
+    RotationChanged,
+  };
+  Signal<SymbolPin, Event>       onEdited;
+  typedef Slot<SymbolPin, Event> OnEditedSlot;
+
   // Constructors / Destructor
   SymbolPin() = delete;
   SymbolPin(const SymbolPin& other) noexcept;
@@ -72,10 +83,10 @@ public:
   const Angle&             getRotation() const noexcept { return mRotation; }
 
   // Setters
-  void setPosition(const Point& pos) noexcept;
-  void setLength(const UnsignedLength& length) noexcept;
-  void setRotation(const Angle& rotation) noexcept;
-  void setName(const CircuitIdentifier& name) noexcept;
+  bool setPosition(const Point& pos) noexcept;
+  bool setLength(const UnsignedLength& length) noexcept;
+  bool setRotation(const Angle& rotation) noexcept;
+  bool setName(const CircuitIdentifier& name) noexcept;
 
   // General Methods
   void registerGraphicsItem(SymbolPinGraphicsItem& item) noexcept;
@@ -109,13 +120,16 @@ struct SymbolPinListNameProvider {
   static constexpr const char* tagname = "pin";
 };
 using SymbolPinList =
-    SerializableObjectList<SymbolPin, SymbolPinListNameProvider>;
+    SerializableObjectList<SymbolPin, SymbolPinListNameProvider,
+                           SymbolPin::Event>;
 using CmdSymbolPinInsert =
-    CmdListElementInsert<SymbolPin, SymbolPinListNameProvider>;
+    CmdListElementInsert<SymbolPin, SymbolPinListNameProvider,
+                         SymbolPin::Event>;
 using CmdSymbolPinRemove =
-    CmdListElementRemove<SymbolPin, SymbolPinListNameProvider>;
+    CmdListElementRemove<SymbolPin, SymbolPinListNameProvider,
+                         SymbolPin::Event>;
 using CmdSymbolPinsSwap =
-    CmdListElementsSwap<SymbolPin, SymbolPinListNameProvider>;
+    CmdListElementsSwap<SymbolPin, SymbolPinListNameProvider, SymbolPin::Event>;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
@@ -44,13 +44,8 @@ namespace editor {
 
 /**
  * @brief The ComponentSignalListEditorWidget class
- *
- * @author ubruhin
- * @date 2017-03-12
  */
-class ComponentSignalListEditorWidget final
-  : public QWidget,
-    private ComponentSignalList::IF_Observer {
+class ComponentSignalListEditorWidget final : public QWidget {
   Q_OBJECT
 
 private:  // Types
@@ -89,15 +84,10 @@ private:  // Slots
   // void isClockChanged(bool checked) noexcept;
   void btnAddRemoveClicked() noexcept;
 
-private:  // Observer
-  void listObjectAdded(
-      const ComponentSignalList& list, int newIndex,
-      const std::shared_ptr<ComponentSignal>& ptr) noexcept override;
-  void listObjectRemoved(
-      const ComponentSignalList& list, int oldIndex,
-      const std::shared_ptr<ComponentSignal>& ptr) noexcept override;
-
 private:  // Methods
+  void signalListEdited(const ComponentSignalList& list, int index,
+                        const std::shared_ptr<const ComponentSignal>& signal,
+                        ComponentSignalList::Event event) noexcept;
   void updateTable() noexcept;
   void setTableRowContent(int row, const tl::optional<Uuid>& uuid,
                           const QString&                   name,
@@ -133,6 +123,9 @@ private:  // Data
   UndoStack*           mUndoStack;
   ComponentSignalList* mSignalList;
   tl::optional<Uuid>   mSelectedSignal;
+
+  // Slots
+  ComponentSignalList::OnEditedSlot mSignalListEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
@@ -495,7 +495,7 @@ void ComponentSymbolVariantItemListEditorWidget::moveItemUp(
 void ComponentSymbolVariantItemListEditorWidget::moveItemDown(
     int index) noexcept {
   Q_ASSERT(index >= 0 && index < mItems->count() - 1);
-  mItems->swap(index, index + 1);
+  mItems->swap(index + 1, index);
   updateTable(mSelectedItem);
   emit edited();
 }

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
@@ -45,7 +45,9 @@ ComponentSymbolVariantListWidget::ComponentSymbolVariantListWidget(
     mTable(new QTableWidget(this)),
     mUndoStack(nullptr),
     mVariantList(nullptr),
-    mEditorProvider(nullptr) {
+    mEditorProvider(nullptr),
+    mVariantListEditedSlot(
+        *this, &ComponentSymbolVariantListWidget::variantListEdited) {
   mTable->setCornerButtonEnabled(false);
   mTable->setSelectionBehavior(QAbstractItemView::SelectRows);
   mTable->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -99,22 +101,14 @@ void ComponentSymbolVariantListWidget::setReferences(
     UndoStack* undoStack, ComponentSymbolVariantList* variants,
     IF_ComponentSymbolVariantEditorProvider* editorProvider) noexcept {
   if (mVariantList) {
-    mVariantList->unregisterObserver(this);
-    for (const ComponentSymbolVariant& variant : *mVariantList) {
-      disconnect(&variant, &ComponentSymbolVariant::edited, this,
-                 &ComponentSymbolVariantListWidget::updateTable);
-    }
+    mVariantList->onEdited.detach(mVariantListEditedSlot);
   }
   mUndoStack       = undoStack;
   mVariantList     = variants;
   mEditorProvider  = editorProvider;
   mSelectedVariant = tl::nullopt;
   if (mVariantList) {
-    mVariantList->registerObserver(this);
-    for (const ComponentSymbolVariant& variant : *mVariantList) {
-      connect(&variant, &ComponentSymbolVariant::edited, this,
-              &ComponentSymbolVariantListWidget::updateTable);
-    }
+    mVariantList->onEdited.attach(mVariantListEditedSlot);
   }
   updateTable();
 }
@@ -198,34 +192,19 @@ void ComponentSymbolVariantListWidget::btnDownClicked() noexcept {
 }
 
 /*******************************************************************************
- *  Observer
- ******************************************************************************/
-
-void ComponentSymbolVariantListWidget::listObjectAdded(
-    const ComponentSymbolVariantList& list, int newIndex,
-    const std::shared_ptr<ComponentSymbolVariant>& ptr) noexcept {
-  Q_UNUSED(list);
-  Q_UNUSED(newIndex);
-  Q_ASSERT(&list == mVariantList);
-  connect(ptr.get(), &ComponentSymbolVariant::edited, this,
-          &ComponentSymbolVariantListWidget::updateTable);
-  updateTable();
-}
-
-void ComponentSymbolVariantListWidget::listObjectRemoved(
-    const ComponentSymbolVariantList& list, int oldIndex,
-    const std::shared_ptr<ComponentSymbolVariant>& ptr) noexcept {
-  Q_UNUSED(list);
-  Q_UNUSED(oldIndex);
-  Q_ASSERT(&list == mVariantList);
-  disconnect(ptr.get(), &ComponentSymbolVariant::edited, this,
-             &ComponentSymbolVariantListWidget::updateTable);
-  updateTable();
-}
-
-/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void ComponentSymbolVariantListWidget::variantListEdited(
+    const ComponentSymbolVariantList& list, int index,
+    const std::shared_ptr<const ComponentSymbolVariant>& variant,
+    ComponentSymbolVariantList::Event                    event) noexcept {
+  Q_UNUSED(list);
+  Q_UNUSED(index);
+  Q_UNUSED(variant);
+  Q_UNUSED(event);
+  updateTable();
+}
 
 void ComponentSymbolVariantListWidget::updateTable() noexcept {
   blockSignals(true);

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
@@ -50,9 +50,7 @@ namespace editor {
  * @author ubruhin
  * @date 2017-03-18
  */
-class ComponentSymbolVariantListWidget final
-  : public QWidget,
-    private ComponentSymbolVariantList::IF_Observer {
+class ComponentSymbolVariantListWidget final : public QWidget {
   Q_OBJECT
 
 private:  // Types
@@ -93,15 +91,11 @@ private:  // Slots
   void btnUpClicked() noexcept;
   void btnDownClicked() noexcept;
 
-private:  // Observer
-  void listObjectAdded(
-      const ComponentSymbolVariantList& list, int newIndex,
-      const std::shared_ptr<ComponentSymbolVariant>& ptr) noexcept override;
-  void listObjectRemoved(
-      const ComponentSymbolVariantList& list, int oldIndex,
-      const std::shared_ptr<ComponentSymbolVariant>& ptr) noexcept override;
-
 private:  // Methods
+  void variantListEdited(
+      const ComponentSymbolVariantList& list, int index,
+      const std::shared_ptr<const ComponentSymbolVariant>& variant,
+      ComponentSymbolVariantList::Event                    event) noexcept;
   void               updateTable() noexcept;
   void               setTableRowContent(int row, const tl::optional<Uuid>& uuid,
                                         const QString& name, const QString& desc,
@@ -135,6 +129,9 @@ private:  // Data
   ComponentSymbolVariantList*              mVariantList;
   IF_ComponentSymbolVariantEditorProvider* mEditorProvider;
   tl::optional<Uuid>                       mSelectedVariant;
+
+  // Slots
+  ComponentSymbolVariantList::OnEditedSlot mVariantListEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
@@ -44,7 +44,8 @@ PadSignalMapEditorWidget::PadSignalMapEditorWidget(QWidget* parent) noexcept
   : QWidget(parent),
     mTable(new QTableWidget(this)),
     mUndoStack(nullptr),
-    mPadSignalMap(nullptr) {
+    mPadSignalMap(nullptr),
+    mMapEditedSlot(*this, &PadSignalMapEditorWidget::mapEdited) {
   mTable->setCornerButtonEnabled(false);
   mTable->setSelectionBehavior(QAbstractItemView::SelectRows);
   mTable->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -81,20 +82,12 @@ PadSignalMapEditorWidget::~PadSignalMapEditorWidget() noexcept {
 void PadSignalMapEditorWidget::setReferences(UndoStack*          undoStack,
                                              DevicePadSignalMap* map) noexcept {
   if (mPadSignalMap) {
-    mPadSignalMap->unregisterObserver(this);
-    for (const DevicePadSignalMapItem& item : *mPadSignalMap) {
-      disconnect(&item, &DevicePadSignalMapItem::signalUuidChanged, this,
-                 &PadSignalMapEditorWidget::updateTable);
-    }
+    mPadSignalMap->onEdited.detach(mMapEditedSlot);
   }
   mUndoStack    = undoStack;
   mPadSignalMap = map;
   if (mPadSignalMap) {
-    mPadSignalMap->registerObserver(this);
-    for (const DevicePadSignalMapItem& item : *mPadSignalMap) {
-      connect(&item, &DevicePadSignalMapItem::signalUuidChanged, this,
-              &PadSignalMapEditorWidget::updateTable);
-    }
+    mPadSignalMap->onEdited.attach(mMapEditedSlot);
   }
   updateTable();
 }
@@ -136,34 +129,19 @@ void PadSignalMapEditorWidget::componentSignalChanged(int index) noexcept {
 }
 
 /*******************************************************************************
- *  Observer
- ******************************************************************************/
-
-void PadSignalMapEditorWidget::listObjectAdded(
-    const DevicePadSignalMap& list, int newIndex,
-    const std::shared_ptr<DevicePadSignalMapItem>& ptr) noexcept {
-  Q_UNUSED(list);
-  Q_UNUSED(newIndex);
-  Q_ASSERT(&list == mPadSignalMap);
-  connect(ptr.get(), &DevicePadSignalMapItem::signalUuidChanged, this,
-          &PadSignalMapEditorWidget::updateTable);
-  updateTable();
-}
-
-void PadSignalMapEditorWidget::listObjectRemoved(
-    const DevicePadSignalMap& list, int oldIndex,
-    const std::shared_ptr<DevicePadSignalMapItem>& ptr) noexcept {
-  Q_UNUSED(list);
-  Q_UNUSED(oldIndex);
-  Q_ASSERT(&list == mPadSignalMap);
-  disconnect(ptr.get(), &DevicePadSignalMapItem::signalUuidChanged, this,
-             &PadSignalMapEditorWidget::updateTable);
-  updateTable();
-}
-
-/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void PadSignalMapEditorWidget::mapEdited(
+    const DevicePadSignalMap& map, int index,
+    const std::shared_ptr<const DevicePadSignalMapItem>& item,
+    DevicePadSignalMap::Event                            event) noexcept {
+  Q_UNUSED(map);
+  Q_UNUSED(index);
+  Q_UNUSED(item);
+  Q_UNUSED(event);
+  updateTable();
+}
 
 void PadSignalMapEditorWidget::updateTable() noexcept {
   blockSignals(true);

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
@@ -50,12 +50,8 @@ namespace editor {
 
 /**
  * @brief The PadSignalMapEditorWidget class
- *
- * @author ubruhin
- * @date 2017-03-25
  */
-class PadSignalMapEditorWidget final : public QWidget,
-                                       private DevicePadSignalMap::IF_Observer {
+class PadSignalMapEditorWidget final : public QWidget {
   Q_OBJECT
 
 private:  // Types
@@ -81,15 +77,10 @@ private:  // Slots
                           int previousColumn) noexcept;
   void componentSignalChanged(int index) noexcept;
 
-private:  // Observer
-  void listObjectAdded(
-      const DevicePadSignalMap& list, int newIndex,
-      const std::shared_ptr<DevicePadSignalMapItem>& ptr) noexcept override;
-  void listObjectRemoved(
-      const DevicePadSignalMap& list, int oldIndex,
-      const std::shared_ptr<DevicePadSignalMapItem>& ptr) noexcept override;
-
 private:  // Methods
+  void mapEdited(const DevicePadSignalMap& map, int index,
+                 const std::shared_ptr<const DevicePadSignalMapItem>& item,
+                 DevicePadSignalMap::Event event) noexcept;
   void updateTable() noexcept;
   void setTableRowContent(int row, const Uuid& padUuid, const QString& padName,
                           const tl::optional<Uuid>& signalUuid) noexcept;
@@ -105,6 +96,9 @@ private:  // Data
   PackagePadList      mPads;
   ComponentSignalList mSignals;
   tl::optional<Uuid>  mSelectedPad;
+
+  // Slots
+  DevicePadSignalMap::OnEditedSlot mMapEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
@@ -44,12 +44,8 @@ namespace editor {
 
 /**
  * @brief The FootprintListEditorWidget class
- *
- * @author ubruhin
- * @date 2017-05-27
  */
-class FootprintListEditorWidget final : public QWidget,
-                                        private FootprintList::IF_Observer {
+class FootprintListEditorWidget final : public QWidget {
   Q_OBJECT
 
 private:  // Types
@@ -84,6 +80,9 @@ private:  // Slots
   void btnAddRemoveClicked() noexcept;
 
 private:  // Methods
+  void        footprintListEdited(const FootprintList& list, int index,
+                                  const std::shared_ptr<const Footprint>& footprint,
+                                  FootprintList::Event event) noexcept;
   void        updateTable(tl::optional<Uuid> selected = tl::nullopt) noexcept;
   void        setTableRowContent(int row, const tl::optional<Uuid>& uuid,
                                  const QString& name) noexcept;
@@ -108,18 +107,14 @@ private:  // Methods
     return row == newFootprintRow();
   }
 
-  // Observer Methods
-  void listObjectAdded(const FootprintList& list, int newIndex,
-                       const std::shared_ptr<Footprint>& ptr) noexcept override;
-  void listObjectRemoved(
-      const FootprintList& list, int oldIndex,
-      const std::shared_ptr<Footprint>& ptr) noexcept override;
-
 private:  // Data
   QTableWidget*      mTable;
   FootprintList*     mFootprintList;
   UndoStack*         mUndoStack;
   tl::optional<Uuid> mSelectedFootprint;
+
+  // Slots
+  FootprintList::OnEditedSlot mFootprintListEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
@@ -48,8 +48,7 @@ namespace editor {
  * @author ubruhin
  * @date 2017-03-27
  */
-class PackagePadListEditorWidget final : public QWidget,
-                                         private PackagePadList::IF_Observer {
+class PackagePadListEditorWidget final : public QWidget {
   Q_OBJECT
 
 private:  // Types
@@ -75,6 +74,9 @@ private:  // Slots
   void btnAddRemoveClicked() noexcept;
 
 private:  // Methods
+  void padListEdited(const PackagePadList& list, int index,
+                     const std::shared_ptr<const PackagePad>& pad,
+                     PackagePadList::Event                    event) noexcept;
   void updateTable(const tl::optional<Uuid>& selected = tl::nullopt) noexcept;
   void setTableRowContent(int row, const tl::optional<Uuid>& uuid,
                           const QString& name) noexcept;
@@ -96,19 +98,14 @@ private:  // Methods
   }
   bool isNewPadRow(int row) const noexcept { return row == newPadRow(); }
 
-  // Observer Methods
-  void listObjectAdded(
-      const PackagePadList& list, int newIndex,
-      const std::shared_ptr<PackagePad>& ptr) noexcept override;
-  void listObjectRemoved(
-      const PackagePadList& list, int oldIndex,
-      const std::shared_ptr<PackagePad>& ptr) noexcept override;
-
 private:  // Data
   QTableWidget*      mTable;
   PackagePadList*    mPadList;
   UndoStack*         mUndoStack;
   tl::optional<Uuid> mSelectedPad;
+
+  // Slots
+  PackagePadList::OnEditedSlot mPadListEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -478,7 +478,7 @@ void BoardGerberExport::drawFootprint(GerberGenerator&    gen,
       Circle e = circle;
       if (footprint.getIsMirrored())
         e.setCenter(e.getCenter().mirrored(Qt::Horizontal));
-      e.translate(footprint.getPosition());
+      e.setCenter(e.getCenter() + footprint.getPosition());
       e.setLineWidth(calcWidthOfLayer(e.getLineWidth(), layer));
       gen.drawCircleOutline(e);
       if (e.isFilled()) {

--- a/libs/librepcb/project/boards/items/bi_device.cpp
+++ b/libs/librepcb/project/boards/items/bi_device.cpp
@@ -89,7 +89,7 @@ BI_Device::BI_Device(Board& board, const SExpression& node)
   mIsMirrored = node.getValueByPath<bool>("mirror");
 
   // load attributes
-  mAttributes.loadFromDomElement(node);  // can throw
+  mAttributes.loadFromSExpression(node);  // can throw
 
   // load footprint
   mFootprint.reset(new BI_Footprint(*this, node));

--- a/libs/librepcb/project/boards/items/bi_stroketext.h
+++ b/libs/librepcb/project/boards/items/bi_stroketext.h
@@ -53,9 +53,7 @@ class BI_Footprint;
 /**
  * @brief The BI_StrokeText class
  */
-class BI_StrokeText final : public BI_Base,
-                            public SerializableObject,
-                            public IF_StrokeTextObserver {
+class BI_StrokeText final : public BI_Base, public SerializableObject {
   Q_OBJECT
 
 public:
@@ -102,55 +100,17 @@ private slots:
 private:  // Methods
   void init();
   void updatePaths() noexcept;
-  void strokeTextLayerNameChanged(
-      const GraphicsLayerName& newLayerName) noexcept override {
-    Q_UNUSED(newLayerName);
-    updateGraphicsItems();
-  }
-  void strokeTextTextChanged(const QString& newText) noexcept override {
-    Q_UNUSED(newText);
-  }
-  void strokeTextPositionChanged(const Point& newPos) noexcept override {
-    Q_UNUSED(newPos);
-    updateGraphicsItems();
-  }
-  void strokeTextRotationChanged(const Angle& newRot) noexcept override {
-    Q_UNUSED(newRot);
-  }
-  void strokeTextHeightChanged(
-      const PositiveLength& newHeight) noexcept override {
-    Q_UNUSED(newHeight);
-  }
-  void strokeTextStrokeWidthChanged(
-      const UnsignedLength& newStrokeWidth) noexcept override {
-    Q_UNUSED(newStrokeWidth);
-  }
-  void strokeTextLetterSpacingChanged(
-      const StrokeTextSpacing& spacing) noexcept override {
-    Q_UNUSED(spacing);
-  }
-  void strokeTextLineSpacingChanged(
-      const StrokeTextSpacing& spacing) noexcept override {
-    Q_UNUSED(spacing);
-  }
-  void strokeTextAlignChanged(const Alignment& newAlign) noexcept override {
-    Q_UNUSED(newAlign);
-  }
-  void strokeTextMirroredChanged(bool mirrored) noexcept override {
-    Q_UNUSED(mirrored);
-  }
-  void strokeTextAutoRotateChanged(bool newAutoRotate) noexcept override {
-    Q_UNUSED(newAutoRotate);
-  }
-  void strokeTextPathsChanged(const QVector<Path>& paths) noexcept override {
-    Q_UNUSED(paths);
-  }
+  void strokeTextEdited(const StrokeText& text,
+                        StrokeText::Event event) noexcept;
 
 private:  // Data
   BI_Footprint*                          mFootprint;
   QScopedPointer<StrokeText>             mText;
   QScopedPointer<StrokeTextGraphicsItem> mGraphicsItem;
   QScopedPointer<LineGraphicsItem>       mAnchorGraphicsItem;
+
+  // Slots
+  StrokeText::OnEditedSlot mOnStrokeTextEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/metadata/projectmetadata.cpp
+++ b/libs/librepcb/project/metadata/projectmetadata.cpp
@@ -58,7 +58,7 @@ ProjectMetadata::ProjectMetadata(const SExpression& node)
   mAuthor  = node.getValueByPath<QString>("author");
   mVersion = node.getValueByPath<QString>("version");
   mCreated = node.getValueByPath<QDateTime>("created");
-  mAttributes.loadFromDomElement(node);  // can throw
+  mAttributes.loadFromSExpression(node);  // can throw
 
   mLastModified = QDateTime::currentDateTime();
 

--- a/tests/unittests/common/fileio/serializableobjectlisttest.cpp
+++ b/tests/unittests/common/fileio/serializableobjectlisttest.cpp
@@ -114,7 +114,8 @@ TEST_F(SerializableObjectListTest, testPointerInitializerListConstructor) {
 }
 
 TEST_F(SerializableObjectListTest, testValueInitializerListConstructor) {
-  List l{Mock(Uuid::createRandom(), "foo"), Mock(Uuid::createRandom(), "bar")};
+  List l{std::make_shared<Mock>(Uuid::createRandom(), "foo"),
+         std::make_shared<Mock>(Uuid::createRandom(), "bar")};
   EXPECT_EQ(2, l.count());
   EXPECT_EQ("foo", l[0]->mName);
   EXPECT_EQ("bar", l[1]->mName);
@@ -284,7 +285,9 @@ TEST_F(SerializableObjectListTest, testSerialize) {
 TEST_F(SerializableObjectListTest, testOperatorEqual) {
   EXPECT_TRUE(List() == List());
   EXPECT_TRUE(List({mMocks[0], mMocks[1]}) == List({mMocks[0], mMocks[1]}));
-  EXPECT_TRUE(List({mMocks[0], mMocks[1]}) == List({*mMocks[0], *mMocks[1]}));
+  EXPECT_TRUE(List({mMocks[0], mMocks[1]}) ==
+              List({std::make_shared<Mock>(*mMocks[0]),
+                    std::make_shared<Mock>(*mMocks[1])}));
   EXPECT_FALSE(List({mMocks[0], mMocks[1]}) == List({mMocks[0], mMocks[2]}));
   EXPECT_FALSE(List({mMocks[0]}) == List({mMocks[0], mMocks[1]}));
 }
@@ -292,7 +295,9 @@ TEST_F(SerializableObjectListTest, testOperatorEqual) {
 TEST_F(SerializableObjectListTest, testOperatorUnequal) {
   EXPECT_FALSE(List() != List());
   EXPECT_FALSE(List({mMocks[0], mMocks[1]}) != List({mMocks[0], mMocks[1]}));
-  EXPECT_FALSE(List({mMocks[0], mMocks[1]}) != List({*mMocks[0], *mMocks[1]}));
+  EXPECT_FALSE(List({mMocks[0], mMocks[1]}) !=
+               List({std::make_shared<Mock>(*mMocks[0]),
+                     std::make_shared<Mock>(*mMocks[1])}));
   EXPECT_TRUE(List({mMocks[0], mMocks[1]}) != List({mMocks[0], mMocks[2]}));
   EXPECT_TRUE(List({mMocks[0]}) != List({mMocks[0], mMocks[1]}));
 }

--- a/tests/unittests/common/fileio/serializableobjectmock.h
+++ b/tests/unittests/common/fileio/serializableobjectmock.h
@@ -26,6 +26,7 @@
 
 #include <gmock/gmock.h>
 #include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/signalslot.h>
 #include <librepcb/common/uuid.h>
 
 #include <QtCore>
@@ -42,11 +43,13 @@ namespace tests {
 
 class MinimalSerializableObjectMock final : public SerializableObject {
 public:
-  QString mValue;
+  QString                               mValue;
+  Signal<MinimalSerializableObjectMock> onEdited;
   MinimalSerializableObjectMock() = delete;
-  MinimalSerializableObjectMock(const QString& value) : mValue(value) {}
+  MinimalSerializableObjectMock(const QString& value)
+    : mValue(value), onEdited(*this) {}
   MinimalSerializableObjectMock(const SExpression& root)
-    : mValue(root.getValueOfFirstChild<QString>()) {}
+    : mValue(root.getValueOfFirstChild<QString>()), onEdited(*this) {}
   MinimalSerializableObjectMock(MinimalSerializableObjectMock&& other) = delete;
   MinimalSerializableObjectMock(const MinimalSerializableObjectMock& other) =
       delete;
@@ -68,18 +71,22 @@ public:
 
 class SerializableObjectMock final : public SerializableObject {
 public:
-  Uuid    mUuid;
-  QString mName;
+  Uuid                           mUuid;
+  QString                        mName;
+  Signal<SerializableObjectMock> onEdited;
   SerializableObjectMock() = delete;
   SerializableObjectMock(const SerializableObjectMock& other) noexcept
-    : mUuid(other.mUuid), mName(other.mName) {}
+    : mUuid(other.mUuid), mName(other.mName), onEdited(*this) {}
   SerializableObjectMock(SerializableObjectMock&& other) noexcept
-    : mUuid(std::move(other.mUuid)), mName(std::move(other.mName)) {}
+    : mUuid(std::move(other.mUuid)),
+      mName(std::move(other.mName)),
+      onEdited(*this) {}
   SerializableObjectMock(const Uuid& uuid, const QString& name)
-    : mUuid(uuid), mName(name) {}
+    : mUuid(uuid), mName(name), onEdited(*this) {}
   SerializableObjectMock(const SExpression& root)
     : mUuid(root.getValueOfFirstChild<Uuid>()),
-      mName(root.getValueByPath<QString>("name")) {}
+      mName(root.getValueByPath<QString>("name")),
+      onEdited(*this) {}
   ~SerializableObjectMock() {}
 
   const Uuid&    getUuid() const noexcept { return mUuid; }


### PR DESCRIPTION
Many objects need to get notified about changes in other objects, for example when clicking CTRL+Z, the undo stack reverts changes in objects and the GUI needs to get notified about these changes. For higher level classes we do this with Qt's signal/slot mechanism as it is easy to use and very safe.

But this works only in classes derived from `QObject` and I'm not sure if it's a good idea to have even low-level classes derived from `QObject`. A typical LibrePCB project contains many thousands of lower level objects, this might lead to performance issues when deriving them all from `QObject`. In addition, inheritance is often a pain and thus it's better to keep the inheritance hierarchy as simple as possible.

Until now, the lower level classes had implemented the observer pattern by declaring an interface for observers and register/unregister methods. But that was also a bit annoying since it leads to a lot of code and multiple inheritance. And it was a bit dangerous since objects and their observers weren't automatically disconnected if either the object or the observer was destroyed. So it was easy to access dangling pointers.

This PR replaces the observer pattern with an implementation which doesn't need any inheritance and is much more safe to use. Accessing dangling pointers should no longer be possible since the objects and their observers are automatically disconnected if either the object or the observer is destroyed.

See implementation in [`libs/librepcb/common/signalslot.h`](https://github.com/LibrePCB/LibrePCB/blob/refactor-observer-pattern/libs/librepcb/common/signalslot.h) (docs [here](https://developers.librepcb.org/_branches/refactor-observer-pattern/d9/daf/classlibrepcb_1_1_signal.html)).

Required for #446 