### PR TITLE
Replace UUID validation RegEx with manual validation

### DIFF
--- a/libs/librepcb/common/uuid.cpp
+++ b/libs/librepcb/common/uuid.cpp
@@ -34,19 +34,59 @@ namespace librepcb {
  *  Static Methods
  ******************************************************************************/
 
+inline bool isLowerHex(const QChar chr) noexcept {
+  return (chr >= QChar('0') && chr <= QChar('9')) || (chr >= QChar('a') && chr <= QChar('f'));
+}
+
 bool Uuid::isValid(const QString& str) noexcept {
-  // check format of string (only accept EXACT matches!)
-  QRegularExpression re(
-      "\\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\z");
-  QRegularExpressionMatch match =
-      re.match(str, 0, QRegularExpression::PartialPreferCompleteMatch);
-  if (!match.hasMatch()) return false;
+  // Note: This used to be done using a RegEx, but when profiling and
+  // optimizing the library rescan code we found that a manually unrolled
+  // comparison loop performs much better than the previous RegEx.
+  // See https://github.com/LibrePCB/LibrePCB/pull/651 for more details.
+  if (str.length() != 36) return false;
+  if (!isLowerHex(str[0])) return false;
+  if (!isLowerHex(str[1])) return false;
+  if (!isLowerHex(str[2])) return false;
+  if (!isLowerHex(str[3])) return false;
+  if (!isLowerHex(str[4])) return false;
+  if (!isLowerHex(str[5])) return false;
+  if (!isLowerHex(str[6])) return false;
+  if (!isLowerHex(str[7])) return false;
+  if (str[8] != QChar('-')) return false;
+  if (!isLowerHex(str[9])) return false;
+  if (!isLowerHex(str[10])) return false;
+  if (!isLowerHex(str[11])) return false;
+  if (!isLowerHex(str[12])) return false;
+  if (str[13] != QChar('-')) return false;
+  if (!isLowerHex(str[14])) return false;
+  if (!isLowerHex(str[15])) return false;
+  if (!isLowerHex(str[16])) return false;
+  if (!isLowerHex(str[17])) return false;
+  if (str[18] != QChar('-')) return false;
+  if (!isLowerHex(str[19])) return false;
+  if (!isLowerHex(str[20])) return false;
+  if (!isLowerHex(str[21])) return false;
+  if (!isLowerHex(str[22])) return false;
+  if (str[23] != QChar('-')) return false;
+  if (!isLowerHex(str[24])) return false;
+  if (!isLowerHex(str[25])) return false;
+  if (!isLowerHex(str[26])) return false;
+  if (!isLowerHex(str[27])) return false;
+  if (!isLowerHex(str[28])) return false;
+  if (!isLowerHex(str[29])) return false;
+  if (!isLowerHex(str[30])) return false;
+  if (!isLowerHex(str[31])) return false;
+  if (!isLowerHex(str[32])) return false;
+  if (!isLowerHex(str[33])) return false;
+  if (!isLowerHex(str[34])) return false;
+  if (!isLowerHex(str[35])) return false;
 
   // check type of uuid
   QUuid quuid(str);
   if (quuid.isNull()) return false;
   if (quuid.variant() != QUuid::DCE) return false;
   if (quuid.version() != QUuid::Random) return false;
+
   return true;
 }
 

--- a/libs/librepcb/common/uuid.cpp
+++ b/libs/librepcb/common/uuid.cpp
@@ -34,16 +34,19 @@ namespace librepcb {
  *  Static Methods
  ******************************************************************************/
 
-inline bool isLowerHex(const QChar chr) noexcept {
-  return (chr >= QChar('0') && chr <= QChar('9')) || (chr >= QChar('a') && chr <= QChar('f'));
-}
-
 bool Uuid::isValid(const QString& str) noexcept {
   // Note: This used to be done using a RegEx, but when profiling and
   // optimizing the library rescan code we found that a manually unrolled
   // comparison loop performs much better than the previous RegEx.
   // See https://github.com/LibrePCB/LibrePCB/pull/651 for more details.
   if (str.length() != 36) return false;
+
+  // Helper function
+  auto isLowerHex = [](const QChar& chr) {
+    return (chr >= QChar('0') && chr <= QChar('9')) ||
+           (chr >= QChar('a') && chr <= QChar('f'));
+  };
+
   if (!isLowerHex(str[0])) return false;
   if (!isLowerHex(str[1])) return false;
   if (!isLowerHex(str[2])) return false;


### PR DESCRIPTION
When analyzing a callgrind profile of a full library rescan, I noticed
that there are a lot of CPU instructions coming from libpcre2, with the
call originating in the UUID validation code.

Previously, the regular expression used for UUID validation was parsed
from a string for every invocation of the validation function. This is
unnecessary. A library rescan will validate thousands of UUIDs (roughly
250k calls to `Uuid::isValid` with 200'000 instructions per call on my
laptop for a library rescan). By moving the code to a static class
member, I achieved a 15% speedup for a full library scan.

---

Library scan duration for five consecutive LibrePCB starts using the release build:

Before:

- 12'419 ms
- 12'239 ms
- 11'992 ms
- 12'377 ms
- 11'766 ms

Avg: 12'159 ms

After:

- 11'366 ms
- 9'975 ms
- 10'113 ms
- 10'149 ms
- 10'020 ms

Avg: 10'325 ms (-15%)