### PR TITLE
About dialog: Mark TEXT_CONTRIBUTE_CODE as nontranslatable

### DIFF
--- a/libs/librepcb/common/dialogs/aboutdialog.ui
+++ b/libs/librepcb/common/dialogs/aboutdialog.ui
@@ -240,7 +240,7 @@
            <item>
             <widget class="QLabel" name="textContributeCode">
              <property name="text">
-              <string>TEXT_CONTRIBUTE_CODE</string>
+              <string notr="true">TEXT_CONTRIBUTE_CODE</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>


### PR DESCRIPTION
As reported on Transifex by _Ed.