### PR TITLE
BomCsvWriter: Refactor to use the new CsvFile class

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -27,6 +27,7 @@
 #include <librepcb/common/bom/bom.h>
 #include <librepcb/common/bom/bomcsvwriter.h>
 #include <librepcb/common/debug.h>
+#include <librepcb/common/fileio/csvfile.h>
 #include <librepcb/common/fileio/fileutils.h>
 #include <librepcb/common/fileio/transactionalfilesystem.h>
 #include <librepcb/library/elements.h>
@@ -454,8 +455,9 @@ bool CommandLineInterface::openProject(
           }
           QString suffix = destStr.split('.').last().toLower();
           if (suffix == "csv") {
-            BomCsvWriter writer;
-            writer.writeToFile(*bom, fp);  // can throw
+            BomCsvWriter             writer(*bom);
+            std::shared_ptr<CsvFile> csv = writer.generateCsv();  // can throw
+            csv->saveToFile(fp);                                  // can throw
             writtenFilesCounter[fp]++;
           } else {
             printErr("  " %

--- a/libs/librepcb/common/bom/bomcsvwriter.h
+++ b/libs/librepcb/common/bom/bomcsvwriter.h
@@ -25,13 +25,15 @@
  ******************************************************************************/
 #include <QtCore>
 
+#include <memory>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 
 class Bom;
-class FilePath;
+class CsvFile;
 
 /*******************************************************************************
  *  Class BomCsvWriter
@@ -45,20 +47,19 @@ class BomCsvWriter final {
 
 public:
   // Constructors / Destructor
-  BomCsvWriter() noexcept;
+  BomCsvWriter()                          = delete;
   BomCsvWriter(const BomCsvWriter& other) = delete;
+  explicit BomCsvWriter(const Bom& bom) noexcept;
   ~BomCsvWriter() noexcept;
 
   // General Methods
-  QList<QStringList> toStringList(const Bom& bom) noexcept;
-  QString            toString(const Bom& bom) noexcept;
-  void               writeToFile(const Bom& bom, const FilePath& csvFp);
+  std::shared_ptr<CsvFile> generateCsv() const;
 
   // Operator Overloadings
   BomCsvWriter& operator=(const BomCsvWriter& rhs) = delete;
 
 private:
-  static QString cleanStr(const QString& str) noexcept;
+  const Bom& mBom;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
Beside the refactoring, this also switches from semicolon-separated values to comma-separated values.

Replaces #633.

Fixes #630.