### PR TITLE
CI: Work around MSYS2 error on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,8 @@ init:
 
 install:
   - git submodule update --init --recursive
+  # Work around https://github.com/msys2/MSYS2-packages/issues/1962
+  - bash -c "pacman -Sy --noconfirm pacman && pacman -Su --noconfirm"
   - bash -c "./ci/install_dependencies.sh"
 
 build_script:


### PR DESCRIPTION
Work around CI failure:

    error: could not open file /var/cache/pacman/pkg/libopenssl-1.1.1.g-2-x86_64.pkg.tar.zst: Child process exited with status 127

See https://github.com/msys2/MSYS2-packages/issues/1962.