### PR TITLE
Fix typos in documentation and source comments 

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -123,7 +123,7 @@ ControlPanel::ControlPanel(Workspace& workspace)
     mUi->projectTreeView->hideColumn(i);
   }
 
-  // load recent and favorite poject models
+  // load recent and favorite project models
   mUi->recentProjectsListView->setModel(&mWorkspace.getRecentProjectsModel());
   mUi->favoriteProjectsListView->setModel(
       &mWorkspace.getFavoriteProjectsModel());

--- a/dev/doxygen/pages/architecture_overview.md
+++ b/dev/doxygen/pages/architecture_overview.md
@@ -3,7 +3,7 @@ Architecture Overview {#doc_architecture_overview}
 
 [TOC]
 
-LibrePCB is splitted up in several libraries which are statically linked to the LibrePCB application
+LibrePCB is split up in several libraries which are statically linked to the LibrePCB application
 or to other applications (e.g. developer tools like the EagleImport).
 
 This diagram shows the available libraries, their purpose and their dependencies:

--- a/dev/doxygen/pages/code_style_guide.md
+++ b/dev/doxygen/pages/code_style_guide.md
@@ -47,7 +47,7 @@ This page describes the code style guide for LibrePCB developers.
 
 # Naming {#doc_code_style_guide_naming}
 
-- File Names: Excatly same naming as classes, but all characters lowercase. Example: `ses_select.cpp`, `ses_select.h`
+- File Names: Exactly same naming as classes, but all characters lowercase. Example: `ses_select.cpp`, `ses_select.h`
 - Include guards: Use the namespace as prefix before the class name. Example: `#ifndef NAMESPACE_CLASSNAME_H`
 - Namespaces: lowercase (with underline as separator if needed)
 - Classes: UpperCamelCase (for common prefixes, use the underline as separator. Example: librepcb::project::editor::SES_Select)

--- a/dev/doxygen/pages/project.md
+++ b/dev/doxygen/pages/project.md
@@ -290,7 +290,7 @@ then cannot be undone. Basically, all changes to the circuit/schematics/boards a
 an undo action. If you are unsure if you should use the project's undo/redo system, try to answer
 the question *do the user wants to undo/redo this action with the undo/redo buttons in the editors?*.
 
-It's possible to use seperate librepcb::UndoStack objects for independent parts of the project. For
+It's possible to use separate librepcb::UndoStack objects for independent parts of the project. For
 example, changing the project settings could be done by using an undo/redo system to provide an undo
 command. But these undo stacks need their own undo/redo buttons. The undo/redo buttons in the
 schematic editor and in the board editor are only connected to the project's undo stack

--- a/dev/doxygen/pages/release_workflow.md
+++ b/dev/doxygen/pages/release_workflow.md
@@ -97,7 +97,7 @@ Translations are automatically checked into the repository
 [LibrePCB/librepcb-i18n](https://github.com/LibrePCB/librepcb-i18n). The
 `master` branch contains translations of the resource `librepcb.ts`, while
 translations of resources for releases are available on branches for the
-corresponsing releases (e.g. `release/0.1` for `librepcb-0.1.ts`).
+corresponding releases (e.g. `release/0.1` for `librepcb-0.1.ts`).
 
 The `librepcb-i18n` repository is included as a submodule in the main
 repository. On the `master` branch, the submodule points to a commit which does

--- a/dev/doxygen/pages/workspace.md
+++ b/dev/doxygen/pages/workspace.md
@@ -52,7 +52,7 @@ unit, ...).
 
 ## v<VERSION>/libraries/ {#doc_workspace_libraries_dir}
 
-Here are all libraries located, splitted up into two subdirectories. By the way, all of these
+Here are all libraries located, split up into two subdirectories. By the way, all of these
 libraries together are sometimes referred as *the workspace library*.
 
 ## v<VERSION>/libraries/local/ {#doc_workspace_local_dir}
@@ -123,7 +123,7 @@ continues using the libraries of the older version. For example an application
 of version `v2.x` may still use the libraries in the [version directory] `v1`.
 So the [version directory] `v2` may only contain workspace settings (i.e.
 `settings.lp`). Or if workspace settings are also compatible with the older
-appplication version, the whole [version directory] `v2` is not created at all.
+application version, the whole [version directory] `v2` is not created at all.
 
 
 # Downgrade workspace to older application version {#doc_workspace_downgrade}

--- a/libs/librepcb/common/debug.h
+++ b/libs/librepcb/common/debug.h
@@ -52,7 +52,7 @@ namespace librepcb {
  * Debug::DebugLevel::Exception.
  *
  * This class can write messages to the stderr output and to a log file. You can
- * set seperate debug levels for both. By default, logging to a file is
+ * set separate debug levels for both. By default, logging to a file is
  * disabled.
  */
 class Debug final {
@@ -68,7 +68,7 @@ public:
     Fatal =
         10,  ///< fatal errors [qFatal()] --> this will quit the application!
     Critical  = 20,  ///< errors [qCritical()]
-    Exception = 30,  ///< throwed exceptions of (sub)class Exception
+    Exception = 30,  ///< thrown exceptions of (sub)class Exception
     Warning   = 40,  ///< warnings [qWarning()]
     Info      = 50,  ///< info messages [qInfo()]
     DebugMsg =

--- a/libs/librepcb/common/exceptions.h
+++ b/libs/librepcb/common/exceptions.h
@@ -174,7 +174,7 @@ private:
  * @brief The LogicError class
  *
  * This exception class is used for exceptions related to the internal logic of
- * the program (a throwed LogicError means that there is a bug in the source
+ * the program (a thrown LogicError means that there is a bug in the source
  * code).
  *
  * @see Exception

--- a/libs/librepcb/common/network/networkrequestbase.cpp
+++ b/libs/librepcb/common/network/networkrequestbase.cpp
@@ -174,7 +174,7 @@ void NetworkRequestBase::replySslErrorsSlot(
   mErrored = true;
   QStringList errorsList;
   foreach (const QSslError& e, errors) { errorsList.append(e.errorString()); }
-  finalize(QString(tr("SSL errors occured:\n\n%1")).arg(errorsList.join("\n")));
+  finalize(QString(tr("SSL errors occurred:\n\n%1")).arg(errorsList.join("\n")));
 }
 
 void NetworkRequestBase::replyDownloadProgressSlot(qint64 bytesReceived,

--- a/libs/librepcb/common/undostack.h
+++ b/libs/librepcb/common/undostack.h
@@ -93,7 +93,7 @@ private:
  * doc_project_undostack
  *
  * Compared with QUndoStack, the biggest differences are the following:
- *  - <b>Support for exceptions:</b> If an exception is throwed in a
+ *  - <b>Support for exceptions:</b> If an exception is thrown in an
  * #UndoCommand object, this undo stack always tries to keep the whole stack
  * consistent (update the index only if the last undo/redo was successful, try
  * to rollback failed changes, ...).

--- a/libs/librepcb/common/units/point.h
+++ b/libs/librepcb/common/units/point.h
@@ -67,7 +67,7 @@ class Angle;
  * a coordinate from millimeters (or another unit) to pixels for a QGraphics*
  * object, you have to use the method Point::toPxQPointF(), which will also
  * invert the Y-coordinate. You should never convert an X and/or Y coordinate
- * with seperate Length objects - which would be possible, but then the sign of
+ * with separate Length objects - which would be possible, but then the sign of
  * the Y-coordinate is wrong! It is also not allowed to get the Y-coordinate in
  * pixels with calling Point.getY().toPx(), this way the sign of the value in
  * pixels is also wrong! You should use Point.toPxQPointF().y() instead for this

--- a/libs/librepcb/project/circuit/circuit.cpp
+++ b/libs/librepcb/project/circuit/circuit.cpp
@@ -105,7 +105,7 @@ Circuit::Circuit(Project& project, bool create)
 }
 
 Circuit::~Circuit() noexcept {
-  // delete all component instances (and catch all throwed exceptions)
+  // delete all component instances (and catch all thrown exceptions)
   foreach (ComponentInstance* compInstance, mComponentInstances)
     try {
       removeComponentInstance(*compInstance);
@@ -113,7 +113,7 @@ Circuit::~Circuit() noexcept {
     } catch (...) {
     }
 
-  // delete all netsignals (and catch all throwed exceptions)
+  // delete all netsignals (and catch all thrown exceptions)
   foreach (NetSignal* netsignal, mNetSignals)
     try {
       removeNetSignal(*netsignal);
@@ -121,7 +121,7 @@ Circuit::~Circuit() noexcept {
     } catch (...) {
     }
 
-  // delete all netclasses (and catch all throwed exceptions)
+  // delete all netclasses (and catch all thrown exceptions)
   foreach (NetClass* netclass, mNetClasses)
     try {
       removeNetClass(*netclass);

--- a/libs/librepcb/project/project.cpp
+++ b/libs/librepcb/project/project.cpp
@@ -220,7 +220,7 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
 Project::~Project() noexcept {
   // free the allocated memory in the reverse order of their allocation
 
-  // delete all boards and schematics (and catch all throwed exceptions)
+  // delete all boards and schematics (and catch all thrown exceptions)
   foreach (Board* board, mBoards) {
     try {
       removeBoard(*board, true);

--- a/libs/librepcb/project/project.h
+++ b/libs/librepcb/project/project.h
@@ -382,7 +382,7 @@ public:
   /**
    * @brief Save the project to the transactional file system
    *
-   * @throw Exception     If an error occured.
+   * @throw Exception     If an error occurred.
    */
   void save();
 

--- a/libs/librepcb/workspace/settings/items/wsi_base.h
+++ b/libs/librepcb/workspace/settings/items/wsi_base.h
@@ -41,7 +41,7 @@ namespace workspace {
 /**
  * @brief The WSI_Base class is the base class of all workspace settings items
  *
- * Every workspace setting is represented by a seperate object. All of these
+ * Every workspace setting is represented by a separate object. All of these
  * objects have this class as base class. The name of all Workspace Settings
  * Items begin with the prefix "WSI_" to easily recognize them.
  */


### PR DESCRIPTION
Found via `codespell -q 3`