### PR TITLE
Board editor: Refactor and improve context menu

### DIFF
--- a/libs/librepcb/common/units/point.cpp
+++ b/libs/librepcb/common/units/point.cpp
@@ -23,6 +23,7 @@
 #include "point.h"
 
 #include "angle.h"
+#include "gridproperties.h"
 
 #include <QtCore>
 
@@ -69,6 +70,11 @@ Point& Point::mapToGrid(const PositiveLength& gridInterval) noexcept {
   mX.mapToGrid(*gridInterval);
   mY.mapToGrid(*gridInterval);
   return *this;
+}
+
+bool Point::isOnGrid(const GridProperties &properties) const noexcept {
+  Point p(*this);
+  return (p.mappedToGrid(properties.getInterval()) == p);
 }
 
 Point Point::rotated(const Angle& angle, const Point& center) const noexcept {

--- a/libs/librepcb/common/units/point.cpp
+++ b/libs/librepcb/common/units/point.cpp
@@ -23,7 +23,6 @@
 #include "point.h"
 
 #include "angle.h"
-#include "gridproperties.h"
 
 #include <QtCore>
 
@@ -72,9 +71,8 @@ Point& Point::mapToGrid(const PositiveLength& gridInterval) noexcept {
   return *this;
 }
 
-bool Point::isOnGrid(const GridProperties &properties) const noexcept {
-  Point p(*this);
-  return (p.mappedToGrid(properties.getInterval()) == p);
+bool Point::isOnGrid(const PositiveLength& gridInterval) const noexcept {
+  return (mappedToGrid(gridInterval) == *this);
 }
 
 Point Point::rotated(const Angle& angle, const Point& center) const noexcept {

--- a/libs/librepcb/common/units/point.h
+++ b/libs/librepcb/common/units/point.h
@@ -34,6 +34,7 @@
 namespace librepcb {
 
 class Angle;
+class GridProperties;
 
 /*******************************************************************************
  *  Class Point
@@ -308,6 +309,8 @@ public:
    * @see ::librepcb::Length::mappedToGrid(), ::librepcb::Point::mapToGrid()
    */
   Point mappedToGrid(const PositiveLength& gridInterval) const noexcept;
+
+  bool isOnGrid(const GridProperties& properties) const noexcept;
 
   /**
    * @brief Map this Point object to a specific grid interval

--- a/libs/librepcb/common/units/point.h
+++ b/libs/librepcb/common/units/point.h
@@ -34,7 +34,6 @@
 namespace librepcb {
 
 class Angle;
-class GridProperties;
 
 /*******************************************************************************
  *  Class Point
@@ -310,8 +309,6 @@ public:
    */
   Point mappedToGrid(const PositiveLength& gridInterval) const noexcept;
 
-  bool isOnGrid(const GridProperties& properties) const noexcept;
-
   /**
    * @brief Map this Point object to a specific grid interval
    *
@@ -322,6 +319,17 @@ public:
    * @see ::librepcb::Length::mapToGrid(), ::librepcb::Point::mappedToGrid()
    */
   Point& mapToGrid(const PositiveLength& gridInterval) noexcept;
+
+  /**
+   * @brief Check whether the Point lies on the grid
+   *
+   * @param gridInterval  See Length::mappedToGrid()
+   *
+   * @return If the point is on the grid.
+   *
+   * @see ::librepcb::Length::mappedToGrid(), ::librepcb::Point::mapToGrid()
+   */
+  bool isOnGrid(const PositiveLength& gridInterval) const noexcept;
 
   /**
    * @brief Get the point rotated by a specific angle with respect to a specific

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
@@ -28,43 +28,6 @@
 #include <QtCore>
 
 /*******************************************************************************
- *  Defines
- ******************************************************************************/
-
-#define ACTION_DELETE(menu, text) \
-  menu.addAction(QIcon(":/img/actions/delete.png"), text)
-
-#define ACTION_DELETE_ALL(menu, text) \
-  menu.addAction(QIcon(":/img/actions/minus.png"), text)
-#define ACTION_DELETE_ALL_DEFAULT(menu) \
-  ACTION_DELETE_ALL(menu, tr("Remove Whole Trace"))
-
-#define ACTION_SELECT_ALL(menu, text) \
-  menu.addAction(QIcon(":/img/actions/bookmark.png"), text)
-#define ACTION_SELECT_ALL_DEFAULT(menu) \
-  ACTION_SELECT_ALL(menu, tr("Select Whole Trace"))
-
-#define ACTION_ROTATE(menu, text) \
-  menu.addAction(QIcon(":/img/actions/rotate_left.png"), text)
-#define ACTION_ROTATE_DEFAULT(menu) ACTION_ROTATE(menu, tr("Rotate"))
-
-#define ACTION_FLIP(menu, text) \
-  menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), text)
-#define ACTION_FLIP_DEFAULT(menu) ACTION_FLIP(menu, tr("Flip"))
-
-#define ACTION_PROPERTIES(menu, text) \
-  menu.addAction(QIcon(":/img/actions/settings.png"), text)
-#define ACTION_PROPERTIES_DEFAULT(menu) ACTION_PROPERTIES(menu, tr("Properties"))
-
-#define ACTION_SNAP(menu, text) \
-  menu.addAction(QIcon(":/img/actions/grid.png"), text)
-#define ACTION_SNAP_DEFAULT(menu) ACTION_SNAP(menu, tr("Snap to grid"))
-
-#define ACTION_MEASURE(menu, text) \
-  menu.addAction(QIcon(":/img/actions/ruler.png"), text)
-#define ACTION_MEASURE_DEFAULT(menu) ACTION_MEASURE(menu, tr("Measure Selected Segments Length"))
-
-/*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
@@ -120,13 +83,30 @@ private:
   ProcRetVal processIdleSceneLeftClick(QGraphicsSceneMouseEvent* mouseEvent,
                                        Board& board) noexcept;
   ProcRetVal processIdleSceneRightMouseButtonReleased(
-      QGraphicsSceneMouseEvent* mouseEvent, Board* board) noexcept;
+      QGraphicsSceneMouseEvent* mouseEvent, Board& board) noexcept;
   ProcRetVal processIdleSceneDoubleClick(QGraphicsSceneMouseEvent* mouseEvent,
                                          Board* board) noexcept;
+
+  // Menu Helpers
+  void addActionRotate(QMenu& menu, const QString& text = tr("Rotate")) noexcept;
+  void addActionFlip(QMenu& menu, const QString& text = tr("Flip")) noexcept;
+  void addActionDelete(QMenu& menu,const QString& text = tr("Remove")) noexcept;
+  void addActionDeleteAll(QMenu& menu, BI_NetSegment& netsegment,
+                const QString& text = tr("Remove Whole Trace")) noexcept;
+  void addActionMeasure(QMenu& menu, BI_NetLine& netline,
+                const QString& text = tr("Measure Selected Segments Length")) noexcept;
+  void addActionProperties(QMenu& menu, Board& board, BI_Base& item,
+                const QString& text = tr("Properties")) noexcept;
+  void addActionSnap(QMenu& menu, const Point pos, Board& board, BI_Base& item,
+                const QString& text = tr("Snap To Grid")) noexcept;
+  void addActionSelectAll(QMenu& menu, BI_NetSegment& netsegment,
+                const QString& text = tr("Select Whole Trace")) noexcept;
+
   bool startMovingSelectedItems(Board& board, const Point& startPos) noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool flipSelectedItems(Qt::Orientation orientation) noexcept;
   bool removeSelectedItems() noexcept;
+
   /**
    * @brief Measure the length of the selected items.
    *
@@ -136,6 +116,7 @@ private:
    * @param netline A selected netline
    */
   bool measureSelectedItems(const BI_NetLine& netline) noexcept;
+
   /**
    * @brief Internal helper method used by #measureSelectedItems
    *
@@ -153,6 +134,7 @@ private:
                                 const BI_NetLine& netline,
                                 QSet<Uuid>&       visitedNetLines,
                                 UnsignedLength&   totalLength);
+
   bool openPropertiesDialog(Board& board, BI_Base* item);
   void openDevicePropertiesDialog(BI_Device& device) noexcept;
   void openViaPropertiesDialog(BI_Via& via) noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
@@ -60,6 +60,10 @@
   menu.addAction(QIcon(":/img/actions/grid.png"), text)
 #define ACTION_SNAP_DEFAULT(menu) ACTION_SNAP(menu, tr("Snap to grid"))
 
+#define ACTION_MEASURE(menu, text) \
+  menu.addAction(QIcon(":/img/actions/ruler.png"), text)
+#define ACTION_MEASURE_DEFAULT(menu) ACTION_MEASURE(menu, tr("Measure Selected Segments Length"))
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -169,6 +173,7 @@ private:
   // Attributes
   SubState mSubState;  ///< the current substate
   QScopedPointer<CmdDragSelectedBoardItems> mSelectedItemsDragCommand;
+  int mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
@@ -28,6 +28,39 @@
 #include <QtCore>
 
 /*******************************************************************************
+ *  Defines
+ ******************************************************************************/
+
+#define ACTION_DELETE(menu, text) \
+  menu.addAction(QIcon(":/img/actions/delete.png"), text)
+
+#define ACTION_DELETE_ALL(menu, text) \
+  menu.addAction(QIcon(":/img/actions/minus.png"), text)
+#define ACTION_DELETE_ALL_DEFAULT(menu) \
+  ACTION_DELETE_ALL(menu, tr("Remove Whole Trace"))
+
+#define ACTION_SELECT_ALL(menu, text) \
+  menu.addAction(QIcon(":/img/actions/bookmark.png"), text)
+#define ACTION_SELECT_ALL_DEFAULT(menu) \
+  ACTION_SELECT_ALL(menu, tr("Select Whole Trace"))
+
+#define ACTION_ROTATE(menu, text) \
+  menu.addAction(QIcon(":/img/actions/rotate_left.png"), text)
+#define ACTION_ROTATE_DEFAULT(menu) ACTION_ROTATE(menu, tr("Rotate"))
+
+#define ACTION_FLIP(menu, text) \
+  menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), text)
+#define ACTION_FLIP_DEFAULT(menu) ACTION_FLIP(menu, tr("Flip"))
+
+#define ACTION_PROPERTIES(menu, text) \
+  menu.addAction(QIcon(":/img/actions/settings.png"), text)
+#define ACTION_PROPERTIES_DEFAULT(menu) ACTION_PROPERTIES(menu, tr("Properties"))
+
+#define ACTION_SNAP(menu, text) \
+  menu.addAction(QIcon(":/img/actions/grid.png"), text)
+#define ACTION_SNAP_DEFAULT(menu) ACTION_SNAP(menu, tr("Snap to grid"))
+
+/*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
@@ -116,6 +149,7 @@ private:
                                 const BI_NetLine& netline,
                                 QSet<Uuid>&       visitedNetLines,
                                 UnsignedLength&   totalLength);
+  bool openPropertiesDialog(Board& board, BI_Base* item);
   void openDevicePropertiesDialog(BI_Device& device) noexcept;
   void openViaPropertiesDialog(BI_Via& via) noexcept;
   void openPlanePropertiesDialog(BI_Plane& plane) noexcept;

--- a/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.cpp
@@ -149,9 +149,12 @@ CmdDragSelectedBoardItems::~CmdDragSelectedBoardItems() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void CmdDragSelectedBoardItems::setCurrentPosition(const Point& pos) noexcept {
+void CmdDragSelectedBoardItems::setCurrentPosition(const Point& pos,
+                                            const bool gridIncrement) noexcept {
   Point delta = pos - mStartPos;
-  delta.mapToGrid(mBoard.getGridProperties().getInterval());
+  if (gridIncrement) {
+    delta.mapToGrid(mBoard.getGridProperties().getInterval());
+  }
 
   if (delta != mDeltaPos) {
     // move selected elements

--- a/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.h
@@ -62,7 +62,8 @@ public:
   ~CmdDragSelectedBoardItems() noexcept;
 
   // General Methods
-  void setCurrentPosition(const Point& pos) noexcept;
+  void setCurrentPosition(const Point& pos, const bool gridIncrement = true)
+    noexcept;
   void rotate(const Angle& angle, bool aroundItemsCenter = false) noexcept;
 
 private:


### PR DESCRIPTION
Previously the menu was build and executed for each different item type separately. This resulted in duplicate code and increased effort when adding an already established action to an item. This PR mainly condenses duplicate code and creates an easy framework for new actions.

# Principle
A range of standard actions are already implemented, that can be used for building the context menu (remove, rotate, flip, snap, ...).
If an item needs a custom action, it must be defined locally and a callback must be connected to the QAction::triggered signal.

# Changes
- Extract and condense code for identical actions
- Add context menu for NetPoints
- Provide functions to create menu entries for some standard actions
- When holding Shift, while clicking on a position with multiple items, cycle through the available items
- Always look if any (not just the first) item at a position was previously selected (Fixes #536)
- create generic openPropertiesDialog function, that handles the type discrimination
- Add option for CmdDragSelectedBoardItems to move without restrictions by the grid
- Add isOnGrid() for Point