### PR TITLE
Initialize *.lppz export filename with default value

### DIFF
--- a/libs/librepcb/projecteditor/projecteditor.cpp
+++ b/libs/librepcb/projecteditor/projecteditor.cpp
@@ -170,9 +170,10 @@ void ProjectEditor::execNetClassesEditorDialog(QWidget* parent) noexcept {
 
 void ProjectEditor::execLppzExportDialog(QWidget* parent) noexcept {
   try {
-    QString filename =
-        FileDialog::getSaveFileName(parent, tr("Export project to *.lppz"),
-                                    mProject.getPath().toStr(), "*.lppz");
+    FilePath defaultFp = mProject.getPath().getPathTo(
+        mProject.getFilepath().getBasename() % ".lppz");
+    QString filename = FileDialog::getSaveFileName(
+        parent, tr("Export project to *.lppz"), defaultFp.toStr(), "*.lppz");
     if (filename.isEmpty()) return;
     if (!filename.endsWith(".lppz")) filename.append(".lppz");
     FilePath fp(filename);


### PR DESCRIPTION
In the "Export project to *.lppz" dialog the filename was initialized with an empty string, so the user had to manually specify the filename. Now the filename gets initialized with the project's filename, e.g. "my-project.lppz" if the project is named "my-project.lpp".