### PR TITLE
Add toggle in the menu bar for dock widgets

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -120,6 +120,12 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   // setCentralWidget(mGraphicsView);
   mUi->centralwidget->layout()->addWidget(mGraphicsView);
 
+  // Add actions to toggle visibility of dock widgets
+  mUi->menuView->addSeparator();
+  mUi->menuView->addAction(mUnplacedComponentsDock->toggleViewAction());
+  mUi->menuView->addAction(mBoardLayersDock->toggleViewAction());
+  mUi->menuView->addAction(mErcMsgDock->toggleViewAction());
+
   // add all boards to the menu and connect to project signals
   for (int i = 0; i < mProject.getBoards().count(); i++) boardAdded(i);
   connect(&mProject, &Project::boardAdded, this, &BoardEditor::boardAdded);

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -102,6 +102,11 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   mGraphicsView->setGridProperties(*mGridProperties);
   setCentralWidget(mGraphicsView);
 
+  // Add actions to toggle visibility of dock widgets
+  mUi->menuView->addSeparator();
+  mUi->menuView->addAction(mPagesDock->toggleViewAction());
+  mUi->menuView->addAction(mErcMsgDock->toggleViewAction());
+
   // connect some actions which are created with the Qt Designer
   connect(mUi->actionSave_Project, &QAction::triggered, &mProjectEditor,
           &ProjectEditor::saveProject);


### PR DESCRIPTION
Prior to this commit, it is impossible to restore dock widgets that were accidentally closed, except by deleting the QSettings storage.