### PR TITLE
Schematic editor: Allow changing pre-selected device of components

### DIFF
--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.cpp
@@ -47,7 +47,9 @@ CmdComponentInstanceEdit::CmdComponentInstanceEdit(
     mOldValue(cmp.getValue()),
     mNewValue(mOldValue),
     mOldAttributes(cmp.getAttributes()),
-    mNewAttributes(mOldAttributes) {
+    mNewAttributes(mOldAttributes),
+    mOldDefaultDeviceUuid(cmp.getDefaultDeviceUuid()),
+    mNewDefaultDeviceUuid(mOldDefaultDeviceUuid) {
 }
 
 CmdComponentInstanceEdit::~CmdComponentInstanceEdit() noexcept {
@@ -73,6 +75,12 @@ void CmdComponentInstanceEdit::setAttributes(
   mNewAttributes = attributes;
 }
 
+void CmdComponentInstanceEdit::setDefaultDeviceUuid(
+    const tl::optional<Uuid>& device) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewDefaultDeviceUuid = device;
+}
+
 /*******************************************************************************
  *  Inherited from UndoCommand
  ******************************************************************************/
@@ -83,6 +91,7 @@ bool CmdComponentInstanceEdit::performExecute() {
   if (mNewName != mOldName) return true;
   if (mNewValue != mOldValue) return true;
   if (mNewAttributes != mOldAttributes) return true;
+  if (mNewDefaultDeviceUuid != mOldDefaultDeviceUuid) return true;
   return false;
 }
 
@@ -90,12 +99,14 @@ void CmdComponentInstanceEdit::performUndo() {
   mCircuit.setComponentInstanceName(mComponentInstance, mOldName);  // can throw
   mComponentInstance.setValue(mOldValue);
   mComponentInstance.setAttributes(mOldAttributes);
+  mComponentInstance.setDefaultDeviceUuid(mOldDefaultDeviceUuid);
 }
 
 void CmdComponentInstanceEdit::performRedo() {
   mCircuit.setComponentInstanceName(mComponentInstance, mNewName);  // can throw
   mComponentInstance.setValue(mNewValue);
   mComponentInstance.setAttributes(mNewAttributes);
+  mComponentInstance.setDefaultDeviceUuid(mNewDefaultDeviceUuid);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.h
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceedit.h
@@ -61,6 +61,7 @@ public:
   void setName(const CircuitIdentifier& name) noexcept;
   void setValue(const QString& value) noexcept;
   void setAttributes(const AttributeList& attributes) noexcept;
+  void setDefaultDeviceUuid(const tl::optional<Uuid>& device) noexcept;
 
 private:
   // Private Methods
@@ -81,12 +82,14 @@ private:
   ComponentInstance& mComponentInstance;
 
   // Misc
-  CircuitIdentifier mOldName;
-  CircuitIdentifier mNewName;
-  QString           mOldValue;
-  QString           mNewValue;
-  AttributeList     mOldAttributes;
-  AttributeList     mNewAttributes;
+  CircuitIdentifier  mOldName;
+  CircuitIdentifier  mNewName;
+  QString            mOldValue;
+  QString            mNewValue;
+  AttributeList      mOldAttributes;
+  AttributeList      mNewAttributes;
+  tl::optional<Uuid> mOldDefaultDeviceUuid;
+  tl::optional<Uuid> mNewDefaultDeviceUuid;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/project/circuit/componentinstance.cpp
@@ -243,6 +243,14 @@ void ComponentInstance::setAttributes(
   }
 }
 
+void ComponentInstance::setDefaultDeviceUuid(
+    const tl::optional<Uuid>& device) noexcept {
+  if (device != mDefaultDeviceUuid) {
+    mDefaultDeviceUuid = device;
+    emit attributesChanged();
+  }
+}
+
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/

--- a/libs/librepcb/project/circuit/componentinstance.h
+++ b/libs/librepcb/project/circuit/componentinstance.h
@@ -136,6 +136,15 @@ public:
 
   void setAttributes(const AttributeList& attributes) noexcept;
 
+  /**
+   * @brief Set the default device of the component
+   *
+   * @param device  The new device UUID
+   *
+   * @undocmd{#librepcb#project#CmdComponentInstanceEdit}
+   */
+  void setDefaultDeviceUuid(const tl::optional<Uuid>& device) noexcept;
+
   // General Methods
   void addToCircuit();
   void removeFromCircuit();

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
@@ -459,8 +459,9 @@ bool SES_Select::removeSelectedItems() noexcept {
 }
 
 void SES_Select::openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept {
-  SymbolInstancePropertiesDialog dialog(mProject, symbol.getComponentInstance(),
-                                        symbol, mUndoStack, &mEditor);
+  SymbolInstancePropertiesDialog dialog(mWorkspace, mProject,
+                                        symbol.getComponentInstance(), symbol,
+                                        mUndoStack, &mEditor);
   dialog.exec();
 }
 

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.h
@@ -36,6 +36,10 @@ namespace librepcb {
 class UndoStack;
 class UndoCommand;
 
+namespace workspace {
+class Workspace;
+}
+
 namespace project {
 
 class Project;
@@ -63,9 +67,10 @@ public:
   SymbolInstancePropertiesDialog() = delete;
   SymbolInstancePropertiesDialog(const SymbolInstancePropertiesDialog& other) =
       delete;
-  SymbolInstancePropertiesDialog(Project& project, ComponentInstance& cmp,
-                                 SI_Symbol& symbol, UndoStack& undoStack,
-                                 QWidget* parent) noexcept;
+  SymbolInstancePropertiesDialog(workspace::Workspace& ws, Project& project,
+                                 ComponentInstance& cmp, SI_Symbol& symbol,
+                                 UndoStack& undoStack,
+                                 QWidget*   parent) noexcept;
   ~SymbolInstancePropertiesDialog() noexcept;
 
   // Operator Overloadings
@@ -78,6 +83,7 @@ private:  // Methods
   bool applyChanges() noexcept;
 
 private:  // Data
+  workspace::Workspace&                              mWorkspace;
   Project&                                           mProject;
   ComponentInstance&                                 mComponentInstance;
   SI_Symbol&                                         mSymbol;

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -99,6 +99,32 @@
       </widget>
      </item>
      <item row="2" column="0" colspan="2">
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Boards</string>
+       </property>
+       <layout class="QFormLayout" name="formLayout_4">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Pre-selected device:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="cbxPreselectedDevice">
+          <property name="currentText">
+           <string notr="true"/>
+          </property>
+          <property name="maxVisibleItems">
+           <number>20</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
       <widget class="QGroupBox" name="gbxCmpLib">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -146,41 +172,6 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Symbol Variant:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="lblSymbVarName">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">TextLabel</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::RichText</enum>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
          <widget class="QLabel" name="label_17">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -193,7 +184,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="1" column="1">
          <widget class="QLabel" name="lblSymbLibName">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">


### PR DESCRIPTION
Adding a dropdown to the symbol/component properties dialog:

![grafik](https://user-images.githubusercontent.com/5374821/67623685-91341280-f828-11e9-88af-7288c843ded0.png)

Fixes #529