### PR TITLE
Library editor: Add "filter" toolbar to filter element lists

### DIFF
--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -52,7 +52,9 @@ namespace editor {
 LibraryOverviewWidget::LibraryOverviewWidget(const Context&  context,
                                              const FilePath& fp,
                                              QWidget*        parent) noexcept
-  : EditorWidgetBase(context, fp, parent), mUi(new Ui::LibraryOverviewWidget) {
+  : EditorWidgetBase(context, fp, parent),
+    mUi(new Ui::LibraryOverviewWidget),
+    mCurrentFilter() {
   mUi->setupUi(this);
   mUi->lstMessages->setHandler(this);
   connect(mUi->btnIcon, &QPushButton::clicked, this,
@@ -128,6 +130,20 @@ LibraryOverviewWidget::LibraryOverviewWidget(const Context&  context,
 }
 
 LibraryOverviewWidget::~LibraryOverviewWidget() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void LibraryOverviewWidget::setFilter(const QString& filter) noexcept {
+  mCurrentFilter = filter.toLower().trimmed();
+  updateElementListFilter(*mUi->lstCmpCat);
+  updateElementListFilter(*mUi->lstPkgCat);
+  updateElementListFilter(*mUi->lstSym);
+  updateElementListFilter(*mUi->lstPkg);
+  updateElementListFilter(*mUi->lstCmp);
+  updateElementListFilter(*mUi->lstDev);
 }
 
 /*******************************************************************************
@@ -320,6 +336,9 @@ void LibraryOverviewWidget::updateElementList(QListWidget& listWidget,
     item->setData(Qt::UserRole, fp.toStr());
     item->setIcon(icon);
   }
+
+  // apply filter
+  updateElementListFilter(listWidget);
 }
 
 QHash<QListWidgetItem*, FilePath>
@@ -335,6 +354,16 @@ LibraryOverviewWidget::getElementListItemFilePaths(
     }
   }
   return itemPaths;
+}
+
+void LibraryOverviewWidget::updateElementListFilter(
+    QListWidget& listWidget) noexcept {
+  for (int i = 0; i < listWidget.count(); ++i) {
+    QListWidgetItem* item = listWidget.item(i);
+    Q_ASSERT(item);
+    item->setHidden((!mCurrentFilter.isEmpty()) &&
+                    (!item->text().toLower().contains(mCurrentFilter)));
+  }
 }
 
 void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -68,6 +68,9 @@ public:
                         QWidget* parent = nullptr) noexcept;
   ~LibraryOverviewWidget() noexcept;
 
+  // Setters
+  void setFilter(const QString& filter) noexcept;
+
   // Getters
   Library& getLibrary() const noexcept { return *mLibrary; }
 
@@ -117,6 +120,7 @@ private:  // Methods
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;
   QHash<QListWidgetItem*, FilePath> getElementListItemFilePaths(
       const QList<QListWidgetItem*>& items) const noexcept;
+  void updateElementListFilter(QListWidget& listWidget) noexcept;
   void openContextMenuAtPos(const QPoint& pos) noexcept;
   void newItem(QListWidget* list) noexcept;
   void editItem(QListWidget* list, const FilePath& fp) noexcept;
@@ -137,6 +141,7 @@ private:  // Data
   QScopedPointer<LibraryListEditorWidget>   mDependenciesEditorWidget;
   QSharedPointer<Library>                   mLibrary;
   QByteArray                                mIcon;
+  QString                                   mCurrentFilter;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -135,6 +135,16 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, const FilePath& libFp,
   setWindowTitle(QString(tr("%1 - LibrePCB Library Editor")).arg(libName));
   setWindowIcon(mLibrary->getIconAsPixmap());
 
+  // setup "filter" toolbar
+  QLineEdit* filterLineEdit = new QLineEdit();
+  filterLineEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+  filterLineEdit->setMaxLength(30);  // avoid too large widget in toolbar
+  filterLineEdit->setClearButtonEnabled(true);  // to quickly reset the filter
+  filterLineEdit->setPlaceholderText(tr("Filter elements"));
+  connect(filterLineEdit, &QLineEdit::textEdited, overviewWidget,
+          &LibraryOverviewWidget::setFilter);
+  mUi->filterToolbar->addWidget(filterLineEdit);
+
   // setup status bar
   mUi->statusBar->setFields(StatusBar::ProgressBar);
   mUi->statusBar->setProgressBarTextFormat(tr("Scanning libraries (%p%)"));
@@ -655,6 +665,7 @@ void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
     action->setEnabled(hasGraphicalEditor);
   }
   mUi->commandToolbar->setEnabled(hasGraphicalEditor);
+  mUi->filterToolbar->setEnabled(isOverviewTab);
   mUi->statusBar->setField(StatusBar::AbsolutePosition, hasGraphicalEditor);
   updateTabTitles();  // force updating the "Save" action title
 }

--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -203,6 +203,17 @@
    <addaction name="actionZoomAll"/>
    <addaction name="actionGridProperties"/>
   </widget>
+  <widget class="QToolBar" name="filterToolbar">
+   <property name="windowTitle">
+    <string>Filter</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
   <widget class="QToolBar" name="commandToolbar">
    <property name="windowTitle">
     <string>Command</string>


### PR DESCRIPTION
The filter applies to all lists at the same time, which is useful to find all elements related to some term (e.g. filtering for "stm32" shows all related categories, symbols, components, etc.).

![filter](https://user-images.githubusercontent.com/5374821/74611199-08542600-50fa-11ea-8335-77e0b3477901.gif)

Fixes #665.