### PR TITLE
Fix possibly wrong grab area of various graphics items

### DIFF
--- a/libs/librepcb/common/toolbox.cpp
+++ b/libs/librepcb/common/toolbox.cpp
@@ -39,7 +39,8 @@ QPainterPath Toolbox::shapeFromPath(const QPainterPath& path, const QPen& pen,
   // http://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/graphicsview/qgraphicsitem.cpp
   // Function: qt_graphicsItem_shapeFromPath()
 
-  if (path == QPainterPath() || pen == Qt::NoPen) {
+  if ((path.isEmpty()) || (pen.style() == Qt::NoPen) ||
+      (pen.brush().style() == Qt::NoBrush)) {
     return path;
   } else {
     QPainterPathStroker ps;
@@ -48,7 +49,7 @@ QPainterPath Toolbox::shapeFromPath(const QPainterPath& path, const QPen& pen,
     ps.setJoinStyle(pen.joinStyle());
     ps.setMiterLimit(pen.miterLimit());
     QPainterPath p = ps.createStroke(path);
-    if (brush != Qt::NoBrush) {
+    if (brush.style() != Qt::NoBrush) {
       p.addPath(path);
     }
     return p;

--- a/tests/unittests/common/toolboxtest.cpp
+++ b/tests/unittests/common/toolboxtest.cpp
@@ -38,6 +38,26 @@ namespace tests {
 class ToolboxTest : public ::testing::Test {};
 
 /*******************************************************************************
+ *  shapeFromPath() Tests
+ ******************************************************************************/
+
+TEST_F(ToolboxTest, testNoPenReturnsUnmodifiedPath) {
+  QPainterPath path;
+  path.addRect(10, 20, 30, 40);
+  QPen   pen(QBrush(Qt::SolidPattern), 1, Qt::NoPen);
+  QBrush brush(Qt::SolidPattern);
+  EXPECT_EQ(path, Toolbox::shapeFromPath(path, pen, brush));
+}
+
+TEST_F(ToolboxTest, testNoPenBrushReturnsUnmodifiedPath) {
+  QPainterPath path;
+  path.addRect(10, 20, 30, 40);
+  QPen   pen(QBrush(Qt::NoBrush), 1, Qt::SolidLine);
+  QBrush brush(Qt::SolidPattern);
+  EXPECT_EQ(path, Toolbox::shapeFromPath(path, pen, brush));
+}
+
+/*******************************************************************************
  *  Parametrized arcCenter() Tests
  ******************************************************************************/
 


### PR DESCRIPTION
The shape was sometimes not calculated properly in `Toolbox::shapeFromPath()`, which lead to wrong grab areas of polygons and probably other graphics items, especially after modifying their properties.

Fixes #578 