### PR TITLE
Remove invalid 'modal' property that causes warning

### DIFF
--- a/libs/librepcb/librarymanager/librarymanager.ui
+++ b/libs/librepcb/librarymanager/librarymanager.ui
@@ -2,9 +2,6 @@
 <ui version="4.0">
  <class>librepcb::library::manager::LibraryManager</class>
  <widget class="QMainWindow" name="librepcb::library::manager::LibraryManager">
-  <property name="modal" stdset="0">
-   <bool>false</bool>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
This property in `librarymanager.ui` is invalid. Modality should be set with the `windowModality` property, but it defaults to `Qt::NonModal`.

The removed lines caused this warning on startup:
`[ WARNING ] librepcb::library::manager::LibraryManager::setProperty: Property "modal" invalid, read-only or does not exist (kernel/qobject.cpp:3953)`