### PR TITLE
Fix empty table row in pick&place and BOM export dialogs

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/boardpickplacegeneratordialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardpickplacegeneratordialog.cpp
@@ -110,9 +110,10 @@ void BoardPickPlaceGeneratorDialog::updateTable() noexcept {
     mUi->tableWidget->setHorizontalHeaderLabels(csv->getHeader());
     for (int column = 0; column < csv->getHeader().count(); ++column) {
       mUi->tableWidget->horizontalHeader()->setSectionResizeMode(
-          column,
-          column == 0 ? QHeaderView::ResizeToContents : QHeaderView::Stretch);
-      for (int row = 0; row < csv->getValues().count() - 1; ++row) {
+          column, (column >= 1) && (column <= 3)
+                      ? QHeaderView::Stretch
+                      : QHeaderView::ResizeToContents);
+      for (int row = 0; row < csv->getValues().count(); ++row) {
         QString text = csv->getValues()[row][column];
         text.replace("\n", " ");
         mUi->tableWidget->setItem(row, column, new QTableWidgetItem(text));

--- a/libs/librepcb/projecteditor/dialogs/bomgeneratordialog.cpp
+++ b/libs/librepcb/projecteditor/dialogs/bomgeneratordialog.cpp
@@ -153,8 +153,8 @@ void BomGeneratorDialog::updateTable() noexcept {
     for (int column = 0; column < csv->getHeader().count(); ++column) {
       mUi->tableWidget->horizontalHeader()->setSectionResizeMode(
           column,
-          column == 0 ? QHeaderView::ResizeToContents : QHeaderView::Stretch);
-      for (int row = 0; row < csv->getValues().count() - 1; ++row) {
+          column <= 1 ? QHeaderView::ResizeToContents : QHeaderView::Stretch);
+      for (int row = 0; row < csv->getValues().count(); ++row) {
         QString text = csv->getValues()[row][column];
         text.replace("\n", " ");
         mUi->tableWidget->setItem(row, column, new QTableWidgetItem(text));


### PR DESCRIPTION
There was an off-by-one index error (only in the GUI, not in the exported CSV) :(

I will merge this as soon as CI succeeds since it should be contained in the 0.1.4 release.