### PR TITLE
Stop using value assignment operator of type_safe::constrained_type

### DIFF
--- a/libs/librepcb/common/widgets/graphicslayercombobox.h
+++ b/libs/librepcb/common/widgets/graphicslayercombobox.h
@@ -23,6 +23,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../graphics/graphicslayername.h"
+
+#include <optional/tl/optional.hpp>
+
 #include <QtCore>
 #include <QtWidgets>
 
@@ -50,23 +54,23 @@ public:
   ~GraphicsLayerComboBox() noexcept;
 
   // Getters
-  QString getCurrentLayerName() const noexcept;
+  tl::optional<GraphicsLayerName> getCurrentLayerName() const noexcept;
 
   // Setters
   void setLayers(const QList<GraphicsLayer*>& layers) noexcept;
-  void setCurrentLayer(const QString& name) noexcept;
+  void setCurrentLayer(const GraphicsLayerName& name) noexcept;
 
   // Operator Overloadings
   GraphicsLayerComboBox& operator=(const GraphicsLayerComboBox& rhs) = delete;
 
 signals:
-  void currentLayerChanged(const QString& name);
+  void currentLayerChanged(const GraphicsLayerName& name);
 
 private:  // Methods
   void currentIndexChanged(int index) noexcept;
 
 private:  // Data
-  QComboBox* mComboBox;
+  QScopedPointer<QComboBox> mComboBox;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/eagleimport/packageconverter.cpp
+++ b/libs/librepcb/eagleimport/packageconverter.cpp
@@ -127,7 +127,7 @@ std::unique_ptr<library::Package> PackageConverter::generate() const {
     }
     PositiveLength height(Length::fromMm(text.getSize()));  // can throw
     if ((textStr == "{{NAME}}") || (textStr == "{{VALUE}}")) {
-      height = Length::fromMm(1);
+      height = PositiveLength(1000000);
     }
     Point     pos = Point::fromMm(text.getPosition().x, text.getPosition().y);
     Angle     rot = Angle::fromDeg(text.getRotation().getAngle());

--- a/libs/librepcb/eagleimport/symbolconverter.cpp
+++ b/libs/librepcb/eagleimport/symbolconverter.cpp
@@ -122,7 +122,7 @@ std::unique_ptr<library::Symbol> SymbolConverter::generate() const {
     }
     PositiveLength height(Length::fromMm(text.getSize()) * 2);  // can throw
     if ((textStr == "{{NAME}}") || (textStr == "{{VALUE}}")) {
-      height = Length::fromMm(2.54);
+      height = PositiveLength(2540000);
     }
     Point     pos = Point::fromMm(text.getPosition().x, text.getPosition().y);
     Angle     rot = Angle::fromDeg(text.getRotation().getAngle());

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -79,7 +79,7 @@ bool PackageEditorState_DrawCircle::entry() noexcept {
       new GraphicsLayerComboBox());
   layerComboBox->setLayers(
       mContext.layerProvider.getBoardGeometryElementLayers());
-  layerComboBox->setCurrentLayer(*mLastLayerName);
+  layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &PackageEditorState_DrawCircle::layerComboBoxValueChanged);
   mContext.commandToolBar.addWidget(std::move(layerComboBox));
@@ -226,10 +226,7 @@ bool PackageEditorState_DrawCircle::abortAddCircle() noexcept {
 }
 
 void PackageEditorState_DrawCircle::layerComboBoxValueChanged(
-    const QString& layerName) noexcept {
-  if (layerName.isEmpty()) {
-    return;
-  }
+    const GraphicsLayerName& layerName) noexcept {
   mLastLayerName = layerName;
   if (mEditCmd) {
     mEditCmd->setLayerName(mLastLayerName, true);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.h
@@ -81,7 +81,7 @@ private:  // Methods
   bool finishAddCircle(const Point& pos) noexcept;
   bool abortAddCircle() noexcept;
 
-  void layerComboBoxValueChanged(const QString& layerName) noexcept;
+  void layerComboBoxValueChanged(const GraphicsLayerName& layerName) noexcept;
   void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;
   void grabAreaCheckBoxCheckedChanged(bool checked) noexcept;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -83,7 +83,7 @@ bool PackageEditorState_DrawPolygonBase::entry() noexcept {
       new GraphicsLayerComboBox());
   layerComboBox->setLayers(
       mContext.layerProvider.getBoardGeometryElementLayers());
-  layerComboBox->setCurrentLayer(*mLastLayerName);
+  layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &PackageEditorState_DrawPolygonBase::layerComboBoxValueChanged);
   mContext.commandToolBar.addWidget(std::move(layerComboBox));
@@ -280,10 +280,7 @@ bool PackageEditorState_DrawPolygonBase::updateCurrentPosition(
 }
 
 void PackageEditorState_DrawPolygonBase::layerComboBoxValueChanged(
-    const QString& layerName) noexcept {
-  if (layerName.isEmpty()) {
-    return;
-  }
+    const GraphicsLayerName& layerName) noexcept {
   mLastLayerName = layerName;
   if (mEditCmd) {
     mEditCmd->setLayerName(mLastLayerName, true);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.h
@@ -88,7 +88,7 @@ private:  // Methods
   bool addNextSegment(const Point& pos) noexcept;
   bool updateCurrentPosition(const Point& pos) noexcept;
 
-  void layerComboBoxValueChanged(const QString& layerName) noexcept;
+  void layerComboBoxValueChanged(const GraphicsLayerName& layerName) noexcept;
   void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
   void angleEditValueChanged(const Angle& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -284,22 +284,22 @@ bool PackageEditorState_DrawTextBase::abortAddText() noexcept {
 void PackageEditorState_DrawTextBase::resetToDefaultParameters() noexcept {
   switch (mMode) {
     case Mode::NAME:
-      mLastLayerName   = GraphicsLayer::sTopNames;
-      mLastHeight      = Length(1000000);
+      mLastLayerName   = GraphicsLayerName(GraphicsLayer::sTopNames);
+      mLastHeight      = PositiveLength(1000000);
       mLastStrokeWidth = UnsignedLength(200000);
       mLastAlignment   = Alignment(HAlign::center(), VAlign::bottom());
       mLastText        = "{{NAME}}";
       break;
     case Mode::VALUE:
-      mLastLayerName   = GraphicsLayer::sTopValues;
-      mLastHeight      = Length(1000000);
+      mLastLayerName   = GraphicsLayerName(GraphicsLayer::sTopValues);
+      mLastHeight      = PositiveLength(1000000);
       mLastStrokeWidth = UnsignedLength(200000);
       mLastAlignment   = Alignment(HAlign::center(), VAlign::top());
       mLastText        = "{{VALUE}}";
       break;
     default:
-      mLastLayerName   = GraphicsLayer::sTopPlacement;
-      mLastHeight      = Length(2000000);
+      mLastLayerName   = GraphicsLayerName(GraphicsLayer::sTopPlacement);
+      mLastHeight      = PositiveLength(2000000);
       mLastStrokeWidth = UnsignedLength(200000);
       mLastAlignment   = Alignment(HAlign::left(), VAlign::bottom());
       mLastText        = "";

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -86,7 +86,7 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
         new GraphicsLayerComboBox());
     layerComboBox->setLayers(
         mContext.layerProvider.getBoardGeometryElementLayers());
-    layerComboBox->setCurrentLayer(*mLastLayerName);
+    layerComboBox->setCurrentLayer(mLastLayerName);
     connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
             this, &PackageEditorState_DrawTextBase::layerComboBoxValueChanged);
     mContext.commandToolBar.addWidget(std::move(layerComboBox));
@@ -308,10 +308,7 @@ void PackageEditorState_DrawTextBase::resetToDefaultParameters() noexcept {
 }
 
 void PackageEditorState_DrawTextBase::layerComboBoxValueChanged(
-    const QString& layerName) noexcept {
-  if (layerName.isEmpty()) {
-    return;
-  }
+    const GraphicsLayerName& layerName) noexcept {
   mLastLayerName = layerName;
   if (mEditCmd) {
     mEditCmd->setLayerName(mLastLayerName, true);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.h
@@ -90,7 +90,7 @@ private:  // Methods
   bool abortAddText() noexcept;
   void resetToDefaultParameters() noexcept;
 
-  void layerComboBoxValueChanged(const QString& layerName) noexcept;
+  void layerComboBoxValueChanged(const GraphicsLayerName& layerName) noexcept;
   void heightEditValueChanged(const PositiveLength& value) noexcept;
   void strokeWidthEditValueChanged(const UnsignedLength& value) noexcept;
   void textComboBoxValueChanged(const QString& value) noexcept;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -79,7 +79,7 @@ bool SymbolEditorState_DrawCircle::entry() noexcept {
       new GraphicsLayerComboBox());
   layerComboBox->setLayers(
       mContext.layerProvider.getSchematicGeometryElementLayers());
-  layerComboBox->setCurrentLayer(*mLastLayerName);
+  layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &SymbolEditorState_DrawCircle::layerComboBoxValueChanged);
   mContext.commandToolBar.addWidget(std::move(layerComboBox));
@@ -225,10 +225,7 @@ bool SymbolEditorState_DrawCircle::abortAddCircle() noexcept {
 }
 
 void SymbolEditorState_DrawCircle::layerComboBoxValueChanged(
-    const QString& layerName) noexcept {
-  if (layerName.isEmpty()) {
-    return;
-  }
+    const GraphicsLayerName& layerName) noexcept {
   mLastLayerName = layerName;
   if (mEditCmd) {
     mEditCmd->setLayerName(mLastLayerName, true);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.h
@@ -81,7 +81,7 @@ private:  // Methods
   bool finishAddCircle(const Point& pos) noexcept;
   bool abortAddCircle() noexcept;
 
-  void layerComboBoxValueChanged(const QString& layerName) noexcept;
+  void layerComboBoxValueChanged(const GraphicsLayerName& layerName) noexcept;
   void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;
   void grabAreaCheckBoxCheckedChanged(bool checked) noexcept;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -83,7 +83,7 @@ bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
       new GraphicsLayerComboBox());
   layerComboBox->setLayers(
       mContext.layerProvider.getSchematicGeometryElementLayers());
-  layerComboBox->setCurrentLayer(*mLastLayerName);
+  layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &SymbolEditorState_DrawPolygonBase::layerComboBoxValueChanged);
   mContext.commandToolBar.addWidget(std::move(layerComboBox));
@@ -279,10 +279,7 @@ bool SymbolEditorState_DrawPolygonBase::updateCurrentPosition(
 }
 
 void SymbolEditorState_DrawPolygonBase::layerComboBoxValueChanged(
-    const QString& layerName) noexcept {
-  if (layerName.isEmpty()) {
-    return;
-  }
+    const GraphicsLayerName& layerName) noexcept {
   mLastLayerName = layerName;
   if (mEditCmd) {
     mEditCmd->setLayerName(mLastLayerName, true);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.h
@@ -88,7 +88,7 @@ private:  // Methods
   bool addNextSegment(const Point& pos) noexcept;
   bool updateCurrentPosition(const Point& pos) noexcept;
 
-  void layerComboBoxValueChanged(const QString& layerName) noexcept;
+  void layerComboBoxValueChanged(const GraphicsLayerName& layerName) noexcept;
   void lineWidthEditValueChanged(const UnsignedLength& value) noexcept;
   void angleEditValueChanged(const Angle& value) noexcept;
   void fillCheckBoxCheckedChanged(bool checked) noexcept;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -245,18 +245,18 @@ bool SymbolEditorState_DrawTextBase::abortAddText() noexcept {
 void SymbolEditorState_DrawTextBase::resetToDefaultParameters() noexcept {
   switch (mMode) {
     case Mode::NAME:
-      mLastLayerName = GraphicsLayer::sSymbolNames;
-      mLastHeight    = Length(2540000);
+      mLastLayerName = GraphicsLayerName(GraphicsLayer::sSymbolNames);
+      mLastHeight    = PositiveLength(2540000);
       mLastText      = "{{NAME}}";
       break;
     case Mode::VALUE:
-      mLastLayerName = GraphicsLayer::sSymbolValues;
-      mLastHeight    = Length(2540000);
+      mLastLayerName = GraphicsLayerName(GraphicsLayer::sSymbolValues);
+      mLastHeight    = PositiveLength(2540000);
       mLastText      = "{{VALUE}}";
       break;
     default:
-      mLastLayerName = GraphicsLayer::sSymbolOutlines;
-      mLastHeight    = Length(2540000);
+      mLastLayerName = GraphicsLayerName(GraphicsLayer::sSymbolOutlines);
+      mLastHeight    = PositiveLength(2540000);
       mLastText      = "Text";
       break;
   }

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -80,7 +80,7 @@ bool SymbolEditorState_DrawTextBase::entry() noexcept {
         new GraphicsLayerComboBox());
     layerComboBox->setLayers(
         mContext.layerProvider.getSchematicGeometryElementLayers());
-    layerComboBox->setCurrentLayer(*mLastLayerName);
+    layerComboBox->setCurrentLayer(mLastLayerName);
     connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
             this, &SymbolEditorState_DrawTextBase::layerComboBoxValueChanged);
     mContext.commandToolBar.addWidget(std::move(layerComboBox));
@@ -271,10 +271,7 @@ Alignment SymbolEditorState_DrawTextBase::getAlignment() const noexcept {
 }
 
 void SymbolEditorState_DrawTextBase::layerComboBoxValueChanged(
-    const QString& layerName) noexcept {
-  if (layerName.isEmpty()) {
-    return;
-  }
+    const GraphicsLayerName& layerName) noexcept {
   mLastLayerName = layerName;
   if (mEditCmd) {
     mEditCmd->setLayerName(mLastLayerName, true);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.h
@@ -91,7 +91,7 @@ private:  // Methods
   void      resetToDefaultParameters() noexcept;
   Alignment getAlignment() const noexcept;
 
-  void layerComboBoxValueChanged(const QString& layerName) noexcept;
+  void layerComboBoxValueChanged(const GraphicsLayerName& layerName) noexcept;
   void heightEditValueChanged(const PositiveLength& value) noexcept;
   void textComboBoxValueChanged(const QString& value) noexcept;
 

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -198,7 +198,7 @@ Board::Board(Project&                                project,
     // try to open/create the board file
     if (create) {
       // set attributes
-      mName                = newName;
+      mName                = ElementName(newName);  // can throw
       mDefaultFontFileName = qApp->getDefaultStrokeFontName();
 
       // load default layer stack

--- a/libs/librepcb/project/schematics/schematic.cpp
+++ b/libs/librepcb/project/schematics/schematic.cpp
@@ -67,7 +67,7 @@ Schematic::Schematic(Project&                                project,
     // try to open/create the schematic file
     if (create) {
       // set attributes
-      mName = newName;
+      mName = ElementName(newName);  // can throw
 
       // load default grid properties
       mGridProperties.reset(new GridProperties());

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.cpp
@@ -112,7 +112,7 @@ bool BES_AddStrokeText::entry(BEE_Base* event) noexcept {
                                   ->getLayerStack()
                                   .getBoardGeometryElementLayers());
   }
-  mLayerComboBox->setCurrentLayer(*mCurrentLayerName);
+  mLayerComboBox->setCurrentLayer(mCurrentLayerName);
   mEditorUi.commandToolbar->addWidget(mLayerComboBox.data());
   connect(mLayerComboBox.data(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &BES_AddStrokeText::layerComboBoxLayerChanged);
@@ -275,7 +275,7 @@ BES_Base::ProcRetVal BES_AddStrokeText::processFlipEvent(
     mEditCmd->mirror(mText->getPosition(), orientation, true);
 
     // update toolbar widgets
-    mLayerComboBox->setCurrentLayer(*mText->getText().getLayerName());
+    mLayerComboBox->setCurrentLayer(mText->getText().getLayerName());
     mMirrorCheckBox->setChecked(mText->getText().getMirrored());
   }
 
@@ -345,7 +345,7 @@ bool BES_AddStrokeText::fixText(const Point& pos) noexcept {
 }
 
 void BES_AddStrokeText::layerComboBoxLayerChanged(
-    const QString& layerName) noexcept {
+    const GraphicsLayerName& layerName) noexcept {
   mCurrentLayerName = layerName;
   if (mEditCmd) {
     mEditCmd->setLayerName(mCurrentLayerName, true);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.h
@@ -74,11 +74,11 @@ private:
   bool       addText(Board& board, const Point& pos) noexcept;
   void       updateTextPosition(const Point& pos) noexcept;
   bool       fixText(const Point& pos) noexcept;
-  void       layerComboBoxLayerChanged(const QString& layerName) noexcept;
-  void       textComboBoxValueChanged(const QString& value) noexcept;
-  void       heightEditValueChanged(const PositiveLength& value) noexcept;
-  void       mirrorCheckBoxToggled(bool checked) noexcept;
-  void       makeSelectedLayerVisible() noexcept;
+  void layerComboBoxLayerChanged(const GraphicsLayerName& layerName) noexcept;
+  void textComboBoxValueChanged(const QString& value) noexcept;
+  void heightEditValueChanged(const PositiveLength& value) noexcept;
+  void mirrorCheckBoxToggled(bool checked) noexcept;
+  void makeSelectedLayerVisible() noexcept;
 
   // State
   bool                              mUndoCmdActive;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.cpp
@@ -140,7 +140,7 @@ bool BES_DrawPlane::entry(BEE_Base* event) noexcept {
     }
     mLayerComboBox->setLayers(layers);
   }
-  mLayerComboBox->setCurrentLayer(*mCurrentLayerName);
+  mLayerComboBox->setCurrentLayer(mCurrentLayerName);
   mEditorUi.commandToolbar->addWidget(mLayerComboBox);
   connect(mLayerComboBox, &GraphicsLayerComboBox::currentLayerChanged, this,
           &BES_DrawPlane::layerComboBoxLayerChanged);
@@ -363,7 +363,7 @@ void BES_DrawPlane::updateVertexPosition(const Point& cursorPos) noexcept {
 }
 
 void BES_DrawPlane::layerComboBoxLayerChanged(
-    const QString& layerName) noexcept {
+    const GraphicsLayerName& layerName) noexcept {
   mCurrentLayerName = layerName;
   if (mCmdEditCurrentPlane) {
     mCmdEditCurrentPlane->setLayerName(mCurrentLayerName, true);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawplane.h
@@ -76,7 +76,7 @@ private:  // Methods
   bool       addSegment(Board& board, const Point& pos) noexcept;
   bool       abort(bool showErrMsgBox) noexcept;
   void       updateVertexPosition(const Point& cursorPos) noexcept;
-  void       layerComboBoxLayerChanged(const QString& layerName) noexcept;
+  void layerComboBoxLayerChanged(const GraphicsLayerName& layerName) noexcept;
   // void widthComboBoxTextChanged(const QString& width) noexcept;
   // void filledCheckBoxCheckedChanged(bool checked) noexcept;
   void makeSelectedLayerVisible() noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
@@ -105,7 +105,7 @@ bool BES_DrawPolygon::entry(BEE_Base* event) noexcept {
     mLayerComboBox->setLayers(
         mEditor.getActiveBoard()->getLayerStack().getAllowedPolygonLayers());
   }
-  mLayerComboBox->setCurrentLayer(*mCurrentLayerName);
+  mLayerComboBox->setCurrentLayer(mCurrentLayerName);
   mEditorUi.commandToolbar->addWidget(mLayerComboBox);
   connect(mLayerComboBox, &GraphicsLayerComboBox::currentLayerChanged, this,
           &BES_DrawPolygon::layerComboBoxLayerChanged);
@@ -359,7 +359,7 @@ void BES_DrawPolygon::updateSegmentPosition(const Point& cursorPos) noexcept {
 }
 
 void BES_DrawPolygon::layerComboBoxLayerChanged(
-    const QString& layerName) noexcept {
+    const GraphicsLayerName& layerName) noexcept {
   mCurrentLayerName = layerName;
   if (mCmdEditCurrentPolygon) {
     mCmdEditCurrentPolygon->setLayerName(mCurrentLayerName, true);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.h
@@ -76,10 +76,10 @@ private:  // Methods
   bool       addSegment(Board& board, const Point& pos) noexcept;
   bool       abort(bool showErrMsgBox) noexcept;
   void       updateSegmentPosition(const Point& cursorPos) noexcept;
-  void       layerComboBoxLayerChanged(const QString& layerName) noexcept;
-  void       widthEditValueChanged(const UnsignedLength& value) noexcept;
-  void       filledCheckBoxCheckedChanged(bool checked) noexcept;
-  void       makeSelectedLayerVisible() noexcept;
+  void layerComboBoxLayerChanged(const GraphicsLayerName& layerName) noexcept;
+  void widthEditValueChanged(const UnsignedLength& value) noexcept;
+  void filledCheckBoxCheckedChanged(bool checked) noexcept;
+  void makeSelectedLayerVisible() noexcept;
 
 private:  // Types
   /// Internal FSM States (substates)


### PR DESCRIPTION
At some locations, the assignment operator of `type_safe::constrained_type` which implicitly converts a value to the corresponding constrained type is used. For example the member `mLastLayerName`:

```cpp
void PackageEditorState_DrawTextBase::layerComboBoxValueChanged(
    const QString& layerName) noexcept {
  mLastLayerName = layerName;  // <-- this can throw!
  if (mEditCmd) {
    mEditCmd->setLayerName(mLastLayerName, true);
  }
}
```

IMHO an assignment operator should not throw exceptions because it's not obvious when looking at the code. Thus I made a patch to the `constrained_type` class which removes the value assignment operator (to get compile errors if used) and fixed all compile errors, e.g. by making the casts explicit.