### PR TITLE
Fix focus issue in polygon editor dialog

### DIFF
--- a/libs/librepcb/common/model/angledelegate.cpp
+++ b/libs/librepcb/common/model/angledelegate.cpp
@@ -61,6 +61,14 @@ QWidget* AngleDelegate::createEditor(QWidget*                    parent,
   edt->setFrame(false);
   edt->setValue(index.data(Qt::EditRole).value<Angle>());
   edt->selectAll();
+
+  // Manually close the editor if editing is finished, because for some reason
+  // the view does not receive the "focus out" event from our own editor widget.
+  // Queued connection is needed to avoid receiving the "enter pressed" key
+  // event if editing was finished by pressing enter.
+  connect(edt, &AngleEdit::editingFinished, this,
+          &AngleDelegate::editingFinished, Qt::QueuedConnection);
+
   return edt;
 }
 
@@ -81,6 +89,16 @@ void AngleDelegate::updateEditorGeometry(QWidget*                    editor,
                                          const QModelIndex& index) const {
   Q_UNUSED(index);
   editor->setGeometry(option.rect);
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void AngleDelegate::editingFinished() noexcept {
+  AngleEdit* edt = static_cast<AngleEdit*>(sender());
+  commitData(edt);
+  closeEditor(edt);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/model/angledelegate.h
+++ b/libs/librepcb/common/model/angledelegate.h
@@ -62,6 +62,9 @@ public:
 
   // Operator Overloadings
   AngleDelegate& operator=(const AngleDelegate& rhs) = delete;
+
+private:  // Methods
+  void editingFinished() noexcept;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/model/lengthdelegate.cpp
+++ b/libs/librepcb/common/model/lengthdelegate.cpp
@@ -71,6 +71,14 @@ QWidget* LengthDelegate::createEditor(QWidget*                    parent,
   edt->setUnit(mUnit);
   edt->setValue(index.data(Qt::EditRole).value<Length>());
   edt->selectAll();
+
+  // Manually close the editor if editing is finished, because for some reason
+  // the view does not receive the "focus out" event from our own editor widget.
+  // Queued connection is needed to avoid receiving the "enter pressed" key
+  // event if editing was finished by pressing enter.
+  connect(edt, &LengthEdit::editingFinished, this,
+          &LengthDelegate::editingFinished, Qt::QueuedConnection);
+
   return edt;
 }
 
@@ -91,6 +99,16 @@ void LengthDelegate::updateEditorGeometry(QWidget*                    editor,
                                           const QModelIndex& index) const {
   Q_UNUSED(index);
   editor->setGeometry(option.rect);
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void LengthDelegate::editingFinished() noexcept {
+  LengthEdit* edt = static_cast<LengthEdit*>(sender());
+  commitData(edt);
+  closeEditor(edt);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/model/lengthdelegate.h
+++ b/libs/librepcb/common/model/lengthdelegate.h
@@ -67,6 +67,9 @@ public:
   // Operator Overloadings
   LengthDelegate& operator=(const LengthDelegate& rhs) = delete;
 
+private:  // Methods
+  void editingFinished() noexcept;
+
 private:  // Data
   LengthUnit mUnit;
 };


### PR DESCRIPTION
Fixing two issues when modifying table cells in the polygon editor dialog:

- If a cell lost focus while modifying, the modification was not committed. For example when pressing the "OK" button while the focus was in a table cell, the dialog was closed but without applying the modification.
- When pressing enter, the whole dialog closed instead of only exiting the edit state.