### PR TITLE
Respect configured workspace length unit in editors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "i18n"]
     path = i18n
     url = https://github.com/LibrePCB/librepcb-i18n.git
+[submodule "libs/muparser"]
+    path = libs/muparser
+    url = https://github.com/LibrePCB/muparser.git

--- a/apps/librepcb-cli/librepcb-cli.pro
+++ b/apps/librepcb-cli/librepcb-cli.pro
@@ -32,6 +32,7 @@ LIBS += \
     -llibrepcbcommon \
     -lsexpresso \
     -lclipper \
+    -lmuparser \
     -lquazip -lz
 
 INCLUDEPATH += \
@@ -52,6 +53,7 @@ DEPENDPATH += \
     ../../libs/quazip \
     ../../libs/sexpresso \
     ../../libs/clipper \
+    ../../libs/muparser \
 
 PRE_TARGETDEPS += \
     $${DESTDIR}/libhoedown.a \
@@ -65,6 +67,7 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/libquazip.a \
     $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libclipper.a \
+    $${DESTDIR}/libmuparser.a \
 
 RESOURCES += \
     ../../img/images.qrc \

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -46,6 +46,7 @@ LIBS += \
     -llibrepcbcommon \
     -lsexpresso \
     -lclipper \
+    -lmuparser \
     -lquazip -lz
 
 INCLUDEPATH += \
@@ -66,6 +67,7 @@ DEPENDPATH += \
     ../../libs/quazip \
     ../../libs/sexpresso \
     ../../libs/clipper \
+    ../../libs/muparser \
 
 PRE_TARGETDEPS += \
     $${DESTDIR}/libhoedown.a \
@@ -79,6 +81,7 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/libquazip.a \
     $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libclipper.a \
+    $${DESTDIR}/libmuparser.a \
 
 RESOURCES += \
     ../../img/images.qrc \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -132,6 +132,7 @@ SOURCES += \
     utils/clipperhelpers.cpp \
     utils/exclusiveactiongroup.cpp \
     utils/graphicslayerstackappearancesettings.cpp \
+    utils/mathparser.cpp \
     utils/toolbarproxy.cpp \
     utils/undostackactiongroup.cpp \
     uuid.cpp \
@@ -278,6 +279,7 @@ HEADERS += \
     utils/clipperhelpers.h \
     utils/exclusiveactiongroup.h \
     utils/graphicslayerstackappearancesettings.h \
+    utils/mathparser.h \
     utils/toolbarproxy.h \
     utils/undostackactiongroup.h \
     uuid.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -148,6 +148,7 @@ SOURCES += \
     widgets/graphicslayercombobox.cpp \
     widgets/halignactiongroup.cpp \
     widgets/lengthedit.cpp \
+    widgets/lengtheditbase.cpp \
     widgets/numbereditbase.cpp \
     widgets/patheditorwidget.cpp \
     widgets/plaintextedit.cpp \
@@ -295,6 +296,7 @@ HEADERS += \
     widgets/graphicslayercombobox.h \
     widgets/halignactiongroup.h \
     widgets/lengthedit.h \
+    widgets/lengtheditbase.h \
     widgets/numbereditbase.h \
     widgets/patheditorwidget.h \
     widgets/plaintextedit.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -26,6 +26,7 @@ INCLUDEPATH += \
     ../../sexpresso \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
+    ../../muparser/include \
 
 RESOURCES += \
     ../../../img/images.qrc \

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
@@ -40,18 +40,9 @@ BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
   : QDialog(parent), mUi(new Ui::BoardDesignRulesDialog), mDesignRules(rules) {
   mUi->setupUi(this);
   mUi->edtStopMaskClrRatio->setSingleStep(5.0);   // [%]
-  mUi->edtStopMaskClrMin->setSingleStep(0.1);     // [mm]
-  mUi->edtStopMaskClrMax->setSingleStep(0.1);     // [mm]
-  mUi->edtStopMaskMaxViaDia->setSingleStep(0.1);  // [mm]
   mUi->edtCreamMaskClrRatio->setSingleStep(5.0);  // [%]
-  mUi->edtCreamMaskClrMin->setSingleStep(0.1);    // [mm]
-  mUi->edtCreamMaskClrMax->setSingleStep(0.1);    // [mm]
   mUi->edtRestringPadsRatio->setSingleStep(5.0);  // [%]
-  mUi->edtRestringPadsMin->setSingleStep(0.1);    // [mm]
-  mUi->edtRestringPadsMax->setSingleStep(0.1);    // [mm]
   mUi->edtRestringViasRatio->setSingleStep(5.0);  // [%]
-  mUi->edtRestringViasMin->setSingleStep(0.1);    // [mm]
-  mUi->edtRestringViasMax->setSingleStep(0.1);    // [mm]
 
   updateWidgets();
 }

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
@@ -36,13 +36,42 @@ namespace librepcb {
  ******************************************************************************/
 
 BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
-                                               QWidget*                parent)
+                                               const LengthUnit& lengthUnit,
+                                               const QString&    settingsPrefix,
+                                               QWidget*          parent)
   : QDialog(parent), mUi(new Ui::BoardDesignRulesDialog), mDesignRules(rules) {
   mUi->setupUi(this);
-  mUi->edtStopMaskClrRatio->setSingleStep(5.0);   // [%]
+  mUi->edtStopMaskClrRatio->setSingleStep(5.0);  // [%]
+  mUi->edtStopMaskClrMin->configure(lengthUnit,
+                                    LengthEditBase::Steps::generic(),
+                                    settingsPrefix % "/stopmask_clearance_min");
+  mUi->edtStopMaskClrMax->configure(lengthUnit,
+                                    LengthEditBase::Steps::generic(),
+                                    settingsPrefix % "/stopmask_clearance_max");
+  mUi->edtStopMaskMaxViaDia->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/stopmask_max_via_diameter");
   mUi->edtCreamMaskClrRatio->setSingleStep(5.0);  // [%]
+  mUi->edtCreamMaskClrMin->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/creammask_clearance_min");
+  mUi->edtCreamMaskClrMax->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/creammask_clearance_max");
   mUi->edtRestringPadsRatio->setSingleStep(5.0);  // [%]
+  mUi->edtRestringPadsMin->configure(lengthUnit,
+                                     LengthEditBase::Steps::generic(),
+                                     settingsPrefix % "/restring_pads_min");
+  mUi->edtRestringPadsMax->configure(lengthUnit,
+                                     LengthEditBase::Steps::generic(),
+                                     settingsPrefix % "/restring_pads_max");
   mUi->edtRestringViasRatio->setSingleStep(5.0);  // [%]
+  mUi->edtRestringViasMin->configure(lengthUnit,
+                                     LengthEditBase::Steps::generic(),
+                                     settingsPrefix % "/restring_vias_min");
+  mUi->edtRestringViasMax->configure(lengthUnit,
+                                     LengthEditBase::Steps::generic(),
+                                     settingsPrefix % "/restring_vias_max");
 
   updateWidgets();
 }

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.h
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.h
@@ -51,8 +51,9 @@ public:
   // Constructors / Destructor
   BoardDesignRulesDialog()                                    = delete;
   BoardDesignRulesDialog(const BoardDesignRulesDialog& other) = delete;
-  explicit BoardDesignRulesDialog(const BoardDesignRules& rules,
-                                  QWidget*                parent = 0);
+  BoardDesignRulesDialog(const BoardDesignRules& rules,
+                         const LengthUnit&       lengthUnit,
+                         const QString& settingsPrefix, QWidget* parent = 0);
   ~BoardDesignRulesDialog();
 
   // Getters

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
@@ -45,8 +45,6 @@ CirclePropertiesDialog::CirclePropertiesDialog(Circle&               circle,
     mUndoStack(undoStack),
     mUi(new Ui::CirclePropertiesDialog) {
   mUi->setupUi(this);
-  mUi->edtLineWidth->setSingleStep(0.1);  // [mm]
-  mUi->edtDiameter->setSingleStep(0.1);   // [mm]
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
@@ -39,12 +39,22 @@ namespace librepcb {
 CirclePropertiesDialog::CirclePropertiesDialog(Circle&               circle,
                                                UndoStack&            undoStack,
                                                QList<GraphicsLayer*> layers,
-                                               QWidget* parent) noexcept
+                                               const LengthUnit&     lengthUnit,
+                                               const QString& settingsPrefix,
+                                               QWidget*       parent) noexcept
   : QDialog(parent),
     mCircle(circle),
     mUndoStack(undoStack),
     mUi(new Ui::CirclePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtLineWidth->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                               settingsPrefix % "/line_width");
+  mUi->edtDiameter->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                              settingsPrefix % "/diameter");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.h
@@ -34,6 +34,7 @@ namespace librepcb {
 class UndoStack;
 class Circle;
 class GraphicsLayer;
+class LengthUnit;
 
 namespace Ui {
 class CirclePropertiesDialog;
@@ -55,6 +56,8 @@ public:
   CirclePropertiesDialog(const CirclePropertiesDialog& other) = delete;
   CirclePropertiesDialog(Circle& circle, UndoStack& undoStack,
                          QList<GraphicsLayer*> layers,
+                         const LengthUnit&     lengthUnit,
+                         const QString&        settingsPrefix,
                          QWidget*              parent = nullptr) noexcept;
   ~CirclePropertiesDialog() noexcept;
 

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
@@ -42,7 +42,6 @@ HolePropertiesDialog::HolePropertiesDialog(Hole& hole, UndoStack& undoStack,
     mUndoStack(undoStack),
     mUi(new Ui::HolePropertiesDialog) {
   mUi->setupUi(this);
-  mUi->edtDiameter->setSingleStep(0.1);  // [mm]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &HolePropertiesDialog::on_buttonBox_clicked);
 

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
@@ -36,12 +36,21 @@
 namespace librepcb {
 
 HolePropertiesDialog::HolePropertiesDialog(Hole& hole, UndoStack& undoStack,
-                                           QWidget* parent) noexcept
+                                           const LengthUnit& lengthUnit,
+                                           const QString&    settingsPrefix,
+                                           QWidget*          parent) noexcept
   : QDialog(parent),
     mHole(hole),
     mUndoStack(undoStack),
     mUi(new Ui::HolePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtDiameter->configure(lengthUnit,
+                              LengthEditBase::Steps::drillDiameter(),
+                              settingsPrefix % "/diameter");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &HolePropertiesDialog::on_buttonBox_clicked);
 

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.h
@@ -33,6 +33,7 @@ namespace librepcb {
 
 class UndoStack;
 class Hole;
+class LengthUnit;
 
 namespace Ui {
 class HolePropertiesDialog;
@@ -53,7 +54,9 @@ public:
   HolePropertiesDialog()                                  = delete;
   HolePropertiesDialog(const HolePropertiesDialog& other) = delete;
   HolePropertiesDialog(Hole& hole, UndoStack& undoStack,
-                       QWidget* parent = nullptr) noexcept;
+                       const LengthUnit& lengthUnit,
+                       const QString&    settingsPrefix,
+                       QWidget*          parent = nullptr) noexcept;
   ~HolePropertiesDialog() noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
@@ -45,7 +45,6 @@ PolygonPropertiesDialog::PolygonPropertiesDialog(Polygon&   polygon,
     mUndoStack(undoStack),
     mUi(new Ui::PolygonPropertiesDialog) {
   mUi->setupUi(this);
-  mUi->edtLineWidth->setSingleStep(0.1);  // [mm]
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
@@ -39,12 +39,17 @@ namespace librepcb {
 PolygonPropertiesDialog::PolygonPropertiesDialog(Polygon&   polygon,
                                                  UndoStack& undoStack,
                                                  QList<GraphicsLayer*> layers,
-                                                 QWidget* parent) noexcept
+                                                 const LengthUnit& lengthUnit,
+                                                 const QString& settingsPrefix,
+                                                 QWidget*       parent) noexcept
   : QDialog(parent),
     mPolygon(polygon),
     mUndoStack(undoStack),
     mUi(new Ui::PolygonPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtLineWidth->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                               settingsPrefix % "/line_width");
+  mUi->pathEditorWidget->setLengthUnit(lengthUnit);
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.h
@@ -58,6 +58,8 @@ public:
   PolygonPropertiesDialog(const PolygonPropertiesDialog& other) = delete;
   PolygonPropertiesDialog(Polygon& polygon, UndoStack& undoStack,
                           QList<GraphicsLayer*> layers,
+                          const LengthUnit&     lengthUnit,
+                          const QString&        settingsPrefix,
                           QWidget*              parent = nullptr) noexcept;
   ~PolygonPropertiesDialog() noexcept;
 

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
@@ -39,12 +39,21 @@ namespace librepcb {
 
 StrokeTextPropertiesDialog::StrokeTextPropertiesDialog(
     StrokeText& text, UndoStack& undoStack, QList<GraphicsLayer*> layers,
+    const LengthUnit& lengthUnit, const QString& settingsPrefix,
     QWidget* parent) noexcept
   : QDialog(parent),
     mText(text),
     mUndoStack(undoStack),
     mUi(new Ui::StrokeTextPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtHeight->configure(lengthUnit, LengthEditBase::Steps::textHeight(),
+                            settingsPrefix % "/height");
+  mUi->edtStrokeWidth->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                                 settingsPrefix % "/stroke_width");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
   mUi->edtRotation->setSingleStep(90.0);  // [°]
 
   foreach (const GraphicsLayer* layer, layers) {

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
@@ -45,9 +45,7 @@ StrokeTextPropertiesDialog::StrokeTextPropertiesDialog(
     mUndoStack(undoStack),
     mUi(new Ui::StrokeTextPropertiesDialog) {
   mUi->setupUi(this);
-  mUi->edtHeight->setSingleStep(0.5);       // [mm]
-  mUi->edtStrokeWidth->setSingleStep(0.1);  // [mm]
-  mUi->edtRotation->setSingleStep(90.0);    // [°]
+  mUi->edtRotation->setSingleStep(90.0);  // [°]
 
   foreach (const GraphicsLayer* layer, layers) {
     mUi->cbxLayer->addItem(layer->getNameTr(), layer->getName());

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.h
@@ -34,6 +34,7 @@ namespace librepcb {
 class UndoStack;
 class StrokeText;
 class GraphicsLayer;
+class LengthUnit;
 
 namespace Ui {
 class StrokeTextPropertiesDialog;
@@ -55,6 +56,8 @@ public:
   StrokeTextPropertiesDialog(const StrokeTextPropertiesDialog& other) = delete;
   StrokeTextPropertiesDialog(StrokeText& text, UndoStack& undoStack,
                              QList<GraphicsLayer*> layers,
+                             const LengthUnit&     lengthUnit,
+                             const QString&        settingsPrefix,
                              QWidget*              parent = nullptr) noexcept;
   ~StrokeTextPropertiesDialog() noexcept;
 

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
@@ -44,7 +44,6 @@ TextPropertiesDialog::TextPropertiesDialog(Text& text, UndoStack& undoStack,
     mUndoStack(undoStack),
     mUi(new Ui::TextPropertiesDialog) {
   mUi->setupUi(this);
-  mUi->edtHeight->setSingleStep(0.5);     // [mm]
   mUi->edtRotation->setSingleStep(90.0);  // [°]
 
   foreach (const GraphicsLayer* layer, layers) {

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
@@ -38,12 +38,20 @@ namespace librepcb {
 
 TextPropertiesDialog::TextPropertiesDialog(Text& text, UndoStack& undoStack,
                                            QList<GraphicsLayer*> layers,
+                                           const LengthUnit&     lengthUnit,
+                                           const QString&        settingsPrefix,
                                            QWidget* parent) noexcept
   : QDialog(parent),
     mText(text),
     mUndoStack(undoStack),
     mUi(new Ui::TextPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtHeight->configure(lengthUnit, LengthEditBase::Steps::textHeight(),
+                            settingsPrefix % "/height");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
   mUi->edtRotation->setSingleStep(90.0);  // [°]
 
   foreach (const GraphicsLayer* layer, layers) {

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.h
@@ -34,6 +34,7 @@ namespace librepcb {
 class UndoStack;
 class Text;
 class GraphicsLayer;
+class LengthUnit;
 
 namespace Ui {
 class TextPropertiesDialog;
@@ -55,6 +56,8 @@ public:
   TextPropertiesDialog(const TextPropertiesDialog& other) = delete;
   TextPropertiesDialog(Text& text, UndoStack& undoStack,
                        QList<GraphicsLayer*> layers,
+                       const LengthUnit&     lengthUnit,
+                       const QString&        settingsPrefix,
                        QWidget*              parent = nullptr) noexcept;
   ~TextPropertiesDialog() noexcept;
 

--- a/libs/librepcb/common/model/lengthdelegate.cpp
+++ b/libs/librepcb/common/model/lengthdelegate.cpp
@@ -70,7 +70,9 @@ QWidget* LengthDelegate::createEditor(QWidget*                    parent,
   Q_UNUSED(option);
   LengthEdit* edt = new LengthEdit(parent);
   edt->setFrame(false);
-  edt->setUnit(mUnit);
+  edt->setButtonSymbols(QAbstractSpinBox::NoButtons);
+  edt->setChangeUnitActionVisible(false);  // avoid wasting space
+  edt->setDefaultUnit(mUnit);
   edt->setValue(index.data(Qt::EditRole).value<Length>());
   edt->selectAll();
 

--- a/libs/librepcb/common/model/lengthdelegate.cpp
+++ b/libs/librepcb/common/model/lengthdelegate.cpp
@@ -58,7 +58,9 @@ void LengthDelegate::setUnit(const LengthUnit& unit) noexcept {
 
 QString LengthDelegate::displayText(const QVariant& value,
                                     const QLocale&  locale) const {
-  return Toolbox::floatToString(value.value<Length>().toMm(), 10, locale) %
+  qreal converted = mUnit.convertToUnit(value.value<Length>());
+  return Toolbox::floatToString(converted,
+                                mUnit.getReasonableNumberOfDecimals(), locale) %
          " " % mUnit.toShortStringTr();
 }
 

--- a/libs/librepcb/common/units/length.cpp
+++ b/libs/librepcb/common/units/length.cpp
@@ -116,6 +116,14 @@ Length Length::fromPx(qreal pixels, const Length& gridInterval) {
   return l.mapToGrid(gridInterval);
 }
 
+Length Length::min() noexcept {
+  return Length(std::numeric_limits<LengthBase_t>::min());
+}
+
+Length Length::max() noexcept {
+  return Length(std::numeric_limits<LengthBase_t>::max());
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/

--- a/libs/librepcb/common/units/length.h
+++ b/libs/librepcb/common/units/length.h
@@ -458,6 +458,20 @@ public:
    */
   static Length fromPx(qreal pixels, const Length& gridInterval = Length(0));
 
+  /**
+   * @brief Get the smallest possible length value
+   *
+   * @return Smallest possible length
+   */
+  static Length min() noexcept;
+
+  /**
+   * @brief Get the highest possible length value
+   *
+   * @return Highest possible length
+   */
+  static Length max() noexcept;
+
   // Operators
   Length& operator=(const Length& rhs) {
     mNanometers = rhs.mNanometers;

--- a/libs/librepcb/common/units/lengthunit.cpp
+++ b/libs/librepcb/common/units/lengthunit.cpp
@@ -95,6 +95,25 @@ QString LengthUnit::toShortStringTr() const noexcept {
   }
 }
 
+int LengthUnit::getReasonableNumberOfDecimals() const noexcept {
+  switch (mUnit) {
+    case LengthUnit_t::Millimeters:
+      return 3;
+    case LengthUnit_t::Micrometers:
+      return 1;
+    case LengthUnit_t::Nanometers:
+      return 0;
+    case LengthUnit_t::Inches:
+      return 5;
+    case LengthUnit_t::Mils:
+      return 2;
+    default:
+      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      Q_ASSERT(false);
+      return 3;
+  }
+}
+
 QStringList LengthUnit::getUserInputSuffixes() const noexcept {
   switch (mUnit) {
     case LengthUnit_t::Millimeters:

--- a/libs/librepcb/common/units/lengthunit.cpp
+++ b/libs/librepcb/common/units/lengthunit.cpp
@@ -173,6 +173,17 @@ Point LengthUnit::convertFromUnit(const QPointF& point) const {
 
 // Static Methods
 
+LengthUnit LengthUnit::fromString(const QString& str) {
+  foreach (const LengthUnit& unit, getAllUnits()) {
+    if (unit.toStr() == str) {
+      return unit;
+    }
+  }
+  throw RuntimeError(
+      __FILE__, __LINE__,
+      QString(LengthUnit::tr("Invalid length unit: \"%1\"")).arg(str));
+}
+
 LengthUnit LengthUnit::fromIndex(int index) {
   if (index >= static_cast<int>(LengthUnit_t::_COUNT))
     throw LogicError(__FILE__, __LINE__, QString::number(index));

--- a/libs/librepcb/common/units/lengthunit.cpp
+++ b/libs/librepcb/common/units/lengthunit.cpp
@@ -95,6 +95,25 @@ QString LengthUnit::toShortStringTr() const noexcept {
   }
 }
 
+QStringList LengthUnit::getUserInputSuffixes() const noexcept {
+  switch (mUnit) {
+    case LengthUnit_t::Millimeters:
+      return QStringList{"mm"};
+    case LengthUnit_t::Micrometers:
+      return QStringList{"μm", "um"};
+    case LengthUnit_t::Nanometers:
+      return QStringList{"nm"};
+    case LengthUnit_t::Inches:
+      return QStringList{"″", "\"", "in", "inch", "inches"};
+    case LengthUnit_t::Mils:
+      return QStringList{"mils"};
+    default:
+      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      Q_ASSERT(false);
+      return QStringList();
+  }
+}
+
 qreal LengthUnit::convertToUnit(const Length& length) const noexcept {
   switch (mUnit) {
     case LengthUnit_t::Millimeters:

--- a/libs/librepcb/common/units/lengthunit.h
+++ b/libs/librepcb/common/units/lengthunit.h
@@ -214,6 +214,17 @@ public:
   // Static Methods
 
   /**
+   * @brief Get the length unit represented by a string
+   *
+   * @param str   The #toStr() representation of the unit.
+   *
+   * @return The LengthUnit of the string.
+   *
+   * @throw Exception If the string did not contain a valid unit.
+   */
+  static LengthUnit fromString(const QString& str);
+
+  /**
    * @brief Get the length unit of a specific index (to use with #getIndex())
    *
    * @param index         The index of the unit in the list of #getAllUnits().
@@ -227,7 +238,6 @@ public:
    * @see #getIndex(), #getAllUnits()
    */
   static LengthUnit fromIndex(int index);
-  ;
 
   /**
    * @brief Get all available length units
@@ -299,22 +309,8 @@ inline SExpression serializeToSExpression(const LengthUnit& obj) {
 template <>
 inline LengthUnit deserializeFromSExpression(const SExpression& sexpr,
                                              bool               throwIfEmpty) {
-  QString str = sexpr.getStringOrToken(throwIfEmpty);
-  if (str == "millimeters")
-    return LengthUnit::millimeters();
-  else if (str == "micrometers")
-    return LengthUnit::micrometers();
-  else if (str == "nanometers")
-    return LengthUnit::nanometers();
-  else if (str == "inches")
-    return LengthUnit::inches();
-  else if (str == "mils")
-    return LengthUnit::mils();
-  else {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(LengthUnit::tr("Invalid length unit: \"%1\"")).arg(str));
-  }
+  return LengthUnit::fromString(
+      sexpr.getStringOrToken(throwIfEmpty));  // can throw
 }
 
 inline QDataStream& operator<<(QDataStream& stream, const LengthUnit& unit) {

--- a/libs/librepcb/common/units/lengthunit.h
+++ b/libs/librepcb/common/units/lengthunit.h
@@ -149,6 +149,23 @@ public:
   QString toShortStringTr() const noexcept;
 
   /**
+   * @brief Get a reasonable number of decimals to be shown
+   *
+   * When displaying length values to the user, often it makes sense to limit
+   * the displayed number of decimal places. But since this number depends on
+   * the unit, this helper method is provided.
+   *
+   * @note  The returned number of decimals will *NOT* be enough to represent
+   *        all possiblle ::librepcb::Length values without loosing precision!
+   *        So a value with truncated number of decimal places may not be
+   *        converted back to a ::librepcb::Length object since this might lead
+   *        to a different value!
+   *
+   * @return Reasonable number of decimals.
+   */
+  int getReasonableNumberOfDecimals() const noexcept;
+
+  /**
    * @brief Get user input suffixes
    *
    * Returns a list of suffixes the user might use to represent this unit. For

--- a/libs/librepcb/common/units/lengthunit.h
+++ b/libs/librepcb/common/units/lengthunit.h
@@ -148,6 +148,17 @@ public:
    */
   QString toShortStringTr() const noexcept;
 
+  /**
+   * @brief Get user input suffixes
+   *
+   * Returns a list of suffixes the user might use to represent this unit. For
+   * example "um" is a typical user input to mean Micrometers since "μm" is
+   * more difficult to write.
+   *
+   * @return A list of user input suffixes
+   */
+  QStringList getUserInputSuffixes() const noexcept;
+
   // General Methods
 
   /**

--- a/libs/librepcb/common/utils/mathparser.cpp
+++ b/libs/librepcb/common/utils/mathparser.cpp
@@ -1,0 +1,82 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "mathparser.h"
+
+#include "muparser/include/muParser.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+MathParser::MathParser() noexcept : mLocale() {
+}
+
+MathParser::~MathParser() noexcept {
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+void MathParser::setLocale(const QLocale& locale) noexcept {
+  mLocale = locale;
+}
+
+MathParser::Result MathParser::parse(const QString& expression) const noexcept {
+  MathParser::Result result;
+
+  try {
+    mu::Parser parser;
+    parser.SetArgSep(';');  // avoid conflict with other separators
+    parser.SetDecSep(mLocale.decimalPoint().toLatin1());
+    parser.SetThousandsSep(mLocale.groupSeparator().toLatin1());
+#if defined(_UNICODE)
+    parser.SetExpr(expression.toStdWString());
+#else
+    parser.SetExpr(expression.toStdString());
+#endif
+    result.value = static_cast<qreal>(parser.Eval());  // can throw
+    result.valid = true;
+  } catch (const mu::Parser::exception_type& e) {
+    result.valid = false;
+    result.error = tr("Failed to parse expression:") % "\n\n";
+#if defined(_UNICODE)
+    result.error += QString::fromStdWString(e.GetMsg());
+#else
+    result.error += QString::fromStdString(e.GetMsg());
+#endif
+  }
+
+  return result;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/utils/mathparser.h
+++ b/libs/librepcb/common/utils/mathparser.h
@@ -1,0 +1,97 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_MATHPARSER_H
+#define LIBREPCB_MATHPARSER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class MathParser
+ ******************************************************************************/
+
+/**
+ * @brief Mathematical expression parser
+ *
+ * This class interprets mathematical expression strings (e.g. "2+3") and
+ * returns the result of the calculation. It is actually only a wrapper around
+ * the [muparser](https://beltoforion.de/article.php?a=muparser) library, so
+ * take a look at its documentation for details.
+ */
+class MathParser {
+  Q_DECLARE_TR_FUNCTIONS(MathParser)
+
+public:
+  struct Result {
+    bool    valid;
+    qreal   value;
+    QString error;
+
+    Result() : valid(false), value(0), error() {}
+  };
+
+  // Constructors / Destructor
+  MathParser() noexcept;
+  MathParser(const MathParser& other) = delete;
+  virtual ~MathParser() noexcept;
+
+  // General Methods
+
+  /**
+   * @brief Set the locale to be used for parsing numbers
+   *
+   * This sets the thousand separator and decimal point to be used for the
+   * evaluation.
+   *
+   * @param locale  The locale to use.
+   */
+  void setLocale(const QLocale& locale) noexcept;
+
+  /**
+   * @brief Parse expression
+   *
+   * @param expression  The expression to parse.
+   *
+   * @return  The result, either valid with a value, or invalid with an error
+   *          message.
+   */
+  Result parse(const QString& expression) const noexcept;
+
+  // Operator Overloadings
+  MathParser& operator=(const MathParser& rhs) = delete;
+
+private:
+  QLocale mLocale;  ///< The locale used for parsing numbers
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_MATHPARSER_H

--- a/libs/librepcb/common/widgets/lengthedit.cpp
+++ b/libs/librepcb/common/widgets/lengthedit.cpp
@@ -34,15 +34,18 @@ namespace librepcb {
  ******************************************************************************/
 
 LengthEdit::LengthEdit(QWidget* parent) noexcept
-  : NumberEditBase(parent),
-    mMinValue(-2000000000L),  // -2'000mm should be sufficient for everything
-    mMaxValue(2000000000L),   // 2'000mm should be sufficient for everything
-    mValue(0),
-    mUnit(LengthUnit::millimeters()) {
-  updateSpinBox();
+  : LengthEditBase(Length::min(), Length::max(), Length(0), parent) {
 }
 
 LengthEdit::~LengthEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+Length LengthEdit::getValue() const noexcept {
+  return mValue;
 }
 
 /*******************************************************************************
@@ -50,46 +53,15 @@ LengthEdit::~LengthEdit() noexcept {
  ******************************************************************************/
 
 void LengthEdit::setValue(const Length& value) noexcept {
-  if (value != mValue) {
-    mValue = value;
-    // Extend allowed range e.g. if a lower/higher value is loaded from file.
-    // Otherwise the edit will clip the value, i.e. the value gets modified
-    // even without user interaction.
-    if (mValue > mMaxValue) mMaxValue = mValue;
-    if (mValue < mMinValue) mMinValue = mValue;
-    updateSpinBox();
-  }
-}
-
-void LengthEdit::setUnit(const LengthUnit& unit) noexcept {
-  if (unit != mUnit) {
-    mUnit = unit;
-    updateSpinBox();
-  }
+  setValueImpl(value);
 }
 
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 
-void LengthEdit::updateSpinBox() noexcept {
-  mSpinBox->setMinimum(mUnit.convertToUnit(mMinValue));
-  mSpinBox->setMaximum(mUnit.convertToUnit(mMaxValue));
-  mSpinBox->setValue(mUnit.convertToUnit(mValue));
-  mSpinBox->setSuffix(" " % mUnit.toShortStringTr());
-}
-
-void LengthEdit::spinBoxValueChanged(double value) noexcept {
-  try {
-    mValue = mUnit.convertFromUnit(value);  // can throw
-    // Clip value with integer arithmetic to avoid floating point issues.
-    if (mValue < mMinValue) mValue = mMinValue;
-    if (mValue > mMaxValue) mValue = mMaxValue;
-    emit valueChanged(mValue);
-  } catch (const Exception& e) {
-    // This should actually never happen, thus no user visible message here.
-    qWarning() << "Invalid length entered:" << e.getMsg();
-  }
+void LengthEdit::valueChangedImpl() noexcept {
+  emit valueChanged(getValue());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/widgets/lengthedit.h
+++ b/libs/librepcb/common/widgets/lengthedit.h
@@ -23,9 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../units/length.h"
-#include "../units/lengthunit.h"
-#include "numbereditbase.h"
+#include "lengtheditbase.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -43,7 +41,7 @@ namespace librepcb {
  * @brief The LengthEdit class is a widget to view/edit ::librepcb::Length
  *        values
  */
-class LengthEdit final : public NumberEditBase {
+class LengthEdit final : public LengthEditBase {
   Q_OBJECT
 
 public:
@@ -53,27 +51,20 @@ public:
   virtual ~LengthEdit() noexcept;
 
   // Getters
-  const Length& getValue() const noexcept { return mValue; }
+  Length getValue() const noexcept;
 
   // Setters
   void setValue(const Length& value) noexcept;
-  void setUnit(const LengthUnit& unit) noexcept;
 
   // Operator Overloadings
   LengthEdit& operator=(const LengthEdit& rhs) = delete;
 
 signals:
-  void valueChanged(const Length& value);
+  // Note: Full namespace librepcb::Length is required for the MOC!
+  void valueChanged(const librepcb::Length& value);
 
-private:  // Methods
-  void updateSpinBox() noexcept override;
-  void spinBoxValueChanged(double value) noexcept override;
-
-private:  // Data
-  Length     mMinValue;
-  Length     mMaxValue;
-  Length     mValue;
-  LengthUnit mUnit;
+private:
+  virtual void valueChangedImpl() noexcept override;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/widgets/lengtheditbase.cpp
+++ b/libs/librepcb/common/widgets/lengtheditbase.cpp
@@ -1,0 +1,327 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "lengtheditbase.h"
+
+#include "../toolbox.h"
+#include "../utils/mathparser.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+LengthEditBase::LengthEditBase(const Length& min, const Length& max,
+                               const Length& value, QWidget* parent) noexcept
+  : QAbstractSpinBox(parent),
+    mChangeUnitAction(lineEdit()->addAction(QIcon(":/img/actions/ruler.png"),
+                                            QLineEdit::TrailingPosition)),
+    mDefaultUnit(LengthUnit::millimeters()),
+    mSelectedUnit(tl::nullopt),
+    mMinimum(min),
+    mMaximum(max),
+    mValue(value),
+    mSteps(Steps::generic()),
+    mSingleStepUp(0),
+    mSingleStepDown(0),
+    // Additional size for the QAction inside the QLineEdit because
+    // QAbstractSpinBox does not respect it.
+    mAdditionalSize(30, 0),
+    mSettingsKey() {
+  Q_ASSERT((mValue >= mMinimum) && (mValue <= mMaximum));
+
+  // Ugly hack to make sizeHint() and minimumSizeHint() working properly.
+  // QAbstractSpinBox uses (among others) the special value text to calculate
+  // the size hint, so let's set it to a dummy string which is long enough to
+  // represent typical length values.
+  setSpecialValueText("000.000 mils");
+
+  // Setup QLineEdit.
+  lineEdit()->setPlaceholderText(tr("Enter numeric expression"));
+  lineEdit()->setMaxLength(50);
+  updateText();
+
+  // editingFinished from the QLineEdit is not always emitted (e.g. when
+  // leaving focus), therefore we need to use editingFinished from
+  // QAbstractSpinBox.
+  connect(this, &LengthEditBase::editingFinished, this,
+          &LengthEditBase::updateText);
+  connect(lineEdit(), &QLineEdit::textEdited, this,
+          &LengthEditBase::updateValueFromText);
+  connect(mChangeUnitAction, &QAction::triggered, this,
+          &LengthEditBase::changeUnitActionTriggered);
+}
+
+LengthEditBase::~LengthEditBase() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+const LengthUnit& LengthEditBase::getDisplayedUnit() const noexcept {
+  return mSelectedUnit ? *mSelectedUnit : mDefaultUnit;
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void LengthEditBase::setDefaultUnit(const LengthUnit& unit) noexcept {
+  if (unit != mDefaultUnit) {
+    mDefaultUnit = unit;
+    updateText();
+  }
+}
+
+void LengthEditBase::setChangeUnitActionVisible(bool visible) noexcept {
+  mChangeUnitAction->setVisible(visible);
+}
+
+void LengthEditBase::setSteps(const QVector<PositiveLength>& steps) noexcept {
+  mSteps = steps;
+  updateSingleStep();
+  update();  // step buttons might need to be repainted
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void LengthEditBase::configureClientSettings(
+    const QString& uniqueIdentifier) noexcept {
+  mSettingsKey = uniqueIdentifier % "/unit";
+
+  try {
+    QSettings clientSettings;
+    QString   unit = clientSettings.value(mSettingsKey).toString();
+    if (!unit.isEmpty()) {
+      mSelectedUnit = LengthUnit::fromString(unit);  // can throw
+    } else {
+      mSelectedUnit = tl::nullopt;
+    }
+  } catch (const Exception& e) {
+    qWarning() << "LengthEditBase: Could not restore unit from user settings:"
+               << e.getMsg();
+  }
+}
+
+void LengthEditBase::configure(const LengthUnit&              defaultUnit,
+                               const QVector<PositiveLength>& steps,
+                               const QString& uniqueIdentifier) noexcept {
+  setDefaultUnit(defaultUnit);
+  setSteps(steps);
+  configureClientSettings(uniqueIdentifier);
+}
+
+/*******************************************************************************
+ *  Reimplemented Methods
+ ******************************************************************************/
+
+QSize LengthEditBase::minimumSizeHint() const {
+  return QAbstractSpinBox::minimumSizeHint() + mAdditionalSize;
+}
+
+QSize LengthEditBase::sizeHint() const {
+  return QAbstractSpinBox::sizeHint() + mAdditionalSize;
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+QAbstractSpinBox::StepEnabled LengthEditBase::stepEnabled() const {
+  QAbstractSpinBox::StepEnabled enabled = QAbstractSpinBox::StepNone;
+  if ((mSingleStepUp > 0) && (mValue < mMaximum)) {
+    enabled |= QAbstractSpinBox::StepUpEnabled;
+  }
+  if ((mSingleStepDown > 0) && (mValue > mMinimum)) {
+    enabled |= QAbstractSpinBox::StepDownEnabled;
+  }
+  return enabled;
+}
+
+void LengthEditBase::stepBy(int steps) {
+  if ((mSingleStepUp > 0) && (steps > 0)) {
+    setValueImpl(mValue + mSingleStepUp * steps);
+  } else if ((mSingleStepDown > 0) && (steps < 0)) {
+    setValueImpl(mValue + mSingleStepDown * steps);
+  }
+}
+
+void LengthEditBase::setValueImpl(Length value) noexcept {
+  // Always clip the value to the allowed range! Otherwise the value might not
+  // be convertible into the constrained Length type of derived classes!
+  value = qBound(mMinimum, value, mMaximum);
+
+  // To avoid unnecessary clearing the QLineEdit selection, only update the
+  // value (and therefore the text) if really needed.
+  if (value != mValue) {
+    mValue = value;
+    updateSingleStep();
+    updateText();
+    valueChangedImpl();
+    update();  // step buttons might need to be repainted
+  }
+}
+
+void LengthEditBase::updateValueFromText(QString text) noexcept {
+  try {
+    LengthUnit         unit   = extractUnitFromExpression(text);
+    MathParser::Result result = MathParser().parse(text);
+    if (result.valid) {
+      Length value = unit.convertFromUnit(result.value);  // can throw
+      // Only accept values in the allowed range.
+      if ((value >= mMinimum) && (value <= mMaximum)) {
+        mValue = value;
+        setSelectedUnit(unit);
+        updateSingleStep();
+        // In contrast to setValueImpl(), do NOT call updateText() to avoid
+        // disturbing the user while writing the text!
+        valueChangedImpl();
+        update();  // step buttons might need to be repainted
+      } else {
+        qWarning() << "LengthEditBase: Entered text was a valid number, but "
+                      "outside the allowed range.";
+      }
+    }
+  } catch (const Exception&) {
+    qWarning() << "LengthEditBase: Entered text was a valid expression, but "
+                  "evaluated to an invalid number:"
+               << text;
+  }
+}
+
+void LengthEditBase::updateSingleStep() noexcept {
+  if ((mValue == 0) || (mValue == mMinimum)) {
+    return;  // keep last step values
+  }
+
+  Length up;
+  Length down;
+  foreach (const PositiveLength& step, mSteps) {
+    if ((mValue % (*step)) == 0) {
+      up = *step;
+      if ((mValue.abs() > (*step)) || (down == 0)) {
+        down = *step;
+      }
+    }
+  }
+  if (mValue < 0) {
+    std::swap(up, down);
+  }
+  // Do not allow to step down if it would lead in a value smaller than the
+  // minimum. This is needed for PositiveLengthEdit to avoid e.g. the next lower
+  // value of 0.1mm would be 0.000001mm because it gets clipped to the minimum.
+  if ((down > 0) && (mValue < (mMinimum + down))) {
+    down = 0;
+  }
+
+  mSingleStepUp   = up;
+  mSingleStepDown = down;
+}
+
+void LengthEditBase::updateText() noexcept {
+  lineEdit()->setText(getValueStr(getDisplayedUnit()));
+}
+
+LengthUnit LengthEditBase::extractUnitFromExpression(QString& expression) const
+    noexcept {
+  foreach (const LengthUnit& unit, LengthUnit::getAllUnits()) {
+    foreach (const QString& suffix, unit.getUserInputSuffixes()) {
+      if (expression.endsWith(suffix)) {
+        expression.chop(suffix.length());
+        return unit;
+      }
+    }
+  }
+  return getDisplayedUnit();  // if no unit specified, use current unit
+}
+
+void LengthEditBase::changeUnitActionTriggered() noexcept {
+  QMenu        menu(this);
+  QActionGroup group(&menu);
+  foreach (const LengthUnit& unit, LengthUnit::getAllUnits()) {
+    QString text = getValueStr(unit);
+    if (unit == LengthUnit::nanometers()) {
+      text += " (" % tr("internal") % ")";
+    }
+    if (unit == mDefaultUnit) {
+      text += " [" % tr("default") % "]";
+    }
+    QAction* action = menu.addAction(text);
+    group.addAction(action);
+    action->setCheckable(true);
+    action->setChecked(unit == getDisplayedUnit());
+    connect(action, &QAction::triggered, [this, unit]() {
+      setSelectedUnit(unit);
+      updateText();
+    });
+  }
+  menu.exec(QCursor::pos());
+}
+
+void LengthEditBase::setSelectedUnit(const LengthUnit& unit) noexcept {
+  tl::optional<LengthUnit> selectedUnit =
+      (unit != mDefaultUnit) ? tl::make_optional(unit) : tl::nullopt;
+  if (selectedUnit != mSelectedUnit) {
+    mSelectedUnit = selectedUnit;
+    saveSelectedUnit();
+  }
+}
+
+void LengthEditBase::saveSelectedUnit() noexcept {
+  if (!mSettingsKey.isEmpty()) {
+    QSettings clientSettings;
+    if (mSelectedUnit) {
+      clientSettings.setValue(mSettingsKey, mSelectedUnit->toStr());
+    } else {
+      clientSettings.remove(mSettingsKey);
+    }
+  }
+}
+
+QString LengthEditBase::getValueStr(const LengthUnit& unit) const noexcept {
+  if (unit == LengthUnit::nanometers()) {
+    return QString::number(mValue.toNm()) % " " % unit.toShortStringTr();
+  } else {
+    // Show only a limited number of decimals to avoid very odd numbers with
+    // many decimals due to converting between different units (e.g. a value
+    // of 0.1mm displayed in mils is 3.937007874, but such a number is annoying
+    // in a GUI). The underlying value is of course not truncated, so it should
+    // be fine to reduce the displayed number of decimals.
+    return Toolbox::floatToString(unit.convertToUnit(mValue),
+                                  unit.getReasonableNumberOfDecimals(),
+                                  locale()) %
+           " " % unit.toShortStringTr();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/widgets/lengtheditbase.h
+++ b/libs/librepcb/common/widgets/lengtheditbase.h
@@ -1,0 +1,160 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_LENGTHEDITBASE_H
+#define LIBREPCB_LENGTHEDITBASE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/length.h"
+#include "../units/lengthunit.h"
+#include "numbereditbase.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class LengthEditBase
+ ******************************************************************************/
+
+/**
+ * @brief The LengthEditBase class
+ */
+class LengthEditBase : public QAbstractSpinBox {
+  Q_OBJECT
+
+public:
+  struct Steps {
+    static QVector<PositiveLength> generic() noexcept {
+      return {
+          PositiveLength(10000),    // 0.01mm
+          PositiveLength(25400),    // 0.0254mm
+          PositiveLength(100000),   // 0.1mm
+          PositiveLength(254000),   // 0.254mm
+          PositiveLength(1000000),  // 1mm
+          PositiveLength(2540000),  // 2.54mm
+      };
+    }
+
+    static QVector<PositiveLength> textHeight() noexcept {
+      return {
+          PositiveLength(100000),  // 0.1mm
+          PositiveLength(254000),  // 0.254mm
+          PositiveLength(500000),  // 0.5mm (default)
+      };
+    }
+
+    static QVector<PositiveLength> pinLength() noexcept {
+      return {
+          PositiveLength(2500000),  // 2.5mm (for metric symbols)
+          PositiveLength(2540000),  // 2.54mm (default)
+      };
+    }
+
+    static QVector<PositiveLength> drillDiameter() noexcept {
+      return {
+          PositiveLength(254000),  // 0.254mm (for imperial drills)
+          PositiveLength(100000),  // 0.1mm (default, for metric drills)
+      };
+    }
+  };
+
+  // Constructors / Destructor
+  LengthEditBase() = delete;
+  explicit LengthEditBase(const Length& min, const Length& max,
+                          const Length& value,
+                          QWidget*      parent = nullptr) noexcept;
+  LengthEditBase(const LengthEditBase& other) = delete;
+  virtual ~LengthEditBase() noexcept;
+
+  // Getters
+  const LengthUnit& getDisplayedUnit() const noexcept;
+
+  // Setters
+  void setDefaultUnit(const LengthUnit& unit) noexcept;
+  void setChangeUnitActionVisible(bool visible) noexcept;
+
+  /**
+   * @brief Set the supported up/down step values
+   *
+   * The step with lowest priority (typically the smallest value) must be the
+   * first element in the list, the step with highest priority (typically the
+   * largest value) the last one.
+   *
+   * Example:
+   * {0.1mm, 1.0mm} leads to the steps 0.0mm, 0.1mm, .. 0.9mm, 1.0mm, 2.0mm, ...
+   *
+   * @param steps   List of supported step values
+   */
+  void setSteps(const QVector<PositiveLength>& steps) noexcept;
+
+  // General Methods
+  void configureClientSettings(const QString& uniqueIdentifier) noexcept;
+  void configure(const LengthUnit&              defaultUnit,
+                 const QVector<PositiveLength>& steps,
+                 const QString&                 uniqueIdentifier) noexcept;
+
+  // Reimplemented Methods
+  QSize minimumSizeHint() const override;
+  QSize sizeHint() const override;
+
+  // Operator Overloadings
+  LengthEditBase& operator=(const LengthEditBase& rhs) = delete;
+
+protected:  // Methods
+  virtual QAbstractSpinBox::StepEnabled stepEnabled() const override;
+  virtual void                          stepBy(int steps) override;
+  void                                  setValueImpl(Length value) noexcept;
+  void         updateValueFromText(QString text) noexcept;
+  void         updateSingleStep() noexcept;
+  void         updateText() noexcept;
+  LengthUnit   extractUnitFromExpression(QString& expression) const noexcept;
+  void         changeUnitActionTriggered() noexcept;
+  void         setSelectedUnit(const LengthUnit& unit) noexcept;
+  void         saveSelectedUnit() noexcept;
+  QString      getValueStr(const LengthUnit& unit) const noexcept;
+  virtual void valueChangedImpl() noexcept = 0;
+
+protected:  // Data
+  QAction*                 mChangeUnitAction;
+  LengthUnit               mDefaultUnit;
+  tl::optional<LengthUnit> mSelectedUnit;
+  Length                   mMinimum;
+  Length                   mMaximum;
+  Length                   mValue;
+  QVector<PositiveLength>  mSteps;
+  Length                   mSingleStepUp;    ///< Zero means "no step available"
+  Length                   mSingleStepDown;  ///< Zero means "no step available"
+  QSize                    mAdditionalSize;
+  QString                  mSettingsKey;  ///< Empty means "do not save"
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_LENGTHEDITBASE_H

--- a/libs/librepcb/common/widgets/patheditorwidget.cpp
+++ b/libs/librepcb/common/widgets/patheditorwidget.cpp
@@ -42,14 +42,14 @@ namespace librepcb {
 PathEditorWidget::PathEditorWidget(QWidget* parent) noexcept
   : QWidget(parent),
     mModel(new PathModel(this)),
-    mView(new EditableTableWidget(this)) {
+    mView(new EditableTableWidget(this)),
+    mLengthDelegateX(new LengthDelegate(this)),
+    mLengthDelegateY(new LengthDelegate(this)) {
   mView->setShowMoveButtons(true);
   mView->setShowCopyButton(true);
   mView->setModel(mModel.data());
-  mView->setItemDelegateForColumn(PathModel::COLUMN_X,
-                                  new LengthDelegate(this));
-  mView->setItemDelegateForColumn(PathModel::COLUMN_Y,
-                                  new LengthDelegate(this));
+  mView->setItemDelegateForColumn(PathModel::COLUMN_X, mLengthDelegateX);
+  mView->setItemDelegateForColumn(PathModel::COLUMN_Y, mLengthDelegateY);
   mView->setItemDelegateForColumn(PathModel::COLUMN_ANGLE,
                                   new AngleDelegate(this));
   mView->horizontalHeader()->setSectionResizeMode(PathModel::COLUMN_X,
@@ -89,6 +89,11 @@ void PathEditorWidget::setPath(const Path& path) noexcept {
 
 const Path& PathEditorWidget::getPath() const noexcept {
   return mModel->getPath();
+}
+
+void PathEditorWidget::setLengthUnit(const LengthUnit& unit) noexcept {
+  mLengthDelegateX->setUnit(unit);
+  mLengthDelegateY->setUnit(unit);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/widgets/patheditorwidget.h
+++ b/libs/librepcb/common/widgets/patheditorwidget.h
@@ -35,6 +35,7 @@ namespace librepcb {
 
 class EditableTableWidget;
 class PathModel;
+class LengthDelegate;
 
 /*******************************************************************************
  *  Class PathEditorWidget
@@ -55,6 +56,7 @@ public:
   // General Methods
   void        setPath(const Path& path) noexcept;
   const Path& getPath() const noexcept;
+  void        setLengthUnit(const LengthUnit& unit) noexcept;
 
   // Operator Overloadings
   PathEditorWidget& operator=(const PathEditorWidget& rhs) = delete;
@@ -62,6 +64,8 @@ public:
 private:  // Data
   QScopedPointer<PathModel>           mModel;
   QScopedPointer<EditableTableWidget> mView;
+  LengthDelegate*                     mLengthDelegateX;
+  LengthDelegate*                     mLengthDelegateY;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/widgets/positivelengthedit.h
+++ b/libs/librepcb/common/widgets/positivelengthedit.h
@@ -23,12 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../units/length.h"
-#include "../units/lengthunit.h"
-#include "numbereditbase.h"
-
-#include <QtCore>
-#include <QtWidgets>
+#include "lengtheditbase.h"
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -43,7 +38,7 @@ namespace librepcb {
  * @brief The PositiveLengthEdit class is a widget to view/edit
  *        ::librepcb::PositiveLength values
  */
-class PositiveLengthEdit final : public NumberEditBase {
+class PositiveLengthEdit final : public LengthEditBase {
   Q_OBJECT
 
 public:
@@ -53,27 +48,20 @@ public:
   virtual ~PositiveLengthEdit() noexcept;
 
   // Getters
-  const PositiveLength& getValue() const noexcept { return mValue; }
+  PositiveLength getValue() const noexcept;
 
   // Setters
   void setValue(const PositiveLength& value) noexcept;
-  void setUnit(const LengthUnit& unit) noexcept;
 
   // Operator Overloadings
   PositiveLengthEdit& operator=(const PositiveLengthEdit& rhs) = delete;
 
 signals:
-  void valueChanged(const PositiveLength& value);
+  // Note: Full namespace librepcb::PositiveLength is required for the MOC!
+  void valueChanged(const librepcb::PositiveLength& value);
 
-private:  // Methods
-  void updateSpinBox() noexcept override;
-  void spinBoxValueChanged(double value) noexcept override;
-
-private:  // Data
-  PositiveLength mMinValue;
-  PositiveLength mMaxValue;
-  PositiveLength mValue;
-  LengthUnit     mUnit;
+private:
+  virtual void valueChangedImpl() noexcept override;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/widgets/statusbar.cpp
+++ b/libs/librepcb/common/widgets/statusbar.cpp
@@ -35,7 +35,7 @@ namespace librepcb {
  ******************************************************************************/
 
 StatusBar::StatusBar(QWidget* parent) noexcept
-  : QStatusBar(parent), mFields(0) {
+  : QStatusBar(parent), mFields(0), mLengthUnit(), mAbsoluteCursorPosition() {
   // absolute position x
   mAbsPosXLabel.reset(new QLabel());
   mAbsPosXLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
@@ -63,7 +63,7 @@ StatusBar::StatusBar(QWidget* parent) noexcept
 
   // init
   setFields(0);
-  setAbsoluteCursorPosition(Point());
+  updateAbsoluteCursorPosition();
   setProgressBarPercent(100);
 }
 
@@ -88,9 +88,14 @@ void StatusBar::setField(Field field, bool enable) noexcept {
   setFields(mFields);
 }
 
+void StatusBar::setLengthUnit(const LengthUnit& unit) noexcept {
+  mLengthUnit = unit;
+  updateAbsoluteCursorPosition();
+}
+
 void StatusBar::setAbsoluteCursorPosition(const Point& pos) noexcept {
-  mAbsPosXLabel->setText(QString("X:%1mm").arg(pos.getX().toMm(), 12, 'f', 6));
-  mAbsPosYLabel->setText(QString("Y:%1mm").arg(pos.getY().toMm(), 12, 'f', 6));
+  mAbsoluteCursorPosition = pos;
+  updateAbsoluteCursorPosition();
 }
 
 void StatusBar::setProgressBarTextFormat(const QString& format) noexcept {
@@ -106,6 +111,23 @@ void StatusBar::setProgressBarPercent(int percent) noexcept {
     mProgressBar->hide();
     mProgressBarPlaceHolder->show();
   }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void StatusBar::updateAbsoluteCursorPosition() noexcept {
+  mAbsPosXLabel->setText(
+      QString("X:%1%2")
+          .arg(mLengthUnit.convertToUnit(mAbsoluteCursorPosition.getX()), 12,
+               'f', 6)
+          .arg(mLengthUnit.toShortStringTr()));
+  mAbsPosYLabel->setText(
+      QString("Y:%1%2")
+          .arg(mLengthUnit.convertToUnit(mAbsoluteCursorPosition.getY()), 12,
+               'f', 6)
+          .arg(mLengthUnit.toShortStringTr()));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/widgets/statusbar.h
+++ b/libs/librepcb/common/widgets/statusbar.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../units/lengthunit.h"
 #include "../units/point.h"
 
 #include <QtCore>
@@ -62,6 +63,7 @@ public:
   // Setters
   void setFields(Fields fields) noexcept;
   void setField(Field field, bool enable) noexcept;
+  void setLengthUnit(const LengthUnit& unit) noexcept;
   void setAbsoluteCursorPosition(const Point& pos) noexcept;
   void setProgressBarTextFormat(const QString& format) noexcept;
   void setProgressBarPercent(int percent) noexcept;
@@ -69,8 +71,13 @@ public:
   // Operator Overloadings
   StatusBar& operator=(const StatusBar& rhs) = delete;
 
+private:  // Methods
+  void updateAbsoluteCursorPosition() noexcept;
+
 private:  // Data
   Fields                       mFields;
+  LengthUnit                   mLengthUnit;
+  Point                        mAbsoluteCursorPosition;
   QScopedPointer<QLabel>       mAbsPosXLabel;
   QScopedPointer<QLabel>       mAbsPosYLabel;
   QScopedPointer<QProgressBar> mProgressBar;

--- a/libs/librepcb/common/widgets/unsignedlengthedit.h
+++ b/libs/librepcb/common/widgets/unsignedlengthedit.h
@@ -23,12 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../units/length.h"
-#include "../units/lengthunit.h"
-#include "numbereditbase.h"
-
-#include <QtCore>
-#include <QtWidgets>
+#include "lengtheditbase.h"
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -43,7 +38,7 @@ namespace librepcb {
  * @brief The UnsignedLengthEdit class is a widget to view/edit
  *        ::librepcb::UnsignedLength values
  */
-class UnsignedLengthEdit final : public NumberEditBase {
+class UnsignedLengthEdit final : public LengthEditBase {
   Q_OBJECT
 
 public:
@@ -53,27 +48,20 @@ public:
   virtual ~UnsignedLengthEdit() noexcept;
 
   // Getters
-  const UnsignedLength& getValue() const noexcept { return mValue; }
+  UnsignedLength getValue() const noexcept;
 
   // Setters
   void setValue(const UnsignedLength& value) noexcept;
-  void setUnit(const LengthUnit& unit) noexcept;
 
   // Operator Overloadings
   UnsignedLengthEdit& operator=(const UnsignedLengthEdit& rhs) = delete;
 
 signals:
-  void valueChanged(const UnsignedLength& value);
+  // Note: Full namespace librepcb::UnsignedLength is required for the MOC!
+  void valueChanged(const librepcb::UnsignedLength& value);
 
-private:  // Methods
-  void updateSpinBox() noexcept override;
-  void spinBoxValueChanged(double value) noexcept override;
-
-private:  // Data
-  UnsignedLength mMinValue;
-  UnsignedLength mMaxValue;
-  UnsignedLength mValue;
-  LengthUnit     mUnit;
+private:
+  virtual void valueChangedImpl() noexcept override;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -148,6 +148,8 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, const FilePath& libFp,
   // setup status bar
   mUi->statusBar->setFields(StatusBar::ProgressBar);
   mUi->statusBar->setProgressBarTextFormat(tr("Scanning libraries (%p%)"));
+  mUi->statusBar->setLengthUnit(
+      mWorkspace.getSettings().defaultLengthUnit.get());
   connect(&mWorkspace.getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanProgressUpdate, mUi->statusBar,
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
@@ -41,12 +41,24 @@ namespace editor {
 
 FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
     const Package& pkg, const Footprint& fpt, FootprintPad& pad,
-    UndoStack& undoStack, QWidget* parent) noexcept
+    UndoStack& undoStack, const LengthUnit& lengthUnit,
+    const QString& settingsPrefix, QWidget* parent) noexcept
   : QDialog(parent),
     mPad(pad),
     mUndoStack(undoStack),
     mUi(new Ui::FootprintPadPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtWidth->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                           settingsPrefix % "/width");
+  mUi->edtHeight->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                            settingsPrefix % "/height");
+  mUi->edtDrillDiameter->configure(lengthUnit,
+                                   LengthEditBase::Steps::drillDiameter(),
+                                   settingsPrefix % "/drill_diameter");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
   mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &FootprintPadPropertiesDialog::on_buttonBox_clicked);

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
@@ -47,10 +47,7 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
     mUndoStack(undoStack),
     mUi(new Ui::FootprintPadPropertiesDialog) {
   mUi->setupUi(this);
-  mUi->edtWidth->setSingleStep(0.1);          // [mm]
-  mUi->edtHeight->setSingleStep(0.1);         // [mm]
-  mUi->edtDrillDiameter->setSingleStep(0.1);  // [mm]
-  mUi->edtRotation->setSingleStep(90.0);      // [°]
+  mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &FootprintPadPropertiesDialog::on_buttonBox_clicked);
 

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
@@ -32,6 +32,7 @@
 namespace librepcb {
 
 class UndoStack;
+class LengthUnit;
 
 namespace library {
 
@@ -62,7 +63,9 @@ public:
       delete;
   FootprintPadPropertiesDialog(const Package& pkg, const Footprint& fpt,
                                FootprintPad& pad, UndoStack& undoStack,
-                               QWidget* parent = nullptr) noexcept;
+                               const LengthUnit& lengthUnit,
+                               const QString&    settingsPrefix,
+                               QWidget*          parent = nullptr) noexcept;
   ~FootprintPadPropertiesDialog() noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.h
@@ -81,6 +81,7 @@ private:  // Types
 
 public:  // Types
   struct Context {
+    workspace::Workspace&                  workspace;
     PackageEditorWidget&                   editorWidget;
     UndoStack&                             undoStack;
     GraphicsScene&                         graphicsScene;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.cpp
@@ -24,6 +24,8 @@
 
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/gridproperties.h>
+#include <librepcb/workspace/settings/workspacesettings.h>
+#include <librepcb/workspace/workspace.h>
 
 #include <QtCore>
 
@@ -51,6 +53,10 @@ PackageEditorState::~PackageEditorState() noexcept {
 
 const PositiveLength& PackageEditorState::getGridInterval() const noexcept {
   return mContext.graphicsView.getGridProperties().getInterval();
+}
+
+const LengthUnit& PackageEditorState::getDefaultLengthUnit() const noexcept {
+  return mContext.workspace.getSettings().defaultLengthUnit.get();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.h
@@ -103,6 +103,7 @@ public:
 
 protected:  // Methods
   const PositiveLength& getGridInterval() const noexcept;
+  const LengthUnit&     getDefaultLengthUnit() const noexcept;
 
 protected:  // Data
   Context& mContext;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
@@ -74,6 +74,9 @@ bool PackageEditorState_AddHoles::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Diameter:"), 10);
 
   std::unique_ptr<PositiveLengthEdit> edtDiameter(new PositiveLengthEdit());
+  edtDiameter->configure(getDefaultLengthUnit(),
+                         LengthEditBase::Steps::drillDiameter(),
+                         "package_editor/add_holes/diameter");
   edtDiameter->setValue(mLastDiameter);
   connect(edtDiameter.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_AddHoles::diameterEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
@@ -74,7 +74,6 @@ bool PackageEditorState_AddHoles::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Diameter:"), 10);
 
   std::unique_ptr<PositiveLengthEdit> edtDiameter(new PositiveLengthEdit());
-  edtDiameter->setSingleStep(0.1);  // [mm]
   edtDiameter->setValue(mLastDiameter);
   connect(edtDiameter.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_AddHoles::diameterEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
@@ -126,7 +126,6 @@ bool PackageEditorState_AddPads::entry() noexcept {
   // width
   mContext.commandToolBar.addLabel(tr("Width:"), 10);
   std::unique_ptr<PositiveLengthEdit> edtWidth(new PositiveLengthEdit());
-  edtWidth->setSingleStep(0.1);  // [mm]
   edtWidth->setValue(mLastPad.getWidth());
   connect(edtWidth.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_AddPads::widthEditValueChanged);
@@ -135,7 +134,6 @@ bool PackageEditorState_AddPads::entry() noexcept {
   // height
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
   std::unique_ptr<PositiveLengthEdit> edtHeight(new PositiveLengthEdit());
-  edtHeight->setSingleStep(0.1);  // [mm]
   edtHeight->setValue(mLastPad.getHeight());
   connect(edtHeight.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_AddPads::heightEditValueChanged);
@@ -146,7 +144,6 @@ bool PackageEditorState_AddPads::entry() noexcept {
     mContext.commandToolBar.addLabel(tr("Drill Diameter:"), 10);
     std::unique_ptr<UnsignedLengthEdit> edtDrillDiameter(
         new UnsignedLengthEdit());
-    edtDrillDiameter->setSingleStep(0.1);  // [mm]
     edtDrillDiameter->setValue(mLastPad.getDrillDiameter());
     connect(edtDrillDiameter.get(), &UnsignedLengthEdit::valueChanged, this,
             &PackageEditorState_AddPads::drillDiameterEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
@@ -126,6 +126,8 @@ bool PackageEditorState_AddPads::entry() noexcept {
   // width
   mContext.commandToolBar.addLabel(tr("Width:"), 10);
   std::unique_ptr<PositiveLengthEdit> edtWidth(new PositiveLengthEdit());
+  edtWidth->configure(getDefaultLengthUnit(), LengthEditBase::Steps::generic(),
+                      "package_editor/add_pads/width");
   edtWidth->setValue(mLastPad.getWidth());
   connect(edtWidth.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_AddPads::widthEditValueChanged);
@@ -134,6 +136,8 @@ bool PackageEditorState_AddPads::entry() noexcept {
   // height
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
   std::unique_ptr<PositiveLengthEdit> edtHeight(new PositiveLengthEdit());
+  edtHeight->configure(getDefaultLengthUnit(), LengthEditBase::Steps::generic(),
+                       "package_editor/add_pads/height");
   edtHeight->setValue(mLastPad.getHeight());
   connect(edtHeight.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_AddPads::heightEditValueChanged);
@@ -144,6 +148,9 @@ bool PackageEditorState_AddPads::entry() noexcept {
     mContext.commandToolBar.addLabel(tr("Drill Diameter:"), 10);
     std::unique_ptr<UnsignedLengthEdit> edtDrillDiameter(
         new UnsignedLengthEdit());
+    edtDrillDiameter->configure(getDefaultLengthUnit(),
+                                LengthEditBase::Steps::drillDiameter(),
+                                "package_editor/add_pads/drill_diameter");
     edtDrillDiameter->setValue(mLastPad.getDrillDiameter());
     connect(edtDrillDiameter.get(), &UnsignedLengthEdit::valueChanged, this,
             &PackageEditorState_AddPads::drillDiameterEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -87,7 +87,6 @@ bool PackageEditorState_DrawCircle::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
-  edtLineWidth->setSingleStep(0.1);  // [mm]
   edtLineWidth->setValue(mLastLineWidth);
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &PackageEditorState_DrawCircle::lineWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -87,6 +87,9 @@ bool PackageEditorState_DrawCircle::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
+  edtLineWidth->configure(getDefaultLengthUnit(),
+                          LengthEditBase::Steps::generic(),
+                          "package_editor/draw_circle/line_width");
   edtLineWidth->setValue(mLastLineWidth);
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &PackageEditorState_DrawCircle::lineWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -92,7 +92,6 @@ bool PackageEditorState_DrawPolygonBase::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
   edtLineWidth->setValue(mLastLineWidth);
-  edtLineWidth->setSingleStep(0.1);  // [mm]
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &PackageEditorState_DrawPolygonBase::lineWidthEditValueChanged);
   mContext.commandToolBar.addWidget(std::move(edtLineWidth));

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -91,6 +91,9 @@ bool PackageEditorState_DrawPolygonBase::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
+  edtLineWidth->configure(getDefaultLengthUnit(),
+                          LengthEditBase::Steps::generic(),
+                          "package_editor/draw_polygon/line_width");
   edtLineWidth->setValue(mLastLineWidth);
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &PackageEditorState_DrawPolygonBase::lineWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -116,7 +116,6 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
   std::unique_ptr<PositiveLengthEdit> edtLineWidth(new PositiveLengthEdit());
-  edtLineWidth->setSingleStep(0.5);  // [mm]
   edtLineWidth->setValue(mLastHeight);
   connect(edtLineWidth.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_DrawTextBase::heightEditValueChanged);
@@ -126,7 +125,6 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Stroke Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> strokeWidthSpinBox(
       new UnsignedLengthEdit());
-  strokeWidthSpinBox->setSingleStep(0.1);  // [mm]
   strokeWidthSpinBox->setValue(mLastStrokeWidth);
   connect(strokeWidthSpinBox.get(), &UnsignedLengthEdit::valueChanged, this,
           &PackageEditorState_DrawTextBase::strokeWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -115,16 +115,22 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
   }
 
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
-  std::unique_ptr<PositiveLengthEdit> edtLineWidth(new PositiveLengthEdit());
-  edtLineWidth->setValue(mLastHeight);
-  connect(edtLineWidth.get(), &PositiveLengthEdit::valueChanged, this,
+  std::unique_ptr<PositiveLengthEdit> edtHeight(new PositiveLengthEdit());
+  edtHeight->configure(getDefaultLengthUnit(),
+                       LengthEditBase::Steps::textHeight(),
+                       "package_editor/draw_text/height");
+  edtHeight->setValue(mLastHeight);
+  connect(edtHeight.get(), &PositiveLengthEdit::valueChanged, this,
           &PackageEditorState_DrawTextBase::heightEditValueChanged);
-  mContext.commandToolBar.addWidget(std::move(edtLineWidth));
+  mContext.commandToolBar.addWidget(std::move(edtHeight));
 
   // Stroke width
   mContext.commandToolBar.addLabel(tr("Stroke Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> strokeWidthSpinBox(
       new UnsignedLengthEdit());
+  strokeWidthSpinBox->configure(getDefaultLengthUnit(),
+                                LengthEditBase::Steps::generic(),
+                                "package_editor/draw_text/stroke_width");
   strokeWidthSpinBox->setValue(mLastStrokeWidth);
   connect(strokeWidthSpinBox.get(), &UnsignedLengthEdit::valueChanged, this,
           &PackageEditorState_DrawTextBase::strokeWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -400,7 +400,9 @@ bool PackageEditorState_Select::openPropertiesDialogOfItemAtPos(
     Q_ASSERT(item);
     FootprintPadPropertiesDialog dialog(
         mContext.package, *mContext.currentFootprint, item->getPad(),
-        mContext.undoStack, &mContext.editorWidget);
+        mContext.undoStack, getDefaultLengthUnit(),
+        "package_editor/footprint_pad_properties_dialog",
+        &mContext.editorWidget);
     dialog.exec();
     return true;
   } else if (texts.count() > 0) {
@@ -410,6 +412,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItemAtPos(
     StrokeTextPropertiesDialog dialog(
         item->getText(), mContext.undoStack,
         mContext.layerProvider.getBoardGeometryElementLayers(),
+        getDefaultLengthUnit(), "package_editor/stroke_text_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
@@ -420,6 +423,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItemAtPos(
     PolygonPropertiesDialog dialog(
         item->getPolygon(), mContext.undoStack,
         mContext.layerProvider.getBoardGeometryElementLayers(),
+        getDefaultLengthUnit(), "package_editor/polygon_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
@@ -430,6 +434,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItemAtPos(
     CirclePropertiesDialog dialog(
         item->getCircle(), mContext.undoStack,
         mContext.layerProvider.getBoardGeometryElementLayers(),
+        getDefaultLengthUnit(), "package_editor/circle_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
@@ -437,8 +442,9 @@ bool PackageEditorState_Select::openPropertiesDialogOfItemAtPos(
     HoleGraphicsItem* item =
         dynamic_cast<HoleGraphicsItem*>(holes.first().data());
     Q_ASSERT(item);
-    HolePropertiesDialog dialog(item->getHole(), mContext.undoStack,
-                                &mContext.editorWidget);
+    HolePropertiesDialog dialog(
+        item->getHole(), mContext.undoStack, getDefaultLengthUnit(),
+        "package_editor/hole_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
   } else {

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
@@ -126,7 +126,8 @@ PackageEditorWidget::PackageEditorWidget(const Context&  context,
           &PackageEditorWidget::commitMetadata);
 
   // Load finite state machine (FSM).
-  PackageEditorFsm::Context fsmContext{*this,
+  PackageEditorFsm::Context fsmContext{mContext.workspace,
+                                       *this,
                                        *mUndoStack,
                                        *mGraphicsScene,
                                        *mUi->graphicsView,

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -46,7 +46,6 @@ SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(SymbolPin& pin,
     mUndoStack(undoStack),
     mUi(new Ui::SymbolPinPropertiesDialog) {
   mUi->setupUi(this);
-  mUi->edtLength->setSingleStep(2.54);    // [mm]
   mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &SymbolPinPropertiesDialog::on_buttonBox_clicked);

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -38,14 +38,20 @@ namespace librepcb {
 namespace library {
 namespace editor {
 
-SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(SymbolPin& pin,
-                                                     UndoStack& undoStack,
-                                                     QWidget*   parent) noexcept
+SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(
+    SymbolPin& pin, UndoStack& undoStack, const LengthUnit& lengthUnit,
+    const QString& settingsPrefix, QWidget* parent) noexcept
   : QDialog(parent),
     mSymbolPin(pin),
     mUndoStack(undoStack),
     mUi(new Ui::SymbolPinPropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtLength->configure(lengthUnit, LengthEditBase::Steps::pinLength(),
+                            settingsPrefix % "/length");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
   mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &SymbolPinPropertiesDialog::on_buttonBox_clicked);

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.h
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.h
@@ -32,6 +32,7 @@
 namespace librepcb {
 
 class UndoStack;
+class LengthUnit;
 
 namespace library {
 
@@ -58,7 +59,9 @@ public:
   SymbolPinPropertiesDialog()                                       = delete;
   SymbolPinPropertiesDialog(const SymbolPinPropertiesDialog& other) = delete;
   SymbolPinPropertiesDialog(SymbolPin& pin, UndoStack& undoStack,
-                            QWidget* parent = nullptr) noexcept;
+                            const LengthUnit& lengthUnit,
+                            const QString&    settingsPrefix,
+                            QWidget*          parent = nullptr) noexcept;
   ~SymbolPinPropertiesDialog() noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.h
@@ -77,6 +77,7 @@ private:  // Types
 
 public:  // Types
   struct Context {
+    workspace::Workspace&           workspace;
     SymbolEditorWidget&             editorWidget;
     UndoStack&                      undoStack;
     const IF_GraphicsLayerProvider& layerProvider;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.cpp
@@ -24,6 +24,8 @@
 
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/gridproperties.h>
+#include <librepcb/workspace/settings/workspacesettings.h>
+#include <librepcb/workspace/workspace.h>
 
 #include <QtCore>
 
@@ -51,6 +53,10 @@ SymbolEditorState::~SymbolEditorState() noexcept {
 
 const PositiveLength& SymbolEditorState::getGridInterval() const noexcept {
   return mContext.graphicsView.getGridProperties().getInterval();
+}
+
+const LengthUnit& SymbolEditorState::getDefaultLengthUnit() const noexcept {
+  return mContext.workspace.getSettings().defaultLengthUnit.get();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.h
@@ -102,6 +102,7 @@ public:
 
 protected:  // Methods
   const PositiveLength& getGridInterval() const noexcept;
+  const LengthUnit&     getDefaultLengthUnit() const noexcept;
 
 protected:  // Data
   Context mContext;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
@@ -82,7 +82,6 @@ bool SymbolEditorState_AddPins::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Length:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLength(new UnsignedLengthEdit());
-  edtLength->setSingleStep(2.54);  // [mm]
   edtLength->setValue(mLastLength);
   connect(edtLength.get(), &UnsignedLengthEdit::valueChanged, this,
           &SymbolEditorState_AddPins::lengthEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_addpins.cpp
@@ -82,6 +82,9 @@ bool SymbolEditorState_AddPins::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Length:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLength(new UnsignedLengthEdit());
+  edtLength->configure(getDefaultLengthUnit(),
+                       LengthEditBase::Steps::pinLength(),
+                       "symbol_editor/add_pins/length");
   edtLength->setValue(mLastLength);
   connect(edtLength.get(), &UnsignedLengthEdit::valueChanged, this,
           &SymbolEditorState_AddPins::lengthEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -87,7 +87,6 @@ bool SymbolEditorState_DrawCircle::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
-  edtLineWidth->setSingleStep(0.1);  // [mm]
   edtLineWidth->setValue(mLastLineWidth);
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &SymbolEditorState_DrawCircle::lineWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -87,6 +87,9 @@ bool SymbolEditorState_DrawCircle::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
+  edtLineWidth->configure(getDefaultLengthUnit(),
+                          LengthEditBase::Steps::generic(),
+                          "symbol_editor/draw_circle/line_width");
   edtLineWidth->setValue(mLastLineWidth);
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &SymbolEditorState_DrawCircle::lineWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -91,7 +91,6 @@ bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
-  edtLineWidth->setSingleStep(0.1);  // [mm]
   edtLineWidth->setValue(mLastLineWidth);
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &SymbolEditorState_DrawPolygonBase::lineWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -91,6 +91,9 @@ bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Line Width:"), 10);
   std::unique_ptr<UnsignedLengthEdit> edtLineWidth(new UnsignedLengthEdit());
+  edtLineWidth->configure(getDefaultLengthUnit(),
+                          LengthEditBase::Steps::generic(),
+                          "symbol_editor/draw_polygon/line_width");
   edtLineWidth->setValue(mLastLineWidth);
   connect(edtLineWidth.get(), &UnsignedLengthEdit::valueChanged, this,
           &SymbolEditorState_DrawPolygonBase::lineWidthEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -106,6 +106,9 @@ bool SymbolEditorState_DrawTextBase::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
   std::unique_ptr<PositiveLengthEdit> edtHeight(new PositiveLengthEdit());
+  edtHeight->configure(getDefaultLengthUnit(),
+                       LengthEditBase::Steps::textHeight(),
+                       "symbol_editor/draw_text/height");
   edtHeight->setValue(mLastHeight);
   connect(edtHeight.get(), &PositiveLengthEdit::valueChanged, this,
           &SymbolEditorState_DrawTextBase::heightEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -106,7 +106,6 @@ bool SymbolEditorState_DrawTextBase::entry() noexcept {
 
   mContext.commandToolBar.addLabel(tr("Height:"), 10);
   std::unique_ptr<PositiveLengthEdit> edtHeight(new PositiveLengthEdit());
-  edtHeight->setSingleStep(0.5);  // [mm]
   edtHeight->setValue(mLastHeight);
   connect(edtHeight.get(), &PositiveLengthEdit::valueChanged, this,
           &SymbolEditorState_DrawTextBase::heightEditValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
@@ -372,8 +372,9 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItemAtPos(
     SymbolPinGraphicsItem* item =
         dynamic_cast<SymbolPinGraphicsItem*>(pins.first().data());
     Q_ASSERT(item);
-    SymbolPinPropertiesDialog dialog(item->getPin(), mContext.undoStack,
-                                     &mContext.editorWidget);
+    SymbolPinPropertiesDialog dialog(
+        item->getPin(), mContext.undoStack, getDefaultLengthUnit(),
+        "symbol_editor/pin_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
   } else if (texts.count() > 0) {
@@ -383,6 +384,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItemAtPos(
     TextPropertiesDialog dialog(
         item->getText(), mContext.undoStack,
         mContext.layerProvider.getSchematicGeometryElementLayers(),
+        getDefaultLengthUnit(), "symbol_editor/text_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
@@ -393,6 +395,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItemAtPos(
     PolygonPropertiesDialog dialog(
         item->getPolygon(), mContext.undoStack,
         mContext.layerProvider.getSchematicGeometryElementLayers(),
+        getDefaultLengthUnit(), "symbol_editor/polygon_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
@@ -403,6 +406,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItemAtPos(
     CirclePropertiesDialog dialog(
         item->getCircle(), mContext.undoStack,
         mContext.layerProvider.getSchematicGeometryElementLayers(),
+        getDefaultLengthUnit(), "symbol_editor/circle_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
@@ -122,10 +122,15 @@ SymbolEditorWidget::SymbolEditorWidget(const Context&  context,
   mUi->graphicsView->zoomAll();
 
   // Load finite state machine (FSM).
-  SymbolEditorFsm::Context fsmContext{
-      *this,           *mUndoStack,          mContext.layerProvider,
-      *mGraphicsScene, *mUi->graphicsView,   *mSymbol,
-      *mGraphicsItem,  *mCommandToolBarProxy};
+  SymbolEditorFsm::Context fsmContext{mContext.workspace,
+                                      *this,
+                                      *mUndoStack,
+                                      mContext.layerProvider,
+                                      *mGraphicsScene,
+                                      *mUi->graphicsView,
+                                      *mSymbol,
+                                      *mGraphicsItem,
+                                      *mCommandToolBarProxy};
   mFsm.reset(new SymbolEditorFsm(fsmContext));
 
   // Last but not least, connect the graphics scene events with the FSM.

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
@@ -45,14 +45,6 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
     QWidget* parent) noexcept
   : QDialog(parent), mBoard(board), mUi(new Ui::BoardDesignRuleCheckDialog) {
   mUi->setupUi(this);
-  mUi->edtClearanceCopperCopper->setSingleStep(0.1);  // [mm]
-  mUi->edtClearanceCopperBoard->setSingleStep(0.1);   // [mm]
-  mUi->edtClearanceCopperNpth->setSingleStep(0.1);    // [mm]
-  mUi->edtMinCopperWidth->setSingleStep(0.1);         // [mm]
-  mUi->edtMinPthRestring->setSingleStep(0.1);         // [mm]
-  mUi->edtMinPthDrillDiameter->setSingleStep(0.1);    // [mm]
-  mUi->edtMinNpthDrillDiameter->setSingleStep(0.1);   // [mm]
-  mUi->edtCourtyardOffset->setSingleStep(0.1);        // [mm]
   connect(mUi->btnRun, &QPushButton::clicked, this,
           &BoardDesignRuleCheckDialog::btnRunDrcClicked);
 

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
@@ -42,9 +42,34 @@ namespace editor {
 
 BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
     Board& board, const BoardDesignRuleCheck::Options& options,
+    const LengthUnit& lengthUnit, const QString& settingsPrefix,
     QWidget* parent) noexcept
   : QDialog(parent), mBoard(board), mUi(new Ui::BoardDesignRuleCheckDialog) {
   mUi->setupUi(this);
+  mUi->edtClearanceCopperCopper->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/clearance_copper_copper");
+  mUi->edtClearanceCopperBoard->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/clearance_copper_board");
+  mUi->edtClearanceCopperNpth->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/clearance_copper_npth");
+  mUi->edtMinCopperWidth->configure(lengthUnit,
+                                    LengthEditBase::Steps::generic(),
+                                    settingsPrefix % "/min_copper_width");
+  mUi->edtMinPthRestring->configure(lengthUnit,
+                                    LengthEditBase::Steps::generic(),
+                                    settingsPrefix % "/min_pth_restring");
+  mUi->edtMinPthDrillDiameter->configure(
+      lengthUnit, LengthEditBase::Steps::drillDiameter(),
+      settingsPrefix % "/min_pth_drill_diameter");
+  mUi->edtMinNpthDrillDiameter->configure(
+      lengthUnit, LengthEditBase::Steps::drillDiameter(),
+      settingsPrefix % "/min_npth_drill_diameter");
+  mUi->edtCourtyardOffset->configure(lengthUnit,
+                                     LengthEditBase::Steps::generic(),
+                                     settingsPrefix % "/courtyard_offset");
   connect(mUi->btnRun, &QPushButton::clicked, this,
           &BoardDesignRuleCheckDialog::btnRunDrcClicked);
 

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.h
@@ -57,9 +57,11 @@ public:
   // Constructors / Destructor
   BoardDesignRuleCheckDialog()                                        = delete;
   BoardDesignRuleCheckDialog(const BoardDesignRuleCheckDialog& other) = delete;
-  explicit BoardDesignRuleCheckDialog(
-      Board& board, const BoardDesignRuleCheck::Options& options,
-      QWidget* parent = 0) noexcept;
+  BoardDesignRuleCheckDialog(Board&                               board,
+                             const BoardDesignRuleCheck::Options& options,
+                             const LengthUnit&                    lengthUnit,
+                             const QString& settingsPrefix,
+                             QWidget*       parent = 0) noexcept;
   ~BoardDesignRuleCheckDialog();
 
   // Getters

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -649,7 +649,9 @@ void BoardEditor::on_actionModifyDesignRules_triggered() {
 
   try {
     BoardDesignRules       originalRules = board->getDesignRules();
-    BoardDesignRulesDialog dialog(board->getDesignRules(), this);
+    BoardDesignRulesDialog dialog(board->getDesignRules(),
+                                  mProjectEditor.getDefaultLengthUnit(),
+                                  "board_editor/design_rules_dialog", this);
     connect(&dialog, &BoardDesignRulesDialog::rulesChanged,
             [&](const BoardDesignRules& rules) {
               board->getDesignRules() = rules;
@@ -671,7 +673,9 @@ void BoardEditor::on_actionDesignRuleCheck_triggered() {
   Board* board = getActiveBoard();
   if (!board) return;
 
-  BoardDesignRuleCheckDialog dialog(*board, mDrcOptions, this);
+  BoardDesignRuleCheckDialog dialog(*board, mDrcOptions,
+                                    mProjectEditor.getDefaultLengthUnit(),
+                                    "board_editor/drc_dialog", this);
   dialog.exec();
   mDrcOptions = dialog.getOptions();
   if (dialog.getMessages()) {

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -257,6 +257,8 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   mUi->statusbar->setFields(StatusBar::AbsolutePosition |
                             StatusBar::ProgressBar);
   mUi->statusbar->setProgressBarTextFormat(tr("Scanning libraries (%p%)"));
+  mUi->statusbar->setLengthUnit(
+      mProjectEditor.getWorkspace().getSettings().defaultLengthUnit.get());
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanProgressUpdate, mUi->statusbar,
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
@@ -46,16 +46,21 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(Project&   project,
-                                                       BI_Plane&  plane,
-                                                       UndoStack& undoStack,
-                                                       QWidget* parent) noexcept
+BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(
+    Project& project, BI_Plane& plane, UndoStack& undoStack,
+    const LengthUnit& lengthUnit, const QString& settingsPrefix,
+    QWidget* parent) noexcept
   : QDialog(parent),
     mProject(project),
     mPlane(plane),
     mUi(new Ui::BoardPlanePropertiesDialog),
     mUndoStack(undoStack) {
   mUi->setupUi(this);
+  mUi->edtMinWidth->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                              settingsPrefix % "/min_width");
+  mUi->edtMinClearance->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                                  settingsPrefix % "/min_clearance");
+  mUi->pathEditorWidget->setLengthUnit(lengthUnit);
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &BoardPlanePropertiesDialog::buttonBoxClicked);
 

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.cpp
@@ -56,8 +56,6 @@ BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(Project&   project,
     mUi(new Ui::BoardPlanePropertiesDialog),
     mUndoStack(undoStack) {
   mUi->setupUi(this);
-  mUi->edtMinWidth->setSingleStep(0.1);      // [mm]
-  mUi->edtMinClearance->setSingleStep(0.1);  // [mm]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &BoardPlanePropertiesDialog::buttonBoxClicked);
 

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.h
@@ -62,7 +62,9 @@ public:
   BoardPlanePropertiesDialog()                                        = delete;
   BoardPlanePropertiesDialog(const BoardPlanePropertiesDialog& other) = delete;
   BoardPlanePropertiesDialog(Project& project, BI_Plane& plane,
-                             UndoStack& undoStack, QWidget* parent) noexcept;
+                             UndoStack& undoStack, const LengthUnit& lengthUnit,
+                             const QString& settingsPrefix,
+                             QWidget*       parent) noexcept;
   ~BoardPlanePropertiesDialog() noexcept;
 
 private:  // GUI Events

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
@@ -53,8 +53,6 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(Project&   project,
     mUi(new Ui::BoardViaPropertiesDialog),
     mUndoStack(undoStack) {
   mUi->setupUi(this);
-  mUi->edtSize->setSingleStep(0.1);           // [mm]
-  mUi->edtDrillDiameter->setSingleStep(0.1);  // [mm]
 
   // shape combobox
   mUi->cbxShape->addItem(tr("Round"), static_cast<int>(BI_Via::Shape::Round));

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
@@ -43,16 +43,25 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BoardViaPropertiesDialog::BoardViaPropertiesDialog(Project&   project,
-                                                   BI_Via&    via,
-                                                   UndoStack& undoStack,
-                                                   QWidget*   parent) noexcept
+BoardViaPropertiesDialog::BoardViaPropertiesDialog(
+    Project& project, BI_Via& via, UndoStack& undoStack,
+    const LengthUnit& lengthUnit, const QString& settingsPrefix,
+    QWidget* parent) noexcept
   : QDialog(parent),
     mProject(project),
     mVia(via),
     mUi(new Ui::BoardViaPropertiesDialog),
     mUndoStack(undoStack) {
   mUi->setupUi(this);
+  mUi->edtSize->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/size");
+  mUi->edtDrillDiameter->configure(lengthUnit,
+                                   LengthEditBase::Steps::drillDiameter(),
+                                   settingsPrefix % "/drill_diameter");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
 
   // shape combobox
   mUi->cbxShape->addItem(tr("Round"), static_cast<int>(BI_Via::Shape::Round));
@@ -79,10 +88,6 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(Project&   project,
 BoardViaPropertiesDialog::~BoardViaPropertiesDialog() noexcept {
   mUi.reset();
 }
-
-/*******************************************************************************
- *  Private Slots
- ******************************************************************************/
 
 /*******************************************************************************
  *  Private Methods

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.h
@@ -33,6 +33,7 @@ namespace librepcb {
 
 class UndoStack;
 class UndoCommand;
+class LengthUnit;
 
 namespace project {
 
@@ -60,8 +61,10 @@ public:
   BoardViaPropertiesDialog()                                      = delete;
   BoardViaPropertiesDialog(const BoardViaPropertiesDialog& other) = delete;
   explicit BoardViaPropertiesDialog(Project& project, BI_Via& via,
-                                    UndoStack& undoStack,
-                                    QWidget*   parent) noexcept;
+                                    UndoStack&        undoStack,
+                                    const LengthUnit& lengthUnit,
+                                    const QString&    settingsPrefix,
+                                    QWidget*          parent) noexcept;
   ~BoardViaPropertiesDialog() noexcept;
 
 private:

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -50,6 +50,7 @@ namespace editor {
 
 DeviceInstancePropertiesDialog::DeviceInstancePropertiesDialog(
     Project& project, BI_Device& device, UndoStack& undoStack,
+    const LengthUnit& lengthUnit, const QString& settingsPrefix,
     QWidget* parent) noexcept
   : QDialog(parent),
     mProject(project),
@@ -58,6 +59,10 @@ DeviceInstancePropertiesDialog::DeviceInstancePropertiesDialog(
     mAttributes(mDevice.getComponentInstance().getAttributes()),
     mUi(new Ui::DeviceInstancePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
   mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &DeviceInstancePropertiesDialog::buttonBoxClicked);

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.h
@@ -63,8 +63,10 @@ public:
   DeviceInstancePropertiesDialog(const DeviceInstancePropertiesDialog& other) =
       delete;
   DeviceInstancePropertiesDialog(Project& project, BI_Device& device,
-                                 UndoStack& undoStack,
-                                 QWidget*   parent) noexcept;
+                                 UndoStack&        undoStack,
+                                 const LengthUnit& lengthUnit,
+                                 const QString&    settingsPrefix,
+                                 QWidget*          parent) noexcept;
   ~DeviceInstancePropertiesDialog() noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addhole.cpp
@@ -93,7 +93,6 @@ bool BES_AddHole::entry(BEE_Base* event) noexcept {
 
   // add the diameter spinbox to the toolbar
   mDiameterEdit.reset(new PositiveLengthEdit());
-  mDiameterEdit->setSingleStep(0.1);  // [mm]
   mDiameterEdit->setValue(mCurrentDiameter);
   connect(mDiameterEdit.data(), &PositiveLengthEdit::valueChanged, this,
           &BES_AddHole::diameterEditValueChanged);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addstroketext.cpp
@@ -143,7 +143,6 @@ bool BES_AddStrokeText::entry(BEE_Base* event) noexcept {
 
   // add the height spinbox to the toolbar
   mHeightEdit.reset(new PositiveLengthEdit());
-  mHeightEdit->setSingleStep(0.5);  // [mm]
   mHeightEdit->setValue(mCurrentHeight);
   connect(mHeightEdit.data(), &PositiveLengthEdit::valueChanged, this,
           &BES_AddStrokeText::heightEditValueChanged);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.cpp
@@ -134,7 +134,6 @@ bool BES_AddVia::entry(BEE_Base* event) noexcept {
   // add the size combobox to the toolbar
   mSizeEdit = new PositiveLengthEdit();
   mSizeEdit->setValue(mCurrentViaSize);
-  mSizeEdit->setSingleStep(0.1);  // [mm]
   mEditorUi.commandToolbar->addWidget(mSizeEdit);
   connect(mSizeEdit, &PositiveLengthEdit::valueChanged, this,
           &BES_AddVia::sizeEditValueChanged);
@@ -147,7 +146,6 @@ bool BES_AddVia::entry(BEE_Base* event) noexcept {
   // add the drill combobox to the toolbar
   mDrillEdit = new PositiveLengthEdit();
   mDrillEdit->setValue(mCurrentViaDrillDiameter);
-  mDrillEdit->setSingleStep(0.1);  // [mm]
   mEditorUi.commandToolbar->addWidget(mDrillEdit);
   connect(mDrillEdit, &PositiveLengthEdit::valueChanged, this,
           &BES_AddVia::drillDiameterEditValueChanged);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.cpp
@@ -26,6 +26,8 @@
 
 #include <librepcb/project/project.h>
 #include <librepcb/projecteditor/projecteditor.h>
+#include <librepcb/workspace/settings/workspacesettings.h>
+#include <librepcb/workspace/workspace.h>
 
 #include <QtCore>
 
@@ -53,6 +55,14 @@ BES_Base::BES_Base(BoardEditor& editor, Ui::BoardEditor& editorUi,
 }
 
 BES_Base::~BES_Base() {
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+const LengthUnit& BES_Base::getDefaultLengthUnit() const noexcept {
+  return mWorkspace.getSettings().defaultLengthUnit.get();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_base.h
@@ -84,6 +84,9 @@ public:
     return true;
   }
 
+protected:  // Methods
+  const LengthUnit& getDefaultLengthUnit() const noexcept;
+
 protected:
   // General Attributes which are needed by some state objects
   workspace::Workspace& mWorkspace;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawpolygon.cpp
@@ -118,7 +118,6 @@ bool BES_DrawPolygon::entry(BEE_Base* event) noexcept {
   // add the widths combobox to the toolbar
   mWidthEdit = new UnsignedLengthEdit();
   mWidthEdit->setValue(mCurrentWidth);
-  mWidthEdit->setSingleStep(0.1);  // [mm]
   mEditorUi.commandToolbar->addWidget(mWidthEdit);
   connect(mWidthEdit, &UnsignedLengthEdit::valueChanged, this,
           &BES_DrawPolygon::widthEditValueChanged);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.cpp
@@ -162,7 +162,6 @@ bool BES_DrawTrace::entry(BEE_Base* event) noexcept {
   // add the widths combobox to the toolbar
   mWidthEdit = new PositiveLengthEdit();
   mWidthEdit->setValue(mCurrentWidth);
-  mWidthEdit->setSingleStep(0.1);  // [mm]
   mEditorUi.commandToolbar->addWidget(mWidthEdit);
   connect(mWidthEdit, &PositiveLengthEdit::valueChanged, this,
           &BES_DrawTrace::wireWidthEditValueChanged);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
@@ -845,17 +845,23 @@ void BES_Select::measureLengthInDirection(bool              directionBackwards,
 }
 
 void BES_Select::openDevicePropertiesDialog(BI_Device& device) noexcept {
-  DeviceInstancePropertiesDialog dialog(mProject, device, mUndoStack, &mEditor);
+  DeviceInstancePropertiesDialog dialog(
+      mProject, device, mUndoStack, getDefaultLengthUnit(),
+      "board_editor/device_properties_dialog", &mEditor);
   dialog.exec();
 }
 
 void BES_Select::openViaPropertiesDialog(BI_Via& via) noexcept {
-  BoardViaPropertiesDialog dialog(mProject, via, mUndoStack, &mEditor);
+  BoardViaPropertiesDialog dialog(
+      mProject, via, mUndoStack, getDefaultLengthUnit(),
+      "board_editor/via_properties_dialog", &mEditor);
   dialog.exec();
 }
 
 void BES_Select::openPlanePropertiesDialog(BI_Plane& plane) noexcept {
-  BoardPlanePropertiesDialog dialog(mProject, plane, mUndoStack, &mEditor);
+  BoardPlanePropertiesDialog dialog(
+      mProject, plane, mUndoStack, getDefaultLengthUnit(),
+      "board_editor/plane_properties_dialog", &mEditor);
 
   // Make sure the plane is visible visible since it's useful to see the actual
   // plane fragments while the plane properties are modified.
@@ -871,20 +877,25 @@ void BES_Select::openPlanePropertiesDialog(BI_Plane& plane) noexcept {
 void BES_Select::openPolygonPropertiesDialog(Board&   board,
                                              Polygon& polygon) noexcept {
   PolygonPropertiesDialog dialog(
-      polygon, mUndoStack, board.getLayerStack().getAllowedPolygonLayers());
+      polygon, mUndoStack, board.getLayerStack().getAllowedPolygonLayers(),
+      getDefaultLengthUnit(), "board_editor/polygon_properties_dialog",
+      &mEditor);
   dialog.exec();
 }
 
 void BES_Select::openStrokeTextPropertiesDialog(Board&      board,
                                                 StrokeText& text) noexcept {
   StrokeTextPropertiesDialog dialog(
-      text, mUndoStack, board.getLayerStack().getAllowedPolygonLayers());
+      text, mUndoStack, board.getLayerStack().getAllowedPolygonLayers(),
+      getDefaultLengthUnit(), "board_editor/stroke_text_properties_dialog",
+      &mEditor);
   dialog.exec();
 }
 
 void BES_Select::openHolePropertiesDialog(Board& board, Hole& hole) noexcept {
   Q_UNUSED(board);
-  HolePropertiesDialog dialog(hole, mUndoStack);
+  HolePropertiesDialog dialog(hole, mUndoStack, getDefaultLengthUnit(),
+                              "board_editor/hole_properties_dialog", &mEditor);
   dialog.exec();
 }
 

--- a/libs/librepcb/projecteditor/projecteditor.cpp
+++ b/libs/librepcb/projecteditor/projecteditor.cpp
@@ -110,6 +110,14 @@ ProjectEditor::~ProjectEditor() noexcept {
 }
 
 /*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+const LengthUnit& ProjectEditor::getDefaultLengthUnit() const noexcept {
+  return mWorkspace.getSettings().defaultLengthUnit.get();
+}
+
+/*******************************************************************************
  *  General Methods
  ******************************************************************************/
 

--- a/libs/librepcb/projecteditor/projecteditor.h
+++ b/libs/librepcb/projecteditor/projecteditor.h
@@ -38,6 +38,7 @@ class QMainWindow;
 namespace librepcb {
 
 class UndoStack;
+class LengthUnit;
 
 namespace workspace {
 class Workspace;
@@ -81,6 +82,7 @@ public:
 
   workspace::Workspace& getWorkspace() const noexcept { return mWorkspace; }
   Project&              getProject() const noexcept { return mProject; }
+  const LengthUnit&     getDefaultLengthUnit() const noexcept;
 
   /**
    * @brief Get a reference to the undo stack of the project

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.cpp
@@ -26,6 +26,8 @@
 
 #include <librepcb/project/project.h>
 #include <librepcb/projecteditor/projecteditor.h>
+#include <librepcb/workspace/settings/workspacesettings.h>
+#include <librepcb/workspace/workspace.h>
 
 #include <QtCore>
 
@@ -53,6 +55,14 @@ SES_Base::SES_Base(SchematicEditor& editor, Ui::SchematicEditor& editorUi,
 }
 
 SES_Base::~SES_Base() {
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+const LengthUnit& SES_Base::getDefaultLengthUnit() const noexcept {
+  return mWorkspace.getSettings().defaultLengthUnit.get();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_base.h
@@ -84,6 +84,9 @@ public:
     return true;
   }
 
+protected:  // Methods
+  const LengthUnit& getDefaultLengthUnit() const noexcept;
+
 protected:
   // General Attributes which are needed by some state objects
   workspace::Workspace& mWorkspace;

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_select.cpp
@@ -459,9 +459,10 @@ bool SES_Select::removeSelectedItems() noexcept {
 }
 
 void SES_Select::openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept {
-  SymbolInstancePropertiesDialog dialog(mWorkspace, mProject,
-                                        symbol.getComponentInstance(), symbol,
-                                        mUndoStack, &mEditor);
+  SymbolInstancePropertiesDialog dialog(
+      mWorkspace, mProject, symbol.getComponentInstance(), symbol, mUndoStack,
+      getDefaultLengthUnit(), "schematic_editor/symbol_properties_dialog",
+      &mEditor);
   dialog.exec();
 }
 

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -219,6 +219,8 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   mUi->statusbar->setFields(StatusBar::AbsolutePosition |
                             StatusBar::ProgressBar);
   mUi->statusbar->setProgressBarTextFormat(tr("Scanning libraries (%p%)"));
+  mUi->statusbar->setLengthUnit(
+      mProjectEditor.getWorkspace().getSettings().defaultLengthUnit.get());
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanProgressUpdate, mUi->statusbar,
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -58,7 +58,8 @@ namespace editor {
 
 SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
     workspace::Workspace& ws, Project& project, ComponentInstance& cmp,
-    SI_Symbol& symbol, UndoStack& undoStack, QWidget* parent) noexcept
+    SI_Symbol& symbol, UndoStack& undoStack, const LengthUnit& lengthUnit,
+    const QString& settingsPrefix, QWidget* parent) noexcept
   : QDialog(parent),
     mWorkspace(ws),
     mProject(project),
@@ -68,6 +69,10 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
     mAttributes(mComponentInstance.getAttributes()),
     mUi(new Ui::SymbolInstancePropertiesDialog) {
   mUi->setupUi(this);
+  mUi->edtSymbInstPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                                  settingsPrefix % "/pos_x");
+  mUi->edtSymbInstPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                                  settingsPrefix % "/pos_y");
   mUi->edtSymbInstRotation->setSingleStep(90.0);  // [°]
   setWindowTitle(QString(tr("Properties of %1")).arg(mSymbol.getName()));
 

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.h
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.h
@@ -69,8 +69,10 @@ public:
       delete;
   SymbolInstancePropertiesDialog(workspace::Workspace& ws, Project& project,
                                  ComponentInstance& cmp, SI_Symbol& symbol,
-                                 UndoStack& undoStack,
-                                 QWidget*   parent) noexcept;
+                                 UndoStack&        undoStack,
+                                 const LengthUnit& lengthUnit,
+                                 const QString&    settingsPrefix,
+                                 QWidget*          parent) noexcept;
   ~SymbolInstancePropertiesDialog() noexcept;
 
   // Operator Overloadings

--- a/libs/libs.pro
+++ b/libs/libs.pro
@@ -7,18 +7,19 @@ SUBDIRS = \
     hoedown \
     googletest \
     librepcb \
+    muparser \
     optional \
     parseagle \
     quazip \
-    sexpresso
+    sexpresso \
 
 librepcb.depends = \
     clipper \
     delaunay-triangulation \
     fontobene \
+    muparser \
     optional \
     parseagle \
     hoedown \
     quazip \
     sexpresso \
-

--- a/tests/unittests/common/utils/mathparsertest.cpp
+++ b/tests/unittests/common/utils/mathparsertest.cpp
@@ -1,0 +1,101 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/common/utils/mathparser.h>
+#include <optional/tl/optional.hpp>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  QString             locale;
+  QString             input;
+  tl::optional<qreal> output;
+} MathParserTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class MathParserTest : public ::testing::TestWithParam<MathParserTestData> {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+TEST_P(MathParserTest, test) {
+  const MathParserTestData& data = GetParam();
+
+  MathParser parser;
+  parser.setLocale(QLocale(data.locale));
+  MathParser::Result result = parser.parse(data.input);
+  if (data.output) {
+    EXPECT_TRUE(result.valid);
+    EXPECT_EQ("", result.error);
+    EXPECT_EQ(*data.output, result.value);
+  } else {
+    EXPECT_FALSE(result.valid);
+    EXPECT_NE("", result.error);
+    EXPECT_EQ(0, result.value);
+  }
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(MathParserTest, MathParserTest, ::testing::Values(
+    // valid cases
+    MathParserTestData({"en_US", "0", 0}),
+    MathParserTestData({"en_US", "0.1234", 0.1234}),
+    MathParserTestData({"en_US", "+0.1234", 0.1234}),
+    MathParserTestData({"en_US", "-0.1234", -0.1234}),
+    MathParserTestData({"en_US", "2+3", 5}),
+    MathParserTestData({"en_US", "(1+2)/2", 1.5}),
+    MathParserTestData({"en_US", " 2 * (1.1 + 2.2) / 3.3 ", 2*(1.1+2.2)/3.3}),
+    MathParserTestData({"en_US", "5,000", 5000}), // thousand separator
+    MathParserTestData({"de_DE", "5,000", 5}), // decimal point
+
+    // invalid cases
+    MathParserTestData({"en_US", "", tl::nullopt}),
+    MathParserTestData({"en_US", " ", tl::nullopt}),
+    MathParserTestData({"en_US", ".", tl::nullopt}),
+    MathParserTestData({"en_US", "/", tl::nullopt}),
+    MathParserTestData({"en_US", "(1+2", tl::nullopt})
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/widgets/lengthedittest.cpp
+++ b/tests/unittests/common/widgets/lengthedittest.cpp
@@ -1,0 +1,150 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/widgets/lengthedit.h>
+
+#include <QtTest/QtTest>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+class LengthEditTest : public ::testing::Test, public QObject {
+protected:
+  void startListening() {
+    connect(&edit, &LengthEdit::valueChanged, this,
+            &LengthEditTest::valueChanged);
+  }
+
+  void valueChanged(const Length& value) noexcept {
+    emittedValues.append(value);
+  }
+
+  LengthEdit      edit;
+  QVector<Length> emittedValues;
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(LengthEditTest, testStep) {
+  edit.setSteps({
+      PositiveLength(100000),   // 0.1mm
+      PositiveLength(254000),   // 0.254mm
+      PositiveLength(1000000),  // 1mm
+      PositiveLength(2540000),  // 2.54mm
+  });
+  edit.setValue(Length(3000000));  // 3mm
+  startListening();
+
+  // Step down from 3mm to -3mm
+  QVector<Length> expectedValues = {
+      Length(2000000), Length(1000000),  Length(900000),   Length(800000),
+      Length(700000),  Length(600000),   Length(500000),   Length(400000),
+      Length(300000),  Length(200000),   Length(100000),   Length(0),
+      Length(-100000), Length(-200000),  Length(-300000),  Length(-400000),
+      Length(-500000), Length(-600000),  Length(-700000),  Length(-800000),
+      Length(-900000), Length(-1000000), Length(-2000000), Length(-3000000),
+  };
+  for (int i = 0; i < expectedValues.count(); ++i) {
+    edit.stepDown();
+    EXPECT_EQ(expectedValues[i].toNm(), edit.getValue().toNm());
+    ASSERT_EQ(1, emittedValues.count());
+    EXPECT_EQ(expectedValues[i].toNm(), emittedValues.takeLast().toNm());
+  }
+
+  // Step up from -3mm to 3mm
+  expectedValues = {
+      Length(-2000000), Length(-1000000), Length(-900000), Length(-800000),
+      Length(-700000),  Length(-600000),  Length(-500000), Length(-400000),
+      Length(-300000),  Length(-200000),  Length(-100000), Length(0),
+      Length(100000),   Length(200000),   Length(300000),  Length(400000),
+      Length(500000),   Length(600000),   Length(700000),  Length(800000),
+      Length(900000),   Length(1000000),  Length(2000000), Length(3000000),
+  };
+  for (int i = 0; i < expectedValues.count(); ++i) {
+    edit.stepUp();
+    EXPECT_EQ(expectedValues[i].toNm(), edit.getValue().toNm());
+    ASSERT_EQ(1, emittedValues.count());
+    EXPECT_EQ(expectedValues[i].toNm(), emittedValues.takeLast().toNm());
+  }
+}
+
+TEST_F(LengthEditTest, testValueChangedWhileTyping) {
+  edit.selectAll();
+  startListening();
+  QTest::keyClicks(&edit, "12+3um");
+  QTest::keyClick(&edit, Qt::Key_Enter);
+
+  QVector<Length> expectedValues = {
+      Length(1000000),   // "1" -> 1mm
+      Length(12000000),  // "12" -> 12mm
+      Length(15000000),  // "12+3" -> 15mm
+      Length(15000),     // "12+3um" -> 15 um
+  };
+
+  ASSERT_EQ(expectedValues.count(), emittedValues.count());
+  for (int i = 0; i < expectedValues.count(); ++i) {
+    EXPECT_EQ(expectedValues[i].toNm(), emittedValues[i].toNm());
+  }
+  EXPECT_EQ(expectedValues.last().toNm(), edit.getValue().toNm());
+}
+
+TEST_F(LengthEditTest, testUnitUpdatedWhileTyping) {
+  edit.selectAll();
+  QTest::keyClicks(&edit, "12+3um");
+  EXPECT_EQ(LengthUnit::micrometers(), edit.getDisplayedUnit());
+}
+
+TEST_F(LengthEditTest, testTextReplacedAfterPressingEnter) {
+  edit.selectAll();
+
+  QTest::keyClicks(&edit, " (-1/2) in ");
+  EXPECT_EQ(-12700000, edit.getValue().toNm());
+  EXPECT_EQ(" (-1/2) in ", edit.text().toStdString());
+
+  QTest::keyClick(&edit, Qt::Key_Enter);
+  EXPECT_EQ(-12700000, edit.getValue().toNm());
+  EXPECT_EQ("-0.5 ″", edit.text().toStdString());
+}
+
+TEST_F(LengthEditTest, testDivisionByZero) {
+  edit.selectAll();
+  QTest::keyClicks(&edit, "5/0");
+  EXPECT_EQ(5000000, edit.getValue().toNm());
+  // Note: It results in 5mm because the term "5" was the last valid value
+  // entered in the text field.
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/widgets/positivelengthedittest.cpp
+++ b/tests/unittests/common/widgets/positivelengthedittest.cpp
@@ -1,0 +1,165 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/widgets/positivelengthedit.h>
+
+#include <QtTest/QtTest>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+class PositiveLengthEditTest : public ::testing::Test, public QObject {
+protected:
+  void startListening() {
+    connect(&edit, &PositiveLengthEdit::valueChanged, this,
+            &PositiveLengthEditTest::valueChanged);
+  }
+
+  void valueChanged(const PositiveLength& value) noexcept {
+    emittedValues.push_back(value);
+  }
+
+  PositiveLengthEdit          edit;
+  std::vector<PositiveLength> emittedValues;
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(PositiveLengthEditTest, testStep) {
+  edit.setSteps({
+      PositiveLength(100000),   // 0.1mm
+      PositiveLength(254000),   // 0.254mm
+      PositiveLength(1000000),  // 1mm
+      PositiveLength(2540000),  // 2.54mm
+  });
+  edit.setValue(PositiveLength(3000000));  // 3mm
+  startListening();
+
+  // Step down from 3mm to 0.1mm
+  std::vector<PositiveLength> expectedValues = {
+      PositiveLength(2000000), PositiveLength(1000000), PositiveLength(900000),
+      PositiveLength(800000),  PositiveLength(700000),  PositiveLength(600000),
+      PositiveLength(500000),  PositiveLength(400000),  PositiveLength(300000),
+      PositiveLength(200000),  PositiveLength(100000),
+  };
+  for (size_t i = 0; i < expectedValues.size(); ++i) {
+    edit.stepDown();
+    EXPECT_EQ(expectedValues[i]->toNm(), edit.getValue()->toNm());
+    ASSERT_EQ(i + 1, emittedValues.size());
+    EXPECT_EQ(expectedValues[i]->toNm(), emittedValues[i]->toNm());
+  }
+  emittedValues.clear();
+
+  // Step down one more time -> this must *NOT* lead to a value of 1nm
+  // (the minimum) since this odd value would break the step-up value!
+  edit.stepDown();
+  EXPECT_EQ(100000, edit.getValue()->toNm());
+
+  // Step up from 0.1mm to 3mm
+  expectedValues = {
+      PositiveLength(200000),  PositiveLength(300000),  PositiveLength(400000),
+      PositiveLength(500000),  PositiveLength(600000),  PositiveLength(700000),
+      PositiveLength(800000),  PositiveLength(900000),  PositiveLength(1000000),
+      PositiveLength(2000000), PositiveLength(3000000),
+  };
+  for (size_t i = 0; i < expectedValues.size(); ++i) {
+    edit.stepUp();
+    EXPECT_EQ(expectedValues[i]->toNm(), edit.getValue()->toNm());
+    ASSERT_EQ(i + 1, emittedValues.size());
+    EXPECT_EQ(expectedValues[i]->toNm(), emittedValues[i]->toNm());
+  }
+}
+
+TEST_F(PositiveLengthEditTest, testValueChangedWhileTyping) {
+  edit.selectAll();
+  startListening();
+  QTest::keyClicks(&edit, "12+3um");
+  QTest::keyClick(&edit, Qt::Key_Enter);
+
+  std::vector<PositiveLength> expectedValues = {
+      PositiveLength(1000000),   // "1" -> 1mm
+      PositiveLength(12000000),  // "12" -> 12mm
+      PositiveLength(15000000),  // "12+3" -> 15mm
+      PositiveLength(15000),     // "12+3um" -> 15 um
+  };
+
+  ASSERT_EQ(expectedValues.size(), emittedValues.size());
+  for (size_t i = 0; i < expectedValues.size(); ++i) {
+    EXPECT_EQ(expectedValues[i]->toNm(), emittedValues[i]->toNm());
+  }
+  EXPECT_EQ(expectedValues.back()->toNm(), edit.getValue()->toNm());
+}
+
+TEST_F(PositiveLengthEditTest, testUnitUpdatedWhileTyping) {
+  edit.selectAll();
+  QTest::keyClicks(&edit, "12+3um");
+  EXPECT_EQ(LengthUnit::micrometers(), edit.getDisplayedUnit());
+}
+
+TEST_F(PositiveLengthEditTest, testTextReplacedAfterPressingEnter) {
+  edit.selectAll();
+
+  QTest::keyClicks(&edit, " (1/2) in ");
+  EXPECT_EQ(12700000, edit.getValue()->toNm());
+  EXPECT_EQ(" (1/2) in ", edit.text().toStdString());
+
+  QTest::keyClick(&edit, Qt::Key_Enter);
+  EXPECT_EQ(12700000, edit.getValue()->toNm());
+  EXPECT_EQ("0.5 ″", edit.text().toStdString());
+}
+
+TEST_F(PositiveLengthEditTest, testDivisionByZero) {
+  edit.selectAll();
+  QTest::keyClicks(&edit, "5/0");
+  EXPECT_EQ(5000000, edit.getValue()->toNm());
+  // Note: It results in 5mm because the term "5" was the last valid value
+  // entered in the text field.
+}
+
+TEST_F(PositiveLengthEditTest, testTooSmallValue) {
+  edit.setValue(PositiveLength(1000000));
+  edit.selectAll();
+
+  QTest::keyClicks(&edit, "0");
+  EXPECT_EQ("0", edit.text().toStdString());    // text entered...
+  EXPECT_EQ(1000000, edit.getValue()->toNm());  // ...but value not updated
+
+  QTest::keyClick(&edit, Qt::Key_Enter);
+  EXPECT_EQ("1.0 mm", edit.text().toStdString());  // text reverted...
+  EXPECT_EQ(1000000, edit.getValue()->toNm());     // ...to the actual value
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/widgets/unsignedlengthedittest.cpp
+++ b/tests/unittests/common/widgets/unsignedlengthedittest.cpp
@@ -1,0 +1,164 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/widgets/unsignedlengthedit.h>
+
+#include <QtTest/QtTest>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+class UnsignedLengthEditTest : public ::testing::Test, public QObject {
+protected:
+  void startListening() {
+    connect(&edit, &UnsignedLengthEdit::valueChanged, this,
+            &UnsignedLengthEditTest::valueChanged);
+  }
+
+  void valueChanged(const UnsignedLength& value) noexcept {
+    emittedValues.push_back(value);
+  }
+
+  UnsignedLengthEdit          edit;
+  std::vector<UnsignedLength> emittedValues;
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(UnsignedLengthEditTest, testStep) {
+  edit.setSteps({
+      PositiveLength(100000),   // 0.1mm
+      PositiveLength(254000),   // 0.254mm
+      PositiveLength(1000000),  // 1mm
+      PositiveLength(2540000),  // 2.54mm
+  });
+  edit.setValue(UnsignedLength(3000000));  // 3mm
+  startListening();
+
+  // Step down from 3mm to 0mm
+  std::vector<UnsignedLength> expectedValues = {
+      UnsignedLength(2000000), UnsignedLength(1000000), UnsignedLength(900000),
+      UnsignedLength(800000),  UnsignedLength(700000),  UnsignedLength(600000),
+      UnsignedLength(500000),  UnsignedLength(400000),  UnsignedLength(300000),
+      UnsignedLength(200000),  UnsignedLength(100000),  UnsignedLength(0),
+  };
+  for (size_t i = 0; i < expectedValues.size(); ++i) {
+    edit.stepDown();
+    EXPECT_EQ(expectedValues[i]->toNm(), edit.getValue()->toNm());
+    ASSERT_EQ(i + 1, emittedValues.size());
+    EXPECT_EQ(expectedValues[i]->toNm(), emittedValues[i]->toNm());
+  }
+  emittedValues.clear();
+
+  // Step down one more time -> must do nothing, i.e. value stays at 0mm.
+  edit.stepDown();
+  EXPECT_EQ(0, edit.getValue()->toNm());
+
+  // Step up from 0mm to 3mm
+  expectedValues = {
+      UnsignedLength(100000),  UnsignedLength(200000),  UnsignedLength(300000),
+      UnsignedLength(400000),  UnsignedLength(500000),  UnsignedLength(600000),
+      UnsignedLength(700000),  UnsignedLength(800000),  UnsignedLength(900000),
+      UnsignedLength(1000000), UnsignedLength(2000000), UnsignedLength(3000000),
+  };
+  for (size_t i = 0; i < expectedValues.size(); ++i) {
+    edit.stepUp();
+    EXPECT_EQ(expectedValues[i]->toNm(), edit.getValue()->toNm());
+    ASSERT_EQ(i + 1, emittedValues.size());
+    EXPECT_EQ(expectedValues[i]->toNm(), emittedValues[i]->toNm());
+  }
+}
+
+TEST_F(UnsignedLengthEditTest, testValueChangedWhileTyping) {
+  edit.selectAll();
+  startListening();
+  QTest::keyClicks(&edit, "12+3um");
+  QTest::keyClick(&edit, Qt::Key_Enter);
+
+  std::vector<UnsignedLength> expectedValues = {
+      UnsignedLength(1000000),   // "1" -> 1mm
+      UnsignedLength(12000000),  // "12" -> 12mm
+      UnsignedLength(15000000),  // "12+3" -> 15mm
+      UnsignedLength(15000),     // "12+3um" -> 15 um
+  };
+
+  ASSERT_EQ(expectedValues.size(), emittedValues.size());
+  for (size_t i = 0; i < expectedValues.size(); ++i) {
+    EXPECT_EQ(expectedValues[i]->toNm(), emittedValues[i]->toNm());
+  }
+  EXPECT_EQ(expectedValues.back()->toNm(), edit.getValue()->toNm());
+}
+
+TEST_F(UnsignedLengthEditTest, testUnitUpdatedWhileTyping) {
+  edit.selectAll();
+  QTest::keyClicks(&edit, "12+3um");
+  EXPECT_EQ(LengthUnit::micrometers(), edit.getDisplayedUnit());
+}
+
+TEST_F(UnsignedLengthEditTest, testTextReplacedAfterPressingEnter) {
+  edit.selectAll();
+
+  QTest::keyClicks(&edit, " (1/2) in ");
+  EXPECT_EQ(12700000, edit.getValue()->toNm());
+  EXPECT_EQ(" (1/2) in ", edit.text().toStdString());
+
+  QTest::keyClick(&edit, Qt::Key_Enter);
+  EXPECT_EQ(12700000, edit.getValue()->toNm());
+  EXPECT_EQ("0.5 ″", edit.text().toStdString());
+}
+
+TEST_F(UnsignedLengthEditTest, testDivisionByZero) {
+  edit.selectAll();
+  QTest::keyClicks(&edit, "5/0");
+  EXPECT_EQ(5000000, edit.getValue()->toNm());
+  // Note: It results in 5mm because the term "5" was the last valid value
+  // entered in the text field.
+}
+
+TEST_F(UnsignedLengthEditTest, testTooSmallValue) {
+  edit.setValue(UnsignedLength(1000000));
+  edit.selectAll();
+
+  QTest::keyClicks(&edit, "-5");
+  EXPECT_EQ("-5", edit.text().toStdString());   // text entered...
+  EXPECT_EQ(1000000, edit.getValue()->toNm());  // ...but value not updated
+
+  QTest::keyClick(&edit, Qt::Key_Enter);
+  EXPECT_EQ("1.0 mm", edit.text().toStdString());  // text reverted...
+  EXPECT_EQ(1000000, edit.getValue()->toNm());     // ...to the actual value
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -13,7 +13,7 @@ include(../../common.pri)
 # Set preprocessor defines
 DEFINES += TEST_DATA_DIR=\\\"$${PWD}/../data\\\"
 
-QT += core widgets network printsupport xml opengl sql concurrent
+QT += core widgets network printsupport xml opengl sql concurrent testlib
 
 CONFIG += console
 CONFIG -= app_bundle
@@ -97,6 +97,9 @@ SOURCES += \
     common/uuidtest.cpp \
     common/versiontest.cpp \
     common/widgets/editabletablewidgettest.cpp \
+    common/widgets/lengthedittest.cpp \
+    common/widgets/positivelengthedittest.cpp \
+    common/widgets/unsignedlengthedittest.cpp \
     eagleimport/deviceconvertertest.cpp \
     eagleimport/devicesetconvertertest.cpp \
     eagleimport/packageconvertertest.cpp \

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -28,6 +28,7 @@ LIBS += \
     -llibrepcbcommon \     # Another order could end up in "undefined reference" errors!
     -lsexpresso \
     -lclipper \
+    -lmuparser \
     -lparseagle -lquazip -lz
 
 INCLUDEPATH += \
@@ -49,6 +50,7 @@ DEPENDPATH += \
     ../../libs/quazip \
     ../../libs/sexpresso \
     ../../libs/clipper \
+    ../../libs/muparser \
 
 PRE_TARGETDEPS += \
     $${DESTDIR}/libgoogletest.a \
@@ -60,6 +62,7 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/libquazip.a \
     $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libclipper.a \
+    $${DESTDIR}/libmuparser.a \
 
 SOURCES += \
     common/algorithm/airwiresbuildertest.cpp \

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -93,6 +93,7 @@ SOURCES += \
     common/units/lengthtest.cpp \
     common/units/pointtest.cpp \
     common/units/ratiotest.cpp \
+    common/utils/mathparsertest.cpp \
     common/uuidtest.cpp \
     common/versiontest.cpp \
     common/widgets/editabletablewidgettest.cpp \


### PR DESCRIPTION
## Problem
Until now, all number edit widgets in all editors always used Millimeters, no matter which unit was configured in workspace settings. Also it was not possible to enter values in other units by explicitly entering the unit, e.g. by writing "100mils". See also #362.

## Changes
This PR heavily refactors these number input widgets in several ways:
- Code refactoring: Add new base class `LengthEditBase`, based directly on `QAbstractSpinBox`
  instead of `QDoubleSpinBox` -> this way the actual value hold by the widget is `Length` instead of `double`.
- By default, show the values in the unit configured in workspace settings.
- Add context menu to switch unit:
![grafik](https://user-images.githubusercontent.com/5374821/79079561-36c43b00-7d10-11ea-94af-76af2411d32b.png)
- Add support for entering mathematical expressions (using [muparser](https://beltoforion.de/article.php?a=muparser)), optionally including the unit:
![Peek 2020-04-12 22-57](https://user-images.githubusercontent.com/5374821/79079754-455f2200-7d11-11ea-8383-ad92decf6125.gif)
- Use automatic spinbox step value, determined from current value (for example if a multiple of 0.1mm is entered, the step is 0.1mm, but if a multiple of 10mils is entered, the step is 10mils):
![Peek 2020-04-12 23-05](https://user-images.githubusercontent.com/5374821/79080010-c2d76200-7d12-11ea-8b12-b84829f4183e.gif)
- Reduce number of displayed decimal places, depending on unit (converting values between different units can lead to very odd numbers with many decimal places, so for readability only a few decimal places are displayed).

# Open Questions

See https://github.com/LibrePCB/LibrePCB/issues/362#issuecomment-612683842.