### PR TITLE
Add support for Solaris based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ about the currently available features, limitations and known bugs.
 
 ### Features
 
-- Cross-platform (Unix/Linux/BSD, macOS, Windows)
+- Cross-platform (Unix/Linux/BSD/Solaris, macOS, Windows)
 - Multilingual (both application and library elements)
 - All-In-One: project management + library/schematic/board editors
 - Intuitive, modern and easy-to-use graphical user interface

--- a/apps/EagleImport/EagleImport.pro
+++ b/apps/EagleImport/EagleImport.pro
@@ -23,6 +23,9 @@ LIBS += \
     -lclipper \
     -lmuparser \
 
+# Solaris based systems need to link against libproc
+solaris:LIBS += -lproc
+
 INCLUDEPATH += \
     ../../libs \
     ../../libs/parseagle \

--- a/apps/UuidGenerator/UuidGenerator.pro
+++ b/apps/UuidGenerator/UuidGenerator.pro
@@ -17,6 +17,9 @@ LIBS += \
     -lclipper \
     -lmuparser \
 
+# Solaris based systems need to link against libproc
+solaris:LIBS += -lproc
+
 INCLUDEPATH += \
     ../../libs \
     ../../libs/type_safe/include \

--- a/apps/librepcb-cli/librepcb-cli.pro
+++ b/apps/librepcb-cli/librepcb-cli.pro
@@ -33,6 +33,9 @@ LIBS += \
     -lmuparser \
     -lsexpresso \
 
+# Solaris based systems need to link against libproc
+solaris:LIBS += -lproc
+
 INCLUDEPATH += \
     ../../libs \
     ../../libs/type_safe/include \

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -47,6 +47,9 @@ LIBS += \
     -lmuparser \
     -lsexpresso \
 
+# Solaris based systems need to link against libproc
+solaris:LIBS += -lproc
+
 INCLUDEPATH += \
     ../../libs \
     ../../libs/type_safe/include \

--- a/tests/unittests/common/systeminfotest.cpp
+++ b/tests/unittests/common/systeminfotest.cpp
@@ -53,6 +53,15 @@ protected:
 #endif
   }
 
+  QString getOwnProcessExeName() const noexcept {
+#if defined(Q_OS_SOLARIS)
+    // Note: Solaris limits process names to 16 bytes
+    return QString("librepcb-unitte");
+#else
+    return QString("librepcb-unittests");
+#endif
+  }
+
   QString getTestProcessExeName() const noexcept {
     return QString("uuid-generator");
   }
@@ -112,7 +121,7 @@ TEST_F(SystemInfoTest, testGetProcessNameByPid) {
   {
     QString processName =
         SystemInfo::getProcessNameByPid(qApp->applicationPid());
-    EXPECT_EQ("librepcb-unittests", processName) << qPrintable(processName);
+    EXPECT_EQ(getOwnProcessExeName(), processName) << qPrintable(processName);
   }
 
   // check another running process

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -29,6 +29,9 @@ LIBS += \
     -lmuparser \
     -lparseagle \
 
+# Solaris based systems need to link against libproc
+solaris:LIBS += -lproc
+
 INCLUDEPATH += \
     ../../libs \
     ../../libs/googletest/googletest/include \


### PR DESCRIPTION
Tested on Illumos (OpenIndiana) :tada: 

![VirtualBox_Illumos Indiana Hipster_09_06_2020_23_35_16](https://user-images.githubusercontent.com/105168/84204385-66db5080-aaab-11ea-80ca-bedaccfbd1d3.png)

The test suite passes as well:

![VirtualBox_Illumos Indiana Hipster_10_06_2020_00_46_07](https://user-images.githubusercontent.com/105168/84208314-c9384f00-aab3-11ea-8581-7691bfff4a46.png)

For compilation to work, it's important that the 64bit version of qmake is invoked (`/usr/lib/qt/5.8/bin/amd64/qmake`, not `/usr/lib/qt/5.8/bin/qmake`).