### PR TITLE
Library Editor: Preselect pin name when opening the pin properties dialog

### DIFF
--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -55,6 +55,9 @@ SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(SymbolPin& pin,
   mUi->spbPosY->setValue(mSymbolPin.getPosition().getY().toMm());
   mUi->spbRotation->setValue(mSymbolPin.getRotation().toDeg());
   mUi->spbLength->setValue(mSymbolPin.getLength()->toMm());
+      
+  // preselect name
+  mUi->edtName->setSelection(0, mUi->edtName->text().size());
 }
 
 SymbolPinPropertiesDialog::~SymbolPinPropertiesDialog() noexcept {

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -55,9 +55,9 @@ SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(SymbolPin& pin,
   mUi->spbPosY->setValue(mSymbolPin.getPosition().getY().toMm());
   mUi->spbRotation->setValue(mSymbolPin.getRotation().toDeg());
   mUi->spbLength->setValue(mSymbolPin.getLength()->toMm());
-      
+
   // preselect name
-  mUi->edtName->setSelection(0, mUi->edtName->text().size());
+  mUi->edtName->selectAll();
 }
 
 SymbolPinPropertiesDialog::~SymbolPinPropertiesDialog() noexcept {


### PR DESCRIPTION
Preselecting the pin name improves the workflow when customizing pins: double-click pin, enter new name and finish with Enter. The deletion or manual selection of the previous name is no longer necessary.