### PR TITLE
Workspace migration wizard: Disable useless buttons

### DIFF
--- a/apps/librepcb/initializeworkspacewizard/initializeworkspacewizard_finalizeimport.cpp
+++ b/apps/librepcb/initializeworkspacewizard/initializeworkspacewizard_finalizeimport.cpp
@@ -103,6 +103,16 @@ void InitializeWorkspaceWizard_FinalizeImport::importFailed(
 void InitializeWorkspaceWizard_FinalizeImport::importSucceeded() noexcept {
   mImportSucceeded = true;
   emit completeChanged();
+
+  // Disable the "cancel" and "back" buttons since they do not make any sense
+  // after the import was completed. The only remaining button is "finish".
+  // In addition, it fixes https://github.com/LibrePCB/LibrePCB/issues/675.
+  if (QAbstractButton* btn = wizard()->button(QWizard::BackButton)) {
+    btn->setEnabled(false);
+  }
+  if (QAbstractButton* btn = wizard()->button(QWizard::CancelButton)) {
+    btn->setEnabled(false);
+  }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
The "back" and "cancel" buttons on the last page of the "initialize Workspace" wizard do not make any sense after the import was completed. Now they are disabled as soon as the import finished, so the only remaining enabled button is "finish".

This fixes #675 since the back button is now disabled :wink: