### PR TITLE
Fix state saving to occur when window is closed

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -249,11 +249,6 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
 }
 
 BoardEditor::~BoardEditor() {
-  // Save Window Geometry
-  QSettings clientSettings;
-  clientSettings.setValue("board_editor/window_geometry", saveGeometry());
-  clientSettings.setValue("board_editor/window_state", saveState());
-
   delete mFsm;
   mFsm = nullptr;
   qDeleteAll(mBoardListActions);
@@ -330,8 +325,14 @@ void BoardEditor::abortAllCommands() noexcept {
 void BoardEditor::closeEvent(QCloseEvent* event) {
   if (!mProjectEditor.windowIsAboutToClose(*this))
     event->ignore();
-  else
+  else {
+    // Save window geometry
+    QSettings clientSettings;
+    clientSettings.setValue("board_editor/window_geometry", saveGeometry());
+    clientSettings.setValue("board_editor/window_state", saveState());
+
     QMainWindow::closeEvent(event);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -216,11 +216,6 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
 }
 
 SchematicEditor::~SchematicEditor() {
-  // Save Window Geometry
-  QSettings clientSettings;
-  clientSettings.setValue("schematic_editor/window_geometry", saveGeometry());
-  clientSettings.setValue("schematic_editor/window_state", saveState());
-
   delete mFsm;
   mFsm = nullptr;
   delete mErcMsgDock;
@@ -299,8 +294,14 @@ void SchematicEditor::abortAllCommands() noexcept {
 void SchematicEditor::closeEvent(QCloseEvent* event) {
   if (!mProjectEditor.windowIsAboutToClose(*this))
     event->ignore();
-  else
+  else {
+    // Save window geometry
+    QSettings clientSettings;
+    clientSettings.setValue("schematic_editor/window_geometry", saveGeometry());
+    clientSettings.setValue("schematic_editor/window_state", saveState());
+
     QMainWindow::closeEvent(event);
+  }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Presently, there's a bug where I close a schematic editor or board editor, and the state is not saved. Later, the state is saved in the destructor called with `delete` in `~ProjectEditor`.

Because the window is already closed, all the widgets are gone in the saved state. When I reopen the window, I do not have any menus or dock widgets.

**Note** I'd also like to address #48 and #49 in this pull request. I haven't done that yet.