### PR TITLE
Replace spinboxes/comboboxes with unit-aware edit widgets

### DIFF
--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -146,6 +146,7 @@ SOURCES += \
     widgets/statusbar.cpp \
     widgets/tabwidget.cpp \
     widgets/unsignedlengthedit.cpp \
+    widgets/unsignedratioedit.cpp \
 
 HEADERS += \
     alignment.h \
@@ -283,6 +284,7 @@ HEADERS += \
     widgets/statusbar.h \
     widgets/tabwidget.h \
     widgets/unsignedlengthedit.h \
+    widgets/unsignedratioedit.h \
 
 FORMS += \
     dialogs/aboutdialog.ui \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -140,6 +140,7 @@ SOURCES += \
     widgets/numbereditbase.cpp \
     widgets/patheditorwidget.cpp \
     widgets/plaintextedit.cpp \
+    widgets/positivelengthedit.cpp \
     widgets/signalrolecombobox.cpp \
     widgets/statusbar.cpp \
     widgets/tabwidget.cpp \
@@ -275,6 +276,7 @@ HEADERS += \
     widgets/numbereditbase.h \
     widgets/patheditorwidget.h \
     widgets/plaintextedit.h \
+    widgets/positivelengthedit.h \
     widgets/signalrolecombobox.h \
     widgets/statusbar.h \
     widgets/tabwidget.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -143,6 +143,7 @@ SOURCES += \
     widgets/signalrolecombobox.cpp \
     widgets/statusbar.cpp \
     widgets/tabwidget.cpp \
+    widgets/unsignedlengthedit.cpp \
 
 HEADERS += \
     alignment.h \
@@ -277,6 +278,7 @@ HEADERS += \
     widgets/signalrolecombobox.h \
     widgets/statusbar.h \
     widgets/tabwidget.h \
+    widgets/unsignedlengthedit.h \
 
 FORMS += \
     dialogs/aboutdialog.ui \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -141,6 +141,7 @@ SOURCES += \
     widgets/patheditorwidget.cpp \
     widgets/plaintextedit.cpp \
     widgets/positivelengthedit.cpp \
+    widgets/ratioedit.cpp \
     widgets/signalrolecombobox.cpp \
     widgets/statusbar.cpp \
     widgets/tabwidget.cpp \
@@ -277,6 +278,7 @@ HEADERS += \
     widgets/patheditorwidget.h \
     widgets/plaintextedit.h \
     widgets/positivelengthedit.h \
+    widgets/ratioedit.h \
     widgets/signalrolecombobox.h \
     widgets/statusbar.h \
     widgets/tabwidget.h \

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
@@ -39,6 +39,19 @@ BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
                                                QWidget*                parent)
   : QDialog(parent), mUi(new Ui::BoardDesignRulesDialog), mDesignRules(rules) {
   mUi->setupUi(this);
+  mUi->edtStopMaskClrRatio->setSingleStep(5.0);   // [%]
+  mUi->edtStopMaskClrMin->setSingleStep(0.1);     // [mm]
+  mUi->edtStopMaskClrMax->setSingleStep(0.1);     // [mm]
+  mUi->edtStopMaskMaxViaDia->setSingleStep(0.1);  // [mm]
+  mUi->edtCreamMaskClrRatio->setSingleStep(5.0);  // [%]
+  mUi->edtCreamMaskClrMin->setSingleStep(0.1);    // [mm]
+  mUi->edtCreamMaskClrMax->setSingleStep(0.1);    // [mm]
+  mUi->edtRestringPadsRatio->setSingleStep(5.0);  // [%]
+  mUi->edtRestringPadsMin->setSingleStep(0.1);    // [mm]
+  mUi->edtRestringPadsMax->setSingleStep(0.1);    // [mm]
+  mUi->edtRestringViasRatio->setSingleStep(5.0);  // [%]
+  mUi->edtRestringViasMin->setSingleStep(0.1);    // [mm]
+  mUi->edtRestringViasMax->setSingleStep(0.1);    // [mm]
 
   updateWidgets();
 }
@@ -80,30 +93,22 @@ void BoardDesignRulesDialog::updateWidgets() noexcept {
   mUi->edtName->setText(*mDesignRules.getName());
   mUi->txtDescription->setPlainText(mDesignRules.getDescription());
   // stop mask
-  mUi->spbxStopMaskClrRatio->setValue(
-      mDesignRules.getStopMaskClearanceRatio()->toPercent());
-  mUi->spbxStopMaskClrMin->setValue(
-      mDesignRules.getStopMaskClearanceMin()->toMm());
-  mUi->spbxStopMaskClrMax->setValue(
-      mDesignRules.getStopMaskClearanceMax()->toMm());
-  mUi->spbxStopMaskMaxViaDia->setValue(
-      mDesignRules.getStopMaskMaxViaDiameter()->toMm());
+  mUi->edtStopMaskClrRatio->setValue(mDesignRules.getStopMaskClearanceRatio());
+  mUi->edtStopMaskClrMin->setValue(mDesignRules.getStopMaskClearanceMin());
+  mUi->edtStopMaskClrMax->setValue(mDesignRules.getStopMaskClearanceMax());
+  mUi->edtStopMaskMaxViaDia->setValue(mDesignRules.getStopMaskMaxViaDiameter());
   // cream mask
-  mUi->spbxCreamMaskClrRatio->setValue(
-      mDesignRules.getCreamMaskClearanceRatio()->toPercent());
-  mUi->spbxCreamMaskClrMin->setValue(
-      mDesignRules.getCreamMaskClearanceMin()->toMm());
-  mUi->spbxCreamMaskClrMax->setValue(
-      mDesignRules.getCreamMaskClearanceMax()->toMm());
+  mUi->edtCreamMaskClrRatio->setValue(
+      mDesignRules.getCreamMaskClearanceRatio());
+  mUi->edtCreamMaskClrMin->setValue(mDesignRules.getCreamMaskClearanceMin());
+  mUi->edtCreamMaskClrMax->setValue(mDesignRules.getCreamMaskClearanceMax());
   // restring
-  mUi->spbxRestringPadsRatio->setValue(
-      mDesignRules.getRestringPadRatio()->toPercent());
-  mUi->spbxRestringPadsMin->setValue(mDesignRules.getRestringPadMin()->toMm());
-  mUi->spbxRestringPadsMax->setValue(mDesignRules.getRestringPadMax()->toMm());
-  mUi->spbxRestringViasRatio->setValue(
-      mDesignRules.getRestringViaRatio()->toPercent());
-  mUi->spbxRestringViasMin->setValue(mDesignRules.getRestringViaMin()->toMm());
-  mUi->spbxRestringViasMax->setValue(mDesignRules.getRestringViaMax()->toMm());
+  mUi->edtRestringPadsRatio->setValue(mDesignRules.getRestringPadRatio());
+  mUi->edtRestringPadsMin->setValue(mDesignRules.getRestringPadMin());
+  mUi->edtRestringPadsMax->setValue(mDesignRules.getRestringPadMax());
+  mUi->edtRestringViasRatio->setValue(mDesignRules.getRestringViaRatio());
+  mUi->edtRestringViasMin->setValue(mDesignRules.getRestringViaMin());
+  mUi->edtRestringViasMax->setValue(mDesignRules.getRestringViaMax());
 }
 
 void BoardDesignRulesDialog::applyRules() noexcept {
@@ -112,34 +117,28 @@ void BoardDesignRulesDialog::applyRules() noexcept {
     mDesignRules.setName(ElementName(mUi->edtName->text()));  // can throw
     mDesignRules.setDescription(mUi->txtDescription->toPlainText());
     // stop mask
-    mDesignRules.setStopMaskClearanceRatio(UnsignedRatio(
-        Ratio::fromPercent(mUi->spbxStopMaskClrRatio->value())));  // can throw
+    mDesignRules.setStopMaskClearanceRatio(
+        mUi->edtStopMaskClrRatio->getValue());
     mDesignRules.setStopMaskClearanceBounds(
-        UnsignedLength(Length::fromMm(mUi->spbxStopMaskClrMin->value())),
-        UnsignedLength(
-            Length::fromMm(mUi->spbxStopMaskClrMax->value())));  // can throw
-    mDesignRules.setStopMaskMaxViaDiameter(UnsignedLength(
-        Length::fromMm(mUi->spbxStopMaskMaxViaDia->value())));  // can throw
+        mUi->edtStopMaskClrMin->getValue(),
+        mUi->edtStopMaskClrMax->getValue());  // can throw
+    mDesignRules.setStopMaskMaxViaDiameter(
+        mUi->edtStopMaskMaxViaDia->getValue());
     // cream mask
-    mDesignRules.setCreamMaskClearanceRatio(UnsignedRatio(
-        Ratio::fromPercent(mUi->spbxCreamMaskClrRatio->value())));  // can throw
+    mDesignRules.setCreamMaskClearanceRatio(
+        mUi->edtCreamMaskClrRatio->getValue());
     mDesignRules.setCreamMaskClearanceBounds(
-        UnsignedLength(Length::fromMm(mUi->spbxCreamMaskClrMin->value())),
-        UnsignedLength(
-            Length::fromMm(mUi->spbxCreamMaskClrMax->value())));  // can throw
+        mUi->edtCreamMaskClrMin->getValue(),
+        mUi->edtCreamMaskClrMax->getValue());  // can throw
     // restring
-    mDesignRules.setRestringPadRatio(UnsignedRatio(
-        Ratio::fromPercent(mUi->spbxRestringPadsRatio->value())));  // can throw
+    mDesignRules.setRestringPadRatio(mUi->edtRestringPadsRatio->getValue());
     mDesignRules.setRestringPadBounds(
-        UnsignedLength(Length::fromMm(mUi->spbxRestringPadsMin->value())),
-        UnsignedLength(
-            Length::fromMm(mUi->spbxRestringPadsMax->value())));  // can throw
-    mDesignRules.setRestringViaRatio(UnsignedRatio(
-        Ratio::fromPercent(mUi->spbxRestringViasRatio->value())));  // can throw
+        mUi->edtRestringPadsMin->getValue(),
+        mUi->edtRestringPadsMax->getValue());  // can throw
+    mDesignRules.setRestringViaRatio(mUi->edtRestringViasRatio->getValue());
     mDesignRules.setRestringViaBounds(
-        UnsignedLength(Length::fromMm(mUi->spbxRestringViasMin->value())),
-        UnsignedLength(
-            Length::fromMm(mUi->spbxRestringViasMax->value())));  // can throw
+        mUi->edtRestringViasMin->getValue(),
+        mUi->edtRestringViasMax->getValue());  // can throw
   } catch (const Exception& e) {
     QMessageBox::warning(this, tr("Could not apply settings"), e.getMsg());
   }

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.ui
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.ui
@@ -56,74 +56,10 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="3">
-    <widget class="QDoubleSpinBox" name="spbxStopMaskMaxViaDia">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="4" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Stop Mask Clearance:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QDoubleSpinBox" name="spbxStopMaskClrMin">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QDoubleSpinBox" name="spbxStopMaskClrRatio">
-     <property name="suffix">
-      <string notr="true">%</string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>10.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QDoubleSpinBox" name="spbxStopMaskClrMax">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
      </property>
     </widget>
    </item>
@@ -134,54 +70,6 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QDoubleSpinBox" name="spbxCreamMaskClrMin">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QDoubleSpinBox" name="spbxCreamMaskClrRatio">
-     <property name="suffix">
-      <string notr="true">%</string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>10.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="3">
-    <widget class="QDoubleSpinBox" name="spbxCreamMaskClrMax">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
@@ -189,106 +77,10 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QDoubleSpinBox" name="spbxRestringPadsMin">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QDoubleSpinBox" name="spbxRestringPadsRatio">
-     <property name="suffix">
-      <string notr="true">%</string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>10.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="3">
-    <widget class="QDoubleSpinBox" name="spbxRestringPadsMax">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label_10">
      <property name="text">
       <string>Restring Vias:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QDoubleSpinBox" name="spbxRestringViasMin">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QDoubleSpinBox" name="spbxRestringViasRatio">
-     <property name="suffix">
-      <string notr="true">%</string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>10.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="3">
-    <widget class="QDoubleSpinBox" name="spbxRestringViasMax">
-     <property name="suffix">
-      <string notr="true">mm</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="maximum">
-      <double>999.999000000000024</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
      </property>
     </widget>
    </item>
@@ -308,8 +100,61 @@
    <item row="0" column="1" colspan="3">
     <widget class="QLineEdit" name="edtName"/>
    </item>
+   <item row="3" column="3">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtStopMaskMaxViaDia" native="true"/>
+   </item>
+   <item row="4" column="1">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtStopMaskClrMin" native="true"/>
+   </item>
+   <item row="5" column="1">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtCreamMaskClrMin" native="true"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtRestringPadsMin" native="true"/>
+   </item>
+   <item row="7" column="1">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtRestringViasMin" native="true"/>
+   </item>
+   <item row="4" column="3">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtStopMaskClrMax" native="true"/>
+   </item>
+   <item row="5" column="3">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtCreamMaskClrMax" native="true"/>
+   </item>
+   <item row="6" column="3">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtRestringPadsMax" native="true"/>
+   </item>
+   <item row="7" column="3">
+    <widget class="librepcb::UnsignedLengthEdit" name="edtRestringViasMax" native="true"/>
+   </item>
+   <item row="4" column="2">
+    <widget class="librepcb::UnsignedRatioEdit" name="edtStopMaskClrRatio" native="true"/>
+   </item>
+   <item row="5" column="2">
+    <widget class="librepcb::UnsignedRatioEdit" name="edtCreamMaskClrRatio" native="true"/>
+   </item>
+   <item row="6" column="2">
+    <widget class="librepcb::UnsignedRatioEdit" name="edtRestringPadsRatio" native="true"/>
+   </item>
+   <item row="7" column="2">
+    <widget class="librepcb::UnsignedRatioEdit" name="edtRestringViasRatio" native="true"/>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedlengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::UnsignedRatioEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedratioedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
@@ -45,6 +45,8 @@ CirclePropertiesDialog::CirclePropertiesDialog(Circle&               circle,
     mUndoStack(undoStack),
     mUi(new Ui::CirclePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtLineWidth->setSingleStep(0.1);  // [mm]
+  mUi->edtDiameter->setSingleStep(0.1);   // [mm]
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());
@@ -55,12 +57,12 @@ CirclePropertiesDialog::CirclePropertiesDialog(Circle&               circle,
 
   // load circle attributes
   selectLayerNameInCombobox(*mCircle.getLayerName());
-  mUi->spbLineWidth->setValue(mCircle.getLineWidth()->toMm());
+  mUi->edtLineWidth->setValue(mCircle.getLineWidth());
   mUi->cbxFillArea->setChecked(mCircle.isFilled());
   mUi->cbxIsGrabArea->setChecked(mCircle.isGrabArea());
-  mUi->spbDiameter->setValue(mCircle.getDiameter()->toMm());
-  mUi->spbPosX->setValue(mCircle.getCenter().getX().toMm());
-  mUi->spbPosY->setValue(mCircle.getCenter().getY().toMm());
+  mUi->edtDiameter->setValue(mCircle.getDiameter());
+  mUi->edtPosX->setValue(mCircle.getCenter().getX());
+  mUi->edtPosY->setValue(mCircle.getCenter().getY());
 }
 
 CirclePropertiesDialog::~CirclePropertiesDialog() noexcept {
@@ -92,9 +94,6 @@ void CirclePropertiesDialog::buttonBoxClicked(
 
 bool CirclePropertiesDialog::applyChanges() noexcept {
   try {
-    PositiveLength diameter =
-        PositiveLength(Length::fromMm(mUi->spbDiameter->value()));  // can throw
-
     QScopedPointer<CmdCircleEdit> cmd(new CmdCircleEdit(mCircle));
     if (mUi->cbxLayer->currentIndex() >= 0 &&
         mUi->cbxLayer->currentData().isValid()) {
@@ -104,11 +103,9 @@ bool CirclePropertiesDialog::applyChanges() noexcept {
     }
     cmd->setIsFilled(mUi->cbxFillArea->isChecked(), false);
     cmd->setIsGrabArea(mUi->cbxIsGrabArea->isChecked(), false);
-    cmd->setLineWidth(
-        UnsignedLength(Length::fromMm(mUi->spbLineWidth->value())),
-        false);  // can throw
-    cmd->setDiameter(diameter, false);
-    cmd->setCenter(Point::fromMm(mUi->spbPosX->value(), mUi->spbPosY->value()),
+    cmd->setLineWidth(mUi->edtLineWidth->getValue(), false);
+    cmd->setDiameter(mUi->edtDiameter->getValue(), false);
+    cmd->setCenter(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
                    false);
     mUndoStack.execCmd(cmd.take());
     return true;

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>312</width>
-    <height>205</height>
+    <height>176</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -61,39 +61,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="spbLineWidth">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Diameter:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="spbDiameter">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>0.254000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.254000000000000</double>
        </property>
       </widget>
      </item>
@@ -107,38 +78,18 @@
      <item row="4" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosX">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosY">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
        </item>
       </layout>
+     </item>
+     <item row="2" column="1">
+      <widget class="librepcb::UnsignedLengthEdit" name="edtLineWidth" native="true"/>
+     </item>
+     <item row="3" column="1">
+      <widget class="librepcb::PositiveLengthEdit" name="edtDiameter" native="true"/>
      </item>
     </layout>
    </item>
@@ -154,6 +105,26 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedlengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
@@ -42,13 +42,14 @@ HolePropertiesDialog::HolePropertiesDialog(Hole& hole, UndoStack& undoStack,
     mUndoStack(undoStack),
     mUi(new Ui::HolePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtDiameter->setSingleStep(0.1);  // [mm]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &HolePropertiesDialog::on_buttonBox_clicked);
 
   // load text attributes
-  mUi->spbDiameter->setValue(mHole.getDiameter()->toMm());
-  mUi->spbPosX->setValue(mHole.getPosition().getX().toMm());
-  mUi->spbPosY->setValue(mHole.getPosition().getY().toMm());
+  mUi->edtDiameter->setValue(mHole.getDiameter());
+  mUi->edtPosX->setValue(mHole.getPosition().getX());
+  mUi->edtPosY->setValue(mHole.getPosition().getY());
 }
 
 HolePropertiesDialog::~HolePropertiesDialog() noexcept {
@@ -80,10 +81,9 @@ void HolePropertiesDialog::on_buttonBox_clicked(QAbstractButton* button) {
 bool HolePropertiesDialog::applyChanges() noexcept {
   try {
     QScopedPointer<CmdHoleEdit> cmd(new CmdHoleEdit(mHole));
-    cmd->setDiameter(PositiveLength(Length::fromMm(mUi->spbDiameter->value())),
-                     false);  // can throw
-    cmd->setPosition(
-        Point::fromMm(mUi->spbPosX->value(), mUi->spbPosY->value()), false);
+    cmd->setDiameter(mUi->edtDiameter->getValue(), false);
+    cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
+                     false);
     mUndoStack.execCmd(cmd.take());
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>304</width>
-    <height>111</height>
+    <height>91</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,25 +23,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QDoubleSpinBox" name="spbDiameter">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>0.000100000000000</double>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
@@ -52,38 +33,15 @@
      <item row="1" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosX">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosY">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
        </item>
       </layout>
+     </item>
+     <item row="0" column="1">
+      <widget class="librepcb::PositiveLengthEdit" name="edtDiameter" native="true"/>
      </item>
     </layout>
    </item>
@@ -99,6 +57,20 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
@@ -45,6 +45,7 @@ PolygonPropertiesDialog::PolygonPropertiesDialog(Polygon&   polygon,
     mUndoStack(undoStack),
     mUi(new Ui::PolygonPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtLineWidth->setSingleStep(0.1);  // [mm]
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());
@@ -55,7 +56,7 @@ PolygonPropertiesDialog::PolygonPropertiesDialog(Polygon&   polygon,
 
   // load polygon attributes
   selectLayerNameInCombobox(*mPolygon.getLayerName());
-  mUi->spbLineWidth->setValue(mPolygon.getLineWidth()->toMm());
+  mUi->edtLineWidth->setValue(mPolygon.getLineWidth());
   mUi->cbxFillArea->setChecked(mPolygon.isFilled());
   mUi->cbxIsGrabArea->setChecked(mPolygon.isGrabArea());
 
@@ -101,9 +102,7 @@ bool PolygonPropertiesDialog::applyChanges() noexcept {
     }
     cmd->setIsFilled(mUi->cbxFillArea->isChecked(), false);
     cmd->setIsGrabArea(mUi->cbxIsGrabArea->isChecked(), false);
-    cmd->setLineWidth(
-        UnsignedLength(Length::fromMm(mUi->spbLineWidth->value())),
-        false);                                             // can throw
+    cmd->setLineWidth(mUi->edtLineWidth->getValue(), false);
     cmd->setPath(mUi->pathEditorWidget->getPath(), false);  // can throw
     mUndoStack.execCmd(cmd.take());
     return true;

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.ui
@@ -62,17 +62,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="spbLineWidth">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
+      <widget class="librepcb::UnsignedLengthEdit" name="edtLineWidth" native="true"/>
      </item>
     </layout>
    </item>
@@ -103,6 +93,12 @@
    <class>librepcb::PathEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/common/widgets/patheditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedlengthedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>328</width>
-    <height>388</height>
+    <width>333</width>
+    <height>411</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -59,28 +59,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="spbHeight">
-       <property name="suffix">
-        <string notr="true">mm</string>
-       </property>
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>0.010000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="8" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
@@ -91,36 +69,10 @@
      <item row="8" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosX">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosY">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
        </item>
       </layout>
      </item>
@@ -131,42 +83,10 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
-      <widget class="QDoubleSpinBox" name="spbRotation">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>45.000000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Stroke Width:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QDoubleSpinBox" name="spbxStrokeWidth">
-       <property name="suffix">
-        <string notr="true">mm</string>
-       </property>
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.050000000000000</double>
        </property>
       </widget>
      </item>
@@ -198,23 +118,7 @@
      <item row="7" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
        <item>
-        <widget class="QDoubleSpinBox" name="spbxLineSpacingRatio">
-         <property name="suffix">
-          <string notr="true">%</string>
-         </property>
-         <property name="decimals">
-          <number>4</number>
-         </property>
-         <property name="minimum">
-          <double>-999.990000000000009</double>
-         </property>
-         <property name="maximum">
-          <double>999.990000000000009</double>
-         </property>
-         <property name="singleStep">
-          <double>10.000000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::RatioEdit" name="edtLineSpacingRatio" native="true"/>
        </item>
        <item>
         <widget class="QCheckBox" name="cbxLineSpacingAuto">
@@ -242,23 +146,7 @@
      <item row="6" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0">
        <item>
-        <widget class="QDoubleSpinBox" name="spbxLetterSpacingRatio">
-         <property name="suffix">
-          <string notr="true">%</string>
-         </property>
-         <property name="decimals">
-          <number>4</number>
-         </property>
-         <property name="minimum">
-          <double>-999.990000000000009</double>
-         </property>
-         <property name="maximum">
-          <double>999.990000000000009</double>
-         </property>
-         <property name="singleStep">
-          <double>5.000000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::RatioEdit" name="edtLetterSpacingRatio" native="true"/>
        </item>
        <item>
         <widget class="QCheckBox" name="cbxLetterSpacingAuto">
@@ -268,6 +156,15 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item row="3" column="1">
+      <widget class="librepcb::PositiveLengthEdit" name="edtHeight" native="true"/>
+     </item>
+     <item row="4" column="1">
+      <widget class="librepcb::UnsignedLengthEdit" name="edtStrokeWidth" native="true"/>
+     </item>
+     <item row="9" column="1">
+      <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
      </item>
     </layout>
    </item>
@@ -285,9 +182,39 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>librepcb::AlignmentSelector</class>
    <extends>QWidget</extends>
    <header>widgets/alignmentselector.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::AngleEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/angleedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedlengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::RatioEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/ratioedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
@@ -44,6 +44,8 @@ TextPropertiesDialog::TextPropertiesDialog(Text& text, UndoStack& undoStack,
     mUndoStack(undoStack),
     mUi(new Ui::TextPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtHeight->setSingleStep(0.5);     // [mm]
+  mUi->edtRotation->setSingleStep(90.0);  // [°]
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());
@@ -56,10 +58,10 @@ TextPropertiesDialog::TextPropertiesDialog(Text& text, UndoStack& undoStack,
   selectLayerNameInCombobox(*mText.getLayerName());
   mUi->edtText->setPlainText(mText.getText());
   mUi->alignmentSelector->setAlignment(mText.getAlign());
-  mUi->spbHeight->setValue(mText.getHeight()->toMm());
-  mUi->spbPosX->setValue(mText.getPosition().getX().toMm());
-  mUi->spbPosY->setValue(mText.getPosition().getY().toMm());
-  mUi->spbRotation->setValue(mText.getRotation().toDeg());
+  mUi->edtHeight->setValue(mText.getHeight());
+  mUi->edtPosX->setValue(mText.getPosition().getX());
+  mUi->edtPosY->setValue(mText.getPosition().getY());
+  mUi->edtRotation->setValue(mText.getRotation());
 }
 
 TextPropertiesDialog::~TextPropertiesDialog() noexcept {
@@ -99,11 +101,10 @@ bool TextPropertiesDialog::applyChanges() noexcept {
     }
     cmd->setText(mUi->edtText->toPlainText().trimmed(), false);
     cmd->setAlignment(mUi->alignmentSelector->getAlignment(), false);
-    cmd->setHeight(PositiveLength(Length::fromMm(mUi->spbHeight->value())),
-                   false);  // can throw
-    cmd->setPosition(
-        Point::fromMm(mUi->spbPosX->value(), mUi->spbPosY->value()), false);
-    cmd->setRotation(Angle::fromDeg(mUi->spbRotation->value()), false);
+    cmd->setHeight(mUi->edtHeight->getValue(), false);
+    cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
+                     false);
+    cmd->setRotation(mUi->edtRotation->getValue(), false);
     mUndoStack.execCmd(cmd.take());
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>310</width>
-    <height>273</height>
+    <height>244</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -59,22 +59,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="spbHeight">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>0.254000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.254000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
@@ -85,36 +69,10 @@
      <item row="4" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosX">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosY">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
        </item>
       </layout>
      </item>
@@ -125,21 +83,11 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="1">
+      <widget class="librepcb::PositiveLengthEdit" name="edtHeight" native="true"/>
+     </item>
      <item row="5" column="1">
-      <widget class="QDoubleSpinBox" name="spbRotation">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>45.000000000000000</double>
-       </property>
-      </widget>
+      <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
      </item>
     </layout>
    </item>
@@ -160,6 +108,24 @@
    <class>librepcb::AlignmentSelector</class>
    <extends>QWidget</extends>
    <header>widgets/alignmentselector.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::AngleEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/angleedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/common/utils/toolbarproxy.cpp
+++ b/libs/librepcb/common/utils/toolbarproxy.cpp
@@ -105,13 +105,17 @@ QAction* ToolBarProxy::addLabel(const QString& text, int indent) noexcept {
   return addWidget(std::move(label));
 }
 
-QAction* ToolBarProxy::addWidget(std::unique_ptr<QWidget> widget) noexcept {
+QAction* ToolBarProxy::addWidget(std::unique_ptr<QWidget> widget,
+                                 int                      indent) noexcept {
   Q_ASSERT(widget);
   Q_ASSERT((widget->parent() == nullptr) || (widget->parent() == this));
 
+  if (indent > 0) {
+    addLabel("", indent);  // A bit ugly, but simple and works :)
+  }
+
   std::unique_ptr<QWidgetAction> action(new QWidgetAction(this));
-  action->setDefaultWidget(
-      widget.release());  // transfer ownership to the action
+  action->setDefaultWidget(widget.release());  // transfer ownership to action
   return addAction(std::move(action));
 }
 

--- a/libs/librepcb/common/utils/toolbarproxy.h
+++ b/libs/librepcb/common/utils/toolbarproxy.h
@@ -58,7 +58,7 @@ public:
   void     clear() noexcept;
   QAction* addAction(std::unique_ptr<QAction> action) noexcept;
   QAction* addLabel(const QString& text, int indent = 0) noexcept;
-  QAction* addWidget(std::unique_ptr<QWidget> widget) noexcept;
+  QAction* addWidget(std::unique_ptr<QWidget> widget, int indent = 0) noexcept;
   QAction* addSeparator() noexcept;
   void     removeAction(QAction* action) noexcept;
 

--- a/libs/librepcb/common/widgets/numbereditbase.cpp
+++ b/libs/librepcb/common/widgets/numbereditbase.cpp
@@ -43,7 +43,7 @@ NumberEditBase::NumberEditBase(QWidget* parent) noexcept
   // errors (e.g. when converting between different units), we need some more
   // decimals.
   mSpinBox->setDecimals(10);
-  mSpinBox->setButtonSymbols(QDoubleSpinBox::NoButtons);
+  setSingleStep(tl::nullopt);
   setFocusProxy(mSpinBox.data());
 
   connect(mSpinBox.data(),
@@ -60,6 +60,16 @@ NumberEditBase::~NumberEditBase() noexcept {
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+void NumberEditBase::setSingleStep(tl::optional<double> step) noexcept {
+  if (step) {
+    mSpinBox->setSingleStep(*step);
+    mSpinBox->setButtonSymbols(QDoubleSpinBox::UpDownArrows);
+  } else {
+    mSpinBox->setSingleStep(0.0);
+    mSpinBox->setButtonSymbols(QDoubleSpinBox::NoButtons);
+  }
+}
 
 void NumberEditBase::setFrame(bool frame) noexcept {
   mSpinBox->setFrame(frame);

--- a/libs/librepcb/common/widgets/numbereditbase.h
+++ b/libs/librepcb/common/widgets/numbereditbase.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <optional/tl/optional.hpp>
+
 #include <QtCore>
 #include <QtWidgets>
 
@@ -53,6 +55,7 @@ public:
   virtual ~NumberEditBase() noexcept;
 
   // General Methods
+  void setSingleStep(tl::optional<double> step) noexcept;
   void setFrame(bool frame) noexcept;
   void selectAll() noexcept;
 

--- a/libs/librepcb/common/widgets/positivelengthedit.cpp
+++ b/libs/librepcb/common/widgets/positivelengthedit.cpp
@@ -1,0 +1,99 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "positivelengthedit.h"
+
+#include "doublespinbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PositiveLengthEdit::PositiveLengthEdit(QWidget* parent) noexcept
+  : NumberEditBase(parent),
+    mMinValue(1),
+    mMaxValue(2000000000L),  // 2'000mm should be sufficient for everything
+    mValue(1),
+    mUnit(LengthUnit::millimeters()) {
+  updateSpinBox();
+}
+
+PositiveLengthEdit::~PositiveLengthEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void PositiveLengthEdit::setValue(const PositiveLength& value) noexcept {
+  if (value != mValue) {
+    mValue = value;
+    // Extend allowed range e.g. if a lower/higher value is loaded from file.
+    // Otherwise the edit will clip the value, i.e. the value gets modified
+    // even without user interaction.
+    if (mValue > mMaxValue) mMaxValue = mValue;
+    if (mValue < mMinValue) mMinValue = mValue;
+    updateSpinBox();
+  }
+}
+
+void PositiveLengthEdit::setUnit(const LengthUnit& unit) noexcept {
+  if (unit != mUnit) {
+    mUnit = unit;
+    updateSpinBox();
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void PositiveLengthEdit::updateSpinBox() noexcept {
+  mSpinBox->setMinimum(mUnit.convertToUnit(*mMinValue));
+  mSpinBox->setMaximum(mUnit.convertToUnit(*mMaxValue));
+  mSpinBox->setValue(mUnit.convertToUnit(*mValue));
+  mSpinBox->setSuffix(" " % mUnit.toShortStringTr());
+}
+
+void PositiveLengthEdit::spinBoxValueChanged(double value) noexcept {
+  try {
+    mValue = PositiveLength(mUnit.convertFromUnit(value));  // can throw
+    // Clip value with integer arithmetic to avoid floating point issues.
+    if (mValue < mMinValue) mValue = mMinValue;
+    if (mValue > mMaxValue) mValue = mMaxValue;
+    emit valueChanged(mValue);
+  } catch (const Exception& e) {
+    // This should actually never happen, thus no user visible message here.
+    qWarning() << "Invalid positive length entered:" << e.getMsg();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/positivelengthedit.h
+++ b/libs/librepcb/common/widgets/positivelengthedit.h
@@ -1,0 +1,85 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_POSITIVELENGTHEDIT_H
+#define LIBREPCB_POSITIVELENGTHEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/length.h"
+#include "../units/lengthunit.h"
+#include "numbereditbase.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class PositiveLengthEdit
+ ******************************************************************************/
+
+/**
+ * @brief The PositiveLengthEdit class is a widget to view/edit
+ *        ::librepcb::PositiveLength values
+ */
+class PositiveLengthEdit final : public NumberEditBase {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit PositiveLengthEdit(QWidget* parent = nullptr) noexcept;
+  PositiveLengthEdit(const PositiveLengthEdit& other) = delete;
+  virtual ~PositiveLengthEdit() noexcept;
+
+  // Getters
+  const PositiveLength& getValue() const noexcept { return mValue; }
+
+  // Setters
+  void setValue(const PositiveLength& value) noexcept;
+  void setUnit(const LengthUnit& unit) noexcept;
+
+  // Operator Overloadings
+  PositiveLengthEdit& operator=(const PositiveLengthEdit& rhs) = delete;
+
+signals:
+  void valueChanged(const PositiveLength& value);
+
+private:  // Methods
+  void updateSpinBox() noexcept override;
+  void spinBoxValueChanged(double value) noexcept override;
+
+private:  // Data
+  PositiveLength mMinValue;
+  PositiveLength mMaxValue;
+  PositiveLength mValue;
+  LengthUnit     mUnit;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_POSITIVELENGTHEDIT_H

--- a/libs/librepcb/common/widgets/ratioedit.cpp
+++ b/libs/librepcb/common/widgets/ratioedit.cpp
@@ -1,0 +1,91 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "ratioedit.h"
+
+#include "doublespinbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+RatioEdit::RatioEdit(QWidget* parent) noexcept
+  : NumberEditBase(parent),
+    mMinValue(-2000000000L),  // -2'000% should be sufficient for everything
+    mMaxValue(2000000000L),   // 2'000% should be sufficient for everything
+    mValue(0) {
+  mSpinBox->setSuffix("%");
+  updateSpinBox();
+}
+
+RatioEdit::~RatioEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void RatioEdit::setValue(const Ratio& value) noexcept {
+  if (value != mValue) {
+    mValue = value;
+    // Extend allowed range e.g. if a lower/higher value is loaded from file.
+    // Otherwise the edit will clip the value, i.e. the value gets modified
+    // even without user interaction.
+    if (mValue > mMaxValue) mMaxValue = mValue;
+    if (mValue < mMinValue) mMinValue = mValue;
+    updateSpinBox();
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void RatioEdit::updateSpinBox() noexcept {
+  mSpinBox->setMinimum(mMinValue.toPercent());
+  mSpinBox->setMaximum(mMaxValue.toPercent());
+  mSpinBox->setValue(mValue.toPercent());
+}
+
+void RatioEdit::spinBoxValueChanged(double value) noexcept {
+  try {
+    mValue = Ratio::fromPercent(value);  // can throw
+    // Clip value with integer arithmetic to avoid floating point issues.
+    if (mValue < mMinValue) mValue = mMinValue;
+    if (mValue > mMaxValue) mValue = mMaxValue;
+    emit valueChanged(mValue);
+  } catch (const Exception& e) {
+    // This should actually never happen, thus no user visible message here.
+    qWarning() << "Invalid ratio entered:" << e.getMsg();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/ratioedit.h
+++ b/libs/librepcb/common/widgets/ratioedit.h
@@ -1,0 +1,81 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_RATIOEDIT_H
+#define LIBREPCB_RATIOEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/ratio.h"
+#include "numbereditbase.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class RatioEdit
+ ******************************************************************************/
+
+/**
+ * @brief The RatioEdit class is a widget to view/edit ::librepcb::Ratio values
+ */
+class RatioEdit final : public NumberEditBase {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit RatioEdit(QWidget* parent = nullptr) noexcept;
+  RatioEdit(const RatioEdit& other) = delete;
+  virtual ~RatioEdit() noexcept;
+
+  // Getters
+  const Ratio& getValue() const noexcept { return mValue; }
+
+  // Setters
+  void setValue(const Ratio& value) noexcept;
+
+  // Operator Overloadings
+  RatioEdit& operator=(const RatioEdit& rhs) = delete;
+
+signals:
+  void valueChanged(const Ratio& value);
+
+private:  // Methods
+  void updateSpinBox() noexcept override;
+  void spinBoxValueChanged(double value) noexcept override;
+
+private:  // Data
+  Ratio mMinValue;
+  Ratio mMaxValue;
+  Ratio mValue;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_RATIOEDIT_H

--- a/libs/librepcb/common/widgets/unsignedlengthedit.cpp
+++ b/libs/librepcb/common/widgets/unsignedlengthedit.cpp
@@ -1,0 +1,99 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "unsignedlengthedit.h"
+
+#include "doublespinbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+UnsignedLengthEdit::UnsignedLengthEdit(QWidget* parent) noexcept
+  : NumberEditBase(parent),
+    mMinValue(0),
+    mMaxValue(2000000000L),  // 2'000mm should be sufficient for everything
+    mValue(0),
+    mUnit(LengthUnit::millimeters()) {
+  updateSpinBox();
+}
+
+UnsignedLengthEdit::~UnsignedLengthEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void UnsignedLengthEdit::setValue(const UnsignedLength& value) noexcept {
+  if (value != mValue) {
+    mValue = value;
+    // Extend allowed range e.g. if a lower/higher value is loaded from file.
+    // Otherwise the edit will clip the value, i.e. the value gets modified
+    // even without user interaction.
+    if (mValue > mMaxValue) mMaxValue = mValue;
+    if (mValue < mMinValue) mMinValue = mValue;
+    updateSpinBox();
+  }
+}
+
+void UnsignedLengthEdit::setUnit(const LengthUnit& unit) noexcept {
+  if (unit != mUnit) {
+    mUnit = unit;
+    updateSpinBox();
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void UnsignedLengthEdit::updateSpinBox() noexcept {
+  mSpinBox->setMinimum(mUnit.convertToUnit(*mMinValue));
+  mSpinBox->setMaximum(mUnit.convertToUnit(*mMaxValue));
+  mSpinBox->setValue(mUnit.convertToUnit(*mValue));
+  mSpinBox->setSuffix(" " % mUnit.toShortStringTr());
+}
+
+void UnsignedLengthEdit::spinBoxValueChanged(double value) noexcept {
+  try {
+    mValue = UnsignedLength(mUnit.convertFromUnit(value));  // can throw
+    // Clip value with integer arithmetic to avoid floating point issues.
+    if (mValue < mMinValue) mValue = mMinValue;
+    if (mValue > mMaxValue) mValue = mMaxValue;
+    emit valueChanged(mValue);
+  } catch (const Exception& e) {
+    // This should actually never happen, thus no user visible message here.
+    qWarning() << "Invalid unsigned length entered:" << e.getMsg();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/unsignedlengthedit.h
+++ b/libs/librepcb/common/widgets/unsignedlengthedit.h
@@ -1,0 +1,85 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_UNSIGNEDLENGTHEDIT_H
+#define LIBREPCB_UNSIGNEDLENGTHEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/length.h"
+#include "../units/lengthunit.h"
+#include "numbereditbase.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class UnsignedLengthEdit
+ ******************************************************************************/
+
+/**
+ * @brief The UnsignedLengthEdit class is a widget to view/edit
+ *        ::librepcb::UnsignedLength values
+ */
+class UnsignedLengthEdit final : public NumberEditBase {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit UnsignedLengthEdit(QWidget* parent = nullptr) noexcept;
+  UnsignedLengthEdit(const UnsignedLengthEdit& other) = delete;
+  virtual ~UnsignedLengthEdit() noexcept;
+
+  // Getters
+  const UnsignedLength& getValue() const noexcept { return mValue; }
+
+  // Setters
+  void setValue(const UnsignedLength& value) noexcept;
+  void setUnit(const LengthUnit& unit) noexcept;
+
+  // Operator Overloadings
+  UnsignedLengthEdit& operator=(const UnsignedLengthEdit& rhs) = delete;
+
+signals:
+  void valueChanged(const UnsignedLength& value);
+
+private:  // Methods
+  void updateSpinBox() noexcept override;
+  void spinBoxValueChanged(double value) noexcept override;
+
+private:  // Data
+  UnsignedLength mMinValue;
+  UnsignedLength mMaxValue;
+  UnsignedLength mValue;
+  LengthUnit     mUnit;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_UNSIGNEDLENGTHEDIT_H

--- a/libs/librepcb/common/widgets/unsignedratioedit.cpp
+++ b/libs/librepcb/common/widgets/unsignedratioedit.cpp
@@ -1,0 +1,91 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "unsignedratioedit.h"
+
+#include "doublespinbox.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+UnsignedRatioEdit::UnsignedRatioEdit(QWidget* parent) noexcept
+  : NumberEditBase(parent),
+    mMinValue(Ratio(0)),
+    mMaxValue(Ratio(2000000000L)),  // 2000% should be sufficient for everything
+    mValue(Ratio(0)) {
+  mSpinBox->setSuffix("%");
+  updateSpinBox();
+}
+
+UnsignedRatioEdit::~UnsignedRatioEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void UnsignedRatioEdit::setValue(const UnsignedRatio& value) noexcept {
+  if (value != mValue) {
+    mValue = value;
+    // Extend allowed range e.g. if a lower/higher value is loaded from file.
+    // Otherwise the edit will clip the value, i.e. the value gets modified
+    // even without user interaction.
+    if (mValue > mMaxValue) mMaxValue = mValue;
+    if (mValue < mMinValue) mMinValue = mValue;
+    updateSpinBox();
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void UnsignedRatioEdit::updateSpinBox() noexcept {
+  mSpinBox->setMinimum(mMinValue->toPercent());
+  mSpinBox->setMaximum(mMaxValue->toPercent());
+  mSpinBox->setValue(mValue->toPercent());
+}
+
+void UnsignedRatioEdit::spinBoxValueChanged(double value) noexcept {
+  try {
+    mValue = UnsignedRatio(Ratio::fromPercent(value));  // can throw
+    // Clip value with integer arithmetic to avoid floating point issues.
+    if (mValue < mMinValue) mValue = mMinValue;
+    if (mValue > mMaxValue) mValue = mMaxValue;
+    emit valueChanged(mValue);
+  } catch (const Exception& e) {
+    // This should actually never happen, thus no user visible message here.
+    qWarning() << "Invalid unsigned ratio entered:" << e.getMsg();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/unsignedratioedit.h
+++ b/libs/librepcb/common/widgets/unsignedratioedit.h
@@ -1,0 +1,82 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_UNSIGNEDRATIOEDIT_H
+#define LIBREPCB_UNSIGNEDRATIOEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/ratio.h"
+#include "numbereditbase.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class UnsignedRatioEdit
+ ******************************************************************************/
+
+/**
+ * @brief The UnsignedRatioEdit class is a widget to view/edit
+ *        ::librepcb::UnsignedRatio values
+ */
+class UnsignedRatioEdit final : public NumberEditBase {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit UnsignedRatioEdit(QWidget* parent = nullptr) noexcept;
+  UnsignedRatioEdit(const UnsignedRatioEdit& other) = delete;
+  virtual ~UnsignedRatioEdit() noexcept;
+
+  // Getters
+  const UnsignedRatio& getValue() const noexcept { return mValue; }
+
+  // Setters
+  void setValue(const UnsignedRatio& value) noexcept;
+
+  // Operator Overloadings
+  UnsignedRatioEdit& operator=(const UnsignedRatioEdit& rhs) = delete;
+
+signals:
+  void valueChanged(const UnsignedRatio& value);
+
+private:  // Methods
+  void updateSpinBox() noexcept override;
+  void spinBoxValueChanged(double value) noexcept override;
+
+private:  // Data
+  UnsignedRatio mMinValue;
+  UnsignedRatio mMaxValue;
+  UnsignedRatio mValue;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_UNSIGNEDRATIOEDIT_H

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
@@ -47,6 +47,10 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
     mUndoStack(undoStack),
     mUi(new Ui::FootprintPadPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtWidth->setSingleStep(0.1);          // [mm]
+  mUi->edtHeight->setSingleStep(0.1);         // [mm]
+  mUi->edtDrillDiameter->setSingleStep(0.1);  // [mm]
+  mUi->edtRotation->setSingleStep(90.0);      // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &FootprintPadPropertiesDialog::on_buttonBox_clicked);
 
@@ -91,17 +95,17 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
       Q_ASSERT(false);
       break;
   }
-  mUi->spbWidth->setValue(mPad.getWidth()->toMm());
-  mUi->spbHeight->setValue(mPad.getHeight()->toMm());
-  mUi->spbDrillDiameter->setValue(mPad.getDrillDiameter()->toMm());
-  mUi->spbPosX->setValue(mPad.getPosition().getX().toMm());
-  mUi->spbPosY->setValue(mPad.getPosition().getY().toMm());
-  mUi->spbRotation->setValue(mPad.getRotation().toDeg());
+  mUi->edtWidth->setValue(mPad.getWidth());
+  mUi->edtHeight->setValue(mPad.getHeight());
+  mUi->edtDrillDiameter->setValue(mPad.getDrillDiameter());
+  mUi->edtPosX->setValue(mPad.getPosition().getX());
+  mUi->edtPosY->setValue(mPad.getPosition().getY());
+  mUi->edtRotation->setValue(mPad.getRotation());
 
   // disable drill diameter for SMT pads
-  mUi->spbDrillDiameter->setEnabled(mUi->rbtnBoardSideTht->isChecked());
-  connect(mUi->rbtnBoardSideTht, &QRadioButton::toggled, mUi->spbDrillDiameter,
-          &QDoubleSpinBox::setEnabled);
+  mUi->edtDrillDiameter->setEnabled(mUi->rbtnBoardSideTht->isChecked());
+  connect(mUi->rbtnBoardSideTht, &QRadioButton::toggled, mUi->edtDrillDiameter,
+          &LengthEdit::setEnabled);
 }
 
 FootprintPadPropertiesDialog::~FootprintPadPropertiesDialog() noexcept {
@@ -155,16 +159,12 @@ bool FootprintPadPropertiesDialog::applyChanges() noexcept {
     } else {
       Q_ASSERT(false);
     }
-    cmd->setWidth(PositiveLength(Length::fromMm(mUi->spbWidth->value())),
-                  false);  // can throw
-    cmd->setHeight(PositiveLength(Length::fromMm(mUi->spbHeight->value())),
-                   false);  // can throw
-    cmd->setDrillDiameter(
-        UnsignedLength(Length::fromMm(mUi->spbDrillDiameter->value())),
-        false);  // can throw
-    cmd->setPosition(
-        Point::fromMm(mUi->spbPosX->value(), mUi->spbPosY->value()), false);
-    cmd->setRotation(Angle::fromDeg(mUi->spbRotation->value()), false);
+    cmd->setWidth(mUi->edtWidth->getValue(), false);
+    cmd->setHeight(mUi->edtHeight->getValue(), false);
+    cmd->setDrillDiameter(mUi->edtDrillDiameter->getValue(), false);
+    cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
+                     false);
+    cmd->setRotation(mUi->edtRotation->getValue(), false);
     mUndoStack.execCmd(cmd.take());
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>330</width>
-    <height>266</height>
+    <height>226</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -125,19 +125,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="spbDrillDiameter">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>9999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="label_7">
        <property name="text">
@@ -148,36 +135,10 @@
      <item row="4" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
-        <widget class="QDoubleSpinBox" name="spbWidth">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::PositiveLengthEdit" name="edtWidth" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbHeight">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::PositiveLengthEdit" name="edtHeight" native="true"/>
        </item>
       </layout>
      </item>
@@ -191,36 +152,10 @@
      <item row="5" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosX">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosY">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
        </item>
       </layout>
      </item>
@@ -231,21 +166,11 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="1">
+      <widget class="librepcb::UnsignedLengthEdit" name="edtDrillDiameter" native="true"/>
+     </item>
      <item row="6" column="1">
-      <widget class="QDoubleSpinBox" name="spbRotation">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>45.000000000000000</double>
-       </property>
-      </widget>
+      <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
      </item>
     </layout>
    </item>
@@ -261,6 +186,32 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::AngleEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/angleedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedlengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
@@ -30,6 +30,7 @@
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/graphics/holegraphicsitem.h>
+#include <librepcb/common/widgets/positivelengthedit.h>
 #include <librepcb/library/pkg/footprint.h>
 #include <librepcb/library/pkg/footprintgraphicsitem.h>
 
@@ -71,17 +72,12 @@ bool PackageEditorState_AddHoles::entry() noexcept {
   // populate command toolbar
   mContext.commandToolBar.addLabel(tr("Diameter:"), 10);
 
-  std::unique_ptr<QDoubleSpinBox> diameterSpinBox(new QDoubleSpinBox());
-  diameterSpinBox->setMinimum(0.0001);
-  diameterSpinBox->setMaximum(100);
-  diameterSpinBox->setSingleStep(0.2);
-  diameterSpinBox->setDecimals(6);
-  diameterSpinBox->setValue(mLastDiameter->toMm());
-  connect(diameterSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &PackageEditorState_AddHoles::diameterSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(diameterSpinBox));
+  std::unique_ptr<PositiveLengthEdit> edtDiameter(new PositiveLengthEdit());
+  edtDiameter->setSingleStep(0.1);  // [mm]
+  edtDiameter->setValue(mLastDiameter);
+  connect(edtDiameter.get(), &PositiveLengthEdit::valueChanged, this,
+          &PackageEditorState_AddHoles::diameterEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtDiameter));
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
@@ -186,9 +182,9 @@ bool PackageEditorState_AddHoles::abortAddHole() noexcept {
   }
 }
 
-void PackageEditorState_AddHoles::diameterSpinBoxValueChanged(
-    double value) noexcept {
-  mLastDiameter = Length::fromMm(value);
+void PackageEditorState_AddHoles::diameterEditValueChanged(
+    const PositiveLength& value) noexcept {
+  mLastDiameter = value;
   if (mEditCmd) {
     mEditCmd->setDiameter(mLastDiameter, true);
   }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.h
@@ -77,7 +77,7 @@ private:  // Methods
   bool startAddHole(const Point& pos) noexcept;
   bool finishAddHole(const Point& pos) noexcept;
   bool abortAddHole() noexcept;
-  void diameterSpinBoxValueChanged(double value) noexcept;
+  void diameterEditValueChanged(const PositiveLength& value) noexcept;
 
 private:  // Data
   Point                       mStartPos;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
@@ -29,6 +29,8 @@
 
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
+#include <librepcb/common/widgets/positivelengthedit.h>
+#include <librepcb/common/widgets/unsignedlengthedit.h>
 #include <librepcb/library/pkg/cmd/cmdfootprintpadedit.h>
 #include <librepcb/library/pkg/footprint.h>
 #include <librepcb/library/pkg/footprintgraphicsitem.h>
@@ -120,47 +122,32 @@ bool PackageEditorState_AddPads::entry() noexcept {
 
   // width
   mContext.commandToolBar.addLabel(tr("Width:"), 10);
-  std::unique_ptr<QDoubleSpinBox> widthSpinBox(new QDoubleSpinBox());
-  widthSpinBox->setMinimum(0);
-  widthSpinBox->setMaximum(999);
-  widthSpinBox->setSingleStep(0.1);
-  widthSpinBox->setDecimals(6);
-  widthSpinBox->setValue(mLastPad.getWidth()->toMm());
-  connect(widthSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &PackageEditorState_AddPads::widthSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(widthSpinBox));
+  std::unique_ptr<PositiveLengthEdit> edtWidth(new PositiveLengthEdit());
+  edtWidth->setSingleStep(0.1);  // [mm]
+  edtWidth->setValue(mLastPad.getWidth());
+  connect(edtWidth.get(), &PositiveLengthEdit::valueChanged, this,
+          &PackageEditorState_AddPads::widthEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtWidth));
 
   // height
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
-  std::unique_ptr<QDoubleSpinBox> heightSpinBox(new QDoubleSpinBox());
-  heightSpinBox->setMinimum(0);
-  heightSpinBox->setMaximum(999);
-  heightSpinBox->setSingleStep(0.1);
-  heightSpinBox->setDecimals(6);
-  heightSpinBox->setValue(mLastPad.getHeight()->toMm());
-  connect(heightSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &PackageEditorState_AddPads::heightSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(heightSpinBox));
+  std::unique_ptr<PositiveLengthEdit> edtHeight(new PositiveLengthEdit());
+  edtHeight->setSingleStep(0.1);  // [mm]
+  edtHeight->setValue(mLastPad.getHeight());
+  connect(edtHeight.get(), &PositiveLengthEdit::valueChanged, this,
+          &PackageEditorState_AddPads::heightEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtHeight));
 
   // drill diameter
   if (mPadType == PadType::THT) {
     mContext.commandToolBar.addLabel(tr("Drill Diameter:"), 10);
-    std::unique_ptr<QDoubleSpinBox> drillDiameterSpinBox(new QDoubleSpinBox());
-    drillDiameterSpinBox->setMinimum(0);
-    drillDiameterSpinBox->setMaximum(100);
-    drillDiameterSpinBox->setSingleStep(0.2);
-    drillDiameterSpinBox->setDecimals(6);
-    drillDiameterSpinBox->setValue(mLastPad.getDrillDiameter()->toMm());
-    connect(drillDiameterSpinBox.get(),
-            static_cast<void (QDoubleSpinBox::*)(double)>(
-                &QDoubleSpinBox::valueChanged),
-            this,
-            &PackageEditorState_AddPads::drillDiameterSpinBoxValueChanged);
-    mContext.commandToolBar.addWidget(std::move(drillDiameterSpinBox));
+    std::unique_ptr<UnsignedLengthEdit> edtDrillDiameter(
+        new UnsignedLengthEdit());
+    edtDrillDiameter->setSingleStep(0.1);  // [mm]
+    edtDrillDiameter->setValue(mLastPad.getDrillDiameter());
+    connect(edtDrillDiameter.get(), &UnsignedLengthEdit::valueChanged, this,
+            &PackageEditorState_AddPads::drillDiameterEditValueChanged);
+    mContext.commandToolBar.addWidget(std::move(edtDrillDiameter));
   }
 
   Point pos =
@@ -322,31 +309,25 @@ void PackageEditorState_AddPads::shapeSelectorCurrentShapeChanged(
   }
 }
 
-void PackageEditorState_AddPads::widthSpinBoxValueChanged(
-    double value) noexcept {
-  Length width = Length::fromMm(value);
-  if (width <= 0) return;
-  mLastPad.setWidth(PositiveLength(width));
+void PackageEditorState_AddPads::widthEditValueChanged(
+    const PositiveLength& value) noexcept {
+  mLastPad.setWidth(value);
   if (mEditCmd) {
     mEditCmd->setWidth(mLastPad.getWidth(), true);
   }
 }
 
-void PackageEditorState_AddPads::heightSpinBoxValueChanged(
-    double value) noexcept {
-  Length height = Length::fromMm(value);
-  if (height <= 0) return;
-  mLastPad.setHeight(PositiveLength(height));
+void PackageEditorState_AddPads::heightEditValueChanged(
+    const PositiveLength& value) noexcept {
+  mLastPad.setHeight(value);
   if (mEditCmd) {
     mEditCmd->setHeight(mLastPad.getHeight(), true);
   }
 }
 
-void PackageEditorState_AddPads::drillDiameterSpinBoxValueChanged(
-    double value) noexcept {
-  Length diameter = Length::fromMm(value);
-  if (diameter < 0) return;
-  mLastPad.setDrillDiameter(UnsignedLength(diameter));
+void PackageEditorState_AddPads::drillDiameterEditValueChanged(
+    const UnsignedLength& value) noexcept {
+  mLastPad.setDrillDiameter(value);
   if (mEditCmd) {
     mEditCmd->setDrillDiameter(mLastPad.getDrillDiameter(), true);
   }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
@@ -89,9 +89,9 @@ private:  // Methods
   void boardSideSelectorCurrentSideChanged(
       FootprintPad::BoardSide side) noexcept;
   void shapeSelectorCurrentShapeChanged(FootprintPad::Shape shape) noexcept;
-  void widthSpinBoxValueChanged(double value) noexcept;
-  void heightSpinBoxValueChanged(double value) noexcept;
-  void drillDiameterSpinBoxValueChanged(double value) noexcept;
+  void widthEditValueChanged(const PositiveLength& value) noexcept;
+  void heightEditValueChanged(const PositiveLength& value) noexcept;
+  void drillDiameterEditValueChanged(const UnsignedLength& value) noexcept;
 
 private:  // Types / Data
   PadType                             mPadType;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -31,6 +31,7 @@
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/widgets/graphicslayercombobox.h>
+#include <librepcb/common/widgets/unsignedlengthedit.h>
 #include <librepcb/library/pkg/footprint.h>
 #include <librepcb/library/pkg/footprintgraphicsitem.h>
 
@@ -84,17 +85,12 @@ bool PackageEditorState_DrawCircle::entry() noexcept {
   mContext.commandToolBar.addWidget(std::move(layerComboBox));
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
-  std::unique_ptr<QDoubleSpinBox> lineWidthSpinBox(new QDoubleSpinBox());
-  lineWidthSpinBox->setMinimum(0);
-  lineWidthSpinBox->setMaximum(100);
-  lineWidthSpinBox->setSingleStep(0.1);
-  lineWidthSpinBox->setDecimals(6);
-  lineWidthSpinBox->setValue(mLastLineWidth->toMm());
-  connect(lineWidthSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &PackageEditorState_DrawCircle::lineWidthSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(lineWidthSpinBox));
+  std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
+  edtLineWidth->setSingleStep(0.1);  // [mm]
+  edtLineWidth->setValue(mLastLineWidth);
+  connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
+          &PackageEditorState_DrawCircle::lineWidthEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtLineWidth));
 
   std::unique_ptr<QCheckBox> fillCheckBox(new QCheckBox(tr("Fill")));
   fillCheckBox->setChecked(mLastFill);
@@ -240,9 +236,9 @@ void PackageEditorState_DrawCircle::layerComboBoxValueChanged(
   }
 }
 
-void PackageEditorState_DrawCircle::lineWidthSpinBoxValueChanged(
-    double value) noexcept {
-  mLastLineWidth = Length::fromMm(value);
+void PackageEditorState_DrawCircle::lineWidthEditValueChanged(
+    const UnsignedLength& value) noexcept {
+  mLastLineWidth = value;
   if (mEditCmd) {
     mEditCmd->setLineWidth(mLastLineWidth, true);
   }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -96,7 +96,7 @@ bool PackageEditorState_DrawCircle::entry() noexcept {
   fillCheckBox->setChecked(mLastFill);
   connect(fillCheckBox.get(), &QCheckBox::toggled, this,
           &PackageEditorState_DrawCircle::fillCheckBoxCheckedChanged);
-  mContext.commandToolBar.addWidget(std::move(fillCheckBox));
+  mContext.commandToolBar.addWidget(std::move(fillCheckBox), 10);
 
   std::unique_ptr<QCheckBox> grabAreaCheckBox(new QCheckBox(tr("Grab Area")));
   grabAreaCheckBox->setChecked(mLastGrabArea);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.h
@@ -82,7 +82,7 @@ private:  // Methods
   bool abortAddCircle() noexcept;
 
   void layerComboBoxValueChanged(const QString& layerName) noexcept;
-  void lineWidthSpinBoxValueChanged(double value) noexcept;
+  void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;
   void grabAreaCheckBoxCheckedChanged(bool checked) noexcept;
 

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -111,7 +111,7 @@ bool PackageEditorState_DrawPolygonBase::entry() noexcept {
     fillCheckBox->setChecked(mLastFill);
     connect(fillCheckBox.get(), &QCheckBox::toggled, this,
             &PackageEditorState_DrawPolygonBase::fillCheckBoxCheckedChanged);
-    mContext.commandToolBar.addWidget(std::move(fillCheckBox));
+    mContext.commandToolBar.addWidget(std::move(fillCheckBox), 10);
   }
 
   if (mMode != Mode::LINE) {

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -30,7 +30,9 @@
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/graphics/polygongraphicsitem.h>
+#include <librepcb/common/widgets/angleedit.h>
 #include <librepcb/common/widgets/graphicslayercombobox.h>
+#include <librepcb/common/widgets/unsignedlengthedit.h>
 #include <librepcb/library/pkg/footprint.h>
 #include <librepcb/library/pkg/footprintgraphicsitem.h>
 
@@ -87,33 +89,21 @@ bool PackageEditorState_DrawPolygonBase::entry() noexcept {
   mContext.commandToolBar.addWidget(std::move(layerComboBox));
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
-  std::unique_ptr<QDoubleSpinBox> lineWidthSpinBox(new QDoubleSpinBox());
-  lineWidthSpinBox->setMinimum(0);
-  lineWidthSpinBox->setMaximum(100);
-  lineWidthSpinBox->setSingleStep(0.1);
-  lineWidthSpinBox->setDecimals(6);
-  lineWidthSpinBox->setValue(mLastLineWidth->toMm());
-  connect(lineWidthSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this,
-          &PackageEditorState_DrawPolygonBase::lineWidthSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(lineWidthSpinBox));
+  std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
+  edtLineWidth->setValue(mLastLineWidth);
+  edtLineWidth->setSingleStep(0.1);  // [mm]
+  connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
+          &PackageEditorState_DrawPolygonBase::lineWidthEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtLineWidth));
 
   if (mMode != Mode::RECT) {
     mContext.commandToolBar.addLabel(tr("Angle:"), 10);
-    std::unique_ptr<QDoubleSpinBox> angleSpinBox(new QDoubleSpinBox());
-    angleSpinBox->setMinimum(-360);
-    angleSpinBox->setMaximum(360);
-    angleSpinBox->setSingleStep(30);
-    angleSpinBox->setDecimals(6);
-    angleSpinBox->setValue(mLastAngle.toDeg());
-    connect(angleSpinBox.get(),
-            static_cast<void (QDoubleSpinBox::*)(double)>(
-                &QDoubleSpinBox::valueChanged),
-            this,
-            &PackageEditorState_DrawPolygonBase::angleSpinBoxValueChanged);
-    mContext.commandToolBar.addWidget(std::move(angleSpinBox));
+    std::unique_ptr<AngleEdit> edtAngle(new AngleEdit());
+    edtAngle->setSingleStep(90.0);  // [°]
+    edtAngle->setValue(mLastAngle);
+    connect(edtAngle.get(), &AngleEdit::valueChanged, this,
+            &PackageEditorState_DrawPolygonBase::angleEditValueChanged);
+    mContext.commandToolBar.addWidget(std::move(edtAngle));
   }
 
   if (mMode != Mode::LINE) {
@@ -300,17 +290,17 @@ void PackageEditorState_DrawPolygonBase::layerComboBoxValueChanged(
   }
 }
 
-void PackageEditorState_DrawPolygonBase::lineWidthSpinBoxValueChanged(
-    double value) noexcept {
-  mLastLineWidth = Length::fromMm(value);
+void PackageEditorState_DrawPolygonBase::lineWidthEditValueChanged(
+    const UnsignedLength& value) noexcept {
+  mLastLineWidth = value;
   if (mEditCmd) {
     mEditCmd->setLineWidth(mLastLineWidth, true);
   }
 }
 
-void PackageEditorState_DrawPolygonBase::angleSpinBoxValueChanged(
-    double value) noexcept {
-  mLastAngle = Angle::fromDeg(value);
+void PackageEditorState_DrawPolygonBase::angleEditValueChanged(
+    const Angle& value) noexcept {
+  mLastAngle = value;
   if (mCurrentPolygon && mEditCmd) {
     Path path = mCurrentPolygon->getPath();
     if (path.getVertices().count() > 1) {

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.h
@@ -89,8 +89,8 @@ private:  // Methods
   bool updateCurrentPosition(const Point& pos) noexcept;
 
   void layerComboBoxValueChanged(const QString& layerName) noexcept;
-  void lineWidthSpinBoxValueChanged(double value) noexcept;
-  void angleSpinBoxValueChanged(double value) noexcept;
+  void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
+  void angleEditValueChanged(const Angle& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;
   void grabAreaCheckBoxCheckedChanged(bool checked) noexcept;
 

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -31,6 +31,7 @@
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/graphics/stroketextgraphicsitem.h>
 #include <librepcb/common/widgets/graphicslayercombobox.h>
+#include <librepcb/common/widgets/positivelengthedit.h>
 #include <librepcb/library/pkg/footprint.h>
 #include <librepcb/library/pkg/footprintgraphicsitem.h>
 
@@ -103,17 +104,12 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
   }
 
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
-  std::unique_ptr<QDoubleSpinBox> lineWidthSpinBox(new QDoubleSpinBox());
-  lineWidthSpinBox->setMinimum(0.1);
-  lineWidthSpinBox->setMaximum(100);
-  lineWidthSpinBox->setSingleStep(0.1);
-  lineWidthSpinBox->setDecimals(6);
-  lineWidthSpinBox->setValue(mLastHeight->toMm());
-  connect(lineWidthSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &PackageEditorState_DrawTextBase::heightSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(lineWidthSpinBox));
+  std::unique_ptr<PositiveLengthEdit> edtLineWidth(new PositiveLengthEdit());
+  edtLineWidth->setSingleStep(0.5);  // [mm]
+  edtLineWidth->setValue(mLastHeight);
+  connect(edtLineWidth.get(), &PositiveLengthEdit::valueChanged, this,
+          &PackageEditorState_DrawTextBase::heightEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtLineWidth));
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
@@ -280,9 +276,9 @@ void PackageEditorState_DrawTextBase::layerComboBoxValueChanged(
   }
 }
 
-void PackageEditorState_DrawTextBase::heightSpinBoxValueChanged(
-    double value) noexcept {
-  mLastHeight = Length::fromMm(value);
+void PackageEditorState_DrawTextBase::heightEditValueChanged(
+    const PositiveLength& value) noexcept {
+  mLastHeight = value;
   if (mEditCmd) {
     mEditCmd->setHeight(mLastHeight, true);
   }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
@@ -90,7 +90,7 @@ private:  // Methods
   void resetToDefaultParameters() noexcept;
 
   void layerComboBoxValueChanged(const QString& layerName) noexcept;
-  void heightSpinBoxValueChanged(double value) noexcept;
+  void heightEditValueChanged(const PositiveLength& value) noexcept;
   void textComboBoxValueChanged(const QString& value) noexcept;
 
 private:  // Types / Data

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -46,15 +46,17 @@ SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(SymbolPin& pin,
     mUndoStack(undoStack),
     mUi(new Ui::SymbolPinPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtLength->setSingleStep(2.54);    // [mm]
+  mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &SymbolPinPropertiesDialog::on_buttonBox_clicked);
 
   // load pin attributes
   mUi->edtName->setText(*mSymbolPin.getName());
-  mUi->spbPosX->setValue(mSymbolPin.getPosition().getX().toMm());
-  mUi->spbPosY->setValue(mSymbolPin.getPosition().getY().toMm());
-  mUi->spbRotation->setValue(mSymbolPin.getRotation().toDeg());
-  mUi->spbLength->setValue(mSymbolPin.getLength()->toMm());
+  mUi->edtPosX->setValue(mSymbolPin.getPosition().getX());
+  mUi->edtPosY->setValue(mSymbolPin.getPosition().getY());
+  mUi->edtRotation->setValue(mSymbolPin.getRotation());
+  mUi->edtLength->setValue(mSymbolPin.getLength());
 
   // preselect name
   mUi->edtName->selectAll();
@@ -91,11 +93,10 @@ bool SymbolPinPropertiesDialog::applyChanges() noexcept {
     CircuitIdentifier name(mUi->edtName->text().trimmed());  // can throw
     QScopedPointer<CmdSymbolPinEdit> cmd(new CmdSymbolPinEdit(mSymbolPin));
     cmd->setName(name, false);
-    cmd->setLength(UnsignedLength(Length::fromMm(mUi->spbLength->value())),
-                   false);  // can throw
-    cmd->setPosition(
-        Point::fromMm(mUi->spbPosX->value(), mUi->spbPosY->value()), false);
-    cmd->setRotation(Angle::fromDeg(mUi->spbRotation->value()), false);
+    cmd->setLength(mUi->edtLength->getValue(), false);
+    cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
+                     false);
+    cmd->setRotation(mUi->edtRotation->getValue(), false);
     mUndoStack.execCmd(cmd.take());
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>313</width>
-    <height>174</height>
+    <height>145</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,19 +37,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="spbLength">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>9999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>2.540000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
@@ -60,36 +47,10 @@
      <item row="2" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosX">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbPosY">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-9999.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>9999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
        </item>
       </layout>
      </item>
@@ -100,21 +61,11 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="1">
+      <widget class="librepcb::UnsignedLengthEdit" name="edtLength" native="true"/>
+     </item>
      <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="spbRotation">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>45.000000000000000</double>
-       </property>
-      </widget>
+      <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
      </item>
     </layout>
    </item>
@@ -130,6 +81,26 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::AngleEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/angleedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedlengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
@@ -26,6 +26,7 @@
 
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
+#include <librepcb/common/widgets/unsignedlengthedit.h>
 #include <librepcb/library/sym/cmd/cmdsymbolpinedit.h>
 #include <librepcb/library/sym/symbol.h>
 #include <librepcb/library/sym/symbolgraphicsitem.h>
@@ -79,17 +80,12 @@ bool SymbolEditorState_AddPins::entry() noexcept {
   mContext.commandToolBar.addWidget(std::move(nameLineEdit));
 
   mContext.commandToolBar.addLabel(tr("Length:"), 10);
-  std::unique_ptr<QDoubleSpinBox> lengthSpinBox(new QDoubleSpinBox());
-  lengthSpinBox->setMinimum(0);
-  lengthSpinBox->setMaximum(100);
-  lengthSpinBox->setSingleStep(1.27);
-  lengthSpinBox->setDecimals(6);
-  lengthSpinBox->setValue(mLastLength->toMm());
-  connect(lengthSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &SymbolEditorState_AddPins::lengthSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(lengthSpinBox));
+  std::unique_ptr<UnsignedLengthEdit> edtLength(new UnsignedLengthEdit());
+  edtLength->setSingleStep(2.54);  // [mm]
+  edtLength->setValue(mLastLength);
+  connect(edtLength.get(), &UnsignedLengthEdit::valueChanged, this,
+          &SymbolEditorState_AddPins::lengthEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtLength));
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
@@ -204,9 +200,9 @@ void SymbolEditorState_AddPins::nameLineEditTextChanged(
   }
 }
 
-void SymbolEditorState_AddPins::lengthSpinBoxValueChanged(
-    double value) noexcept {
-  mLastLength = Length::fromMm(value);
+void SymbolEditorState_AddPins::lengthEditValueChanged(
+    const UnsignedLength& value) noexcept {
+  mLastLength = value;
   if (mEditCmd) {
     mEditCmd->setLength(mLastLength, true);
   }

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.h
@@ -78,7 +78,7 @@ public:
 private:  // Methods
   bool    addNextPin(const Point& pos, const Angle& rot) noexcept;
   void    nameLineEditTextChanged(const QString& text) noexcept;
-  void    lengthSpinBoxValueChanged(double value) noexcept;
+  void    lengthEditValueChanged(const UnsignedLength& value) noexcept;
   QString determineNextPinName() const noexcept;
   bool    hasPin(const QString& name) const noexcept;
 

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -96,7 +96,7 @@ bool SymbolEditorState_DrawCircle::entry() noexcept {
   fillCheckBox->setChecked(mLastFill);
   connect(fillCheckBox.get(), &QCheckBox::toggled, this,
           &SymbolEditorState_DrawCircle::fillCheckBoxCheckedChanged);
-  mContext.commandToolBar.addWidget(std::move(fillCheckBox));
+  mContext.commandToolBar.addWidget(std::move(fillCheckBox), 10);
 
   std::unique_ptr<QCheckBox> grabAreaCheckBox(new QCheckBox(tr("Grab Area")));
   grabAreaCheckBox->setChecked(mLastGrabArea);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -31,6 +31,7 @@
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/widgets/graphicslayercombobox.h>
+#include <librepcb/common/widgets/unsignedlengthedit.h>
 #include <librepcb/library/sym/symbol.h>
 #include <librepcb/library/sym/symbolgraphicsitem.h>
 
@@ -84,17 +85,12 @@ bool SymbolEditorState_DrawCircle::entry() noexcept {
   mContext.commandToolBar.addWidget(std::move(layerComboBox));
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
-  std::unique_ptr<QDoubleSpinBox> lineWidthSpinBox(new QDoubleSpinBox());
-  lineWidthSpinBox->setMinimum(0);
-  lineWidthSpinBox->setMaximum(100);
-  lineWidthSpinBox->setSingleStep(0.1);
-  lineWidthSpinBox->setDecimals(6);
-  lineWidthSpinBox->setValue(mLastLineWidth->toMm());
-  connect(lineWidthSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &SymbolEditorState_DrawCircle::lineWidthSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(lineWidthSpinBox));
+  std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
+  edtLineWidth->setSingleStep(0.1);  // [mm]
+  edtLineWidth->setValue(mLastLineWidth);
+  connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
+          &SymbolEditorState_DrawCircle::lineWidthEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtLineWidth));
 
   std::unique_ptr<QCheckBox> fillCheckBox(new QCheckBox(tr("Fill")));
   fillCheckBox->setChecked(mLastFill);
@@ -239,9 +235,9 @@ void SymbolEditorState_DrawCircle::layerComboBoxValueChanged(
   }
 }
 
-void SymbolEditorState_DrawCircle::lineWidthSpinBoxValueChanged(
-    double value) noexcept {
-  mLastLineWidth = Length::fromMm(value);
+void SymbolEditorState_DrawCircle::lineWidthEditValueChanged(
+    const UnsignedLength& value) noexcept {
+  mLastLineWidth = value;
   if (mEditCmd) {
     mEditCmd->setLineWidth(mLastLineWidth, true);
   }

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.h
@@ -82,7 +82,7 @@ private:  // Methods
   bool abortAddCircle() noexcept;
 
   void layerComboBoxValueChanged(const QString& layerName) noexcept;
-  void lineWidthSpinBoxValueChanged(double value) noexcept;
+  void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;
   void grabAreaCheckBoxCheckedChanged(bool checked) noexcept;
 

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -111,7 +111,7 @@ bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
     fillCheckBox->setChecked(mLastFill);
     connect(fillCheckBox.get(), &QCheckBox::toggled, this,
             &SymbolEditorState_DrawPolygonBase::fillCheckBoxCheckedChanged);
-    mContext.commandToolBar.addWidget(std::move(fillCheckBox));
+    mContext.commandToolBar.addWidget(std::move(fillCheckBox), 10);
   }
 
   if (mMode != Mode::LINE) {

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.h
@@ -89,8 +89,8 @@ private:  // Methods
   bool updateCurrentPosition(const Point& pos) noexcept;
 
   void layerComboBoxValueChanged(const QString& layerName) noexcept;
-  void lineWidthSpinBoxValueChanged(double value) noexcept;
-  void angleSpinBoxValueChanged(double value) noexcept;
+  void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
+  void angleEditValueChanged(const Angle& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;
   void grabAreaCheckBoxCheckedChanged(bool checked) noexcept;
 

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -31,6 +31,7 @@
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/graphics/textgraphicsitem.h>
 #include <librepcb/common/widgets/graphicslayercombobox.h>
+#include <librepcb/common/widgets/positivelengthedit.h>
 #include <librepcb/library/sym/symbol.h>
 #include <librepcb/library/sym/symbolgraphicsitem.h>
 
@@ -104,17 +105,12 @@ bool SymbolEditorState_DrawTextBase::entry() noexcept {
   }
 
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
-  std::unique_ptr<QDoubleSpinBox> lineWidthSpinBox(new QDoubleSpinBox());
-  lineWidthSpinBox->setMinimum(0.1);
-  lineWidthSpinBox->setMaximum(100);
-  lineWidthSpinBox->setSingleStep(0.5);
-  lineWidthSpinBox->setDecimals(6);
-  lineWidthSpinBox->setValue(mLastHeight->toMm());
-  connect(lineWidthSpinBox.get(),
-          static_cast<void (QDoubleSpinBox::*)(double)>(
-              &QDoubleSpinBox::valueChanged),
-          this, &SymbolEditorState_DrawTextBase::heightSpinBoxValueChanged);
-  mContext.commandToolBar.addWidget(std::move(lineWidthSpinBox));
+  std::unique_ptr<PositiveLengthEdit> edtHeight(new PositiveLengthEdit());
+  edtHeight->setSingleStep(0.5);  // [mm]
+  edtHeight->setValue(mLastHeight);
+  connect(edtHeight.get(), &PositiveLengthEdit::valueChanged, this,
+          &SymbolEditorState_DrawTextBase::heightEditValueChanged);
+  mContext.commandToolBar.addWidget(std::move(edtHeight));
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
@@ -285,9 +281,9 @@ void SymbolEditorState_DrawTextBase::layerComboBoxValueChanged(
   }
 }
 
-void SymbolEditorState_DrawTextBase::heightSpinBoxValueChanged(
-    double value) noexcept {
-  mLastHeight = Length::fromMm(value);
+void SymbolEditorState_DrawTextBase::heightEditValueChanged(
+    const PositiveLength& value) noexcept {
+  mLastHeight = value;
   if (mEditCmd) {
     mEditCmd->setHeight(mLastHeight, true);
   }

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
@@ -92,7 +92,7 @@ private:  // Methods
   Alignment getAlignment() const noexcept;
 
   void layerComboBoxValueChanged(const QString& layerName) noexcept;
-  void heightSpinBoxValueChanged(double value) noexcept;
+  void heightEditValueChanged(const PositiveLength& value) noexcept;
   void textComboBoxValueChanged(const QString& value) noexcept;
 
 private:  // Types / Data

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.cpp
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.cpp
@@ -60,8 +60,8 @@ CmdDeviceInstanceEditAll::~CmdDeviceInstanceEditAll() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void CmdDeviceInstanceEditAll::setPosition(Point& pos,
-                                           bool   immediate) noexcept {
+void CmdDeviceInstanceEditAll::setPosition(const Point& pos,
+                                           bool         immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   translate(pos - mDevEditCmd->mNewPos, immediate);
 }

--- a/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.h
+++ b/libs/librepcb/project/boards/cmd/cmddeviceinstanceeditall.h
@@ -54,7 +54,7 @@ public:
   ~CmdDeviceInstanceEditAll() noexcept;
 
   // General Methods
-  void setPosition(Point& pos, bool immediate) noexcept;
+  void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
@@ -56,6 +56,8 @@ BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(Project&   project,
     mUi(new Ui::BoardPlanePropertiesDialog),
     mUndoStack(undoStack) {
   mUi->setupUi(this);
+  mUi->edtMinWidth->setSingleStep(0.1);      // [mm]
+  mUi->edtMinClearance->setSingleStep(0.1);  // [mm]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &BoardPlanePropertiesDialog::buttonBoxClicked);
 
@@ -79,8 +81,8 @@ BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(Project&   project,
       mUi->cbxLayer->findData(*mPlane.getLayerName()));
 
   // minimum width / clearance spinbox
-  mUi->spbMinWidth->setValue(mPlane.getMinWidth()->toMm());
-  mUi->spbMinClearance->setValue(mPlane.getMinClearance()->toMm());
+  mUi->edtMinWidth->setValue(mPlane.getMinWidth());
+  mUi->edtMinClearance->setValue(mPlane.getMinClearance());
 
   // connect style combobox
   mUi->cbxConnectStyle->addItem(tr("None"),
@@ -154,10 +156,8 @@ bool BoardPlanePropertiesDialog::applyChanges() noexcept {
     }
 
     // min width/clearance
-    cmd->setMinWidth(UnsignedLength(
-        Length::fromMm(mUi->spbMinWidth->value())));  // can throw
-    cmd->setMinClearance(UnsignedLength(
-        Length::fromMm(mUi->spbMinClearance->value())));  // can throw
+    cmd->setMinWidth(mUi->edtMinWidth->getValue());
+    cmd->setMinClearance(mUi->edtMinClearance->getValue());
 
     // connect style
     cmd->setConnectStyle(static_cast<BI_Plane::ConnectStyle>(

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
@@ -46,36 +46,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="spbMinWidth">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Min. Clearance:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="spbMinClearance">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
        </property>
       </widget>
      </item>
@@ -119,6 +93,12 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="1">
+      <widget class="librepcb::UnsignedLengthEdit" name="edtMinWidth" native="true"/>
+     </item>
+     <item row="3" column="1">
+      <widget class="librepcb::UnsignedLengthEdit" name="edtMinClearance" native="true"/>
+     </item>
     </layout>
    </item>
    <item>
@@ -148,6 +128,12 @@
    <class>librepcb::PathEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/common/widgets/patheditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/unsignedlengthedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
@@ -53,6 +53,8 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(Project&   project,
     mUi(new Ui::BoardViaPropertiesDialog),
     mUndoStack(undoStack) {
   mUi->setupUi(this);
+  mUi->edtSize->setSingleStep(0.1);           // [mm]
+  mUi->edtDrillDiameter->setSingleStep(0.1);  // [mm]
 
   // shape combobox
   mUi->cbxShape->addItem(tr("Round"), static_cast<int>(BI_Via::Shape::Round));
@@ -63,14 +65,14 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(Project&   project,
       mUi->cbxShape->findData(static_cast<int>(mVia.getShape())));
 
   // Position spinboxes
-  mUi->spbxPosX->setValue(mVia.getPosition().getX().toMm());
-  mUi->spbxPosY->setValue(mVia.getPosition().getY().toMm());
+  mUi->edtPosX->setValue(mVia.getPosition().getX());
+  mUi->edtPosY->setValue(mVia.getPosition().getY());
 
   // size spinbox
-  mUi->spbxSize->setValue(mVia.getSize()->toMm());
+  mUi->edtSize->setValue(mVia.getSize());
 
   // drill diameter spinbox
-  mUi->spbxDrillDiameter->setValue(mVia.getDrillDiameter()->toMm());
+  mUi->edtDrillDiameter->setValue(mVia.getDrillDiameter());
 
   // netsignal combobox
   mUi->lblNetSignal->setText(*mVia.getNetSignalOfNetSegment().getName());
@@ -114,14 +116,10 @@ bool BoardViaPropertiesDialog::applyChanges() noexcept {
     cmd->setShape(
         static_cast<BI_Via::Shape>(mUi->cbxShape->currentData().toInt()),
         false);
-    cmd->setPosition(Point(Length::fromMm(mUi->spbxPosX->value()),
-                           Length::fromMm(mUi->spbxPosY->value())),
+    cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
                      false);
-    cmd->setSize(PositiveLength(Length::fromMm(mUi->spbxSize->value())),
-                 false);  // can throw
-    cmd->setDrillDiameter(
-        PositiveLength(Length::fromMm(mUi->spbxDrillDiameter->value())),
-        false);  // can throw
+    cmd->setSize(mUi->edtSize->getValue(), false);
+    cmd->setDrillDiameter(mUi->edtDrillDiameter->getValue(), false);
     mUndoStack.execCmd(cmd.take());
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>346</width>
-    <height>197</height>
+    <height>168</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -50,72 +50,10 @@
      <item row="2" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QDoubleSpinBox" name="spbxPosX">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::UpDownArrows</enum>
-         </property>
-         <property name="suffix">
-          <string notr="true">mm</string>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-2000.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>2000.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
        </item>
        <item>
-        <widget class="QDoubleSpinBox" name="spbxPosY">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::UpDownArrows</enum>
-         </property>
-         <property name="suffix">
-          <string notr="true">mm</string>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-2000.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>2000.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>2.540000000000000</double>
-         </property>
-        </widget>
+        <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
        </item>
       </layout>
      </item>
@@ -126,19 +64,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="spbxSize">
-       <property name="suffix">
-        <string notr="true">mm</string>
-       </property>
-       <property name="minimum">
-        <double>0.010000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
@@ -146,18 +71,11 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="1">
+      <widget class="librepcb::PositiveLengthEdit" name="edtSize" native="true"/>
+     </item>
      <item row="4" column="1">
-      <widget class="QDoubleSpinBox" name="spbxDrillDiameter">
-       <property name="suffix">
-        <string notr="true">mm</string>
-       </property>
-       <property name="minimum">
-        <double>0.010000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
+      <widget class="librepcb::PositiveLengthEdit" name="edtDrillDiameter" native="true"/>
      </item>
     </layout>
    </item>
@@ -173,6 +91,20 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -58,6 +58,7 @@ DeviceInstancePropertiesDialog::DeviceInstancePropertiesDialog(
     mAttributes(mDevice.getComponentInstance().getAttributes()),
     mUi(new Ui::DeviceInstancePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &DeviceInstancePropertiesDialog::buttonBoxClicked);
   setWindowTitle(QString(tr("Properties of %1"))
@@ -93,9 +94,9 @@ DeviceInstancePropertiesDialog::DeviceInstancePropertiesDialog(
       mDevice.getLibFootprint().getDescriptions().value(localeOrder));
 
   // Device/Footprint Attributes
-  mUi->spbxPosX->setValue(mDevice.getPosition().getX().toMm());
-  mUi->spbxPosY->setValue(mDevice.getPosition().getY().toMm());
-  mUi->spbxRotation->setValue(mDevice.getRotation().toDeg());
+  mUi->edtPosX->setValue(mDevice.getPosition().getX());
+  mUi->edtPosY->setValue(mDevice.getPosition().getY());
+  mUi->edtRotation->setValue(mDevice.getRotation());
   mUi->cbxMirror->setChecked(mDevice.getIsMirrored());
 
   // set focus to component instance name
@@ -166,13 +167,11 @@ bool DeviceInstancePropertiesDialog::applyChanges() noexcept {
     transaction.append(cmdCmp.take());  // can throw
 
     // Device Instance
-    Point pos(Length::fromMm(mUi->spbxPosX->value()),
-              Length::fromMm(mUi->spbxPosY->value()));
-    Angle rotation = Angle::fromDeg(mUi->spbxRotation->value());
     QScopedPointer<CmdDeviceInstanceEditAll> cmdDev(
         new CmdDeviceInstanceEditAll(mDevice));
-    cmdDev->setPosition(pos, false);
-    cmdDev->setRotation(rotation, false);
+    cmdDev->setPosition(
+        Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()), false);
+    cmdDev->setRotation(mUi->edtRotation->getValue(), false);
     cmdDev->setMirrored(mUi->cbxMirror->isChecked(), false);  // can throw
     transaction.append(cmdDev.take());                        // can throw
 

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
@@ -38,40 +38,6 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QDoubleSpinBox" name="spbxPosX">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::UpDownArrows</enum>
-          </property>
-          <property name="suffix">
-           <string notr="true">mm</string>
-          </property>
-          <property name="decimals">
-           <number>6</number>
-          </property>
-          <property name="minimum">
-           <double>-2000.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>2000.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>2.540000000000000</double>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_7">
           <property name="text">
@@ -79,72 +45,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QDoubleSpinBox" name="spbxPosY">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="suffix">
-           <string notr="true">mm</string>
-          </property>
-          <property name="decimals">
-           <number>6</number>
-          </property>
-          <property name="minimum">
-           <double>-2000.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>2000.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>2.540000000000000</double>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_8">
           <property name="text">
            <string>Rotation:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="spbxRotation">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="suffix">
-           <string notr="true">°</string>
-          </property>
-          <property name="decimals">
-           <number>6</number>
-          </property>
-          <property name="minimum">
-           <double>-360.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>360.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>45.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -161,6 +65,15 @@
            <string/>
           </property>
          </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="librepcb::LengthEdit" name="edtPosY" native="true"/>
+        </item>
+        <item row="2" column="1">
+         <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
         </item>
        </layout>
       </widget>
@@ -363,6 +276,18 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::AngleEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/angleedit.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>librepcb::AttributeListEditorWidget</class>
    <extends>QWidget</extends>

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.h
@@ -35,6 +35,7 @@
 namespace librepcb {
 
 class CmdHoleEdit;
+class PositiveLengthEdit;
 
 namespace project {
 
@@ -69,7 +70,7 @@ private:
   bool       addHole(Board& board, const Point& pos) noexcept;
   void       updateHolePosition(const Point& pos) noexcept;
   bool       fixHole(const Point& pos) noexcept;
-  void       diameterSpinBoxValueChanged(double value) noexcept;
+  void       diameterEditValueChanged(const PositiveLength& value) noexcept;
   void       makeLayerVisible() noexcept;
 
   // State
@@ -79,8 +80,8 @@ private:
   PositiveLength              mCurrentDiameter;
 
   // Widgets for the command toolbar
-  QScopedPointer<QLabel>         mDiameterLabel;
-  QScopedPointer<QDoubleSpinBox> mDiameterSpinBox;
+  QScopedPointer<QLabel>             mDiameterLabel;
+  QScopedPointer<PositiveLengthEdit> mDiameterEdit;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.h
@@ -36,6 +36,7 @@ namespace librepcb {
 
 class GraphicsLayerComboBox;
 class CmdStrokeTextEdit;
+class PositiveLengthEdit;
 
 namespace project {
 
@@ -75,7 +76,7 @@ private:
   bool       fixText(const Point& pos) noexcept;
   void       layerComboBoxLayerChanged(const QString& layerName) noexcept;
   void       textComboBoxValueChanged(const QString& value) noexcept;
-  void       heightSpinBoxValueChanged(double value) noexcept;
+  void       heightEditValueChanged(const PositiveLength& value) noexcept;
   void       mirrorCheckBoxToggled(bool checked) noexcept;
   void       makeSelectedLayerVisible() noexcept;
 
@@ -95,7 +96,7 @@ private:
   QScopedPointer<QLabel>                mTextLabel;
   QScopedPointer<QComboBox>             mTextComboBox;
   QScopedPointer<QLabel>                mHeightLabel;
-  QScopedPointer<QDoubleSpinBox>        mHeightSpinBox;
+  QScopedPointer<PositiveLengthEdit>    mHeightEdit;
   QScopedPointer<QLabel>                mMirrorLabel;
   QScopedPointer<QCheckBox>             mMirrorCheckBox;
 };

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.h
@@ -33,6 +33,9 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class PositiveLengthEdit;
+
 namespace project {
 
 class Board;
@@ -69,7 +72,9 @@ private:
   bool       updateVia(Board& board, const Point& pos) noexcept;
   bool       fixVia(const Point& pos) noexcept;
   void       updateShapeActionsCheckedState() noexcept;
-  void       setNetSignal(NetSignal* netsignal) noexcept;
+  void       sizeEditValueChanged(const PositiveLength& value) noexcept;
+  void drillDiameterEditValueChanged(const PositiveLength& value) noexcept;
+  void setNetSignal(NetSignal* netsignal) noexcept;
 
   // General Attributes
   bool                            mUndoCmdActive;
@@ -84,9 +89,9 @@ private:
   QHash<int, QAction*> mShapeActions;
   QList<QAction*>      mActionSeparators;
   QLabel*              mSizeLabel;
-  QComboBox*           mSizeComboBox;
+  PositiveLengthEdit*  mSizeEdit;
   QLabel*              mDrillLabel;
-  QComboBox*           mDrillComboBox;
+  PositiveLengthEdit*  mDrillEdit;
   QLabel*              mNetSignalLabel;
   QComboBox*           mNetSignalComboBox;
 };

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.h
@@ -37,6 +37,7 @@ namespace librepcb {
 
 class CmdPolygonEdit;
 class GraphicsLayerComboBox;
+class UnsignedLengthEdit;
 
 namespace project {
 
@@ -76,7 +77,7 @@ private:  // Methods
   bool       abort(bool showErrMsgBox) noexcept;
   void       updateSegmentPosition(const Point& cursorPos) noexcept;
   void       layerComboBoxLayerChanged(const QString& layerName) noexcept;
-  void       widthComboBoxTextChanged(const QString& width) noexcept;
+  void       widthEditValueChanged(const UnsignedLength& value) noexcept;
   void       filledCheckBoxCheckedChanged(bool checked) noexcept;
   void       makeSelectedLayerVisible() noexcept;
 
@@ -102,7 +103,7 @@ private:  // Data
   QLabel*                mLayerLabel;
   GraphicsLayerComboBox* mLayerComboBox;
   QLabel*                mWidthLabel;
-  QComboBox*             mWidthComboBox;
+  UnsignedLengthEdit*    mWidthEdit;
   QLabel*                mFillLabel;
   QCheckBox*             mFillCheckBox;
 };

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
@@ -34,6 +34,7 @@
 namespace librepcb {
 
 class GraphicsLayer;
+class PositiveLengthEdit;
 
 namespace project {
 
@@ -116,7 +117,7 @@ private:
                           const QSet<BI_NetLine*>& except = {}) const noexcept;
   void        updateNetpointPositions(const Point& cursorPos) noexcept;
   void        layerComboBoxIndexChanged(int index) noexcept;
-  void        wireWidthComboBoxTextChanged(const QString& width) noexcept;
+  void        wireWidthEditValueChanged(const PositiveLength& value) noexcept;
   void        updateWireModeActionsCheckedState() noexcept;
   Point calcMiddlePointPos(const Point& p1, const Point p2, WireMode mode) const
       noexcept;
@@ -139,7 +140,7 @@ private:
   QLabel*                   mLayerLabel;
   QComboBox*                mLayerComboBox;
   QLabel*                   mWidthLabel;
-  QComboBox*                mWidthComboBox;
+  PositiveLengthEdit*       mWidthEdit;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -62,6 +62,7 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
     mAttributes(mComponentInstance.getAttributes()),
     mUi(new Ui::SymbolInstancePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtSymbInstRotation->setSingleStep(90.0);  // [°]
   setWindowTitle(QString(tr("Properties of %1")).arg(mSymbol.getName()));
 
   // Component Instance Attributes
@@ -96,9 +97,9 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
 
   // Symbol Instance Attributes
   mUi->lblSymbInstName->setText(mSymbol.getName());
-  mUi->spbxSymbInstPosX->setValue(mSymbol.getPosition().getX().toMm());
-  mUi->spbxSymbInstPosY->setValue(mSymbol.getPosition().getY().toMm());
-  mUi->spbxSymbInstAngle->setValue(mSymbol.getRotation().toDeg());
+  mUi->edtSymbInstPosX->setValue(mSymbol.getPosition().getX());
+  mUi->edtSymbInstPosY->setValue(mSymbol.getPosition().getY());
+  mUi->edtSymbInstRotation->setValue(mSymbol.getRotation());
   mUi->cbxMirror->setChecked(mSymbol.getMirrored());
 
   // Symbol Library Element Attributes
@@ -159,14 +160,13 @@ bool SymbolInstancePropertiesDialog::applyChanges() noexcept {
     transaction.append(cmdCmp.take());
 
     // Symbol Instance
-    Point pos(Length::fromMm(mUi->spbxSymbInstPosX->value()),
-              Length::fromMm(mUi->spbxSymbInstPosY->value()));
-    Angle rotation = Angle::fromDeg(mUi->spbxSymbInstAngle->value());
-    bool  mirrored = mUi->cbxMirror->isChecked();
+    bool mirrored = mUi->cbxMirror->isChecked();
     QScopedPointer<CmdSymbolInstanceEdit> cmdSym(
         new CmdSymbolInstanceEdit(mSymbol));
-    cmdSym->setPosition(pos, false);
-    cmdSym->setRotation(rotation, false);
+    cmdSym->setPosition(Point(mUi->edtSymbInstPosX->getValue(),
+                              mUi->edtSymbInstPosY->getValue()),
+                        false);
+    cmdSym->setRotation(mUi->edtSymbInstRotation->getValue(), false);
     cmdSym->setMirrored(mirrored, false);
     transaction.append(cmdSym.take());
 

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -58,40 +58,6 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QDoubleSpinBox" name="spbxSymbInstPosX">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::UpDownArrows</enum>
-          </property>
-          <property name="suffix">
-           <string notr="true">mm</string>
-          </property>
-          <property name="decimals">
-           <number>6</number>
-          </property>
-          <property name="minimum">
-           <double>-2000.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>2000.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>2.540000000000000</double>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_7">
           <property name="text">
@@ -99,72 +65,10 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="spbxSymbInstPosY">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="suffix">
-           <string notr="true">mm</string>
-          </property>
-          <property name="decimals">
-           <number>6</number>
-          </property>
-          <property name="minimum">
-           <double>-2000.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>2000.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>2.540000000000000</double>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="0">
          <widget class="QLabel" name="label_8">
           <property name="text">
            <string>Rotation:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QDoubleSpinBox" name="spbxSymbInstAngle">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="suffix">
-           <string notr="true">°</string>
-          </property>
-          <property name="decimals">
-           <number>6</number>
-          </property>
-          <property name="minimum">
-           <double>-360.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>360.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>45.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -181,6 +85,15 @@
            <string/>
           </property>
          </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="librepcb::LengthEdit" name="edtSymbInstPosX" native="true"/>
+        </item>
+        <item row="2" column="1">
+         <widget class="librepcb::LengthEdit" name="edtSymbInstPosY" native="true"/>
+        </item>
+        <item row="3" column="1">
+         <widget class="librepcb::AngleEdit" name="edtSymbInstRotation" native="true"/>
         </item>
        </layout>
       </widget>
@@ -383,6 +296,18 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>librepcb::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::AngleEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/angleedit.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>librepcb::AttributeListEditorWidget</class>
    <extends>QWidget</extends>


### PR DESCRIPTION
#519 added the `LengthEdit` and `AngleEdit` widgets, which simplify the handling of `Length` resp. `Angle` values in the GUI. Thus now I also added `UnsignedLengthEdit`, `PositiveLengthEdit`, `RatioEdit` and `UnsignedRatioEdit` and refactored a lot of GUI code to use these new widgets. Basically it's a code refactoring, but it also leads to small user experience improvements since the unit (e.g. `mm`, `%` or `°`) is now shown in most number input fields.