### PR TITLE
LibraryEditor: Fix missing message box when closing tab

### DIFF
--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -564,6 +564,15 @@ bool LibraryEditor::closeTab(int index) noexcept {
     return false;
   }
 
+  // Move focus out of the editor widget to enforce updating the "dirty" state
+  // of the editor before closing it. This is needed to make sure the
+  // "save changes?" message box appears if the user just edited some property
+  // of the library element and the focus is still in the property editor
+  // widget. See https://github.com/LibrePCB/LibrePCB/issues/492.
+  if (QWidget* focus = focusWidget()) {
+    focus->clearFocus();
+  }
+
   // Handle closing
   if (widget == mCurrentEditorWidget) {
     setActiveEditorWidget(nullptr);


### PR DESCRIPTION
When closing a tab in the library editor while some property (like name,
description, ...) was just modified, the "save changes?" message box did
not appear. Now the focus is explicitly moved out from the editor widget
to ensure the "dirty" state of editors gets updated when closing a tab.

Fixes #492.