### PR TITLE
Device editor: Show warning if no pads are connected

### DIFF
--- a/libs/librepcb/library/dev/device.h
+++ b/libs/librepcb/library/dev/device.h
@@ -78,6 +78,9 @@ public:
   void setComponentUuid(const Uuid& uuid) noexcept;
   void setPackageUuid(const Uuid& uuid) noexcept;
 
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
+
   // Operator Overloadings
   Device& operator=(const Device& rhs) = delete;
 

--- a/libs/librepcb/library/dev/devicecheck.h
+++ b/libs/librepcb/library/dev/devicecheck.h
@@ -1,0 +1,73 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_DEVICECHECK_H
+#define LIBREPCB_LIBRARY_DEVICECHECK_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "libraryelementcheck.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+class Device;
+
+/*******************************************************************************
+ *  Class DeviceCheck
+ ******************************************************************************/
+
+/**
+ * @brief The DeviceCheck class
+ */
+class DeviceCheck : public LibraryElementCheck {
+public:
+  // Constructors / Destructor
+  DeviceCheck()                         = delete;
+  DeviceCheck(const DeviceCheck& other) = delete;
+  explicit DeviceCheck(const Device& device) noexcept;
+  virtual ~DeviceCheck() noexcept;
+
+  // General Methods
+  virtual LibraryElementCheckMessageList runChecks() const override;
+
+  // Operator Overloadings
+  DeviceCheck& operator=(const DeviceCheck& rhs) = delete;
+
+protected:  // Methods
+  void checkNoPadsConnected(MsgList& msgs) const;
+
+private:  // Data
+  const Device& mDevice;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_DEVICECHECK_H

--- a/libs/librepcb/library/dev/msg/msgnopadsindeviceconnected.cpp
+++ b/libs/librepcb/library/dev/msg/msgnopadsindeviceconnected.cpp
@@ -1,0 +1,56 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "msgnopadsindeviceconnected.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+MsgNoPadsInDeviceConnected::MsgNoPadsInDeviceConnected() noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,  // Only warning because it could be a false-positive
+        tr("No pads connected"),
+        tr("The chosen package contains pads, but none of them are connected "
+           "to component signals. So these pads have no electrical function "
+           "and when adding the device to a PCB, no traces can be connected to "
+           "them.\n\nTo fix this issue, connect the package pads to their "
+           "corresponding component signals in the table widget.\n\nIf all "
+           "pads have only a mechanical purpose and thus don't need to be "
+           "connected to component signals, this message can be ignored.")) {
+}
+
+MsgNoPadsInDeviceConnected::~MsgNoPadsInDeviceConnected() noexcept {
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb

--- a/libs/librepcb/library/dev/msg/msgnopadsindeviceconnected.h
+++ b/libs/librepcb/library/dev/msg/msgnopadsindeviceconnected.h
@@ -1,0 +1,61 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LIBRARY_MSGNOPADSINDEVICECONNECTED_H
+#define LIBREPCB_LIBRARY_MSGNOPADSINDEVICECONNECTED_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../msg/libraryelementcheckmessage.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+
+/*******************************************************************************
+ *  Class MsgNoPadsInDeviceConnected
+ ******************************************************************************/
+
+/**
+ * @brief The MsgNoPadsInDeviceConnected class
+ */
+class MsgNoPadsInDeviceConnected final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgNoPadsInDeviceConnected)
+
+public:
+  // Constructors / Destructor
+  MsgNoPadsInDeviceConnected() noexcept;
+  MsgNoPadsInDeviceConnected(const MsgNoPadsInDeviceConnected& other) noexcept
+    : LibraryElementCheckMessage(other) {}
+  virtual ~MsgNoPadsInDeviceConnected() noexcept;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace library
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LIBRARY_MSGNOPADSINDEVICECONNECTED_H

--- a/libs/librepcb/library/library.pro
+++ b/libs/librepcb/library/library.pro
@@ -54,8 +54,10 @@ SOURCES += \
     dev/cmd/cmddeviceedit.cpp \
     dev/cmd/cmddevicepadsignalmapitemedit.cpp \
     dev/device.cpp \
+    dev/devicecheck.cpp \
     dev/devicepadsignalmap.cpp \
     dev/devicepadsignalmapmodel.cpp \
+    dev/msg/msgnopadsindeviceconnected.cpp \
     library.cpp \
     librarybaseelement.cpp \
     librarybaseelementcheck.cpp \
@@ -135,8 +137,10 @@ HEADERS += \
     dev/cmd/cmddeviceedit.h \
     dev/cmd/cmddevicepadsignalmapitemedit.h \
     dev/device.h \
+    dev/devicecheck.h \
     dev/devicepadsignalmap.h \
     dev/devicepadsignalmapmodel.h \
+    dev/msg/msgnopadsindeviceconnected.h \
     elements.h \
     library.h \
     librarybaseelement.h \


### PR DESCRIPTION
Shows a warning in the device editor if there are package pads, but none of them is connected. As soon as one pad gets connected, the message disappears.

I used the severity "warning" instead of "error" because there are situations where this message is a false-positive: If the package has only pads for mechanical reasons, but does not provide an electrical functionality, this message needs to be ignored.

Fixes #412 