### PR TITLE
Respect configured grid unit in statusbar

### DIFF
--- a/libs/librepcb/common/dialogs/gridsettingsdialog.cpp
+++ b/libs/librepcb/common/dialogs/gridsettingsdialog.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "gridsettingsdialog.h"
 
+#include "../widgets/lengtheditbase.h"
 #include "ui_gridsettingsdialog.h"
 
 #include <QtCore>
@@ -36,12 +37,16 @@ namespace librepcb {
  ******************************************************************************/
 
 GridSettingsDialog::GridSettingsDialog(const GridProperties& grid,
-                                       QWidget*              parent)
+                                       QWidget*              parent) noexcept
   : QDialog(parent),
     mUi(new Ui::GridSettingsDialog),
     mOriginalGrid(grid),
     mCurrentGrid(grid) {
   mUi->setupUi(this);
+  mUi->edtInterval->setDefaultUnit(mCurrentGrid.getUnit());
+  mUi->edtInterval->setStepBehavior(
+      LengthEditBase::StepBehavior::HalfAndDouble);
+  mUi->edtInterval->setValue(mCurrentGrid.getInterval());
 
   // set radiobutton id's
   mUi->rbtnGroup->setId(mUi->rbtnNoGrid,
@@ -55,117 +60,85 @@ GridSettingsDialog::GridSettingsDialog(const GridProperties& grid,
   mUi->rbtnGroup->button(static_cast<int>(mCurrentGrid.getType()))
       ->setChecked(true);
 
-  // fill the combobox with all available units
-  foreach (const LengthUnit& itemUnit, LengthUnit::getAllUnits())
-    mUi->cbxUnits->addItem(itemUnit.toStringTr(), itemUnit.getIndex());
-  mUi->cbxUnits->setCurrentIndex(mCurrentGrid.getUnit().getIndex());
-
-  // update spinbox value
-  mUi->spbxInterval->setValue(
-      mCurrentGrid.getUnit().convertToUnit(*mCurrentGrid.getInterval()));
-
   // connect UI signal with slots
-  connect(mUi->rbtnGroup, SIGNAL(buttonClicked(int)), this,
-          SLOT(rbtnGroupClicked(int)));
-  connect(mUi->spbxInterval, SIGNAL(valueChanged(double)), this,
-          SLOT(spbxIntervalChanged(double)));
-  connect(mUi->cbxUnits, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(cbxUnitsChanged(int)));
-  connect(mUi->btnMul2, &QToolButton::clicked, this,
-          &GridSettingsDialog::btnMul2Clicked);
-  connect(mUi->btnDiv2, &QToolButton::clicked, this,
-          &GridSettingsDialog::btnDiv2Clicked);
+  connect(
+      mUi->rbtnGroup,
+      static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked),
+      this, &GridSettingsDialog::rbtnGroupClicked);
+  connect(mUi->edtInterval, &PositiveLengthEdit::valueChanged, this,
+          &GridSettingsDialog::edtIntervalValueChanged);
+  connect(mUi->edtInterval, &PositiveLengthEdit::displayedUnitChanged, this,
+          &GridSettingsDialog::edtIntervalUnitChanged);
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &GridSettingsDialog::buttonBoxClicked);
 
-  updateInternalRepresentation();
+  // preselect interval so the user can immediately start typing
+  mUi->edtInterval->selectAll();
+  mUi->edtInterval->setFocus();
 }
 
-GridSettingsDialog::~GridSettingsDialog() {
-  delete mUi;
-  mUi = 0;
-}
-
-/*******************************************************************************
- *  Private Slots
- ******************************************************************************/
-
-void GridSettingsDialog::rbtnGroupClicked(int id) {
-  if (id < 0) return;
-  mCurrentGrid.setType(static_cast<GridProperties::Type_t>(id));
-  emit gridPropertiesChanged(mCurrentGrid);
-}
-
-void GridSettingsDialog::spbxIntervalChanged(double value) {
-  Length interval = mCurrentGrid.getUnit().convertFromUnit(value);
-  if (interval < 1) return;  // must be positive!
-  mCurrentGrid.setInterval(PositiveLength(interval));
-  updateInternalRepresentation();
-  emit gridPropertiesChanged(mCurrentGrid);
-}
-
-void GridSettingsDialog::cbxUnitsChanged(int index) {
-  try {
-    mCurrentGrid.setUnit(LengthUnit::fromIndex(index));
-    mUi->spbxInterval->setValue(
-        mCurrentGrid.getUnit().convertToUnit(*mCurrentGrid.getInterval()));
-    updateInternalRepresentation();
-    emit gridPropertiesChanged(mCurrentGrid);
-  } catch (Exception& e) {
-    QMessageBox::critical(this, tr("Error"), e.getMsg());
-  }
-}
-
-void GridSettingsDialog::btnMul2Clicked() {
-  mUi->spbxInterval->setValue(mUi->spbxInterval->value() * 2);
-}
-
-void GridSettingsDialog::btnDiv2Clicked() {
-  mUi->spbxInterval->setValue(mUi->spbxInterval->value() / 2);
-}
-
-void GridSettingsDialog::buttonBoxClicked(QAbstractButton* button) {
-  switch (mUi->buttonBox->buttonRole(button)) {
-    case QDialogButtonBox::AcceptRole:
-      // nothing to do here
-      break;
-
-    case QDialogButtonBox::ResetRole: {
-      mCurrentGrid = GridProperties();
-
-      // update widgets
-      mUi->rbtnGroup->blockSignals(true);
-      mUi->cbxUnits->blockSignals(true);
-      mUi->spbxInterval->blockSignals(true);
-      mUi->rbtnGroup->button(static_cast<int>(mCurrentGrid.getType()))
-          ->setChecked(true);
-      mUi->cbxUnits->setCurrentIndex(mCurrentGrid.getUnit().getIndex());
-      mUi->spbxInterval->setValue(
-          mCurrentGrid.getUnit().convertToUnit(*mCurrentGrid.getInterval()));
-      mUi->rbtnGroup->blockSignals(false);
-      mUi->cbxUnits->blockSignals(false);
-      mUi->spbxInterval->blockSignals(false);
-      updateInternalRepresentation();
-      break;
-    }
-
-    default:
-      // restore initial settings
-      mCurrentGrid = mOriginalGrid;
-      break;
-  }
-
-  emit gridPropertiesChanged(mCurrentGrid);
+GridSettingsDialog::~GridSettingsDialog() noexcept {
 }
 
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 
-void GridSettingsDialog::updateInternalRepresentation() noexcept {
-  QLocale locale;  // this loads the application's default locale
-  mUi->lblIntervalNm->setText(QString("%1 nm").arg(
-      locale.toString(mCurrentGrid.getInterval()->toNm())));
+void GridSettingsDialog::rbtnGroupClicked(int id) noexcept {
+  if (id < 0) return;
+  mCurrentGrid.setType(static_cast<GridProperties::Type_t>(id));
+  emit gridPropertiesChanged(mCurrentGrid);
+}
+
+void GridSettingsDialog::edtIntervalValueChanged(
+    const PositiveLength& value) noexcept {
+  mCurrentGrid.setInterval(value);
+  emit gridPropertiesChanged(mCurrentGrid);
+}
+
+void GridSettingsDialog::edtIntervalUnitChanged(
+    const LengthUnit& unit) noexcept {
+  mCurrentGrid.setUnit(unit);
+  emit gridPropertiesChanged(mCurrentGrid);
+}
+
+void GridSettingsDialog::buttonBoxClicked(QAbstractButton* button) noexcept {
+  switch (mUi->buttonBox->buttonRole(button)) {
+    case QDialogButtonBox::AcceptRole: {
+      accept();
+      break;
+    }
+
+    case QDialogButtonBox::RejectRole: {
+      // restore initial settings
+      mCurrentGrid = mOriginalGrid;
+      emit gridPropertiesChanged(mCurrentGrid);
+      reject();
+      break;
+    }
+
+    case QDialogButtonBox::ResetRole: {
+      mCurrentGrid = GridProperties();
+      emit gridPropertiesChanged(mCurrentGrid);
+
+      // update widgets
+      mUi->rbtnGroup->blockSignals(true);
+      mUi->edtInterval->blockSignals(true);
+      mUi->rbtnGroup->button(static_cast<int>(mCurrentGrid.getType()))
+          ->setChecked(true);
+      mUi->edtInterval->resetUnit();
+      mUi->edtInterval->setDefaultUnit(mCurrentGrid.getUnit());
+      mUi->edtInterval->setValue(mCurrentGrid.getInterval());
+      mUi->rbtnGroup->blockSignals(false);
+      mUi->edtInterval->blockSignals(false);
+      break;
+    }
+
+    default: {
+      Q_ASSERT(false);
+      break;
+    }
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/dialogs/gridsettingsdialog.h
+++ b/libs/librepcb/common/dialogs/gridsettingsdialog.h
@@ -50,39 +50,31 @@ class GridSettingsDialog final : public QDialog {
 
 public:
   // Constructors / Destructor
-  explicit GridSettingsDialog(const GridProperties& grid, QWidget* parent = 0);
-  ~GridSettingsDialog();
+  GridSettingsDialog()                                = delete;
+  GridSettingsDialog(const GridSettingsDialog& other) = delete;
+  explicit GridSettingsDialog(const GridProperties& grid,
+                              QWidget*              parent = nullptr) noexcept;
+  ~GridSettingsDialog() noexcept;
 
   // Getters
   const GridProperties& getGrid() const noexcept { return mCurrentGrid; }
 
-private slots:
-
-  // Private Slots
-  void rbtnGroupClicked(int id);
-  void spbxIntervalChanged(double value);
-  void cbxUnitsChanged(int index);
-  void btnMul2Clicked();
-  void btnDiv2Clicked();
-  void buttonBoxClicked(QAbstractButton* button);
+  // Operator Overloadings
+  GridSettingsDialog& operator=(const GridSettingsDialog& rhs) = delete;
 
 signals:
-
   void gridPropertiesChanged(const GridProperties& grid);
 
-private:
-  // make some methods inaccessible...
-  GridSettingsDialog();
-  GridSettingsDialog(const GridSettingsDialog& other);
-  GridSettingsDialog& operator=(const GridSettingsDialog& rhs);
+private:  // Methods
+  void rbtnGroupClicked(int id) noexcept;
+  void edtIntervalValueChanged(const PositiveLength& value) noexcept;
+  void edtIntervalUnitChanged(const LengthUnit& unit) noexcept;
+  void buttonBoxClicked(QAbstractButton* button) noexcept;
 
-  // Private Methods
-  void updateInternalRepresentation() noexcept;
-
-  // General Attributes
-  Ui::GridSettingsDialog* mUi;
-  GridProperties          mOriginalGrid;
-  GridProperties          mCurrentGrid;
+private:  // Data
+  QScopedPointer<Ui::GridSettingsDialog> mUi;
+  GridProperties                         mOriginalGrid;
+  GridProperties                         mCurrentGrid;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/dialogs/gridsettingsdialog.ui
+++ b/libs/librepcb/common/dialogs/gridsettingsdialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>503</width>
-    <height>205</height>
+    <width>324</width>
+    <height>97</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,151 +22,62 @@
   <property name="windowTitle">
    <string>Grid Settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Interval:</string>
      </property>
-     <property name="title">
-      <string>Appearance</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QRadioButton" name="rbtnNoGrid">
-        <property name="text">
-         <string>No Grid</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">rbtnGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="rbtnDots">
-        <property name="text">
-         <string>Dots</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">rbtnGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="rbtnLines">
-        <property name="text">
-         <string>Lines</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">rbtnGroup</string>
-        </attribute>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="0" column="1">
+    <widget class="librepcb::PositiveLengthEdit" name="edtInterval" native="true"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Appearance:</string>
      </property>
-     <property name="title">
-      <string>Grid Parameter</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Interval:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QComboBox" name="cbxUnits"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>In Nanometers:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="lblIntervalNm">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>(internal representation)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QDoubleSpinBox" name="spbxInterval">
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::NoButtons</enum>
-          </property>
-          <property name="decimals">
-           <number>6</number>
-          </property>
-          <property name="minimum">
-           <double>0.000001000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1000000000.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>2.540000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="btnMul2">
-          <property name="text">
-           <string>-</string>
-          </property>
-          <property name="arrowType">
-           <enum>Qt::UpArrow</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="btnDiv2">
-          <property name="text">
-           <string>+</string>
-          </property>
-          <property name="arrowType">
-           <enum>Qt::DownArrow</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
     </widget>
    </item>
-   <item>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QRadioButton" name="rbtnNoGrid">
+       <property name="text">
+        <string>No Grid</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">rbtnGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbtnDots">
+       <property name="text">
+        <string>Dots</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">rbtnGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbtnLines">
+       <property name="text">
+        <string>Lines</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">rbtnGroup</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -178,41 +89,22 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>edtInterval</tabstop>
+  <tabstop>rbtnNoGrid</tabstop>
+  <tabstop>rbtnDots</tabstop>
+  <tabstop>rbtnLines</tabstop>
+ </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::GridSettingsDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::GridSettingsDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
  <buttongroups>
   <buttongroup name="rbtnGroup"/>
  </buttongroups>

--- a/libs/librepcb/common/widgets/lengtheditbase.h
+++ b/libs/librepcb/common/widgets/lengtheditbase.h
@@ -81,6 +81,11 @@ public:
     }
   };
 
+  enum class StepBehavior {
+    PredefinedSteps,
+    HalfAndDouble,
+  };
+
   // Constructors / Destructor
   LengthEditBase() = delete;
   explicit LengthEditBase(const Length& min, const Length& max,
@@ -95,6 +100,7 @@ public:
   // Setters
   void setDefaultUnit(const LengthUnit& unit) noexcept;
   void setChangeUnitActionVisible(bool visible) noexcept;
+  void setStepBehavior(StepBehavior behavior) noexcept;
 
   /**
    * @brief Set the supported up/down step values
@@ -111,6 +117,7 @@ public:
   void setSteps(const QVector<PositiveLength>& steps) noexcept;
 
   // General Methods
+  void resetUnit() noexcept;
   void configureClientSettings(const QString& uniqueIdentifier) noexcept;
   void configure(const LengthUnit&              defaultUnit,
                  const QVector<PositiveLength>& steps,
@@ -123,12 +130,17 @@ public:
   // Operator Overloadings
   LengthEditBase& operator=(const LengthEditBase& rhs) = delete;
 
+signals:
+  void displayedUnitChanged(const LengthUnit& unit);
+
 protected:  // Methods
   virtual QAbstractSpinBox::StepEnabled stepEnabled() const override;
   virtual void                          stepBy(int steps) override;
   void                                  setValueImpl(Length value) noexcept;
   void         updateValueFromText(QString text) noexcept;
   void         updateSingleStep() noexcept;
+  void         updateSingleStepPredefined() noexcept;
+  void         updateSingleStepHalfDouble() noexcept;
   void         updateText() noexcept;
   LengthUnit   extractUnitFromExpression(QString& expression) const noexcept;
   void         changeUnitActionTriggered() noexcept;
@@ -144,6 +156,7 @@ protected:  // Data
   Length                   mMinimum;
   Length                   mMaximum;
   Length                   mValue;
+  StepBehavior             mStepBehavior;
   QVector<PositiveLength>  mSteps;
   Length                   mSingleStepUp;    ///< Zero means "no step available"
   Length                   mSingleStepDown;  ///< Zero means "no step available"

--- a/libs/librepcb/common/widgets/statusbar.cpp
+++ b/libs/librepcb/common/widgets/statusbar.cpp
@@ -121,12 +121,12 @@ void StatusBar::updateAbsoluteCursorPosition() noexcept {
   mAbsPosXLabel->setText(
       QString("X:%1%2")
           .arg(mLengthUnit.convertToUnit(mAbsoluteCursorPosition.getX()), 12,
-               'f', 6)
+               'f', mLengthUnit.getReasonableNumberOfDecimals())
           .arg(mLengthUnit.toShortStringTr()));
   mAbsPosYLabel->setText(
       QString("Y:%1%2")
           .arg(mLengthUnit.convertToUnit(mAbsoluteCursorPosition.getY()), 12,
-               'f', 6)
+               'f', mLengthUnit.getReasonableNumberOfDecimals())
           .arg(mLengthUnit.toShortStringTr()));
 }
 

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
@@ -26,6 +26,7 @@
 #include <librepcb/common/utils/exclusiveactiongroup.h>
 #include <librepcb/common/utils/toolbarproxy.h>
 #include <librepcb/common/utils/undostackactiongroup.h>
+#include <librepcb/common/widgets/statusbar.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
 #include <librepcb/workspace/workspace.h>
 
@@ -53,6 +54,7 @@ EditorWidgetBase::EditorWidgetBase(const Context& context, const FilePath& fp,
                                       &askForRestoringBackup)),  // can throw
     mUndoStackActionGroup(nullptr),
     mToolsActionGroup(nullptr),
+    mStatusBar(nullptr),
     mIsInterfaceBroken(false) {
   mUndoStack.reset(new UndoStack());
   connect(mUndoStack.data(), &UndoStack::cleanChanged, this,
@@ -105,6 +107,26 @@ void EditorWidgetBase::setToolsActionGroup(
 
 void EditorWidgetBase::setCommandToolBar(QToolBar* toolbar) noexcept {
   mCommandToolBarProxy->setToolBar(toolbar);
+}
+
+void EditorWidgetBase::setStatusBar(StatusBar* statusbar) noexcept {
+  if (statusbar == mStatusBar) {
+    return;
+  }
+
+  if (mStatusBar) {
+    disconnect(this, &EditorWidgetBase::cursorPositionChanged, mStatusBar,
+               &StatusBar::setAbsoluteCursorPosition);
+    mStatusBar->setField(StatusBar::AbsolutePosition, false);
+  }
+
+  mStatusBar = statusbar;
+
+  if (mStatusBar) {
+    mStatusBar->setField(StatusBar::AbsolutePosition, hasGraphicalEditor());
+    connect(this, &EditorWidgetBase::cursorPositionChanged, mStatusBar,
+            &StatusBar::setAbsoluteCursorPosition);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.h
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.h
@@ -40,6 +40,7 @@ namespace librepcb {
 class ExclusiveActionGroup;
 class UndoStackActionGroup;
 class ToolBarProxy;
+class StatusBar;
 class IF_GraphicsLayerProvider;
 
 namespace workspace {
@@ -106,6 +107,7 @@ public:
   virtual void setUndoStackActionGroup(UndoStackActionGroup* group) noexcept;
   virtual void setToolsActionGroup(ExclusiveActionGroup* group) noexcept;
   virtual void setCommandToolBar(QToolBar* toolbar) noexcept;
+  virtual void setStatusBar(StatusBar* statusbar) noexcept;
 
   // Operator Overloadings
   EditorWidgetBase& operator=(const EditorWidgetBase& rhs) = delete;
@@ -180,6 +182,7 @@ protected:  // Data
   QScopedPointer<UndoStack>                mUndoStack;
   UndoStackActionGroup*                    mUndoStackActionGroup;
   ExclusiveActionGroup*                    mToolsActionGroup;
+  StatusBar*                               mStatusBar;
   QScopedPointer<ToolBarProxy>             mCommandToolBarProxy;
   bool                                     mIsInterfaceBroken;
 };

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -148,8 +148,6 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, const FilePath& libFp,
   // setup status bar
   mUi->statusBar->setFields(StatusBar::ProgressBar);
   mUi->statusBar->setProgressBarTextFormat(tr("Scanning libraries (%p%)"));
-  mUi->statusBar->setLengthUnit(
-      mWorkspace.getSettings().defaultLengthUnit.get());
   connect(&mWorkspace.getLibraryDb(),
           &workspace::WorkspaceLibraryDb::scanProgressUpdate, mUi->statusBar,
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);
@@ -547,8 +545,6 @@ void LibraryEditor::editLibraryElementTriggered(const FilePath& fp,
     EditWidgetType*           widget = new EditWidgetType(context, fp);
     connect(widget, &QWidget::windowTitleChanged, this,
             &LibraryEditor::updateTabTitles);
-    connect(widget, &EditorWidgetBase::cursorPositionChanged, mUi->statusBar,
-            &StatusBar::setAbsoluteCursorPosition);
     connect(widget, &EditorWidgetBase::dirtyChanged, this,
             &LibraryEditor::updateTabTitles);
     connect(widget, &EditorWidgetBase::elementEdited,
@@ -629,12 +625,6 @@ bool LibraryEditor::closeTab(int index) noexcept {
   return true;
 }
 
-void LibraryEditor::cursorPositionChanged(const Point& pos) noexcept {
-  mUi->statusBar->showMessage(QString("(%1mm | %2mm)")
-                                  .arg(pos.toMmQPointF().x())
-                                  .arg(pos.toMmQPointF().y()));
-}
-
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
@@ -647,12 +637,14 @@ void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
     mCurrentEditorWidget->setUndoStackActionGroup(nullptr);
     mCurrentEditorWidget->setToolsActionGroup(nullptr);
     mCurrentEditorWidget->setCommandToolBar(nullptr);
+    mCurrentEditorWidget->setStatusBar(nullptr);
   }
   mCurrentEditorWidget = widget;
   if (mCurrentEditorWidget) {
     mCurrentEditorWidget->setUndoStackActionGroup(mUndoStackActionGroup.data());
     mCurrentEditorWidget->setToolsActionGroup(mToolsActionGroup.data());
     mCurrentEditorWidget->setCommandToolBar(mUi->commandToolbar);
+    mCurrentEditorWidget->setStatusBar(mUi->statusBar);
     hasGraphicalEditor = mCurrentEditorWidget->hasGraphicalEditor();
     supportsFlip       = mCurrentEditorWidget->supportsFlip();
   }
@@ -668,7 +660,6 @@ void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
   }
   mUi->commandToolbar->setEnabled(hasGraphicalEditor);
   mUi->filterToolbar->setEnabled(isOverviewTab);
-  mUi->statusBar->setField(StatusBar::AbsolutePosition, hasGraphicalEditor);
   updateTabTitles();  // force updating the "Save" action title
 }
 

--- a/libs/librepcb/libraryeditor/libraryeditor.h
+++ b/libs/librepcb/libraryeditor/libraryeditor.h
@@ -169,7 +169,6 @@ private:  // GUI Event Handlers
   void currentTabChanged(int index) noexcept;
   void tabCloseRequested(int index) noexcept;
   bool closeTab(int index) noexcept;
-  void cursorPositionChanged(const Point& pos) noexcept;
 
 private:  // Methods
   void setActiveEditorWidget(EditorWidgetBase* widget);

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.h
@@ -78,6 +78,7 @@ public:
 
   // Setters
   void setToolsActionGroup(ExclusiveActionGroup* group) noexcept override;
+  void setStatusBar(StatusBar* statusbar) noexcept override;
 
   // Operator Overloadings
   PackageEditorWidget& operator=(const PackageEditorWidget& rhs) = delete;

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.h
@@ -76,6 +76,7 @@ public:
 
   // Setters
   void setToolsActionGroup(ExclusiveActionGroup* group) noexcept override;
+  void setStatusBar(StatusBar* statusbar) noexcept override;
 
   // Operator Overloadings
   SymbolEditorWidget& operator=(const SymbolEditorWidget& rhs) = delete;

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -37,7 +37,6 @@
 namespace librepcb {
 
 class GraphicsView;
-class GridProperties;
 class UndoStackActionGroup;
 class ExclusiveActionGroup;
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addcomponent.cpp
@@ -247,8 +247,9 @@ SES_Base::ProcRetVal SES_AddComponent::processSceneEvent(
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
       Q_ASSERT(sceneEvent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       // set temporary position of the current symbol
       Q_ASSERT(mCurrentSymbolEditCommand);
       mCurrentSymbolEditCommand->setPosition(pos, true);
@@ -260,8 +261,9 @@ SES_Base::ProcRetVal SES_AddComponent::processSceneEvent(
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
       Q_ASSERT(sceneEvent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       switch (sceneEvent->button()) {
         case Qt::LeftButton: {
           try {

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_addnetlabel.cpp
@@ -123,8 +123,9 @@ SES_Base::ProcRetVal SES_AddNetLabel::processSceneEvent(
     case QEvent::GraphicsSceneMousePress: {
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       switch (sceneEvent->button()) {
         case Qt::LeftButton: {
           if (mUndoCmdActive) {
@@ -145,8 +146,9 @@ SES_Base::ProcRetVal SES_AddNetLabel::processSceneEvent(
     case QEvent::GraphicsSceneMouseRelease: {
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       switch (sceneEvent->button()) {
         case Qt::RightButton: {
           if (mUndoCmdActive &&
@@ -167,8 +169,9 @@ SES_Base::ProcRetVal SES_AddNetLabel::processSceneEvent(
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
       Q_ASSERT(sceneEvent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       updateLabel(pos);
       return ForceStayInState;
     }

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/ses_drawwire.cpp
@@ -212,8 +212,9 @@ SES_Base::ProcRetVal SES_DrawWire::processIdleSceneEvent(
     case QEvent::GraphicsSceneMousePress: {
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
 
       switch (sceneEvent->button()) {
         case Qt::LeftButton:
@@ -259,8 +260,9 @@ SES_Base::ProcRetVal SES_DrawWire::processPositioningSceneEvent(
     case QEvent::GraphicsSceneMousePress: {
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       switch (sceneEvent->button()) {
         case Qt::LeftButton:
           // fix the current point and add a new point + line
@@ -277,8 +279,9 @@ SES_Base::ProcRetVal SES_DrawWire::processPositioningSceneEvent(
     case QEvent::GraphicsSceneMouseRelease: {
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       switch (sceneEvent->button()) {
         case Qt::RightButton:
           if (sceneEvent->screenPos() ==
@@ -302,8 +305,9 @@ SES_Base::ProcRetVal SES_DrawWire::processPositioningSceneEvent(
       QGraphicsSceneMouseEvent* sceneEvent =
           dynamic_cast<QGraphicsSceneMouseEvent*>(qevent);
       Q_ASSERT(sceneEvent);
-      Point pos = Point::fromPx(sceneEvent->scenePos())
-                      .mappedToGrid(mEditor.getGridProperties().getInterval());
+      Point pos =
+          Point::fromPx(sceneEvent->scenePos())
+              .mappedToGrid(schematic->getGridProperties().getInterval());
       updateNetpointPositions(pos);
       return ForceStayInState;
     }

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -34,7 +34,6 @@
 namespace librepcb {
 
 class GraphicsView;
-class GridProperties;
 class UndoStackActionGroup;
 class ExclusiveActionGroup;
 
@@ -74,10 +73,7 @@ public:
   ProjectEditor& getProjectEditor() const noexcept { return mProjectEditor; }
   Project&       getProject() const noexcept { return mProject; }
   int getActiveSchematicIndex() const noexcept { return mActiveSchematicIndex; }
-  Schematic*            getActiveSchematic() const noexcept;
-  const GridProperties& getGridProperties() const noexcept {
-    return *mGridProperties;
-  }
+  Schematic* getActiveSchematic() const noexcept;
 
   // Setters
   bool setActiveSchematicIndex(int index) noexcept;
@@ -130,7 +126,6 @@ private:
   Project&                             mProject;
   Ui::SchematicEditor*                 mUi;
   GraphicsView*                        mGraphicsView;
-  GridProperties*                      mGridProperties;
   QScopedPointer<UndoStackActionGroup> mUndoStackActionGroup;
   QScopedPointer<ExclusiveActionGroup> mToolsActionGroup;
 


### PR DESCRIPTION
In #684 I adjusted the editors to display the cursor position in the statusbar in the unit from workspace settings. But now while testing the 0.1.4 release candidate I realized that it probably makes even more sense to use the unit configured in the grid settings of the opened editor. So for example if you configure the schematics grid to 0.1 inches, the schematic editor will show the cursor position in inches too, while at the same time the board editor might show Millimeters if the board grid is set to e.g. 0.1mm.

In addition, I completely refactored and cleaned up the grid settings dialog. It is now also using the new length edit widget instead of using spinbox+buttons+combobox.

Old:
![grafik](https://user-images.githubusercontent.com/5374821/80308943-02ea1a80-87d2-11ea-8fa1-f0d50d9b6b5b.png)

New:
![grafik](https://user-images.githubusercontent.com/5374821/80309004-5a888600-87d2-11ea-803f-7145cfeafc76.png)

Summary: Less and cleaner code, simpler UI and more functionality :grin: