### PR TITLE
Draw Trace: Allow connection to multiple anchors

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
@@ -217,6 +217,8 @@ private:
    */
   void showVia(bool isVisible) noexcept;
 
+  BI_NetLineAnchor* combineAnchors(BI_NetLineAnchor& a, BI_NetLineAnchor& b);
+
   // Callback Functions for the Gui elements
   void layerComboBoxIndexChanged(int index) noexcept;
   void updateShapeActionsCheckedState() noexcept;


### PR DESCRIPTION
# Principle
1. Construct a List of all available anchors at the target position
2. Connect the new trace as previously for each anchor
3. Connect skipped NetPoints due to combining NetSegments

# Changes
- Fixes #750
- Fix error where finishing a trace at a Via or FootprintPad without NetLines was impossible