### PR TITLE
Change predefined norms to "IEC 60617" + "IEEE 315"

### DIFF
--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -214,6 +214,7 @@ HEADERS += \
     network/networkrequest.h \
     network/networkrequestbase.h \
     network/repository.h \
+    norms.h \
     scopeguard.h \
     scopeguardlist.h \
     signalrole.h \

--- a/libs/librepcb/common/norms.h
+++ b/libs/librepcb/common/norms.h
@@ -1,0 +1,55 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_NORMS_H
+#define LIBREPCB_NORMS_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  List of norms
+ ******************************************************************************/
+
+/**
+ * @brief Get a list of available "built-in" norms
+ *
+ * These norms are used e.g. in the library editor and workspace/project
+ * settings dialogs.
+ *
+ * @return List of norms
+ */
+inline QStringList getAvailableNorms() noexcept {
+  return QStringList{"IEC 60617", "IEEE 315"};
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_NORMS_H

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
@@ -27,6 +27,7 @@
 #include <librepcb/common/fileio/transactionalfilesystem.h>
 #include <librepcb/common/graphics/defaultgraphicslayerprovider.h>
 #include <librepcb/common/graphics/graphicsscene.h>
+#include <librepcb/common/norms.h>
 #include <librepcb/library/cmp/component.h>
 #include <librepcb/library/cmp/componentsymbolvariant.h>
 #include <librepcb/library/sym/symbol.h>
@@ -59,6 +60,7 @@ ComponentSymbolVariantEditDialog::ComponentSymbolVariantEditDialog(
     mUi(new Ui::ComponentSymbolVariantEditDialog),
     mGraphicsScene(new GraphicsScene()) {
   mUi->setupUi(this);
+  mUi->cbxNorm->addItems(getAvailableNorms());
   mUi->graphicsView->setScene(mGraphicsScene.data());
   mUi->graphicsView->setOriginCrossVisible(false);
   mGraphicsLayerProvider.reset(new DefaultGraphicsLayerProvider());
@@ -66,7 +68,7 @@ ComponentSymbolVariantEditDialog::ComponentSymbolVariantEditDialog(
   // load metadata
   mUi->edtName->setText(*mSymbVar.getNames().getDefaultValue());
   mUi->edtDescription->setText(mSymbVar.getDescriptions().getDefaultValue());
-  mUi->edtNorm->setText(mSymbVar.getNorm());
+  mUi->cbxNorm->setCurrentText(mSymbVar.getNorm());
 
   // load symbol items
   mUi->symbolListWidget->setVariant(mWorkspace, *mGraphicsLayerProvider,
@@ -96,7 +98,7 @@ void ComponentSymbolVariantEditDialog::accept() noexcept {
     ElementName name(mUi->edtName->text().trimmed());  // can throw
     mSymbVar.setName("", name);
     mSymbVar.setDescription("", mUi->edtDescription->text().trimmed());
-    mSymbVar.setNorm(mUi->edtNorm->text().trimmed());
+    mSymbVar.setNorm(mUi->cbxNorm->currentText().trimmed());
     mOriginalSymbVar = mSymbVar;
     QDialog::accept();
   } catch (const Exception& e) {

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.ui
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.ui
@@ -77,9 +77,18 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="edtNorm">
-        <property name="maxLength">
-         <number>20</number>
+       <widget class="QComboBox" name="cbxNorm">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+        <property name="insertPolicy">
+         <enum>QComboBox::NoInsert</enum>
         </property>
        </widget>
       </item>

--- a/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.cpp
@@ -24,6 +24,7 @@
 
 #include "ui_projectsettingsdialog.h"
 
+#include <librepcb/common/norms.h>
 #include <librepcb/common/undostack.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/settings/cmd/cmdprojectsettingschange.h>
@@ -72,8 +73,8 @@ ProjectSettingsDialog::ProjectSettingsDialog(ProjectSettings& settings,
   mUi->cbxLocales->setCurrentIndex(mUi->cbxLocales->findData(QLocale().name()));
 
   // list norms
-  mUi->cbxNorms->addItem(
-      "DIN EN 81346");  // TODO: add more norms (dynamically?)
+  mUi->cbxNorms->addItems(getAvailableNorms());
+  mUi->cbxNorms->clearEditText();
 
   // update GUI elements
   updateGuiFromSettings();

--- a/libs/librepcb/workspace/settings/items/wsi_librarynormorder.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_librarynormorder.cpp
@@ -22,6 +22,8 @@
  ******************************************************************************/
 #include "wsi_librarynormorder.h"
 
+#include <librepcb/common/norms.h>
+
 #include <QtCore>
 #include <QtWidgets>
 
@@ -53,7 +55,8 @@ WSI_LibraryNormOrder::WSI_LibraryNormOrder(const SExpression& node)
   // create a QComboBox with all available norms
   mComboBox.reset(new QComboBox());
   mComboBox->setEditable(true);
-  mComboBox->addItem("DIN EN 81346");  // TODO: add more norms (dynamically?)
+  mComboBox->addItems(getAvailableNorms());
+  mComboBox->clearEditText();
 
   // create all buttons
   mBtnUp.reset(new QToolButton());


### PR DESCRIPTION
See discussion here: https://librepcb.discourse.group/t/how-do-i-add-ieee-315-to-my-preferences/88

I'm not completely happy with this solution, but it's for sure better than the current situation. IEC 60617 and IEEE 315 are the only two norms used in our official libraries so far, thus I think it makes sense to have these norms as suggestions in the workspace/project settings dialogs.

I also updated the component symbol variant editor dialog to use a combobox instead of a text field for specifying the norm, this way it should be more intuitive and easier to choose a norm.