### PR TITLE
Fix various translation issues

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -748,7 +748,7 @@ void ControlPanel::on_favoriteProjectsListView_customContextMenuRequested(
   }
 }
 
-void ControlPanel::on_actionRescanLibrary_triggered() {
+void ControlPanel::on_actionRescanLibraries_triggered() {
   mWorkspace.getLibraryDb().startLibraryRescan();
 }
 

--- a/apps/librepcb/controlpanel/controlpanel.h
+++ b/apps/librepcb/controlpanel/controlpanel.h
@@ -117,7 +117,7 @@ private slots:
   void on_recentProjectsListView_customContextMenuRequested(const QPoint& pos);
   void on_favoriteProjectsListView_customContextMenuRequested(
       const QPoint& pos);
-  void on_actionRescanLibrary_triggered();
+  void on_actionRescanLibraries_triggered();
 
 private:
   // make some methods inaccessible...

--- a/apps/librepcb/controlpanel/controlpanel.ui
+++ b/apps/librepcb/controlpanel/controlpanel.ui
@@ -477,7 +477,7 @@ QListView::item
     <string>Quit</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Q</string>
+    <string notr="true">Ctrl+Q</string>
    </property>
    <property name="menuRole">
     <enum>QAction::QuitRole</enum>
@@ -486,6 +486,9 @@ QListView::item
   <action name="actionAbout_Qt">
    <property name="text">
     <string>About Qt</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutQtRole</enum>
@@ -499,6 +502,9 @@ QListView::item
    <property name="text">
     <string>&amp;About LibrePCB</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>
    </property>
@@ -511,6 +517,9 @@ QListView::item
    <property name="text">
     <string>New Project</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionOpen_Project">
    <property name="icon">
@@ -520,10 +529,16 @@ QListView::item
    <property name="text">
     <string>Open Project</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionSwitch_Workspace">
    <property name="text">
     <string>Switch Workspace</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionWorkspace_Settings">
@@ -533,6 +548,9 @@ QListView::item
    </property>
    <property name="text">
     <string>Workspace Settings</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>
@@ -549,6 +567,9 @@ QListView::item
    <property name="toolTip">
     <string>Open Library Manager</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionClose_all_open_projects">
    <property name="icon">
@@ -557,6 +578,9 @@ QListView::item
    </property>
    <property name="text">
     <string>Close all open projects</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionRescanLibraries">
@@ -568,7 +592,7 @@ QListView::item
     <string>Rescan Libraries</string>
    </property>
    <property name="shortcut">
-    <string>F5</string>
+    <string notr="true">F5</string>
    </property>
   </action>
   <action name="actionOnlineDocumentation">
@@ -580,7 +604,7 @@ QListView::item
     <string>Online Documentation</string>
    </property>
    <property name="shortcut">
-    <string>F1</string>
+    <string notr="true">F1</string>
    </property>
   </action>
   <action name="actionOpenWebsite">
@@ -590,6 +614,9 @@ QListView::item
    </property>
    <property name="text">
     <string>LibrePCB Website</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
  </widget>

--- a/apps/librepcb/controlpanel/controlpanel.ui
+++ b/apps/librepcb/controlpanel/controlpanel.ui
@@ -458,7 +458,7 @@ QListView::item
     <property name="title">
      <string>Extras</string>
     </property>
-    <addaction name="actionRescanLibrary"/>
+    <addaction name="actionRescanLibraries"/>
     <addaction name="actionOpen_Library_Manager"/>
     <addaction name="separator"/>
     <addaction name="actionWorkspace_Settings"/>
@@ -559,9 +559,16 @@ QListView::item
     <string>Close all open projects</string>
    </property>
   </action>
-  <action name="actionRescanLibrary">
+  <action name="actionRescanLibraries">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
+   </property>
    <property name="text">
-    <string>Rescan Library</string>
+    <string>Rescan Libraries</string>
+   </property>
+   <property name="shortcut">
+    <string>F5</string>
    </property>
   </action>
   <action name="actionOnlineDocumentation">

--- a/libs/librepcb/library/cmp/cmpsigpindisplaytype.cpp
+++ b/libs/librepcb/library/cmp/cmpsigpindisplaytype.cpp
@@ -80,8 +80,7 @@ const CmpSigPinDisplayType& CmpSigPinDisplayType::fromString(
   }
   throw RuntimeError(
       __FILE__, __LINE__,
-      QString(tr("Invalid component signal pin display type: \"%1\""))
-          .arg(str));
+      QString("Invalid component signal pin display type: \"%1\"").arg(str));
 }
 
 const QList<CmpSigPinDisplayType>&

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -72,7 +72,7 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, const FilePath& libFp,
           &LibraryEditor::saveTriggered);
   connect(mUi->actionShowElementInFileManager, &QAction::triggered, this,
           &LibraryEditor::showElementInFileExplorerTriggered);
-  connect(mUi->actionUpdateLibraryDb, &QAction::triggered,
+  connect(mUi->actionRescanLibraries, &QAction::triggered,
           &mWorkspace.getLibraryDb(),
           &workspace::WorkspaceLibraryDb::startLibraryRescan);
   connect(mUi->actionCut, &QAction::triggered, this,

--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -87,7 +87,7 @@
     <addaction name="actionSave"/>
     <addaction name="actionShowElementInFileManager"/>
     <addaction name="separator"/>
-    <addaction name="actionUpdateLibraryDb"/>
+    <addaction name="actionRescanLibraries"/>
     <addaction name="separator"/>
     <addaction name="actionClose"/>
    </widget>
@@ -569,13 +569,13 @@
     <string>Draw &amp;Rectangle</string>
    </property>
   </action>
-  <action name="actionUpdateLibraryDb">
+  <action name="actionRescanLibraries">
    <property name="icon">
     <iconset>
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Update Library Database</string>
+    <string>&amp;Rescan Libraries</string>
    </property>
    <property name="shortcut">
     <string>F5</string>

--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -260,6 +260,9 @@
    <property name="text">
     <string>&amp;About LibrePCB</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>
    </property>
@@ -267,6 +270,9 @@
   <action name="actionAbout_Qt">
    <property name="text">
     <string>About &amp;Qt</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutQtRole</enum>
@@ -280,6 +286,9 @@
    <property name="text">
     <string>&amp;Close Library Editor</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionNew">
    <property name="icon">
@@ -290,7 +299,7 @@
     <string>&amp;New</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+N</string>
+    <string notr="true">Ctrl+N</string>
    </property>
   </action>
   <action name="actionSave">
@@ -302,7 +311,7 @@
     <string notr="true">&amp;Save</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+S</string>
+    <string notr="true">Ctrl+S</string>
    </property>
   </action>
   <action name="actionUndo">
@@ -314,7 +323,7 @@
     <string>&amp;Undo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Z</string>
+    <string notr="true">Ctrl+Z</string>
    </property>
   </action>
   <action name="actionRedo">
@@ -326,7 +335,7 @@
     <string>&amp;Redo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Y</string>
+    <string notr="true">Ctrl+Y</string>
    </property>
   </action>
   <action name="actionAbortCommand">
@@ -338,7 +347,7 @@
     <string>Abort Command</string>
    </property>
    <property name="shortcut">
-    <string>Esc</string>
+    <string notr="true">Esc</string>
    </property>
   </action>
   <action name="actionZoomIn">
@@ -350,7 +359,7 @@
     <string>&amp;Zoom In</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl++</string>
+    <string notr="true">Ctrl++</string>
    </property>
   </action>
   <action name="actionZoomOut">
@@ -362,7 +371,7 @@
     <string>Zoom &amp;Out</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+-</string>
+    <string notr="true">Ctrl+-</string>
    </property>
   </action>
   <action name="actionZoomAll">
@@ -372,6 +381,9 @@
    </property>
    <property name="text">
     <string>Zoo&amp;m All</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionRotateCcw">
@@ -383,7 +395,7 @@
     <string>R&amp;otate Counterclockwise</string>
    </property>
    <property name="shortcut">
-    <string>R</string>
+    <string notr="true">R</string>
    </property>
   </action>
   <action name="actionRotateCw">
@@ -395,7 +407,7 @@
     <string>Rotate C&amp;lockwise</string>
    </property>
    <property name="shortcut">
-    <string>Shift+R</string>
+    <string notr="true">Shift+R</string>
    </property>
   </action>
   <action name="actionCopy">
@@ -407,7 +419,7 @@
     <string>&amp;Copy</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+C</string>
+    <string notr="true">Ctrl+C</string>
    </property>
   </action>
   <action name="actionCut">
@@ -419,7 +431,7 @@
     <string>Cut</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+X</string>
+    <string notr="true">Ctrl+X</string>
    </property>
   </action>
   <action name="actionPaste">
@@ -431,7 +443,7 @@
     <string>&amp;Paste</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+V</string>
+    <string notr="true">Ctrl+V</string>
    </property>
   </action>
   <action name="actionRemove">
@@ -443,7 +455,7 @@
     <string>R&amp;emove</string>
    </property>
    <property name="shortcut">
-    <string>Del</string>
+    <string notr="true">Del</string>
    </property>
   </action>
   <action name="actionToolSelect">
@@ -453,6 +465,9 @@
    </property>
    <property name="text">
     <string>&amp;Select</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionAddSymbolPin">
@@ -464,7 +479,7 @@
     <string>Add S&amp;ymbol Pin</string>
    </property>
    <property name="shortcut">
-    <string>I</string>
+    <string notr="true">I</string>
    </property>
   </action>
   <action name="actionAddThtPad">
@@ -476,7 +491,7 @@
     <string>Add THT Pad</string>
    </property>
    <property name="shortcut">
-    <string>H</string>
+    <string notr="true">H</string>
    </property>
   </action>
   <action name="actionAddSmtPad">
@@ -488,7 +503,7 @@
     <string>Add S&amp;MT Pad</string>
    </property>
    <property name="shortcut">
-    <string>S</string>
+    <string notr="true">S</string>
    </property>
   </action>
   <action name="actionDrawLine">
@@ -498,6 +513,9 @@
    </property>
    <property name="text">
     <string>&amp;Draw Line</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionAddText">
@@ -509,7 +527,7 @@
     <string>&amp;Add Text</string>
    </property>
    <property name="shortcut">
-    <string>T</string>
+    <string notr="true">T</string>
    </property>
   </action>
   <action name="actionDrawPolygon">
@@ -521,7 +539,7 @@
     <string>Draw &amp;Polygon</string>
    </property>
    <property name="shortcut">
-    <string>P</string>
+    <string notr="true">P</string>
    </property>
   </action>
   <action name="actionDrawCircle">
@@ -536,7 +554,7 @@
     <string>Draw Circle</string>
    </property>
    <property name="shortcut">
-    <string>C</string>
+    <string notr="true">C</string>
    </property>
   </action>
   <action name="actionAddHole">
@@ -548,7 +566,7 @@
     <string>Add &amp;Hole (NPTH)</string>
    </property>
    <property name="shortcut">
-    <string>O</string>
+    <string notr="true">O</string>
    </property>
   </action>
   <action name="actionGridProperties">
@@ -559,6 +577,9 @@
    <property name="text">
     <string>&amp;Grid</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionDrawRect">
    <property name="icon">
@@ -567,6 +588,9 @@
    </property>
    <property name="text">
     <string>Draw &amp;Rectangle</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionRescanLibraries">
@@ -578,7 +602,7 @@
     <string>&amp;Rescan Libraries</string>
    </property>
    <property name="shortcut">
-    <string>F5</string>
+    <string notr="true">F5</string>
    </property>
   </action>
   <action name="actionRemoveElement">
@@ -589,6 +613,9 @@
    <property name="text">
     <string>&amp;Remove Element</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionAddName">
    <property name="icon">
@@ -597,6 +624,9 @@
    </property>
    <property name="text">
     <string>Add Name</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionAddValue">
@@ -607,6 +637,9 @@
    <property name="text">
     <string>Add Value</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionShowElementInFileManager">
    <property name="icon">
@@ -615,6 +648,9 @@
    </property>
    <property name="text">
     <string>Show element in file manager</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionOnlineDocumentation">
@@ -626,7 +662,7 @@
     <string>Online Documentation</string>
    </property>
    <property name="shortcut">
-    <string>F1</string>
+    <string notr="true">F1</string>
    </property>
   </action>
   <action name="actionOpenWebsite">
@@ -636,6 +672,9 @@
    </property>
    <property name="text">
     <string>LibrePCB Website</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionMirror">
@@ -647,7 +686,7 @@
     <string>Mirror</string>
    </property>
    <property name="shortcut">
-    <string>M</string>
+    <string notr="true">M</string>
    </property>
   </action>
   <action name="actionFlip">
@@ -659,7 +698,7 @@
     <string>Flip</string>
    </property>
    <property name="shortcut">
-    <string>F</string>
+    <string notr="true">F</string>
    </property>
   </action>
  </widget>

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -280,8 +280,8 @@ Board::Board(Project&                                project,
                 device->getComponentInstanceUuid())) {
           throw RuntimeError(
               __FILE__, __LINE__,
-              QString(tr("There is already a device of the component instance "
-                         "\"%1\"!"))
+              QString("There is already a device of the component instance "
+                      "\"%1\"!")
                   .arg(device->getComponentInstanceUuid().toStr()));
         }
         mDeviceInstances.insert(device->getComponentInstanceUuid(), device);
@@ -293,7 +293,7 @@ Board::Board(Project&                                project,
         if (getNetSegmentByUuid(netsegment->getUuid())) {
           throw RuntimeError(
               __FILE__, __LINE__,
-              QString(tr("There is already a netsegment with the UUID \"%1\"!"))
+              QString("There is already a netsegment with the UUID \"%1\"!")
                   .arg(netsegment->getUuid().toStr()));
         }
         mNetSegments.append(netsegment);
@@ -585,8 +585,7 @@ void Board::addDeviceInstance(BI_Device& instance) {
           instance.getComponentInstance().getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(
-            tr("There is already a device with the component instance \"%1\"!"))
+        QString("There is already a device with the component instance \"%1\"!")
             .arg(instance.getComponentInstance().getUuid().toStr()));
   }
   // add to board
@@ -628,7 +627,7 @@ void Board::addNetSegment(BI_NetSegment& netsegment) {
   if (getNetSegmentByUuid(netsegment.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a netsegment with the UUID \"%1\"!"))
+        QString("There is already a netsegment with the UUID \"%1\"!")
             .arg(netsegment.getUuid().toStr()));
   }
   // add to board

--- a/libs/librepcb/project/boards/items/bi_device.cpp
+++ b/libs/librepcb/project/boards/items/bi_device.cpp
@@ -75,7 +75,7 @@ BI_Device::BI_Device(Board& board, const SExpression& node)
   if (!mCompInstance) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Could not find the component instance with UUID \"%1\"!"))
+        QString("Could not find the component instance with UUID \"%1\"!")
             .arg(compInstUuid.toStr()));
   }
   // get device and footprint uuid
@@ -135,8 +135,8 @@ void BI_Device::initDeviceAndPackageAndFootprint(const Uuid& deviceUuid,
       mCompInstance->getLibComponent().getUuid()) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("The device \"%1\" does not match with the component"
-                   "instance \"%2\"."))
+        QString("The device \"%1\" does not match with the component"
+                "instance \"%2\".")
             .arg(mLibDevice->getUuid().toStr(),
                  mCompInstance->getUuid().toStr()));
   }
@@ -163,7 +163,7 @@ void BI_Device::init() {
     if ((signalUuid) && (!mCompInstance->getSignalInstance(*signalUuid))) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("Unknown signal \"%1\" found in device \"%2\""))
+          QString("Unknown signal \"%1\" found in device \"%2\"")
               .arg(signalUuid->toStr(), mLibDevice->getUuid().toStr()));
     }
   }

--- a/libs/librepcb/project/boards/items/bi_footprint.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprint.cpp
@@ -85,14 +85,13 @@ void BI_Footprint::init() {
     if (mPads.contains(libPad.getPackagePadUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(
-              tr("The footprint pad UUID \"%1\" is defined multiple times."))
+          QString("The footprint pad UUID \"%1\" is defined multiple times.")
               .arg(libPad.getPackagePadUuid().toStr()));
     }
     if (!libDev.getPadSignalMap().contains(libPad.getPackagePadUuid())) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("Footprint pad \"%1\" not found in "
-                                    "pad-signal-map of device \"%2\"."))
+                         QString("Footprint pad \"%1\" not found in "
+                                 "pad-signal-map of device \"%2\".")
                              .arg(libPad.getPackagePadUuid().toStr(),
                                   libDev.getUuid().toStr()));
     }

--- a/libs/librepcb/project/boards/items/bi_netline.cpp
+++ b/libs/librepcb/project/boards/items/bi_netline.cpp
@@ -115,15 +115,14 @@ BI_NetLine::BI_NetLine(BI_NetSegment& segment, const SExpression& node)
   mStartPoint = deserializeAnchor(node, "from");
   mEndPoint   = deserializeAnchor(node, "to");
   if ((!mStartPoint) || (!mEndPoint)) {
-    throw RuntimeError(__FILE__, __LINE__, tr("Invalid trace anchor!"));
+    throw RuntimeError(__FILE__, __LINE__, "Invalid trace anchor!");
   }
 
   QString layerName = node.getValueByPath<QString>("layer", true);
   mLayer            = mBoard.getLayerStack().getLayer(layerName);
   if (!mLayer) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("Invalid board layer: \"%1\"")).arg(layerName));
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("Invalid board layer: \"%1\"").arg(layerName));
   }
 
   init();
@@ -146,17 +145,16 @@ BI_NetLine::BI_NetLine(BI_NetSegment& segment, BI_NetLineAnchor& startPoint,
 void BI_NetLine::init() {
   // check layer
   if (!mLayer->isCopperLayer()) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("The layer of netpoint \"%1\" is invalid (%2)."))
-            .arg(mUuid.toStr())
-            .arg(mLayer->getName()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("The layer of netpoint \"%1\" is invalid (%2).")
+                           .arg(mUuid.toStr())
+                           .arg(mLayer->getName()));
   }
 
   // check if both netpoints are different
   if (mStartPoint == mEndPoint) {
     throw LogicError(__FILE__, __LINE__,
-                     tr("BI_NetLine: both endpoints are the same."));
+                     "BI_NetLine: both endpoints are the same.");
   }
 
   mGraphicsItem.reset(new BGI_NetLine(*this));

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -71,7 +71,7 @@ void BI_NetPoint::init() {
   mErcMsgDeadNetPoint.reset(
       new ErcMsg(mBoard.getProject(), *this, mUuid.toStr(), "Dead",
                  ErcMsg::ErcMsgType_t::BoardError,
-                 QString(tr("Dead net point in board page \"%1\": %2"))
+                 QString(tr("Dead net point in board \"%1\": %2"))
                      .arg(*mBoard.getName())
                      .arg(mUuid.toStr())));
 }

--- a/libs/librepcb/project/boards/items/bi_netsegment.cpp
+++ b/libs/librepcb/project/boards/items/bi_netsegment.cpp
@@ -97,7 +97,7 @@ BI_NetSegment::BI_NetSegment(Board& board, const SExpression& node)
         mBoard.getProject().getCircuit().getNetSignalByUuid(netSignalUuid);
     if (!mNetSignal) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("Invalid net signal UUID: \"%1\""))
+                         QString("Invalid net signal UUID: \"%1\"")
                              .arg(netSignalUuid.toStr()));
     }
 
@@ -107,7 +107,7 @@ BI_NetSegment::BI_NetSegment(Board& board, const SExpression& node)
       if (getViaByUuid(via->getUuid())) {
         throw RuntimeError(
             __FILE__, __LINE__,
-            QString(tr("There is already a via with the UUID \"%1\"!"))
+            QString("There is already a via with the UUID \"%1\"!")
                 .arg(via->getUuid().toStr()));
       }
       mVias.append(via);
@@ -119,7 +119,7 @@ BI_NetSegment::BI_NetSegment(Board& board, const SExpression& node)
       if (getNetPointByUuid(netpoint->getUuid())) {
         throw RuntimeError(
             __FILE__, __LINE__,
-            QString(tr("There is already a netpoint with the UUID \"%1\"!"))
+            QString("There is already a netpoint with the UUID \"%1\"!")
                 .arg(netpoint->getUuid().toStr()));
       }
       mNetPoints.append(netpoint);
@@ -132,7 +132,7 @@ BI_NetSegment::BI_NetSegment(Board& board, const SExpression& node)
       if (getNetLineByUuid(netline->getUuid())) {
         throw RuntimeError(
             __FILE__, __LINE__,
-            QString(tr("There is already a netline with the UUID \"%1\"!"))
+            QString("There is already a netline with the UUID \"%1\"!")
                 .arg(netline->getUuid().toStr()));
       }
       mNetLines.append(netline);
@@ -141,7 +141,7 @@ BI_NetSegment::BI_NetSegment(Board& board, const SExpression& node)
     if (!areAllNetPointsConnectedTogether()) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+          QString("The netsegment with the UUID \"%1\" is not cohesive!")
               .arg(mUuid.toStr()));
     }
 
@@ -298,10 +298,9 @@ void BI_NetSegment::addElements(const QList<BI_Via*>&      vias,
     }
     // check if there is no via with the same uuid in the list
     if (getViaByUuid(via->getUuid())) {
-      throw RuntimeError(
-          __FILE__, __LINE__,
-          QString(tr("There is already a via with the UUID \"%1\"!"))
-              .arg(via->getUuid().toStr()));
+      throw RuntimeError(__FILE__, __LINE__,
+                         QString("There is already a via with the UUID \"%1\"!")
+                             .arg(via->getUuid().toStr()));
     }
     // add to board
     via->addToBoard();  // can throw
@@ -320,7 +319,7 @@ void BI_NetSegment::addElements(const QList<BI_Via*>&      vias,
     if (getNetPointByUuid(netpoint->getUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("There is already a netpoint with the UUID \"%1\"!"))
+          QString("There is already a netpoint with the UUID \"%1\"!")
               .arg(netpoint->getUuid().toStr()));
     }
     // add to board
@@ -339,7 +338,7 @@ void BI_NetSegment::addElements(const QList<BI_Via*>&      vias,
     if (getNetLineByUuid(netline->getUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("There is already a netline with the UUID \"%1\"!"))
+          QString("There is already a netline with the UUID \"%1\"!")
               .arg(netline->getUuid().toStr()));
     }
     // add to board
@@ -354,7 +353,7 @@ void BI_NetSegment::addElements(const QList<BI_Via*>&      vias,
   if (!areAllNetPointsConnectedTogether()) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+        QString("The netsegment with the UUID \"%1\" is not cohesive!")
             .arg(mUuid.toStr()));
   }
 
@@ -409,7 +408,7 @@ void BI_NetSegment::removeElements(const QList<BI_Via*>&      vias,
   if (!areAllNetPointsConnectedTogether()) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+        QString("The netsegment with the UUID \"%1\" is not cohesive!")
             .arg(mUuid.toStr()));
   }
 

--- a/libs/librepcb/project/circuit/circuit.cpp
+++ b/libs/librepcb/project/circuit/circuit.cpp
@@ -155,7 +155,7 @@ void Circuit::addNetClass(NetClass& netclass) {
   if (getNetClassByUuid(netclass.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a net class with the UUID \"%1\"!"))
+        QString("There is already a net class with the UUID \"%1\"!")
             .arg(netclass.getUuid().toStr()));
   }
   // check if there is no netclass with the same name in the list
@@ -243,7 +243,7 @@ void Circuit::addNetSignal(NetSignal& netsignal) {
   if (getNetSignalByUuid(netsignal.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a net signal with the UUID \"%1\"!"))
+        QString("There is already a net signal with the UUID \"%1\"!")
             .arg(netsignal.getUuid().toStr()));
   }
   // check if there is no netsignal with the same name in the list
@@ -330,7 +330,7 @@ void Circuit::addComponentInstance(ComponentInstance& cmp) {
   if (getComponentInstanceByUuid(cmp.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a component with the UUID \"%1\"!"))
+        QString("There is already a component with the UUID \"%1\"!")
             .arg(cmp.getUuid().toStr()));
   }
   // check if there is no component with the same name in the list

--- a/libs/librepcb/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/project/circuit/componentinstance.cpp
@@ -83,8 +83,7 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node)
     if (mSignals.contains(signal->getCompSignal().getUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(
-              tr("The signal with the UUID \"%1\" is defined multiple times."))
+          QString("The signal with the UUID \"%1\" is defined multiple times.")
               .arg(signal->getCompSignal().getUuid().toStr()));
     }
     mSignals.insert(signal->getCompSignal().getUuid(), signal);
@@ -93,8 +92,8 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node)
     qDebug() << mSignals.count() << "!=" << mLibComponent->getSignals().count();
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("The signal count of the component instance \"%1\" does "
-                   "not match with the signal count of the component \"%2\"."))
+        QString("The signal count of the component instance \"%1\" does "
+                "not match with the signal count of the component \"%2\".")
             .arg(mUuid.toStr())
             .arg(mLibComponent->getUuid().toStr()));
   }
@@ -296,13 +295,13 @@ void ComponentInstance::registerSymbol(SI_Symbol& symbol) {
   Uuid itemUuid = symbol.getCompSymbVarItem().getUuid();
   if (!mCompSymbVar->getSymbolItems().find(itemUuid)) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Invalid symbol item in circuit: \"%1\"."))
+                       QString("Invalid symbol item in circuit: \"%1\".")
                            .arg(itemUuid.toStr()));
   }
   if (mRegisteredSymbols.contains(itemUuid)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Symbol item UUID already exists in circuit: \"%1\"."))
+        QString("Symbol item UUID already exists in circuit: \"%1\".")
             .arg(itemUuid.toStr()));
   }
   if (!mRegisteredSymbols.isEmpty()) {

--- a/libs/librepcb/project/circuit/componentsignalinstance.cpp
+++ b/libs/librepcb/project/circuit/componentsignalinstance.cpp
@@ -68,7 +68,7 @@ ComponentSignalInstance::ComponentSignalInstance(Circuit&           circuit,
     mNetSignal = mCircuit.getNetSignalByUuid(*netsignalUuid);
     if (!mNetSignal) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("Invalid netsignal UUID: \"%1\""))
+                         QString("Invalid netsignal UUID: \"%1\"")
                              .arg(netsignalUuid->toStr()));
     }
   }

--- a/libs/librepcb/project/circuit/componentsignalinstance.cpp
+++ b/libs/librepcb/project/circuit/componentsignalinstance.cpp
@@ -173,9 +173,8 @@ void ComponentSignalInstance::setNetSignal(NetSignal* netsignal) {
   if (arePinsOrPadsUsed()) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("The net signal of the "
-                   "component signal \"%1:%2\" cannot be changed because it is "
-                   "still in use!"))
+        QString(tr("The net signal of the component signal \"%1:%2\" cannot be "
+                   "changed because it is still in use!"))
             .arg(*mComponentInstance.getName(), *mComponentSignal->getName()));
   }
   ScopeGuardList sgl;

--- a/libs/librepcb/project/circuit/netsignal.cpp
+++ b/libs/librepcb/project/circuit/netsignal.cpp
@@ -58,7 +58,7 @@ NetSignal::NetSignal(Circuit& circuit, const SExpression& node)
   if (!mNetClass) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Invalid netclass UUID: \"%1\"")).arg(netclassUuid.toStr()));
+        QString("Invalid netclass UUID: \"%1\"").arg(netclassUuid.toStr()));
   }
 
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);

--- a/libs/librepcb/project/library/projectlibrary.cpp
+++ b/libs/librepcb/project/library/projectlibrary.cpp
@@ -163,8 +163,8 @@ void ProjectLibrary::loadElements(const QString& dirname, const QString& type,
     if (elementList.contains(element->getUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("There are multiple library elements with the same "
-                     "UUID in the directory \"%1\""))
+          QString("There are multiple library elements with the same "
+                  "UUID in the directory \"%1\"")
               .arg(dir->getAbsPath().toNative()));
     }
 
@@ -182,8 +182,8 @@ void ProjectLibrary::addElement(ElementType&               element,
                                 QHash<Uuid, ElementType*>& elementList) {
   if (elementList.contains(element.getUuid())) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("There is already an element with the same "
-                                "UUID in the project's library: %1"))
+                     QString("There is already an element with the same "
+                             "UUID in the project's library: %1")
                          .arg(element.getUuid().toStr()));
   }
   TransactionalDirectory dir(*mDirectory, element.getShortElementName());

--- a/libs/librepcb/project/project.cpp
+++ b/libs/librepcb/project/project.cpp
@@ -288,7 +288,7 @@ void Project::addSchematic(Schematic& schematic, int newIndex) {
   if (getSchematicByUuid(schematic.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a schematic with the UUID \"%1\"!"))
+        QString("There is already a schematic with the UUID \"%1\"!")
             .arg(schematic.getUuid().toStr()));
   }
   if (getSchematicByName(*schematic.getName())) {
@@ -446,10 +446,9 @@ void Project::addBoard(Board& board, int newIndex) {
     throw LogicError(__FILE__, __LINE__);
   }
   if (getBoardByUuid(board.getUuid())) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There is already a board with the UUID \"%1\"!"))
-            .arg(board.getUuid().toStr()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("There is already a board with the UUID \"%1\"!")
+                           .arg(board.getUuid().toStr()));
   }
   if (getBoardByName(*board.getName())) {
     throw RuntimeError(

--- a/libs/librepcb/project/schematics/items/si_netline.cpp
+++ b/libs/librepcb/project/schematics/items/si_netline.cpp
@@ -56,7 +56,7 @@ SI_NetLine::SI_NetLine(SI_NetSegment& segment, const SExpression& node)
   mStartPoint = deserializeAnchor(node, "from");
   mEndPoint   = deserializeAnchor(node, "to");
   if ((!mStartPoint) || (!mEndPoint)) {
-    throw RuntimeError(__FILE__, __LINE__, tr("Invalid trace anchor!"));
+    throw RuntimeError(__FILE__, __LINE__, "Invalid trace anchor!");
   }
 
   init();
@@ -78,7 +78,7 @@ void SI_NetLine::init() {
   // check if both netpoints are different
   if (mStartPoint == mEndPoint) {
     throw LogicError(__FILE__, __LINE__,
-                     tr("SI_NetLine: both endpoints are the same."));
+                     "SI_NetLine: both endpoints are the same.");
   }
 
   mGraphicsItem.reset(new SGI_NetLine(*this));

--- a/libs/librepcb/project/schematics/items/si_netsegment.cpp
+++ b/libs/librepcb/project/schematics/items/si_netsegment.cpp
@@ -58,7 +58,7 @@ SI_NetSegment::SI_NetSegment(Schematic& schematic, const SExpression& node)
         mSchematic.getProject().getCircuit().getNetSignalByUuid(netSignalUuid);
     if (!mNetSignal) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("Invalid net signal UUID: \"%1\""))
+                         QString("Invalid net signal UUID: \"%1\"")
                              .arg(netSignalUuid.toStr()));
     }
 
@@ -68,7 +68,7 @@ SI_NetSegment::SI_NetSegment(Schematic& schematic, const SExpression& node)
       if (getNetPointByUuid(netpoint->getUuid())) {
         throw RuntimeError(
             __FILE__, __LINE__,
-            QString(tr("There is already a netpoint with the UUID \"%1\"!"))
+            QString("There is already a netpoint with the UUID \"%1\"!")
                 .arg(netpoint->getUuid().toStr()));
       }
       mNetPoints.append(netpoint);
@@ -81,7 +81,7 @@ SI_NetSegment::SI_NetSegment(Schematic& schematic, const SExpression& node)
       if (getNetLineByUuid(netline->getUuid())) {
         throw RuntimeError(
             __FILE__, __LINE__,
-            QString(tr("There is already a netline with the UUID \"%1\"!"))
+            QString("There is already a netline with the UUID \"%1\"!")
                 .arg(netline->getUuid().toStr()));
       }
       mNetLines.append(netline);
@@ -94,7 +94,7 @@ SI_NetSegment::SI_NetSegment(Schematic& schematic, const SExpression& node)
       if (getNetLabelByUuid(netlabel->getUuid())) {
         throw RuntimeError(
             __FILE__, __LINE__,
-            QString(tr("There is already a netlabel with the UUID \"%1\"!"))
+            QString("There is already a netlabel with the UUID \"%1\"!")
                 .arg(netlabel->getUuid().toStr()));
       }
       mNetLabels.append(netlabel);
@@ -103,7 +103,7 @@ SI_NetSegment::SI_NetSegment(Schematic& schematic, const SExpression& node)
     if (!areAllNetPointsConnectedTogether()) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+          QString("The netsegment with the UUID \"%1\" is not cohesive!")
               .arg(mUuid.toStr()));
     }
 
@@ -306,7 +306,7 @@ void SI_NetSegment::addNetPointsAndNetLines(
     if (getNetPointByUuid(netpoint->getUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("There is already a netpoint with the UUID \"%1\"!"))
+          QString("There is already a netpoint with the UUID \"%1\"!")
               .arg(netpoint->getUuid().toStr()));
     }
     // add to schematic
@@ -325,7 +325,7 @@ void SI_NetSegment::addNetPointsAndNetLines(
     if (getNetLineByUuid(netline->getUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("There is already a netline with the UUID \"%1\"!"))
+          QString("There is already a netline with the UUID \"%1\"!")
               .arg(netline->getUuid().toStr()));
     }
     // add to schematic
@@ -340,7 +340,7 @@ void SI_NetSegment::addNetPointsAndNetLines(
   if (!areAllNetPointsConnectedTogether()) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+        QString("The netsegment with the UUID \"%1\" is not cohesive!")
             .arg(mUuid.toStr()));
   }
 
@@ -384,7 +384,7 @@ void SI_NetSegment::removeNetPointsAndNetLines(
   if (!areAllNetPointsConnectedTogether()) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("The netsegment with the UUID \"%1\" is not cohesive!"))
+        QString("The netsegment with the UUID \"%1\" is not cohesive!")
             .arg(mUuid.toStr()));
   }
 
@@ -413,7 +413,7 @@ void SI_NetSegment::addNetLabel(SI_NetLabel& netlabel) {
   if (getNetLabelByUuid(netlabel.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a netlabel with the UUID \"%1\"!"))
+        QString("There is already a netlabel with the UUID \"%1\"!")
             .arg(netlabel.getUuid().toStr()));
   }
   // add to schematic

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -61,7 +61,7 @@ SI_Symbol::SI_Symbol(Schematic& schematic, const SExpression& node)
   if (!mComponentInstance) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("No component with the UUID \"%1\" found in the circuit!"))
+        QString("No component with the UUID \"%1\" found in the circuit!")
             .arg(gcUuid.toStr()));
   }
   Uuid symbVarItemUuid = node.getValueByPath<Uuid>("lib_gate");
@@ -105,16 +105,16 @@ void SI_Symbol::init(const Uuid& symbVarItemUuid) {
     if (mPins.contains(libPin.getUuid())) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The symbol pin UUID \"%1\" is defined multiple times."))
+          QString("The symbol pin UUID \"%1\" is defined multiple times.")
               .arg(libPin.getUuid().toStr()));
     }
     mPins.insert(libPin.getUuid(), pin);
   }
   if (mPins.count() != mSymbVarItem->getPinSignalMap().count()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The pin count of the symbol instance \"%1\" "
-                                  "does not match with "
-                                  "the pin-signal-map of its component."))
+                       QString("The pin count of the symbol instance \"%1\" "
+                               "does not match with "
+                               "the pin-signal-map of its component.")
                            .arg(mUuid.toStr()));
   }
 

--- a/libs/librepcb/project/schematics/schematic.cpp
+++ b/libs/librepcb/project/schematics/schematic.cpp
@@ -90,7 +90,7 @@ Schematic::Schematic(Project&                                project,
         if (getSymbolByUuid(symbol->getUuid())) {
           throw RuntimeError(
               __FILE__, __LINE__,
-              QString(tr("There is already a symbol with the UUID \"%1\"!"))
+              QString("There is already a symbol with the UUID \"%1\"!")
                   .arg(symbol->getUuid().toStr()));
         }
         mSymbols.append(symbol);
@@ -102,7 +102,7 @@ Schematic::Schematic(Project&                                project,
         if (getNetSegmentByUuid(netsegment->getUuid())) {
           throw RuntimeError(
               __FILE__, __LINE__,
-              QString(tr("There is already a netsegment with the UUID \"%1\"!"))
+              QString("There is already a netsegment with the UUID \"%1\"!")
                   .arg(netsegment->getUuid().toStr()));
         }
         mNetSegments.append(netsegment);
@@ -258,7 +258,7 @@ void Schematic::addSymbol(SI_Symbol& symbol) {
   if (getSymbolByUuid(symbol.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a symbol with the UUID \"%1\"!"))
+        QString("There is already a symbol with the UUID \"%1\"!")
             .arg(symbol.getUuid().toStr()));
   }
   // add to schematic
@@ -295,7 +295,7 @@ void Schematic::addNetSegment(SI_NetSegment& netsegment) {
   if (getNetSegmentByUuid(netsegment.getUuid())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a netsegment with the UUID \"%1\"!"))
+        QString("There is already a netsegment with the UUID \"%1\"!")
             .arg(netsegment.getUuid().toStr()));
   }
   // add to schematic

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -299,7 +299,7 @@
     <string>&amp;Save Project</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+S</string>
+    <string notr="true">Ctrl+S</string>
    </property>
   </action>
   <action name="actionProjectClose">
@@ -309,6 +309,9 @@
    </property>
    <property name="text">
     <string>&amp;Close Project</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionPrint">
@@ -320,7 +323,7 @@
     <string>&amp;Print</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+P</string>
+    <string notr="true">Ctrl+P</string>
    </property>
   </action>
   <action name="actionQuit">
@@ -332,7 +335,7 @@
     <string>&amp;Quit</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Q</string>
+    <string notr="true">Ctrl+Q</string>
    </property>
   </action>
   <action name="actionExportAsPdf">
@@ -343,6 +346,9 @@
    <property name="text">
     <string>PDF &amp;Export</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionShowControlPanel">
    <property name="icon">
@@ -352,6 +358,9 @@
    <property name="text">
     <string>Show Control Panel</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionShowSchematicEditor">
    <property name="icon">
@@ -360,6 +369,9 @@
    </property>
    <property name="text">
     <string>Show Schematic Editor</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionUndo">
@@ -371,7 +383,7 @@
     <string>&amp;Undo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Z</string>
+    <string notr="true">Ctrl+Z</string>
    </property>
   </action>
   <action name="actionRedo">
@@ -383,7 +395,7 @@
     <string>&amp;Redo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Y</string>
+    <string notr="true">Ctrl+Y</string>
    </property>
   </action>
   <action name="actionOnlineDocumentation">
@@ -395,7 +407,7 @@
     <string>Online Documentation</string>
    </property>
    <property name="shortcut">
-    <string>F1</string>
+    <string notr="true">F1</string>
    </property>
   </action>
   <action name="actionOpenWebsite">
@@ -405,6 +417,9 @@
    </property>
    <property name="text">
     <string>LibrePCB Website</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionRotate_CCW">
@@ -416,7 +431,7 @@
     <string>R&amp;otate Counterclockwise</string>
    </property>
    <property name="shortcut">
-    <string>R</string>
+    <string notr="true">R</string>
    </property>
   </action>
   <action name="actionRotate_CW">
@@ -428,7 +443,7 @@
     <string>Rotate C&amp;lockwise</string>
    </property>
    <property name="shortcut">
-    <string>Shift+R</string>
+    <string notr="true">Shift+R</string>
    </property>
   </action>
   <action name="actionCopy">
@@ -440,7 +455,7 @@
     <string>&amp;Copy</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+C</string>
+    <string notr="true">Ctrl+C</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -455,7 +470,7 @@
     <string>Cut</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+X</string>
+    <string notr="true">Ctrl+X</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -470,7 +485,7 @@
     <string>&amp;Paste</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+V</string>
+    <string notr="true">Ctrl+V</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -485,7 +500,7 @@
     <string>R&amp;emove</string>
    </property>
    <property name="shortcut">
-    <string>Del</string>
+    <string notr="true">Del</string>
    </property>
   </action>
   <action name="actionGrid">
@@ -495,6 +510,9 @@
    </property>
    <property name="text">
     <string>&amp;Grid</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionZoomIn">
@@ -506,7 +524,7 @@
     <string>&amp;Zoom In</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl++</string>
+    <string notr="true">Ctrl++</string>
    </property>
   </action>
   <action name="actionZoomOut">
@@ -518,7 +536,7 @@
     <string>Zoom &amp;Out</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+-</string>
+    <string notr="true">Ctrl+-</string>
    </property>
   </action>
   <action name="actionZoomAll">
@@ -529,6 +547,9 @@
    <property name="text">
     <string>Zoo&amp;m All</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionProjectProperties">
    <property name="text">
@@ -536,6 +557,9 @@
    </property>
    <property name="toolTip">
     <string>Edit Project Properties</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionProjectSettings">
@@ -549,6 +573,9 @@
    <property name="toolTip">
     <string>Project Settings</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionAbout">
    <property name="icon">
@@ -558,6 +585,9 @@
    <property name="text">
     <string>&amp;About LibrePCB</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>
    </property>
@@ -565,6 +595,9 @@
   <action name="actionAboutQt">
    <property name="text">
     <string>About &amp;Qt</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutQtRole</enum>
@@ -578,6 +611,9 @@
    <property name="text">
     <string>&amp;Select</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionCommandAbort">
    <property name="icon">
@@ -588,7 +624,7 @@
     <string>Abort Command</string>
    </property>
    <property name="shortcut">
-    <string>Esc</string>
+    <string notr="true">Esc</string>
    </property>
   </action>
   <action name="actionNewBoard">
@@ -600,12 +636,15 @@
     <string>&amp;New Board</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+N</string>
+    <string notr="true">Ctrl+N</string>
    </property>
   </action>
   <action name="actionEditNetClasses">
    <property name="text">
     <string>&amp;Net Classes</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionFlipHorizontal">
@@ -617,7 +656,7 @@
     <string>&amp;Flip Horizontal</string>
    </property>
    <property name="shortcut">
-    <string>F</string>
+    <string notr="true">F</string>
    </property>
   </action>
   <action name="actionFlipVertical">
@@ -629,7 +668,7 @@
     <string>Flip &amp;Vertical</string>
    </property>
    <property name="shortcut">
-    <string>Shift+F</string>
+    <string notr="true">Shift+F</string>
    </property>
   </action>
   <action name="actionToolDrawTrace">
@@ -640,6 +679,9 @@
    <property name="text">
     <string>&amp;Draw Trace</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionToolAddVia">
    <property name="icon">
@@ -649,6 +691,9 @@
    <property name="text">
     <string>&amp;Add Via</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionCopyBoard">
    <property name="icon">
@@ -657,6 +702,9 @@
    </property>
    <property name="text">
     <string>&amp;Copy Board</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionGenerateFabricationData">
@@ -670,15 +718,24 @@
    <property name="toolTip">
     <string>Generate Fabrication Data</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionModifyDesignRules">
    <property name="text">
     <string>&amp;Design Rules</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionLayerStackSetup">
    <property name="text">
     <string>&amp;Layer Stack Setup</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionRemoveBoard">
@@ -689,6 +746,9 @@
    <property name="text">
     <string>Remove &amp;Board</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionToolDrawPolygon">
    <property name="icon">
@@ -697,6 +757,9 @@
    </property>
    <property name="text">
     <string>D&amp;raw Polygon</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionRebuildPlanes">
@@ -707,6 +770,9 @@
    <property name="text">
     <string>&amp;Rebuild Planes</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionToolAddPlane">
    <property name="icon">
@@ -715,6 +781,9 @@
    </property>
    <property name="text">
     <string>Add &amp;Plane</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionToolAddText">
@@ -725,6 +794,9 @@
    <property name="text">
     <string>Add T&amp;ext</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionToolAddHole">
    <property name="icon">
@@ -734,6 +806,9 @@
    <property name="text">
     <string>Add &amp;Hole</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionUpdateLibrary">
    <property name="icon">
@@ -742,6 +817,9 @@
    </property>
    <property name="text">
     <string>Update Library</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionExportLppz">
@@ -755,6 +833,9 @@
    <property name="toolTip">
     <string>Export project to *.lppz</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionGenerateBom">
    <property name="icon">
@@ -767,6 +848,9 @@
    <property name="toolTip">
     <string>Generate BOM</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionShowAllPlanes">
    <property name="icon">
@@ -775,6 +859,9 @@
    </property>
    <property name="text">
     <string>Show All Planes</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionHideAllPlanes">
@@ -785,6 +872,9 @@
    <property name="text">
     <string>Hide All Planes</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionDesignRuleCheck">
    <property name="icon">
@@ -793,6 +883,9 @@
    </property>
    <property name="text">
     <string>Design Rule Check</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionGeneratePickPlace">
@@ -803,6 +896,9 @@
    <property name="text">
     <string>Generate Pick&amp;&amp;Place Files</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionExportAsSvg">
    <property name="icon">
@@ -811,6 +907,9 @@
    </property>
    <property name="text">
     <string>SVG Export</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
  </widget>

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
@@ -383,28 +383,28 @@ BES_Base::ProcRetVal BES_Select::processIdleSceneRightMouseButtonReleased(
       Q_ASSERT(netline);
 
       // build the context menu
-      QAction* aRemove =
-          menu.addAction(QIcon(":/img/actions/delete.png"), "Remove Trace");
-      QAction* aRemoveSegment = menu.addAction(QIcon(":/img/actions/minus.png"),
-                                               "Remove Whole Segment");
+      QAction* aRemoveSegment = menu.addAction(
+          QIcon(":/img/actions/delete.png"), "Remove Trace Segment");
+      QAction* aRemoveTrace = menu.addAction(QIcon(":/img/actions/minus.png"),
+                                             "Remove Whole Trace");
       menu.addSeparator();
-      QAction* aSelectSegment = menu.addAction(
-          QIcon(":/img/actions/bookmark.png"), tr("Select Whole Segment"));
+      QAction* aSelectTrace = menu.addAction(
+          QIcon(":/img/actions/bookmark.png"), tr("Select Whole Trace"));
       menu.addSeparator();
       QAction* aMeasureSelection =
           menu.addAction(QIcon(":/img/actions/ruler.png"),
-                         tr("Measure Selected Trace Length"));
+                         tr("Measure Selected Segments Length"));
 
       // execute the context menu
       QAction* action = menu.exec(mouseEvent->screenPos());
       if (action == nullptr) {
         // aborted --> nothing to do
-      } else if (action == aRemove) {
-        removeSelectedItems();
       } else if (action == aRemoveSegment) {
+        removeSelectedItems();
+      } else if (action == aRemoveTrace) {
         netline->getNetSegment().setSelected(true);
         removeSelectedItems();
-      } else if (action == aSelectSegment) {
+      } else if (action == aSelectTrace) {
         netline->getNetSegment().setSelected(true);
       } else if (action == aMeasureSelection) {
         measureSelectedItems(*netline);
@@ -419,11 +419,11 @@ BES_Base::ProcRetVal BES_Select::processIdleSceneRightMouseButtonReleased(
       // build the context menu
       QAction* aRemove =
           menu.addAction(QIcon(":/img/actions/delete.png"), "Remove Via");
-      QAction* aRemoveSegment = menu.addAction(QIcon(":/img/actions/minus.png"),
-                                               "Remove Whole Segment");
+      QAction* aRemoveTrace = menu.addAction(QIcon(":/img/actions/minus.png"),
+                                             "Remove Whole Trace");
       menu.addSeparator();
-      QAction* aSelectSegment = menu.addAction(
-          QIcon(":/img/actions/bookmark.png"), tr("Select Whole Segment"));
+      QAction* aSelectTrace = menu.addAction(
+          QIcon(":/img/actions/bookmark.png"), tr("Select Whole Trace"));
       menu.addSeparator();
       QAction* aProperties = menu.addAction(tr("Properties"));
 
@@ -433,10 +433,10 @@ BES_Base::ProcRetVal BES_Select::processIdleSceneRightMouseButtonReleased(
         // aborted --> nothing to do
       } else if (action == aRemove) {
         removeSelectedItems();
-      } else if (action == aRemoveSegment) {
+      } else if (action == aRemoveTrace) {
         via->getNetSegment().setSelected(true);
         removeSelectedItems();
-      } else if (action == aSelectSegment) {
+      } else if (action == aSelectTrace) {
         via->getNetSegment().setSelected(true);
       } else if (action == aProperties) {
         openViaPropertiesDialog(*via);
@@ -805,15 +805,15 @@ bool BES_Select::measureSelectedItems(const BI_NetLine& netline) noexcept {
   QLocale locale;
   QString title = tr("Measurement Result");
   QString text =
-      tr("Total length of %n trace(s): %2 mm / %3 in", "",
+      tr("Total length of %n trace segment(s): %2 mm / %3 in", "",
          visitedNetLines.count())
           .arg(Toolbox::floatToString(totalLength->toMm(), 6, locale))
           .arg(Toolbox::floatToString(totalLength->toInch(), 6, locale));
   if (totalSelectedNetlines == visitedNetLines.count()) {
     QMessageBox::information(&mEditor, title, text);
   } else {
-    text += "\n\n" + tr("WARNING: There are %1 traces selected, but not all "
-                        "of them are connected!")
+    text += "\n\n" + tr("WARNING: There are %1 trace segments selected, but "
+                        "not all of them are connected!")
                          .arg(totalSelectedNetlines);
     QMessageBox::warning(&mEditor, title, text);
   }
@@ -840,7 +840,7 @@ void BES_Select::measureLengthInDirection(bool              directionBackwards,
         if (nextNetline != nullptr) {
           // There's already another connected and selected netline
           throw LogicError(__FILE__, __LINE__,
-                           tr("Selected traces may not branch!"));
+                           tr("Selected trace segments may not branch!"));
         }
 
         totalLength += nl->getLength();

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
@@ -805,8 +805,8 @@ bool BES_Select::measureSelectedItems(const BI_NetLine& netline) noexcept {
   QLocale locale;
   QString title = tr("Measurement Result");
   QString text =
-      tr("Total length of %1 traces: %2 mm / %3 in")
-          .arg(visitedNetLines.count())
+      tr("Total length of %n trace(s): %2 mm / %3 in", "",
+         visitedNetLines.count())
           .arg(Toolbox::floatToString(totalLength->toMm(), 6, locale))
           .arg(Toolbox::floatToString(totalLength->toInch(), 6, locale));
   if (totalSelectedNetlines == visitedNetLines.count()) {

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -276,7 +276,7 @@
     <string>&amp;Quit</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Q</string>
+    <string notr="true">Ctrl+Q</string>
    </property>
    <property name="menuRole">
     <enum>QAction::QuitRole</enum>
@@ -291,7 +291,7 @@
     <string>&amp;Save Project</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+S</string>
+    <string notr="true">Ctrl+S</string>
    </property>
   </action>
   <action name="actionAbout">
@@ -302,6 +302,9 @@
    <property name="text">
     <string>&amp;About LibrePCB</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>
    </property>
@@ -309,6 +312,9 @@
   <action name="actionAbout_Qt">
    <property name="text">
     <string>About &amp;Qt</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutQtRole</enum>
@@ -323,7 +329,7 @@
     <string>&amp;Print</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+P</string>
+    <string notr="true">Ctrl+P</string>
    </property>
   </action>
   <action name="actionPDF_Export">
@@ -333,6 +339,9 @@
    </property>
    <property name="text">
     <string>Export schematics to &amp;PDF</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
    <property name="visible">
     <bool>true</bool>
@@ -346,6 +355,9 @@
    <property name="text">
     <string>Show Control Panel</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionShow_Board_Editor">
    <property name="icon">
@@ -354,6 +366,9 @@
    </property>
    <property name="text">
     <string>Show Board Editor</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionUndo">
@@ -365,7 +380,7 @@
     <string>&amp;Undo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Z</string>
+    <string notr="true">Ctrl+Z</string>
    </property>
   </action>
   <action name="actionRedo">
@@ -377,7 +392,7 @@
     <string>&amp;Redo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Y</string>
+    <string notr="true">Ctrl+Y</string>
    </property>
   </action>
   <action name="actionZoom_In">
@@ -389,7 +404,7 @@
     <string>&amp;Zoom In</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl++</string>
+    <string notr="true">Ctrl++</string>
    </property>
   </action>
   <action name="actionZoom_Out">
@@ -401,7 +416,7 @@
     <string>Zoom &amp;Out</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+-</string>
+    <string notr="true">Ctrl+-</string>
    </property>
   </action>
   <action name="actionZoom_All">
@@ -411,6 +426,9 @@
    </property>
    <property name="text">
     <string>Zoo&amp;m All</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionOnlineDocumentation">
@@ -422,7 +440,7 @@
     <string>Online Documentation</string>
    </property>
    <property name="shortcut">
-    <string>F1</string>
+    <string notr="true">F1</string>
    </property>
   </action>
   <action name="actionOpenWebsite">
@@ -432,6 +450,9 @@
    </property>
    <property name="text">
     <string>LibrePCB Website</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionRotate_CCW">
@@ -443,7 +464,7 @@
     <string>R&amp;otate Counterclockwise</string>
    </property>
    <property name="shortcut">
-    <string>R</string>
+    <string notr="true">R</string>
    </property>
   </action>
   <action name="actionRotate_CW">
@@ -455,7 +476,7 @@
     <string>Rotate C&amp;lockwise</string>
    </property>
    <property name="shortcut">
-    <string>Shift+R</string>
+    <string notr="true">Shift+R</string>
    </property>
   </action>
   <action name="actionMirror">
@@ -467,7 +488,7 @@
     <string>M&amp;irror</string>
    </property>
    <property name="shortcut">
-    <string>M</string>
+    <string notr="true">M</string>
    </property>
   </action>
   <action name="actionCopy">
@@ -479,7 +500,7 @@
     <string>&amp;Copy</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+C</string>
+    <string notr="true">Ctrl+C</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -494,7 +515,7 @@
     <string>Cut</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+X</string>
+    <string notr="true">Ctrl+X</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -509,7 +530,7 @@
     <string>&amp;Paste</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+V</string>
+    <string notr="true">Ctrl+V</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -524,7 +545,7 @@
     <string>R&amp;emove</string>
    </property>
    <property name="shortcut">
-    <string>Del</string>
+    <string notr="true">Del</string>
    </property>
   </action>
   <action name="actionClose_Project">
@@ -535,6 +556,9 @@
    <property name="text">
     <string>&amp;Close Project</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionToolSelect">
    <property name="icon">
@@ -543,6 +567,9 @@
    </property>
    <property name="text">
     <string>&amp;Select</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionToolAddComponent">
@@ -553,6 +580,9 @@
    <property name="text">
     <string>Add &amp;Component</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionToolDrawWire">
    <property name="icon">
@@ -561,6 +591,9 @@
    </property>
    <property name="text">
     <string>&amp;Draw Wire</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionCommandAbort">
@@ -572,7 +605,7 @@
     <string>Abort Command</string>
    </property>
    <property name="shortcut">
-    <string>Esc</string>
+    <string notr="true">Esc</string>
    </property>
   </action>
   <action name="actionGrid">
@@ -583,10 +616,16 @@
    <property name="text">
     <string>&amp;Grid</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionEditNetclasses">
    <property name="text">
     <string>&amp;Net Classes</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionAddComp_Resistor">
@@ -596,6 +635,9 @@
    </property>
    <property name="text">
     <string>Add Resistor</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionAddComp_BipolarCapacitor">
@@ -609,6 +651,9 @@
    <property name="toolTip">
     <string>Add Bipolar Capacitor</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionAddComp_Inductor">
    <property name="icon">
@@ -617,6 +662,9 @@
    </property>
    <property name="text">
     <string>Add Inductor</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionAddComp_gnd">
@@ -627,6 +675,9 @@
    <property name="text">
     <string>Add GND</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionAddComp_vcc">
    <property name="icon">
@@ -636,10 +687,16 @@
    <property name="text">
     <string>Add VCC</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionProjectProperties">
    <property name="text">
     <string>&amp;Properties</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionProjectSettings">
@@ -650,6 +707,9 @@
    <property name="text">
     <string>&amp;Settings</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionToolAddNetLabel">
    <property name="icon">
@@ -659,6 +719,9 @@
    <property name="text">
     <string>&amp;Add Netlabel</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionAddComp_UnipolarCapacitor">
    <property name="icon">
@@ -667,6 +730,9 @@
    </property>
    <property name="text">
     <string>Add Unipolar Capacitor</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionNew_Schematic_Page">
@@ -678,7 +744,7 @@
     <string>&amp;New Schematic Page</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+N</string>
+    <string notr="true">Ctrl+N</string>
    </property>
   </action>
   <action name="actionUpdateLibrary">
@@ -688,6 +754,9 @@
    </property>
    <property name="text">
     <string>Update Library</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionExportLppz">
@@ -701,6 +770,9 @@
    <property name="toolTip">
     <string>Export project to *.lppz</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionGenerateBom">
    <property name="icon">
@@ -710,10 +782,16 @@
    <property name="text">
     <string>Generate BOM</string>
    </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
   </action>
   <action name="actionRenameSheet">
    <property name="text">
     <string>Rename Sheet</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
   <action name="actionExportAsSvg">
@@ -723,6 +801,9 @@
    </property>
    <property name="text">
     <string>Export sheet to SVG</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Fixing some of the translation issues reported at [Transifex](https://www.transifex.com/librepcb/):
- Fix inconsistent "rescan libraries" menu items
  - Rename "Rescan Library" to "Rescan Libraries"
  - Rename "Update Library Database" to "Rescan Libraries"
  - Use consistent icon and keyboard shortcut
- Stop translating low-level error messages (see [discussion](https://librepcb.discourse.group/t/translation-for-low-level-error-messages/119)).

Open question: Should we stop translating keyboard shortcuts (like "Ctrl+S")? There are a lot of keyboard shortcuts in the translation files, but I'm not sure if that makes sense. Unfortunately I didn't find a good documentation how translation of keyboard shortcuts should be handled...