### PR TITLE
Fix fontobene-qt5 config in libs.pro

### DIFF
--- a/libs/libs.pro
+++ b/libs/libs.pro
@@ -25,7 +25,7 @@ librepcb.depends = \
     librepcb.depends += quazip
 }
 
-!contains(UNBUNDLE, quazip) {
+!contains(UNBUNDLE, fontobene-qt5) {
     SUBDIRS += fontobene-qt5
     librepcb.depends += fontobene-qt5
 }


### PR DESCRIPTION
Probably a copy paste error.