### PR TITLE
CLI: Add "--strict" option

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -131,6 +131,10 @@ int CommandLineInterface::execute() noexcept {
   QCommandLineOption saveOption(
       "save",
       tr("Save project before closing it (useful to upgrade file format)."));
+  QCommandLineOption prjStrictOption(
+      "strict", tr("Fail if the project files are not strictly canonical, i.e. "
+                   "there would be changes when saving the project. Note that "
+                   "this option is not available for *.lppz files."));
 
   // Define options for "open-library"
   QCommandLineOption libAllOption(
@@ -139,6 +143,9 @@ int CommandLineInterface::execute() noexcept {
   QCommandLineOption libSaveOption(
       "save", tr("Save library (and contained elements if '--all' is given) "
                  "before closing them (useful to upgrade file format)."));
+  QCommandLineOption libStrictOption(
+      "strict", tr("Fail if the opened files are not strictly canonical, i.e. "
+                   "there would be changes when saving the library elements."));
 
   // First parse to get the supplied command (ignoring errors because the parser
   // does not yet know the command-dependent options).
@@ -166,6 +173,7 @@ int CommandLineInterface::execute() noexcept {
     parser.addOption(pcbFabricationSettingsOption);
     parser.addOption(boardOption);
     parser.addOption(saveOption);
+    parser.addOption(prjStrictOption);
   } else if (command == "open-library") {
     parser.clearPositionalArguments();
     parser.addPositionalArgument(command, commands[command].first,
@@ -174,6 +182,7 @@ int CommandLineInterface::execute() noexcept {
                                  tr("Path to library directory (*.lplib)."));
     parser.addOption(libAllOption);
     parser.addOption(libSaveOption);
+    parser.addOption(libStrictOption);
   } else if (!command.isEmpty()) {
     printErr(QString(tr("Unknown command '%1'.")).arg(command), 2);
     print(parser.helpText(), 0);
@@ -234,7 +243,8 @@ int CommandLineInterface::execute() noexcept {
         parser.isSet(exportPcbFabricationDataOption),  // export PCB fab. data
         parser.value(pcbFabricationSettingsOption),    // PCB fab. settings
         parser.values(boardOption),                    // boards
-        parser.isSet(saveOption)                       // save project
+        parser.isSet(saveOption),                      // save project
+        parser.isSet(prjStrictOption)                  // strict mode
     );
   } else if (command == "open-library") {
     if (positionalArgs.count() != 1) {
@@ -242,9 +252,10 @@ int CommandLineInterface::execute() noexcept {
       print(parser.helpText(), 0);
       return 1;
     }
-    cmdSuccess = openLibrary(positionalArgs.value(0),     // library directory
-                             parser.isSet(libAllOption),  // all elements
-                             parser.isSet(libSaveOption)  // save
+    cmdSuccess = openLibrary(positionalArgs.value(0),       // library directory
+                             parser.isSet(libAllOption),    // all elements
+                             parser.isSet(libSaveOption),   // save
+                             parser.isSet(libStrictOption)  // strict mode
     );
   } else {
     printErr(tr("Internal failure."));
@@ -267,7 +278,7 @@ bool CommandLineInterface::openProject(
     const QStringList& exportSchematicsFiles, const QStringList& exportBomFiles,
     const QStringList& exportBoardBomFiles, const QString& bomAttributes,
     bool exportPcbFabricationData, const QString& pcbFabricationSettingsPath,
-    const QStringList& boards, bool save) const noexcept {
+    const QStringList& boards, bool save, bool strict) const noexcept {
   try {
     bool                success = true;
     QMap<FilePath, int> writtenFilesCounter;
@@ -294,6 +305,31 @@ bool CommandLineInterface::openProject(
     Project project(std::unique_ptr<TransactionalDirectory>(
                         new TransactionalDirectory(projectFs)),
                     projectFileName);  // can throw
+
+    // Check for non-canonical files (strict mode)
+    if (strict) {
+      print(tr("Check for non-canonical files..."));
+      if (projectFp.getSuffix() == "lppz") {
+        printErr("  " % tr("ERROR: The option '--strict' is not available for "
+                           "*.lppz files!"));
+        success = false;
+      } else {
+        project.save();                                          // can throw
+        QStringList paths = projectFs->checkForModifications();  // can throw
+        // ignore user config files
+        paths = paths.filter(QRegularExpression("^((?!\\.user\\.lp).)*$"));
+        // sort file paths to increases readability of console output
+        std::sort(paths.begin(), paths.end());
+        foreach (const QString& path, paths) {
+          printErr(
+              QString("    - Non-canonical file: %1")
+                  .arg(prettyPath(projectFs->getAbsPath(path), projectFile)));
+        }
+        if (paths.count() > 0) {
+          success = false;
+        }
+      }
+    }
 
     // ERC
     if (runErc) {
@@ -501,7 +537,7 @@ bool CommandLineInterface::openProject(
 }
 
 bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
-                                       bool save) const noexcept {
+                                       bool save, bool strict) const noexcept {
   try {
     bool success = true;
 
@@ -512,8 +548,9 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     std::shared_ptr<TransactionalFileSystem> libFs =
         TransactionalFileSystem::open(libFp, save);  // can throw
     Library lib(std::unique_ptr<TransactionalDirectory>(
-        new TransactionalDirectory(libFs)));      // can throw
-    processLibraryElement(libDir, *libFs, save);  // can throw
+        new TransactionalDirectory(libFs)));  // can throw
+    processLibraryElement(libDir, *libFs, lib, save, strict,
+                          success);  // can throw
 
     // Open all component categories
     if (all) {
@@ -526,8 +563,9 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         ComponentCategory element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));      // can throw
-        processLibraryElement(libDir, *fs, save);  // can throw
+            new TransactionalDirectory(fs)));  // can throw
+        processLibraryElement(libDir, *fs, element, save, strict,
+                              success);  // can throw
       }
     }
 
@@ -542,8 +580,9 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         PackageCategory element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));      // can throw
-        processLibraryElement(libDir, *fs, save);  // can throw
+            new TransactionalDirectory(fs)));  // can throw
+        processLibraryElement(libDir, *fs, element, save, strict,
+                              success);  // can throw
       }
     }
 
@@ -557,8 +596,9 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Symbol element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));      // can throw
-        processLibraryElement(libDir, *fs, save);  // can throw
+            new TransactionalDirectory(fs)));  // can throw
+        processLibraryElement(libDir, *fs, element, save, strict,
+                              success);  // can throw
       }
     }
 
@@ -572,8 +612,9 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Package element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));      // can throw
-        processLibraryElement(libDir, *fs, save);  // can throw
+            new TransactionalDirectory(fs)));  // can throw
+        processLibraryElement(libDir, *fs, element, save, strict,
+                              success);  // can throw
       }
     }
 
@@ -587,8 +628,9 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Component element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));      // can throw
-        processLibraryElement(libDir, *fs, save);  // can throw
+            new TransactionalDirectory(fs)));  // can throw
+        processLibraryElement(libDir, *fs, element, save, strict,
+                              success);  // can throw
       }
     }
 
@@ -602,8 +644,9 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Device element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));      // can throw
-        processLibraryElement(libDir, *fs, save);  // can throw
+            new TransactionalDirectory(fs)));  // can throw
+        processLibraryElement(libDir, *fs, element, save, strict,
+                              success);  // can throw
       }
     }
 
@@ -616,13 +659,41 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
 
 void CommandLineInterface::processLibraryElement(const QString& libDir,
                                                  TransactionalFileSystem& fs,
-                                                 bool save) const {
+                                                 LibraryBaseElement& element,
+                                                 bool save, bool strict,
+                                                 bool& success) const {
+  // Save element to transactional file system, if needed
+  if (strict || save) {
+    element.save();  // can throw
+  }
+
+  // Check for non-canonical files (strict mode)
+  if (strict) {
+    qInfo() << QString(tr("Check '%1' for non-canonical files..."))
+                   .arg(prettyPath(fs.getPath(), libDir));
+
+    QStringList paths = fs.checkForModifications();  // can throw
+    // sort file paths to increases readability of console output
+    std::sort(paths.begin(), paths.end());
+    foreach (const QString& path, paths) {
+      printErr(QString("    - Non-canonical file: %1")
+                   .arg(prettyPath(fs.getAbsPath(path), libDir)));
+    }
+    if (paths.count() > 0) {
+      success = false;
+    }
+  }
+
   // Save element to file system, if needed
   if (save) {
     qInfo()
         << QString(tr("Save '%1'...")).arg(prettyPath(fs.getPath(), libDir));
     fs.save();  // can throw
   }
+
+  // Do not propagate changes in the transactional file system to the
+  // following checks
+  fs.discardChanges();
 }
 
 QString CommandLineInterface::prettyPath(const FilePath& path,

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -512,7 +512,8 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     std::shared_ptr<TransactionalFileSystem> libFs =
         TransactionalFileSystem::open(libFp, save);  // can throw
     Library lib(std::unique_ptr<TransactionalDirectory>(
-        new TransactionalDirectory(libFs)));  // can throw
+        new TransactionalDirectory(libFs)));      // can throw
+    processLibraryElement(libDir, *libFs, save);  // can throw
 
     // Open all component categories
     if (all) {
@@ -525,12 +526,8 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         ComponentCategory element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));  // can throw
-        if (save) {
-          qInfo() << QString(tr("Save '%1'...")).arg(prettyPath(fp, libDir));
-          element.save();  // can throw
-          fs->save();      // can throw
-        }
+            new TransactionalDirectory(fs)));      // can throw
+        processLibraryElement(libDir, *fs, save);  // can throw
       }
     }
 
@@ -545,12 +542,8 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         PackageCategory element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));  // can throw
-        if (save) {
-          qInfo() << QString(tr("Save '%1'...")).arg(prettyPath(fp, libDir));
-          element.save();  // can throw
-          fs->save();      // can throw
-        }
+            new TransactionalDirectory(fs)));      // can throw
+        processLibraryElement(libDir, *fs, save);  // can throw
       }
     }
 
@@ -564,12 +557,8 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Symbol element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));  // can throw
-        if (save) {
-          qInfo() << QString(tr("Save '%1'...")).arg(prettyPath(fp, libDir));
-          element.save();  // can throw
-          fs->save();      // can throw
-        }
+            new TransactionalDirectory(fs)));      // can throw
+        processLibraryElement(libDir, *fs, save);  // can throw
       }
     }
 
@@ -583,12 +572,8 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Package element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));  // can throw
-        if (save) {
-          qInfo() << QString(tr("Save '%1'...")).arg(prettyPath(fp, libDir));
-          element.save();  // can throw
-          fs->save();      // can throw
-        }
+            new TransactionalDirectory(fs)));      // can throw
+        processLibraryElement(libDir, *fs, save);  // can throw
       }
     }
 
@@ -602,12 +587,8 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Component element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));  // can throw
-        if (save) {
-          qInfo() << QString(tr("Save '%1'...")).arg(prettyPath(fp, libDir));
-          element.save();  // can throw
-          fs->save();      // can throw
-        }
+            new TransactionalDirectory(fs)));      // can throw
+        processLibraryElement(libDir, *fs, save);  // can throw
       }
     }
 
@@ -621,26 +602,26 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Device element(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));  // can throw
-        if (save) {
-          qInfo() << QString(tr("Save '%1'...")).arg(prettyPath(fp, libDir));
-          element.save();  // can throw
-          fs->save();      // can throw
-        }
+            new TransactionalDirectory(fs)));      // can throw
+        processLibraryElement(libDir, *fs, save);  // can throw
       }
-    }
-
-    // Save library
-    if (save) {
-      print(QString(tr("Save library '%1'...")).arg(prettyPath(libFp, libDir)));
-      lib.save();     // can throw
-      libFs->save();  // can throw
     }
 
     return success;
   } catch (const Exception& e) {
     printErr(QString(tr("ERROR: %1")).arg(e.getMsg()));
     return false;
+  }
+}
+
+void CommandLineInterface::processLibraryElement(const QString& libDir,
+                                                 TransactionalFileSystem& fs,
+                                                 bool save) const {
+  // Save element to file system, if needed
+  if (save) {
+    qInfo()
+        << QString(tr("Save '%1'...")).arg(prettyPath(fs.getPath(), libDir));
+    fs.save();  // can throw
   }
 }
 

--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -32,6 +32,11 @@ namespace librepcb {
 
 class Application;
 class FilePath;
+class TransactionalFileSystem;
+
+namespace library {
+class LibraryBaseElement;
+}
 
 namespace cli {
 
@@ -63,6 +68,8 @@ private:  // Methods
                    const QString&     pcbFabricationSettingsPath,
                    const QStringList& boards, bool save) const noexcept;
   bool openLibrary(const QString& libDir, bool all, bool save) const noexcept;
+  void processLibraryElement(const QString& libDir, TransactionalFileSystem& fs,
+                             bool save) const;
   static QString prettyPath(const FilePath& path,
                             const QString&  style) noexcept;
   static void    print(const QString& str, int newlines = 1) noexcept;

--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -66,10 +66,13 @@ private:  // Methods
                    const QStringList& exportBoardBomFiles,
                    const QString& bomAttributes, bool exportPcbFabricationData,
                    const QString&     pcbFabricationSettingsPath,
-                   const QStringList& boards, bool save) const noexcept;
-  bool openLibrary(const QString& libDir, bool all, bool save) const noexcept;
+                   const QStringList& boards, bool save, bool strict) const
+      noexcept;
+  bool openLibrary(const QString& libDir, bool all, bool save,
+                   bool strict) const noexcept;
   void processLibraryElement(const QString& libDir, TransactionalFileSystem& fs,
-                             bool save) const;
+                             library::LibraryBaseElement& element, bool save,
+                             bool strict, bool& success) const;
   static QString prettyPath(const FilePath& path,
                             const QString&  style) noexcept;
   static void    print(const QString& str, int newlines = 1) noexcept;

--- a/libs/librepcb/common/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.cpp
@@ -267,6 +267,38 @@ void TransactionalFileSystem::exportToZip(const FilePath& fp) const {
   }
 }
 
+QStringList TransactionalFileSystem::checkForModifications() const {
+  QStringList modifications;
+
+  // removed directories
+  foreach (const QString& dir, mRemovedDirs) {
+    FilePath fp = mFilePath.getPathTo(dir);
+    if (fp.isExistingDir()) {
+      modifications.append(dir);
+    }
+  }
+
+  // removed files
+  foreach (const QString& filepath, mRemovedFiles) {
+    FilePath fp = mFilePath.getPathTo(filepath);
+    if (fp.isExistingFile()) {
+      modifications.append(filepath);
+    }
+  }
+
+  // new or modified files
+  foreach (const QString& filepath, mModifiedFiles.keys()) {
+    FilePath   fp      = mFilePath.getPathTo(filepath);
+    QByteArray content = mModifiedFiles.value(filepath);
+    if ((!fp.isExistingFile()) ||
+        (FileUtils::readFile(fp) != content)) {  // can throw
+      modifications.append(filepath);
+    }
+  }
+
+  return modifications;
+}
+
 void TransactionalFileSystem::autosave() {
   saveDiff("autosave");  // can throw
 }

--- a/libs/librepcb/common/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.cpp
@@ -267,6 +267,12 @@ void TransactionalFileSystem::exportToZip(const FilePath& fp) const {
   }
 }
 
+void TransactionalFileSystem::discardChanges() noexcept {
+  mModifiedFiles.clear();
+  mRemovedFiles.clear();
+  mRemovedDirs.clear();
+}
+
 QStringList TransactionalFileSystem::checkForModifications() const {
   QStringList modifications;
 
@@ -479,12 +485,6 @@ void TransactionalFileSystem::removeDiff(const QString& type) {
 
   // then remove the whole directory
   FileUtils::removeDirRecursively(dir);  // can throw
-}
-
-void TransactionalFileSystem::discardChanges() noexcept {
-  mModifiedFiles.clear();
-  mRemovedFiles.clear();
-  mRemovedDirs.clear();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/fileio/transactionalfilesystem.h
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.h
@@ -80,7 +80,8 @@ public:
   virtual ~TransactionalFileSystem() noexcept;
 
   // Getters
-  bool isWritable() const noexcept { return mIsWritable; }
+  const FilePath& getPath() const noexcept { return mFilePath; }
+  bool            isWritable() const noexcept { return mIsWritable; }
   bool isRestoredFromAutosave() const noexcept { return mRestoredFromAutosave; }
 
   // Inherited from FileSystem

--- a/libs/librepcb/common/fileio/transactionalfilesystem.h
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.h
@@ -98,6 +98,7 @@ public:
   // General Methods
   void        loadFromZip(const FilePath& fp);
   void        exportToZip(const FilePath& fp) const;
+  void        discardChanges() noexcept;
   QStringList checkForModifications() const;
   void        autosave();
   void        save();
@@ -128,7 +129,6 @@ private:  // Methods
   void saveDiff(const QString& type) const;
   void loadDiff(const FilePath& fp);
   void removeDiff(const QString& type);
-  void discardChanges() noexcept;
 
 private:  // Data
   FilePath      mFilePath;

--- a/libs/librepcb/common/fileio/transactionalfilesystem.h
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.h
@@ -96,10 +96,11 @@ public:
   virtual void removeDirRecursively(const QString& path = "") override;
 
   // General Methods
-  void loadFromZip(const FilePath& fp);
-  void exportToZip(const FilePath& fp) const;
-  void autosave();
-  void save();
+  void        loadFromZip(const FilePath& fp);
+  void        exportToZip(const FilePath& fp) const;
+  QStringList checkForModifications() const;
+  void        autosave();
+  void        save();
 
   // Static Methods
   static std::shared_ptr<TransactionalFileSystem> open(

--- a/tests/cli/open-project/test_save.py
+++ b/tests/cli/open-project/test_save.py
@@ -9,9 +9,6 @@ import pytest
 Test command "open-project --save"
 """
 
-PROJECT_LPP = 'data/Empty Project/Empty Project.lpp'
-PROJECT_LPPZ = 'data/Empty Project.lppz'
-
 
 @pytest.mark.parametrize("project", [
     params.EMPTY_PROJECT_LPP_PARAM,

--- a/tests/cli/open-project/test_strict.py
+++ b/tests/cli/open-project/test_strict.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import params
+
+"""
+Test command "open-project --strict"
+"""
+
+
+def test_valid_lpp(cli):
+    project = params.EMPTY_PROJECT_LPP
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    code, stdout, stderr = cli.run('open-project', '--strict', project.path)
+    assert code == 0
+    assert len(stderr) == 0
+    assert len(stdout) > 0
+    assert stdout[-1] == 'SUCCESS'
+
+
+def test_invalid_lpp(cli):
+    project = params.EMPTY_PROJECT_LPP
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    # append some zeros to the project file
+    path = cli.abspath(project.path)
+    with open(path, 'ab') as f:
+        f.write(b'\0\0')
+    # open project
+    code, stdout, stderr = cli.run('open-project', '--strict', project.path)
+    assert code == 1
+    assert len(stderr) == 1
+    assert 'Non-canonical file:' in stderr[0]
+    assert len(stdout) > 0
+    assert stdout[-1] == 'Finished with errors!'
+
+
+def test_lppz_fails(cli):
+    project = params.PROJECT_WITH_TWO_BOARDS_LPPZ
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    code, stdout, stderr = cli.run('open-project', '--strict', project.path)
+    assert code == 1
+    assert len(stderr) == 1
+    assert "The option '--strict' is not available" in stderr[0]
+    assert len(stdout) > 0
+    assert stdout[-1] == 'Finished with errors!'

--- a/tests/unittests/common/fileio/transactionalfilesystemtest.cpp
+++ b/tests/unittests/common/fileio/transactionalfilesystemtest.cpp
@@ -92,6 +92,11 @@ TEST_F(TransactionalFileSystemTest, testConstructorPopulatedDir) {
   TransactionalFileSystem fs(mPopulatedDir, true);
 }
 
+TEST_F(TransactionalFileSystemTest, testGetPath) {
+  TransactionalFileSystem fs(mPopulatedDir, false);
+  EXPECT_EQ(mPopulatedDir, fs.getPath());
+}
+
 TEST_F(TransactionalFileSystemTest, testIsWritableFalse) {
   TransactionalFileSystem fs(mPopulatedDir, false);
   EXPECT_FALSE(fs.isWritable());


### PR DESCRIPTION
With the `--strict` option, the CLI reports files which are not canonical, i.e. files which would be modified when saving the opened project or library element. Useful for continuous integration of libraries, mainly to check library elements which were generated (i.e. not made with LibrePCB).

Example:

```bash
$ librepcb-cli open-library LibrePCB_Connectors.lplib --all --strict
Open library 'LibrePCB_Connectors.lplib'...
    - Non-canonical file: LibrePCB_Connectors.lplib/library.lp
Process 0 component categories...
Process 0 package categories...
Process 198 symbols...
Process 514 packages...
Process 198 components...
Process 514 devices...
    - Non-canonical file: LibrePCB_Connectors.lplib/dev/0b53aefa-f8fb-4f31-bfa2-24325a58428b/.librepcb-dev
    - Non-canonical file: LibrePCB_Connectors.lplib/dev/0b53aefa-f8fb-4f31-bfa2-24325a58428b/device.lp
Finished with errors!
```