### PR TITLE
Move model-view classes from library to library::editor

### DIFF
--- a/libs/librepcb/library/library.pro
+++ b/libs/librepcb/library/library.pro
@@ -39,13 +39,9 @@ SOURCES += \
     cmp/component.cpp \
     cmp/componentcheck.cpp \
     cmp/componentpinsignalmap.cpp \
-    cmp/componentpinsignalmapmodel.cpp \
     cmp/componentsignal.cpp \
-    cmp/componentsignallistmodel.cpp \
     cmp/componentsymbolvariant.cpp \
     cmp/componentsymbolvariantitem.cpp \
-    cmp/componentsymbolvariantitemlistmodel.cpp \
-    cmp/componentsymbolvariantlistmodel.cpp \
     cmp/msg/msgduplicatesignalname.cpp \
     cmp/msg/msgmissingcomponentdefaultvalue.cpp \
     cmp/msg/msgmissingcomponentprefix.cpp \
@@ -56,13 +52,11 @@ SOURCES += \
     dev/device.cpp \
     dev/devicecheck.cpp \
     dev/devicepadsignalmap.cpp \
-    dev/devicepadsignalmapmodel.cpp \
     dev/msg/msgnopadsindeviceconnected.cpp \
     library.cpp \
     librarybaseelement.cpp \
     librarybaseelementcheck.cpp \
     libraryelement.cpp \
-    libraryelementcache.cpp \
     libraryelementcheck.cpp \
     msg/libraryelementcheckmessage.cpp \
     msg/msgmissingauthor.cpp \
@@ -73,7 +67,6 @@ SOURCES += \
     pkg/cmd/cmdpackagepadedit.cpp \
     pkg/footprint.cpp \
     pkg/footprintgraphicsitem.cpp \
-    pkg/footprintlistmodel.cpp \
     pkg/footprintpad.cpp \
     pkg/footprintpadgraphicsitem.cpp \
     pkg/footprintpadpreviewgraphicsitem.cpp \
@@ -87,7 +80,6 @@ SOURCES += \
     pkg/package.cpp \
     pkg/packagecheck.cpp \
     pkg/packagepad.cpp \
-    pkg/packagepadlistmodel.cpp \
     sym/cmd/cmdsymbolpinedit.cpp \
     sym/msg/msgduplicatepinname.cpp \
     sym/msg/msgmissingsymbolname.cpp \
@@ -120,15 +112,11 @@ HEADERS += \
     cmp/component.h \
     cmp/componentcheck.h \
     cmp/componentpinsignalmap.h \
-    cmp/componentpinsignalmapmodel.h \
     cmp/componentprefix.h \
     cmp/componentsignal.h \
-    cmp/componentsignallistmodel.h \
     cmp/componentsymbolvariant.h \
     cmp/componentsymbolvariantitem.h \
-    cmp/componentsymbolvariantitemlistmodel.h \
     cmp/componentsymbolvariantitemsuffix.h \
-    cmp/componentsymbolvariantlistmodel.h \
     cmp/msg/msgduplicatesignalname.h \
     cmp/msg/msgmissingcomponentdefaultvalue.h \
     cmp/msg/msgmissingcomponentprefix.h \
@@ -139,14 +127,12 @@ HEADERS += \
     dev/device.h \
     dev/devicecheck.h \
     dev/devicepadsignalmap.h \
-    dev/devicepadsignalmapmodel.h \
     dev/msg/msgnopadsindeviceconnected.h \
     elements.h \
     library.h \
     librarybaseelement.h \
     librarybaseelementcheck.h \
     libraryelement.h \
-    libraryelementcache.h \
     libraryelementcheck.h \
     msg/libraryelementcheckmessage.h \
     msg/msgmissingauthor.h \
@@ -157,7 +143,6 @@ HEADERS += \
     pkg/cmd/cmdpackagepadedit.h \
     pkg/footprint.h \
     pkg/footprintgraphicsitem.h \
-    pkg/footprintlistmodel.h \
     pkg/footprintpad.h \
     pkg/footprintpadgraphicsitem.h \
     pkg/footprintpadpreviewgraphicsitem.h \
@@ -171,7 +156,6 @@ HEADERS += \
     pkg/package.h \
     pkg/packagecheck.h \
     pkg/packagepad.h \
-    pkg/packagepadlistmodel.h \
     sym/cmd/cmdsymbolpinedit.h \
     sym/msg/msgduplicatepinname.h \
     sym/msg/msgmissingsymbolname.h \

--- a/libs/librepcb/libraryeditor/cmp/componentpinsignalmapmodel.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentpinsignalmapmodel.cpp
@@ -22,10 +22,10 @@
  ******************************************************************************/
 #include "componentpinsignalmapmodel.h"
 
-#include "cmd/cmdcomponentpinsignalmapitemedit.h"
-#include "librepcb/library/libraryelementcache.h"
+#include "../libraryelementcache.h"
 
 #include <librepcb/common/undostack.h>
+#include <librepcb/library/cmp/cmd/cmdcomponentpinsignalmapitemedit.h>
 #include <librepcb/library/sym/symbol.h>
 
 #include <QtCore>
@@ -37,6 +37,7 @@
  ******************************************************************************/
 namespace librepcb {
 namespace library {
+namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -413,5 +414,6 @@ void ComponentPinSignalMapModel::getRowItem(
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -24,7 +24,7 @@
 
 #include <librepcb/common/model/sortfilterproxymodel.h>
 #include <librepcb/common/widgets/editabletablewidget.h>
-#include <librepcb/library/cmp/componentsignallistmodel.h>
+#include <librepcb/libraryeditor/cmp/componentsignallistmodel.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
@@ -38,10 +38,9 @@ class EditableTableWidget;
 class SortFilterProxyModel;
 
 namespace library {
+namespace editor {
 
 class ComponentSignalListModel;
-
-namespace editor {
 
 /*******************************************************************************
  *  Class ComponentSignalListEditorWidget

--- a/libs/librepcb/libraryeditor/cmp/componentsignallistmodel.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallistmodel.h
@@ -17,16 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_COMPONENTPINSIGNALMAPMODEL_H
-#define LIBREPCB_LIBRARY_COMPONENTPINSIGNALMAPMODEL_H
+#ifndef LIBREPCB_LIBRARY_EDITOR_COMPONENTSIGNALLISTMODEL_H
+#define LIBREPCB_LIBRARY_EDITOR_COMPONENTSIGNALLISTMODEL_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "componentsignal.h"
-#include "componentsymbolvariant.h"
-
-#include <librepcb/common/model/comboboxdelegate.h>
+#include <librepcb/library/cmp/componentsignal.h>
 
 #include <QtCore>
 
@@ -38,43 +35,40 @@ namespace librepcb {
 class UndoStack;
 
 namespace library {
-
-class LibraryElementCache;
+namespace editor {
 
 /*******************************************************************************
- *  Class ComponentPinSignalMapModel
+ *  Class ComponentSignalListModel
  ******************************************************************************/
 
 /**
- * @brief The ComponentPinSignalMapModel class
+ * @brief The ComponentSignalListModel class
  */
-class ComponentPinSignalMapModel final : public QAbstractTableModel {
+class ComponentSignalListModel final : public QAbstractTableModel {
   Q_OBJECT
 
 public:
   enum Column {
-    COLUMN_SYMBOL,
-    COLUMN_PIN,
-    COLUMN_SIGNAL,
-    COLUMN_DISPLAY,
+    COLUMN_NAME,
+    COLUMN_ISREQUIRED,
+    COLUMN_FORCEDNETNAME,
+    COLUMN_ACTIONS,
     _COLUMN_COUNT
   };
 
   // Constructors / Destructor
-  ComponentPinSignalMapModel() = delete;
-  ComponentPinSignalMapModel(const ComponentPinSignalMapModel& other) noexcept;
-  explicit ComponentPinSignalMapModel(QObject* parent = nullptr) noexcept;
-  ~ComponentPinSignalMapModel() noexcept;
+  ComponentSignalListModel() = delete;
+  ComponentSignalListModel(const ComponentSignalListModel& other) noexcept;
+  explicit ComponentSignalListModel(QObject* parent = nullptr) noexcept;
+  ~ComponentSignalListModel() noexcept;
 
   // Setters
-  void setSymbolVariant(ComponentSymbolVariant* variant) noexcept;
-  void setSignalList(const ComponentSignalList* list) noexcept;
-  void setSymbolsCache(
-      const std::shared_ptr<const LibraryElementCache>& cache) noexcept;
+  void setSignalList(ComponentSignalList* list) noexcept;
   void setUndoStack(UndoStack* stack) noexcept;
 
-  // General Methods
-  void autoAssignSignals() noexcept;
+  // Slots
+  void addSignal(const QVariant& editData) noexcept;
+  void removeSignal(const QVariant& editData) noexcept;
 
   // Inherited from QAbstractItemModel
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -88,42 +82,34 @@ public:
                         int role = Qt::EditRole) override;
 
   // Operator Overloadings
-  ComponentPinSignalMapModel& operator=(
-      const ComponentPinSignalMapModel& rhs) noexcept;
+  ComponentSignalListModel& operator=(
+      const ComponentSignalListModel& rhs) noexcept;
 
 private:
-  void symbolItemsEdited(
-      const ComponentSymbolVariantItemList& list, int index,
-      const std::shared_ptr<const ComponentSymbolVariantItem>& item,
-      ComponentSymbolVariantItemList::Event                    event) noexcept;
-  void signalListEdited(const ComponentSignalList& list, int index,
-                        const std::shared_ptr<const ComponentSignal>& signal,
-                        ComponentSignalList::Event event) noexcept;
-  void execCmd(UndoCommand* cmd);
-  void updateSignalComboBoxItems() noexcept;
-  void getRowItem(int row, int& symbolItemIndex,
-                  std::shared_ptr<ComponentSymbolVariantItem>& symbolItem,
-                  std::shared_ptr<ComponentPinSignalMapItem>&  mapItem) const
-      noexcept;
+  void              signalListEdited(const ComponentSignalList& list, int index,
+                                     const std::shared_ptr<const ComponentSignal>& signal,
+                                     ComponentSignalList::Event event) noexcept;
+  void              execCmd(UndoCommand* cmd);
+  CircuitIdentifier validateNameOrThrow(const QString& name) const;
+  static QString    cleanForcedNetName(const QString& name) noexcept;
 
 private:  // Data
-  ComponentSymbolVariant*                    mSymbolVariant;
-  const ComponentSignalList*                 mSignals;
-  std::shared_ptr<const LibraryElementCache> mSymbolsCache;
-  UndoStack*                                 mUndoStack;
-  ComboBoxDelegate::Items                    mSignalComboBoxItems;
-  ComboBoxDelegate::Items                    mDisplayTypeComboBoxItems;
+  ComponentSignalList* mSignalList;
+  UndoStack*           mUndoStack;
+  QString              mNewName;
+  bool                 mNewIsRequired;
+  QString              mNewForcedNetName;
 
   // Slots
-  ComponentSymbolVariantItemList::OnEditedSlot mOnItemsEditedSlot;
-  ComponentSignalList::OnEditedSlot            mOnSignalsEditedSlot;
+  ComponentSignalList::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_COMPONENTPINSIGNALMAPMODEL_H
+#endif

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
@@ -30,9 +30,9 @@
 #include <librepcb/common/norms.h>
 #include <librepcb/library/cmp/component.h>
 #include <librepcb/library/cmp/componentsymbolvariant.h>
-#include <librepcb/library/libraryelementcache.h>
 #include <librepcb/library/sym/symbol.h>
 #include <librepcb/library/sym/symbolgraphicsitem.h>
+#include <librepcb/libraryeditor/libraryelementcache.h>
 #include <librepcb/workspace/library/workspacelibrarydb.h>
 #include <librepcb/workspace/workspace.h>
 

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.h
@@ -46,9 +46,10 @@ namespace library {
 class Component;
 class Symbol;
 class SymbolGraphicsItem;
-class LibraryElementCache;
 
 namespace editor {
+
+class LibraryElementCache;
 
 namespace Ui {
 class ComponentSymbolVariantEditDialog;

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
@@ -25,7 +25,7 @@
 #include "../common/symbolchooserdialog.h"
 
 #include <librepcb/common/widgets/editabletablewidget.h>
-#include <librepcb/library/cmp/componentsymbolvariantitemlistmodel.h>
+#include <librepcb/libraryeditor/cmp/componentsymbolvariantitemlistmodel.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.h
@@ -42,11 +42,10 @@ class Workspace;
 }
 
 namespace library {
+namespace editor {
 
 class LibraryElementCache;
 class ComponentSymbolVariantItemListModel;
-
-namespace editor {
 
 /*******************************************************************************
  *  Class ComponentSymbolVariantItemListEditorWidget

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlistmodel.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlistmodel.cpp
@@ -23,11 +23,11 @@
 #include "componentsymbolvariantitemlistmodel.h"
 
 #include "../libraryelementcache.h"
-#include "../sym/symbol.h"
-#include "cmd/cmdcomponentsymbolvariantedit.h"
-#include "cmd/cmdcomponentsymbolvariantitemedit.h"
 
 #include <librepcb/common/undostack.h>
+#include <librepcb/library/cmp/cmd/cmdcomponentsymbolvariantedit.h>
+#include <librepcb/library/cmp/cmd/cmdcomponentsymbolvariantitemedit.h>
+#include <librepcb/library/sym/symbol.h>
 
 #include <QtCore>
 
@@ -36,6 +36,7 @@
  ******************************************************************************/
 namespace librepcb {
 namespace library {
+namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -516,5 +517,6 @@ void ComponentSymbolVariantItemListModel::execCmd(UndoCommand* cmd) {
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlistmodel.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlistmodel.h
@@ -17,13 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_COMPONENTSYMBOLVARIANTITEMLISTMODEL_H
-#define LIBREPCB_LIBRARY_COMPONENTSYMBOLVARIANTITEMLISTMODEL_H
+#ifndef LIBREPCB_LIBRARY_EDITOR_COMPONENTSYMBOLVARIANTITEMLISTMODEL_H
+#define LIBREPCB_LIBRARY_EDITOR_COMPONENTSYMBOLVARIANTITEMLISTMODEL_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "componentsymbolvariant.h"
+#include <librepcb/library/cmp/componentsymbolvariant.h>
 
 #include <QtCore>
 
@@ -35,6 +35,7 @@ namespace librepcb {
 class UndoStack;
 
 namespace library {
+namespace editor {
 
 class LibraryElementCache;
 
@@ -122,7 +123,8 @@ private:  // Data
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_COMPONENTSYMBOLVARIANTITEMLISTMODEL_H
+#endif

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistmodel.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistmodel.cpp
@@ -22,9 +22,8 @@
  ******************************************************************************/
 #include "componentsymbolvariantlistmodel.h"
 
-#include "cmd/cmdcomponentsymbolvariantedit.h"
-
 #include <librepcb/common/undostack.h>
+#include <librepcb/library/cmp/cmd/cmdcomponentsymbolvariantedit.h>
 
 #include <QtCore>
 
@@ -33,6 +32,7 @@
  ******************************************************************************/
 namespace librepcb {
 namespace library {
+namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -412,5 +412,6 @@ ElementName ComponentSymbolVariantListModel::validateNameOrThrow(
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistmodel.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistmodel.h
@@ -17,13 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_COMPONENTSIGNALLISTMODEL_H
-#define LIBREPCB_LIBRARY_COMPONENTSIGNALLISTMODEL_H
+#ifndef LIBREPCB_LIBRARY_EDITOR_COMPONENTSYMBOLVARIANTLISTMODEL_H
+#define LIBREPCB_LIBRARY_EDITOR_COMPONENTSYMBOLVARIANTLISTMODEL_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "componentsignal.h"
+#include <librepcb/library/cmp/componentsymbolvariant.h>
 
 #include <QtCore>
 
@@ -35,39 +35,44 @@ namespace librepcb {
 class UndoStack;
 
 namespace library {
+namespace editor {
 
 /*******************************************************************************
- *  Class ComponentSignalListModel
+ *  Class ComponentSymbolVariantListModel
  ******************************************************************************/
 
 /**
- * @brief The ComponentSignalListModel class
+ * @brief The ComponentSymbolVariantListModel class
  */
-class ComponentSignalListModel final : public QAbstractTableModel {
+class ComponentSymbolVariantListModel final : public QAbstractTableModel {
   Q_OBJECT
 
 public:
   enum Column {
     COLUMN_NAME,
-    COLUMN_ISREQUIRED,
-    COLUMN_FORCEDNETNAME,
+    COLUMN_DESCRIPTION,
+    COLUMN_NORM,
+    COLUMN_SYMBOLCOUNT,
     COLUMN_ACTIONS,
     _COLUMN_COUNT
   };
 
   // Constructors / Destructor
-  ComponentSignalListModel() = delete;
-  ComponentSignalListModel(const ComponentSignalListModel& other) noexcept;
-  explicit ComponentSignalListModel(QObject* parent = nullptr) noexcept;
-  ~ComponentSignalListModel() noexcept;
+  ComponentSymbolVariantListModel() = delete;
+  ComponentSymbolVariantListModel(
+      const ComponentSymbolVariantListModel& other) noexcept;
+  explicit ComponentSymbolVariantListModel(QObject* parent = nullptr) noexcept;
+  ~ComponentSymbolVariantListModel() noexcept;
 
   // Setters
-  void setSignalList(ComponentSignalList* list) noexcept;
+  void setSymbolVariantList(ComponentSymbolVariantList* list) noexcept;
   void setUndoStack(UndoStack* stack) noexcept;
 
   // Slots
-  void addSignal(const QVariant& editData) noexcept;
-  void removeSignal(const QVariant& editData) noexcept;
+  void addSymbolVariant(const QVariant& editData) noexcept;
+  void removeSymbolVariant(const QVariant& editData) noexcept;
+  void moveSymbolVariantUp(const QVariant& editData) noexcept;
+  void moveSymbolVariantDown(const QVariant& editData) noexcept;
 
   // Inherited from QAbstractItemModel
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -81,33 +86,34 @@ public:
                         int role = Qt::EditRole) override;
 
   // Operator Overloadings
-  ComponentSignalListModel& operator=(
-      const ComponentSignalListModel& rhs) noexcept;
+  ComponentSymbolVariantListModel& operator=(
+      const ComponentSymbolVariantListModel& rhs) noexcept;
 
 private:
-  void              signalListEdited(const ComponentSignalList& list, int index,
-                                     const std::shared_ptr<const ComponentSignal>& signal,
-                                     ComponentSignalList::Event event) noexcept;
-  void              execCmd(UndoCommand* cmd);
-  CircuitIdentifier validateNameOrThrow(const QString& name) const;
-  static QString    cleanForcedNetName(const QString& name) noexcept;
+  void symbolVariantListEdited(
+      const ComponentSymbolVariantList& list, int index,
+      const std::shared_ptr<const ComponentSymbolVariant>& variant,
+      ComponentSymbolVariantList::Event                    event) noexcept;
+  void        execCmd(UndoCommand* cmd);
+  ElementName validateNameOrThrow(const QString& name) const;
 
 private:  // Data
-  ComponentSignalList* mSignalList;
-  UndoStack*           mUndoStack;
-  QString              mNewName;
-  bool                 mNewIsRequired;
-  QString              mNewForcedNetName;
+  ComponentSymbolVariantList* mSymbolVariantList;
+  UndoStack*                  mUndoStack;
+  QString                     mNewName;
+  QString                     mNewDescription;
+  QString                     mNewNorm;
 
   // Slots
-  ComponentSignalList::OnEditedSlot mOnEditedSlot;
+  ComponentSymbolVariantList::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_COMPONENTSIGNALLISTMODEL_H
+#endif

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
@@ -25,7 +25,7 @@
 #include <librepcb/common/undostack.h>
 #include <librepcb/common/widgets/editabletablewidget.h>
 #include <librepcb/library/cmp/cmd/cmdcomponentsymbolvariantedit.h>
-#include <librepcb/library/cmp/componentsymbolvariantlistmodel.h>
+#include <librepcb/libraryeditor/cmp/componentsymbolvariantlistmodel.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
@@ -39,10 +39,9 @@ class UndoStack;
 class EditableTableWidget;
 
 namespace library {
+namespace editor {
 
 class ComponentSymbolVariantListModel;
-
-namespace editor {
 
 /*******************************************************************************
  *  Class ComponentSymbolVariantListWidget

--- a/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.cpp
@@ -24,7 +24,7 @@
 
 #include <librepcb/common/model/comboboxdelegate.h>
 #include <librepcb/common/model/sortfilterproxymodel.h>
-#include <librepcb/library/cmp/componentpinsignalmapmodel.h>
+#include <librepcb/libraryeditor/cmp/componentpinsignalmapmodel.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.h
@@ -38,11 +38,12 @@ class SortFilterProxyModel;
 
 namespace library {
 
-class LibraryElementCache;
 class ComponentSymbolVariant;
-class ComponentPinSignalMapModel;
 
 namespace editor {
+
+class LibraryElementCache;
+class ComponentPinSignalMapModel;
 
 /*******************************************************************************
  *  Class CompSymbVarPinSignalMapEditorWidget

--- a/libs/librepcb/libraryeditor/dev/devicepadsignalmapmodel.cpp
+++ b/libs/librepcb/libraryeditor/dev/devicepadsignalmapmodel.cpp
@@ -22,9 +22,8 @@
  ******************************************************************************/
 #include "devicepadsignalmapmodel.h"
 
-#include "cmd/cmddevicepadsignalmapitemedit.h"
-
 #include <librepcb/common/undostack.h>
+#include <librepcb/library/dev/cmd/cmddevicepadsignalmapitemedit.h>
 
 #include <QtCore>
 
@@ -35,6 +34,7 @@
  ******************************************************************************/
 namespace librepcb {
 namespace library {
+namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -280,5 +280,6 @@ void DevicePadSignalMapModel::updateComboBoxItems() noexcept {
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb

--- a/libs/librepcb/libraryeditor/dev/devicepadsignalmapmodel.h
+++ b/libs/librepcb/libraryeditor/dev/devicepadsignalmapmodel.h
@@ -17,13 +17,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_COMPONENTSYMBOLVARIANTLISTMODEL_H
-#define LIBREPCB_LIBRARY_COMPONENTSYMBOLVARIANTLISTMODEL_H
+#ifndef LIBREPCB_LIBRARY_EDITOR_DEVICEPADSIGNALMAPMODEL_H
+#define LIBREPCB_LIBRARY_EDITOR_DEVICEPADSIGNALMAPMODEL_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "componentsymbolvariant.h"
+#include <librepcb/common/model/comboboxdelegate.h>
+#include <librepcb/library/cmp/componentsignal.h>
+#include <librepcb/library/dev/devicepadsignalmap.h>
+#include <librepcb/library/pkg/packagepad.h>
 
 #include <QtCore>
 
@@ -35,43 +38,32 @@ namespace librepcb {
 class UndoStack;
 
 namespace library {
+namespace editor {
 
 /*******************************************************************************
- *  Class ComponentSymbolVariantListModel
+ *  Class DevicePadSignalMapModel
  ******************************************************************************/
 
 /**
- * @brief The ComponentSymbolVariantListModel class
+ * @brief The DevicePadSignalMapModel class
  */
-class ComponentSymbolVariantListModel final : public QAbstractTableModel {
+class DevicePadSignalMapModel final : public QAbstractTableModel {
   Q_OBJECT
 
 public:
-  enum Column {
-    COLUMN_NAME,
-    COLUMN_DESCRIPTION,
-    COLUMN_NORM,
-    COLUMN_SYMBOLCOUNT,
-    COLUMN_ACTIONS,
-    _COLUMN_COUNT
-  };
+  enum Column { COLUMN_PAD, COLUMN_SIGNAL, _COLUMN_COUNT };
 
   // Constructors / Destructor
-  ComponentSymbolVariantListModel() = delete;
-  ComponentSymbolVariantListModel(
-      const ComponentSymbolVariantListModel& other) noexcept;
-  explicit ComponentSymbolVariantListModel(QObject* parent = nullptr) noexcept;
-  ~ComponentSymbolVariantListModel() noexcept;
+  DevicePadSignalMapModel() = delete;
+  DevicePadSignalMapModel(const DevicePadSignalMapModel& other) noexcept;
+  explicit DevicePadSignalMapModel(QObject* parent = nullptr) noexcept;
+  ~DevicePadSignalMapModel() noexcept;
 
   // Setters
-  void setSymbolVariantList(ComponentSymbolVariantList* list) noexcept;
+  void setPadSignalMap(DevicePadSignalMap* map) noexcept;
   void setUndoStack(UndoStack* stack) noexcept;
-
-  // Slots
-  void addSymbolVariant(const QVariant& editData) noexcept;
-  void removeSymbolVariant(const QVariant& editData) noexcept;
-  void moveSymbolVariantUp(const QVariant& editData) noexcept;
-  void moveSymbolVariantDown(const QVariant& editData) noexcept;
+  void setSignalList(const ComponentSignalList& list) noexcept;
+  void setPadList(const PackagePadList& list) noexcept;
 
   // Inherited from QAbstractItemModel
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -85,33 +77,34 @@ public:
                         int role = Qt::EditRole) override;
 
   // Operator Overloadings
-  ComponentSymbolVariantListModel& operator=(
-      const ComponentSymbolVariantListModel& rhs) noexcept;
+  DevicePadSignalMapModel& operator=(
+      const DevicePadSignalMapModel& rhs) noexcept;
 
 private:
-  void symbolVariantListEdited(
-      const ComponentSymbolVariantList& list, int index,
-      const std::shared_ptr<const ComponentSymbolVariant>& variant,
-      ComponentSymbolVariantList::Event                    event) noexcept;
-  void        execCmd(UndoCommand* cmd);
-  ElementName validateNameOrThrow(const QString& name) const;
+  void padSignalMapEdited(
+      const DevicePadSignalMap& map, int index,
+      const std::shared_ptr<const DevicePadSignalMapItem>& item,
+      DevicePadSignalMap::Event                            event) noexcept;
+  void execCmd(UndoCommand* cmd);
+  void updateComboBoxItems() noexcept;
 
 private:  // Data
-  ComponentSymbolVariantList* mSymbolVariantList;
-  UndoStack*                  mUndoStack;
-  QString                     mNewName;
-  QString                     mNewDescription;
-  QString                     mNewNorm;
+  DevicePadSignalMap*     mPadSignalMap;
+  UndoStack*              mUndoStack;
+  ComponentSignalList     mSignals;
+  PackagePadList          mPads;
+  ComboBoxDelegate::Items mComboBoxItems;
 
   // Slots
-  ComponentSymbolVariantList::OnEditedSlot mOnEditedSlot;
+  DevicePadSignalMap::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_COMPONENTSYMBOLVARIANTLISTMODEL_H
+#endif

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
@@ -24,7 +24,7 @@
 
 #include <librepcb/common/model/comboboxdelegate.h>
 #include <librepcb/common/model/sortfilterproxymodel.h>
-#include <librepcb/library/dev/devicepadsignalmapmodel.h>
+#include <librepcb/libraryeditor/dev/devicepadsignalmapmodel.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
@@ -43,10 +43,9 @@ class Workspace;
 }
 
 namespace library {
+namespace editor {
 
 class DevicePadSignalMapModel;
-
-namespace editor {
 
 /*******************************************************************************
  *  Class PadSignalMapEditorWidget

--- a/libs/librepcb/libraryeditor/libraryeditor.pro
+++ b/libs/librepcb/libraryeditor/libraryeditor.pro
@@ -25,9 +25,13 @@ RESOURCES += \
 SOURCES += \
     cmp/cmpsigpindisplaytypecombobox.cpp \
     cmp/componenteditorwidget.cpp \
+    cmp/componentpinsignalmapmodel.cpp \
     cmp/componentsignallisteditorwidget.cpp \
+    cmp/componentsignallistmodel.cpp \
     cmp/componentsymbolvarianteditdialog.cpp \
     cmp/componentsymbolvariantitemlisteditorwidget.cpp \
+    cmp/componentsymbolvariantitemlistmodel.cpp \
+    cmp/componentsymbolvariantlistmodel.cpp \
     cmp/componentsymbolvariantlistwidget.cpp \
     cmp/compsymbvarpinsignalmapeditorwidget.cpp \
     cmpcat/componentcategoryeditorwidget.cpp \
@@ -40,10 +44,12 @@ SOURCES += \
     common/packagechooserdialog.cpp \
     common/symbolchooserdialog.cpp \
     dev/deviceeditorwidget.cpp \
+    dev/devicepadsignalmapmodel.cpp \
     dev/padsignalmapeditorwidget.cpp \
     lib/librarylisteditorwidget.cpp \
     lib/libraryoverviewwidget.cpp \
     libraryeditor.cpp \
+    libraryelementcache.cpp \
     newelementwizard/newelementwizard.cpp \
     newelementwizard/newelementwizardcontext.cpp \
     newelementwizard/newelementwizardpage_choosetype.cpp \
@@ -58,6 +64,7 @@ SOURCES += \
     pkg/dialogs/footprintpadpropertiesdialog.cpp \
     pkg/footprintclipboarddata.cpp \
     pkg/footprintlisteditorwidget.cpp \
+    pkg/footprintlistmodel.cpp \
     pkg/fsm/cmd/cmddragselectedfootprintitems.cpp \
     pkg/fsm/cmd/cmdpastefootprintitems.cpp \
     pkg/fsm/cmd/cmdremoveselectedfootprintitems.cpp \
@@ -77,6 +84,7 @@ SOURCES += \
     pkg/fsm/packageeditorstate_select.cpp \
     pkg/packageeditorwidget.cpp \
     pkg/packagepadlisteditorwidget.cpp \
+    pkg/packagepadlistmodel.cpp \
     pkg/widgets/boardsideselectorwidget.cpp \
     pkg/widgets/footprintpadshapeselectorwidget.cpp \
     pkg/widgets/packagepadcombobox.cpp \
@@ -104,9 +112,13 @@ SOURCES += \
 HEADERS += \
     cmp/cmpsigpindisplaytypecombobox.h \
     cmp/componenteditorwidget.h \
+    cmp/componentpinsignalmapmodel.h \
     cmp/componentsignallisteditorwidget.h \
+    cmp/componentsignallistmodel.h \
     cmp/componentsymbolvarianteditdialog.h \
     cmp/componentsymbolvariantitemlisteditorwidget.h \
+    cmp/componentsymbolvariantitemlistmodel.h \
+    cmp/componentsymbolvariantlistmodel.h \
     cmp/componentsymbolvariantlistwidget.h \
     cmp/compsymbvarpinsignalmapeditorwidget.h \
     cmp/if_componentsymbolvarianteditorprovider.h \
@@ -120,10 +132,12 @@ HEADERS += \
     common/packagechooserdialog.h \
     common/symbolchooserdialog.h \
     dev/deviceeditorwidget.h \
+    dev/devicepadsignalmapmodel.h \
     dev/padsignalmapeditorwidget.h \
     lib/librarylisteditorwidget.h \
     lib/libraryoverviewwidget.h \
     libraryeditor.h \
+    libraryelementcache.h \
     newelementwizard/newelementwizard.h \
     newelementwizard/newelementwizardcontext.h \
     newelementwizard/newelementwizardpage_choosetype.h \
@@ -138,6 +152,7 @@ HEADERS += \
     pkg/dialogs/footprintpadpropertiesdialog.h \
     pkg/footprintclipboarddata.h \
     pkg/footprintlisteditorwidget.h \
+    pkg/footprintlistmodel.h \
     pkg/fsm/cmd/cmddragselectedfootprintitems.h \
     pkg/fsm/cmd/cmdpastefootprintitems.h \
     pkg/fsm/cmd/cmdremoveselectedfootprintitems.h \
@@ -157,6 +172,7 @@ HEADERS += \
     pkg/fsm/packageeditorstate_select.h \
     pkg/packageeditorwidget.h \
     pkg/packagepadlisteditorwidget.h \
+    pkg/packagepadlistmodel.h \
     pkg/widgets/boardsideselectorwidget.h \
     pkg/widgets/footprintpadshapeselectorwidget.h \
     pkg/widgets/packagepadcombobox.h \

--- a/libs/librepcb/libraryeditor/libraryelementcache.cpp
+++ b/libs/librepcb/libraryeditor/libraryelementcache.cpp
@@ -22,9 +22,8 @@
  ******************************************************************************/
 #include "libraryelementcache.h"
 
-#include "elements.h"
-
 #include <librepcb/common/fileio/transactionalfilesystem.h>
+#include <librepcb/library/elements.h>
 #include <librepcb/workspace/library/workspacelibrarydb.h>
 
 #include <QtCore>
@@ -34,6 +33,7 @@
  ******************************************************************************/
 namespace librepcb {
 namespace library {
+namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -114,5 +114,6 @@ std::shared_ptr<const T> LibraryElementCache::getElement(
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb

--- a/libs/librepcb/libraryeditor/libraryelementcache.h
+++ b/libs/librepcb/libraryeditor/libraryelementcache.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_LIBRARYELEMENTCACHE_H
-#define LIBREPCB_LIBRARY_LIBRARYELEMENTCACHE_H
+#ifndef LIBREPCB_LIBRARY_EDITOR_LIBRARYELEMENTCACHE_H
+#define LIBREPCB_LIBRARY_EDITOR_LIBRARYELEMENTCACHE_H
 
 /*******************************************************************************
  *  Includes
@@ -47,6 +47,8 @@ class Symbol;
 class Package;
 class Component;
 class Device;
+
+namespace editor {
 
 /*******************************************************************************
  *  Class LibraryElementCache
@@ -101,7 +103,8 @@ private:  // Data
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_LIBRARYELEMENTCACHE_H
+#endif

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentpinsignalmap.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentpinsignalmap.cpp
@@ -25,7 +25,7 @@
 #include "ui_newelementwizardpage_componentpinsignalmap.h"
 
 #include <librepcb/library/cmp/component.h>
-#include <librepcb/library/libraryelementcache.h>
+#include <librepcb/libraryeditor/libraryelementcache.h>
 #include <librepcb/workspace/workspace.h>
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsymbols.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_componentsymbols.cpp
@@ -25,7 +25,7 @@
 #include "ui_newelementwizardpage_componentsymbols.h"
 
 #include <librepcb/library/cmp/component.h>
-#include <librepcb/library/libraryelementcache.h>
+#include <librepcb/libraryeditor/libraryelementcache.h>
 #include <librepcb/workspace/workspace.h>
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
@@ -23,7 +23,7 @@
 #include "footprintlisteditorwidget.h"
 
 #include <librepcb/common/widgets/editabletablewidget.h>
-#include <librepcb/library/pkg/footprintlistmodel.h>
+#include <librepcb/libraryeditor/pkg/footprintlistmodel.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
@@ -37,10 +37,9 @@ class UndoStack;
 class EditableTableWidget;
 
 namespace library {
+namespace editor {
 
 class FootprintListModel;
-
-namespace editor {
 
 /*******************************************************************************
  *  Class FootprintListEditorWidget

--- a/libs/librepcb/libraryeditor/pkg/footprintlistmodel.cpp
+++ b/libs/librepcb/libraryeditor/pkg/footprintlistmodel.cpp
@@ -22,9 +22,8 @@
  ******************************************************************************/
 #include "footprintlistmodel.h"
 
-#include "cmd/cmdfootprintedit.h"
-
 #include <librepcb/common/undostack.h>
+#include <librepcb/library/pkg/cmd/cmdfootprintedit.h>
 
 #include <QtCore>
 
@@ -33,6 +32,7 @@
  ******************************************************************************/
 namespace librepcb {
 namespace library {
+namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -359,5 +359,6 @@ ElementName FootprintListModel::validateNameOrThrow(const QString& name) const {
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb

--- a/libs/librepcb/libraryeditor/pkg/footprintlistmodel.h
+++ b/libs/librepcb/libraryeditor/pkg/footprintlistmodel.h
@@ -17,13 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_FOOTPRINTLISTMODEL_H
-#define LIBREPCB_LIBRARY_FOOTPRINTLISTMODEL_H
+#ifndef LIBREPCB_LIBRARY_EDITOR_FOOTPRINTLISTMODEL_H
+#define LIBREPCB_LIBRARY_EDITOR_FOOTPRINTLISTMODEL_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "footprint.h"
+#include <librepcb/library/pkg/footprint.h>
 
 #include <QtCore>
 
@@ -35,6 +35,7 @@ namespace librepcb {
 class UndoStack;
 
 namespace library {
+namespace editor {
 
 /*******************************************************************************
  *  Class FootprintListModel
@@ -100,7 +101,8 @@ private:  // Data
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_FOOTPRINTLISTMODEL_H
+#endif

--- a/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.cpp
@@ -24,7 +24,7 @@
 
 #include <librepcb/common/model/sortfilterproxymodel.h>
 #include <librepcb/common/widgets/editabletablewidget.h>
-#include <librepcb/library/pkg/packagepadlistmodel.h>
+#include <librepcb/libraryeditor/pkg/packagepadlistmodel.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
@@ -38,10 +38,9 @@ class EditableTableWidget;
 class SortFilterProxyModel;
 
 namespace library {
+namespace editor {
 
 class PackagePadListModel;
-
-namespace editor {
 
 /*******************************************************************************
  *  Class PackagePadListEditorWidget

--- a/libs/librepcb/libraryeditor/pkg/packagepadlistmodel.h
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlistmodel.h
@@ -17,17 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_DEVICEPADSIGNALMAPMODEL_H
-#define LIBREPCB_LIBRARY_DEVICEPADSIGNALMAPMODEL_H
+#ifndef LIBREPCB_LIBRARY_EDITOR_PACKAGEPADLISTMODEL_H
+#define LIBREPCB_LIBRARY_EDITOR_PACKAGEPADLISTMODEL_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../cmp/componentsignal.h"
-#include "../pkg/packagepad.h"
-#include "devicepadsignalmap.h"
-
-#include <librepcb/common/model/comboboxdelegate.h>
+#include <librepcb/library/pkg/packagepad.h>
 
 #include <QtCore>
 
@@ -39,31 +35,34 @@ namespace librepcb {
 class UndoStack;
 
 namespace library {
+namespace editor {
 
 /*******************************************************************************
- *  Class DevicePadSignalMapModel
+ *  Class PackagePadListModel
  ******************************************************************************/
 
 /**
- * @brief The DevicePadSignalMapModel class
+ * @brief The PackagePadListModel class
  */
-class DevicePadSignalMapModel final : public QAbstractTableModel {
+class PackagePadListModel final : public QAbstractTableModel {
   Q_OBJECT
 
 public:
-  enum Column { COLUMN_PAD, COLUMN_SIGNAL, _COLUMN_COUNT };
+  enum Column { COLUMN_NAME, COLUMN_ACTIONS, _COLUMN_COUNT };
 
   // Constructors / Destructor
-  DevicePadSignalMapModel() = delete;
-  DevicePadSignalMapModel(const DevicePadSignalMapModel& other) noexcept;
-  explicit DevicePadSignalMapModel(QObject* parent = nullptr) noexcept;
-  ~DevicePadSignalMapModel() noexcept;
+  PackagePadListModel() = delete;
+  PackagePadListModel(const PackagePadListModel& other) noexcept;
+  explicit PackagePadListModel(QObject* parent = nullptr) noexcept;
+  ~PackagePadListModel() noexcept;
 
   // Setters
-  void setPadSignalMap(DevicePadSignalMap* map) noexcept;
+  void setPadList(PackagePadList* list) noexcept;
   void setUndoStack(UndoStack* stack) noexcept;
-  void setSignalList(const ComponentSignalList& list) noexcept;
-  void setPadList(const PackagePadList& list) noexcept;
+
+  // Slots
+  void addPad(const QVariant& editData) noexcept;
+  void removePad(const QVariant& editData) noexcept;
 
   // Inherited from QAbstractItemModel
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -77,33 +76,31 @@ public:
                         int role = Qt::EditRole) override;
 
   // Operator Overloadings
-  DevicePadSignalMapModel& operator=(
-      const DevicePadSignalMapModel& rhs) noexcept;
+  PackagePadListModel& operator=(const PackagePadListModel& rhs) noexcept;
 
 private:
-  void padSignalMapEdited(
-      const DevicePadSignalMap& map, int index,
-      const std::shared_ptr<const DevicePadSignalMapItem>& item,
-      DevicePadSignalMap::Event                            event) noexcept;
-  void execCmd(UndoCommand* cmd);
-  void updateComboBoxItems() noexcept;
+  void              padListEdited(const PackagePadList& list, int index,
+                                  const std::shared_ptr<const PackagePad>& pad,
+                                  PackagePadList::Event                    event) noexcept;
+  void              execCmd(UndoCommand* cmd);
+  CircuitIdentifier validateNameOrThrow(const QString& name) const;
+  QString           getNextPadNameProposal() const noexcept;
 
 private:  // Data
-  DevicePadSignalMap*     mPadSignalMap;
-  UndoStack*              mUndoStack;
-  ComponentSignalList     mSignals;
-  PackagePadList          mPads;
-  ComboBoxDelegate::Items mComboBoxItems;
+  PackagePadList* mPadList;
+  UndoStack*      mUndoStack;
+  QString         mNewName;
 
   // Slots
-  DevicePadSignalMap::OnEditedSlot mOnEditedSlot;
+  PackagePadList::OnEditedSlot mOnEditedSlot;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_DEVICEPADSIGNALMAPMODEL_H
+#endif


### PR DESCRIPTION
Fixes the software architecture violation reported in https://github.com/LibrePCB/LibrePCB/pull/698#issuecomment-630493839.

@dbrgn Could you check if this also fixes the linker error?