### PR TITLE
Automatically choose next free numerical pad name

### DIFF
--- a/libs/librepcb/library/pkg/packagepadlistmodel.cpp
+++ b/libs/librepcb/library/pkg/packagepadlistmodel.cpp
@@ -88,6 +88,10 @@ void PackagePadListModel::addPad(const QVariant& editData) noexcept {
   try {
     QScopedPointer<UndoCommandGroup> cmd(
         new UndoCommandGroup(tr("Add package pad(s)")));
+    // if no name is set we search for the next free numerical pad name
+    if (mNewName.isEmpty()) {
+      mNewName = getNextPadNameProposal();
+    }
     foreach (const QString& name, Toolbox::expandRangesInString(mNewName)) {
       std::shared_ptr<PackagePad> pad = std::make_shared<PackagePad>(
           Uuid::createRandom(), validateNameOrThrow(name));
@@ -305,6 +309,14 @@ CircuitIdentifier PackagePadListModel::validateNameOrThrow(
         QString(tr("There is already a pad with the name \"%1\".")).arg(name));
   }
   return CircuitIdentifier(name);  // can throw
+}
+
+QString PackagePadListModel::getNextPadNameProposal() const noexcept {
+  int i = 1;
+  while (mPadList->contains(QString::number(i))) {
+    ++i;
+  }
+  return QString::number(i);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/pkg/packagepadlistmodel.h
+++ b/libs/librepcb/library/pkg/packagepadlistmodel.h
@@ -83,6 +83,7 @@ private:
                                   PackagePadList::Event                    event) noexcept;
   void              execCmd(UndoCommand* cmd);
   CircuitIdentifier validateNameOrThrow(const QString& name) const;
+  QString           getNextPadNameProposal() const noexcept;
 
 private:  // Data
   PackagePadList* mPadList;


### PR DESCRIPTION
If no pad name is set search for the next free numerical one.

Fixes #469 