### PR TITLE
Board editor: Snap to nearest anchor when starting a trace

### DIFF
--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -162,6 +162,17 @@ public:
   QList<BI_FootprintPad*> getPadsAtScenePos(
       const Point& pos, const GraphicsLayer* layer = nullptr,
       const NetSignal* netsignal = nullptr) const noexcept;
+
+  BI_NetPoint* getNetPointNextToScenePos(
+      const Point& pos, UnsignedLength& maxDistance,
+      const GraphicsLayer* layer     = nullptr,
+      const NetSignal*     netsignal = nullptr) const;
+  BI_Via* getViaNextToScenePos(const Point& pos, UnsignedLength& maxDistance,
+                               const NetSignal* netsignal = nullptr) const;
+  BI_FootprintPad* getPadNextToScenePos(
+      const Point& pos, UnsignedLength& maxDistance,
+      const GraphicsLayer* layer     = nullptr,
+      const NetSignal*     netsignal = nullptr) const;
   QList<BI_Base*> getAllItems() const noexcept;
 
   // Setters: General

--- a/libs/librepcb/project/boards/items/bi_netsegment.cpp
+++ b/libs/librepcb/project/boards/items/bi_netsegment.cpp
@@ -226,6 +226,41 @@ int BI_NetSegment::getNetLinesAtScenePos(const Point&         pos,
   return count;
 }
 
+BI_NetPoint* BI_NetSegment::getNetPointNextToScenePos(
+    const Point& pos, const GraphicsLayer* layer,
+    UnsignedLength& maxDistance) const noexcept {
+  BI_NetPoint* result = nullptr;
+  foreach (BI_NetPoint* netpoint, mNetPoints) {
+    if (netpoint->isSelectable() &&
+        ((!layer) || (netpoint->getLayerOfLines() == layer))) {
+      UnsignedLength distance = (netpoint->getPosition() - pos).getLength();
+      if (distance < maxDistance) {
+        maxDistance = distance;
+        result      = netpoint;
+      }
+    }
+  }
+  return result;
+}
+
+BI_Via* BI_NetSegment::getViaNextToScenePos(const Point&    pos,
+                                            UnsignedLength& maxDistance) const
+    noexcept {
+  BI_Via* result = nullptr;
+  foreach (BI_Via* via, mVias) {
+    if (via->isSelectable()) {
+      // NOTE(5n8ke): maxDistance is depending on the center of the via and
+      // not the actual distance between the position and the edge of the via
+      UnsignedLength distance = (via->getPosition() - pos).getLength();
+      if (distance < maxDistance) {
+        maxDistance = distance;
+        result      = via;
+      }
+    }
+  }
+  return result;
+}
+
 /*******************************************************************************
  *  Setters
  ******************************************************************************/

--- a/libs/librepcb/project/boards/items/bi_netsegment.h
+++ b/libs/librepcb/project/boards/items/bi_netsegment.h
@@ -77,6 +77,13 @@ public:
   int getNetLinesAtScenePos(const Point& pos, const GraphicsLayer* layer,
                             QList<BI_NetLine*>& lines) const noexcept;
 
+  BI_NetPoint* getNetPointNextToScenePos(const Point&         pos,
+                                         const GraphicsLayer* layer,
+                                         UnsignedLength&      maxDistance) const
+      noexcept;
+  BI_Via* getViaNextToScenePos(const Point&    pos,
+                               UnsignedLength& maxDistance) const noexcept;
+
   // Setters
   void setNetSignal(NetSignal& netsignal);
 

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
@@ -191,6 +191,13 @@ private:
                           GraphicsLayer*           layer     = nullptr,
                           NetSignal*               netsignal = nullptr,
                           const QSet<BI_NetLine*>& except = {}) const noexcept;
+
+  BI_NetLineAnchor* findAnchorNextTo(Board& board, const Point& pos,
+                                     const UnsignedLength& maxDistance,
+                                     GraphicsLayer*        layer = nullptr,
+                                     NetSignal* netsignal = nullptr) const
+      noexcept;
+
   /**
    * @brief Update the currently active traces according
    * to the set parameters.


### PR DESCRIPTION
When no anchor is found at the start location of drawing a trace, look in a radius of 1cm for other possible candidates.
Currently supports
- NetPoints
- Vias
- Pads

# Principle
The search function looks for anchors in the radius of maxDistance around the specified position on a given layer. When a candidate is found, the radius is reduced to the distance between the position and the center point of the anchor.
The function searches for NetPoints, Vias, and Pads in the given order. It returns the last found anchor since it laid within the smallest search radius.

## Caveat
Currently (similar to the rendering of airwires) NetLines are not considered, even if a new NetPoint would result in a closer anchor.

# Linked items
- Merge #632 with current master
- Fixes #631 
