### PR TITLE
Ensure that parent dir exists when moving files or directories

### DIFF
--- a/libs/librepcb/common/fileio/fileutils.cpp
+++ b/libs/librepcb/common/fileio/fileutils.cpp
@@ -127,6 +127,8 @@ void FileUtils::move(const FilePath& source, const FilePath& dest) {
                      QString(tr("The file or directory \"%1\" exists already."))
                          .arg(dest.toNative()));
   }
+  // Note: QDir::rename() fails if the parent directory does not yet exist
+  makePath(dest.getParentDir());
   if (!QDir().rename(source.toStr(), dest.toStr())) {
     throw RuntimeError(__FILE__, __LINE__,
                        QString(tr("Could not move \"%1\" to \"%2\"."))


### PR DESCRIPTION
QDir::rename() fails if the parent directory does not yet exist.

Fixes #714.