### PR TITLE
Add "search" toolbar to schematic- and board editor

### DIFF
--- a/libs/librepcb/project/boards/items/bi_footprint.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprint.cpp
@@ -141,6 +141,10 @@ bool BI_Footprint::isUsed() const noexcept {
   return false;
 }
 
+QRectF BI_Footprint::getBoundingRect() const noexcept {
+  return mGraphicsItem->sceneTransform().mapRect(mGraphicsItem->boundingRect());
+}
+
 /*******************************************************************************
  *  StrokeText Methods
  ******************************************************************************/

--- a/libs/librepcb/project/boards/items/bi_footprint.h
+++ b/libs/librepcb/project/boards/items/bi_footprint.h
@@ -79,6 +79,7 @@ public:
   const Angle&                        getRotation() const noexcept;
   bool                                isSelectable() const noexcept override;
   bool                                isUsed() const noexcept;
+  QRectF                              getBoundingRect() const noexcept;
   BGI_Footprint& getGraphicsItem() noexcept { return *mGraphicsItem; }
 
   // StrokeText Methods

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -144,6 +144,10 @@ QString SI_Symbol::getName() const noexcept {
   }
 }
 
+QRectF SI_Symbol::getBoundingRect() const noexcept {
+  return mGraphicsItem->sceneTransform().mapRect(mGraphicsItem->boundingRect());
+}
+
 /*******************************************************************************
  *  Setters
  ******************************************************************************/

--- a/libs/librepcb/project/schematics/items/si_symbol.h
+++ b/libs/librepcb/project/schematics/items/si_symbol.h
@@ -86,6 +86,7 @@ public:
       noexcept {
     return *mSymbVarItem;
   }
+  QRectF getBoundingRect() const noexcept;
 
   // Setters
   void setPosition(const Point& newPos) noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -127,12 +127,14 @@ private:
   BoardEditor& operator=(const BoardEditor& rhs) = delete;
 
   // Private Methods
-  bool graphicsViewEventHandler(QEvent* event);
-  void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
-  void unplacedComponentsCountChanged(int count) noexcept;
-  void highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,
-                           bool                               zoomTo) noexcept;
-  void clearDrcMarker() noexcept;
+  bool        graphicsViewEventHandler(QEvent* event);
+  void        toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void        unplacedComponentsCountChanged(int count) noexcept;
+  void        highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,
+                                  bool                               zoomTo) noexcept;
+  void        clearDrcMarker() noexcept;
+  QStringList getSearchToolBarCompleterList() noexcept;
+  void        goToDevice(const QString& name) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -234,6 +234,29 @@
    <addaction name="actionPaste"/>
    <addaction name="actionRemove"/>
   </widget>
+  <widget class="QToolBar" name="viewToolbar">
+   <property name="windowTitle">
+    <string>View</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+   <addaction name="actionGrid"/>
+  </widget>
+  <widget class="librepcb::project::editor::SearchToolBar" name="searchToolbar">
+   <property name="windowTitle">
+    <string>Search</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
   <widget class="QToolBar" name="toolsToolbar">
    <property name="windowTitle">
     <string>Tools</string>
@@ -266,18 +289,6 @@
     <bool>true</bool>
    </attribute>
    <addaction name="actionCommandAbort"/>
-  </widget>
-  <widget class="QToolBar" name="viewToolbar">
-   <property name="windowTitle">
-    <string>View</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-   <addaction name="actionGrid"/>
   </widget>
   <action name="actionProjectSave">
    <property name="icon">
@@ -813,6 +824,11 @@
    <class>QTabBar</class>
    <extends>QWidget</extends>
    <header>qtabbar.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::project::editor::SearchToolBar</class>
+   <extends>QToolBar</extends>
+   <header location="global">librepcb/projecteditor/toolbars/searchtoolbar.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -86,6 +86,7 @@ SOURCES += \
     schematiceditor/schematiceditor.cpp \
     schematiceditor/schematicpagesdock.cpp \
     schematiceditor/symbolinstancepropertiesdialog.cpp \
+    toolbars/searchtoolbar.cpp \
 
 HEADERS += \
     boardeditor/boarddesignrulecheckdialog.h \
@@ -151,6 +152,7 @@ HEADERS += \
     schematiceditor/schematiceditor.h \
     schematiceditor/schematicpagesdock.h \
     schematiceditor/symbolinstancepropertiesdialog.h \
+    toolbars/searchtoolbar.h \
 
 FORMS += \
     boardeditor/boarddesignrulecheckdialog.ui \

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -117,11 +117,13 @@ private:
   SchematicEditor& operator=(const SchematicEditor& rhs);
 
   // Private Methods
-  bool graphicsViewEventHandler(QEvent* event);
-  void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
-  void addSchematic() noexcept;
-  void removeSchematic(int index) noexcept;
-  void renameSchematic(int index) noexcept;
+  bool        graphicsViewEventHandler(QEvent* event);
+  void        toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void        addSchematic() noexcept;
+  void        removeSchematic(int index) noexcept;
+  void        renameSchematic(int index) noexcept;
+  QStringList getSearchToolBarCompleterList() noexcept;
+  void        goToSymbol(const QString& name) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -91,7 +91,6 @@
      <string>&amp;View</string>
     </property>
     <addaction name="actionGrid"/>
-    <addaction name="actionLayers"/>
     <addaction name="separator"/>
     <addaction name="actionZoom_In"/>
     <addaction name="actionZoom_Out"/>
@@ -204,8 +203,18 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actionLayers"/>
    <addaction name="actionGrid"/>
+  </widget>
+  <widget class="librepcb::project::editor::SearchToolBar" name="searchToolbar">
+   <property name="windowTitle">
+    <string>Search</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
   </widget>
   <widget class="QToolBar" name="toolsToolbar">
    <property name="windowTitle">
@@ -566,18 +575,6 @@
     <string>Esc</string>
    </property>
   </action>
-  <action name="actionLayers">
-   <property name="icon">
-    <iconset>
-     <normaloff>:/img/actions/layers.png</normaloff>:/img/actions/layers.png</iconset>
-   </property>
-   <property name="text">
-    <string>&amp;Layers</string>
-   </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
-  </action>
   <action name="actionGrid">
    <property name="icon">
     <iconset>
@@ -734,6 +731,11 @@
    <class>librepcb::StatusBar</class>
    <extends>QStatusBar</extends>
    <header location="global">librepcb/common/widgets/statusbar.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::project::editor::SearchToolBar</class>
+   <extends>QToolBar</extends>
+   <header location="global">librepcb/projecteditor/toolbars/searchtoolbar.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/libs/librepcb/projecteditor/toolbars/searchtoolbar.cpp
+++ b/libs/librepcb/projecteditor/toolbars/searchtoolbar.cpp
@@ -1,0 +1,91 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "searchtoolbar.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+SearchToolBar::SearchToolBar(QWidget* parent) noexcept
+  : QToolBar(parent), mCompleterListFunction(), mLineEdit(new QLineEdit()) {
+  mLineEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+  mLineEdit->setMaxLength(30);             // avoid too large widget in toolbar
+  mLineEdit->setClearButtonEnabled(true);  // to quickly clear the search term
+  connect(mLineEdit.data(), &QLineEdit::textEdited, this,
+          &SearchToolBar::textEdited);
+  connect(mLineEdit.data(), &QLineEdit::returnPressed, this,
+          &SearchToolBar::enterPressed);
+  addWidget(mLineEdit.data());
+}
+
+SearchToolBar::~SearchToolBar() noexcept {
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void SearchToolBar::updateCompleter() noexcept {
+  QStringList list =
+      mCompleterListFunction ? mCompleterListFunction() : QStringList();
+
+  QCollator collator;
+  collator.setCaseSensitivity(Qt::CaseInsensitive);
+  collator.setIgnorePunctuation(false);
+  collator.setNumericMode(true);
+  std::sort(list.begin(), list.end(),
+            [&collator](const QString& lhs, const QString& rhs) {
+              return collator(lhs, rhs);
+            });
+
+  QCompleter* completer = new QCompleter(list);
+  completer->setCaseSensitivity(Qt::CaseInsensitive);
+  mLineEdit->setCompleter(completer);
+}
+
+void SearchToolBar::textEdited(const QString& text) noexcept {
+  Q_UNUSED(text);
+  updateCompleter();
+}
+
+void SearchToolBar::enterPressed() noexcept {
+  emit goToTriggered(mLineEdit->text().trimmed());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
+++ b/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
@@ -1,0 +1,88 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_SEARCHTOOLBAR_H
+#define LIBREPCB_PROJECT_EDITOR_SEARCHTOOLBAR_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+#include <functional>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Class SearchToolBar
+ ******************************************************************************/
+
+/**
+ * @brief The SearchToolBar class
+ */
+class SearchToolBar final : public QToolBar {
+  Q_OBJECT
+
+public:
+  typedef std::function<QStringList()> CompleterListFunction;
+
+  // Constructors / Destructor
+  SearchToolBar(const SearchToolBar& other) = delete;
+  explicit SearchToolBar(QWidget* parent = nullptr) noexcept;
+  ~SearchToolBar() noexcept;
+
+  // Setters
+  void setPlaceholderText(const QString& text) noexcept {
+    mLineEdit->setPlaceholderText(text);
+  }
+  void setCompleterListFunction(CompleterListFunction fun) noexcept {
+    mCompleterListFunction = fun;
+  }
+
+  // Operator Overloadings
+  SearchToolBar& operator=(const SearchToolBar& rhs) = delete;
+
+signals:
+  void goToTriggered(const QString& name);
+
+private:
+  void updateCompleter() noexcept;
+  void textEdited(const QString& text) noexcept;
+  void enterPressed() noexcept;
+
+private:
+  CompleterListFunction     mCompleterListFunction;
+  QScopedPointer<QLineEdit> mLineEdit;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif  // LIBREPCB_PROJECT_EDITOR_SEARCHTOOLBAR_H


### PR DESCRIPTION
Allows searching symbols and devices by name and jumping to its graphics item:

![goto symbol](https://user-images.githubusercontent.com/5374821/74609080-cec5ef80-50e6-11ea-952a-d6558ebc67aa.gif)

Fixes #585 