### PR TITLE
TransactionalFileSystem: Use callback to ask for restoring

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.h
+++ b/apps/librepcb/controlpanel/controlpanel.h
@@ -204,6 +204,18 @@ private:
   project::editor::ProjectEditor* getOpenProject(const FilePath& filepath) const
       noexcept;
 
+  /**
+   * @brief Ask the user whether to restore a backup of a project
+   *
+   * @param dir   The project directory to be restored.
+   *
+   * @retval true   Restore backup.
+   * @retval false  Do not restore backup.
+   *
+   * @throw Exception to abort opening the project.
+   */
+  static bool askForRestoringBackup(const FilePath& dir);
+
   // Library Management
   void openLibraryEditor(const FilePath& libDir) noexcept;
   void libraryEditorDestroyed() noexcept;

--- a/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
+++ b/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
@@ -102,7 +102,7 @@ void ProjectLibraryUpdater::btnUpdateClicked() {
       std::shared_ptr<TransactionalFileSystem> fs =
           TransactionalFileSystem::openRW(
               mProjectFilePath.getParentDir(),
-              TransactionalFileSystem::RestoreMode::ABORT);
+              &TransactionalFileSystem::RestoreMode::abort);
 
       // update all elements
       updateElements(fs, "cmp", &WorkspaceLibraryDb::getLatestComponent);

--- a/libs/librepcb/common/application.cpp
+++ b/libs/librepcb/common/application.cpp
@@ -160,7 +160,7 @@ Application::Application(int& argc, char** argv) noexcept
   // load all stroke fonts
   TransactionalFileSystem strokeFontsDir(
       getResourcesFilePath("fontobene"), false,
-      TransactionalFileSystem::RestoreMode::NO);
+      &TransactionalFileSystem::RestoreMode::no);
   mStrokeFontPool.reset(new StrokeFontPool(strokeFontsDir));
   getDefaultStrokeFont();  // ensure that the default font is available (aborts
                            // if not)

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.h
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.h
@@ -143,6 +143,17 @@ private slots:
   void updateCheckMessages() noexcept;
 
 private:  // Methods
+  /**
+   * @brief Ask the user whether to restore a backup of a library element
+   *
+   * @param dir   The library element directory to be restored.
+   *
+   * @retval true   Restore backup.
+   * @retval false  Do not restore backup.
+   *
+   * @throw Exception to abort opening the library element.
+   */
+  static bool  askForRestoringBackup(const FilePath& dir);
   void         toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
   void         undoStackCleanChanged(bool clean) noexcept;
   void         scheduleLibraryElementChecks() noexcept;

--- a/tests/unittests/common/fileio/transactionalfilesystemtest.cpp
+++ b/tests/unittests/common/fileio/transactionalfilesystemtest.cpp
@@ -503,7 +503,7 @@ TEST_F(TransactionalFileSystemTest, testRestoreAutosave) {
 
   // open another file system on the same directory to restore the autosave
   TransactionalFileSystem fs2(mPopulatedDir, true,
-                              TransactionalFileSystem::RestoreMode::YES);
+                              &TransactionalFileSystem::RestoreMode::yes);
   EXPECT_TRUE(fs2.isRestoredFromAutosave());
 
   // check state in memory


### PR DESCRIPTION
Instead of passing an enum for choosing the restore mode (yes/no/ask/abort), a callback can now be passed. The callback then returns a bool to choose whether the backup should be restored or not. This way the message box has to be implemented in higher level classes, and thus can be more specific.

See https://github.com/LibrePCB/LibrePCB/pull/668#discussion_r379836306