### PR TITLE
Change BOM export CSV format

### DIFF
--- a/libs/librepcb/common/bom/bomcsvwriter.cpp
+++ b/libs/librepcb/common/bom/bomcsvwriter.cpp
@@ -50,13 +50,18 @@ QList<QStringList> BomCsvWriter::toStringList(const Bom& bom) noexcept {
   QList<QStringList> lines;
   // Don't translate the CSV header to make BOMs independent of the user's
   // language.
-  lines.append(QStringList{"Quantity", "Designators"} + bom.getColumns());
+  QStringList header = QStringList{"Quantity", "Designators"} + bom.getColumns();
+  QStringList headerCols;
+  foreach (const QString& headerItem, header) {
+    headerCols += '"' + headerItem + '"';
+  }
+  lines.append(headerCols);
   foreach (const BomItem& item, bom.getItems()) {
     QStringList cols;
     cols += QString::number(item.getDesignators().count());
-    cols += cleanStr(item.getDesignators().join(", "));
+    cols += '"' + cleanStr(item.getDesignators().join(", ")) + '"';
     foreach (const QString& attribute, item.getAttributes()) {
-      cols += cleanStr(attribute);
+      cols += '"' + cleanStr(attribute) + '"';
     }
     lines.append(cols);
   }
@@ -66,7 +71,7 @@ QList<QStringList> BomCsvWriter::toStringList(const Bom& bom) noexcept {
 QString BomCsvWriter::toString(const Bom& bom) noexcept {
   QString str;
   foreach (const QStringList& line, toStringList(bom)) {
-    str += line.join(";") + "\n";
+    str += line.join(",") + "\n";
   }
   return str;
 }

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -498,6 +498,21 @@ QList<BI_Via*> Board::getViasAtScenePos(const Point&     pos,
   return list;
 }
 
+BI_NetPoint* Board::getNetPointNextToScenePos(const Point& pos,
+                                              const GraphicsLayer* layer,
+                                              const NetSignal* netsignal) {
+  BI_NetPoint* bestMatch = NULL;
+  UnsignedLength maxDistance = UnsignedLength(10 * 1000 * 1000);
+
+  foreach (BI_NetSegment* segment, mNetSegments) {
+    if ((!netsignal) || (&segment->getNetSignal() == netsignal)) {
+      segment->getNetPointNextToScenePos(pos, layer, &bestMatch, &maxDistance);
+    }
+  }
+
+  return bestMatch;
+}
+
 QList<BI_NetPoint*> Board::getNetPointsAtScenePos(
     const Point& pos, const GraphicsLayer* layer,
     const NetSignal* netsignal) const noexcept {

--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -156,6 +156,9 @@ public:
                                              const GraphicsLayer* layer,
                                              const NetSignal* netsignal) const
       noexcept;
+  BI_NetPoint*        getNetPointNextToScenePos(const Point&         pos,
+                                                const GraphicsLayer* layer,
+                                                const NetSignal*     netsignal);
   QList<BI_NetLine*> getNetLinesAtScenePos(const Point&         pos,
                                            const GraphicsLayer* layer,
                                            const NetSignal*     netsignal) const

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -161,6 +161,10 @@ void BI_NetPoint::serialize(SExpression& root) const {
   root.appendChild(mPosition.serializeToDomElement("position"), false);
 }
 
+UnsignedLength BI_NetPoint::distance(Point destination) {
+  return (this->getPosition() - destination).getLength();
+}
+
 /*******************************************************************************
  *  Inherited from BI_Base
  ******************************************************************************/

--- a/libs/librepcb/project/boards/items/bi_netpoint.h
+++ b/libs/librepcb/project/boards/items/bi_netpoint.h
@@ -75,6 +75,7 @@ public:
   // General Methods
   void addToBoard() override;
   void removeFromBoard() override;
+  UnsignedLength distance(Point destination);
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;

--- a/libs/librepcb/project/boards/items/bi_netsegment.cpp
+++ b/libs/librepcb/project/boards/items/bi_netsegment.cpp
@@ -194,6 +194,24 @@ int BI_NetSegment::getViasAtScenePos(const Point&    pos,
   return count;
 }
 
+int BI_NetSegment::getNetPointNextToScenePos(const Point&         pos,
+                                             const GraphicsLayer* layer,
+                                             BI_NetPoint** bestMatch,
+                                             UnsignedLength* maxDistance) const
+    noexcept {
+  foreach (BI_NetPoint* netpoint, mNetPoints) {
+    if (netpoint->isSelectable() && ((!layer) || (netpoint->getLayerOfLines() == layer))) {
+      UnsignedLength distance = netpoint->distance(pos);
+      if (! maxDistance || distance < *maxDistance) {
+        *maxDistance = distance;
+        *bestMatch = netpoint;
+      }
+    }
+  }
+  return 0;
+}
+
+
 int BI_NetSegment::getNetPointsAtScenePos(const Point&         pos,
                                           const GraphicsLayer* layer,
                                           QList<BI_NetPoint*>& points) const

--- a/libs/librepcb/project/boards/items/bi_netsegment.h
+++ b/libs/librepcb/project/boards/items/bi_netsegment.h
@@ -72,6 +72,10 @@ public:
   NetSignal&  getNetSignal() const noexcept { return *mNetSignal; }
   bool        isUsed() const noexcept;
   int getViasAtScenePos(const Point& pos, QList<BI_Via*>& vias) const noexcept;
+  int getNetPointNextToScenePos(const Point&         pos,
+                                const GraphicsLayer* layer,
+                                BI_NetPoint**        bestMatch,
+                                UnsignedLength* maxDistance) const noexcept;
   int getNetPointsAtScenePos(const Point& pos, const GraphicsLayer* layer,
                              QList<BI_NetPoint*>& points) const noexcept;
   int getNetLinesAtScenePos(const Point& pos, const GraphicsLayer* layer,

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
@@ -386,6 +386,12 @@ bool BES_DrawTrace::startPositioning(Board& board, const Point& pos,
           new CmdBoardNetSegmentRemoveElements(*netsegment));
       cmdRemove->removeNetLine(*netline);
       mUndoStack.appendToCmdGroup(cmdRemove.take());  // can throw
+    } else if (BI_NetPoint* netpoint = findNetPointNextTo(board, pos)) {
+      mFixedStartAnchor = netpoint;
+      netsegment        = &netpoint->getNetSegment();
+      if (GraphicsLayer* linesLayer = netpoint->getLayerOfLines()) {
+        layer = linesLayer;
+      }
     } else {
       throw Exception(__FILE__, __LINE__, tr("Nothing here to connect."));
     }
@@ -613,6 +619,13 @@ BI_FootprintPad* BES_DrawTrace::findPad(Board& board, const Point& pos,
     }
   }
   return nullptr;
+}
+
+BI_NetPoint* BES_DrawTrace::findNetPointNextTo(Board& board, const Point& pos,
+                                               GraphicsLayer*            layer,
+                                               NetSignal*                netsignal) const
+    noexcept {
+  return board.getNetPointNextToScenePos(pos, layer, netsignal);
 }
 
 BI_NetPoint* BES_DrawTrace::findNetPoint(Board& board, const Point& pos,

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
@@ -106,6 +106,10 @@ private:
   BI_FootprintPad* findPad(Board& board, const Point& pos,
                            GraphicsLayer* layer     = nullptr,
                            NetSignal*     netsignal = nullptr) const noexcept;
+  BI_NetPoint*     findNetPointNextTo(Board& board, const Point& pos,
+                                      GraphicsLayer*            layer     = nullptr,
+                                      NetSignal*                netsignal = nullptr) const
+      noexcept;
   BI_NetPoint*     findNetPoint(Board& board, const Point& pos,
                                 GraphicsLayer*            layer     = nullptr,
                                 NetSignal*                netsignal = nullptr,


### PR DESCRIPTION
As described in Issue #630 the CSV format with ';' and without string separators is not optimal for many use cases.