### PR TITLE
CI: Update Linux and macOS build environment

### DIFF
--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -11,17 +11,15 @@ jobs:
         IMAGE: librepcb/librepcb-dev:ubuntu-14.04-2
       Ubuntu_1604_GCC:
         IMAGE: librepcb/librepcb-dev:ubuntu-16.04-2
-      Ubuntu_1604_Qt_5_12_3_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.12.3-3
+      Ubuntu_1604_Qt_5_14_2_GCC:
+        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.14.2-1
         DEPLOY: true
       Ubuntu_1804_Clang:
         IMAGE: librepcb/librepcb-dev:ubuntu-18.04-2
         CC: clang
         CXX: clang++
-      Ubuntu_1904_GCC9:
-        IMAGE: librepcb/librepcb-dev:ubuntu-19.04-2
-        CC: gcc-9
-        CXX: g++-9
+      Ubuntu_2004_GCC:
+        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-1
   container: $[ variables['IMAGE'] ]
   steps:
   - checkout: self

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-QTIFW_VERSION="3.0.4"
+QTIFW_VERSION="3.2.2"
 QTIFW_URL_BASE="https://download.qt.io/official_releases/qt-installer-framework/$QTIFW_VERSION"
 
 # Install dependencies on Linux


### PR DESCRIPTION
- Update Linux jobs to latest Docker images, and thus using the latest available Qt version for our official binary releases. It also fixes missing translations of Qt built-in strings, see https://github.com/LibrePCB/LibrePCB/pull/674#issuecomment-590505008.
- Update Qt installer framework on macOS

Notes:
- I can't update the Windows build environment at the moment because of two issues:
  - ~~https://github.com/parkouss/funq/pull/71~~ Merged
  - When switching the Qt version, ccache cannot restore the cache and then we hit the AppVeyor build time limit of 60 minutes :sob: I already asked the AppVeyor team to increase the limit for LibrePCB...
- I didn't update the macOS version from 10.14 to 10.15 because it might reduce binary compatibility of our releases(?). I don't know much about macOS, but on Linux it's better to build on an old system to get maximum binary compatibility, and I suspect the same might apply to macOS.