### PR TITLE
Board editor: Sort items in "Change Device" context menu

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
@@ -57,6 +57,12 @@ class CmdDragSelectedBoardItems;
 class BES_Select final : public BES_Base {
   Q_OBJECT
 
+  struct DeviceMenuItem {
+    QString name;
+    QIcon   icon;
+    Uuid    uuid;
+  };
+
 public:
   // Constructors / Destructor
   explicit BES_Select(BoardEditor& editor, Ui::BoardEditor& editorUi,
@@ -116,6 +122,8 @@ private:
   void openPolygonPropertiesDialog(Board& board, Polygon& polygon) noexcept;
   void openStrokeTextPropertiesDialog(Board& board, StrokeText& text) noexcept;
   void openHolePropertiesDialog(Board& board, Hole& hole) noexcept;
+  QList<DeviceMenuItem> getDeviceMenuItems(
+      const ComponentInstance& cmpInst) const noexcept;
 
   // Types
   /// enum for all possible substates


### PR DESCRIPTION
Until now, the list of devices was in a random order, which made it difficult to find a specific device. In a sorted list it's much easier to find a device by its name. In addition, I added icons to these menu items (not that useful, but why not :grin:):

![image](https://user-images.githubusercontent.com/5374821/76683559-5f6bee80-6605-11ea-91f4-24974e817532.png)