### PR TITLE
Fix broken window settings when closing windows with OpenGL enabled

### DIFF
--- a/libs/librepcb/common/graphics/graphicsview.cpp
+++ b/libs/librepcb/common/graphics/graphicsview.cpp
@@ -85,11 +85,25 @@ QRectF GraphicsView::getVisibleSceneRect() const noexcept {
 
 void GraphicsView::setUseOpenGl(bool useOpenGl) noexcept {
   if (useOpenGl != mUseOpenGl) {
-    if (useOpenGl)
+    if (useOpenGl) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+      // Try to make schematics/boards looking good by choosing reasonable
+      // format options (with default options, it looks ugly).
+      QSurfaceFormat format = QSurfaceFormat::defaultFormat();
+      format.setDepthBufferSize(24);
+      format.setSamples(8);
+      format.setStencilBufferSize(8);
+      format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
+      QOpenGLWidget* viewport = new QOpenGLWidget();
+      viewport->setFormat(format);
+      setViewport(viewport);
+#else
       setViewport(new QGLWidget(QGLFormat(
           QGL::DoubleBuffer | QGL::AlphaChannel | QGL::SampleBuffers)));
-    else
+#endif
+    } else {
       setViewport(nullptr);
+    }
     mUseOpenGl = useOpenGl;
   }
   viewport()->grabGesture(Qt::PinchGesture);

--- a/tests/funq/aliases
+++ b/tests/funq/aliases
@@ -240,7 +240,12 @@ libraryEditorNewElementWizardDevicePropertiesChoosePackageDialogAcceptButton = {
 schematicEditor = librepcb__project__editor__SchematicEditor
 schematicEditorWidget = {schematicEditor}::centralWidget
 
+# Toolbars
+schematicEditorToolbarFile = {schematicEditor}::fileToolbar
+schematicEditorDockErcMsg = {schematicEditor}::librepcb__project__editor__ErcMsgDock
+
 # Actions
+schematicEditorActionCloseProject = {schematicEditor}::actionClose_Project
 schematicEditorActionAddComponent = {schematicEditor}::actionToolAddComponent
 
 # Graphics view
@@ -268,3 +273,10 @@ schematicEditorAddComponentDialogDeviceNameLabel = {schematicEditorAddComponentD
 # Main window
 boardEditor = librepcb__project__editor__BoardEditor
 boardEditorWidget = {boardEditor}::centralWidget
+
+# Toolbars
+boardEditorToolbarFile = {boardEditor}::fileToolbar
+boardEditorDockErcMsg = {boardEditor}::librepcb__project__editor__ErcMsgDock
+
+# Actions
+boardEditorActionCloseProject = {boardEditor}::actionClose_Project

--- a/tests/funq/conftest.py
+++ b/tests/funq/conftest.py
@@ -95,10 +95,13 @@ class LibrePcbFixture(object):
         config_ini = os.path.join(config_dir, 'LibrePCB.ini')
         if not os.path.exists(config_dir):
             os.makedirs(config_dir)
-        with open(config_ini, 'w') as f:
-            if self.workspace_path:
-                f.write("[workspaces]\n")
-                f.write("most_recently_used=\"{}\"\n".format(self.workspace_path.replace('\\', '/')))
+        # Only create config file once per test, so tests can check if settings
+        # are stored permanently.
+        if not os.path.exists(config_ini):
+            with open(config_ini, 'w') as f:
+                if self.workspace_path:
+                    f.write("[workspaces]\n")
+                    f.write("most_recently_used=\"{}\"\n".format(self.workspace_path.replace('\\', '/')))
 
     def _args(self):
         args = []

--- a/tests/funq/projecteditor/test_window_settings.py
+++ b/tests/funq/projecteditor/test_window_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+"""
+Test if window settings (position, size, toolbar visibility, ...) are saved and
+restored properly.
+"""
+
+project = 'data/fixtures/Empty Project/Empty Project.lpp'
+
+
+def close_application(app):
+    pass  # nothing to do, it will be closed automatically
+
+
+def close_project_action(app):
+    app.action('schematicEditorActionCloseProject').trigger()
+
+
+def close_schematic_editor_first(app):
+    app.widget('schematicEditor').close()
+    app.widget('boardEditor').close()
+
+
+def close_board_editor_first(app):
+    app.widget('boardEditor').close()
+    app.widget('schematicEditor').close()
+
+
+@pytest.mark.parametrize('close_method', [
+    close_application,
+    close_project_action,
+    close_schematic_editor_first,
+    close_board_editor_first,
+])
+def test(librepcb, close_method):
+    """
+    Check settings with multiple variants how the windows can be closed:
+      - Whole application closed by the OS
+      - Project closed with "Close Project" tool button
+      - Schematic and board editor windows closed, in both orders
+
+    This is needed to check if settings are saved/restored properly in all
+    cases.
+    """
+    new_sch_pos = (50, 60)
+    new_sch_size = (810, 610)
+    new_brd_pos = (70, 80)
+    new_brd_size = (820, 620)
+
+    librepcb.set_project(project)
+    with librepcb.open() as app:
+        # check default settings (LibrePCB.ini did not exist yet)
+        assert app.widget('schematicEditorToolbarFile').properties()['visible'] is True
+        assert app.widget('schematicEditorDockErcMsg').properties()['visible'] is True
+        assert app.widget('boardEditorToolbarFile').properties()['visible'] is True
+        assert app.widget('boardEditorDockErcMsg').properties()['visible'] is True
+
+        # change some settings
+        new_sch_pos = app.widget('schematicEditor').move(*new_sch_pos)
+        new_sch_size = app.widget('schematicEditor').resize(*new_sch_size)
+        new_brd_pos = app.widget('boardEditor').move(*new_brd_pos)
+        new_brd_size = app.widget('boardEditor').resize(*new_brd_size)
+
+        # close application with specified method
+        close_method(app)
+
+    # restart librepcb
+    with librepcb.open() as app:
+        # check settings
+        assert app.widget('schematicEditorToolbarFile').properties()['visible'] is True
+        assert app.widget('schematicEditorDockErcMsg').properties()['visible'] is True
+        assert app.widget('boardEditorToolbarFile').properties()['visible'] is True
+        assert app.widget('boardEditorDockErcMsg').properties()['visible'] is True
+
+        # Note: Window positions aren't checked because the window manager
+        # might place the window on another position and thus that test would
+        # not be reliable.
+
+        props = app.widget('schematicEditor').properties()
+        # assert (props['x'], props['y']) == new_sch_pos
+        assert (props['width'], props['height']) == new_sch_size
+
+        props = app.widget('boardEditor').properties()
+        # assert (props['x'], props['y']) == new_brd_pos
+        assert (props['width'], props['height']) == new_brd_size
+
+        # hide all toolbars and docks
+        app.widget('schematicEditorToolbarFile').set_properties(visible=False)
+        app.widget('schematicEditorDockErcMsg').set_properties(visible=False)
+        app.widget('boardEditorToolbarFile').set_properties(visible=False)
+        app.widget('boardEditorDockErcMsg').set_properties(visible=False)
+
+        # close application with specified method
+        close_method(app)
+
+    # restart librepcb
+    with librepcb.open() as app:
+        # check if all toolbars and docks are hidden
+        assert app.widget('schematicEditorToolbarFile', wait_active=False).properties()['visible'] is False
+        assert app.widget('schematicEditorDockErcMsg', wait_active=False).properties()['visible'] is False
+        assert app.widget('boardEditorToolbarFile', wait_active=False).properties()['visible'] is False
+        assert app.widget('boardEditorDockErcMsg', wait_active=False).properties()['visible'] is False

--- a/tests/funq/requirements.txt
+++ b/tests/funq/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/parkouss/funq.git@2006fe5fee6f6e87915ba1e328a5f1a4ec063207#egg=funq-server&subdirectory=server
-git+https://github.com/parkouss/funq.git@2006fe5fee6f6e87915ba1e328a5f1a4ec063207#egg=funq&subdirectory=client
+git+https://github.com/parkouss/funq.git@8fa127fd0fb3b72a0fde09f533e5b1d5322fc662#egg=funq-server&subdirectory=server
+git+https://github.com/parkouss/funq.git@8fa127fd0fb3b72a0fde09f533e5b1d5322fc662#egg=funq&subdirectory=client
 pytest~=3.6.3


### PR DESCRIPTION
- Use `QOpenGLWidget` instead of `QGLWidget` fixes possibly broken client settings
- Add functional tests for window state save/restore

See discussion in #488.