### PR TITLE
Fix wrong rotation of mirrored pads in plane cut-outs

### DIFF
--- a/libs/librepcb/project/boards/items/bi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.cpp
@@ -211,7 +211,8 @@ Path BI_FootprintPad::getOutline(const Length& expansion) const noexcept {
 }
 
 Path BI_FootprintPad::getSceneOutline(const Length& expansion) const noexcept {
-  return getOutline(expansion).rotated(mRotation).translated(mPosition);
+  Angle rotation = getIsMirrored() ? -mRotation : mRotation;
+  return getOutline(expansion).rotated(rotation).translated(mPosition);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Pads from mirrored footprints in boards were cut out with wrong rotation from planes:

![grafik](https://user-images.githubusercontent.com/5374821/64080187-8a3dc780-ccf1-11e9-8b64-93c37cf2ce6c.png)
