### PR TITLE
CI: Create archive for deployment on Linux

### DIFF
--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -37,6 +37,9 @@ jobs:
   - bash: ./ci/build_linux_appimage.sh
     displayName: Build AppImage
     condition: and(succeeded(), eq(variables['DEPLOY'], 'true'))
+  - bash: ./ci/build_linux_archive.sh
+    displayName: Build Archive
+    condition: and(succeeded(), eq(variables['DEPLOY'], 'true'))
   - bash: ./ci/build_installer.sh
     displayName: Build Installer
     condition: and(succeeded(), eq(variables['DEPLOY'], 'true'))

--- a/ci/build_linux_appimage.sh
+++ b/ci/build_linux_appimage.sh
@@ -3,15 +3,16 @@
 # set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
 set -euv -o pipefail
 
-# Manually specify icon to be used for the AppImage
-cp "./build/install/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" "./build/install/org.librepcb.LibrePCB.svg"
-
 # Build CLI AppImage
-cp -r "./build/install" "./build/install-cli"
-mv -f "./build/install-cli/opt/bin/librepcb-cli" "./build/install-cli/opt/bin/librepcb"
-linuxdeployqt "./build/install-cli/opt/share/applications/org.librepcb.LibrePCB.desktop" -bundle-non-qt-libs -appimage
+cp -r "./build/install" "./build/appimage-cli"
+mv -f "./build/appimage-cli/opt/bin/librepcb-cli" "./build/appimage-cli/opt/bin/librepcb"
+cp "./build/appimage-cli/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" \
+  "./build/appimage-cli/org.librepcb.LibrePCB.svg"
+linuxdeployqt "./build/appimage-cli/opt/share/applications/org.librepcb.LibrePCB.desktop" -bundle-non-qt-libs -appimage
 mv ./LibrePCB-*-x86_64.AppImage ./artifacts/nightly_builds/librepcb-cli-nightly-linux-x86_64.AppImage
 
 # Build LibrePCB AppImage
-linuxdeployqt "./build/install/opt/share/applications/org.librepcb.LibrePCB.desktop" -bundle-non-qt-libs -appimage
+cp -r "./build/install" "./build/appimage"
+cp "./build/appimage/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" "./build/appimage/org.librepcb.LibrePCB.svg"
+linuxdeployqt "./build/appimage/opt/share/applications/org.librepcb.LibrePCB.desktop" -bundle-non-qt-libs -appimage
 cp ./LibrePCB-*-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-x86_64.AppImage

--- a/ci/build_linux_archive.sh
+++ b/ci/build_linux_archive.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
+set -euv -o pipefail
+
+# run linuxdeployqt to bundle Qt libs
+linuxdeployqt "./build/install/opt/bin/librepcb-cli" -bundle-non-qt-libs -always-overwrite
+linuxdeployqt "./build/install/opt/bin/librepcb" -bundle-non-qt-libs -always-overwrite
+
+# copy to artifacts
+cp -r "./build/install/opt" "./artifacts/nightly_builds/librepcb-nightly-linux-x86_64"


### PR DESCRIPTION
Currently we provide two ways to install LibrePCB binaries on Linux: Installer and AppImage. But the installer is a pain for automated installation, and the AppImage does not work out-of-the-box in Docker containers (because FUSE is missing). To avoid these issues, I think it makes sense to also provide the binaries in a *.tar.gz archive for Linux. It's basically "for free", since we just need to bundle the already available binaries in a *.tar.gz.

Interestingly I also realized that the `librepcb-cli` currently doesn't work on Linux when installed with the installer, because that binary was not patched with `linuxdeployqt`. That's also fixed with this PR, so it should now work on Linux too.