### PR TITLE
Schematic editor: Fix device when adding component multiple times

### DIFF
--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
@@ -304,10 +304,13 @@ SES_Base::ProcRetVal SES_AddComponent::processSceneEvent(
                   mCurrentComponent->getLibComponent().getUuid();
               Uuid symbVarUuid =
                   mCurrentComponent->getSymbolVariant().getUuid();
+              tl::optional<Uuid> defaultDeviceUuid =
+                  mCurrentComponent->getDefaultDeviceUuid();
               mUndoStack.commitCmdGroup();
               mIsUndoCmdActive = false;
               abortCommand(false);  // reset attributes
-              startAddingComponent(componentUuid, symbVarUuid, true);
+              startAddingComponent(componentUuid, symbVarUuid,
+                                   defaultDeviceUuid, true);
               return ForceStayInState;
             }
           } catch (Exception& e) {
@@ -365,6 +368,7 @@ SES_Base::ProcRetVal SES_AddComponent::processSceneEvent(
 
 void SES_AddComponent::startAddingComponent(const tl::optional<Uuid>& cmp,
                                             const tl::optional<Uuid>& symbVar,
+                                            const tl::optional<Uuid>& dev,
                                             bool keepValue) {
   Schematic* schematic = mEditor.getActiveSchematic();
   Q_ASSERT(schematic);
@@ -378,8 +382,8 @@ void SES_AddComponent::startAddingComponent(const tl::optional<Uuid>& cmp,
 
     if (cmp && symbVar) {
       // add selected component to circuit
-      auto* cmd =
-          new CmdAddComponentToCircuit(mWorkspace, mProject, *cmp, *symbVar);
+      auto* cmd = new CmdAddComponentToCircuit(mWorkspace, mProject, *cmp,
+                                               *symbVar, dev);
       mUndoStack.appendToCmdGroup(cmd);
       mCurrentComponent = cmd->getComponentInstance();
     } else {

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.h
@@ -81,6 +81,7 @@ private:
   ProcRetVal processSceneEvent(SEE_Base* event) noexcept;
   void       startAddingComponent(const tl::optional<Uuid>& cmp = tl::nullopt,
                                   const tl::optional<Uuid>& symbVar = tl::nullopt,
+                                  const tl::optional<Uuid>& dev = tl::nullopt,
                                   bool                      keepValue = false);
   bool       abortCommand(bool showErrMsgBox) noexcept;
   std::shared_ptr<const Attribute> getToolbarAttribute() const noexcept;


### PR DESCRIPTION
When adding a component with a pre-selected device multiple times to a schematic, the device was set only on the first component placed. All successive components didn't have a device selected.

Fixes #547