### PR TITLE
Change macOS default target directory

### DIFF
--- a/dist/installer/update_metadata.sh
+++ b/dist/installer/update_metadata.sh
@@ -35,7 +35,7 @@ then
   DEFAULT_TARGET_DIR="@homeDir@/LibrePCB"
 elif [[ "$TARGET_NAME" == mac* ]]
 then
-  DEFAULT_TARGET_DIR="@homeDir@/Applications/LibrePCB"
+  DEFAULT_TARGET_DIR="/Applications/LibrePCB"
 fi
 
 # copy to destination directory


### PR DESCRIPTION
Instead of `~/Applications/`, use the system-wide `/Applications/` directory.

Fixes #644.

I haven't tested this. Will opening a PR automatically result in the branch being built in CI, or do we have to merge to master in order for a nightly to be created?

(I can test this on a macOS machine next week, but don't have any build toolchain on there to build the installer manually.)