### PR TITLE
Gerber export: Add support for non-square octagon pads

### DIFF
--- a/libs/librepcb/common/cam/gerberaperturelist.cpp
+++ b/libs/librepcb/common/cam/gerberaperturelist.cpp
@@ -118,6 +118,18 @@ int GerberApertureList::setRegularPolygon(const UnsignedLength& dia, int n,
   return setCurrentAperture(generateRegularPolygon(dia, n, grbRot, hole));
 }
 
+int GerberApertureList::setOctagon(const UnsignedLength& w,
+                                   const UnsignedLength& h,
+                                   const UnsignedLength& edge, const Angle& rot,
+                                   const UnsignedLength& hole) noexcept {
+  if (hole > 0) {
+    addMacro(generateRotatedOctagonMacroWithHole());
+  } else {
+    addMacro(generateRotatedOctagonMacro());
+  }
+  return setCurrentAperture(generateRotatedOctagon(w, h, edge, rot, hole));
+}
+
 void GerberApertureList::reset() noexcept {
   // mApertureMacros.clear();
   mApertures.clear();
@@ -210,6 +222,39 @@ QString GerberApertureList::generateRotatedObroundMacroWithHole() {
       "4,0*1,0,$6,0,0,0");
 }
 
+QString GerberApertureList::generateRotatedOctagonMacro() {
+  // parameters: width, height, edge, rotation
+  return QString(
+      "ROTATEDOCTAGON*4,1,8,"
+      "-($1/2),($2/2)-$3,"
+      "-($1/2)+$3,($2/2),"
+      "($1/2)-$3,($2/2),"
+      "($1/2),($2/2)-$3,"
+      "($1/2),-($2/2)+$3,"
+      "($1/2)-$3,-($2/2),"
+      "-($1/2)+$3,-($2/2),"
+      "-($1/2),-($2/2)+$3,"
+      "-($1/2),($2/2)-$3,"
+      "$4");
+}
+
+QString GerberApertureList::generateRotatedOctagonMacroWithHole() {
+  // parameters: width, height, edge, rotation, hole
+  return QString(
+      "ROTATEDOCTAGONWITHHOLE*4,1,8,"
+      "-($1/2),($2/2)-$3,"
+      "-($1/2)+$3,($2/2),"
+      "($1/2)-$3,($2/2),"
+      "($1/2),($2/2)-$3,"
+      "($1/2),-($2/2)+$3,"
+      "($1/2)-$3,-($2/2),"
+      "-($1/2)+$3,-($2/2),"
+      "-($1/2),-($2/2)+$3,"
+      "-($1/2),($2/2)-$3,"
+      "$4"
+      "*1,0,$5,0,0,0");
+}
+
 QString GerberApertureList::generateRotatedRect(
     const UnsignedLength& w, const UnsignedLength& h, const Angle& rot,
     const UnsignedLength& hole) noexcept {
@@ -239,6 +284,21 @@ QString GerberApertureList::generateRotatedObround(
         .arg(start.getX().toMmString(), start.getY().toMmString(),
              end.getX().toMmString(), end.getY().toMmString(),
              width->toMmString());
+  }
+}
+
+QString GerberApertureList::generateRotatedOctagon(
+    const UnsignedLength& w, const UnsignedLength& h,
+    const UnsignedLength& edge, const Angle& rot,
+    const UnsignedLength& hole) noexcept {
+  if (hole > 0) {
+    return QString("ROTATEDOCTAGONWITHHOLE,%1X%2X%3X%4X%5")
+        .arg(w->toMmString(), h->toMmString(), edge->toMmString(),
+             rot.toDegString(), hole->toMmString());
+  } else {
+    return QString("ROTATEDOCTAGON,%1X%2X%3X%4")
+        .arg(w->toMmString(), h->toMmString(), edge->toMmString(),
+             rot.toDegString());
   }
 }
 

--- a/libs/librepcb/common/cam/gerberaperturelist.h
+++ b/libs/librepcb/common/cam/gerberaperturelist.h
@@ -63,6 +63,9 @@ public:
                   const Angle& rot, const UnsignedLength& hole) noexcept;
   int  setRegularPolygon(const UnsignedLength& dia, int n, const Angle& rot,
                          const UnsignedLength& hole) noexcept;
+  int  setOctagon(const UnsignedLength& w, const UnsignedLength& h,
+                  const UnsignedLength& edge, const Angle& rot,
+                  const UnsignedLength& hole) noexcept;
   void reset() noexcept;
 
   // Operator Overloadings
@@ -88,11 +91,18 @@ private:
   static QString generateRotatedRectMacroWithHole();
   static QString generateRotatedObroundMacro();
   static QString generateRotatedObroundMacroWithHole();
+  static QString generateRotatedOctagonMacro();
+  static QString generateRotatedOctagonMacroWithHole();
   static QString generateRotatedRect(const UnsignedLength& w,
                                      const UnsignedLength& h, const Angle& rot,
                                      const UnsignedLength& hole) noexcept;
   static QString generateRotatedObround(const UnsignedLength& w,
                                         const UnsignedLength& h,
+                                        const Angle&          rot,
+                                        const UnsignedLength& hole) noexcept;
+  static QString generateRotatedOctagon(const UnsignedLength& w,
+                                        const UnsignedLength& h,
+                                        const UnsignedLength& edge,
                                         const Angle&          rot,
                                         const UnsignedLength& hole) noexcept;
 

--- a/libs/librepcb/common/cam/gerbergenerator.cpp
+++ b/libs/librepcb/common/cam/gerbergenerator.cpp
@@ -152,6 +152,14 @@ void GerberGenerator::flashRegularPolygon(const Point&          pos,
   flashAtPosition(pos);
 }
 
+void GerberGenerator::flashOctagon(const Point& pos, const UnsignedLength& w,
+                                   const UnsignedLength& h,
+                                   const UnsignedLength& edge, const Angle& rot,
+                                   const UnsignedLength& hole) noexcept {
+  setCurrentAperture(mApertureList->setOctagon(w, h, edge, rot, hole));
+  flashAtPosition(pos);
+}
+
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/

--- a/libs/librepcb/common/cam/gerbergenerator.h
+++ b/libs/librepcb/common/cam/gerbergenerator.h
@@ -89,6 +89,9 @@ public:
   void flashRegularPolygon(const Point& pos, const UnsignedLength& dia, int n,
                            const Angle&          rot,
                            const UnsignedLength& hole) noexcept;
+  void flashOctagon(const Point& pos, const UnsignedLength& w,
+                    const UnsignedLength& h, const UnsignedLength& edge,
+                    const Angle& rot, const UnsignedLength& hole) noexcept;
 
   // General Methods
   void reset() noexcept;

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -572,13 +572,16 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator&       gen,
       break;
     }
     case library::FootprintPad::Shape::OCTAGON: {
-      if (width != height) {
-        throw LogicError(
-            __FILE__, __LINE__,
-            tr("Sorry, non-square octagons are not yet supported."));
+      if (width == height) {
+        gen.flashRegularPolygon(pad.getPosition(), uWidth, 8, rot,
+                                UnsignedLength(0));
+      } else {
+        // Calculate edge equal to Path::octagon()!
+        UnsignedLength edge(Length::fromMm(qMin(width / 2, height / 2).toMm() *
+                                           (2 - qSqrt(2))));
+        gen.flashOctagon(pad.getPosition(), uWidth, uHeight, edge, rot,
+                         UnsignedLength(0));
       }
-      gen.flashRegularPolygon(pad.getPosition(), uWidth, 8, rot,
-                              UnsignedLength(0));
       break;
     }
     default: { throw LogicError(__FILE__, __LINE__); }


### PR DESCRIPTION
Octagon footprint pads with width!=height were not supported until now (error during Gerber export). This fixes the error and exports the pads properly.