### PR TITLE
Fix deprecation warnings when compiling with Qt 5.13

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -37,6 +37,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -292,7 +294,8 @@ bool CommandLineInterface::openProject(
       print("  " % QString(tr("Approved messages: %1")).arg(approvedMsgCount));
       print("  " %
             QString(tr("Non-approved messages: %1")).arg(messages.count()));
-      qSort(messages);  // increases readability of console output
+      // sort messages to increases readability of console output
+      std::sort(messages.begin(), messages.end());
       foreach (const QString& msg, messages) { printErr(msg); }
       if (messages.count() > 0) {
         success = false;

--- a/libs/librepcb/common/attributes/attributelistmodel.cpp
+++ b/libs/librepcb/common/attributes/attributelistmodel.cpp
@@ -30,6 +30,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -55,11 +57,11 @@ AttributeListModel::AttributeListModel(QObject* parent) noexcept
   }
   QCollator collator;
   collator.setCaseSensitivity(Qt::CaseInsensitive);
-  qSort(mTypeComboBoxItems.begin(), mTypeComboBoxItems.end(),
-        [&collator](const QPair<QString, QVariant>& lhs,
-                    const QPair<QString, QVariant>& rhs) {
-          return collator(lhs.first, rhs.first);
-        });
+  std::sort(mTypeComboBoxItems.begin(), mTypeComboBoxItems.end(),
+            [&collator](const QPair<QString, QVariant>& lhs,
+                        const QPair<QString, QVariant>& rhs) {
+              return collator(lhs.first, rhs.first);
+            });
 }
 
 AttributeListModel::~AttributeListModel() noexcept {

--- a/libs/librepcb/common/fileio/serializableobjectlist.h
+++ b/libs/librepcb/common/fileio/serializableobjectlist.h
@@ -29,6 +29,7 @@
 
 #include <QtCore>
 
+#include <algorithm>
 #include <memory>
 
 /*******************************************************************************
@@ -352,19 +353,21 @@ public:
   SerializableObjectList<T, P, OnEditedArgs...> sortedByUuid() const noexcept {
     SerializableObjectList<T, P, OnEditedArgs...> copiedList;
     copiedList.mObjects = mObjects;  // copy only the pointers, not the objects!
-    qSort(copiedList.mObjects.begin(), copiedList.mObjects.end(),
-          [](const std::shared_ptr<T>& ptr1, const std::shared_ptr<T>& ptr2) {
-            return ptr1->getUuid() < ptr2->getUuid();
-          });
+    std::sort(
+        copiedList.mObjects.begin(), copiedList.mObjects.end(),
+        [](const std::shared_ptr<T>& ptr1, const std::shared_ptr<T>& ptr2) {
+          return ptr1->getUuid() < ptr2->getUuid();
+        });
     return copiedList;
   }
   SerializableObjectList<T, P, OnEditedArgs...> sortedByName() const noexcept {
     SerializableObjectList<T, P, OnEditedArgs...> copiedList;
     copiedList.mObjects = mObjects;  // copy only the pointers, not the objects!
-    qSort(copiedList.mObjects.begin(), copiedList.mObjects.end(),
-          [](const std::shared_ptr<T>& ptr1, const std::shared_ptr<T>& ptr2) {
-            return ptr1->getName() < ptr2->getName();
-          });
+    std::sort(
+        copiedList.mObjects.begin(), copiedList.mObjects.end(),
+        [](const std::shared_ptr<T>& ptr1, const std::shared_ptr<T>& ptr2) {
+          return ptr1->getName() < ptr2->getName();
+        });
     return copiedList;
   }
 

--- a/libs/librepcb/common/toolbox.h
+++ b/libs/librepcb/common/toolbox.h
@@ -30,6 +30,8 @@
 #include <QtCore>
 #include <QtWidgets>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -58,14 +60,14 @@ public:
   template <typename T>
   static QList<T> sortedQSet(const QSet<T>& set) noexcept {
     QList<T> list = set.toList();
-    qSort(list);
+    std::sort(list.begin(), list.end());
     return list;
   }
 
   template <typename T>
   static T sorted(const T& container) noexcept {
     T copy(container);
-    qSort(copy);
+    std::sort(copy.begin(), copy.end());
     return copy;
   }
 

--- a/libs/librepcb/library/cmp/componentpinsignalmapmodel.cpp
+++ b/libs/librepcb/library/cmp/componentpinsignalmapmodel.cpp
@@ -30,6 +30,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -388,11 +390,11 @@ void ComponentPinSignalMapModel::updateSignalComboBoxItems() noexcept {
   collator.setCaseSensitivity(Qt::CaseInsensitive);
   collator.setIgnorePunctuation(false);
   collator.setNumericMode(true);
-  qSort(mSignalComboBoxItems.begin(), mSignalComboBoxItems.end(),
-        [&collator](const QPair<QString, QVariant>& lhs,
-                    const QPair<QString, QVariant>& rhs) {
-          return collator(lhs.first, rhs.first);
-        });
+  std::sort(mSignalComboBoxItems.begin(), mSignalComboBoxItems.end(),
+            [&collator](const QPair<QString, QVariant>& lhs,
+                        const QPair<QString, QVariant>& rhs) {
+              return collator(lhs.first, rhs.first);
+            });
   mSignalComboBoxItems.insert(
       0, qMakePair(QString("(%1)").arg(tr("unconnected")), QVariant()));
 }

--- a/libs/librepcb/library/dev/devicepadsignalmapmodel.cpp
+++ b/libs/librepcb/library/dev/devicepadsignalmapmodel.cpp
@@ -28,6 +28,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -272,11 +274,11 @@ void DevicePadSignalMapModel::updateComboBoxItems() noexcept {
   collator.setCaseSensitivity(Qt::CaseInsensitive);
   collator.setIgnorePunctuation(false);
   collator.setNumericMode(true);
-  qSort(mComboBoxItems.begin(), mComboBoxItems.end(),
-        [&collator](const QPair<QString, QVariant>& lhs,
-                    const QPair<QString, QVariant>& rhs) {
-          return collator(lhs.first, rhs.first);
-        });
+  std::sort(mComboBoxItems.begin(), mComboBoxItems.end(),
+            [&collator](const QPair<QString, QVariant>& lhs,
+                        const QPair<QString, QVariant>& rhs) {
+              return collator(lhs.first, rhs.first);
+            });
   mComboBoxItems.insert(
       0, qMakePair(QString("(%1)").arg(tr("unconnected")), QVariant()));
 }

--- a/libs/librepcb/library/sym/msg/msgoverlappingsymbolpins.cpp
+++ b/libs/librepcb/library/sym/msg/msgoverlappingsymbolpins.cpp
@@ -24,6 +24,8 @@
 
 #include "../symbolpin.h"
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -57,7 +59,7 @@ QString MsgOverlappingSymbolPins::buildMessage(
   foreach (const auto& pin, pins) {
     pinNames.append("'" % pin->getName() % "'");
   }
-  qSort(pinNames);
+  std::sort(pinNames.begin(), pinNames.end());
   return QString(tr("Overlapping pins: %1")).arg(pinNames.join(", "));
 }
 

--- a/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.cpp
+++ b/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.cpp
@@ -22,6 +22,8 @@
  ******************************************************************************/
 #include "libraryelementchecklistwidget.h"
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -59,11 +61,11 @@ void LibraryElementCheckListWidget::setHandler(
 void LibraryElementCheckListWidget::setMessages(
     LibraryElementCheckMessageList messages) noexcept {
   // Sort by severity and message.
-  qSort(messages.begin(), messages.end(),
-        [](std::shared_ptr<const LibraryElementCheckMessage> a,
-           std::shared_ptr<const LibraryElementCheckMessage> b) {
-          return (a && b) ? (*b) < (*a) : false;
-        });
+  std::sort(messages.begin(), messages.end(),
+            [](std::shared_ptr<const LibraryElementCheckMessage> a,
+               std::shared_ptr<const LibraryElementCheckMessage> b) {
+              return (a && b) ? (*b) < (*a) : false;
+            });
 
   // Detect if messages have changed.
   bool isSame = (mMessages.count() == messages.count());

--- a/libs/librepcb/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/librarymanager/addlibrarywidget.cpp
@@ -371,7 +371,7 @@ void AddLibraryWidget::repositoryLibraryListReceived(
 void AddLibraryWidget::errorWhileFetchingLibraryList(
     const QString& errorMsg) noexcept {
   QListWidgetItem* item = new QListWidgetItem(errorMsg, mUi->lstRepoLibs);
-  item->setBackgroundColor(Qt::red);
+  item->setBackground(Qt::red);
   item->setForeground(Qt::white);
 }
 

--- a/libs/librepcb/librarymanager/librarymanager.cpp
+++ b/libs/librepcb/librarymanager/librarymanager.cpp
@@ -35,6 +35,8 @@
 #include <QtCore>
 #include <QtWidgets>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -148,7 +150,7 @@ void LibraryManager::updateLibraryList() noexcept {
   }
 
   // sort all list widget items
-  qSort(widgets.begin(), widgets.end(), widgetsLessThan);
+  std::sort(widgets.begin(), widgets.end(), widgetsLessThan);
 
   // populate the list widget
   int selectedLibraryIndex = 0;

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -59,6 +59,8 @@
 #include <QtCore>
 #include <QtWidgets>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -665,10 +667,10 @@ void Board::removePlane(BI_Plane& plane) {
 
 void Board::rebuildAllPlanes() noexcept {
   QList<BI_Plane*> planes = mPlanes;
-  qSort(planes.begin(), planes.end(),
-        [](const BI_Plane* p1, const BI_Plane* p2) {
-          return !(*p1 < *p2);
-        });  // sort by priority (highest priority first)
+  std::sort(planes.begin(), planes.end(),
+            [](const BI_Plane* p1, const BI_Plane* p2) {
+              return !(*p1 < *p2);
+            });  // sort by priority (highest priority first)
   foreach (BI_Plane* plane, planes) { plane->rebuild(); }
 }
 

--- a/libs/librepcb/project/boards/boardgerberexport.h
+++ b/libs/librepcb/project/boards/boardgerberexport.h
@@ -29,6 +29,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -123,7 +125,7 @@ private:
   static QList<T*> sortedByUuid(const QList<T*>& list) noexcept {
     // sort a list of objects by their UUID to get reproducable gerber files
     QList<T*> copy = list;
-    qSort(copy.begin(), copy.end(), [](const T* o1, const T* o2) {
+    std::sort(copy.begin(), copy.end(), [](const T* o1, const T* o2) {
       return o1->getUuid() < o2->getUuid();
     });
     return copy;

--- a/libs/librepcb/projecteditor/boardeditor/boardlayersdock.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayersdock.cpp
@@ -146,7 +146,7 @@ void BoardLayersDock::updateListWidget() noexcept {
     item->setCheckState(layer->getVisible() ? Qt::Checked : Qt::Unchecked);
     QColor color = layer->getColor(false);
     color.setAlphaF(color.alphaF() * 0.3);
-    item->setBackgroundColor(color);
+    item->setBackground(color);
     // still add, but hide disabled layers because of the condition above:
     // "mUi->listWidget->count() == layerNames.count()"
     item->setHidden(!layer->isEnabled());

--- a/libs/librepcb/workspace/library/cat/categorytreeitem.cpp
+++ b/libs/librepcb/workspace/library/cat/categorytreeitem.cpp
@@ -26,6 +26,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -66,10 +68,10 @@ CategoryTreeItem<ElementType>::CategoryTreeItem(
       }
 
       // sort childs
-      qSort(mChilds.begin(), mChilds.end(),
-            [](const ChildType& a, const ChildType& b) {
-              return a->data(Qt::DisplayRole) < b->data(Qt::DisplayRole);
-            });
+      std::sort(mChilds.begin(), mChilds.end(),
+                [](const ChildType& a, const ChildType& b) {
+                  return a->data(Qt::DisplayRole) < b->data(Qt::DisplayRole);
+                });
     }
 
     if (!mParent) {

--- a/libs/librepcb/workspace/settings/items/wsi_librarylocaleorder.cpp
+++ b/libs/librepcb/workspace/settings/items/wsi_librarylocaleorder.cpp
@@ -25,6 +25,8 @@
 #include <QtCore>
 #include <QtWidgets>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -63,10 +65,10 @@ WSI_LibraryLocaleOrder::WSI_LibraryLocaleOrder(const SExpression& node)
   mComboBox.reset(new QComboBox());
   QList<QLocale> allLocales = QLocale::matchingLocales(
       QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry);
-  qSort(allLocales.begin(), allLocales.end(),
-        [](const QLocale& l1, const QLocale& l2) {
-          return l1.name() < l2.name();
-        });
+  std::sort(allLocales.begin(), allLocales.end(),
+            [](const QLocale& l1, const QLocale& l2) {
+              return l1.name() < l2.name();
+            });
   foreach (const QLocale& locale, allLocales) {
     QString str = QString("[%1] %2 (%3)")
                       .arg(locale.name(), locale.nativeLanguageName(),

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -40,6 +40,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -185,7 +187,7 @@ QList<Version> Workspace::getFileFormatVersionsOfWorkspace(
         }
       }
     }
-    qSort(list);
+    std::sort(list.begin(), list.end());
   }
   return list;
 }

--- a/tests/unittests/common/fileio/transactionalfilesystemtest.cpp
+++ b/tests/unittests/common/fileio/transactionalfilesystemtest.cpp
@@ -651,8 +651,8 @@ static TransactionalFileSystemGetSubDirsTestData sGetSubDirsTestData[] = {
 // clang-format on
 
 INSTANTIATE_TEST_SUITE_P(TransactionalFileSystemGetSubDirsTest,
-                        TransactionalFileSystemGetSubDirsTest,
-                        ::testing::ValuesIn(sGetSubDirsTestData));
+                         TransactionalFileSystemGetSubDirsTest,
+                         ::testing::ValuesIn(sGetSubDirsTestData));
 
 /*******************************************************************************
  *  Parametrized getFilesInDir() Tests
@@ -707,8 +707,8 @@ static TransactionalFileSystemGetFilesInDirTestData sGetFilesInDirTestData[] = {
 // clang-format on
 
 INSTANTIATE_TEST_SUITE_P(TransactionalFileSystemGetFilesInDirTest,
-                        TransactionalFileSystemGetFilesInDirTest,
-                        ::testing::ValuesIn(sGetFilesInDirTestData));
+                         TransactionalFileSystemGetFilesInDirTest,
+                         ::testing::ValuesIn(sGetFilesInDirTestData));
 
 /*******************************************************************************
  *  Parametrized fileExists() and read() Tests
@@ -771,8 +771,8 @@ static TransactionalFileSystemFileExistsTestData sFileExistsTestData[] = {
 // clang-format on
 
 INSTANTIATE_TEST_SUITE_P(TransactionalFileSystemFileExistsTest,
-                        TransactionalFileSystemFileExistsTest,
-                        ::testing::ValuesIn(sFileExistsTestData));
+                         TransactionalFileSystemFileExistsTest,
+                         ::testing::ValuesIn(sFileExistsTestData));
 
 /*******************************************************************************
  *  Parametrized cleanPath() Tests
@@ -808,8 +808,8 @@ static TransactionalFileSystemCleanPathTestData sCleanPathTestData[] = {
 // clang-format on
 
 INSTANTIATE_TEST_SUITE_P(TransactionalFileSystemCleanPathTest,
-                        TransactionalFileSystemCleanPathTest,
-                        ::testing::ValuesIn(sCleanPathTestData));
+                         TransactionalFileSystemCleanPathTest,
+                         ::testing::ValuesIn(sCleanPathTestData));
 
 /*******************************************************************************
  *  End of File

--- a/tests/unittests/common/geometry/pathtest.cpp
+++ b/tests/unittests/common/geometry/pathtest.cpp
@@ -139,7 +139,7 @@ static PathObroundWidthHeightTestData sObroundWidthHeightTestData[] = {
 // clang-format on
 
 INSTANTIATE_TEST_SUITE_P(PathObroundWidthHeightTest, PathObroundWidthHeightTest,
-                        ::testing::ValuesIn(sObroundWidthHeightTestData));
+                         ::testing::ValuesIn(sObroundWidthHeightTestData));
 
 /*******************************************************************************
  *  Parametrized obround(p1, p2, width) Tests
@@ -224,7 +224,7 @@ static PathObroundP1P2WidthTestData sObroundP1P2WidthTestData[] = {
 // clang-format on
 
 INSTANTIATE_TEST_SUITE_P(PathObroundP1P2WidthTest, PathObroundP1P2WidthTest,
-                        ::testing::ValuesIn(sObroundP1P2WidthTestData));
+                         ::testing::ValuesIn(sObroundP1P2WidthTestData));
 
 /*******************************************************************************
  *  End of File


### PR DESCRIPTION
CI on MacOS is currently broken because homebrew always installs the latest version of Qt, which is now Qt 5.13 and throws some deprecation warnings. This PR fixes the deprecation warnings to make CI successful again:

- Replace `qSort()` by `std::sort()`
- Replace `QListWidgetItem::setBackgroundColor()` by `QListWidgetItem::setBackground()`