### PR TITLE
Library editor: Disable "move to other library" if empty

### DIFF
--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -395,6 +395,8 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
         aMoveToLibChildren.insert(action, item.filepath);
       }
     }
+    // Disable menu item if it doesn't contain children.
+    menuMoveToLib->setEnabled(!aMoveToLibChildren.isEmpty());
   }
   QAction* aNew = menu.addAction(QIcon(":/img/actions/new.png"), tr("New"));
   aNew->setVisible(selectedItemPaths.count() <= 1);


### PR DESCRIPTION
If no local libraries are available, the context menu item "move to other library" did not contain children, which looks strange. Now the menu item is disabled if it doesn't contain children.

I will merge this as soon as CI succeeds since it should be contained in the 0.1.4 release.