### PR TITLE
Fix possible crash caused by low-level signal/slots

### DIFF
--- a/libs/librepcb/common/signalslot.h
+++ b/libs/librepcb/common/signalslot.h
@@ -23,9 +23,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <QtCore>
+
 #include <functional>
-#include <set>
-#include <vector>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -84,7 +84,7 @@ public:
    */
   ~Signal() noexcept {
     for (auto slot : mSlots) {
-      slot->mSignals.erase(this);
+      slot->mSignals.remove(this);
     }
   }
 
@@ -104,8 +104,8 @@ public:
    * @param slot  Reference to the slot to detach
    */
   void detach(Slot<Tsender, Args...>& slot) const noexcept {
-    slot.mSignals.erase(this);
-    mSlots.erase(&slot);
+    slot.mSignals.remove(this);
+    mSlots.remove(&slot);
   }
 
   /**
@@ -114,8 +114,18 @@ public:
    * @param args  Arguments passed to the slots
    */
   void notify(Args... args) noexcept {
-    for (auto slot : mSlots) {
-      slot->mCallback(mSender, args...);
+    // Note: A "foreach" loop with a Qt container first creates an implicitly
+    // shared copy of the container (see
+    // https://doc.qt.io/qt-5/containers.html#foreach). This is very important
+    // since the callback might modify the container while iterating over it!
+    // With std containers this would be much more complicated (or less
+    // efficient).
+    foreach (const auto& slot, mSlots) {
+      // Check existence of the slot again because we must not call it if it
+      // was detached (i.e. removed from the container) in the meantime.
+      if (mSlots.contains(slot)) {
+        slot->mCallback(mSender, args...);
+      }
     }
   }
 
@@ -124,7 +134,7 @@ public:
 
 private:
   const Tsender& mSender;  ///< Reference to the sender object
-  mutable std::set<Slot<Tsender, Args...>*> mSlots;  ///< All attached slots
+  mutable QSet<Slot<Tsender, Args...>*> mSlots;  ///< All attached slots
 };
 
 /*******************************************************************************
@@ -194,7 +204,7 @@ public:
    */
   void detachAll() noexcept {
     for (auto signal : mSignals) {
-      signal->mSlots.erase(this);
+      signal->mSlots.remove(this);
     }
     mSignals.clear();
   }
@@ -204,7 +214,7 @@ public:
 
 private:
   /// All signals this slot is attached to
-  std::set<const Signal<Tsender, Args...>*> mSignals;
+  QSet<const Signal<Tsender, Args...>*> mSignals;
 
   /// The registered callback function
   std::function<void(const Tsender&, Args...)> mCallback;

--- a/libs/librepcb/common/signalslot.h
+++ b/libs/librepcb/common/signalslot.h
@@ -89,6 +89,13 @@ public:
   }
 
   /**
+   * @brief Get the count of registered slots
+   *
+   * @return Count of registered slots
+   */
+  int getSlotCount() const noexcept { return mSlots.count(); }
+
+  /**
    * @brief Attach a slot
    *
    * @param slot  Reference to the slot to attach
@@ -175,7 +182,8 @@ public:
    *
    * @warning The function must never throw an exception!!!
    */
-  explicit Slot(std::function<void(const Tsender&, Args...)>& callback) noexcept
+  explicit Slot(
+      const std::function<void(const Tsender&, Args...)>& callback) noexcept
     : mCallback(callback) {}
 
   /**
@@ -198,6 +206,13 @@ public:
    * Automatically disconnects from all signals.
    */
   ~Slot() noexcept { detachAll(); }
+
+  /**
+   * @brief Get the count of registered signals
+   *
+   * @return Count of registered signals
+   */
+  int getSignalCount() const noexcept { return mSignals.count(); }
 
   /**
    * @brief Detach from all signals

--- a/tests/unittests/common/signalslottest.cpp
+++ b/tests/unittests/common/signalslottest.cpp
@@ -1,0 +1,106 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2016 The LibrePCB developers
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <librepcb/common/signalslot.h>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Helpers
+ ******************************************************************************/
+
+struct Sender {
+  Signal<Sender, int> signal;
+  Sender() : signal(*this) {}
+};
+
+struct Receiver {
+  Slot<Sender, int> slot;
+  Receiver() : slot(*this, &Receiver::callback) {}
+  MOCK_METHOD2(callback, void(const Sender&, int));
+};
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+class SignalSlotTest : public ::testing::Test {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST(SignalSlotTest, testDuringCallbackAttachedSlotsAreNotCalled) {
+  Sender                           sender;
+  QList<std::shared_ptr<Receiver>> receivers;
+  Slot<Sender, int>                slot([&](const Sender&, int) {
+    for (int i = 0; i < 100; ++i) {
+      std::shared_ptr<Receiver> receiver = std::make_shared<Receiver>();
+      sender.signal.attach(receiver->slot);
+      receivers.append(receiver);
+    }
+  });
+  sender.signal.attach(slot);
+
+  EXPECT_EQ(1, sender.signal.getSlotCount());
+  sender.signal.notify(42);
+  EXPECT_EQ(101, sender.signal.getSlotCount());
+  foreach (const auto& receiver, receivers) {
+    EXPECT_CALL(*receiver, callback(testing::_, testing::_)).Times(0);
+  }
+}
+
+TEST(SignalSlotTest, testDuringCallbackDetachedSlotsAreNotCalled) {
+  int                                       callbackCounter = 0;
+  Sender                                    sender;
+  QList<std::shared_ptr<Slot<Sender, int>>> receivers;
+  for (int i = 0; i < 100; ++i) {
+    std::shared_ptr<Slot<Sender, int>> receiver =
+        std::make_shared<Slot<Sender, int>>([&](const Sender&, int) {
+          ++callbackCounter;
+          foreach (const auto& r, receivers) { sender.signal.detach(*r); }
+        });
+    receivers.append(receiver);
+    sender.signal.attach(*receiver);
+  }
+
+  EXPECT_EQ(100, sender.signal.getSlotCount());
+  sender.signal.notify(42);
+  EXPECT_EQ(0, sender.signal.getSlotCount());
+  EXPECT_EQ(1, callbackCounter);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -73,6 +73,7 @@ SOURCES += \
     common/network/filedownloadtest.cpp \
     common/network/networkrequesttest.cpp \
     common/scopeguardtest.cpp \
+    common/signalslottest.cpp \
     common/sqlitedatabasetest.cpp \
     common/systeminfotest.cpp \
     common/toolboxtest.cpp \


### PR DESCRIPTION
In some rare cases it was possible to crash the application because slots were detached from signals inside the callback of a slot, probably because following loop was not safe for modifying the `std::set` while iterating over it:

https://github.com/LibrePCB/LibrePCB/blob/7437d2898cb3453d86cdc246e04d9c0b8095da22/libs/librepcb/common/signalslot.h#L117-L119

Thus I changed the loop to this:

https://github.com/LibrePCB/LibrePCB/blob/c26c847961ea1745f7685b26cd56efd268b6c5c2/libs/librepcb/common/signalslot.h#L126-L128

@rnestler Do you know if this way it is safe to modify the container `mSlots` inside the callback? I'm not absolutely sure, but at least now I can't reproduce the crash I was experiencing before this chnge :wink: