### PR TITLE
SchematicPagesDock: Disable wrapping of schematic pages

### DIFF
--- a/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicpagesdock.cpp
@@ -45,6 +45,10 @@ SchematicPagesDock::SchematicPagesDock(Project& project, QWidget* parent)
   : QDockWidget(parent), mProject(project), mUi(new Ui::SchematicPagesDock) {
   mUi->setupUi(this);
 
+  // disable wrapping to avoid "disappearing" schematic pages, see
+  // https://github.com/LibrePCB/LibrePCB/issues/681
+  mUi->listWidget->setWrapping(false);
+
   // add all schematics to list widget
   for (int i = 0; i < mProject.getSchematics().count(); i++) schematicAdded(i);
   mUi->listWidget->setCurrentRow(-1);


### PR DESCRIPTION
If there is not enough space available to display the schematic pages in a vertical layout, QListWidget was allowed to wrap pages to the right, i.e. using a horizontal layout. In some situations (depending on the width of the dock widget), the wrapped pages were not visible anymore, so it looked like some schematic pages disappeared. By disabling wrapping, QListWidget always uses a vertical layout.

Fixes #681 