### PR TITLE
Fix inconsistent appearance of polygons between editor and Gerber export

### DIFF
--- a/libs/librepcb/common/graphics/polygongraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/polygongraphicsitem.cpp
@@ -76,6 +76,7 @@ void PolygonGraphicsItem::polygonEdited(const Polygon& polygon,
       break;
     case Polygon::Event::PathChanged:
       setPath(polygon.getPath().toQPainterPathPx());
+      updateFillLayer();  // path "closed" might have changed
       break;
     default:
       qWarning() << "Unhandled switch-case in "
@@ -85,7 +86,8 @@ void PolygonGraphicsItem::polygonEdited(const Polygon& polygon,
 }
 
 void PolygonGraphicsItem::updateFillLayer() noexcept {
-  if (mPolygon.isFilled()) {
+  // Don't fill if path is not closed (for consistency with Gerber export)!
+  if (mPolygon.isFilled() && mPolygon.getPath().isClosed()) {
     setFillLayer(mLayerProvider.getLayer(*mPolygon.getLayerName()));
   } else if (mPolygon.isGrabArea()) {
     setFillLayer(mLayerProvider.getGrabAreaLayer(*mPolygon.getLayerName()));

--- a/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
@@ -155,7 +155,7 @@ void FootprintPreviewGraphicsItem::paint(QPainter* painter,
       painter->setPen(pen);
     } else
       painter->setPen(Qt::NoPen);
-    if (polygon.isFilled())
+    if (polygon.isFilled() && polygon.getPath().isClosed())
       layer = mLayerProvider.getLayer(*polygon.getLayerName());
     else if (polygon.isGrabArea())
       layer = mLayerProvider.getLayer(GraphicsLayer::sTopGrabAreas);

--- a/libs/librepcb/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/library/pkg/packagecheck.cpp
@@ -137,7 +137,7 @@ void PackageCheck::checkPadsOverlapWithPlacement(MsgList& msgs) const {
         pen.setWidthF(polygon.getLineWidth()->toPx());
       }
       QBrush brush(Qt::NoBrush);
-      if (polygon.isFilled()) {
+      if (polygon.isFilled() && polygon.getPath().isClosed()) {
         brush.setStyle(Qt::SolidPattern);
       }
       QPainterPath area = Toolbox::shapeFromPath(

--- a/libs/librepcb/library/sym/symbolpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/sym/symbolpreviewgraphicsitem.cpp
@@ -240,7 +240,7 @@ void SymbolPreviewGraphicsItem::paint(QPainter*                       painter,
     } else {
       painter->setPen(Qt::NoPen);
     }
-    if (polygon.isFilled())
+    if (polygon.isFilled() && polygon.getPath().isClosed())
       layer = mLayerProvider.getLayer(*polygon.getLayerName());
     else if (polygon.isGrabArea())
       layer = mLayerProvider.getLayer(GraphicsLayer::sSymbolGrabAreas);

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -462,7 +462,9 @@ void BoardGerberExport::drawFootprint(GerberGenerator&    gen,
       path.translate(footprint.getPosition());
       gen.drawPathOutline(path,
                           calcWidthOfLayer(polygon.getLineWidth(), layer));
-      if (polygon.isFilled()) {
+      // Only fill closed paths (for consistency with the appearance in the
+      // board editor, and because Gerber expects area outlines as closed).
+      if (polygon.isFilled() && path.isClosed()) {
         gen.drawPathArea(path);
       }
     }

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -389,6 +389,12 @@ void BoardGerberExport::drawLayer(GerberGenerator& gen,
       UnsignedLength lineWidth =
           calcWidthOfLayer(polygon->getPolygon().getLineWidth(), layerName);
       gen.drawPathOutline(polygon->getPolygon().getPath(), lineWidth);
+      // Only fill closed paths (for consistency with the appearance in the
+      // board editor, and because Gerber expects area outlines as closed).
+      if (polygon->getPolygon().isFilled() &&
+          polygon->getPolygon().getPath().isClosed()) {
+        gen.drawPathArea(polygon->getPolygon().getPath());
+      }
     }
   }
 

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprint.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprint.cpp
@@ -147,7 +147,7 @@ void BGI_Footprint::paint(QPainter*                       painter,
       painter->setPen(Qt::NoPen);
 
     // set brush
-    if (!polygon.isFilled()) {
+    if ((!polygon.isFilled()) || (!polygon.getPath().isClosed())) {
       if (polygon.isGrabArea())
         layer = getLayer(GraphicsLayer::sTopGrabAreas);
       else

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.cpp
@@ -205,7 +205,7 @@ void SGI_Symbol::paint(QPainter*                       painter,
                            Qt::RoundCap, Qt::RoundJoin));
     else
       painter->setPen(Qt::NoPen);
-    if (polygon.isFilled())
+    if (polygon.isFilled() && polygon.getPath().isClosed())
       layer = getLayer(*polygon.getLayerName());
     else if (polygon.isGrabArea())
       layer = getLayer(GraphicsLayer::sSymbolGrabAreas);


### PR DESCRIPTION
- Only fill polygons if they are closed (filled but non-closed polygons look strange -> avoid them).
- Fix missing area of filled polygons in Gerber export (filled polygons were drawn correctly in editors, but wrong in Gerber export).

Fixes #473 

#478 must be merged first since CI is currently broken for MacOS.