### PR TITLE
Fix grammar: was crashed -> crashed

### DIFF
--- a/dev/doxygen/pages/project.md
+++ b/dev/doxygen/pages/project.md
@@ -192,7 +192,7 @@ To avoid such problems, the constructor of librepcb::project::Project tries to l
 directory with a librepcb::DirectoryLock object (librepcb::project::Project::mLock). If the project
 is already locked by another application instance, the project cannot be opened again (the
 constructor of librepcb::project::Project throws an exception). If the lock file exists because the
-application was crashed while the project was open, the user gets a message box which asks whether
+application crashed while the project was open, the user gets a message box which asks whether
 the last automatic backup should be restored or not (see also @ref doc_project_save). The lock will
 be released automatically when the librepcb::project::Project instance is destroyed (RAII, see
 librepcb::DirectoryLock).

--- a/libs/librepcb/common/fileio/directorylock.h
+++ b/libs/librepcb/common/fileio/directorylock.h
@@ -79,12 +79,12 @@ namespace librepcb {
  *
  * The lock file (and especially its content) is also used to detect application
  * crashes. If the application crashes while a directory was locked, the lock
- * file will still exist after the application was crashed. Now, if the user
+ * file will still exist after the application crashed. Now, if the user
  * tries to open the locked directory again, the content of the lock file will
  * be parsed. If the username and the hostname in the lock file is equal to the
  * current user which tries to get the lock, it's clear that the lock file does
  * NOT exist because the locked directory is already open, but that the
- * application was crashed while the directory was locked. If there exists a
+ * application crashed while the directory was locked. If there exists a
  * backup of the locked directory (e.g. project auto-save), this allows to ask
  * the user whether the backup should be restored or not.
  *
@@ -129,7 +129,7 @@ namespace librepcb {
  *                      throw Exception("Directory is locked!");
  *                      break;
  *                  case StaleLock:
- *                      // The application was crashed while the lock was
+ *                      // The application crashed while the lock was
  * active.
  *                      // Ask the user whether a backup should be restored or
  * not. break; default:

--- a/libs/librepcb/common/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.cpp
@@ -68,8 +68,8 @@ TransactionalFileSystem::TransactionalFileSystem(const FilePath& filepath,
     if (restoreMode == RestoreMode::ASK) {
       QMessageBox::StandardButton btn = QMessageBox::question(
           0, tr("Restore autosave backup?"),
-          tr("It seems that the application was crashed the last time. "
-             "Do you want to restore the last autosave backup?"),
+          tr("It seems that the application crashed the last time you opened "
+             "this project. Do you want to restore the last autosave backup?"),
           QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
           QMessageBox::Cancel);
       switch (btn) {

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -85,7 +85,7 @@ Workspace::Workspace(const FilePath& wsPath)
   FileUtils::makePath(mMetadataPath);   // can throw
   FileUtils::makePath(mLibrariesPath);  // can throw
 
-  // Check if the workspace is locked (already open or application was crashed).
+  // Check if the workspace is locked (already open or application crashed).
   switch (mLock.getStatus())  // can throw
   {
     case DirectoryLock::LockStatus::Unlocked: {


### PR DESCRIPTION
Crashing is an active verb, not a passive one.