### PR TITLE
Doxygen: Show TOC on markdown pages

### DIFF
--- a/dev/doxygen/Doxyfile
+++ b/dev/doxygen/Doxyfile
@@ -310,7 +310,7 @@ MARKDOWN_SUPPORT       = YES
 # Minimum value: 0, maximum value: 99, default value: 0.
 # This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
 
-TOC_INCLUDE_HEADINGS   = 0
+TOC_INCLUDE_HEADINGS   = 2
 
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can


### PR DESCRIPTION
From the Doxygen docs[1]:

> Note that the TOC_INCLUDE_HEADINGS has to be set to a value > 0
> otherwise no table of contents is shown when using Markdown Headers.

I set the value to `2`, so that 2 levels of headings are included in
the table of contents.

[1] http://doxygen.nl/manual/markdown.html#md_toc