### PR TITLE
ControlPanel::projectEditorClosed: Use toUnique on file path

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -451,7 +451,9 @@ void ControlPanel::projectEditorClosed() noexcept {
   if (!editor) return;
 
   Project* project = &editor->getProject();
-  mOpenProjectEditors.remove(project->getFilepath().toStr());
+  Q_ASSERT(mOpenProjectEditors.contains(
+      project->getFilepath().toUnique().toStr()));
+  mOpenProjectEditors.remove(project->getFilepath().toUnique().toStr());
   delete project;
 }
 


### PR DESCRIPTION
Because the `toUnique` call was missing, projects on a symlinked path
were not removed from the `mOpenProjectEditors` hash map. This in turn
would trigger a segfault when reopening a project due to a
use-after-free.

Fixes #432.