### PR TITLE
Board editor: Add PDF export and print support

### DIFF
--- a/apps/EagleImport/EagleImport.pro
+++ b/apps/EagleImport/EagleImport.pro
@@ -10,7 +10,7 @@ TARGET = eagle-import
 # Use common project definitions
 include(../../common.pri)
 
-QT += core widgets xml network
+QT += core widgets xml network printsupport
 
 LIBS += \
     -L$${DESTDIR} \

--- a/apps/WorkspaceLibraryUpdater/WorkspaceLibraryUpdater.pro
+++ b/apps/WorkspaceLibraryUpdater/WorkspaceLibraryUpdater.pro
@@ -10,7 +10,7 @@ TARGET = workspace-library-updater
 # Use common project definitions
 include(../../common.pri)
 
-QT += core widgets xml sql network
+QT += core widgets xml sql network printsupport
 
 LIBS += \
     -L$${DESTDIR} \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -15,7 +15,7 @@ DEFINES += BUILD_OUTPUT_DIRECTORY="\\\"$${OUTPUT_DIR_ABS}\\\""
 DEFINES += SHARE_DIRECTORY_SOURCE="\\\"$${SHARE_DIR_ABS}\\\""
 DEFINES += GIT_COMMIT_SHA="\\\"$(shell git -C \""$$_PRO_FILE_PWD_"\" rev-parse --verify HEAD)\\\""
 
-QT += core widgets xml opengl network sql
+QT += core widgets xml opengl network sql printsupport
 
 CONFIG += staticlib
 

--- a/libs/librepcb/common/graphics/holegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/holegraphicsitem.cpp
@@ -52,6 +52,7 @@ HoleGraphicsItem::HoleGraphicsItem(Hole&                           hole,
 
   // add origin cross
   mOriginCrossGraphicsItem.reset(new OriginCrossGraphicsItem(this));
+  mOriginCrossGraphicsItem->setVisibleInPrintOutput(true);
   mOriginCrossGraphicsItem->setRotation(Angle::deg45());
   mOriginCrossGraphicsItem->setSize(positiveToUnsigned(mHole.getDiameter()) +
                                     UnsignedLength(500000));

--- a/libs/librepcb/common/graphics/origincrossgraphicsitem.h
+++ b/libs/librepcb/common/graphics/origincrossgraphicsitem.h
@@ -54,6 +54,7 @@ public:
   void setRotation(const Angle& rot) noexcept;
   void setSize(const UnsignedLength& size) noexcept;
   void setLayer(const GraphicsLayer* layer) noexcept;
+  void setVisibleInPrintOutput(bool visible) noexcept;
 
   // Inherited from QGraphicsItem
   QRectF       boundingRect() const noexcept override { return mBoundingRect; }
@@ -79,6 +80,7 @@ private:  // Data
   QLineF               mLineV;
   QRectF               mBoundingRect;
   QPainterPath         mShape;
+  bool                 mVisibleInPrintOutput;
 
   // Slots
   GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;

--- a/libs/librepcb/common/graphics/primitivecirclegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivecirclegraphicsitem.cpp
@@ -24,6 +24,7 @@
 
 #include "../toolbox.h"
 
+#include <QPrinter>
 #include <QtCore>
 #include <QtWidgets>
 
@@ -109,13 +110,23 @@ void PrimitiveCircleGraphicsItem::paint(QPainter*                       painter,
                                         const QStyleOptionGraphicsItem* option,
                                         QWidget* widget) noexcept {
   Q_UNUSED(widget);
-  if (option->state.testFlag(QStyle::State_Selected)) {
-    painter->setPen(mPenHighlighted);
-    painter->setBrush(mBrushHighlighted);
-  } else {
-    painter->setPen(mPen);
-    painter->setBrush(mBrush);
+
+  const bool isSelected = option->state.testFlag(QStyle::State_Selected);
+  const bool deviceIsPrinter =
+      (dynamic_cast<QPrinter*>(painter->device()) != nullptr);
+
+  QPen   pen   = isSelected ? mPenHighlighted : mPen;
+  QBrush brush = isSelected ? mBrushHighlighted : mBrush;
+
+  // When printing, enforce a minimum line width to make sure the line will be
+  // visible (too thin lines will not be visible).
+  qreal minPrintLineWidth = Length(100000).toPx();
+  if (deviceIsPrinter && (pen.widthF() < minPrintLineWidth)) {
+    pen.setWidthF(minPrintLineWidth);
   }
+
+  painter->setPen(pen);
+  painter->setBrush(brush);
   painter->drawEllipse(mCircleRect);
 }
 

--- a/libs/librepcb/common/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivepathgraphicsitem.cpp
@@ -24,6 +24,7 @@
 
 #include "../toolbox.h"
 
+#include <QPrinter>
 #include <QtCore>
 #include <QtWidgets>
 
@@ -116,13 +117,23 @@ void PrimitivePathGraphicsItem::paint(QPainter*                       painter,
                                       const QStyleOptionGraphicsItem* option,
                                       QWidget* widget) noexcept {
   Q_UNUSED(widget);
-  if (option->state.testFlag(QStyle::State_Selected)) {
-    painter->setPen(mPenHighlighted);
-    painter->setBrush(mBrushHighlighted);
-  } else {
-    painter->setPen(mPen);
-    painter->setBrush(mBrush);
+
+  const bool isSelected = option->state.testFlag(QStyle::State_Selected);
+  const bool deviceIsPrinter =
+      (dynamic_cast<QPrinter*>(painter->device()) != nullptr);
+
+  QPen   pen   = isSelected ? mPenHighlighted : mPen;
+  QBrush brush = isSelected ? mBrushHighlighted : mBrush;
+
+  // When printing, enforce a minimum line width to make sure the line will be
+  // visible (too thin lines will not be visible).
+  qreal minPrintLineWidth = Length(100000).toPx();
+  if (deviceIsPrinter && (pen.widthF() < minPrintLineWidth)) {
+    pen.setWidthF(minPrintLineWidth);
   }
+
+  painter->setPen(pen);
+  painter->setBrush(brush);
   painter->drawPath(mPainterPath);
 }
 

--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -34,6 +34,7 @@
 #include <librepcb/common/units/all_length_units.h>
 #include <librepcb/common/uuid.h>
 
+#include <QPrinter>
 #include <QtCore>
 #include <QtWidgets>
 
@@ -226,6 +227,23 @@ public:
   void addToProject();
   void removeFromProject();
   void save();
+  /**
+   * @brief Print board to a QPrinter (printer or file)
+   *
+   * This is a helper function to print the board into w QPrinter. It does
+   * following:
+   *
+   * - Clear selection (#clearSelection())
+   * - Adjust layer colors to avoid too bright (almost invisible) elements
+   * - Render the board with scale 1:1 (#renderToQPainter())
+   * - Revert layer colors
+   *
+   * @param printer   The QPrinter where to print the board
+   *
+   * @throw Exception     On error
+   */
+  void print(QPrinter& printer);
+  void renderToQPainter(QPainter& painter, int dpi) const;
   void showInView(GraphicsView& view) noexcept;
   void saveViewSceneRect(const QRectF& rect) noexcept { mViewRect = rect; }
   const QRectF& restoreViewSceneRect() const noexcept { return mViewRect; }

--- a/libs/librepcb/project/boards/graphicsitems/bgi_plane.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_plane.cpp
@@ -97,18 +97,19 @@ void BGI_Plane::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
   Q_UNUSED(widget);
 
   const bool selected = mPlane.isSelected();
-  // const bool deviceIsPrinter = (dynamic_cast<QPrinter*>(painter->device()) !=
-  // 0);
+  const bool deviceIsPrinter =
+      (dynamic_cast<QPrinter*>(painter->device()) != nullptr);
   const qreal lod =
       option->levelOfDetailFromTransform(painter->worldTransform());
-  Q_UNUSED(option);
 
   if (mLayer && mLayer->isVisible()) {
-    // draw outline
-    painter->setPen(
-        QPen(mLayer->getColor(selected), 3 / lod, Qt::DashLine, Qt::RoundCap));
-    painter->setBrush(Qt::NoBrush);
-    painter->drawPath(mOutline);
+    // draw outline only on screen, not for print or PDF export
+    if (!deviceIsPrinter) {
+      painter->setPen(QPen(mLayer->getColor(selected), 3 / lod, Qt::DashLine,
+                           Qt::RoundCap));
+      painter->setBrush(Qt::NoBrush);
+      painter->drawPath(mOutline);
+    }
 
     // draw plane only if plane should be visible
     if (mPlane.isVisible()) {

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -100,6 +100,7 @@ private slots:
   void on_actionCopyBoard_triggered();
   void on_actionRemoveBoard_triggered();
   void on_actionGrid_triggered();
+  void on_actionPrint_triggered();
   void on_actionExportAsPdf_triggered();
   void on_actionGenerateFabricationData_triggered();
   void on_actionGenerateBom_triggered();

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -17,7 +17,7 @@
    <string>Board Editor</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../../../img/images.qrc">
+   <iconset>
     <normaloff>:/img/actions/board_editor.png</normaloff>:/img/actions/board_editor.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -78,12 +78,11 @@
      <string>&amp;File</string>
     </property>
     <addaction name="actionProjectSave"/>
-    <addaction name="actionPrint"/>
-    <addaction name="actionExportAsPdf"/>
     <addaction name="actionExportLppz"/>
-    <addaction name="separator"/>
-    <addaction name="actionGenerateFabricationData"/>
+    <addaction name="actionExportAsPdf"/>
     <addaction name="actionGenerateBom"/>
+    <addaction name="actionGenerateFabricationData"/>
+    <addaction name="actionPrint"/>
     <addaction name="separator"/>
     <addaction name="actionProjectClose"/>
     <addaction name="actionQuit"/>
@@ -278,7 +277,7 @@
   </widget>
   <action name="actionProjectSave">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
    </property>
    <property name="text">
@@ -290,7 +289,7 @@
   </action>
   <action name="actionProjectClose">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
@@ -298,11 +297,8 @@
    </property>
   </action>
   <action name="actionPrint">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/print.png</normaloff>:/img/actions/print.png</iconset>
    </property>
    <property name="text">
@@ -311,13 +307,10 @@
    <property name="shortcut">
     <string>Ctrl+P</string>
    </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/quit.png</normaloff>:/img/actions/quit.png</iconset>
    </property>
    <property name="text">
@@ -329,19 +322,16 @@
   </action>
   <action name="actionExportAsPdf">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/pdf.png</normaloff>:/img/actions/pdf.png</iconset>
    </property>
    <property name="text">
     <string>PDF &amp;Export</string>
    </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
   </action>
   <action name="actionShowControlPanel">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/home.png</normaloff>:/img/actions/home.png</iconset>
    </property>
    <property name="text">
@@ -350,7 +340,7 @@
   </action>
   <action name="actionShowSchematicEditor">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/schematic.png</normaloff>:/img/actions/schematic.png</iconset>
    </property>
    <property name="text">
@@ -359,7 +349,7 @@
   </action>
   <action name="actionUndo">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
    </property>
    <property name="text">
@@ -371,7 +361,7 @@
   </action>
   <action name="actionRedo">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/redo.png</normaloff>:/img/actions/redo.png</iconset>
    </property>
    <property name="text">
@@ -383,7 +373,7 @@
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
@@ -395,7 +385,7 @@
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
@@ -404,7 +394,7 @@
   </action>
   <action name="actionRotate_CCW">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/rotate_left.png</normaloff>:/img/actions/rotate_left.png</iconset>
    </property>
    <property name="text">
@@ -416,7 +406,7 @@
   </action>
   <action name="actionRotate_CW">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/rotate_right.png</normaloff>:/img/actions/rotate_right.png</iconset>
    </property>
    <property name="text">
@@ -428,7 +418,7 @@
   </action>
   <action name="actionCopy">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -443,7 +433,7 @@
   </action>
   <action name="actionCut">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/cut.png</normaloff>:/img/actions/cut.png</iconset>
    </property>
    <property name="text">
@@ -458,7 +448,7 @@
   </action>
   <action name="actionPaste">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/paste.png</normaloff>:/img/actions/paste.png</iconset>
    </property>
    <property name="text">
@@ -473,7 +463,7 @@
   </action>
   <action name="actionRemove">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -485,7 +475,7 @@
   </action>
   <action name="actionGrid">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/grid.png</normaloff>:/img/actions/grid.png</iconset>
    </property>
    <property name="text">
@@ -494,7 +484,7 @@
   </action>
   <action name="actionZoomIn">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/zoom_in.png</normaloff>:/img/actions/zoom_in.png</iconset>
    </property>
    <property name="text">
@@ -506,7 +496,7 @@
   </action>
   <action name="actionZoomOut">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/zoom_out.png</normaloff>:/img/actions/zoom_out.png</iconset>
    </property>
    <property name="text">
@@ -518,7 +508,7 @@
   </action>
   <action name="actionZoomAll">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/zoom_all.png</normaloff>:/img/actions/zoom_all.png</iconset>
    </property>
    <property name="text">
@@ -535,7 +525,7 @@
   </action>
   <action name="actionProjectSettings">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
    </property>
    <property name="text">
@@ -547,7 +537,7 @@
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
@@ -567,7 +557,7 @@
   </action>
   <action name="actionToolSelect">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/select.png</normaloff>:/img/actions/select.png</iconset>
    </property>
    <property name="text">
@@ -576,7 +566,7 @@
   </action>
   <action name="actionCommandAbort">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/stop.png</normaloff>:/img/actions/stop.png</iconset>
    </property>
    <property name="text">
@@ -588,7 +578,7 @@
   </action>
   <action name="actionNewBoard">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/new_2.png</normaloff>:/img/actions/new_2.png</iconset>
    </property>
    <property name="text">
@@ -605,7 +595,7 @@
   </action>
   <action name="actionFlipHorizontal">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/flip_horizontal.png</normaloff>:/img/actions/flip_horizontal.png</iconset>
    </property>
    <property name="text">
@@ -617,7 +607,7 @@
   </action>
   <action name="actionFlipVertical">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/flip_vertical.png</normaloff>:/img/actions/flip_vertical.png</iconset>
    </property>
    <property name="text">
@@ -629,7 +619,7 @@
   </action>
   <action name="actionToolDrawTrace">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/draw_wire.png</normaloff>:/img/actions/draw_wire.png</iconset>
    </property>
    <property name="text">
@@ -638,7 +628,7 @@
   </action>
   <action name="actionToolAddVia">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/add_via.png</normaloff>:/img/actions/add_via.png</iconset>
    </property>
    <property name="text">
@@ -647,7 +637,7 @@
   </action>
   <action name="actionCopyBoard">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -656,7 +646,7 @@
   </action>
   <action name="actionGenerateFabricationData">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/export_gerber.png</normaloff>:/img/actions/export_gerber.png</iconset>
    </property>
    <property name="text">
@@ -678,7 +668,7 @@
   </action>
   <action name="actionRemoveBoard">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -687,7 +677,7 @@
   </action>
   <action name="actionToolDrawPolygon">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/draw_polygon.png</normaloff>:/img/actions/draw_polygon.png</iconset>
    </property>
    <property name="text">
@@ -696,7 +686,7 @@
   </action>
   <action name="actionRebuildPlanes">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/rebuild_plane.png</normaloff>:/img/actions/rebuild_plane.png</iconset>
    </property>
    <property name="text">
@@ -705,7 +695,7 @@
   </action>
   <action name="actionToolAddPlane">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/add_plane.png</normaloff>:/img/actions/add_plane.png</iconset>
    </property>
    <property name="text">
@@ -714,7 +704,7 @@
   </action>
   <action name="actionToolAddText">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/add_text.png</normaloff>:/img/actions/add_text.png</iconset>
    </property>
    <property name="text">
@@ -723,7 +713,7 @@
   </action>
   <action name="actionToolAddHole">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/add_hole.png</normaloff>:/img/actions/add_hole.png</iconset>
    </property>
    <property name="text">
@@ -732,7 +722,7 @@
   </action>
   <action name="actionUpdateLibrary">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
@@ -741,7 +731,7 @@
   </action>
   <action name="actionExportLppz">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/export_zip.png</normaloff>:/img/actions/export_zip.png</iconset>
    </property>
    <property name="text">
@@ -753,7 +743,7 @@
   </action>
   <action name="actionGenerateBom">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/generate_bom.png</normaloff>:/img/actions/generate_bom.png</iconset>
    </property>
    <property name="text">
@@ -765,7 +755,7 @@
   </action>
   <action name="actionShowAllPlanes">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/show_planes.png</normaloff>:/img/actions/show_planes.png</iconset>
    </property>
    <property name="text">
@@ -774,7 +764,7 @@
   </action>
   <action name="actionHideAllPlanes">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/hide_planes.png</normaloff>:/img/actions/hide_planes.png</iconset>
    </property>
    <property name="text">
@@ -794,9 +784,6 @@
    <header>qtabbar.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Adding initial support for PDF export and printing boards. It's not perfect, but much better than nothing :wink: Since only the currently visible layers are printed, it can be used for different use cases, depending on layer selection. For example one could print an assembly plan like this:

![grafik](https://user-images.githubusercontent.com/5374821/68060750-f2188a80-fd01-11e9-9385-cafa621b2676.png)
