### PR TITLE
ERC: Disregard schematic-only components in net pin count

### DIFF
--- a/libs/librepcb/project/circuit/componentsignalinstance.h
+++ b/libs/librepcb/project/circuit/componentsignalinstance.h
@@ -83,6 +83,9 @@ public:
     return *mComponentSignal;
   }
   NetSignal* getNetSignal() const noexcept { return mNetSignal; }
+  ComponentInstance& getComponentInstance() const noexcept {
+    return mComponentInstance;
+  }
   bool       isNetSignalNameForced() const noexcept;
   QString    getForcedNetSignalName() const noexcept;
   const QList<SI_SymbolPin*>& getRegisteredSymbolPins() const noexcept {

--- a/libs/librepcb/project/circuit/netsignal.cpp
+++ b/libs/librepcb/project/circuit/netsignal.cpp
@@ -27,9 +27,11 @@
 #include "../erc/ercmsg.h"
 #include "../schematics/items/si_netsegment.h"
 #include "circuit.h"
+#include "componentinstance.h"
 #include "componentsignalinstance.h"
 #include "netclass.h"
 
+#include <librepcb/library/cmp/component.h>
 #include <librepcb/common/exceptions.h>
 
 #include <QtCore>
@@ -263,7 +265,13 @@ void NetSignal::updateErcMessages() noexcept {
     mErcMsgUnusedNetSignal.reset();
   }
 
-  if (mIsAddedToCircuit && (mRegisteredComponentSignals.count() < 2)) {
+  int registeredRealComponentCount = 0;//mRegisteredComponentSignals.count();
+  foreach (ComponentSignalInstance* signal, mRegisteredComponentSignals) {
+    if (!signal->getComponentInstance().getLibComponent().isSchematicOnly()) {
+      registeredRealComponentCount++;
+    }
+  }
+  if (mIsAddedToCircuit && (registeredRealComponentCount < 2)) {
     if (!mErcMsgConnectedToLessThanTwoPins) {
       mErcMsgConnectedToLessThanTwoPins.reset(new ErcMsg(
           mCircuit.getProject(), *this, mUuid.toStr(),

--- a/libs/librepcb/project/circuit/netsignal.cpp
+++ b/libs/librepcb/project/circuit/netsignal.cpp
@@ -265,7 +265,11 @@ void NetSignal::updateErcMessages() noexcept {
     mErcMsgUnusedNetSignal.reset();
   }
 
-  int registeredRealComponentCount = 0;//mRegisteredComponentSignals.count();
+  // Raise a warning if the net signal is connected to less then two component
+  // signals. But do not count component signals of schematic-only components
+  // since these are just "virtual" connections, i.e. not represented by a
+  // real pad (see https://github.com/LibrePCB/LibrePCB/issues/739).
+  int registeredRealComponentCount = 0;
   foreach (ComponentSignalInstance* signal, mRegisteredComponentSignals) {
     if (!signal->getComponentInstance().getLibComponent().isSchematicOnly()) {
       registeredRealComponentCount++;


### PR DESCRIPTION
Only components that are not schematic only are counted when determining if a NetSignal is connected to less than two pins.

- Fixes #739 