### PR TITLE
Fix regex of various constrained strings

### DIFF
--- a/libs/librepcb/common/attributes/attributekey.h
+++ b/libs/librepcb/common/attributes/attributekey.h
@@ -61,7 +61,7 @@ struct AttributeKeyVerifier {
 
 struct AttributeKeyConstraint {
   bool operator()(const QString& value) const noexcept {
-    return QRegularExpression("^[_0-9A-Z]{1,40}$")
+    return QRegularExpression("\\A[_0-9A-Z]{1,40}\\z")
         .match(value, 0, QRegularExpression::PartialPreferCompleteMatch)
         .hasMatch();
   }

--- a/libs/librepcb/common/circuitidentifier.h
+++ b/libs/librepcb/common/circuitidentifier.h
@@ -62,7 +62,7 @@ struct CircuitIdentifierVerifier {
 
 struct CircuitIdentifierConstraint {
   bool operator()(const QString& value) const noexcept {
-    return QRegularExpression("^[-a-zA-Z0-9_+/!?@#$]{1,32}$")
+    return QRegularExpression("\\A[-a-zA-Z0-9_+/!?@#$]{1,32}\\z")
         .match(value, 0, QRegularExpression::PartialPreferCompleteMatch)
         .hasMatch();
   }

--- a/libs/librepcb/common/graphics/graphicslayername.h
+++ b/libs/librepcb/common/graphics/graphicslayername.h
@@ -55,7 +55,7 @@ struct GraphicsLayerNameVerifier {
 
 struct GraphicsLayerNameConstraint {
   bool operator()(const QString& value) const noexcept {
-    return QRegularExpression("^[a-z][_0-9a-z]{0,39}$")
+    return QRegularExpression("\\A[a-z][_0-9a-z]{0,39}\\z")
         .match(value, 0, QRegularExpression::PartialPreferCompleteMatch)
         .hasMatch();
   }

--- a/libs/librepcb/common/uuid.cpp
+++ b/libs/librepcb/common/uuid.cpp
@@ -37,7 +37,7 @@ namespace librepcb {
 bool Uuid::isValid(const QString& str) noexcept {
   // check format of string (only accept EXACT matches!)
   QRegularExpression re(
-      "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+      "\\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\z");
   QRegularExpressionMatch match =
       re.match(str, 0, QRegularExpression::PartialPreferCompleteMatch);
   if (!match.hasMatch()) return false;

--- a/libs/librepcb/library/cmp/componentprefix.h
+++ b/libs/librepcb/library/cmp/componentprefix.h
@@ -55,7 +55,7 @@ struct ComponentPrefixVerifier {
 
 struct ComponentPrefixConstraint {
   bool operator()(const QString& value) const noexcept {
-    return QRegularExpression("^[a-zA-Z_]{0,16}$")
+    return QRegularExpression("\\A[a-zA-Z_]{0,16}\\z")
         .match(value, 0, QRegularExpression::PartialPreferCompleteMatch)
         .hasMatch();
   }

--- a/libs/librepcb/library/cmp/componentsymbolvariantitemsuffix.h
+++ b/libs/librepcb/library/cmp/componentsymbolvariantitemsuffix.h
@@ -55,7 +55,7 @@ struct ComponentSymbolVariantItemSuffixVerifier {
 
 struct ComponentSymbolVariantItemSuffixConstraint {
   bool operator()(const QString& value) const noexcept {
-    return QRegularExpression("^[0-9a-zA-Z_]{0,16}$")
+    return QRegularExpression("\\A[0-9a-zA-Z_]{0,16}\\z")
         .match(value, 0, QRegularExpression::PartialPreferCompleteMatch)
         .hasMatch();
   }

--- a/tests/unittests/common/attributes/attributekeytest.cpp
+++ b/tests/unittests/common/attributes/attributekeytest.cpp
@@ -1,0 +1,111 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/attributes/attributekey.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  QString input;
+  bool    valid;
+} AttributeKeyTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class AttributeKeyTest : public ::testing::TestWithParam<AttributeKeyTestData> {
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_P(AttributeKeyTest, testConstructor) {
+  const AttributeKeyTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, *AttributeKey(data.input));
+  } else {
+    EXPECT_THROW(AttributeKey(data.input), RuntimeError);
+  }
+}
+
+TEST_P(AttributeKeyTest, testClean) {
+  const AttributeKeyTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, cleanAttributeKey(data.input));
+  } else {
+    QString cleaned = cleanAttributeKey(data.input);
+    if (!cleaned.isEmpty()) {
+      AttributeKey key(cleaned);  // must not throw
+    }
+  }
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(AttributeKeyTest, AttributeKeyTest, ::testing::Values(
+    // valid keys
+    AttributeKeyTestData({"1", true}),
+    AttributeKeyTestData({"A", true}),
+    AttributeKeyTestData({"_", true}),
+    AttributeKeyTestData({"_A_2_C_", true}),
+    AttributeKeyTestData({"0123456789012345678901234567890123456789", true}),
+
+    // invalid keys
+    AttributeKeyTestData({"", false}), // empty
+    AttributeKeyTestData({"01234567890123456789012345678901234567890", false}), // too long
+    AttributeKeyTestData({" ", false}), // space
+    AttributeKeyTestData({"A B", false}), // space
+    AttributeKeyTestData({"z", false}), // lowercase character
+    AttributeKeyTestData({";", false}), // invalid character
+    AttributeKeyTestData({":1234", false}), // invalid character at start
+    AttributeKeyTestData({"AS:DF", false}), // invalid character in the middle
+    AttributeKeyTestData({"1234:", false}), // invalid character at end
+    AttributeKeyTestData({"\n", false}), // invalid character
+    AttributeKeyTestData({"FOO\tBAR", false}), // invalid character in the middle
+    AttributeKeyTestData({"FOO\nBAR", false}), // invalid character in the middle
+    AttributeKeyTestData({"\nFOO", false}), // invalid character at start
+    AttributeKeyTestData({"FOO\n", false}) // invalid character at end
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/circuitidentifiertest.cpp
+++ b/tests/unittests/common/circuitidentifiertest.cpp
@@ -1,0 +1,113 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/circuitidentifier.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  QString input;
+  bool    valid;
+} CircuitIdentifierTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class CircuitIdentifierTest
+  : public ::testing::TestWithParam<CircuitIdentifierTestData> {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_P(CircuitIdentifierTest, testConstructor) {
+  const CircuitIdentifierTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, *CircuitIdentifier(data.input));
+  } else {
+    EXPECT_THROW(CircuitIdentifier(data.input), RuntimeError);
+  }
+}
+
+TEST_P(CircuitIdentifierTest, testClean) {
+  const CircuitIdentifierTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, cleanCircuitIdentifier(data.input));
+  } else {
+    QString cleaned = cleanCircuitIdentifier(data.input);
+    if (!cleaned.isEmpty()) {
+      CircuitIdentifier identifier(cleaned);  // must not throw
+    }
+  }
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(CircuitIdentifierTest, CircuitIdentifierTest, ::testing::Values(
+    // valid identifiers
+    CircuitIdentifierTestData({"1", true}),
+    CircuitIdentifierTestData({"A", true}),
+    CircuitIdentifierTestData({"z", true}),
+    CircuitIdentifierTestData({"_", true}),
+    CircuitIdentifierTestData({"+", true}),
+    CircuitIdentifierTestData({"-", true}),
+    CircuitIdentifierTestData({"01234567890123456789012345678901", true}),
+    CircuitIdentifierTestData({"_+-/!?@#$asDF1234", true}),
+
+    // invalid identifiers
+    CircuitIdentifierTestData({"", false}), // empty
+    CircuitIdentifierTestData({"012345678901234567890123456789012", false}), // too long
+    CircuitIdentifierTestData({" ", false}), // space
+    CircuitIdentifierTestData({"A B", false}), // space
+    CircuitIdentifierTestData({";", false}), // invalid character
+    CircuitIdentifierTestData({":1234", false}), // invalid character at start
+    CircuitIdentifierTestData({"AS:df", false}), // invalid character in the middle
+    CircuitIdentifierTestData({"1234:", false}), // invalid character at end
+    CircuitIdentifierTestData({"\n", false}), // invalid character
+    CircuitIdentifierTestData({"Foo\tBar", false}), // invalid character in the middle
+    CircuitIdentifierTestData({"Foo\nBar", false}), // invalid character in the middle
+    CircuitIdentifierTestData({"\nFoo", false}), // invalid character at start
+    CircuitIdentifierTestData({"Foo\n", false}) // invalid character at end
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/graphics/graphicslayernametest.cpp
+++ b/tests/unittests/common/graphics/graphicslayernametest.cpp
@@ -1,0 +1,99 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/graphics/graphicslayername.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  QString input;
+  bool    valid;
+} GraphicsLayerNameTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class GraphicsLayerNameTest
+  : public ::testing::TestWithParam<GraphicsLayerNameTestData> {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_P(GraphicsLayerNameTest, testConstructor) {
+  const GraphicsLayerNameTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, *GraphicsLayerName(data.input));
+  } else {
+    EXPECT_THROW(GraphicsLayerName(data.input), RuntimeError);
+  }
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(GraphicsLayerNameTest, GraphicsLayerNameTest, ::testing::Values(
+    // valid keys
+    GraphicsLayerNameTestData({"a", true}),
+    GraphicsLayerNameTestData({"a1", true}),
+    GraphicsLayerNameTestData({"a_b_c_1_2_3", true}),
+    GraphicsLayerNameTestData({"abcdefghijklmnopqrstuvwabcdefghijklmnopq", true}),
+
+    // invalid keys
+    GraphicsLayerNameTestData({"", false}), // empty
+    GraphicsLayerNameTestData({"abcdefghijklmnopqrstuvwabcdefghijklmnopqr", false}), // too long
+    GraphicsLayerNameTestData({" ", false}), // space
+    GraphicsLayerNameTestData({"1a", false}), // digit at start
+    GraphicsLayerNameTestData({"_a", false}), // underscore at start
+    GraphicsLayerNameTestData({"A", false}), // upperspace letter
+    GraphicsLayerNameTestData({"a b", false}), // space
+    GraphicsLayerNameTestData({";", false}), // invalid character
+    GraphicsLayerNameTestData({":abcd", false}), // invalid character at start
+    GraphicsLayerNameTestData({"as:df", false}), // invalid character in the middle
+    GraphicsLayerNameTestData({"abcd:", false}), // invalid character at end
+    GraphicsLayerNameTestData({"\n", false}), // invalid character
+    GraphicsLayerNameTestData({"foo\tbar", false}), // invalid character in the middle
+    GraphicsLayerNameTestData({"foo\nbar", false}), // invalid character in the middle
+    GraphicsLayerNameTestData({"\nfoo", false}), // invalid character at start
+    GraphicsLayerNameTestData({"foo\n", false}) // invalid character at end
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/uuidtest.cpp
+++ b/tests/unittests/common/uuidtest.cpp
@@ -261,6 +261,8 @@ INSTANTIATE_TEST_SUITE_P(UuidTest, UuidTest, ::testing::Values(
     UuidTestData({false, ""                                      }),    // empty
     UuidTestData({false, "                                    "  }),    // empty
     UuidTestData({false, QString()}),                                   // null
+    UuidTestData({false, "\nbdf7bea5-b88e-41b2-be85-c1604e8ddfca"}),    // newline
+    UuidTestData({false, "bdf7bea5-b88e-41b2-be85-c1604e8ddfca\n"}),    // newline
     UuidTestData({false, "74CA6127-E785-4355-8580-1CED4F0A0E9E"  }),    // uppercase
     UuidTestData({false, "568EB40D-CD69-47A5-8932-4F5CC4B2D3FA"  }),    // uppercase
     UuidTestData({false, "29401DCB-6CB6-47A1-8F7D-72DD7F9F4939"  }),    // uppercase

--- a/tests/unittests/library/cmp/componentprefixtest.cpp
+++ b/tests/unittests/library/cmp/componentprefixtest.cpp
@@ -1,0 +1,100 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/library/cmp/componentprefix.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  QString input;
+  bool    valid;
+} ComponentPrefixTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class ComponentPrefixTest
+  : public ::testing::TestWithParam<ComponentPrefixTestData> {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_P(ComponentPrefixTest, testConstructor) {
+  const ComponentPrefixTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, *ComponentPrefix(data.input));
+  } else {
+    EXPECT_THROW(ComponentPrefix(data.input), RuntimeError);
+  }
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(ComponentPrefixTest, ComponentPrefixTest, ::testing::Values(
+    // valid keys
+    ComponentPrefixTestData({"", true}),
+    ComponentPrefixTestData({"A", true}),
+    ComponentPrefixTestData({"z", true}),
+    ComponentPrefixTestData({"_", true}),
+    ComponentPrefixTestData({"_a_B_C_", true}),
+    ComponentPrefixTestData({"abcdefghijklmnop", true}),
+
+    // invalid keys
+    ComponentPrefixTestData({"abcdefghijklmnopq", false}), // too long
+    ComponentPrefixTestData({" ", false}), // space
+    ComponentPrefixTestData({"A1", false}), // digit
+    ComponentPrefixTestData({"A B", false}), // space
+    ComponentPrefixTestData({";", false}), // invalid character
+    ComponentPrefixTestData({":abcd", false}), // invalid character at start
+    ComponentPrefixTestData({"AS:df", false}), // invalid character in the middle
+    ComponentPrefixTestData({"abcd:", false}), // invalid character at end
+    ComponentPrefixTestData({"\n", false}), // invalid character
+    ComponentPrefixTestData({"Foo\tBar", false}), // invalid character in the middle
+    ComponentPrefixTestData({"Foo\nBar", false}), // invalid character in the middle
+    ComponentPrefixTestData({"\nFoo", false}), // invalid character at start
+    ComponentPrefixTestData({"Foo\n", false}) // invalid character at end
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace library
+}  // namespace librepcb

--- a/tests/unittests/library/cmp/componentsymbolvariantitemsuffixtest.cpp
+++ b/tests/unittests/library/cmp/componentsymbolvariantitemsuffixtest.cpp
@@ -1,0 +1,101 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/library/cmp/componentsymbolvariantitemsuffix.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  QString input;
+  bool    valid;
+} ComponentSymbolVariantItemSuffixTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class ComponentSymbolVariantItemSuffixTest
+  : public ::testing::TestWithParam<ComponentSymbolVariantItemSuffixTestData> {
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_P(ComponentSymbolVariantItemSuffixTest, testConstructor) {
+  const ComponentSymbolVariantItemSuffixTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, *ComponentSymbolVariantItemSuffix(data.input));
+  } else {
+    EXPECT_THROW(ComponentSymbolVariantItemSuffix(data.input), RuntimeError);
+  }
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(ComponentSymbolVariantItemSuffixTest,ComponentSymbolVariantItemSuffixTest, ::testing::Values(
+    // valid keys
+    ComponentSymbolVariantItemSuffixTestData({"", true}),
+    ComponentSymbolVariantItemSuffixTestData({"1", true}),
+    ComponentSymbolVariantItemSuffixTestData({"A", true}),
+    ComponentSymbolVariantItemSuffixTestData({"z", true}),
+    ComponentSymbolVariantItemSuffixTestData({"_", true}),
+    ComponentSymbolVariantItemSuffixTestData({"_a_B_C_", true}),
+    ComponentSymbolVariantItemSuffixTestData({"0123456789012345", true}),
+
+    // invalid keys
+    ComponentSymbolVariantItemSuffixTestData({"01234567890123456", false}), // too long
+    ComponentSymbolVariantItemSuffixTestData({" ", false}), // space
+    ComponentSymbolVariantItemSuffixTestData({"A B", false}), // space
+    ComponentSymbolVariantItemSuffixTestData({";", false}), // invalid character
+    ComponentSymbolVariantItemSuffixTestData({":1234", false}), // invalid character at start
+    ComponentSymbolVariantItemSuffixTestData({"AS:df", false}), // invalid character in the middle
+    ComponentSymbolVariantItemSuffixTestData({"1234:", false}), // invalid character at end
+    ComponentSymbolVariantItemSuffixTestData({"\n", false}), // invalid character
+    ComponentSymbolVariantItemSuffixTestData({"Foo\tBar", false}), // invalid character in the middle
+    ComponentSymbolVariantItemSuffixTestData({"Foo\nBar", false}), // invalid character in the middle
+    ComponentSymbolVariantItemSuffixTestData({"\nFoo", false}), // invalid character at start
+    ComponentSymbolVariantItemSuffixTestData({"Foo\n", false}) // invalid character at end
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace library
+}  // namespace librepcb

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -64,7 +64,9 @@ PRE_TARGETDEPS += \
 SOURCES += \
     common/alignmenttest.cpp \
     common/applicationtest.cpp \
+    common/attributes/attributekeytest.cpp \
     common/attributes/attributesubstitutortest.cpp \
+    common/circuitidentifiertest.cpp \
     common/fileio/directorylocktest.cpp \
     common/fileio/filepathtest.cpp \
     common/fileio/serializableobjectlisttest.cpp \
@@ -72,6 +74,7 @@ SOURCES += \
     common/fileio/transactionalfilesystemtest.cpp \
     common/geometry/pathmodeltest.cpp \
     common/geometry/pathtest.cpp \
+    common/graphics/graphicslayernametest.cpp \
     common/network/filedownloadtest.cpp \
     common/network/networkrequesttest.cpp \
     common/scopeguardtest.cpp \
@@ -91,6 +94,8 @@ SOURCES += \
     eagleimport/devicesetconvertertest.cpp \
     eagleimport/packageconvertertest.cpp \
     eagleimport/symbolconvertertest.cpp \
+    library/cmp/componentprefixtest.cpp \
+    library/cmp/componentsymbolvariantitemsuffixtest.cpp \
     library/cmp/componentsymbolvariantitemtest.cpp \
     library/librarybaseelementtest.cpp \
     main.cpp \


### PR DESCRIPTION
The regex to check following constrained strings allowed a trailing newline by accident (see #603):

- AttributeKey
- CircuitIdentifier
- ComponentPrefix
- ComponentSymbolVariantItemSuffix
- GraphicsLayerName
- Uuid

Fixed the regex by using "\A" instead of "^" and "\z" instead of "$".
Also added some unit tests to check for correct behavior.

Fixes #603.