### PR TITLE
Library editor: Adjust default values of sym/pkg elements

### DIFF
--- a/libs/librepcb/eagleimport/symbolconverter.cpp
+++ b/libs/librepcb/eagleimport/symbolconverter.cpp
@@ -122,7 +122,7 @@ std::unique_ptr<library::Symbol> SymbolConverter::generate() const {
     }
     PositiveLength height(Length::fromMm(text.getSize()) * 2);  // can throw
     if ((textStr == "{{NAME}}") || (textStr == "{{VALUE}}")) {
-      height = PositiveLength(2540000);
+      height = PositiveLength(2500000);
     }
     Point     pos = Point::fromMm(text.getPosition().x, text.getPosition().y);
     Angle     rot = Angle::fromDeg(text.getRotation().getAngle());

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
@@ -52,7 +52,8 @@ PackageEditorState_AddHoles::PackageEditorState_AddHoles(
   : PackageEditorState(context),
     mCurrentHole(nullptr),
     mCurrentGraphicsItem(nullptr),
-    mLastDiameter(1000000) {
+    mLastDiameter(1000000)  // Commonly used drill diameter
+{
 }
 
 PackageEditorState_AddHoles::~PackageEditorState_AddHoles() noexcept {

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
@@ -57,16 +57,19 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(Context& context,
     mCurrentPad(nullptr),
     mCurrentGraphicsItem(nullptr),
     mPackagePadComboBox(nullptr),
-    mLastPad(Uuid::createRandom(), Point(0, 0), Angle::deg0(),
-             FootprintPad::Shape::ROUND, PositiveLength(2540000),
-             PositiveLength(1270000), UnsignedLength(800000),
-             FootprintPad::BoardSide::THT) {
+    mLastPad(
+        Uuid::createRandom(), Point(0, 0), Angle::deg0(),
+        FootprintPad::Shape::ROUND,  // Commonly used pad shape
+        PositiveLength(2500000),     // There is no default/recommended pad size
+        PositiveLength(1300000),     // -> choose reasonable multiple of 0.1mm
+        UnsignedLength(800000),      // Commonly used drill diameter
+        FootprintPad::BoardSide::THT) {
   if (mPadType == PadType::SMT) {
-    mLastPad.setBoardSide(FootprintPad::BoardSide::TOP);
-    mLastPad.setShape(FootprintPad::Shape::RECT);
-    mLastPad.setDrillDiameter(UnsignedLength(0));
-    mLastPad.setWidth(PositiveLength(1270000));
-    mLastPad.setHeight(PositiveLength(635000));
+    mLastPad.setBoardSide(FootprintPad::BoardSide::TOP);  // Default side
+    mLastPad.setShape(FootprintPad::Shape::RECT);  // Commonly used SMT shape
+    mLastPad.setDrillDiameter(UnsignedLength(0));  // Disable drill
+    mLastPad.setWidth(PositiveLength(1500000));    // Same as for THT pads ->
+    mLastPad.setHeight(PositiveLength(700000));  // reasonable multiple of 0.1mm
   }
 }
 

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -53,10 +53,11 @@ PackageEditorState_DrawCircle::PackageEditorState_DrawCircle(
   : PackageEditorState(context),
     mCurrentCircle(nullptr),
     mCurrentGraphicsItem(nullptr),
-    mLastLayerName(GraphicsLayer::sTopPlacement),
-    mLastLineWidth(254000),
-    mLastFill(false),
-    mLastGrabArea(true) {
+    mLastLayerName(GraphicsLayer::sTopPlacement),  // Most important layer
+    mLastLineWidth(200000),  // typical width according library conventions
+    mLastFill(false),        // Fill is needed very rarely
+    mLastGrabArea(false)     // Avoid creating annoying grab areas "by accident"
+{
 }
 
 PackageEditorState_DrawCircle::~PackageEditorState_DrawCircle() noexcept {

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -55,11 +55,12 @@ PackageEditorState_DrawPolygonBase::PackageEditorState_DrawPolygonBase(
     mMode(mode),
     mCurrentPolygon(nullptr),
     mCurrentGraphicsItem(nullptr),
-    mLastLayerName(GraphicsLayer::sTopPlacement),
-    mLastLineWidth(200000),
+    mLastLayerName(GraphicsLayer::sTopPlacement),  // Most important layer
+    mLastLineWidth(200000),  // Typical width according library conventions
     mLastAngle(0),
-    mLastFill(false),
-    mLastGrabArea(mode != Mode::LINE) {
+    mLastFill(false),     // Fill is needed very rarely
+    mLastGrabArea(false)  // Avoid creating annoying grab areas "by accident"
+{
 }
 
 PackageEditorState_DrawPolygonBase::

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -284,6 +284,7 @@ bool PackageEditorState_DrawTextBase::abortAddText() noexcept {
 void PackageEditorState_DrawTextBase::resetToDefaultParameters() noexcept {
   switch (mMode) {
     case Mode::NAME:
+      // Set all properties according library conventions
       mLastLayerName   = GraphicsLayerName(GraphicsLayer::sTopNames);
       mLastHeight      = PositiveLength(1000000);
       mLastStrokeWidth = UnsignedLength(200000);
@@ -291,6 +292,7 @@ void PackageEditorState_DrawTextBase::resetToDefaultParameters() noexcept {
       mLastText        = "{{NAME}}";
       break;
     case Mode::VALUE:
+      // Set all properties according library conventions
       mLastLayerName   = GraphicsLayerName(GraphicsLayer::sTopValues);
       mLastHeight      = PositiveLength(1000000);
       mLastStrokeWidth = UnsignedLength(200000);
@@ -298,11 +300,12 @@ void PackageEditorState_DrawTextBase::resetToDefaultParameters() noexcept {
       mLastText        = "{{VALUE}}";
       break;
     default:
+      // Set properties to something reasonable
       mLastLayerName   = GraphicsLayerName(GraphicsLayer::sTopPlacement);
       mLastHeight      = PositiveLength(2000000);
       mLastStrokeWidth = UnsignedLength(200000);
       mLastAlignment   = Alignment(HAlign::left(), VAlign::bottom());
-      mLastText        = "";
+      mLastText        = "Text";  // Non-empty to avoid invisible graphics item
       break;
   }
 }

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
@@ -52,7 +52,8 @@ SymbolEditorState_AddPins::SymbolEditorState_AddPins(
     mCurrentPin(nullptr),
     mCurrentGraphicsItem(nullptr),
     mNameLineEdit(nullptr),
-    mLastLength(2540000) {
+    mLastLength(2540000)  // Default length according library conventions
+{
 }
 
 SymbolEditorState_AddPins::~SymbolEditorState_AddPins() noexcept {

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -53,10 +53,11 @@ SymbolEditorState_DrawCircle::SymbolEditorState_DrawCircle(
   : SymbolEditorState(context),
     mCurrentCircle(nullptr),
     mCurrentGraphicsItem(nullptr),
-    mLastLayerName(GraphicsLayer::sSymbolOutlines),
-    mLastLineWidth(254000),
-    mLastFill(false),
-    mLastGrabArea(true) {
+    mLastLayerName(GraphicsLayer::sSymbolOutlines),  // Most important layer
+    mLastLineWidth(200000),  // Typical width according library conventions
+    mLastFill(false),        // Fill is needed very rarely
+    mLastGrabArea(true)      // Most symbol outlines are used as grab areas
+{
 }
 
 SymbolEditorState_DrawCircle::~SymbolEditorState_DrawCircle() noexcept {

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -55,11 +55,12 @@ SymbolEditorState_DrawPolygonBase::SymbolEditorState_DrawPolygonBase(
     mMode(mode),
     mCurrentPolygon(nullptr),
     mCurrentGraphicsItem(nullptr),
-    mLastLayerName(GraphicsLayer::sSymbolOutlines),
-    mLastLineWidth(254000),
+    mLastLayerName(GraphicsLayer::sSymbolOutlines),  // Most important layer
+    mLastLineWidth(200000),  // Typical width according library conventions
     mLastAngle(0),
-    mLastFill(false),
-    mLastGrabArea(mode != Mode::LINE) {
+    mLastFill(false),                  // Fill is needed very rarely
+    mLastGrabArea(mode != Mode::LINE)  // Most symbol outlines are grab areas
+{
 }
 
 SymbolEditorState_DrawPolygonBase::

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -245,19 +245,22 @@ bool SymbolEditorState_DrawTextBase::abortAddText() noexcept {
 void SymbolEditorState_DrawTextBase::resetToDefaultParameters() noexcept {
   switch (mMode) {
     case Mode::NAME:
+      // Set all properties according library conventions
       mLastLayerName = GraphicsLayerName(GraphicsLayer::sSymbolNames);
-      mLastHeight    = PositiveLength(2540000);
+      mLastHeight    = PositiveLength(2500000);
       mLastText      = "{{NAME}}";
       break;
     case Mode::VALUE:
+      // Set all properties according library conventions
       mLastLayerName = GraphicsLayerName(GraphicsLayer::sSymbolValues);
-      mLastHeight    = PositiveLength(2540000);
+      mLastHeight    = PositiveLength(2500000);
       mLastText      = "{{VALUE}}";
       break;
     default:
+      // Set properties to something reasonable
       mLastLayerName = GraphicsLayerName(GraphicsLayer::sSymbolOutlines);
-      mLastHeight    = PositiveLength(2540000);
-      mLastText      = "Text";
+      mLastHeight    = PositiveLength(2500000);
+      mLastText      = "Text";  // Non-empty to avoid invisible graphics item
       break;
   }
 }


### PR DESCRIPTION
When creating symbols or packages, some properties were initialized with default values which aren't reasonable IMHO. Thus I reviewed and documented (in code) all default values and adjusted some of them.

To comply with our [library conventions](https://docs.librepcb.org/#libraryconventions):
- Footprint circle line width changed from 0.254mm to 0.2mm

To avoid unnecessary grab areas "by accident":
- Footprint circle/polygon grab area disabled

To avoid inch-based numbers with many decimal places where metric numbers could be used instead (most spinboxes have an interval of 0.1mm, thus it's more reasonable to use default numbers which are a multiple of 0.1mm):
- Footprint THT pad size changed from 1.27mm x 0.635mm to 1.5mm x 0.7mm
- Footprint SMT pad size changed from 2.54mm x 1.27mm to 2.5mm x 1.3mm
- Symbol text height changed from 2.54mm to 2.5mm
- Symbol circle/polygon line width changed from 0.254mm to 0.2mm

The latter change is actually the one with the most impact; it would require to adjust all already existing symbols to use an outline width of 0.2mm instead of 0.254mm. Actually the symbol outline width is not documented yet in our library conventions, but I would now recommend to use 0.2mm. Same for text height, I would recommend 2.5mm instead of 2.54mm. Or what do you think @dbrgn?