### PR TITLE
Gerber: Always use multi-quadrant mode

### DIFF
--- a/libs/librepcb/common/cam/gerbergenerator.cpp
+++ b/libs/librepcb/common/cam/gerbergenerator.cpp
@@ -108,11 +108,10 @@ void GerberGenerator::drawPathOutline(
       linearInterpolateToPosition(v.getPos());
     } else {
       // arc segment
-      if (v0.getAngle().abs() <= Angle::deg90()) {
-        setMultiQuadrantArcModeOff();
-      } else {
-        setMultiQuadrantArcModeOn();
-      }
+      // note: due to buggy clients when using single quadrant mode,
+      // we always use multi quadrant mode.
+      // see https://github.com/LibrePCB/LibrePCB/issues/247
+      setMultiQuadrantArcModeOn();
       if (v0.getAngle() < 0) {
         switchToCircularCwInterpolationModeG02();
       } else {
@@ -142,11 +141,10 @@ void GerberGenerator::drawPathArea(const Path& path) noexcept {
       linearInterpolateToPosition(v.getPos());
     } else {
       // arc segment
-      if (v0.getAngle().abs() <= Angle::deg90()) {
-        setMultiQuadrantArcModeOff();
-      } else {
-        setMultiQuadrantArcModeOn();
-      }
+      // note: due to buggy clients when using single quadrant mode,
+      // we always use multi quadrant mode.
+      // see https://github.com/LibrePCB/LibrePCB/issues/247
+      setMultiQuadrantArcModeOn();
       if (v0.getAngle() < 0) {
         switchToCircularCwInterpolationModeG02();
       } else {

--- a/libs/librepcb/common/cam/gerbergenerator.h
+++ b/libs/librepcb/common/cam/gerbergenerator.h
@@ -38,6 +38,7 @@ namespace librepcb {
 class Circle;
 class Path;
 class GerberApertureList;
+class Vertex;
 
 /*******************************************************************************
  *  Class GerberGenerator
@@ -111,6 +112,7 @@ private:
   void    linearInterpolateToPosition(const Point& pos) noexcept;
   void    circularInterpolateToPosition(const Point& start, const Point& center,
                                         const Point& end) noexcept;
+  void    interpolateBetween(const Vertex& from, const Vertex& to) noexcept;
   void    flashAtPosition(const Point& pos) noexcept;
   void    printHeader() noexcept;
   void    printApertureList() noexcept;


### PR DESCRIPTION
@ubruhin here's a first attempt at fixing this issue.

The spec says:

> Another option is not to use very small arcs, e.g. by replacing them with
draws - the error is very small and draws are stable.

Right now I'm replacing arcs shorter than 0.01mm (point-to-point) with straight lines. 

We probably need to handle some special cases, right? A full circle has start==end with angle=360, right? We should probably still draw arcs if start and end are identical.

I guess we can ignore cases where the two points are closer together than 0.01mm with a lage angle, right?

Fixes #247.