### PR TITLE
Fix too few decimal places in polygon editor dialog

### DIFF
--- a/libs/librepcb/common/application.cpp
+++ b/libs/librepcb/common/application.cpp
@@ -76,6 +76,8 @@ Application::Application(int& argc, char** argv) noexcept
   // register meta types
   qRegisterMetaType<FilePath>();
   qRegisterMetaType<Point>();
+  qRegisterMetaType<Length>();
+  qRegisterMetaType<Angle>();
 
   // set application version
   QApplication::setApplicationVersion(APP_VERSION);

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -127,6 +127,7 @@ SOURCES += \
     uuid.cpp \
     version.cpp \
     widgets/alignmentselector.cpp \
+    widgets/angleedit.cpp \
     widgets/attributelisteditorwidget.cpp \
     widgets/attributetypecombobox.cpp \
     widgets/attributeunitcombobox.cpp \
@@ -259,6 +260,7 @@ HEADERS += \
     uuid.h \
     version.h \
     widgets/alignmentselector.h \
+    widgets/angleedit.h \
     widgets/attributelisteditorwidget.h \
     widgets/attributetypecombobox.h \
     widgets/attributeunitcombobox.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -130,6 +130,7 @@ SOURCES += \
     widgets/attributetypecombobox.cpp \
     widgets/attributeunitcombobox.cpp \
     widgets/centeredcheckbox.cpp \
+    widgets/doublespinbox.cpp \
     widgets/editabletablewidget.cpp \
     widgets/graphicslayercombobox.cpp \
     widgets/numbereditbase.cpp \
@@ -259,6 +260,7 @@ HEADERS += \
     widgets/attributetypecombobox.h \
     widgets/attributeunitcombobox.h \
     widgets/centeredcheckbox.h \
+    widgets/doublespinbox.h \
     widgets/editabletablewidget.h \
     widgets/graphicslayercombobox.h \
     widgets/numbereditbase.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -132,6 +132,7 @@ SOURCES += \
     widgets/centeredcheckbox.cpp \
     widgets/editabletablewidget.cpp \
     widgets/graphicslayercombobox.cpp \
+    widgets/numbereditbase.cpp \
     widgets/patheditorwidget.cpp \
     widgets/plaintextedit.cpp \
     widgets/signalrolecombobox.cpp \
@@ -260,6 +261,7 @@ HEADERS += \
     widgets/centeredcheckbox.h \
     widgets/editabletablewidget.h \
     widgets/graphicslayercombobox.h \
+    widgets/numbereditbase.h \
     widgets/patheditorwidget.h \
     widgets/plaintextedit.h \
     widgets/signalrolecombobox.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -99,6 +99,7 @@ SOURCES += \
     graphics/stroketextgraphicsitem.cpp \
     graphics/textgraphicsitem.cpp \
     gridproperties.cpp \
+    model/angledelegate.cpp \
     model/comboboxdelegate.cpp \
     model/lengthdelegate.cpp \
     model/sortfilterproxymodel.cpp \
@@ -227,6 +228,7 @@ HEADERS += \
     graphics/stroketextgraphicsitem.h \
     graphics/textgraphicsitem.h \
     gridproperties.h \
+    model/angledelegate.h \
     model/comboboxdelegate.h \
     model/lengthdelegate.h \
     model/sortfilterproxymodel.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -100,6 +100,7 @@ SOURCES += \
     graphics/textgraphicsitem.cpp \
     gridproperties.cpp \
     model/comboboxdelegate.cpp \
+    model/lengthdelegate.cpp \
     model/sortfilterproxymodel.cpp \
     network/filedownload.cpp \
     network/networkaccessmanager.cpp \
@@ -226,6 +227,7 @@ HEADERS += \
     graphics/textgraphicsitem.h \
     gridproperties.h \
     model/comboboxdelegate.h \
+    model/lengthdelegate.h \
     model/sortfilterproxymodel.h \
     network/filedownload.h \
     network/networkaccessmanager.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -133,6 +133,7 @@ SOURCES += \
     widgets/doublespinbox.cpp \
     widgets/editabletablewidget.cpp \
     widgets/graphicslayercombobox.cpp \
+    widgets/lengthedit.cpp \
     widgets/numbereditbase.cpp \
     widgets/patheditorwidget.cpp \
     widgets/plaintextedit.cpp \
@@ -263,6 +264,7 @@ HEADERS += \
     widgets/doublespinbox.h \
     widgets/editabletablewidget.h \
     widgets/graphicslayercombobox.h \
+    widgets/lengthedit.h \
     widgets/numbereditbase.h \
     widgets/patheditorwidget.h \
     widgets/plaintextedit.h \

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>450</width>
     <height>394</height>
    </rect>
   </property>

--- a/libs/librepcb/common/geometry/pathmodel.cpp
+++ b/libs/librepcb/common/geometry/pathmodel.cpp
@@ -133,9 +133,8 @@ QVariant PathModel::data(const QModelIndex& index, int role) const {
           mPath.getVertices().value(index.row(), mNewVertex).getPos().getX();
       switch (role) {
         case Qt::DisplayRole:
-          return val.toMmString() + " mm";
         case Qt::EditRole:
-          return val.toMm();
+          return QVariant::fromValue(val);
         default:
           return QVariant();
       }
@@ -145,9 +144,8 @@ QVariant PathModel::data(const QModelIndex& index, int role) const {
           mPath.getVertices().value(index.row(), mNewVertex).getPos().getY();
       switch (role) {
         case Qt::DisplayRole:
-          return val.toMmString() + " mm";
         case Qt::EditRole:
-          return val.toMm();
+          return QVariant::fromValue(val);
         default:
           return QVariant();
       }
@@ -156,9 +154,8 @@ QVariant PathModel::data(const QModelIndex& index, int role) const {
       Angle val = mPath.getVertices().value(index.row(), mNewVertex).getAngle();
       switch (role) {
         case Qt::DisplayRole:
-          return val.toDegString() + "°";
         case Qt::EditRole:
-          return val.toDeg();
+          return QVariant::fromValue(val);
         default:
           return QVariant();
       }
@@ -237,33 +234,33 @@ bool PathModel::setData(const QModelIndex& index, const QVariant& value,
       vertex = &mPath.getVertices()[index.row()];
     }
     if ((index.column() == COLUMN_X) && role == Qt::EditRole) {
-      QString valueStr = value.toString().trimmed();
+      Length x = value.value<Length>();
       if (vertex) {
         Point pos = vertex->getPos();
-        pos.setX(Length::fromMm(valueStr));
+        pos.setX(x);
         vertex->setPos(pos);
       } else {
         Point pos = mNewVertex.getPos();
-        pos.setX(Length::fromMm(valueStr));
+        pos.setX(x);
         mNewVertex.setPos(pos);
       }
     } else if ((index.column() == COLUMN_Y) && role == Qt::EditRole) {
-      QString valueStr = value.toString().trimmed();
+      Length y = value.value<Length>();
       if (vertex) {
         Point pos = vertex->getPos();
-        pos.setY(Length::fromMm(valueStr));
+        pos.setY(y);
         vertex->setPos(pos);
       } else {
         Point pos = mNewVertex.getPos();
-        pos.setY(Length::fromMm(valueStr));
+        pos.setY(y);
         mNewVertex.setPos(pos);
       }
     } else if ((index.column() == COLUMN_ANGLE) && role == Qt::EditRole) {
-      QString valueStr = value.toString().trimmed();
+      Angle angle = value.value<Angle>();
       if (vertex) {
-        vertex->setAngle(Angle::fromDeg(valueStr));
+        vertex->setAngle(angle);
       } else {
-        mNewVertex.setAngle(Angle::fromDeg(valueStr));
+        mNewVertex.setAngle(angle);
       }
     } else {
       return false;

--- a/libs/librepcb/common/model/angledelegate.cpp
+++ b/libs/librepcb/common/model/angledelegate.cpp
@@ -1,0 +1,90 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "angledelegate.h"
+
+#include "../toolbox.h"
+#include "../units/angle.h"
+#include "../widgets/angleedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+AngleDelegate::AngleDelegate(QObject* parent) noexcept
+  : QStyledItemDelegate(parent) {
+}
+
+AngleDelegate::~AngleDelegate() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from QStyledItemDelegate
+ ******************************************************************************/
+
+QString AngleDelegate::displayText(const QVariant& value,
+                                   const QLocale&  locale) const {
+  return Toolbox::floatToString(value.value<Angle>().toDeg(), 10, locale) % "°";
+}
+
+QWidget* AngleDelegate::createEditor(QWidget*                    parent,
+                                     const QStyleOptionViewItem& option,
+                                     const QModelIndex&          index) const {
+  Q_UNUSED(option);
+  AngleEdit* edt = new AngleEdit(parent);
+  edt->setFrame(false);
+  edt->setValue(index.data(Qt::EditRole).value<Angle>());
+  edt->selectAll();
+  return edt;
+}
+
+void AngleDelegate::setEditorData(QWidget*           editor,
+                                  const QModelIndex& index) const {
+  AngleEdit* edt = static_cast<AngleEdit*>(editor);
+  edt->setValue(index.data(Qt::EditRole).value<Angle>());
+}
+
+void AngleDelegate::setModelData(QWidget* editor, QAbstractItemModel* model,
+                                 const QModelIndex& index) const {
+  AngleEdit* edt = static_cast<AngleEdit*>(editor);
+  model->setData(index, QVariant::fromValue(edt->getValue()), Qt::EditRole);
+}
+
+void AngleDelegate::updateEditorGeometry(QWidget*                    editor,
+                                         const QStyleOptionViewItem& option,
+                                         const QModelIndex& index) const {
+  Q_UNUSED(index);
+  editor->setGeometry(option.rect);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/model/angledelegate.h
+++ b/libs/librepcb/common/model/angledelegate.h
@@ -1,0 +1,73 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_ANGLEDELEGATE_H
+#define LIBREPCB_ANGLEDELEGATE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/lengthunit.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class AngleDelegate
+ ******************************************************************************/
+
+/**
+ * @brief Subclass of QStyledItemDelegate to display/edit librepcb::Angle values
+ */
+class AngleDelegate final : public QStyledItemDelegate {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit AngleDelegate(QObject* parent = nullptr) noexcept;
+  AngleDelegate(const AngleDelegate& other) = delete;
+  ~AngleDelegate() noexcept;
+
+  // Inherited from QStyledItemDelegate
+  QString  displayText(const QVariant& value,
+                       const QLocale&  locale) const override;
+  QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
+                        const QModelIndex& index) const override;
+  void setEditorData(QWidget* editor, const QModelIndex& index) const override;
+  void setModelData(QWidget* editor, QAbstractItemModel* model,
+                    const QModelIndex& index) const override;
+  void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option,
+                            const QModelIndex& index) const override;
+
+  // Operator Overloadings
+  AngleDelegate& operator=(const AngleDelegate& rhs) = delete;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_ANGLEDELEGATE_H

--- a/libs/librepcb/common/model/lengthdelegate.cpp
+++ b/libs/librepcb/common/model/lengthdelegate.cpp
@@ -1,0 +1,100 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "lengthdelegate.h"
+
+#include "../toolbox.h"
+#include "../units/length.h"
+#include "../widgets/lengthedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+LengthDelegate::LengthDelegate(QObject* parent) noexcept
+  : QStyledItemDelegate(parent), mUnit(LengthUnit::millimeters()) {
+}
+
+LengthDelegate::~LengthDelegate() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void LengthDelegate::setUnit(const LengthUnit& unit) noexcept {
+  mUnit = unit;
+}
+
+/*******************************************************************************
+ *  Inherited from QStyledItemDelegate
+ ******************************************************************************/
+
+QString LengthDelegate::displayText(const QVariant& value,
+                                    const QLocale&  locale) const {
+  return Toolbox::floatToString(value.value<Length>().toMm(), 10, locale) %
+         " " % mUnit.toShortStringTr();
+}
+
+QWidget* LengthDelegate::createEditor(QWidget*                    parent,
+                                      const QStyleOptionViewItem& option,
+                                      const QModelIndex&          index) const {
+  Q_UNUSED(option);
+  LengthEdit* edt = new LengthEdit(parent);
+  edt->setFrame(false);
+  edt->setUnit(mUnit);
+  edt->setValue(index.data(Qt::EditRole).value<Length>());
+  edt->selectAll();
+  return edt;
+}
+
+void LengthDelegate::setEditorData(QWidget*           editor,
+                                   const QModelIndex& index) const {
+  LengthEdit* edt = static_cast<LengthEdit*>(editor);
+  edt->setValue(index.data(Qt::EditRole).value<Length>());
+}
+
+void LengthDelegate::setModelData(QWidget* editor, QAbstractItemModel* model,
+                                  const QModelIndex& index) const {
+  LengthEdit* edt = static_cast<LengthEdit*>(editor);
+  model->setData(index, QVariant::fromValue(edt->getValue()), Qt::EditRole);
+}
+
+void LengthDelegate::updateEditorGeometry(QWidget*                    editor,
+                                          const QStyleOptionViewItem& option,
+                                          const QModelIndex& index) const {
+  Q_UNUSED(index);
+  editor->setGeometry(option.rect);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/model/lengthdelegate.h
+++ b/libs/librepcb/common/model/lengthdelegate.h
@@ -1,0 +1,80 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LENGTHDELEGATE_H
+#define LIBREPCB_LENGTHDELEGATE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/lengthunit.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class LengthDelegate
+ ******************************************************************************/
+
+/**
+ * @brief Subclass of QStyledItemDelegate to display/edit librepcb::Length
+ *        values
+ */
+class LengthDelegate final : public QStyledItemDelegate {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit LengthDelegate(QObject* parent = nullptr) noexcept;
+  LengthDelegate(const LengthDelegate& other) = delete;
+  ~LengthDelegate() noexcept;
+
+  // Setters
+  void setUnit(const LengthUnit& unit) noexcept;
+
+  // Inherited from QStyledItemDelegate
+  QString  displayText(const QVariant& value,
+                       const QLocale&  locale) const override;
+  QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
+                        const QModelIndex& index) const override;
+  void setEditorData(QWidget* editor, const QModelIndex& index) const override;
+  void setModelData(QWidget* editor, QAbstractItemModel* model,
+                    const QModelIndex& index) const override;
+  void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option,
+                            const QModelIndex& index) const override;
+
+  // Operator Overloadings
+  LengthDelegate& operator=(const LengthDelegate& rhs) = delete;
+
+private:  // Data
+  LengthUnit mUnit;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LENGTHDELEGATE_H

--- a/libs/librepcb/common/toolbox.h
+++ b/libs/librepcb/common/toolbox.h
@@ -182,6 +182,25 @@ public:
                                       int            maxLength = -1) noexcept;
 
   /**
+   * @brief Convert a float or double to a localized string
+   *
+   * Same as QLocale::toString<float/double>(), but with omitted trailing zeros
+   * and without group separators.
+   */
+  template <typename T>
+  static QString floatToString(T value, int decimals,
+                               const QLocale& locale) noexcept {
+    QString s = locale.toString(value, 'f', decimals);
+    for (int i = 1; (i < decimals) && s.endsWith(locale.zeroDigit()); ++i) {
+      s.chop(1);
+    }
+    if (qAbs(value) >= 1000) {
+      s.remove(locale.groupSeparator());
+    }
+    return s;
+  }
+
+  /**
    * @brief Convert a fixed point decimal number from an integer to a QString
    *
    * @param value    Value to convert

--- a/libs/librepcb/common/units/angle.h
+++ b/libs/librepcb/common/units/angle.h
@@ -420,4 +420,6 @@ inline uint qHash(const Angle& key, uint seed = 0) noexcept {
 
 }  // namespace librepcb
 
+Q_DECLARE_METATYPE(librepcb::Angle)
+
 #endif  // LIBREPCB_ANGLE_H

--- a/libs/librepcb/common/units/length.h
+++ b/libs/librepcb/common/units/length.h
@@ -953,4 +953,6 @@ inline uint qHash(const PositiveLength& key, uint seed = 0) noexcept {
 
 }  // namespace librepcb
 
+Q_DECLARE_METATYPE(librepcb::Length)
+
 #endif  // LIBREPCB_LENGTH_H

--- a/libs/librepcb/common/units/lengthunit.cpp
+++ b/libs/librepcb/common/units/lengthunit.cpp
@@ -133,7 +133,7 @@ QPointF LengthUnit::convertToUnit(const Point& point) const noexcept {
   }
 }
 
-Length LengthUnit::convertFromUnit(qreal length) const noexcept {
+Length LengthUnit::convertFromUnit(qreal length) const {
   switch (mUnit) {
     case LengthUnit_t::Millimeters:
       return Length::fromMm(length);
@@ -152,7 +152,7 @@ Length LengthUnit::convertFromUnit(qreal length) const noexcept {
   }
 }
 
-Point LengthUnit::convertFromUnit(const QPointF& point) const noexcept {
+Point LengthUnit::convertFromUnit(const QPointF& point) const {
   switch (mUnit) {
     case LengthUnit_t::Millimeters:
       return Point::fromMm(point);

--- a/libs/librepcb/common/units/lengthunit.h
+++ b/libs/librepcb/common/units/lengthunit.h
@@ -195,7 +195,7 @@ public:
    * @warning As this method always uses floating point numbers, there is a
    * little risk that the conversion is not lossless. So be careful with it.
    */
-  Length convertFromUnit(qreal length) const noexcept;
+  Length convertFromUnit(qreal length) const;
 
   /**
    * @brief Convert floating point numbers with this unit to a Point object
@@ -209,7 +209,7 @@ public:
    * @warning As this method always uses floating point numbers, there is a
    * little risk that the conversion is not lossless. So be careful with it.
    */
-  Point convertFromUnit(const QPointF& point) const noexcept;
+  Point convertFromUnit(const QPointF& point) const;
 
   // Static Methods
 

--- a/libs/librepcb/common/units/lengthunit.h
+++ b/libs/librepcb/common/units/lengthunit.h
@@ -261,7 +261,12 @@ public:
     mUnit = rhs.mUnit;
     return *this;
   }
-  bool operator==(const LengthUnit& rhs) noexcept { return mUnit == rhs.mUnit; }
+  bool operator==(const LengthUnit& rhs) const noexcept {
+    return mUnit == rhs.mUnit;
+  }
+  bool operator!=(const LengthUnit& rhs) const noexcept {
+    return mUnit != rhs.mUnit;
+  }
 
 private:
   // Private Methods

--- a/libs/librepcb/common/widgets/angleedit.cpp
+++ b/libs/librepcb/common/widgets/angleedit.cpp
@@ -1,0 +1,80 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "angleedit.h"
+
+#include "doublespinbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+AngleEdit::AngleEdit(QWidget* parent) noexcept
+  : NumberEditBase(parent), mValue(0) {
+  mSpinBox->setMinimum(-361.0);  // < -360° to avoid rounding issues
+  mSpinBox->setMaximum(361.0);   // > 360° to avoid rounding issues
+  mSpinBox->setSuffix("°");
+  updateSpinBox();
+}
+
+AngleEdit::~AngleEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void AngleEdit::setValue(const Angle& value) noexcept {
+  if (value != mValue) {
+    mValue = value;
+    updateSpinBox();
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void AngleEdit::updateSpinBox() noexcept {
+  mSpinBox->setValue(mValue.toDeg());
+}
+
+void AngleEdit::spinBoxValueChanged(double value) noexcept {
+  try {
+    mValue = Angle::fromDeg(value);  // can throw
+    emit valueChanged(mValue);
+  } catch (const Exception& e) {
+    // This should actually never happen, thus no user visible message here.
+    qWarning() << "Invalid angle entered:" << e.getMsg();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/angleedit.h
+++ b/libs/librepcb/common/widgets/angleedit.h
@@ -1,0 +1,79 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_ANGLEEDIT_H
+#define LIBREPCB_ANGLEEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/angle.h"
+#include "numbereditbase.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class AngleEdit
+ ******************************************************************************/
+
+/**
+ * @brief The AngleEdit class is a widget to view/edit ::librepcb::Angle values
+ */
+class AngleEdit final : public NumberEditBase {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit AngleEdit(QWidget* parent = nullptr) noexcept;
+  AngleEdit(const AngleEdit& other) = delete;
+  virtual ~AngleEdit() noexcept;
+
+  // Getters
+  const Angle& getValue() const noexcept { return mValue; }
+
+  // Setters
+  void setValue(const Angle& value) noexcept;
+
+  // Operator Overloadings
+  AngleEdit& operator=(const AngleEdit& rhs) = delete;
+
+signals:
+  void valueChanged(const Angle& value);
+
+private:  // Methods
+  void updateSpinBox() noexcept override;
+  void spinBoxValueChanged(double value) noexcept override;
+
+private:  // Data
+  Angle mValue;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_ANGLEEDIT_H

--- a/libs/librepcb/common/widgets/doublespinbox.cpp
+++ b/libs/librepcb/common/widgets/doublespinbox.cpp
@@ -1,0 +1,55 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "doublespinbox.h"
+
+#include "../toolbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+DoubleSpinBox::DoubleSpinBox(QWidget* parent) noexcept
+  : QDoubleSpinBox(parent) {
+}
+
+DoubleSpinBox::~DoubleSpinBox() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited Methods
+ ******************************************************************************/
+
+QString DoubleSpinBox::textFromValue(double val) const {
+  return Toolbox::floatToString(val, decimals(), locale());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/doublespinbox.h
+++ b/libs/librepcb/common/widgets/doublespinbox.h
@@ -1,0 +1,66 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_DOUBLESPINBOX_H
+#define LIBREPCB_DOUBLESPINBOX_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class DoubleSpinBox
+ ******************************************************************************/
+
+/**
+ * @brief The DoubleSpinBox class is a customized QDoubleSpinBox widget
+ *
+ * Differences to QDoubleSpinBox:
+ *   - Trailing zeros are omitted
+ */
+class DoubleSpinBox final : public QDoubleSpinBox {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit DoubleSpinBox(QWidget* parent = nullptr) noexcept;
+  DoubleSpinBox(const DoubleSpinBox& other) = delete;
+  virtual ~DoubleSpinBox() noexcept;
+
+  // Operator Overloadings
+  DoubleSpinBox& operator=(const DoubleSpinBox& rhs) = delete;
+
+  // Inherited Methods
+  virtual QString textFromValue(double val) const override;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_DOUBLESPINBOX_H

--- a/libs/librepcb/common/widgets/lengthedit.cpp
+++ b/libs/librepcb/common/widgets/lengthedit.cpp
@@ -1,0 +1,99 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "lengthedit.h"
+
+#include "doublespinbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+LengthEdit::LengthEdit(QWidget* parent) noexcept
+  : NumberEditBase(parent),
+    mMinValue(-2000000000L),  // -2'000mm should be sufficient for everything
+    mMaxValue(2000000000L),   // 2'000mm should be sufficient for everything
+    mValue(0),
+    mUnit(LengthUnit::millimeters()) {
+  updateSpinBox();
+}
+
+LengthEdit::~LengthEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void LengthEdit::setValue(const Length& value) noexcept {
+  if (value != mValue) {
+    mValue = value;
+    // Extend allowed range e.g. if a lower/higher value is loaded from file.
+    // Otherwise the edit will clip the value, i.e. the value gets modified
+    // even without user interaction.
+    if (mValue > mMaxValue) mMaxValue = mValue;
+    if (mValue < mMinValue) mMinValue = mValue;
+    updateSpinBox();
+  }
+}
+
+void LengthEdit::setUnit(const LengthUnit& unit) noexcept {
+  if (unit != mUnit) {
+    mUnit = unit;
+    updateSpinBox();
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void LengthEdit::updateSpinBox() noexcept {
+  mSpinBox->setMinimum(mUnit.convertToUnit(mMinValue));
+  mSpinBox->setMaximum(mUnit.convertToUnit(mMaxValue));
+  mSpinBox->setValue(mUnit.convertToUnit(mValue));
+  mSpinBox->setSuffix(" " % mUnit.toShortStringTr());
+}
+
+void LengthEdit::spinBoxValueChanged(double value) noexcept {
+  try {
+    mValue = mUnit.convertFromUnit(value);  // can throw
+    // Clip value with integer arithmetic to avoid floating point issues.
+    if (mValue < mMinValue) mValue = mMinValue;
+    if (mValue > mMaxValue) mValue = mMaxValue;
+    emit valueChanged(mValue);
+  } catch (const Exception& e) {
+    // This should actually never happen, thus no user visible message here.
+    qWarning() << "Invalid length entered:" << e.getMsg();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/lengthedit.h
+++ b/libs/librepcb/common/widgets/lengthedit.h
@@ -1,0 +1,85 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LENGTHEDIT_H
+#define LIBREPCB_LENGTHEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/length.h"
+#include "../units/lengthunit.h"
+#include "numbereditbase.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class LengthEdit
+ ******************************************************************************/
+
+/**
+ * @brief The LengthEdit class is a widget to view/edit ::librepcb::Length
+ *        values
+ */
+class LengthEdit final : public NumberEditBase {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit LengthEdit(QWidget* parent = nullptr) noexcept;
+  LengthEdit(const LengthEdit& other) = delete;
+  virtual ~LengthEdit() noexcept;
+
+  // Getters
+  const Length& getValue() const noexcept { return mValue; }
+
+  // Setters
+  void setValue(const Length& value) noexcept;
+  void setUnit(const LengthUnit& unit) noexcept;
+
+  // Operator Overloadings
+  LengthEdit& operator=(const LengthEdit& rhs) = delete;
+
+signals:
+  void valueChanged(const Length& value);
+
+private:  // Methods
+  void updateSpinBox() noexcept override;
+  void spinBoxValueChanged(double value) noexcept override;
+
+private:  // Data
+  Length     mMinValue;
+  Length     mMaxValue;
+  Length     mValue;
+  LengthUnit mUnit;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LENGTHEDIT_H

--- a/libs/librepcb/common/widgets/numbereditbase.cpp
+++ b/libs/librepcb/common/widgets/numbereditbase.cpp
@@ -1,0 +1,76 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "numbereditbase.h"
+
+#include "doublespinbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+NumberEditBase::NumberEditBase(QWidget* parent) noexcept
+  : QWidget(parent), mSpinBox(new DoubleSpinBox(this)) {
+  QVBoxLayout* layout = new QVBoxLayout(this);
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->addWidget(mSpinBox.data());
+
+  // Actually for most units we only need 6 decimals, but to avoid rounding
+  // errors (e.g. when converting between different units), we need some more
+  // decimals.
+  mSpinBox->setDecimals(10);
+  mSpinBox->setButtonSymbols(QDoubleSpinBox::NoButtons);
+  setFocusProxy(mSpinBox.data());
+
+  connect(mSpinBox.data(),
+          static_cast<void (QDoubleSpinBox::*)(double)>(
+              &QDoubleSpinBox::valueChanged),
+          this, &NumberEditBase::spinBoxValueChanged);
+  connect(mSpinBox.data(), &DoubleSpinBox::editingFinished, this,
+          &NumberEditBase::editingFinished);
+}
+
+NumberEditBase::~NumberEditBase() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void NumberEditBase::setFrame(bool frame) noexcept {
+  mSpinBox->setFrame(frame);
+}
+
+void NumberEditBase::selectAll() noexcept {
+  mSpinBox->selectAll();
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/numbereditbase.h
+++ b/libs/librepcb/common/widgets/numbereditbase.h
@@ -1,0 +1,79 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_NUMBEREDITBASE_H
+#define LIBREPCB_NUMBEREDITBASE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class DoubleSpinBox;
+
+/*******************************************************************************
+ *  Class NumberEditBase
+ ******************************************************************************/
+
+/**
+ * @brief The NumberEditBase class is a widget base class to edit various kinds
+ *        of numbers
+ *
+ * See subclasses for details.
+ */
+class NumberEditBase : public QWidget {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit NumberEditBase(QWidget* parent = nullptr) noexcept;
+  NumberEditBase(const NumberEditBase& other) = delete;
+  virtual ~NumberEditBase() noexcept;
+
+  // General Methods
+  void setFrame(bool frame) noexcept;
+  void selectAll() noexcept;
+
+  // Operator Overloadings
+  NumberEditBase& operator=(const NumberEditBase& rhs) = delete;
+
+signals:
+  void editingFinished();
+
+protected:  // Methods
+  virtual void updateSpinBox() noexcept                   = 0;
+  virtual void spinBoxValueChanged(double value) noexcept = 0;
+
+protected:  // Data
+  QScopedPointer<DoubleSpinBox> mSpinBox;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_NUMBEREDITBASE_H

--- a/libs/librepcb/common/widgets/patheditorwidget.cpp
+++ b/libs/librepcb/common/widgets/patheditorwidget.cpp
@@ -23,6 +23,8 @@
 #include "patheditorwidget.h"
 
 #include "../geometry/pathmodel.h"
+#include "../model/angledelegate.h"
+#include "../model/lengthdelegate.h"
 #include "editabletablewidget.h"
 
 #include <QtCore>
@@ -44,6 +46,12 @@ PathEditorWidget::PathEditorWidget(QWidget* parent) noexcept
   mView->setShowMoveButtons(true);
   mView->setShowCopyButton(true);
   mView->setModel(mModel.data());
+  mView->setItemDelegateForColumn(PathModel::COLUMN_X,
+                                  new LengthDelegate(this));
+  mView->setItemDelegateForColumn(PathModel::COLUMN_Y,
+                                  new LengthDelegate(this));
+  mView->setItemDelegateForColumn(PathModel::COLUMN_ANGLE,
+                                  new AngleDelegate(this));
   mView->horizontalHeader()->setSectionResizeMode(PathModel::COLUMN_X,
                                                   QHeaderView::Stretch);
   mView->horizontalHeader()->setSectionResizeMode(PathModel::COLUMN_Y,

--- a/tests/unittests/common/geometry/pathmodeltest.cpp
+++ b/tests/unittests/common/geometry/pathmodeltest.cpp
@@ -1,0 +1,86 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/common/geometry/pathmodel.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class PathModelTest : public ::testing::Test {
+protected:
+  static Path createPopulatedPath() noexcept {
+    Path path;
+    path.addVertex(Point(1, 2), Angle(3));
+    path.addVertex(Point(0, 0), Angle(0));
+    path.addVertex(Point(1000, 2000), Angle(3000));
+    return path;
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(PathModelTest, testData) {
+  PathModel model(nullptr);
+  model.setPath(createPopulatedPath());
+  EXPECT_EQ(QVariant::fromValue(Length(1000)),
+            model.data(model.index(2, PathModel::COLUMN_X)));
+  EXPECT_EQ(QVariant::fromValue(Length(2000)),
+            model.data(model.index(2, PathModel::COLUMN_Y)));
+  EXPECT_EQ(QVariant::fromValue(Angle(3)),
+            model.data(model.index(0, PathModel::COLUMN_ANGLE)));
+}
+
+TEST_F(PathModelTest, testSetData) {
+  PathModel model(nullptr);
+  model.setPath(createPopulatedPath());
+  bool r = model.setData(model.index(1, PathModel::COLUMN_X),
+                         QVariant::fromValue(Length(5080000)));
+  EXPECT_TRUE(r);
+  r = model.setData(model.index(1, PathModel::COLUMN_Y),
+                    QVariant::fromValue(Length(1234568)));
+  EXPECT_TRUE(r);
+  r = model.setData(model.index(1, PathModel::COLUMN_ANGLE),
+                    QVariant::fromValue(Angle(45000000)));
+  EXPECT_TRUE(r);
+
+  Path expected             = createPopulatedPath();
+  expected.getVertices()[1] = Vertex(Point(5080000, 1234568), Angle(45000000));
+  EXPECT_EQ(expected, model.getPath());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/toolboxtest.cpp
+++ b/tests/unittests/common/toolboxtest.cpp
@@ -167,6 +167,46 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(sToolboxExpandRangesInStringTestData));
 
 /*******************************************************************************
+ *  Parametrized floatToString() Tests
+ ******************************************************************************/
+
+struct ToolboxFloatToStringTestData {
+  double  number;
+  int     decimals;
+  QLocale locale;
+  QString output;
+};
+
+class ToolboxFloatToStringTest
+  : public ToolboxTest,
+    public ::testing::WithParamInterface<ToolboxFloatToStringTestData> {};
+
+TEST_P(ToolboxFloatToStringTest, test) {
+  const ToolboxFloatToStringTestData& data = GetParam();
+
+  QString res = Toolbox::floatToString(data.number, data.decimals, data.locale);
+  EXPECT_EQ(data.output.toStdString(), res.toStdString());
+}
+
+// clang-format off
+static ToolboxFloatToStringTestData
+    sToolboxFloatToStringTestData[] = {
+// number,      decimals, locale,                 output
+  {0.0,         0,        QLocale::c(),           "0"},
+  {-2.6,        0,        QLocale::c(),           "-3"},
+  {12345.6789,  0,        QLocale::c(),           "12346"},
+  {0.0,         1,        QLocale::c(),           "0.0"},
+  {-1234.567,   1,        QLocale::c(),           "-1234.6"},
+  {1234.567891, 5,        QLocale::c(),           "1234.56789"},
+  {0.0,         5,        QLocale("de_DE"),       "0,0"},
+  {12345.6789,  5,        QLocale("de_DE"),       "12345,6789"},
+};
+// clang-format on
+
+INSTANTIATE_TEST_SUITE_P(ToolboxFloatToStringTest, ToolboxFloatToStringTest,
+                         ::testing::ValuesIn(sToolboxFloatToStringTestData));
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -70,6 +70,7 @@ SOURCES += \
     common/fileio/serializableobjectlisttest.cpp \
     common/fileio/transactionaldirectorytest.cpp \
     common/fileio/transactionalfilesystemtest.cpp \
+    common/geometry/pathmodeltest.cpp \
     common/geometry/pathtest.cpp \
     common/network/filedownloadtest.cpp \
     common/network/networkrequesttest.cpp \


### PR DESCRIPTION
This adds the custom widgets `LengthEdit` and `AngleEdit` which are similar to `QLineEdit`, but specifically designed to enter `Length` resp. `Angle` values. Those are now used in `PathEditorWidget` (in the polygon properties dialog) to edit vertices. 

This leads to following improvements:
- Providing proper count of decimal places (fixes #512)
- Displaying numbers with locale-aware decimal separator (fixes #506)
- Displaying "mm" resp. "°" suffix to make clear what unit the numbers have
- Preparation to allow displaying/editing numbers in units other than Millimeters (see #362)

With locale "de_DE" (comma as decimal separator):

![grafik](https://user-images.githubusercontent.com/5374821/65319645-6b1fb080-dba0-11e9-9308-509fd66ab232.png)