### PR TITLE
Schematic Editor: Add support for renaming sheets

### DIFF
--- a/libs/librepcb/project/project.pro
+++ b/libs/librepcb/project/project.pro
@@ -106,6 +106,7 @@ SOURCES += \
     metadata/projectmetadata.cpp \
     project.cpp \
     schematics/cmd/cmdschematicadd.cpp \
+    schematics/cmd/cmdschematicedit.cpp \
     schematics/cmd/cmdschematicnetlabeladd.cpp \
     schematics/cmd/cmdschematicnetlabelanchorsupdate.cpp \
     schematics/cmd/cmdschematicnetlabeledit.cpp \
@@ -227,6 +228,7 @@ HEADERS += \
     metadata/projectmetadata.h \
     project.h \
     schematics/cmd/cmdschematicadd.h \
+    schematics/cmd/cmdschematicedit.h \
     schematics/cmd/cmdschematicnetlabeladd.h \
     schematics/cmd/cmdschematicnetlabelanchorsupdate.h \
     schematics/cmd/cmdschematicnetlabeledit.h \

--- a/libs/librepcb/project/schematics/cmd/cmdschematicedit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicedit.cpp
@@ -1,0 +1,82 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdschematicedit.h"
+
+#include "../schematic.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdSchematicEdit::CmdSchematicEdit(Schematic& schematic) noexcept
+  : UndoCommand(tr("Edit sheet properties")),
+    mSchematic(schematic),
+    mOldName(schematic.getName()),
+    mNewName(mOldName) {
+}
+
+CmdSchematicEdit::~CmdSchematicEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CmdSchematicEdit::setName(const ElementName& name) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewName = name;
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdSchematicEdit::performExecute() {
+  performRedo();  // can throw
+
+  if (mNewName != mOldName) return true;
+  return false;
+}
+
+void CmdSchematicEdit::performUndo() {
+  mSchematic.setName(mOldName);
+}
+
+void CmdSchematicEdit::performRedo() {
+  mSchematic.setName(mNewName);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/project/schematics/cmd/cmdschematicedit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicedit.h
@@ -1,0 +1,84 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICEDIT_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/elementname.h>
+#include <librepcb/common/undocommand.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+class Schematic;
+
+/*******************************************************************************
+ *  Class CmdSchematicEdit
+ ******************************************************************************/
+
+/**
+ * @brief The CmdSchematicEdit class
+ */
+class CmdSchematicEdit final : public UndoCommand {
+public:
+  // Constructors / Destructor
+  CmdSchematicEdit()                              = delete;
+  CmdSchematicEdit(const CmdSchematicEdit& other) = delete;
+  explicit CmdSchematicEdit(Schematic& schematic) noexcept;
+  ~CmdSchematicEdit() noexcept;
+
+  // Setters
+  void setName(const ElementName& name) noexcept;
+
+  // Operator Overloadings
+  CmdSchematicEdit& operator=(const CmdSchematicEdit& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  bool performExecute() override;
+
+  /// @copydoc UndoCommand::performUndo()
+  void performUndo() override;
+
+  /// @copydoc UndoCommand::performRedo()
+  void performRedo() override;
+
+private:  // Data
+  Schematic& mSchematic;
+
+  ElementName mOldName;
+  ElementName mNewName;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace project
+}  // namespace librepcb
+
+#endif  // LIBREPCB_PROJECT_CMDSCHEMATICEDIT_H

--- a/libs/librepcb/project/schematics/schematic.cpp
+++ b/libs/librepcb/project/schematics/schematic.cpp
@@ -226,11 +226,16 @@ QList<SI_SymbolPin*> Schematic::getPinsAtScenePos(const Point& pos) const
 }
 
 /*******************************************************************************
- *  Setters: General
+ *  Setters
  ******************************************************************************/
 
 void Schematic::setGridProperties(const GridProperties& grid) noexcept {
   *mGridProperties = grid;
+}
+
+void Schematic::setName(const ElementName& name) noexcept {
+  mName = name;
+  emit mProject.attributesChanged();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/schematic.h
+++ b/libs/librepcb/project/schematics/schematic.h
@@ -138,6 +138,9 @@ public:
   const ElementName& getName() const noexcept { return mName; }
   const QIcon&       getIcon() const noexcept { return mIcon; }
 
+  // Setters: Attributes
+  void setName(const ElementName& name) noexcept;
+
   // Symbol Methods
   QList<SI_Symbol*> getSymbols() const noexcept { return mSymbols; }
   SI_Symbol*        getSymbolByUuid(const Uuid& uuid) const noexcept;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -43,6 +43,7 @@
 #include <librepcb/project/metadata/projectmetadata.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/schematics/cmd/cmdschematicadd.h>
+#include <librepcb/project/schematics/cmd/cmdschematicremove.h>
 #include <librepcb/project/schematics/schematic.h>
 #include <librepcb/project/settings/projectsettings.h>
 #include <librepcb/workspace/library/workspacelibrarydb.h>
@@ -86,7 +87,15 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   setWindowTitle(QString("%1 - LibrePCB Schematic Editor").arg(filenameStr));
 
   // Add Dock Widgets
-  mPagesDock = new SchematicPagesDock(mProject, *this);
+  mPagesDock = new SchematicPagesDock(mProject, this);
+  connect(this, &SchematicEditor::activeSchematicChanged, mPagesDock,
+          &SchematicPagesDock::setSelectedSchematic);
+  connect(mPagesDock, &SchematicPagesDock::selectedSchematicChanged, this,
+          &SchematicEditor::setActiveSchematicIndex);
+  connect(mPagesDock, &SchematicPagesDock::addSchematicTriggered, this,
+          &SchematicEditor::addSchematic);
+  connect(mPagesDock, &SchematicPagesDock::removeSchematicTriggered, this,
+          &SchematicEditor::removeSchematic);
   addDockWidget(Qt::LeftDockWidgetArea, mPagesDock, Qt::Vertical);
   mErcMsgDock = new ErcMsgDock(mProject);
   addDockWidget(Qt::RightDockWidgetArea, mErcMsgDock, Qt::Vertical);
@@ -109,6 +118,8 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   mUi->menuView->addAction(mErcMsgDock->toggleViewAction());
 
   // connect some actions which are created with the Qt Designer
+  connect(mUi->actionNew_Schematic_Page, &QAction::triggered, this,
+          &SchematicEditor::addSchematic);
   connect(mUi->actionSave_Project, &QAction::triggered, &mProjectEditor,
           &ProjectEditor::saveProject);
   connect(mUi->actionQuit, &QAction::triggered, this, &SchematicEditor::close);
@@ -282,8 +293,8 @@ bool SchematicEditor::setActiveSchematicIndex(int index) noexcept {
   }
 
   // schematic page has changed!
-  emit activeSchematicChanged(mActiveSchematicIndex, index);
   mActiveSchematicIndex = index;
+  emit activeSchematicChanged(mActiveSchematicIndex);
   return true;
 }
 
@@ -315,22 +326,6 @@ void SchematicEditor::closeEvent(QCloseEvent* event) {
 
 void SchematicEditor::on_actionClose_Project_triggered() {
   mProjectEditor.closeAndDestroy(true, this);
-}
-
-void SchematicEditor::on_actionNew_Schematic_Page_triggered() {
-  bool    ok   = false;
-  QString name = QInputDialog::getText(this, tr("Add schematic page"),
-                                       tr("Choose a name:"), QLineEdit::Normal,
-                                       tr("New Page"), &ok);
-  if (!ok) return;
-
-  try {
-    CmdSchematicAdd* cmd =
-        new CmdSchematicAdd(mProject, ElementName(name));  // can throw
-    mProjectEditor.getUndoStack().execCmd(cmd);
-  } catch (Exception& e) {
-    QMessageBox::critical(this, tr("Error"), e.getMsg());
-  }
 }
 
 void SchematicEditor::on_actionGrid_triggered() {
@@ -510,6 +505,35 @@ void SchematicEditor::toolActionGroupChangeTriggered(
       Q_ASSERT(false);
       qCritical() << "Unknown tool triggered!";
       break;
+  }
+}
+
+void SchematicEditor::addSchematic() noexcept {
+  bool    ok   = false;
+  QString name = QInputDialog::getText(this, tr("Add schematic page"),
+                                       tr("Choose a name:"), QLineEdit::Normal,
+                                       tr("New Page"), &ok);
+  if (!ok) return;
+
+  try {
+    CmdSchematicAdd* cmd =
+        new CmdSchematicAdd(mProject, ElementName(name));  // can throw
+    mProjectEditor.getUndoStack().execCmd(cmd);
+    setActiveSchematicIndex(mProject.getSchematics().count() - 1);
+  } catch (Exception& e) {
+    QMessageBox::critical(this, tr("Error"), e.getMsg());
+  }
+}
+
+void SchematicEditor::removeSchematic(int index) noexcept {
+  Schematic* schematic = mProject.getSchematicByIndex(index);
+  if (!schematic) return;
+
+  try {
+    CmdSchematicRemove* cmd = new CmdSchematicRemove(mProject, *schematic);
+    mProjectEditor.getUndoStack().execCmd(cmd);
+  } catch (Exception& e) {
+    QMessageBox::critical(this, tr("Error"), e.getMsg());
   }
 }
 

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -92,6 +92,7 @@ private slots:
 
   // Actions
   void on_actionClose_Project_triggered();
+  void on_actionRenameSheet_triggered();
   void on_actionGrid_triggered();
   void on_actionPrint_triggered();
   void on_actionPDF_Export_triggered();
@@ -119,6 +120,7 @@ private:
   void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
   void addSchematic() noexcept;
   void removeSchematic(int index) noexcept;
+  void renameSchematic(int index) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -92,7 +92,6 @@ private slots:
 
   // Actions
   void on_actionClose_Project_triggered();
-  void on_actionNew_Schematic_Page_triggered();
   void on_actionGrid_triggered();
   void on_actionPrint_triggered();
   void on_actionPDF_Export_triggered();
@@ -107,8 +106,7 @@ private slots:
   void on_actionUpdateLibrary_triggered();
 
 signals:
-
-  void activeSchematicChanged(int oldIndex, int newIndex);
+  void activeSchematicChanged(int index);
 
 private:
   // make some methods inaccessible...
@@ -119,6 +117,8 @@ private:
   // Private Methods
   bool graphicsViewEventHandler(QEvent* event);
   void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void addSchematic() noexcept;
+  void removeSchematic(int index) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -14,7 +14,7 @@
    <string>Schematic Editor</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../../../img/images.qrc">
+   <iconset>
     <normaloff>:/img/actions/schematic.png</normaloff>:/img/actions/schematic.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -114,9 +114,16 @@
     <addaction name="separator"/>
     <addaction name="actionUpdateLibrary"/>
    </widget>
+   <widget class="QMenu" name="menuSchematic">
+    <property name="title">
+     <string>Schematic</string>
+    </property>
+    <addaction name="actionRenameSheet"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
+   <addaction name="menuSchematic"/>
    <addaction name="menuProject"/>
    <addaction name="menuTools"/>
    <addaction name="menuHelp"/>
@@ -252,7 +259,7 @@
   </widget>
   <action name="actionQuit">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/quit.png</normaloff>:/img/actions/quit.png</iconset>
    </property>
    <property name="text">
@@ -267,7 +274,7 @@
   </action>
   <action name="actionSave_Project">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
    </property>
    <property name="text">
@@ -279,7 +286,7 @@
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
@@ -299,7 +306,7 @@
   </action>
   <action name="actionPrint">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/print.png</normaloff>:/img/actions/print.png</iconset>
    </property>
    <property name="text">
@@ -311,7 +318,7 @@
   </action>
   <action name="actionPDF_Export">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/pdf.png</normaloff>:/img/actions/pdf.png</iconset>
    </property>
    <property name="text">
@@ -323,7 +330,7 @@
   </action>
   <action name="actionShow_Control_Panel">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/home.png</normaloff>:/img/actions/home.png</iconset>
    </property>
    <property name="text">
@@ -332,7 +339,7 @@
   </action>
   <action name="actionShow_Board_Editor">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/board_editor.png</normaloff>:/img/actions/board_editor.png</iconset>
    </property>
    <property name="text">
@@ -341,7 +348,7 @@
   </action>
   <action name="actionUndo">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
    </property>
    <property name="text">
@@ -353,7 +360,7 @@
   </action>
   <action name="actionRedo">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/redo.png</normaloff>:/img/actions/redo.png</iconset>
    </property>
    <property name="text">
@@ -365,7 +372,7 @@
   </action>
   <action name="actionZoom_In">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/zoom_in.png</normaloff>:/img/actions/zoom_in.png</iconset>
    </property>
    <property name="text">
@@ -377,7 +384,7 @@
   </action>
   <action name="actionZoom_Out">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/zoom_out.png</normaloff>:/img/actions/zoom_out.png</iconset>
    </property>
    <property name="text">
@@ -389,7 +396,7 @@
   </action>
   <action name="actionZoom_All">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/zoom_all.png</normaloff>:/img/actions/zoom_all.png</iconset>
    </property>
    <property name="text">
@@ -398,7 +405,7 @@
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
@@ -410,7 +417,7 @@
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
@@ -419,7 +426,7 @@
   </action>
   <action name="actionRotate_CCW">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/rotate_left.png</normaloff>:/img/actions/rotate_left.png</iconset>
    </property>
    <property name="text">
@@ -431,7 +438,7 @@
   </action>
   <action name="actionRotate_CW">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/rotate_right.png</normaloff>:/img/actions/rotate_right.png</iconset>
    </property>
    <property name="text">
@@ -443,7 +450,7 @@
   </action>
   <action name="actionMirror">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/flip_horizontal.png</normaloff>:/img/actions/flip_horizontal.png</iconset>
    </property>
    <property name="text">
@@ -455,7 +462,7 @@
   </action>
   <action name="actionCopy">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -470,7 +477,7 @@
   </action>
   <action name="actionCut">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/cut.png</normaloff>:/img/actions/cut.png</iconset>
    </property>
    <property name="text">
@@ -485,7 +492,7 @@
   </action>
   <action name="actionPaste">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/paste.png</normaloff>:/img/actions/paste.png</iconset>
    </property>
    <property name="text">
@@ -500,7 +507,7 @@
   </action>
   <action name="actionRemove">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -512,7 +519,7 @@
   </action>
   <action name="actionClose_Project">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
@@ -521,7 +528,7 @@
   </action>
   <action name="actionToolSelect">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/select.png</normaloff>:/img/actions/select.png</iconset>
    </property>
    <property name="text">
@@ -530,7 +537,7 @@
   </action>
   <action name="actionToolAddComponent">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/add_component.png</normaloff>:/img/actions/add_component.png</iconset>
    </property>
    <property name="text">
@@ -539,7 +546,7 @@
   </action>
   <action name="actionToolDrawWire">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/draw_wire.png</normaloff>:/img/actions/draw_wire.png</iconset>
    </property>
    <property name="text">
@@ -548,7 +555,7 @@
   </action>
   <action name="actionCommandAbort">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/stop.png</normaloff>:/img/actions/stop.png</iconset>
    </property>
    <property name="text">
@@ -560,7 +567,7 @@
   </action>
   <action name="actionLayers">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/layers.png</normaloff>:/img/actions/layers.png</iconset>
    </property>
    <property name="text">
@@ -572,7 +579,7 @@
   </action>
   <action name="actionGrid">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/grid.png</normaloff>:/img/actions/grid.png</iconset>
    </property>
    <property name="text">
@@ -586,7 +593,7 @@
   </action>
   <action name="actionAddComp_Resistor">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/library/resistor_eu.png</normaloff>:/img/library/resistor_eu.png</iconset>
    </property>
    <property name="text">
@@ -595,7 +602,7 @@
   </action>
   <action name="actionAddComp_BipolarCapacitor">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/library/bipolar_capacitor_eu.png</normaloff>:/img/library/bipolar_capacitor_eu.png</iconset>
    </property>
    <property name="text">
@@ -607,7 +614,7 @@
   </action>
   <action name="actionAddComp_Inductor">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/library/inductor_eu.png</normaloff>:/img/library/inductor_eu.png</iconset>
    </property>
    <property name="text">
@@ -616,7 +623,7 @@
   </action>
   <action name="actionAddComp_gnd">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/library/gnd.png</normaloff>:/img/library/gnd.png</iconset>
    </property>
    <property name="text">
@@ -625,7 +632,7 @@
   </action>
   <action name="actionAddComp_vcc">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/library/vcc.png</normaloff>:/img/library/vcc.png</iconset>
    </property>
    <property name="text">
@@ -639,7 +646,7 @@
   </action>
   <action name="actionProjectSettings">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
    </property>
    <property name="text">
@@ -648,7 +655,7 @@
   </action>
   <action name="actionToolAddNetLabel">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/draw_netlabel.png</normaloff>:/img/actions/draw_netlabel.png</iconset>
    </property>
    <property name="text">
@@ -657,7 +664,7 @@
   </action>
   <action name="actionAddComp_UnipolarCapacitor">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/library/unipolar_capacitor_eu.png</normaloff>:/img/library/unipolar_capacitor_eu.png</iconset>
    </property>
    <property name="text">
@@ -666,7 +673,7 @@
   </action>
   <action name="actionNew_Schematic_Page">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/new_2.png</normaloff>:/img/actions/new_2.png</iconset>
    </property>
    <property name="text">
@@ -678,7 +685,7 @@
   </action>
   <action name="actionUpdateLibrary">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
@@ -687,7 +694,7 @@
   </action>
   <action name="actionExportLppz">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/export_zip.png</normaloff>:/img/actions/export_zip.png</iconset>
    </property>
    <property name="text">
@@ -699,11 +706,16 @@
   </action>
   <action name="actionGenerateBom">
    <property name="icon">
-    <iconset resource="../../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/generate_bom.png</normaloff>:/img/actions/generate_bom.png</iconset>
    </property>
    <property name="text">
     <string>Generate BOM</string>
+   </property>
+  </action>
+  <action name="actionRenameSheet">
+   <property name="text">
+    <string>Rename Sheet</string>
    </property>
   </action>
  </widget>
@@ -714,9 +726,6 @@
    <header location="global">librepcb/common/widgets/statusbar.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.cpp
@@ -60,6 +60,8 @@ SchematicPagesDock::SchematicPagesDock(Project& project, QWidget* parent)
           &SchematicPagesDock::schematicAdded);
   connect(&mProject, &Project::schematicRemoved, this,
           &SchematicPagesDock::schematicRemoved);
+  connect(&mProject, &Project::attributesChanged, this,
+          &SchematicPagesDock::updateSchematicNames);
 
   // install event filter on the list widget to implement keyboard shortcuts
   mUi->listWidget->installEventFilter(this);
@@ -95,6 +97,11 @@ bool SchematicPagesDock::eventFilter(QObject* obj, QEvent* event) noexcept {
         event->accept();
         return true;
       }
+      case Qt::Key_F2: {
+        renameSelectedSchematic();
+        event->accept();
+        return true;
+      }
       default:
         break;
     }
@@ -110,6 +117,10 @@ void SchematicPagesDock::removeSelectedSchematic() noexcept {
   emit removeSchematicTriggered(mUi->listWidget->currentRow());
 }
 
+void SchematicPagesDock::renameSelectedSchematic() noexcept {
+  emit renameSchematicTriggered(mUi->listWidget->currentRow());
+}
+
 void SchematicPagesDock::schematicAdded(int newIndex) noexcept {
   Schematic* schematic = mProject.getSchematicByIndex(newIndex);
   Q_ASSERT(schematic);
@@ -123,6 +134,16 @@ void SchematicPagesDock::schematicAdded(int newIndex) noexcept {
 
 void SchematicPagesDock::schematicRemoved(int oldIndex) noexcept {
   delete mUi->listWidget->item(oldIndex);
+}
+
+void SchematicPagesDock::updateSchematicNames() noexcept {
+  for (int i = 0; i < mUi->listWidget->count(); ++i) {
+    QListWidgetItem* item      = mUi->listWidget->item(i);
+    const Schematic* schematic = mProject.getSchematicByIndex(i);
+    if (item && schematic) {
+      item->setText(*schematic->getName());
+    }
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.h
@@ -36,8 +36,6 @@ class Project;
 
 namespace editor {
 
-class SchematicEditor;
-
 namespace Ui {
 class SchematicPagesDock;
 }
@@ -54,35 +52,34 @@ class SchematicPagesDock final : public QDockWidget {
 
 public:
   // Constructors / Destructor
-  explicit SchematicPagesDock(Project& project, SchematicEditor& editor);
+  SchematicPagesDock()                                = delete;
+  SchematicPagesDock(const SchematicPagesDock& other) = delete;
+  SchematicPagesDock(Project& project, QWidget* parent = nullptr);
   ~SchematicPagesDock();
 
-  // Inherited from QDockWidget
-  void resizeEvent(QResizeEvent* event);
+  // General Methods
+  void setSelectedSchematic(int index) noexcept;
 
-public slots:
+  // Operator Overloadings
+  SchematicPagesDock& operator=(const SchematicPagesDock& rhs) = delete;
 
-  void activeSchematicChanged(int oldIndex, int newIndex);
-  void schematicAdded(int newIndex);
-  void schematicRemoved(int oldIndex);
+signals:
+  void selectedSchematicChanged(int index);
+  void addSchematicTriggered();
+  void removeSchematicTriggered(int index);
 
-private slots:
+protected:
+  void resizeEvent(QResizeEvent* event) noexcept override;
+  bool eventFilter(QObject* obj, QEvent* event) noexcept override;
 
-  // UI
-  void on_btnNewSchematic_clicked();
-  void on_btnRemoveSchematic_clicked();
-  void on_listWidget_currentRowChanged(int currentRow);
+private:  // Methods
+  void removeSelectedSchematic() noexcept;
+  void schematicAdded(int newIndex) noexcept;
+  void schematicRemoved(int oldIndex) noexcept;
 
-private:
-  // make some methods inaccessible...
-  SchematicPagesDock();
-  SchematicPagesDock(const SchematicPagesDock& other);
-  SchematicPagesDock& operator=(const SchematicPagesDock& rhs);
-
-  // General
-  Project&                mProject;
-  SchematicEditor&        mEditor;
-  Ui::SchematicPagesDock* mUi;
+private:  // Data
+  Project&                               mProject;
+  QScopedPointer<Ui::SchematicPagesDock> mUi;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.h
@@ -67,6 +67,7 @@ signals:
   void selectedSchematicChanged(int index);
   void addSchematicTriggered();
   void removeSchematicTriggered(int index);
+  void renameSchematicTriggered(int index);
 
 protected:
   void resizeEvent(QResizeEvent* event) noexcept override;
@@ -74,8 +75,10 @@ protected:
 
 private:  // Methods
   void removeSelectedSchematic() noexcept;
+  void renameSelectedSchematic() noexcept;
   void schematicAdded(int newIndex) noexcept;
   void schematicRemoved(int oldIndex) noexcept;
+  void updateSchematicNames() noexcept;
 
 private:  // Data
   Project&                               mProject;


### PR DESCRIPTION
Renaming schematic pages was not possible at all until now. This PR adds a menu item "Schematic->Rename Sheet" to the schematic editor, and the keyboard shortcut "F2" to the schematic pages dock widget. An input dialog then asks for the new sheet name.

Discussion: https://librepcb.discourse.group/t/how-to-change-the-name-of-a-schematic-page/150