### PR TITLE
Board Editor: Simplify Trace command

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,3 +16,4 @@ yourself by creating a pull request (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 - [@chrisgwerder](https://github.com/chrisgwerder)
 - [@0xB767B](https://github.com/0xB767B)
 - Josua Schmid ([@schmijos](https://github.com/schmijos))
+- Lucas Keune ([@5n8ke](https://github.com/5n8ke))

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -140,11 +140,17 @@ void BI_NetPoint::removeFromBoard() {
 }
 
 void BI_NetPoint::registerNetLine(BI_NetLine& netline) {
-  if ((!isAddedToBoard()) || (mRegisteredNetLines.contains(&netline)) ||
-      (&netline.getNetSegment() != &mNetSegment) ||
-      ((mRegisteredNetLines.count() > 0) &&
-       (&netline.getLayer() != getLayerOfLines()))) {
-    throw LogicError(__FILE__, __LINE__);
+  if (!isAddedToBoard()) {
+    throw LogicError(__FILE__, __LINE__, "NetPoint is not added to the board.");
+  } else if (mRegisteredNetLines.contains(&netline)) {
+    throw LogicError(__FILE__, __LINE__,
+                     "NetLine already registered to NetPoint.");
+  } else if (&netline.getNetSegment() != &mNetSegment) {
+    throw LogicError(__FILE__, __LINE__,
+                     "NetLine is part of a different NetSegment.");
+  } else if ((mRegisteredNetLines.count() > 0) &&
+             (&netline.getLayer() != getLayerOfLines())) {
+    throw LogicError(__FILE__, __LINE__, "NetLine is on a different layer.");
   }
   mRegisteredNetLines.insert(&netline);
   netline.updateLine();

--- a/libs/librepcb/project/boards/items/bi_netsegment.cpp
+++ b/libs/librepcb/project/boards/items/bi_netsegment.cpp
@@ -399,13 +399,15 @@ void BI_NetSegment::removeElements(const QList<BI_Via*>&      vias,
                                    const QList<BI_NetPoint*>& netpoints,
                                    const QList<BI_NetLine*>&  netlines) {
   if (!isAddedToBoard()) {
-    throw LogicError(__FILE__, __LINE__);
+    throw LogicError(__FILE__, __LINE__,
+                     "Element to be removed not added to board.");
   }
 
   ScopeGuardList sgl(netpoints.count() + netlines.count());
   foreach (BI_NetLine* netline, netlines) {
     if (!mNetLines.contains(netline)) {
-      throw LogicError(__FILE__, __LINE__);
+      throw LogicError(__FILE__, __LINE__,
+                       "Netline to be removed not part of the netsegment.");
     }
     // remove from board
     netline->removeFromBoard();  // can throw
@@ -417,7 +419,8 @@ void BI_NetSegment::removeElements(const QList<BI_Via*>&      vias,
   }
   foreach (BI_NetPoint* netpoint, netpoints) {
     if (!mNetPoints.contains(netpoint)) {
-      throw LogicError(__FILE__, __LINE__);
+      throw LogicError(__FILE__, __LINE__,
+                       "Netpoint to be removed not part of the netsegment.");
     }
     // remove from board
     netpoint->removeFromBoard();  // can throw
@@ -429,7 +432,8 @@ void BI_NetSegment::removeElements(const QList<BI_Via*>&      vias,
   }
   foreach (BI_Via* via, vias) {
     if (!mVias.contains(via)) {
-      throw LogicError(__FILE__, __LINE__);
+      throw LogicError(__FILE__, __LINE__,
+                       "Via to be removed not part of the netsegment.");
     }
     // remove from board
     via->removeFromBoard();  // can throw

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -138,6 +138,8 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
                                mUi->actionToolAddText);
   mToolsActionGroup->addAction(BoardEditorFsm::State::ADD_HOLE,
                                mUi->actionToolAddHole);
+  mToolsActionGroup->addAction(BoardEditorFsm::State::SIMPLIFY,
+                               mUi->actionToolSimplify);
   mToolsActionGroup->setCurrentAction(mFsm->getCurrentState());
   connect(mFsm.data(), &BoardEditorFsm::stateChanged, mToolsActionGroup.data(),
           &ExclusiveActionGroup::setCurrentAction);
@@ -873,6 +875,9 @@ void BoardEditor::toolActionGroupChangeTriggered(
       break;
     case BoardEditorFsm::State::ADD_HOLE:
       mFsm->processAddHole();
+      break;
+    case BoardEditorFsm::State::SIMPLIFY:
+      mFsm->processSimplify();
       break;
     default:
       Q_ASSERT(false);

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -17,7 +17,7 @@
    <string>Board Editor</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../../../img/images.qrc">
     <normaloff>:/img/actions/board_editor.png</normaloff>:/img/actions/board_editor.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -70,7 +70,7 @@
      <x>0</x>
      <y>0</y>
      <width>886</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -138,6 +138,7 @@
     <addaction name="actionToolSelect"/>
     <addaction name="actionToolAddVia"/>
     <addaction name="actionToolDrawTrace"/>
+    <addaction name="actionToolSimplify"/>
     <addaction name="actionToolDrawPolygon"/>
     <addaction name="actionToolAddText"/>
     <addaction name="actionToolAddHole"/>
@@ -272,6 +273,7 @@
    <addaction name="actionToolSelect"/>
    <addaction name="actionToolAddVia"/>
    <addaction name="actionToolDrawTrace"/>
+   <addaction name="actionToolSimplify"/>
    <addaction name="actionToolDrawPolygon"/>
    <addaction name="actionToolAddText"/>
    <addaction name="actionToolAddHole"/>
@@ -294,7 +296,7 @@
   </widget>
   <action name="actionProjectSave">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
    </property>
    <property name="text">
@@ -306,7 +308,7 @@
   </action>
   <action name="actionProjectClose">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
@@ -318,7 +320,7 @@
   </action>
   <action name="actionPrint">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/print.png</normaloff>:/img/actions/print.png</iconset>
    </property>
    <property name="text">
@@ -330,7 +332,7 @@
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/quit.png</normaloff>:/img/actions/quit.png</iconset>
    </property>
    <property name="text">
@@ -342,7 +344,7 @@
   </action>
   <action name="actionExportAsPdf">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/pdf.png</normaloff>:/img/actions/pdf.png</iconset>
    </property>
    <property name="text">
@@ -354,7 +356,7 @@
   </action>
   <action name="actionShowControlPanel">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/home.png</normaloff>:/img/actions/home.png</iconset>
    </property>
    <property name="text">
@@ -366,7 +368,7 @@
   </action>
   <action name="actionShowSchematicEditor">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/schematic.png</normaloff>:/img/actions/schematic.png</iconset>
    </property>
    <property name="text">
@@ -378,7 +380,7 @@
   </action>
   <action name="actionUndo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
    </property>
    <property name="text">
@@ -390,7 +392,7 @@
   </action>
   <action name="actionRedo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/redo.png</normaloff>:/img/actions/redo.png</iconset>
    </property>
    <property name="text">
@@ -402,7 +404,7 @@
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
@@ -414,7 +416,7 @@
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
@@ -426,7 +428,7 @@
   </action>
   <action name="actionRotate_CCW">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_left.png</normaloff>:/img/actions/rotate_left.png</iconset>
    </property>
    <property name="text">
@@ -438,7 +440,7 @@
   </action>
   <action name="actionRotate_CW">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_right.png</normaloff>:/img/actions/rotate_right.png</iconset>
    </property>
    <property name="text">
@@ -450,7 +452,7 @@
   </action>
   <action name="actionCopy">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -465,7 +467,7 @@
   </action>
   <action name="actionCut">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/cut.png</normaloff>:/img/actions/cut.png</iconset>
    </property>
    <property name="text">
@@ -480,7 +482,7 @@
   </action>
   <action name="actionPaste">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/paste.png</normaloff>:/img/actions/paste.png</iconset>
    </property>
    <property name="text">
@@ -495,7 +497,7 @@
   </action>
   <action name="actionRemove">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -507,7 +509,7 @@
   </action>
   <action name="actionGrid">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/grid.png</normaloff>:/img/actions/grid.png</iconset>
    </property>
    <property name="text">
@@ -519,7 +521,7 @@
   </action>
   <action name="actionZoomIn">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_in.png</normaloff>:/img/actions/zoom_in.png</iconset>
    </property>
    <property name="text">
@@ -531,7 +533,7 @@
   </action>
   <action name="actionZoomOut">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_out.png</normaloff>:/img/actions/zoom_out.png</iconset>
    </property>
    <property name="text">
@@ -543,7 +545,7 @@
   </action>
   <action name="actionZoomAll">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_all.png</normaloff>:/img/actions/zoom_all.png</iconset>
    </property>
    <property name="text">
@@ -566,7 +568,7 @@
   </action>
   <action name="actionProjectSettings">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
    </property>
    <property name="text">
@@ -581,7 +583,7 @@
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
@@ -607,7 +609,7 @@
   </action>
   <action name="actionToolSelect">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/select.png</normaloff>:/img/actions/select.png</iconset>
    </property>
    <property name="text">
@@ -619,7 +621,7 @@
   </action>
   <action name="actionCommandAbort">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/stop.png</normaloff>:/img/actions/stop.png</iconset>
    </property>
    <property name="text">
@@ -631,7 +633,7 @@
   </action>
   <action name="actionNewBoard">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/new_2.png</normaloff>:/img/actions/new_2.png</iconset>
    </property>
    <property name="text">
@@ -651,7 +653,7 @@
   </action>
   <action name="actionFlipHorizontal">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/flip_horizontal.png</normaloff>:/img/actions/flip_horizontal.png</iconset>
    </property>
    <property name="text">
@@ -663,7 +665,7 @@
   </action>
   <action name="actionFlipVertical">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/flip_vertical.png</normaloff>:/img/actions/flip_vertical.png</iconset>
    </property>
    <property name="text">
@@ -675,7 +677,7 @@
   </action>
   <action name="actionToolDrawTrace">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/draw_wire.png</normaloff>:/img/actions/draw_wire.png</iconset>
    </property>
    <property name="text">
@@ -687,7 +689,7 @@
   </action>
   <action name="actionToolAddVia">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_via.png</normaloff>:/img/actions/add_via.png</iconset>
    </property>
    <property name="text">
@@ -699,7 +701,7 @@
   </action>
   <action name="actionCopyBoard">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -711,7 +713,7 @@
   </action>
   <action name="actionGenerateFabricationData">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_gerber.png</normaloff>:/img/actions/export_gerber.png</iconset>
    </property>
    <property name="text">
@@ -742,7 +744,7 @@
   </action>
   <action name="actionRemoveBoard">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -754,7 +756,7 @@
   </action>
   <action name="actionToolDrawPolygon">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/draw_polygon.png</normaloff>:/img/actions/draw_polygon.png</iconset>
    </property>
    <property name="text">
@@ -766,7 +768,7 @@
   </action>
   <action name="actionRebuildPlanes">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rebuild_plane.png</normaloff>:/img/actions/rebuild_plane.png</iconset>
    </property>
    <property name="text">
@@ -778,7 +780,7 @@
   </action>
   <action name="actionToolAddPlane">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_plane.png</normaloff>:/img/actions/add_plane.png</iconset>
    </property>
    <property name="text">
@@ -790,7 +792,7 @@
   </action>
   <action name="actionToolAddText">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_text.png</normaloff>:/img/actions/add_text.png</iconset>
    </property>
    <property name="text">
@@ -802,7 +804,7 @@
   </action>
   <action name="actionToolAddHole">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_hole.png</normaloff>:/img/actions/add_hole.png</iconset>
    </property>
    <property name="text">
@@ -814,7 +816,7 @@
   </action>
   <action name="actionUpdateLibrary">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
@@ -826,7 +828,7 @@
   </action>
   <action name="actionExportLppz">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_zip.png</normaloff>:/img/actions/export_zip.png</iconset>
    </property>
    <property name="text">
@@ -841,7 +843,7 @@
   </action>
   <action name="actionGenerateBom">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/generate_bom.png</normaloff>:/img/actions/generate_bom.png</iconset>
    </property>
    <property name="text">
@@ -856,7 +858,7 @@
   </action>
   <action name="actionShowAllPlanes">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/show_planes.png</normaloff>:/img/actions/show_planes.png</iconset>
    </property>
    <property name="text">
@@ -868,7 +870,7 @@
   </action>
   <action name="actionHideAllPlanes">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/hide_planes.png</normaloff>:/img/actions/hide_planes.png</iconset>
    </property>
    <property name="text">
@@ -880,7 +882,7 @@
   </action>
   <action name="actionDesignRuleCheck">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/drc.png</normaloff>:/img/actions/drc.png</iconset>
    </property>
    <property name="text">
@@ -892,7 +894,7 @@
   </action>
   <action name="actionGeneratePickPlace">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_pick_place_file.png</normaloff>:/img/actions/export_pick_place_file.png</iconset>
    </property>
    <property name="text">
@@ -904,7 +906,7 @@
   </action>
   <action name="actionExportAsSvg">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_svg.png</normaloff>:/img/actions/export_svg.png</iconset>
    </property>
    <property name="text">
@@ -916,7 +918,7 @@
   </action>
   <action name="actionSelectAll">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/select_all.png</normaloff>:/img/actions/select_all.png</iconset>
    </property>
    <property name="text">
@@ -924,6 +926,18 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+A</string>
+   </property>
+  </action>
+  <action name="actionToolSimplify">
+   <property name="icon">
+    <iconset resource="../../../../img/images.qrc">
+     <normaloff>:/img/actions/ruler.png</normaloff>:/img/actions/ruler.png</iconset>
+   </property>
+   <property name="text">
+    <string>Simplify</string>
+   </property>
+   <property name="toolTip">
+    <string>Simplify Trace</string>
    </property>
   </action>
  </widget>
@@ -944,6 +958,15 @@
    <header location="global">librepcb/projecteditor/toolbars/searchtoolbar.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorfsm.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorfsm.cpp
@@ -30,6 +30,7 @@
 #include "boardeditorstate_drawpolygon.h"
 #include "boardeditorstate_drawtrace.h"
 #include "boardeditorstate_select.h"
+#include "boardeditorstate_simplify.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -60,6 +61,7 @@ BoardEditorFsm::BoardEditorFsm(const Context& context, QObject* parent) noexcept
                  new BoardEditorState_DrawPolygon(context));
   mStates.insert(State::DRAW_PLANE, new BoardEditorState_DrawPlane(context));
   mStates.insert(State::DRAW_TRACE, new BoardEditorState_DrawTrace(context));
+  mStates.insert(State::SIMPLIFY, new BoardEditorState_Simplify(context));
   enterNextState(State::SELECT);
 }
 
@@ -115,6 +117,10 @@ bool BoardEditorFsm::processDrawPlane() noexcept {
 
 bool BoardEditorFsm::processDrawTrace() noexcept {
   return setNextState(State::DRAW_TRACE);
+}
+
+bool BoardEditorFsm::processSimplify() noexcept {
+  return setNextState(State::SIMPLIFY);
 }
 
 bool BoardEditorFsm::processAbortCommand() noexcept {

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorfsm.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorfsm.h
@@ -84,6 +84,8 @@ public:
     DRAW_PLANE,
     /// ::librepcb::project::editor::BoardEditorState_DrawTrace
     DRAW_TRACE,
+    /// ::librepcb::project::editor::BoardEditorState_Simplify
+    SIMPLIFY,
   };
 
   /// FSM Context
@@ -116,6 +118,7 @@ public:
   bool processDrawPolygon() noexcept;
   bool processDrawPlane() noexcept;
   bool processDrawTrace() noexcept;
+  bool processSimplify() noexcept;
   bool processAbortCommand() noexcept;
   bool processSelectAll() noexcept;
   bool processCut() noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
@@ -233,8 +233,6 @@ private:
    */
   void showVia(bool isVisible) noexcept;
 
-  BI_NetLineAnchor* combineAnchors(BI_NetLineAnchor& a, BI_NetLineAnchor& b);
-
   // Callback Functions for the Gui elements
   void layerComboBoxIndexChanged(int index) noexcept;
   void updateShapeActionsCheckedState() noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_simplify.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_simplify.cpp
@@ -1,0 +1,278 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include "boardeditorstate_simplify.h"
+
+#include "../../cmd/cmdboardcombineanchors.h"
+#include "../../cmd/cmdboardsplitnetline.h"
+
+#include <librepcb/common/graphics/graphicslayer.h>
+#include <librepcb/common/undostack.h>
+#include <librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h>
+#include <librepcb/project/boards/cmd/cmdboardnetsegmentremoveelements.h>
+#include <librepcb/project/boards/items/bi_footprintpad.h>
+#include <librepcb/project/boards/items/bi_netline.h>
+#include <librepcb/project/boards/items/bi_netpoint.h>
+#include <librepcb/project/boards/items/bi_netsegment.h>
+#include <librepcb/project/boards/items/bi_via.h>
+#include <librepcb/project/circuit/circuit.h>
+#include <librepcb/project/circuit/netsignal.h>
+#include <librepcb/project/project.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BoardEditorState_Simplify::BoardEditorState_Simplify(
+    const Context& context) noexcept
+  : BoardEditorState(context) {
+}
+
+BoardEditorState_Simplify::~BoardEditorState_Simplify() {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+bool BoardEditorState_Simplify::entry() noexcept {
+  return true;
+}
+
+bool BoardEditorState_Simplify::exit() noexcept {
+  mContext.project.getCircuit().setHighlightedNetSignal(nullptr);
+  return true;
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool BoardEditorState_Simplify::processGraphicsSceneLeftMouseButtonPressed(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  Board* board = getActiveBoard();
+  if (!board) return false;
+  Point pos = Point::fromPx(e.scenePos());
+  simplify(*board, pos);
+  return true;
+}
+
+void BoardEditorState_Simplify::simplify(Board& board, Point& pos) noexcept {
+  try {
+    QSet<NetSignal*> netSignals = findNetSignals(board, pos);
+    if (netSignals.empty()) return;
+    NetSignal& chosenSignal = **netSignals.begin();
+    mContext.project.getCircuit().setHighlightedNetSignal(&chosenSignal);
+    mContext.undoStack.beginCmdGroup(
+        tr("Simplify Traces of \"%1\"").arg(*chosenSignal.getName()));
+    foreach (BI_NetSegment* segment, chosenSignal.getBoardNetSegments()) {
+      Q_ASSERT(segment);
+      simplifySegment(*segment);
+    }
+    // TODO(5n8ke): Connect disjunct net segments
+    mContext.undoStack.commitCmdGroup();
+  } catch (...) {
+  }
+}
+
+void BoardEditorState_Simplify::simplifySegment(
+    BI_NetSegment& segment) noexcept {
+  removeDuplicateNetLines(segment);
+  combineDuplicateNetPoints(segment);
+
+  // connect NetPoints with NetLines
+  foreach (BI_NetPoint* netpoint, Toolbox::toSet(segment.getNetPoints())) {
+    // get NetLines at the netpoint position, but only consider the ones that
+    // are not connected to the netpoint already
+    QList<BI_NetLine*> netlines = {};
+    segment.getNetLinesAtScenePos(netpoint->getPosition(),
+                                  netpoint->getLayerOfLines(), netlines);
+    QSet<BI_NetLine*> notConnectedNetlines = Toolbox::toSet(netlines);
+    notConnectedNetlines -= netpoint->getNetLines();
+    foreach (BI_NetLine* netline, notConnectedNetlines) {
+      QScopedPointer<CmdBoardSplitNetLine> cmdSplit(
+          new CmdBoardSplitNetLine(*netline, netpoint->getPosition()));
+      BI_NetLineAnchor* splitPoint = cmdSplit->getSplitPoint();
+      mContext.undoStack.appendToCmdGroup(cmdSplit.take());
+      QScopedPointer<CmdBoardCombineAnchors> cmdCombine(
+          new CmdBoardCombineAnchors(*splitPoint, *netpoint));
+      mContext.undoStack.appendToCmdGroup(cmdCombine.take());
+    }
+  }
+
+  // connect Vias with NetPoints and NetLines
+  foreach (BI_Via* via, Toolbox::toSet(segment.getVias())) {
+    Q_ASSERT(via);
+    // connect Vias with NetPoints
+    QList<BI_NetPoint*> netpoints = {};
+    segment.getNetPointsAtScenePos(via->getPosition(), nullptr, netpoints);
+    foreach (BI_NetPoint* netpoint, netpoints) {
+      QScopedPointer<CmdBoardCombineAnchors> cmdCombine(
+          new CmdBoardCombineAnchors(*netpoint, *via));
+      mContext.undoStack.appendToCmdGroup(cmdCombine.take());
+    }
+
+    // connect Vias with NetLines
+    // get NetLines at the Via position, but only consider the ones that are not
+    // connected to the Via already
+    QList<BI_NetLine*> netlines = {};
+    segment.getNetLinesAtScenePos(via->getPosition(), nullptr, netlines);
+    QSet<BI_NetLine*> notConnectedNetlines = Toolbox::toSet(netlines);
+    notConnectedNetlines -= via->getNetLines();
+    foreach (BI_NetLine* netline, notConnectedNetlines) {
+      QScopedPointer<CmdBoardSplitNetLine> cmdSplit(
+          new CmdBoardSplitNetLine(*netline, via->getPosition()));
+      BI_NetLineAnchor* splitPoint = cmdSplit->getSplitPoint();
+      mContext.undoStack.appendToCmdGroup(cmdSplit.take());
+      QScopedPointer<CmdBoardCombineAnchors> cmdCombine(
+          new CmdBoardCombineAnchors(*splitPoint, *via));
+      mContext.undoStack.appendToCmdGroup(cmdCombine.take());
+    }
+  }
+
+  // TODO(5n8ke): Connect crossing NetLines
+
+  removeDuplicateNetLines(segment);
+
+  // Connect NetLines forming a straight line
+  foreach (BI_NetPoint* netpoint, Toolbox::toSet(segment.getNetPoints())) {
+    Q_ASSERT(netpoint);
+    QScopedPointer<CmdBoardNetSegmentAddElements> cmdAdd(
+        new CmdBoardNetSegmentAddElements(segment));
+    QScopedPointer<CmdBoardNetSegmentRemoveElements> cmdRemove(
+        new CmdBoardNetSegmentRemoveElements(segment));
+    QList<BI_NetLine*> netlines = netpoint->getNetLines().values();
+    if (netlines.count() == 2) {
+      BI_NetLineAnchor* A = netlines[0]->getOtherPoint(*netpoint);
+      BI_NetLineAnchor* B = netlines[1]->getOtherPoint(*netpoint);
+      Q_ASSERT(netlines[0]->getLayer().getName() ==
+               netlines[1]->getLayer().getName());
+      if (netlines[0]->getWidth() != netlines[1]->getWidth()) continue;
+      if (Toolbox::shortestDistanceBetweenPointAndLine(netpoint->getPosition(),
+                                                       A->getPosition(),
+                                                       B->getPosition()) == 0) {
+        cmdAdd->addNetLine(*A, *B, netlines[0]->getLayer(),
+                           netlines[0]->getWidth());
+        cmdRemove->removeNetLine(*netlines[0]);
+        cmdRemove->removeNetLine(*netlines[1]);
+        cmdRemove->removeNetPoint(*netpoint);
+      }
+    }
+    mContext.undoStack.appendToCmdGroup(cmdAdd.take());
+    mContext.undoStack.appendToCmdGroup(cmdRemove.take());
+  }
+
+  removeDuplicateNetLines(segment);
+}
+
+void BoardEditorState_Simplify::removeDuplicateNetLines(
+    BI_NetSegment& segment) noexcept {
+  // Remove NetLines with the same start and end points
+  QScopedPointer<CmdBoardNetSegmentRemoveElements> cmdRemove(
+      new CmdBoardNetSegmentRemoveElements(segment));
+  foreach (BI_NetLine* netline, Toolbox::toSet(segment.getNetLines())) {
+    Q_ASSERT(netline);
+    if (!netline->isAddedToBoard()) continue;
+    cmdRemove.reset(new CmdBoardNetSegmentRemoveElements(segment));
+    BI_NetLineAnchor* startPoint    = &netline->getStartPoint();
+    BI_NetLineAnchor* endPoint      = &netline->getEndPoint();
+    QSet<BI_NetLine*> otherNetlines = startPoint->getNetLines();
+    otherNetlines -= netline;
+    foreach (BI_NetLine* otherNetline, otherNetlines) {
+      Q_ASSERT(otherNetline);
+      if ((otherNetline->getOtherPoint(*startPoint) == endPoint) &&
+          (netline->getLayer().getName() ==
+           otherNetline->getLayer().getName())) {
+        cmdRemove->removeNetLine(*otherNetline);
+      }
+    }
+    mContext.undoStack.appendToCmdGroup(cmdRemove.take());
+  }
+}
+
+void BoardEditorState_Simplify::combineDuplicateNetPoints(
+    BI_NetSegment& segment) noexcept {
+  QSet<BI_NetPoint*> netpoints = Toolbox::toSet(segment.getNetPoints());
+  // for every position and layer on the board choose a single NetPoint that
+  // will be kept.
+  QMap<QPair<Point, QString>, BI_NetLineAnchor*> uniquePositions = {};
+  foreach (BI_NetPoint* netpoint, netpoints) {
+    if (!netpoint->isAddedToBoard()) continue;
+    QPair<Point, QString> identifier(netpoint->getPosition(),
+                                     netpoint->getLayerOfLines()->getName());
+    if (uniquePositions.contains(identifier)) {
+      BI_NetLineAnchor& keepPoint = **uniquePositions.find(identifier);
+      QScopedPointer<CmdBoardCombineAnchors> cmdCombine(
+          new CmdBoardCombineAnchors(*netpoint, keepPoint));
+      uniquePositions[identifier] = cmdCombine->getKeepAnchor();
+      mContext.undoStack.appendToCmdGroup(cmdCombine.take());
+    } else {
+      uniquePositions.insert(identifier, netpoint);
+    }
+  }
+}
+
+QSet<NetSignal*> BoardEditorState_Simplify::findNetSignals(
+    Board& board, Point& pos, QSet<BI_Base*> except) const noexcept {
+  QSet<NetSignal*> result = QSet<NetSignal*>();
+  foreach (BI_Via* via, board.getViasAtScenePos(pos)) {
+    if (except.contains(via)) continue;
+    if (!result.contains(&via->getNetSignalOfNetSegment())) {
+      result.insert(&via->getNetSignalOfNetSegment());
+    }
+  }
+  foreach (BI_NetPoint* netpoint, board.getNetPointsAtScenePos(pos)) {
+    if (except.contains(netpoint)) continue;
+    if (!result.contains(&netpoint->getNetSignalOfNetSegment())) {
+      result.insert(&netpoint->getNetSignalOfNetSegment());
+    }
+  }
+  foreach (BI_NetLine* netline, board.getNetLinesAtScenePos(pos)) {
+    if (except.contains(netline)) continue;
+    if (!result.contains(&netline->getNetSignalOfNetSegment())) {
+      result.insert(&netline->getNetSignalOfNetSegment());
+    }
+  }
+  foreach (BI_FootprintPad* pad, board.getPadsAtScenePos(pos)) {
+    if (except.contains(pad)) continue;
+    if (!result.contains(pad->getCompSigInstNetSignal())) {
+      result.insert(pad->getCompSigInstNetSignal());
+    }
+  }
+  return result;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_simplify.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_simplify.h
@@ -1,0 +1,123 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_BOARDEDITORSTATE_SIMPLIFY_H
+#define LIBREPCB_PROJECT_EDITOR_BOARDEDITORSTATE_SIMPLIFY_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "boardeditorstate.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+class BI_NetSegment;
+class BI_Base;
+class NetSignal;
+
+namespace editor {
+
+/*******************************************************************************
+ *  Class BoardEditorState_Simplify
+ ******************************************************************************/
+
+/**
+ * @brief The "simplify" state/tool of the board editor
+ */
+class BoardEditorState_Simplify final : public BoardEditorState {
+  Q_OBJECT
+public:
+  // Constructors / Destructor
+  BoardEditorState_Simplify()                                       = delete;
+  BoardEditorState_Simplify(const BoardEditorState_Simplify& other) = delete;
+  explicit BoardEditorState_Simplify(const Context& context) noexcept;
+  ~BoardEditorState_Simplify();
+
+  // General Methods
+  virtual bool entry() noexcept override;
+  virtual bool exit() noexcept override;
+
+  // Event Handlers
+  virtual bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+
+  // Operator Overloadings
+  BoardEditorState_Simplify& operator=(const BoardEditorState_Simplify& rhs) =
+      delete;
+
+private:
+  /**
+   * @brief Simplify the netsignal at the specified position.
+   *
+   * Every segment of the found netsignal will be simplified.
+   *
+   * @param board The board of the netsignal.
+   * @param pos The search position of the netsignal.
+   */
+  void simplify(Board& board, Point& pos) noexcept;
+
+  /**
+   * @brief Simplify a segment.
+   *
+   * Simplifies the specified segment by:
+   *   - removing duplicate netlines (same start and end points)
+   *   - removing duplicate netpoints (same position and layer)
+   *   - connecting netpoints and vias with netlines at the same position (and
+   * layer)
+   *   - remove intermitting points of multiple netlines forming a straigt line
+   *
+   * @param segment The segment to be simplified.
+   */
+  void simplifySegment(BI_NetSegment& segment) noexcept;
+
+  /**
+   * @brief Remove duplicate netlines.
+   *
+   * Keep only one netline, per layer, when two netpoints are connected by
+   * multiple netlines.
+   *
+   * @param segment The segment which will be cleaned.
+   */
+  void removeDuplicateNetLines(BI_NetSegment& segment) noexcept;
+
+  /**
+   * @brief Combine duplicate netpoints of the segment.
+   * @param segment The segment which will be cleaned.
+   */
+  void             combineDuplicateNetPoints(BI_NetSegment& segment) noexcept;
+  QSet<NetSignal*> findNetSignals(Board& board, Point& pos,
+                                  QSet<BI_Base*> except = {}) const noexcept;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif  // LIBREPCB_PROJECT_EDITOR_BOARDEDITORSTATE_SIMPLIFY_H

--- a/libs/librepcb/projecteditor/cmd/cmdboardcombineanchors.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdboardcombineanchors.cpp
@@ -1,0 +1,98 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdboardcombineanchors.h"
+
+#include <librepcb/common/scopeguard.h>
+#include <librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h>
+#include <librepcb/project/boards/cmd/cmdboardnetsegmentremove.h>
+#include <librepcb/project/boards/cmd/cmdboardnetsegmentremoveelements.h>
+#include <librepcb/project/boards/items/bi_netline.h>
+#include <librepcb/project/boards/items/bi_netpoint.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+CmdBoardCombineAnchors::CmdBoardCombineAnchors(BI_NetLineAnchor& removeAnchor,
+                                               BI_NetLineAnchor& keepAnchor)
+  : UndoCommandGroup(tr("Combine anchors")),
+    mRemovePoint(nullptr),
+    mKeepAnchor(nullptr) {
+  // TODO(5n8ke): Check for same NetSignal, ...
+  if (&removeAnchor == &keepAnchor) {
+    mKeepAnchor = &removeAnchor;
+  } else if (BI_NetPoint* removePoint =
+                 dynamic_cast<BI_NetPoint*>(&removeAnchor)) {
+    mRemovePoint = removePoint;
+    mKeepAnchor  = &keepAnchor;
+  } else if (BI_NetPoint* removePoint =
+                 dynamic_cast<BI_NetPoint*>(&keepAnchor)) {
+    mRemovePoint = removePoint;
+    mKeepAnchor  = &removeAnchor;
+  } else {
+    throw LogicError(__FILE__, __LINE__, "No netpoint to be combined with.");
+  }
+}
+
+CmdBoardCombineAnchors::~CmdBoardCombineAnchors() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdBoardCombineAnchors::performExecute() {
+  if (mRemovePoint) {
+    BI_NetSegment& segment = mRemovePoint->getNetSegment();
+    QScopedPointer<CmdBoardNetSegmentAddElements> cmdAdd(
+        new CmdBoardNetSegmentAddElements(segment));
+    QScopedPointer<CmdBoardNetSegmentRemoveElements> cmdRemove(
+        new CmdBoardNetSegmentRemoveElements(segment));
+    foreach (BI_NetLine* netline, mRemovePoint->getNetLines()) {
+      BI_NetLineAnchor* anchor = netline->getOtherPoint(*mRemovePoint);
+      if (anchor != mKeepAnchor) {
+        cmdAdd->addNetLine(*mKeepAnchor, *anchor, netline->getLayer(),
+                           netline->getWidth());
+      }
+      cmdRemove->removeNetLine(*netline);
+    }
+    cmdRemove->removeNetPoint(*mRemovePoint);
+    appendChild(cmdAdd.take());
+    appendChild(cmdRemove.take());
+  }
+
+  return UndoCommandGroup::performExecute();
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/cmd/cmdboardcombineanchors.h
+++ b/libs/librepcb/projecteditor/cmd/cmdboardcombineanchors.h
@@ -1,0 +1,93 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_CMDBOARDCOMBINEANCHORS_H
+#define LIBREPCB_PROJECT_EDITOR_CMDBOARDCOMBINEANCHORS_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/undocommandgroup.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+class BI_NetLineAnchor;
+class BI_NetPoint;
+
+namespace editor {
+
+/*******************************************************************************
+ *  Class CmdBoardSplitNetLine
+ ******************************************************************************/
+
+/**
+ * @brief Undo command to combine two ::librepcb::project::BI_NetLineAnchor
+ */
+class CmdBoardCombineAnchors : public UndoCommandGroup {
+public:
+  // Constructors / Destructor
+  /**
+   * @brief CmdBoardCombineAnchors
+   *
+   * At least one of the anchors _must_ be a ::librepcb::project::BI_NetPoint
+   * since only these can be gracefully removed.
+   *
+   * @param removeAnchor The anchor to be removed. If this is not a
+   * ::librepcb::project::BI_NetPoint, keepAnchor will be chosen for removal.
+   * @param keepAnchor The anchor to be kept. May be chosen for removal if
+   * removeAnchor is not a ::librepcb::project::BI_NetPoint.
+   *
+   * @throws LogicError Error when no anchor is a
+   * ::librepcb::project::BI_NetPoint
+   */
+  explicit CmdBoardCombineAnchors(BI_NetLineAnchor& removeAnchor,
+                                  BI_NetLineAnchor& keepAnchor);
+  ~CmdBoardCombineAnchors() noexcept;
+
+  /**
+   * @brief Get the anchor that will be kept after removal.
+   * @return The anchor that will be kept.
+   */
+  BI_NetLineAnchor* getKeepAnchor() { return mKeepAnchor; }
+
+private:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  bool performExecute() override;
+
+  // Private Member Variables
+  BI_NetPoint* mRemovePoint;  ///< The point that will be removed. Is nullptr if
+                              ///< it would be identical to mKeepAnchor.
+  BI_NetLineAnchor* mKeepAnchor;  ///< The anchor that will be kept.
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif  // LIBREPCB_PROJECT_EDITOR_CMDBOARDCOMBINEANCHORS_H

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -46,10 +46,12 @@ SOURCES += \
     boardeditor/fsm/boardeditorstate_drawpolygon.cpp \
     boardeditor/fsm/boardeditorstate_drawtrace.cpp \
     boardeditor/fsm/boardeditorstate_select.cpp \
+    boardeditor/fsm/boardeditorstate_simplify.cpp \
     boardeditor/unplacedcomponentsdock.cpp \
     cmd/cmdaddcomponenttocircuit.cpp \
     cmd/cmdadddevicetoboard.cpp \
     cmd/cmdaddsymboltoschematic.cpp \
+    cmd/cmdboardcombineanchors.cpp \
     cmd/cmdboardsplitnetline.cpp \
     cmd/cmdchangenetsignalofschematicnetsegment.cpp \
     cmd/cmdcombineboardnetsegments.cpp \
@@ -114,10 +116,12 @@ HEADERS += \
     boardeditor/fsm/boardeditorstate_drawpolygon.h \
     boardeditor/fsm/boardeditorstate_drawtrace.h \
     boardeditor/fsm/boardeditorstate_select.h \
+    boardeditor/fsm/boardeditorstate_simplify.h \
     boardeditor/unplacedcomponentsdock.h \
     cmd/cmdaddcomponenttocircuit.h \
     cmd/cmdadddevicetoboard.h \
     cmd/cmdaddsymboltoschematic.h \
+    cmd/cmdboardcombineanchors.h \
     cmd/cmdboardsplitnetline.h \
     cmd/cmdchangenetsignalofschematicnetsegment.h \
     cmd/cmdcombineboardnetsegments.h \


### PR DESCRIPTION
A command that simplifies all the NetSegments of a NetSignal by removing duplicate items and combining disconnected parts of a NetSegment.
# Features
## Summary
- Combine NetPoints at the same location
- Replace NetPoints with Vias at the same location
- Combine NetLines forming a straight line
- Combine NetPoints and Vias with underlying NetLines
- Remove duplicate NetLines connecting the same two anchors

## Principle
1. Select a NetSignal to be simplified.
2. **(TODO)** Connect disjunct NetSegments
3. Simplify every NetSegment of the NetSignal
   1. Remove duplicate NetLines
   2. Combine duplicate NetPoints at the same location and layer
   3. Connect NetPoints with NetLines crossing their location
   4. **(TODO)** Connect NetLines crossing each other
   5. For every Via
      1. Replace NetPoints at the Via location with the Via
      2. Connect the Via with NetLines crossing its location
   6. Remove Duplicate NetLines
   7. Combine NetLines forming a straight line (Fixes #710)

During the operation, duplicate NetLines and NetPoints are combined multiple times, since some of the more complex simplifications can create these duplicate items.

# TODO
- Replace NetPoints with Pads at the same location
- Connect disjunct NetSegments
- Connect crossing traces
- Connect planes