### PR TITLE
BoardEditor: Fix unintended tool change after double click on footprint

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
@@ -545,7 +545,7 @@ BES_Base::ProcRetVal BES_Select::proccessIdleSceneDoubleClick(
         BI_Footprint* footprint = dynamic_cast<BI_Footprint*>(items.first());
         Q_ASSERT(footprint);
         openDevicePropertiesDialog(footprint->getDeviceInstance());
-        return ForceLeaveState;
+        return ForceStayInState;
       }
       case BI_Base::Type_t::Via: {
         BI_Via* via = dynamic_cast<BI_Via*>(items.first());


### PR DESCRIPTION
After double-clicking on a footprint in the board editor (which opens the properties dialog), the editor changed back to the last active tool, which is of course not intended. Reason was a wrong return value of the state machine...