### PR TITLE
Fix missing resources in QtCreator designer

### DIFF
--- a/apps/EagleImport/EagleImport.pro
+++ b/apps/EagleImport/EagleImport.pro
@@ -44,6 +44,9 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libclipper.a \
 
+RESOURCES += \
+    ../../img/images.qrc \
+
 SOURCES += \
     main.cpp \
     mainwindow.cpp \

--- a/apps/UuidGenerator/UuidGenerator.pro
+++ b/apps/UuidGenerator/UuidGenerator.pro
@@ -27,6 +27,9 @@ DEPENDPATH += \
 PRE_TARGETDEPS += \
     $${DESTDIR}/liblibrepcbcommon.a
 
+RESOURCES += \
+    ../../img/images.qrc \
+
 SOURCES += \
     main.cpp \
     mainwindow.cpp \

--- a/apps/librepcb-cli/librepcb-cli.pro
+++ b/apps/librepcb-cli/librepcb-cli.pro
@@ -67,7 +67,7 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/libclipper.a \
 
 RESOURCES += \
-    ../../img/images.qrc
+    ../../img/images.qrc \
 
 SOURCES += \
     commandlineinterface.cpp \

--- a/apps/librepcb/controlpanel/controlpanel.ui
+++ b/apps/librepcb/controlpanel/controlpanel.ui
@@ -14,7 +14,7 @@
    <string>LibrePCB ControlPanel</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../../img/images.qrc">
+   <iconset>
     <normaloff>:/img/app/librepcb.png</normaloff>:/img/app/librepcb.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -168,7 +168,7 @@
               <string>New Project</string>
              </property>
              <property name="icon">
-              <iconset resource="../../../img/images.qrc">
+              <iconset>
                <normaloff>:/img/actions/new.png</normaloff>:/img/actions/new.png</iconset>
              </property>
              <property name="iconSize">
@@ -185,7 +185,7 @@
               <string>Open Project</string>
              </property>
              <property name="icon">
-              <iconset resource="../../../img/images.qrc">
+              <iconset>
                <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
              </property>
              <property name="iconSize">
@@ -202,7 +202,7 @@
               <string>Library Manager</string>
              </property>
              <property name="icon">
-              <iconset resource="../../../img/images.qrc">
+              <iconset>
                <normaloff>:/img/library/symbol.png</normaloff>:/img/library/symbol.png</iconset>
              </property>
              <property name="iconSize">
@@ -470,7 +470,7 @@ QListView::item
   <widget class="librepcb::StatusBar" name="statusBar"/>
   <action name="actionQuit">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/quit.png</normaloff>:/img/actions/quit.png</iconset>
    </property>
    <property name="text">
@@ -493,7 +493,7 @@ QListView::item
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
@@ -505,7 +505,7 @@ QListView::item
   </action>
   <action name="actionNew_Project">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/new.png</normaloff>:/img/actions/new.png</iconset>
    </property>
    <property name="text">
@@ -514,7 +514,7 @@ QListView::item
   </action>
   <action name="actionOpen_Project">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
    </property>
    <property name="text">
@@ -528,7 +528,7 @@ QListView::item
   </action>
   <action name="actionWorkspace_Settings">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
    </property>
    <property name="text">
@@ -540,7 +540,7 @@ QListView::item
   </action>
   <action name="actionOpen_Library_Manager">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/library/symbol.png</normaloff>:/img/library/symbol.png</iconset>
    </property>
    <property name="text">
@@ -552,7 +552,7 @@ QListView::item
   </action>
   <action name="actionClose_all_open_projects">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
@@ -566,7 +566,7 @@ QListView::item
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
@@ -578,7 +578,7 @@ QListView::item
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset resource="../../../img/images.qrc">
+    <iconset>
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
@@ -594,9 +594,7 @@ QListView::item
    <header location="global">librepcb/common/widgets/statusbar.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>newProjectButton</sender>

--- a/apps/librepcb/firstrunwizard/firstrunwizard.ui
+++ b/apps/librepcb/firstrunwizard/firstrunwizard.ui
@@ -17,15 +17,13 @@
    <string>Choose LibrePCB Workspace</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../../img/images.qrc">
+   <iconset>
     <normaloff>:/img/app/librepcb.png</normaloff>:/img/app/librepcb.png</iconset>
   </property>
   <property name="wizardStyle">
    <enum>QWizard::ModernStyle</enum>
   </property>
  </widget>
- <resources>
-  <include location="../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -81,7 +81,7 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/libclipper.a \
 
 RESOURCES += \
-    ../../img/images.qrc
+    ../../img/images.qrc \
 
 SOURCES += \
     controlpanel/controlpanel.cpp \

--- a/dev/sort_qmake_file_entries.py
+++ b/dev/sort_qmake_file_entries.py
@@ -40,7 +40,8 @@ def sort_qmake_file(project_root, filepath):
             is_headers = line.startswith("HEADERS += \\")
             is_sources = line.startswith("SOURCES += \\")
             is_forms = line.startswith("FORMS += \\")
-            if is_headers or is_sources or is_forms:
+            is_resources = line.startswith("RESOURCES += \\")
+            if is_headers or is_sources or is_forms or is_resources:
                 block_start_index = line_index + 1
         else:
             if not line.strip():

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -27,6 +27,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     alignment.cpp \
     application.cpp \

--- a/libs/librepcb/eagleimport/eagleimport.pro
+++ b/libs/librepcb/eagleimport/eagleimport.pro
@@ -20,6 +20,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     converterdb.cpp \
     deviceconverter.cpp \

--- a/libs/librepcb/library/library.pro
+++ b/libs/librepcb/library/library.pro
@@ -19,6 +19,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     cat/cmd/cmdlibrarycategoryedit.cpp \
     cat/componentcategory.cpp \

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.ui
@@ -190,7 +190,7 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../../../../img/images.qrc">
+        <iconset>
          <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
        </property>
       </widget>
@@ -239,9 +239,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.ui
@@ -125,7 +125,7 @@
                <string/>
               </property>
               <property name="icon">
-               <iconset resource="../../../../img/images.qrc">
+               <iconset>
                 <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
               </property>
               <property name="iconSize">
@@ -208,7 +208,7 @@
                <string/>
               </property>
               <property name="icon">
-               <iconset resource="../../../../img/images.qrc">
+               <iconset>
                 <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
               </property>
               <property name="iconSize">
@@ -448,9 +448,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.ui
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.ui
@@ -63,7 +63,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="../../../../img/images.qrc">
+        <iconset>
          <normaloff>:/img/actions/add.png</normaloff>:/img/actions/add.png</iconset>
        </property>
       </widget>
@@ -74,7 +74,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset resource="../../../../img/images.qrc">
+        <iconset>
          <normaloff>:/img/actions/minus.png</normaloff>:/img/actions/minus.png</iconset>
        </property>
       </widget>
@@ -83,8 +83,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/libraryeditor.pro
+++ b/libs/librepcb/libraryeditor/libraryeditor.pro
@@ -19,6 +19,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     cmp/cmpsigpindisplaytypecombobox.cpp \
     cmp/componenteditorwidget.cpp \

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizard.ui
@@ -17,15 +17,13 @@
    <string>New Library Element</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../../img/images.qrc">
+   <iconset>
     <normaloff>:/img/app/librepcb.png</normaloff>:/img/app/librepcb.png</iconset>
   </property>
   <property name="wizardStyle">
    <enum>QWizard::ModernStyle</enum>
   </property>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_choosetype.ui
@@ -36,7 +36,7 @@
 (e.g. OpAmps)</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../img/images.qrc">
+      <iconset>
        <normaloff>:/img/places/folder.png</normaloff>:/img/places/folder.png</iconset>
      </property>
      <property name="iconSize">
@@ -66,7 +66,7 @@
 (e.g. DIP)</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../img/images.qrc">
+      <iconset>
        <normaloff>:/img/places/folder_green.png</normaloff>:/img/places/folder_green.png</iconset>
      </property>
      <property name="iconSize">
@@ -96,7 +96,7 @@
 (e.g. OpAmpChannel)</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../img/images.qrc">
+      <iconset>
        <normaloff>:/img/library/symbol.png</normaloff>:/img/library/symbol.png</iconset>
      </property>
      <property name="iconSize">
@@ -126,7 +126,7 @@
 (e.g. DIP8)</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../img/images.qrc">
+      <iconset>
        <normaloff>:/img/library/package.png</normaloff>:/img/library/package.png</iconset>
      </property>
      <property name="iconSize">
@@ -156,7 +156,7 @@
 (e.g. SingleOpAmp)</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../img/images.qrc">
+      <iconset>
        <normaloff>:/img/library/component.png</normaloff>:/img/library/component.png</iconset>
      </property>
      <property name="iconSize">
@@ -186,7 +186,7 @@
 (e.g. LM358)</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../img/images.qrc">
+      <iconset>
        <normaloff>:/img/library/device.png</normaloff>:/img/library/device.png</iconset>
      </property>
      <property name="iconSize">
@@ -237,8 +237,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
@@ -164,7 +164,7 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../../../../img/images.qrc">
+        <iconset>
          <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
        </property>
       </widget>
@@ -173,8 +173,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.ui
@@ -193,7 +193,7 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../../../../img/images.qrc">
+        <iconset>
          <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
        </property>
       </widget>
@@ -235,9 +235,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/librarymanager/librarymanager.pro
+++ b/libs/librepcb/librarymanager/librarymanager.pro
@@ -19,6 +19,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     addlibrarywidget.cpp \
     librarydownload.cpp \

--- a/libs/librepcb/project/project.pro
+++ b/libs/librepcb/project/project.pro
@@ -19,6 +19,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     boards/board.cpp \
     boards/boardairwiresbuilder.cpp \

--- a/libs/librepcb/projecteditor/dialogs/bomgeneratordialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/bomgeneratordialog.ui
@@ -103,7 +103,7 @@
         <string notr="true"/>
        </property>
        <property name="icon">
-        <iconset resource="../../../../img/images.qrc">
+        <iconset>
          <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
        </property>
       </widget>
@@ -129,10 +129,7 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.ui
@@ -68,7 +68,7 @@
            <item>
             <widget class="QToolButton" name="btnLocaleAdd">
              <property name="icon">
-              <iconset resource="../../../../img/images.qrc">
+              <iconset>
                <normaloff>:/img/actions/plus_2.png</normaloff>:/img/actions/plus_2.png</iconset>
              </property>
             </widget>
@@ -76,7 +76,7 @@
            <item>
             <widget class="QToolButton" name="btnLocaleRemove">
              <property name="icon">
-              <iconset resource="../../../../img/images.qrc">
+              <iconset>
                <normaloff>:/img/actions/minus.png</normaloff>:/img/actions/minus.png</iconset>
              </property>
             </widget>
@@ -129,7 +129,7 @@
            <item>
             <widget class="QToolButton" name="btnNormAdd">
              <property name="icon">
-              <iconset resource="../../../../img/images.qrc">
+              <iconset>
                <normaloff>:/img/actions/plus_2.png</normaloff>:/img/actions/plus_2.png</iconset>
              </property>
             </widget>
@@ -137,7 +137,7 @@
            <item>
             <widget class="QToolButton" name="btnNormRemove">
              <property name="icon">
-              <iconset resource="../../../../img/images.qrc">
+              <iconset>
                <normaloff>:/img/actions/minus.png</normaloff>:/img/actions/minus.png</iconset>
              </property>
             </widget>
@@ -176,9 +176,7 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/libs/librepcb/projecteditor/docks/ercmsgdock.ui
+++ b/libs/librepcb/projecteditor/docks/ercmsgdock.ui
@@ -81,7 +81,7 @@
        <string>Approve Selected Messages</string>
       </property>
       <property name="icon">
-       <iconset resource="../../../../img/images.qrc">
+       <iconset>
         <normaloff>:/img/actions/apply.png</normaloff>:/img/actions/apply.png</iconset>
       </property>
       <property name="checkable">
@@ -95,8 +95,6 @@
    </layout>
   </widget>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcb/projecteditor/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -147,7 +147,7 @@
       </size>
      </property>
      <property name="pixmap">
-      <pixmap resource="../../../../img/images.qrc">:/img/status/info.png</pixmap>
+      <pixmap>:/img/status/info.png</pixmap>
      </property>
      <property name="scaledContents">
       <bool>true</bool>
@@ -211,8 +211,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -19,6 +19,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     boardeditor/boarddesignrulecheckdialog.cpp \
     boardeditor/boarddesignrulecheckmessagesdock.cpp \

--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.ui
@@ -81,7 +81,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../../../../img/images.qrc">
+         <iconset>
           <normaloff>:/img/actions/plus_2.png</normaloff>:/img/actions/plus_2.png</iconset>
         </property>
         <property name="iconSize">
@@ -107,7 +107,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../../../../img/images.qrc">
+         <iconset>
           <normaloff>:/img/actions/minus.png</normaloff>:/img/actions/minus.png</iconset>
         </property>
         <property name="iconSize">
@@ -173,8 +173,6 @@
    </layout>
   </widget>
  </widget>
- <resources>
-  <include location="../../../../img/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/workspace/workspace.pro
+++ b/libs/librepcb/workspace/workspace.pro
@@ -19,6 +19,9 @@ INCLUDEPATH += \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
 
+RESOURCES += \
+    ../../../img/images.qrc \
+
 SOURCES += \
     favoriteprojectsmodel.cpp \
     fileiconprovider.cpp \


### PR DESCRIPTION
With recent QtCreator releases, in some (or even all?) *.ui files it's no longer possible to choose images from our `images.qrc` resource file. I have no idea why (with older QtCreator releases it worked properly), but it seems to be fixed if every *.pro file links to the resource file...

In addition, older QtCreator versions sometimes(?) added the path to the resource file to *.ui files, but that doesn't fix the issue above and it seems to have no effect, thus I removed them (for consistency, since most *.ui files don't have it too).

I tested the nightly builds from this branch and all images are still there, so probably it doesn't break anything ;)