### PR TITLE
Auto-select attribute unit when entering unit in value field

### DIFF
--- a/libs/librepcb/common/attributes/attributelistmodel.cpp
+++ b/libs/librepcb/common/attributes/attributelistmodel.cpp
@@ -360,11 +360,19 @@ bool AttributeListModel::setData(const QModelIndex& index,
         mNewUnit  = unit;
       }
     } else if ((index.column() == COLUMN_VALUE) && role == Qt::EditRole) {
-      QString attrValue = value.toString().trimmed();
+      QString              attrValue = value.toString().trimmed();
+      const AttributeType* type      = item ? &item->getType() : mNewType;
+      const AttributeUnit* unit      = type->tryExtractUnitFromValue(attrValue);
       if (cmd) {
         cmd->setValue(attrValue);
+        if (unit) {
+          cmd->setUnit(unit);
+        }
       } else {
         mNewValue = attrValue;
+        if (unit) {
+          mNewUnit = unit;
+        }
       }
     } else if ((index.column() == COLUMN_UNIT) && role == Qt::EditRole) {
       const AttributeType* type = item ? &item->getType() : mNewType;

--- a/libs/librepcb/common/attributes/attributetype.cpp
+++ b/libs/librepcb/common/attributes/attributetype.cpp
@@ -84,6 +84,20 @@ bool AttributeType::isUnitAvailable(const AttributeUnit* unit) const noexcept {
   }
 }
 
+const AttributeUnit* AttributeType::tryExtractUnitFromValue(
+    QString& value) const noexcept {
+  foreach (const AttributeUnit* unit, mAvailableUnits) {
+    foreach (const QString& suffix, unit->getUserInputSuffixes()) {
+      if (value.endsWith(suffix)) {
+        value.chop(suffix.length());
+        value = value.trimmed();
+        return unit;
+      }
+    }
+  }
+  return nullptr;
+}
+
 /*******************************************************************************
  *  Static Methods
  ******************************************************************************/

--- a/libs/librepcb/common/attributes/attributetype.cpp
+++ b/libs/librepcb/common/attributes/attributetype.cpp
@@ -84,14 +84,6 @@ bool AttributeType::isUnitAvailable(const AttributeUnit* unit) const noexcept {
   }
 }
 
-void AttributeType::throwIfValueInvalid(const QString& value) const {
-  if (!isValueValid(value)) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("Invalid %1 value: \"%2\"")).arg(mTypeNameTr, value));
-  }
-}
-
 /*******************************************************************************
  *  Static Methods
  ******************************************************************************/

--- a/libs/librepcb/common/attributes/attributetype.h
+++ b/libs/librepcb/common/attributes/attributetype.h
@@ -72,11 +72,12 @@ public:
   }
   const AttributeUnit* getUnitFromString(const QString& unit) const;
   const AttributeUnit* getDefaultUnit() const noexcept { return mDefaultUnit; }
-  bool            isUnitAvailable(const AttributeUnit* unit) const noexcept;
-  virtual bool    isValueValid(const QString& value) const noexcept = 0;
-  virtual QString valueFromTr(const QString& value) const noexcept  = 0;
-  virtual QString printableValueTr(const QString&       value,
-                                   const AttributeUnit* unit = nullptr) const
+  bool isUnitAvailable(const AttributeUnit* unit) const noexcept;
+  const AttributeUnit* tryExtractUnitFromValue(QString& value) const noexcept;
+  virtual bool         isValueValid(const QString& value) const noexcept = 0;
+  virtual QString      valueFromTr(const QString& value) const noexcept  = 0;
+  virtual QString      printableValueTr(const QString&       value,
+                                        const AttributeUnit* unit = nullptr) const
       noexcept = 0;
 
   // Static Methods

--- a/libs/librepcb/common/attributes/attributetype.h
+++ b/libs/librepcb/common/attributes/attributetype.h
@@ -73,7 +73,6 @@ public:
   const AttributeUnit* getUnitFromString(const QString& unit) const;
   const AttributeUnit* getDefaultUnit() const noexcept { return mDefaultUnit; }
   bool            isUnitAvailable(const AttributeUnit* unit) const noexcept;
-  void            throwIfValueInvalid(const QString& value) const;
   virtual bool    isValueValid(const QString& value) const noexcept = 0;
   virtual QString valueFromTr(const QString& value) const noexcept  = 0;
   virtual QString printableValueTr(const QString&       value,

--- a/libs/librepcb/common/attributes/attributeunit.cpp
+++ b/libs/librepcb/common/attributes/attributeunit.cpp
@@ -33,9 +33,9 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-AttributeUnit::AttributeUnit(const QString& name,
-                             const QString& symbolTr) noexcept
-  : mName(name), mSymbolTr(symbolTr) {
+AttributeUnit::AttributeUnit(const QString& name, const QString& symbolTr,
+                             const QStringList& userInputSuffixes) noexcept
+  : mName(name), mSymbolTr(symbolTr), mUserInputSuffixes(userInputSuffixes) {
 }
 
 AttributeUnit::~AttributeUnit() noexcept {

--- a/libs/librepcb/common/attributes/attributeunit.h
+++ b/libs/librepcb/common/attributes/attributeunit.h
@@ -42,12 +42,16 @@ namespace librepcb {
 class AttributeUnit final {
 public:
   // Constructors / Destructor
-  explicit AttributeUnit(const QString& name, const QString& symbolTr) noexcept;
+  explicit AttributeUnit(const QString& name, const QString& symbolTr,
+                         const QStringList& userInputSuffixes) noexcept;
   ~AttributeUnit() noexcept;
 
   // Getters
-  const QString& getName() const noexcept { return mName; }
-  const QString& getSymbolTr() const noexcept { return mSymbolTr; }
+  const QString&     getName() const noexcept { return mName; }
+  const QString&     getSymbolTr() const noexcept { return mSymbolTr; }
+  const QStringList& getUserInputSuffixes() const noexcept {
+    return mUserInputSuffixes;
+  }
 
 private:
   // make some methods inaccessible...
@@ -56,8 +60,9 @@ private:
   AttributeUnit& operator=(const AttributeUnit& rhs) = delete;
 
   // General Attributes
-  QString mName;      ///< to convert from/to string, e.g. "millivolt"
-  QString mSymbolTr;  ///< e.g. "mV"
+  QString     mName;      ///< to convert from/to string, e.g. "millivolt"
+  QString     mSymbolTr;  ///< e.g. "mV"
+  QStringList mUserInputSuffixes;  ///< user input suffixes, e.g. "k" or "meg"
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/attributes/attrtypecapacitance.cpp
+++ b/libs/librepcb/common/attributes/attrtypecapacitance.cpp
@@ -37,13 +37,16 @@ namespace librepcb {
 
 AttrTypeCapacitance::AttrTypeCapacitance() noexcept
   : AttributeType(Type_t::Capacitance, "capacitance", tr("Capacitance")) {
-  mDefaultUnit = new AttributeUnit("microfarad", "μF");
+  mDefaultUnit = new AttributeUnit("microfarad", "μF", {"u", "uf", "uF"});
 
-  mAvailableUnits.append(new AttributeUnit("picofarad", "pF"));
-  mAvailableUnits.append(new AttributeUnit("nanofarad", "nF"));
+  mAvailableUnits.append(
+      new AttributeUnit("picofarad", "pF", {"p", "pf", "pF"}));
+  mAvailableUnits.append(
+      new AttributeUnit("nanofarad", "nF", {"n", "nf", "nF"}));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("millifarad", "mF"));
-  mAvailableUnits.append(new AttributeUnit("farad", "F"));
+  mAvailableUnits.append(
+      new AttributeUnit("millifarad", "mF", {"m", "mf", "mF"}));
+  mAvailableUnits.append(new AttributeUnit("farad", "F", {"f", "F"}));
 }
 
 AttrTypeCapacitance::~AttrTypeCapacitance() noexcept {

--- a/libs/librepcb/common/attributes/attrtypecurrent.cpp
+++ b/libs/librepcb/common/attributes/attrtypecurrent.cpp
@@ -37,15 +37,21 @@ namespace librepcb {
 
 AttrTypeCurrent::AttrTypeCurrent() noexcept
   : AttributeType(Type_t::Current, "current", tr("Current")) {
-  mDefaultUnit = new AttributeUnit("ampere", "A");
+  mDefaultUnit = new AttributeUnit("ampere", "A", {"a", "A"});
 
-  mAvailableUnits.append(new AttributeUnit("picoampere", "pA"));
-  mAvailableUnits.append(new AttributeUnit("nanoampere", "nA"));
-  mAvailableUnits.append(new AttributeUnit("microampere", "μA"));
-  mAvailableUnits.append(new AttributeUnit("milliampere", "mA"));
+  mAvailableUnits.append(
+      new AttributeUnit("picoampere", "pA", {"p", "pa", "pA"}));
+  mAvailableUnits.append(
+      new AttributeUnit("nanoampere", "nA", {"n", "na", "nA"}));
+  mAvailableUnits.append(
+      new AttributeUnit("microampere", "μA", {"u", "ua", "uA"}));
+  mAvailableUnits.append(
+      new AttributeUnit("milliampere", "mA", {"m", "ma", "mA"}));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kiloampere", "kA"));
-  mAvailableUnits.append(new AttributeUnit("megaampere", "MA"));
+  mAvailableUnits.append(
+      new AttributeUnit("kiloampere", "kA", {"k", "ka", "kA"}));
+  mAvailableUnits.append(
+      new AttributeUnit("megaampere", "MA", {"M", "meg", "MA"}));
 }
 
 AttrTypeCurrent::~AttrTypeCurrent() noexcept {

--- a/libs/librepcb/common/attributes/attrtypefrequency.cpp
+++ b/libs/librepcb/common/attributes/attrtypefrequency.cpp
@@ -37,14 +37,19 @@ namespace librepcb {
 
 AttrTypeFrequency::AttrTypeFrequency() noexcept
   : AttributeType(Type_t::Frequency, "frequency", tr("Frequency")) {
-  mDefaultUnit = new AttributeUnit("hertz", "Hz");
+  mDefaultUnit = new AttributeUnit("hertz", "Hz", {"hz", "Hz"});
 
-  mAvailableUnits.append(new AttributeUnit("microhertz", "μHz"));
-  mAvailableUnits.append(new AttributeUnit("millihertz", "mHz"));
+  mAvailableUnits.append(
+      new AttributeUnit("microhertz", "μHz", {"u", "uhz", "uHz"}));
+  mAvailableUnits.append(
+      new AttributeUnit("millihertz", "mHz", {"m", "mhz", "mHz"}));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kilohertz", "kHz"));
-  mAvailableUnits.append(new AttributeUnit("megahertz", "MHz"));
-  mAvailableUnits.append(new AttributeUnit("gigahertz", "GHz"));
+  mAvailableUnits.append(
+      new AttributeUnit("kilohertz", "kHz", {"k", "khz", "kHz"}));
+  mAvailableUnits.append(
+      new AttributeUnit("megahertz", "MHz", {"M", "meg", "MHz"}));
+  mAvailableUnits.append(
+      new AttributeUnit("gigahertz", "GHz", {"g", "G", "ghz", "GHz"}));
 }
 
 AttrTypeFrequency::~AttrTypeFrequency() noexcept {

--- a/libs/librepcb/common/attributes/attrtypeinductance.cpp
+++ b/libs/librepcb/common/attributes/attrtypeinductance.cpp
@@ -37,12 +37,14 @@ namespace librepcb {
 
 AttrTypeInductance::AttrTypeInductance() noexcept
   : AttributeType(Type_t::Inductance, "inductance", tr("Inductance")) {
-  mDefaultUnit = new AttributeUnit("millihenry", "mH");
+  mDefaultUnit = new AttributeUnit("millihenry", "mH", {"m", "mh", "mH"});
 
-  mAvailableUnits.append(new AttributeUnit("nanohenry", "nH"));
-  mAvailableUnits.append(new AttributeUnit("microhenry", "μH"));
+  mAvailableUnits.append(
+      new AttributeUnit("nanohenry", "nH", {"n", "nh", "nH"}));
+  mAvailableUnits.append(
+      new AttributeUnit("microhenry", "μH", {"u", "uh", "uH"}));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("henry", "H"));
+  mAvailableUnits.append(new AttributeUnit("henry", "H", {"h", "H"}));
 }
 
 AttrTypeInductance::~AttrTypeInductance() noexcept {

--- a/libs/librepcb/common/attributes/attrtypepower.cpp
+++ b/libs/librepcb/common/attributes/attrtypepower.cpp
@@ -37,15 +37,21 @@ namespace librepcb {
 
 AttrTypePower::AttrTypePower() noexcept
   : AttributeType(Type_t::Power, "power", tr("Power")) {
-  mDefaultUnit = new AttributeUnit("watt", "W");
+  mDefaultUnit = new AttributeUnit("watt", "W", {"w", "W"});
 
-  mAvailableUnits.append(new AttributeUnit("nanowatt", "nW"));
-  mAvailableUnits.append(new AttributeUnit("microwatt", "μW"));
-  mAvailableUnits.append(new AttributeUnit("milliwatt", "mW"));
+  mAvailableUnits.append(
+      new AttributeUnit("nanowatt", "nW", {"n", "nw", "nW"}));
+  mAvailableUnits.append(
+      new AttributeUnit("microwatt", "μW", {"u", "uw", "uW"}));
+  mAvailableUnits.append(
+      new AttributeUnit("milliwatt", "mW", {"m", "mw", "mW"}));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kilowatt", "kW"));
-  mAvailableUnits.append(new AttributeUnit("megawatt", "MW"));
-  mAvailableUnits.append(new AttributeUnit("gigawatt", "GW"));
+  mAvailableUnits.append(
+      new AttributeUnit("kilowatt", "kW", {"k", "kw", "kW"}));
+  mAvailableUnits.append(
+      new AttributeUnit("megawatt", "MW", {"M", "meg", "MW"}));
+  mAvailableUnits.append(
+      new AttributeUnit("gigawatt", "GW", {"g", "G", "gw", "GW"}));
 }
 
 AttrTypePower::~AttrTypePower() noexcept {

--- a/libs/librepcb/common/attributes/attrtyperesistance.cpp
+++ b/libs/librepcb/common/attributes/attrtyperesistance.cpp
@@ -37,13 +37,13 @@ namespace librepcb {
 
 AttrTypeResistance::AttrTypeResistance() noexcept
   : AttributeType(Type_t::Resistance, "resistance", tr("Resistance")) {
-  mDefaultUnit = new AttributeUnit("ohm", "Ω");
+  mDefaultUnit = new AttributeUnit("ohm", "Ω", {"r", "R"});
 
-  mAvailableUnits.append(new AttributeUnit("microohm", "μΩ"));
-  mAvailableUnits.append(new AttributeUnit("milliohm", "mΩ"));
+  mAvailableUnits.append(new AttributeUnit("microohm", "μΩ", {"u"}));
+  mAvailableUnits.append(new AttributeUnit("milliohm", "mΩ", {"m"}));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kiloohm", "kΩ"));
-  mAvailableUnits.append(new AttributeUnit("megaohm", "MΩ"));
+  mAvailableUnits.append(new AttributeUnit("kiloohm", "kΩ", {"k"}));
+  mAvailableUnits.append(new AttributeUnit("megaohm", "MΩ", {"M", "meg"}));
 }
 
 AttrTypeResistance::~AttrTypeResistance() noexcept {

--- a/libs/librepcb/common/attributes/attrtypevoltage.cpp
+++ b/libs/librepcb/common/attributes/attrtypevoltage.cpp
@@ -37,14 +37,19 @@ namespace librepcb {
 
 AttrTypeVoltage::AttrTypeVoltage() noexcept
   : AttributeType(Type_t::Voltage, "voltage", tr("Voltage")) {
-  mDefaultUnit = new AttributeUnit("volt", "V");
+  mDefaultUnit = new AttributeUnit("volt", "V", {"v", "V"});
 
-  mAvailableUnits.append(new AttributeUnit("nanovolt", "nV"));
-  mAvailableUnits.append(new AttributeUnit("microvolt", "μV"));
-  mAvailableUnits.append(new AttributeUnit("millivolt", "mV"));
+  mAvailableUnits.append(
+      new AttributeUnit("nanovolt", "nV", {"n", "nv", "nV"}));
+  mAvailableUnits.append(
+      new AttributeUnit("microvolt", "μV", {"u", "uv", "uV"}));
+  mAvailableUnits.append(
+      new AttributeUnit("millivolt", "mV", {"m", "mv", "mV"}));
   mAvailableUnits.append(mDefaultUnit);
-  mAvailableUnits.append(new AttributeUnit("kilovolt", "kV"));
-  mAvailableUnits.append(new AttributeUnit("megavolt", "MV"));
+  mAvailableUnits.append(
+      new AttributeUnit("kilovolt", "kV", {"k", "kv", "kV"}));
+  mAvailableUnits.append(
+      new AttributeUnit("megavolt", "MV", {"M", "meg", "MV"}));
 }
 
 AttrTypeVoltage::~AttrTypeVoltage() noexcept {

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
@@ -506,7 +506,16 @@ void SES_AddComponent::attributeChanged() noexcept {
   if (!attribute) return;
   const AttributeType& type  = attribute->getType();
   QString              value = toMultiLine(mAttributeValueEdit->text());
-  const AttributeUnit* unit  = mAttributeUnitComboBox->getCurrentItem();
+  if (const AttributeUnit* unit = type.tryExtractUnitFromValue(value)) {
+    // avoid recursion by blocking signals from combobox
+    const bool wasBlocked = mAttributeUnitComboBox->blockSignals(true);
+    mAttributeUnitComboBox->setCurrentItem(unit);
+    mAttributeUnitComboBox->blockSignals(wasBlocked);
+    mAttributeUnitComboBox->setEnabled(false);
+  } else {
+    mAttributeUnitComboBox->setEnabled(true);
+  }
+  const AttributeUnit* unit = mAttributeUnitComboBox->getCurrentItem();
   if (type.isValueValid(value) && type.isUnitAvailable(unit)) {
     attribute->setTypeValueUnit(attribute->getType(), value, unit);
     mCurrentComponent->setAttributes(attributes);


### PR DESCRIPTION
Select the proper unit automatically when entering suffixes like "u", "k" or "meg".

![grafik](https://user-images.githubusercontent.com/5374821/62168265-6881a700-b325-11e9-884a-cdd8c3274af5.png)

Fixes #465.