### PR TITLE
Improve keyboard navigation in dialogs

### DIFF
--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.cpp
@@ -74,6 +74,9 @@ BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
                                      settingsPrefix % "/restring_vias_max");
 
   updateWidgets();
+
+  // set focus to name so the user can immediately start typing to change it
+  mUi->edtName->setFocus();
 }
 
 BoardDesignRulesDialog::~BoardDesignRulesDialog() {

--- a/libs/librepcb/common/dialogs/boarddesignrulesdialog.ui
+++ b/libs/librepcb/common/dialogs/boarddesignrulesdialog.ui
@@ -95,7 +95,11 @@
     </widget>
    </item>
    <item row="1" column="1" colspan="3">
-    <widget class="QPlainTextEdit" name="txtDescription"/>
+    <widget class="QPlainTextEdit" name="txtDescription">
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item row="0" column="1" colspan="3">
     <widget class="QLineEdit" name="edtName"/>
@@ -155,6 +159,23 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtName</tabstop>
+  <tabstop>txtDescription</tabstop>
+  <tabstop>edtStopMaskMaxViaDia</tabstop>
+  <tabstop>edtStopMaskClrMin</tabstop>
+  <tabstop>edtStopMaskClrRatio</tabstop>
+  <tabstop>edtStopMaskClrMax</tabstop>
+  <tabstop>edtCreamMaskClrMin</tabstop>
+  <tabstop>edtCreamMaskClrRatio</tabstop>
+  <tabstop>edtCreamMaskClrMax</tabstop>
+  <tabstop>edtRestringPadsMin</tabstop>
+  <tabstop>edtRestringPadsRatio</tabstop>
+  <tabstop>edtRestringPadsMax</tabstop>
+  <tabstop>edtRestringViasMin</tabstop>
+  <tabstop>edtRestringViasRatio</tabstop>
+  <tabstop>edtRestringViasMax</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.ui
@@ -125,6 +125,15 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>cbxLayer</tabstop>
+  <tabstop>cbxFillArea</tabstop>
+  <tabstop>cbxIsGrabArea</tabstop>
+  <tabstop>edtLineWidth</tabstop>
+  <tabstop>edtDiameter</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
@@ -58,6 +58,9 @@ HolePropertiesDialog::HolePropertiesDialog(Hole& hole, UndoStack& undoStack,
   mUi->edtDiameter->setValue(mHole.getDiameter());
   mUi->edtPosX->setValue(mHole.getPosition().getX());
   mUi->edtPosY->setValue(mHole.getPosition().getY());
+
+  // set focus to diameter so the user can immediately start typing to change it
+  mUi->edtDiameter->setFocus();
 }
 
 HolePropertiesDialog::~HolePropertiesDialog() noexcept {

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.ui
@@ -71,6 +71,11 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtDiameter</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.ui
@@ -102,6 +102,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>cbxLayer</tabstop>
+  <tabstop>cbxFillArea</tabstop>
+  <tabstop>cbxIsGrabArea</tabstop>
+  <tabstop>edtLineWidth</tabstop>
+  <tabstop>pathEditorWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
@@ -100,6 +100,10 @@ StrokeTextPropertiesDialog::StrokeTextPropertiesDialog(
   mUi->edtRotation->setValue(mText.getRotation());
   mUi->cbxMirrored->setChecked(mText.getMirrored());
   mUi->cbxAutoRotate->setChecked(mText.getAutoRotate());
+
+  // set focus to text so the user can immediately start typing to change it
+  mUi->edtText->selectAll();
+  mUi->edtText->setFocus();
 }
 
 StrokeTextPropertiesDialog::~StrokeTextPropertiesDialog() noexcept {

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.ui
@@ -17,16 +17,6 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Layer:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="cbxLayer"/>
-     </item>
-     <item row="1" column="0">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -39,8 +29,22 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="QPlainTextEdit" name="edtText">
+       <property name="tabChangesFocus">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Layer:</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="1">
-      <widget class="QPlainTextEdit" name="edtText"/>
+      <widget class="QComboBox" name="cbxLayer"/>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_7">
@@ -59,14 +63,69 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
+     <item row="3" column="1">
+      <widget class="librepcb::PositiveLengthEdit" name="edtHeight" native="true"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Stroke Width:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="librepcb::UnsignedLengthEdit" name="edtStrokeWidth" native="true"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Letter Spacing:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0">
+       <item>
+        <widget class="librepcb::RatioEdit" name="edtLetterSpacingRatio" native="true"/>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbxLetterSpacingAuto">
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Line Spacing:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
+       <item>
+        <widget class="librepcb::RatioEdit" name="edtLineSpacingRatio" native="true"/>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbxLineSpacingAuto">
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="7" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Position:</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="7" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="librepcb::LengthEdit" name="edtPosX" native="true"/>
@@ -76,28 +135,24 @@
        </item>
       </layout>
      </item>
-     <item row="9" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Rotation:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Stroke Width:</string>
-       </property>
-      </widget>
+     <item row="8" column="1">
+      <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
      </item>
-     <item row="10" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="label_9">
        <property name="text">
         <string>Options:</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="9" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QCheckBox" name="cbxMirrored">
@@ -114,57 +169,6 @@
         </widget>
        </item>
       </layout>
-     </item>
-     <item row="7" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
-       <item>
-        <widget class="librepcb::RatioEdit" name="edtLineSpacingRatio" native="true"/>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbxLineSpacingAuto">
-         <property name="text">
-          <string>Auto</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Line Spacing:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_10">
-       <property name="text">
-        <string>Letter Spacing:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0">
-       <item>
-        <widget class="librepcb::RatioEdit" name="edtLetterSpacingRatio" native="true"/>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbxLetterSpacingAuto">
-         <property name="text">
-          <string>Auto</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="3" column="1">
-      <widget class="librepcb::PositiveLengthEdit" name="edtHeight" native="true"/>
-     </item>
-     <item row="4" column="1">
-      <widget class="librepcb::UnsignedLengthEdit" name="edtStrokeWidth" native="true"/>
-     </item>
-     <item row="9" column="1">
-      <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
      </item>
     </layout>
    </item>
@@ -188,12 +192,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>librepcb::AlignmentSelector</class>
-   <extends>QWidget</extends>
-   <header>widgets/alignmentselector.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>librepcb::AngleEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/common/widgets/angleedit.h</header>
@@ -212,12 +210,34 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>librepcb::AlignmentSelector</class>
+   <extends>QWidget</extends>
+   <header>widgets/alignmentselector.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>librepcb::RatioEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/common/widgets/ratioedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtText</tabstop>
+  <tabstop>cbxLayer</tabstop>
+  <tabstop>alignmentSelector</tabstop>
+  <tabstop>edtHeight</tabstop>
+  <tabstop>edtStrokeWidth</tabstop>
+  <tabstop>edtLetterSpacingRatio</tabstop>
+  <tabstop>cbxLetterSpacingAuto</tabstop>
+  <tabstop>edtLineSpacingRatio</tabstop>
+  <tabstop>cbxLineSpacingAuto</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+  <tabstop>edtRotation</tabstop>
+  <tabstop>cbxMirrored</tabstop>
+  <tabstop>cbxAutoRotate</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
@@ -69,6 +69,10 @@ TextPropertiesDialog::TextPropertiesDialog(Text& text, UndoStack& undoStack,
   mUi->edtPosX->setValue(mText.getPosition().getX());
   mUi->edtPosY->setValue(mText.getPosition().getY());
   mUi->edtRotation->setValue(mText.getRotation());
+
+  // set focus to text so the user can immediately start typing to change it
+  mUi->edtText->selectAll();
+  mUi->edtText->setFocus();
 }
 
 TextPropertiesDialog::~TextPropertiesDialog() noexcept {

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.ui
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.ui
@@ -17,16 +17,6 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Layer:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="cbxLayer"/>
-     </item>
-     <item row="1" column="0">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -39,8 +29,22 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="QPlainTextEdit" name="edtText">
+       <property name="tabChangesFocus">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Layer:</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="1">
-      <widget class="QPlainTextEdit" name="edtText"/>
+      <widget class="QComboBox" name="cbxLayer"/>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_7">
@@ -58,6 +62,9 @@
         <string>Height:</string>
        </property>
       </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="librepcb::PositiveLengthEdit" name="edtHeight" native="true"/>
      </item>
      <item row="4" column="0">
       <widget class="QLabel" name="label_4">
@@ -83,9 +90,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="librepcb::PositiveLengthEdit" name="edtHeight" native="true"/>
-     </item>
      <item row="5" column="1">
       <widget class="librepcb::AngleEdit" name="edtRotation" native="true"/>
      </item>
@@ -105,18 +109,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>librepcb::AlignmentSelector</class>
-   <extends>QWidget</extends>
-   <header>widgets/alignmentselector.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::PositiveLengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>librepcb::LengthEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/common/widgets/lengthedit.h</header>
@@ -128,7 +120,28 @@
    <header location="global">librepcb/common/widgets/angleedit.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>librepcb::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/common/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::AlignmentSelector</class>
+   <extends>QWidget</extends>
+   <header>widgets/alignmentselector.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtText</tabstop>
+  <tabstop>cbxLayer</tabstop>
+  <tabstop>alignmentSelector</tabstop>
+  <tabstop>edtHeight</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+  <tabstop>edtRotation</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.ui
@@ -34,7 +34,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QWidget" name="widget" native="true">
+      <widget class="QWidget" name="boardSideWidget" native="true">
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <property name="leftMargin">
          <number>0</number>
@@ -80,7 +80,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QWidget" name="widget_2" native="true">
+      <widget class="QWidget" name="shapeWidget" native="true">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <property name="leftMargin">
          <number>0</number>
@@ -212,6 +212,17 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>cbxPackagePad</tabstop>
+  <tabstop>boardSideWidget</tabstop>
+  <tabstop>shapeWidget</tabstop>
+  <tabstop>edtDrillDiameter</tabstop>
+  <tabstop>edtWidth</tabstop>
+  <tabstop>edtHeight</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+  <tabstop>edtRotation</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.ui
@@ -101,6 +101,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtName</tabstop>
+  <tabstop>edtLength</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+  <tabstop>edtRotation</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.ui
@@ -190,6 +190,17 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>btnRun</tabstop>
+  <tabstop>edtClearanceCopperCopper</tabstop>
+  <tabstop>edtClearanceCopperBoard</tabstop>
+  <tabstop>edtClearanceCopperNpth</tabstop>
+  <tabstop>edtMinCopperWidth</tabstop>
+  <tabstop>edtMinPthRestring</tabstop>
+  <tabstop>edtMinPthDrillDiameter</tabstop>
+  <tabstop>edtMinNpthDrillDiameter</tabstop>
+  <tabstop>edtCourtyardOffset</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardplanepropertiesdialog.ui
@@ -137,6 +137,16 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>cbxNetSignal</tabstop>
+  <tabstop>cbxLayer</tabstop>
+  <tabstop>edtMinWidth</tabstop>
+  <tabstop>edtMinClearance</tabstop>
+  <tabstop>spbPriority</tabstop>
+  <tabstop>cbxConnectStyle</tabstop>
+  <tabstop>cbKeepOrphans</tabstop>
+  <tabstop>pathEditorWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.ui
@@ -105,6 +105,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>cbxShape</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+  <tabstop>edtSize</tabstop>
+  <tabstop>edtDrillDiameter</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.ui
@@ -238,6 +238,9 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="tabChangesFocus">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
        </layout>
@@ -295,6 +298,15 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtCompInstName</tabstop>
+  <tabstop>edtCompInstValue</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+  <tabstop>edtRotation</tabstop>
+  <tabstop>cbxMirror</tabstop>
+  <tabstop>attributeListEditorWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/fabricationoutputdialog.ui
@@ -415,6 +415,35 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>edtBasePath</tabstop>
+  <tabstop>btnDefaultSuffixes</tabstop>
+  <tabstop>btnProtelSuffixes</tabstop>
+  <tabstop>edtSuffixOutlines</tabstop>
+  <tabstop>edtSuffixCopperInner</tabstop>
+  <tabstop>edtSuffixCopperTop</tabstop>
+  <tabstop>edtSuffixCopperBot</tabstop>
+  <tabstop>edtSuffixSoldermaskTop</tabstop>
+  <tabstop>edtSuffixSoldermaskBot</tabstop>
+  <tabstop>edtSuffixSilkscreenTop</tabstop>
+  <tabstop>edtSuffixSilkscreenBot</tabstop>
+  <tabstop>edtSuffixDrillsNpth</tabstop>
+  <tabstop>edtSuffixDrillsPth</tabstop>
+  <tabstop>cbxDrillsMerge</tabstop>
+  <tabstop>edtSuffixDrills</tabstop>
+  <tabstop>cbxSolderPasteTop</tabstop>
+  <tabstop>edtSuffixSolderPasteTop</tabstop>
+  <tabstop>cbxSolderPasteBot</tabstop>
+  <tabstop>edtSuffixSolderPasteBot</tabstop>
+  <tabstop>cbxSilkTopPlacement</tabstop>
+  <tabstop>cbxSilkTopNames</tabstop>
+  <tabstop>cbxSilkTopValues</tabstop>
+  <tabstop>cbxSilkBotPlacement</tabstop>
+  <tabstop>cbxSilkBotNames</tabstop>
+  <tabstop>cbxSilkBotValues</tabstop>
+  <tabstop>btnGenerate</tabstop>
+  <tabstop>btnBrowseOutputDir</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.cpp
@@ -59,6 +59,9 @@ ProjectPropertiesEditorDialog::ProjectPropertiesEditorDialog(
   mUi->lblLastModifiedDateTime->setText(
       mMetadata.getLastModified().toString(Qt::DefaultLocaleLongDate));
   mUi->attributeListEditorWidget->setReferences(nullptr, &mAttributes);
+
+  // set focus to name so the user can immediately start typing to change it
+  mUi->edtName->setFocus();
 }
 
 ProjectPropertiesEditorDialog::~ProjectPropertiesEditorDialog() noexcept {

--- a/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/projectpropertieseditordialog.ui
@@ -128,6 +128,12 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtName</tabstop>
+  <tabstop>edtAuthor</tabstop>
+  <tabstop>edtVersion</tabstop>
+  <tabstop>attributeListEditorWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/projecteditor/schematiceditor/renamenetsegmentdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/renamenetsegmentdialog.ui
@@ -91,6 +91,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cbxNetName</tabstop>
+  <tabstop>rbtnRenameNetSegmentOnly</tabstop>
+  <tabstop>rbtnRenameWholeNet</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -249,6 +249,9 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="tabChangesFocus">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
        </layout>
@@ -306,6 +309,16 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edtCompInstName</tabstop>
+  <tabstop>edtCompInstValue</tabstop>
+  <tabstop>edtSymbInstPosX</tabstop>
+  <tabstop>edtSymbInstPosY</tabstop>
+  <tabstop>edtSymbInstRotation</tabstop>
+  <tabstop>cbxMirror</tabstop>
+  <tabstop>attributeListEditorWidget</tabstop>
+  <tabstop>cbxPreselectedDevice</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
During testing of the 0.1.4 release candidate, I realized that the keyboard navigation of most dialogs with input fields was not very user friendly. This PR improves following things:

- Adjust order of widgets to always have the most important input field at the top of the dialog.
- Pre-select the value of the most important input field so one can immediately start typing a new value after opening the dialog.
- In multiline text edit widgets, make tabulator key navigating to the next widget instead of inserting a tab.
- Set reasonable tab order (usually from top to bottom).

Might make @dbrgn more happy when using LibrePCB :grin: