### PR TITLE
Enable pluralization for net renaming string

### DIFF
--- a/libs/librepcb/projecteditor/schematiceditor/renamenetsegmentdialog.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/renamenetsegmentdialog.ui
@@ -57,7 +57,7 @@
    <item>
     <widget class="QRadioButton" name="rbtnRenameWholeNet">
      <property name="text">
-      <string extracomment="Number of segments (&gt;=1)">Rename whole net (%1 segments)</string>
+      <string extracomment="Number of segments (&gt;=1)">Rename whole net (%n segment(s))</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
As requested by a translator on Transifex.

Hope this is correct (as per https://doc.qt.io/qt-5/i18n-source-translation.html#handling-plurals).