### PR TITLE
Fix possibly disappearing airwires

### DIFF
--- a/libs/librepcb/common/algorithm/airwiresbuilder.cpp
+++ b/libs/librepcb/common/algorithm/airwiresbuilder.cpp
@@ -1,0 +1,185 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "airwiresbuilder.h"
+
+#include <unordered_map>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+AirWiresBuilder::AirWiresBuilder() noexcept {
+}
+
+AirWiresBuilder::~AirWiresBuilder() noexcept {
+}
+
+/*******************************************************************************
+ *  Public Methods
+ ******************************************************************************/
+
+int AirWiresBuilder::addPoint(const Point& p) noexcept {
+  int id = mPoints.size();
+  mPoints.emplace_back(p.getX().toNm(), p.getY().toNm(), id);
+  return id;
+}
+
+void AirWiresBuilder::addEdge(int p1, int p2) noexcept {
+  mEdges.emplace_back(mPoints[p1], mPoints[p2], -1);
+}
+
+AirWiresBuilder::AirWires AirWiresBuilder::buildAirWires() noexcept {
+  // remember how many edges are already known as connected
+  uint connectedEdges = mEdges.size();
+
+  // determine additional edges between found points (candidates for airwires)
+  if (mPoints.size() >= 3) {  // minimum 3 points needed for triangulation
+    delaunay::Delaunay<qreal> del;
+    del.triangulate(mPoints);
+    mEdges.insert(mEdges.end(), del.getEdges().begin(), del.getEdges().end());
+  } else if (mPoints.size() == 2) {
+    mEdges.emplace_back(mPoints[0], mPoints[1], -1);
+  }
+
+  // determine weights of these new edges
+  for (uint i = connectedEdges; i < mEdges.size(); ++i) {
+    mEdges[i].weight = mEdges[i].p1.dist2(mEdges[i].p2);
+  }
+
+  // find airwires in list of edges
+  return AirWiresBuilder::kruskalMst();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+// adapted from horizon/kicad
+AirWiresBuilder::AirWires AirWiresBuilder::kruskalMst() noexcept {
+  unsigned int nodeNumber      = mPoints.size();
+  unsigned int mstExpectedSize = nodeNumber - 1;
+  unsigned int mstSize         = 0;
+  bool         ratsnestLines   = false;
+
+  // printf("mst nodes : %d edges : %d\n", mPoints.size(), mEdges.size () );
+  // The output
+  AirWires mst;
+
+  // Set tags for marking cycles
+  std::unordered_map<int, int> tags;
+  unsigned int                 tag = 0;
+
+  for (auto& node : mPoints) {
+    node.tag      = tag;
+    tags[node.id] = tag++;
+  }
+
+  // Lists of nodes connected together (subtrees) to detect cycles in the
+  // graph
+  std::vector<std::list<int>> cycles(nodeNumber);
+
+  for (unsigned int i = 0; i < nodeNumber; ++i) cycles[i].push_back(i);
+
+  // Kruskal algorithm requires edges to be sorted by their weight
+  std::sort(mEdges.begin(), mEdges.end(),
+            [](const delaunay::Edge<qreal>& a, const delaunay::Edge<qreal>& b) {
+              return a.weight > b.weight;
+            });
+
+  while (mstSize < mstExpectedSize && !mEdges.empty()) {
+    auto& dt = mEdges.back();
+
+    int srcTag = tags[dt.p1.id];
+    int trgTag = tags[dt.p2.id];
+    // printf("mstSize %d %d %f %d<>%d\n", mstSize, mstExpectedSize,
+    // dt.weight, srcTag, trgTag);
+
+    // Check if by adding this edge we are going to join two different
+    // forests
+    if (srcTag != trgTag) {
+      // Because edges are sorted by their weight, first we always process
+      // connected
+      // items (weight == 0). Once we stumble upon an edge with non-zero
+      // weight,
+      // it means that the rest of the lines are ratsnest.
+      if (!ratsnestLines && dt.weight >= 0) ratsnestLines = true;
+
+      // Update tags
+      if (ratsnestLines) {
+        for (auto it = cycles[trgTag].begin(); it != cycles[trgTag].end();
+             ++it) {
+          tags[mPoints[*it].id] = srcTag;
+        }
+
+        // Do a copy of edge, but make it RN_EDGE_MST. In contrary to
+        // RN_EDGE,
+        // RN_EDGE_MST saves both source and target node and does not
+        // require any other
+        // edges to exist for getting source/target nodes
+        // CN_EDGE newEdge ( dt.GetSourceNode(), dt.GetTargetNode(),
+        // dt.GetWeight() );
+
+        // assert( newEdge.GetSourceNode()->GetTag() !=
+        // newEdge.GetTargetNode()->GetTag() );
+        // assert(dt.p1.tag != dt.p2.tag);
+        mst.append(qMakePair(Point(dt.p1.x, dt.p1.y), Point(dt.p2.x, dt.p2.y)));
+        ++mstSize;
+      } else {
+        // for( it = cycles[trgTag].begin(), itEnd =
+        // cycles[trgTag].end(); it != itEnd; ++it )
+        // for( auto it : cycles[trgTag] )
+        for (auto it = cycles[trgTag].begin(); it != cycles[trgTag].end();
+             ++it) {
+          tags[mPoints[*it].id] = srcTag;
+          mPoints[*it].tag      = srcTag;
+        }
+
+        // Processing a connection, decrease the expected size of the
+        // ratsnest MST
+        --mstExpectedSize;
+      }
+
+      // Move nodes that were marked with old tag to the list marked with
+      // the new tag
+      cycles[srcTag].splice(cycles[srcTag].end(), cycles[trgTag]);
+    }
+
+    // Remove the edge that was just processed
+    mEdges.pop_back();
+  }
+
+  return mst;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/algorithm/airwiresbuilder.h
+++ b/libs/librepcb/common/algorithm/airwiresbuilder.h
@@ -1,0 +1,112 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_AIRWIRESBUILDER_H
+#define LIBREPCB_AIRWIRESBUILDER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../units/point.h"
+
+#include <delaunay-triangulation/delaunay.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class AirWiresBuilder
+ ******************************************************************************/
+
+/**
+ * @brief The AirWiresBuilder class
+ */
+class AirWiresBuilder final {
+  Q_DECLARE_TR_FUNCTIONS(AirWiresBuilder)
+
+public:
+  // Types
+  typedef QPair<Point, Point> AirWire;
+  typedef QVector<AirWire>    AirWires;
+
+  // Constructors / Destructor
+
+  /**
+   * @brief Default constructor
+   */
+  AirWiresBuilder() noexcept;
+
+  /**
+   * @brief Copy constructor
+   *
+   * @param other     Another ::librepcb::AirWiresBuilder object
+   */
+  AirWiresBuilder(const AirWiresBuilder& other) = delete;
+
+  /**
+   * Destructor
+   */
+  ~AirWiresBuilder() noexcept;
+
+  /**
+   * @brief Add a new point
+   *
+   * @param p   The point to add
+   *
+   * @return The ID of the added point
+   */
+  int addPoint(const Point& p) noexcept;
+
+  /**
+   * @brief Add an edge between two points
+   *
+   * @param p1  ID of first point
+   * @param p2  ID of second point
+   */
+  void addEdge(int p1, int p2) noexcept;
+
+  /**
+   * @brief Build the air wires
+   *
+   * @return Coordinates of air wires
+   */
+  AirWires buildAirWires() noexcept;
+
+  // Operator overloadings
+  AirWiresBuilder& operator=(const AirWiresBuilder& rhs) = delete;
+
+private:  // Methods
+  AirWires kruskalMst() noexcept;
+
+private:  // Data
+  std::vector<delaunay::Vector2<qreal>> mPoints;
+  std::vector<delaunay::Edge<qreal>>    mEdges;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif  // LIBREPCB_AIRWIRESBUILDER_H

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -31,6 +31,7 @@ RESOURCES += \
     ../../../img/images.qrc \
 
 SOURCES += \
+    algorithm/airwiresbuilder.cpp \
     alignment.cpp \
     application.cpp \
     attributes/attribute.cpp \
@@ -158,6 +159,7 @@ SOURCES += \
     widgets/valignactiongroup.cpp \
 
 HEADERS += \
+    algorithm/airwiresbuilder.h \
     alignment.h \
     application.h \
     attributes/attribute.h \

--- a/libs/librepcb/common/units/point.h
+++ b/libs/librepcb/common/units/point.h
@@ -463,6 +463,35 @@ public:
     return (mX != rhs.mX) || (mY != rhs.mY);
   }
 
+  //@{
+  /**
+   * @brief Less/Greater comparison operator overloadings
+   *
+   * This comparison operator doesn't make much sense, but it's useful to to
+   * sort ::librepcb::Point objects, e.g. for using them as a key in a sorted
+   * map. The comparison is first done on the X coordinate, and only if they
+   * are equal, the Y coordinate is also taken into account. So the "smallest"
+   * point is at (-infinity, -infinity) and the "greatest" point at
+   * (infinity, infinity).
+   *
+   * @param rhs   The other object to compare
+   *
+   * @return Result of the comparison
+   */
+  bool operator<(const Point& rhs) const noexcept {
+    return (mX < rhs.mX) || ((mX == rhs.mX) && (mY < rhs.mY));
+  }
+  bool operator<=(const Point& rhs) const noexcept {
+    return (mX < rhs.mX) || ((mX == rhs.mX) && (mY <= rhs.mY));
+  }
+  bool operator>(const Point& rhs) const noexcept {
+    return (mX > rhs.mX) || ((mX == rhs.mX) && (mY > rhs.mY));
+  }
+  bool operator>=(const Point& rhs) const noexcept {
+    return (mX > rhs.mX) || ((mX == rhs.mX) && (mY >= rhs.mY));
+  }
+  //@}
+
 private:
   Length mX;  ///< the X coordinate
   Length mY;  ///< the Y coordinate

--- a/libs/librepcb/project/boards/boardairwiresbuilder.cpp
+++ b/libs/librepcb/project/boards/boardairwiresbuilder.cpp
@@ -34,10 +34,9 @@
 #include "items/bi_plane.h"
 #include "items/bi_via.h"
 
-#include <delaunay-triangulation/delaunay.h>
+#include <librepcb/common/algorithm/airwiresbuilder.h>
 #include <librepcb/common/graphics/graphicslayer.h>
 #include <librepcb/library/pkg/footprintpad.h>
-#include <unordered_map>
 
 #include <QtCore>
 
@@ -46,105 +45,6 @@
  ******************************************************************************/
 namespace librepcb {
 namespace project {
-
-// adapted from horizon/kicad
-static QVector<QPair<Point, Point>> kruskalMst(
-    std::vector<delaunay::Edge<qreal>>&    aEdges,
-    std::vector<delaunay::Vector2<qreal>>& aNodes) noexcept {
-  unsigned int nodeNumber      = aNodes.size();
-  unsigned int mstExpectedSize = nodeNumber - 1;
-  unsigned int mstSize         = 0;
-  bool         ratsnestLines   = false;
-
-  // printf("mst nodes : %d edges : %d\n", aNodes.size(), aEdges.size () );
-  // The output
-  QVector<QPair<Point, Point>> mst;
-
-  // Set tags for marking cycles
-  std::unordered_map<int, int> tags;
-  unsigned int                 tag = 0;
-
-  for (auto& node : aNodes) {
-    node.tag      = tag;
-    tags[node.id] = tag++;
-  }
-
-  // Lists of nodes connected together (subtrees) to detect cycles in the
-  // graph
-  std::vector<std::list<int>> cycles(nodeNumber);
-
-  for (unsigned int i = 0; i < nodeNumber; ++i) cycles[i].push_back(i);
-
-  // Kruskal algorithm requires edges to be sorted by their weight
-  std::sort(aEdges.begin(), aEdges.end(),
-            [](const delaunay::Edge<qreal>& a, const delaunay::Edge<qreal>& b) {
-              return a.weight > b.weight;
-            });
-
-  while (mstSize < mstExpectedSize && !aEdges.empty()) {
-    auto& dt = aEdges.back();
-
-    int srcTag = tags[dt.p1.id];
-    int trgTag = tags[dt.p2.id];
-    // printf("mstSize %d %d %f %d<>%d\n", mstSize, mstExpectedSize,
-    // dt.weight, srcTag, trgTag);
-
-    // Check if by adding this edge we are going to join two different
-    // forests
-    if (srcTag != trgTag) {
-      // Because edges are sorted by their weight, first we always process
-      // connected
-      // items (weight == 0). Once we stumble upon an edge with non-zero
-      // weight,
-      // it means that the rest of the lines are ratsnest.
-      if (!ratsnestLines && dt.weight >= 0) ratsnestLines = true;
-
-      // Update tags
-      if (ratsnestLines) {
-        for (auto it = cycles[trgTag].begin(); it != cycles[trgTag].end();
-             ++it) {
-          tags[aNodes[*it].id] = srcTag;
-        }
-
-        // Do a copy of edge, but make it RN_EDGE_MST. In contrary to
-        // RN_EDGE,
-        // RN_EDGE_MST saves both source and target node and does not
-        // require any other
-        // edges to exist for getting source/target nodes
-        // CN_EDGE newEdge ( dt.GetSourceNode(), dt.GetTargetNode(),
-        // dt.GetWeight() );
-
-        // assert( newEdge.GetSourceNode()->GetTag() !=
-        // newEdge.GetTargetNode()->GetTag() );
-        // assert(dt.p1.tag != dt.p2.tag);
-        mst.append(qMakePair(Point(dt.p1.x, dt.p1.y), Point(dt.p2.x, dt.p2.y)));
-        ++mstSize;
-      } else {
-        // for( it = cycles[trgTag].begin(), itEnd =
-        // cycles[trgTag].end(); it != itEnd; ++it )
-        // for( auto it : cycles[trgTag] )
-        for (auto it = cycles[trgTag].begin(); it != cycles[trgTag].end();
-             ++it) {
-          tags[aNodes[*it].id] = srcTag;
-          aNodes[*it].tag      = srcTag;
-        }
-
-        // Processing a connection, decrease the expected size of the
-        // ratsnest MST
-        --mstExpectedSize;
-      }
-
-      // Move nodes that were marked with old tag to the list marked with
-      // the new tag
-      cycles[srcTag].splice(cycles[srcTag].end(), cycles[trgTag]);
-    }
-
-    // Remove the edge that was just processed
-    aEdges.pop_back();
-  }
-
-  return mst;
-}
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -163,26 +63,23 @@ BoardAirWiresBuilder::~BoardAirWiresBuilder() noexcept {
  ******************************************************************************/
 
 QVector<QPair<Point, Point>> BoardAirWiresBuilder::buildAirWires() const {
-  std::vector<delaunay::Vector2<qreal>> points;
-  QHash<const BI_NetLineAnchor*, int>   anchorMap;
-  QHash<int, QString>                   layerMap;
-  std::vector<delaunay::Edge<qreal>>    edges;
+  AirWiresBuilder                       builder;
+  QHash<int, std::pair<Point, QString>> pointLayerMap;  // ID -> (point, layer)
+  QHash<const BI_NetLineAnchor*, int>   anchorMap;      // anchor -> ID
 
   // pads
   foreach (ComponentSignalInstance* cmpSig, mNetSignal.getComponentSignals()) {
     Q_ASSERT(cmpSig);
     foreach (BI_FootprintPad* pad, cmpSig->getRegisteredFootprintPads()) {
       if (&pad->getBoard() != &mBoard) continue;
-      int   id  = points.size();
-      Point pos = pad->getPosition();
-      points.emplace_back(pos.getX().toNm(), pos.getY().toNm(), id);
+      const Point& pos = pad->getPosition();
+      int          id  = builder.addPoint(pos);
+      pointLayerMap[id] =
+          std::make_pair(pos, (pad->getLibPad().getBoardSide() ==
+                               library::FootprintPad::BoardSide::THT)
+                                  ? QString()  // on all layers
+                                  : pad->getLayerName());
       anchorMap[pad] = id;
-      if (pad->getLibPad().getBoardSide() ==
-          library::FootprintPad::BoardSide::THT) {
-        layerMap[id] = QString();  // on all layers
-      } else {
-        layerMap[id] = pad->getLayerName();
-      }
     }
   }
 
@@ -192,28 +89,26 @@ QVector<QPair<Point, Point>> BoardAirWiresBuilder::buildAirWires() const {
     if (&netsegment->getBoard() != &mBoard) continue;
     foreach (const BI_Via* via, netsegment->getVias()) {
       Q_ASSERT(via);
-      int   id  = points.size();
-      Point pos = via->getPosition();
-      points.emplace_back(pos.getX().toNm(), pos.getY().toNm(), id);
-      anchorMap[via] = id;
-      layerMap[id]   = QString();  // on all layers
+      const Point& pos  = via->getPosition();
+      int          id   = builder.addPoint(pos);
+      pointLayerMap[id] = std::make_pair(pos, QString());  // on all layers
+      anchorMap[via]    = id;
     }
     foreach (const BI_NetPoint* netpoint, netsegment->getNetPoints()) {
       Q_ASSERT(netpoint);
       if (const GraphicsLayer* layer = netpoint->getLayerOfLines()) {
-        int   id  = points.size();
-        Point pos = netpoint->getPosition();
-        points.emplace_back(pos.getX().toNm(), pos.getY().toNm(), id);
+        Point pos           = netpoint->getPosition();
+        int   id            = builder.addPoint(pos);
+        pointLayerMap[id]   = std::make_pair(pos, layer->getName());
         anchorMap[netpoint] = id;
-        layerMap[id]        = layer->getName();
       }
     }
     foreach (const BI_NetLine* netline, netsegment->getNetLines()) {
       Q_ASSERT(netline);
       Q_ASSERT(anchorMap.contains(&netline->getStartPoint()));
       Q_ASSERT(anchorMap.contains(&netline->getEndPoint()));
-      edges.emplace_back(points[anchorMap[&netline->getStartPoint()]],
-                         points[anchorMap[&netline->getEndPoint()]], -1);
+      builder.addEdge(anchorMap[&netline->getStartPoint()],
+                      anchorMap[&netline->getEndPoint()]);
     }
   }
 
@@ -222,41 +117,25 @@ QVector<QPair<Point, Point>> BoardAirWiresBuilder::buildAirWires() const {
     Q_ASSERT(plane);
     if (&plane->getBoard() != &mBoard) continue;
     foreach (const Path& fragment, plane->getFragments()) {
-      int lastId = -1;
-      for (const auto& point : points) {
-        QString pointLayer = layerMap[point.id];
+      int                                           lastId = -1;
+      QHashIterator<int, std::pair<Point, QString>> i(pointLayerMap);
+      while (i.hasNext()) {
+        i.next();
+        const Point&   pos        = i.value().first;
+        const QString& pointLayer = i.value().second;
         if (pointLayer.isNull() || (pointLayer == plane->getLayerName())) {
-          Point p(point.x, point.y);
-          if (fragment.toQPainterPathPx().contains(p.toPxQPointF())) {
+          if (fragment.toQPainterPathPx().contains(pos.toPxQPointF())) {
             if (lastId >= 0) {
-              edges.emplace_back(points[lastId], points[point.id], -1);
+              builder.addEdge(lastId, i.key());
             }
-            lastId = point.id;
+            lastId = i.key();
           }
         }
       }
     }
   }
 
-  // remember how many edges are already known as connected
-  uint connectedEdges = edges.size();
-
-  // determine additional edges between found points (candidates for airwires)
-  if (points.size() >= 3) {  // minimum 3 points needed for triangulation
-    delaunay::Delaunay<qreal> del;
-    del.triangulate(points);
-    edges.insert(edges.end(), del.getEdges().begin(), del.getEdges().end());
-  } else if (points.size() == 2) {
-    edges.emplace_back(points[0], points[1], -1);
-  }
-
-  // determine weights of these new edges
-  for (uint i = connectedEdges; i < edges.size(); ++i) {
-    edges[i].weight = edges[i].p1.dist2(edges[i].p2);
-  }
-
-  // find airwires in list of edges
-  return kruskalMst(edges, points);
+  return builder.buildAirWires();
 }
 
 /*******************************************************************************

--- a/tests/unittests/common/algorithm/airwiresbuildertest.cpp
+++ b/tests/unittests/common/algorithm/airwiresbuildertest.cpp
@@ -1,0 +1,186 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/common/algorithm/airwiresbuilder.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class AirWiresBuilderTest : public ::testing::Test {
+protected:
+  static AirWiresBuilder::AirWires sorted(
+      AirWiresBuilder::AirWires airwires) noexcept {
+    for (AirWiresBuilder::AirWire& airwire : airwires) {
+      if (airwire.second < airwire.first) {
+        std::swap(airwire.second, airwire.first);
+      }
+    }
+    std::sort(airwires.begin(), airwires.end());
+    return airwires;
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(AirWiresBuilderTest, testEmpty) {
+  AirWiresBuilder           builder;
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  EXPECT_EQ(0, airwires.size());
+}
+
+TEST_F(AirWiresBuilderTest, testOnePoint) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(1000000, 2000000));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  EXPECT_EQ(0, airwires.size());
+}
+
+TEST_F(AirWiresBuilderTest, testTwoUnconnectedPoints) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(1000000, 2000000));
+  builder.addPoint(Point(3000000, 4000000));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {
+      {Point(1000000, 2000000), Point(3000000, 4000000)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+TEST_F(AirWiresBuilderTest, testTwoUnconnectedOverlappingPoints) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(100000, 200000));
+  builder.addPoint(Point(100000, 200000));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {
+      {Point(100000, 200000), Point(100000, 200000)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+TEST_F(AirWiresBuilderTest, testTwoConnectedPoints) {
+  AirWiresBuilder builder;
+  int             id0 = builder.addPoint(Point(100000, 200000));
+  int             id1 = builder.addPoint(Point(300000, 400000));
+  builder.addEdge(id0, id1);
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  EXPECT_EQ(0, airwires.size());
+}
+
+TEST_F(AirWiresBuilderTest, testThreeUnconnectedPoints) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(100000, 200000));
+  builder.addPoint(Point(300000, 400000));
+  builder.addPoint(Point(-50000, -50000));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {
+      {Point(-50000, -50000), Point(100000, 200000)},
+      {Point(100000, 200000), Point(300000, 400000)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+TEST_F(AirWiresBuilderTest, testThreeUnconnectedPointsVshape) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(-50000, 0));
+  builder.addPoint(Point(100000, 0));
+  builder.addPoint(Point(0, -1000000));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {{Point(-50000, 0), Point(0, -1000000)},
+                                        {Point(-50000, 0), Point(100000, 0)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+// Test added for bug https://github.com/LibrePCB/LibrePCB/issues/588
+TEST_F(AirWiresBuilderTest, testThreeUnconnectedColinearPoints) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(0, 0));
+  builder.addPoint(Point(100000, 0));
+  builder.addPoint(Point(-100000, 0));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {{Point(-100000, 0), Point(0, 0)},
+                                        {Point(0, 0), Point(100000, 0)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+// Test added for bug https://github.com/LibrePCB/LibrePCB/issues/588
+TEST_F(AirWiresBuilderTest, testThreeUnconnectedDiagonalColinearPoints) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(0, 0));
+  builder.addPoint(Point(1000000, 1000000));
+  builder.addPoint(Point(2000000, 2000000));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {
+      {Point(0, 0), Point(1000000, 1000000)},
+      {Point(1000000, 1000000), Point(2000000, 2000000)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+// Test added for bug https://github.com/LibrePCB/LibrePCB/issues/588
+TEST_F(AirWiresBuilderTest, testThreeUnconnectedDiagonalColinearPoints2) {
+  AirWiresBuilder builder;
+  builder.addPoint(Point(71437500, 78898800));
+  builder.addPoint(Point(70485000, 80010000));
+  builder.addPoint(Point(72707500, 77470000));
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {
+      {Point(70485000, 80010000), Point(71437500, 78898800)},
+      {Point(71437500, 78898800), Point(72707500, 77470000)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+// Test added for bug https://github.com/LibrePCB/LibrePCB/issues/588
+TEST_F(AirWiresBuilderTest, testPartlyConnectedColinearPoints) {
+  AirWiresBuilder builder;
+  /*int id0 = */ builder.addPoint(Point(0, 0));
+  int id1 = builder.addPoint(Point(100000, 100000));
+  int id2 = builder.addPoint(Point(200000, 200000));
+  /*int id3 = */ builder.addPoint(Point(300000, 300000));
+  /*int id4 = */ builder.addPoint(Point(400000, 400000));
+  /*int id5 = */ builder.addPoint(Point(500000, 500000));
+  /*int id5 = */ builder.addPoint(Point(600000, 600000));
+  builder.addEdge(id1, id2);
+  AirWiresBuilder::AirWires airwires = sorted(builder.buildAirWires());
+  AirWiresBuilder::AirWires expected = {
+      {Point(0, 0), Point(100000, 100000)},
+      {Point(200000, 200000), Point(300000, 300000)},
+      {Point(300000, 300000), Point(400000, 400000)},
+      {Point(400000, 400000), Point(500000, 500000)},
+      {Point(500000, 500000), Point(600000, 600000)}};
+  EXPECT_EQ(expected, airwires);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/common/units/pointtest.cpp
+++ b/tests/unittests/common/units/pointtest.cpp
@@ -69,6 +69,62 @@ TEST_P(PointTest, testRotate) {
   EXPECT_EQ(data.pB, p);
 }
 
+TEST_P(PointTest, testOperatorLessThan) {
+  EXPECT_FALSE(Point(Length(0), Length(0)) < Point(Length(0), Length(0)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) < Point(Length(9), Length(19)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) < Point(Length(9), Length(21)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) < Point(Length(10), Length(19)));
+  EXPECT_FALSE(Point(Length(-10), Length(20)) < Point(Length(-11), Length(0)));
+  EXPECT_TRUE(Point(Length(0), Length(0)) < Point(Length(0), Length(1)));
+  EXPECT_TRUE(Point(Length(0), Length(0)) < Point(Length(1), Length(0)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) < Point(Length(11), Length(19)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) < Point(Length(11), Length(21)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) < Point(Length(10), Length(21)));
+  EXPECT_TRUE(Point(Length(-1), Length(-2)) < Point(Length(-1), Length(-1)));
+}
+
+TEST_P(PointTest, testOperatorLessEqual) {
+  EXPECT_FALSE(Point(Length(10), Length(20)) <= Point(Length(9), Length(19)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) <= Point(Length(9), Length(21)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) <= Point(Length(10), Length(19)));
+  EXPECT_FALSE(Point(Length(-10), Length(20)) <= Point(Length(-11), Length(0)));
+  EXPECT_TRUE(Point(Length(0), Length(0)) <= Point(Length(0), Length(0)));
+  EXPECT_TRUE(Point(Length(0), Length(0)) <= Point(Length(0), Length(1)));
+  EXPECT_TRUE(Point(Length(0), Length(0)) <= Point(Length(1), Length(0)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) <= Point(Length(11), Length(19)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) <= Point(Length(11), Length(21)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) <= Point(Length(10), Length(21)));
+  EXPECT_TRUE(Point(Length(-1), Length(-2)) <= Point(Length(-1), Length(-1)));
+}
+
+TEST_P(PointTest, testOperatorGreaterThan) {
+  EXPECT_FALSE(Point(Length(0), Length(0)) > Point(Length(0), Length(0)));
+  EXPECT_FALSE(Point(Length(0), Length(0)) > Point(Length(0), Length(1)));
+  EXPECT_FALSE(Point(Length(0), Length(0)) > Point(Length(1), Length(0)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) > Point(Length(11), Length(19)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) > Point(Length(11), Length(21)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) > Point(Length(10), Length(21)));
+  EXPECT_FALSE(Point(Length(-1), Length(-2)) > Point(Length(-1), Length(-1)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) > Point(Length(9), Length(19)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) > Point(Length(9), Length(21)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) > Point(Length(10), Length(19)));
+  EXPECT_TRUE(Point(Length(-10), Length(20)) > Point(Length(-11), Length(0)));
+}
+
+TEST_P(PointTest, testOperatorGreaterEqual) {
+  EXPECT_FALSE(Point(Length(0), Length(0)) >= Point(Length(0), Length(1)));
+  EXPECT_FALSE(Point(Length(0), Length(0)) >= Point(Length(1), Length(0)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) >= Point(Length(11), Length(19)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) >= Point(Length(11), Length(21)));
+  EXPECT_FALSE(Point(Length(10), Length(20)) >= Point(Length(10), Length(21)));
+  EXPECT_FALSE(Point(Length(-1), Length(-2)) >= Point(Length(-1), Length(-1)));
+  EXPECT_TRUE(Point(Length(0), Length(0)) >= Point(Length(0), Length(0)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) >= Point(Length(9), Length(19)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) >= Point(Length(9), Length(21)));
+  EXPECT_TRUE(Point(Length(10), Length(20)) >= Point(Length(10), Length(19)));
+  EXPECT_TRUE(Point(Length(-10), Length(20)) >= Point(Length(-11), Length(0)));
+}
+
 /*******************************************************************************
  *  Test Data
  ******************************************************************************/

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -62,6 +62,7 @@ PRE_TARGETDEPS += \
     $${DESTDIR}/libclipper.a \
 
 SOURCES += \
+    common/algorithm/airwiresbuildertest.cpp \
     common/alignmenttest.cpp \
     common/applicationtest.cpp \
     common/attributes/attributekeytest.cpp \


### PR DESCRIPTION
It's actually not a fix, but a workaround for issue #588. The Delaunay triangulation library is not able to handle colinear points in the input data (our net points) and silently ignores some of the input points, so there are edges (our airwires) missing in the output.

I spend quite some time on this issue, and I think it's not possible to actually fix this problem on our side, so the fix needs to be done in [delaunay-triangulation](https://github.com/Bl4ckb0ne/delaunay-triangulation). But actually I'm not sure if it's worth investigating and fixing the issue in that library - in my opinion the overall quality of that library is not acceptable for an EDA tool anyway. For long-term, we might switch to a different library, for example [delaunator-cpp](https://github.com/abellgithub/delaunator-cpp) which seems to be developed more seriously. But they currently also have a similar issue (https://github.com/abellgithub/delaunator-cpp/issues/8), so we should wait until this issue is resolved.

However, to get LibrePCB 0.1.4 released as soon as possible with disappearing airwires fixed, I simply implemented some kind of "fallback". Even if delaunay-triangulation failed to add some edges, we now still get all edges connected, but connections might not be "optimal", i.e. not the shortest distance is shown. But at least no airwires disappear now, so the risk of producing PCBs with missing connections is gone.

I also refactored the airwires builder to make it easier testable, and added some unittests which are able to detect the current bug.