### PR TITLE
Board editor: Implement clipboard cut/copy/paste

### DIFF
--- a/libs/librepcb/project/boards/boardselectionquery.cpp
+++ b/libs/librepcb/project/boards/boardselectionquery.cpp
@@ -69,6 +69,21 @@ BoardSelectionQuery::~BoardSelectionQuery() noexcept {
  *  Getters: General
  ******************************************************************************/
 
+QHash<BI_NetSegment*, BoardSelectionQuery::NetSegmentItems>
+BoardSelectionQuery::getNetSegmentItems() const noexcept {
+  QHash<BI_NetSegment*, NetSegmentItems> result;
+  foreach (BI_Via* via, mResultVias) {
+    result[&via->getNetSegment()].vias.insert(via);
+  }
+  foreach (BI_NetPoint* netpoint, mResultNetPoints) {
+    result[&netpoint->getNetSegment()].netpoints.insert(netpoint);
+  }
+  foreach (BI_NetLine* netline, mResultNetLines) {
+    result[&netline->getNetSegment()].netlines.insert(netline);
+  }
+  return result;
+}
+
 int BoardSelectionQuery::getResultCount() const noexcept {
   return mResultDeviceInstances.count() + mResultNetPoints.count() +
          mResultNetLines.count() + mResultVias.count() + mResultPlanes.count() +

--- a/libs/librepcb/project/boards/boardselectionquery.cpp
+++ b/libs/librepcb/project/boards/boardselectionquery.cpp
@@ -160,12 +160,19 @@ void BoardSelectionQuery::addSelectedHoles() noexcept {
   }
 }
 
-void BoardSelectionQuery::addNetPointsOfNetLines() noexcept {
+void BoardSelectionQuery::addNetPointsOfNetLines(
+    bool onlyIfAllNetLinesSelected) noexcept {
   foreach (BI_NetLine* netline, mResultNetLines) {
     BI_NetPoint* p1 = dynamic_cast<BI_NetPoint*>(&netline->getStartPoint());
     BI_NetPoint* p2 = dynamic_cast<BI_NetPoint*>(&netline->getEndPoint());
-    if (p1) mResultNetPoints.insert(p1);
-    if (p2) mResultNetPoints.insert(p2);
+    if (p1 && ((!onlyIfAllNetLinesSelected) ||
+               (mResultNetLines.contains(p1->getNetLines())))) {
+      mResultNetPoints.insert(p1);
+    }
+    if (p2 && ((!onlyIfAllNetLinesSelected) ||
+               (mResultNetLines.contains(p2->getNetLines())))) {
+      mResultNetPoints.insert(p2);
+    }
   }
 }
 

--- a/libs/librepcb/project/boards/boardselectionquery.h
+++ b/libs/librepcb/project/boards/boardselectionquery.h
@@ -57,6 +57,13 @@ class BoardSelectionQuery final : public QObject {
   Q_OBJECT
 
 public:
+  // Types
+  struct NetSegmentItems {
+    QSet<BI_Via*>      vias;
+    QSet<BI_NetPoint*> netpoints;
+    QSet<BI_NetLine*>  netlines;
+  };
+
   // Constructors / Destructor
   BoardSelectionQuery()                                 = delete;
   BoardSelectionQuery(const BoardSelectionQuery& other) = delete;
@@ -87,7 +94,18 @@ public:
     return mResultStrokeTexts;
   }
   const QSet<BI_Hole*>& getHoles() const noexcept { return mResultHoles; }
-  int                   getResultCount() const noexcept;
+
+  /**
+   * @brief Get vias, net points and net lines grouped by net segement
+   *
+   * Same as #getVias(), #getNetPoints() and #getNetLines(), but grouped
+   * by their corresponding net segments. Only net segments containing selected
+   * items are returned.
+   *
+   * @return List of net segments containing the selected items
+   */
+  QHash<BI_NetSegment*, NetSegmentItems> getNetSegmentItems() const noexcept;
+  int                                    getResultCount() const noexcept;
   bool isResultEmpty() const noexcept { return (getResultCount() == 0); }
 
   // General Methods

--- a/libs/librepcb/project/boards/boardselectionquery.h
+++ b/libs/librepcb/project/boards/boardselectionquery.h
@@ -100,7 +100,16 @@ public:
   void addSelectedBoardStrokeTexts() noexcept;
   void addSelectedFootprintStrokeTexts() noexcept;
   void addSelectedHoles() noexcept;
-  void addNetPointsOfNetLines() noexcept;
+  /**
+   * @brief Add net points of the selected net lines
+   *
+   * @param onlyIfAllNetLinesSelected   If true, net points are added only if
+   *                                    *all* connected net lines are selected.
+   *                                    If false, net points are added if at
+   *                                    least one of the connected net lines
+   *                                    is selected.
+   */
+  void addNetPointsOfNetLines(bool onlyIfAllNetLinesSelected = false) noexcept;
 
   // Operator Overloadings
   BoardSelectionQuery& operator=(const BoardSelectionQuery& rhs) = delete;

--- a/libs/librepcb/projecteditor/boardeditor/boardclipboarddata.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardclipboarddata.cpp
@@ -1,0 +1,161 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "boardclipboarddata.h"
+
+#include <librepcb/common/fileio/transactionaldirectory.h>
+#include <librepcb/common/fileio/transactionalfilesystem.h>
+#include <librepcb/project/circuit/netsignal.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BoardClipboardData::BoardClipboardData(const Uuid&  boardUuid,
+                                       const Point& cursorPos) noexcept
+  : mFileSystem(TransactionalFileSystem::openRW(FilePath::getRandomTempPath())),
+    mBoardUuid(boardUuid),
+    mCursorPos(cursorPos),
+    mDevices(),
+    mNetSegments(),
+    mPlanes(),
+    mPolygons(),
+    mStrokeTexts(),
+    mHoles(),
+    mPadPositions() {
+}
+
+BoardClipboardData::BoardClipboardData(const QByteArray& mimeData)
+  : BoardClipboardData(Uuid::createRandom(), Point()) {
+  mFileSystem->loadFromZip(mimeData);  // can throw
+
+  SExpression root =
+      SExpression::parse(mFileSystem->read("board.lp"), FilePath());
+  mBoardUuid = root.getValueByPath<Uuid>("board");
+  mCursorPos = Point(root.getChildByPath("cursor_position"));
+  mDevices.loadFromSExpression(root);
+  mNetSegments.loadFromSExpression(root);
+  mPlanes.loadFromSExpression(root);
+  mPolygons.loadFromSExpression(root);
+  mStrokeTexts.loadFromSExpression(root);
+  mHoles.loadFromSExpression(root);
+
+  foreach (const SExpression& child, root.getChildren("pad_position")) {
+    mPadPositions.insert(std::make_pair(child.getValueByPath<Uuid>("device"),
+                                        child.getValueByPath<Uuid>("pad")),
+                         Point(child.getChildByPath("position")));
+  }
+}
+
+BoardClipboardData::~BoardClipboardData() noexcept {
+  // Clean up the temporary directory, but destroy the TransactionalFileSystem
+  // object first since it has a lock on the directory.
+  FilePath fp = mFileSystem->getAbsPath();
+  mFileSystem.reset();
+  QDir(fp.toStr()).removeRecursively();
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+std::unique_ptr<TransactionalDirectory> BoardClipboardData::getDirectory(
+    const QString& path) noexcept {
+  return std::unique_ptr<TransactionalDirectory>(
+      new TransactionalDirectory(mFileSystem, path));
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+std::unique_ptr<QMimeData> BoardClipboardData::toMimeData() const {
+  SExpression sexpr =
+      serializeToDomElement("librepcb_clipboard_board");  // can throw
+  mFileSystem->write("board.lp", sexpr.toByteArray());
+
+  QByteArray zip = mFileSystem->exportToZip();
+
+  std::unique_ptr<QMimeData> data(new QMimeData());
+  data->setData(getMimeType(), zip);
+  data->setData("application/zip", zip);
+  data->setText(sexpr.toByteArray());  // TODO: Remove this
+  return data;
+}
+
+std::unique_ptr<BoardClipboardData> BoardClipboardData::fromMimeData(
+    const QMimeData* mime) {
+  QByteArray content = mime ? mime->data(getMimeType()) : QByteArray();
+  if (!content.isNull()) {
+    return std::unique_ptr<BoardClipboardData>(
+        new BoardClipboardData(content));  // can throw
+  } else {
+    return nullptr;
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void BoardClipboardData::serialize(SExpression& root) const {
+  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"), true);
+  root.appendChild("board", mBoardUuid, true);
+  mDevices.serialize(root);
+  mNetSegments.serialize(root);
+  mPlanes.serialize(root);
+  mPolygons.serialize(root);
+  mStrokeTexts.serialize(root);
+  mHoles.serialize(root);
+
+  for (auto it = mPadPositions.constBegin(); it != mPadPositions.constEnd();
+       ++it) {
+    SExpression child = SExpression::createList("pad_position");
+    child.appendChild("device", it.key().first, false);
+    child.appendChild("pad", it.key().second, false);
+    child.appendChild(it.value().serializeToDomElement("position"), false);
+    root.appendChild(child, true);
+  }
+}
+
+QString BoardClipboardData::getMimeType() noexcept {
+  return QString("application/x-librepcb-clipboard.board; version=%1")
+      .arg(qApp->applicationVersion());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/boardeditor/boardclipboarddata.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardclipboarddata.h
@@ -1,0 +1,259 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_BOARDCLIPBOARDDATA_H
+#define LIBREPCB_PROJECT_EDITOR_BOARDCLIPBOARDDATA_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/fileio/serializableobjectlist.h>
+#include <librepcb/common/geometry/hole.h>
+#include <librepcb/common/geometry/junction.h>
+#include <librepcb/common/geometry/polygon.h>
+#include <librepcb/common/geometry/stroketext.h>
+#include <librepcb/common/geometry/trace.h>
+#include <librepcb/common/geometry/via.h>
+#include <librepcb/common/signalslot.h>
+#include <librepcb/common/units/all_length_units.h>
+#include <librepcb/common/uuid.h>
+#include <librepcb/project/boards/items/bi_plane.h>
+#include <librepcb/project/circuit/circuit.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class TransactionalFileSystem;
+class TransactionalDirectory;
+
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Class BoardClipboardData
+ ******************************************************************************/
+
+/**
+ * @brief The BoardClipboardData class
+ */
+class BoardClipboardData final : public SerializableObject {
+public:
+  // Types
+  struct Device : public SerializableObject {
+    static constexpr const char* tagname = "device";
+
+    Uuid           componentUuid;
+    Uuid           libDeviceUuid;
+    Uuid           libFootprintUuid;
+    Point          position;
+    Angle          rotation;
+    bool           mirrored;
+    StrokeTextList strokeTexts;
+    Signal<Device> onEdited;  ///< Dummy event, not used
+
+    Device(const Uuid& componentUuid, const Uuid& libDeviceUuid,
+           const Uuid& libFootprintUuid, const Point& position,
+           const Angle& rotation, bool mirrored,
+           const StrokeTextList& strokeTexts)
+      : componentUuid(componentUuid),
+        libDeviceUuid(libDeviceUuid),
+        libFootprintUuid(libFootprintUuid),
+        position(position),
+        rotation(rotation),
+        mirrored(mirrored),
+        strokeTexts(strokeTexts),
+        onEdited(*this) {}
+
+    explicit Device(const SExpression& node)
+      : componentUuid(node.getChildByIndex(0).getValue<Uuid>()),
+        libDeviceUuid(node.getValueByPath<Uuid>("lib_device")),
+        libFootprintUuid(node.getValueByPath<Uuid>("lib_footprint")),
+        position(node.getChildByPath("position")),
+        rotation(node.getValueByPath<Angle>("rotation")),
+        mirrored(node.getValueByPath<bool>("mirror")),
+        strokeTexts(node),
+        onEdited(*this) {}
+
+    /// @copydoc ::librepcb::SerializableObject::serialize()
+    void serialize(SExpression& root) const override {
+      root.appendChild(componentUuid);
+      root.appendChild("lib_device", libDeviceUuid, true);
+      root.appendChild("lib_footprint", libFootprintUuid, true);
+      root.appendChild(position.serializeToDomElement("position"), true);
+      root.appendChild("rotation", rotation, false);
+      root.appendChild("mirror", mirrored, false);
+      strokeTexts.serialize(root);
+    }
+  };
+
+  struct NetSegment : public SerializableObject {
+    static constexpr const char* tagname = "netsegment";
+
+    CircuitIdentifier  netName;
+    ViaList            vias;
+    JunctionList       junctions;
+    TraceList          traces;
+    Signal<NetSegment> onEdited;  ///< Dummy event, not used
+
+    explicit NetSegment(const CircuitIdentifier& netName)
+      : netName(netName), vias(), junctions(), traces(), onEdited(*this) {}
+
+    explicit NetSegment(const SExpression& node)
+      : netName(node.getValueByPath<CircuitIdentifier>("net")),
+        vias(node),
+        junctions(node),
+        traces(node),
+        onEdited(*this) {}
+
+    /// @copydoc ::librepcb::SerializableObject::serialize()
+    void serialize(SExpression& root) const override {
+      root.appendChild("net", netName, true);
+      vias.serialize(root);
+      junctions.serialize(root);
+      traces.serialize(root);
+    }
+  };
+
+  struct Plane : public SerializableObject {
+    static constexpr const char* tagname = "plane";
+
+    Uuid                   uuid;
+    QString                layer;
+    QString                netSignalName;
+    Path                   outline;
+    UnsignedLength         minWidth;
+    UnsignedLength         minClearance;
+    bool                   keepOrphans;
+    int                    priority;
+    BI_Plane::ConnectStyle connectStyle;
+    Signal<Plane>          onEdited;  ///< Dummy event, not used
+
+    Plane(const Uuid& uuid, const QString& layer, const QString& netSignalName,
+          const Path& outline, const UnsignedLength& minWidth,
+          const UnsignedLength& minClearance, bool keepOrphans, int priority,
+          BI_Plane::ConnectStyle connectStyle)
+      : uuid(uuid),
+        layer(layer),
+        netSignalName(netSignalName),
+        outline(outline),
+        minWidth(minWidth),
+        minClearance(minClearance),
+        keepOrphans(keepOrphans),
+        priority(priority),
+        connectStyle(connectStyle),
+        onEdited(*this) {}
+
+    explicit Plane(const SExpression& node)
+      : uuid(node.getChildByIndex(0).getValue<Uuid>()),
+        layer(node.getValueByPath<QString>("layer", true)),
+        netSignalName(node.getValueByPath<QString>("net", true)),
+        outline(node),
+        minWidth(node.getValueByPath<UnsignedLength>("min_width")),
+        minClearance(node.getValueByPath<UnsignedLength>("min_clearance")),
+        keepOrphans(node.getValueByPath<bool>("keep_orphans")),
+        priority(node.getValueByPath<int>("priority")),
+        connectStyle(
+            node.getValueByPath<BI_Plane::ConnectStyle>("connect_style")),
+        onEdited(*this) {}
+
+    /// @copydoc ::librepcb::SerializableObject::serialize()
+    void serialize(SExpression& root) const override {
+      root.appendChild(uuid);
+      root.appendChild("layer", layer, false);
+      root.appendChild("net", netSignalName, true);
+      root.appendChild("priority", priority, false);
+      root.appendChild("min_width", minWidth, true);
+      root.appendChild("min_clearance", minClearance, false);
+      root.appendChild("keep_orphans", keepOrphans, false);
+      root.appendChild("connect_style", connectStyle, true);
+      outline.serialize(root);
+    }
+  };
+
+  // Constructors / Destructor
+  BoardClipboardData()                                = delete;
+  BoardClipboardData(const BoardClipboardData& other) = delete;
+  BoardClipboardData(const Uuid& boardUuid, const Point& cursorPos) noexcept;
+  explicit BoardClipboardData(const QByteArray& mimeData);
+  ~BoardClipboardData() noexcept;
+
+  // Getters
+  std::unique_ptr<TransactionalDirectory> getDirectory(
+      const QString& path = "") noexcept;
+  const Uuid&  getBoardUuid() const noexcept { return mBoardUuid; }
+  const Point& getCursorPos() const noexcept { return mCursorPos; }
+  SerializableObjectList<Device, Device>& getDevices() noexcept {
+    return mDevices;
+  }
+  SerializableObjectList<NetSegment, NetSegment>& getNetSegments() noexcept {
+    return mNetSegments;
+  }
+  SerializableObjectList<Plane, Plane>& getPlanes() noexcept { return mPlanes; }
+  PolygonList&    getPolygons() noexcept { return mPolygons; }
+  StrokeTextList& getStrokeTexts() noexcept { return mStrokeTexts; }
+  HoleList&       getHoles() noexcept { return mHoles; }
+  QMap<std::pair<Uuid, Uuid>, Point>& getPadPositions() noexcept {
+    return mPadPositions;
+  }
+
+  // General Methods
+  std::unique_ptr<QMimeData>                 toMimeData() const;
+  static std::unique_ptr<BoardClipboardData> fromMimeData(
+      const QMimeData* mime);
+
+  // Operator Overloadings
+  BoardClipboardData& operator=(const BoardClipboardData& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc ::librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  static QString getMimeType() noexcept;
+
+private:  // Data
+  std::shared_ptr<TransactionalFileSystem>       mFileSystem;
+  Uuid                                           mBoardUuid;
+  Point                                          mCursorPos;
+  SerializableObjectList<Device, Device>         mDevices;
+  SerializableObjectList<NetSegment, NetSegment> mNetSegments;
+  SerializableObjectList<Plane, Plane>           mPlanes;
+  PolygonList                                    mPolygons;
+  StrokeTextList                                 mStrokeTexts;
+  HoleList                                       mHoles;
+  QMap<std::pair<Uuid, Uuid>, Point>             mPadPositions;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/projecteditor/boardeditor/boardclipboarddatabuilder.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardclipboarddatabuilder.cpp
@@ -1,0 +1,198 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "boardclipboarddatabuilder.h"
+
+#include "boardnetsegmentsplitter.h"
+
+#include <librepcb/common/graphics/graphicslayer.h>
+#include <librepcb/library/dev/device.h>
+#include <librepcb/library/pkg/package.h>
+#include <librepcb/project/boards/board.h>
+#include <librepcb/project/boards/boardselectionquery.h>
+#include <librepcb/project/boards/items/bi_device.h>
+#include <librepcb/project/boards/items/bi_footprint.h>
+#include <librepcb/project/boards/items/bi_footprintpad.h>
+#include <librepcb/project/boards/items/bi_hole.h>
+#include <librepcb/project/boards/items/bi_netline.h>
+#include <librepcb/project/boards/items/bi_netpoint.h>
+#include <librepcb/project/boards/items/bi_netsegment.h>
+#include <librepcb/project/boards/items/bi_plane.h>
+#include <librepcb/project/boards/items/bi_polygon.h>
+#include <librepcb/project/boards/items/bi_stroketext.h>
+#include <librepcb/project/boards/items/bi_via.h>
+#include <librepcb/project/circuit/netsignal.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BoardClipboardDataBuilder::BoardClipboardDataBuilder(Board& board) noexcept
+  : mBoard(board) {
+}
+
+BoardClipboardDataBuilder::~BoardClipboardDataBuilder() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+std::unique_ptr<BoardClipboardData> BoardClipboardDataBuilder::generate(
+    const Point& cursorPos) const noexcept {
+  std::unique_ptr<BoardClipboardData> data(
+      new BoardClipboardData(mBoard.getUuid(), cursorPos));
+
+  // Get all selected items
+  std::unique_ptr<BoardSelectionQuery> query(mBoard.createSelectionQuery());
+  query->addDeviceInstancesOfSelectedFootprints();
+  query->addSelectedVias();
+  query->addSelectedNetLines();
+  query->addSelectedPlanes();
+  query->addSelectedPolygons();
+  query->addSelectedBoardStrokeTexts();
+  query->addSelectedHoles();
+  query->addNetPointsOfNetLines();
+
+  // Add devices
+  foreach (BI_Device* device, query->getDeviceInstances()) {
+    // Copy library device
+    std::unique_ptr<TransactionalDirectory> devDir =
+        data->getDirectory("dev/" % device->getLibDevice().getUuid().toStr());
+    if (devDir->getFiles().isEmpty()) {
+      device->getLibDevice().getDirectory().copyTo(*devDir);
+    }
+    // Copy library package
+    std::unique_ptr<TransactionalDirectory> pkgDir =
+        data->getDirectory("pkg/" % device->getLibPackage().getUuid().toStr());
+    if (pkgDir->getFiles().isEmpty()) {
+      device->getLibPackage().getDirectory().copyTo(*pkgDir);
+    }
+    // Create list of stroke texts
+    StrokeTextList strokeTexts;
+    foreach (const BI_StrokeText* t, device->getFootprint().getStrokeTexts()) {
+      strokeTexts.append(std::make_shared<StrokeText>(t->getText()));
+    }
+    // Add device
+    data->getDevices().append(std::make_shared<BoardClipboardData::Device>(
+        device->getComponentInstanceUuid(), device->getLibDevice().getUuid(),
+        device->getLibFootprint().getUuid(), device->getPosition(),
+        device->getRotation(), device->getIsMirrored(), strokeTexts));
+    // Add pad positions
+    foreach (const BI_FootprintPad* pad, device->getFootprint().getPads()) {
+      data->getPadPositions().insert(
+          std::make_pair(device->getComponentInstanceUuid(),
+                         pad->getLibPadUuid()),
+          pad->getPosition());
+    }
+  }
+
+  // Add (splitted) net segments including vias, netpoints, and netlines
+  QHash<BI_NetSegment*, BoardSelectionQuery::NetSegmentItems> netSegmentItems =
+      query->getNetSegmentItems();
+  for (auto it = netSegmentItems.constBegin(); it != netSegmentItems.constEnd();
+       ++it) {
+    BoardNetSegmentSplitter splitter;
+    foreach (BI_Device* device, mBoard.getDeviceInstances()) {
+      foreach (BI_FootprintPad* pad, device->getFootprint().getPads()) {
+        if (pad->getNetSegmentOfLines() == it.key()) {
+          if (!query->getDeviceInstances().contains(device)) {
+            // Pad is currently connected to this net segment, but will not be
+            // copied. Thus it needs to be replaced by junctions.
+            splitter.replaceFootprintPadByJunctions(pad->toTraceAnchor(),
+                                                    pad->getPosition());
+          }
+        }
+      }
+    }
+    foreach (BI_Via* via, it.key()->getVias()) {
+      bool replaceByJunctions = !it.value().vias.contains(via);
+      splitter.addVia(via->getVia(), replaceByJunctions);
+    }
+    foreach (BI_NetPoint* netpoint, it.value().netpoints) {
+      splitter.addJunction(netpoint->getJunction());
+    }
+    foreach (BI_NetLine* netline, it.value().netlines) {
+      splitter.addTrace(netline->getTrace());
+    }
+
+    foreach (const BoardNetSegmentSplitter::Segment& segment,
+             splitter.split()) {
+      std::shared_ptr<BoardClipboardData::NetSegment> newSegment =
+          std::make_shared<BoardClipboardData::NetSegment>(
+              it.key()->getNetSignal().getName());
+      newSegment->vias      = segment.vias;
+      newSegment->junctions = segment.junctions;
+      newSegment->traces    = segment.traces;
+      data->getNetSegments().append(newSegment);
+    }
+  }
+
+  // Add planes
+  foreach (BI_Plane* plane, query->getPlanes()) {
+    std::shared_ptr<BoardClipboardData::Plane> newPlane =
+        std::make_shared<BoardClipboardData::Plane>(
+            plane->getUuid(), *plane->getLayerName(),
+            *plane->getNetSignal().getName(), plane->getOutline(),
+            plane->getMinWidth(), plane->getMinClearance(),
+            plane->getKeepOrphans(), plane->getPriority(),
+            plane->getConnectStyle());
+    data->getPlanes().append(newPlane);
+  }
+
+  // Add polygons
+  foreach (BI_Polygon* polygon, query->getPolygons()) {
+    data->getPolygons().append(
+        std::make_shared<Polygon>(polygon->getPolygon()));
+  }
+
+  // Add stroke texts
+  foreach (BI_StrokeText* text, query->getStrokeTexts()) {
+    data->getStrokeTexts().append(
+        std::make_shared<StrokeText>(text->getText()));
+  }
+
+  // Add holes
+  foreach (BI_Hole* hole, query->getHoles()) {
+    data->getHoles().append(std::make_shared<Hole>(hole->getHole()));
+  }
+
+  return data;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/boardeditor/boardclipboarddatabuilder.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardclipboarddatabuilder.h
@@ -1,0 +1,79 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_BOARDCLIPBOARDDATABUILDER_H
+#define LIBREPCB_PROJECT_EDITOR_BOARDCLIPBOARDDATABUILDER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include "boardclipboarddata.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+class Board;
+
+namespace editor {
+
+/*******************************************************************************
+ *  Class BoardClipboardDataBuilder
+ ******************************************************************************/
+
+/**
+ * @brief The BoardClipboardDataBuilder class
+ */
+class BoardClipboardDataBuilder final {
+public:
+  // Constructors / Destructor
+  BoardClipboardDataBuilder()                                       = delete;
+  BoardClipboardDataBuilder(const BoardClipboardDataBuilder& other) = delete;
+  explicit BoardClipboardDataBuilder(Board& board) noexcept;
+  ~BoardClipboardDataBuilder() noexcept;
+
+  // General Methods
+  std::unique_ptr<BoardClipboardData> generate(const Point& cursorPos) const
+      noexcept;
+
+  // Operator Overloadings
+  BoardClipboardDataBuilder& operator=(const BoardClipboardDataBuilder& rhs) =
+      delete;
+
+private:  // Data
+  Board& mBoard;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -459,9 +459,6 @@
    <property name="shortcut">
     <string notr="true">Ctrl+C</string>
    </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
   </action>
   <action name="actionCut">
    <property name="icon">
@@ -474,9 +471,6 @@
    <property name="shortcut">
     <string notr="true">Ctrl+X</string>
    </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
   </action>
   <action name="actionPaste">
    <property name="icon">
@@ -488,9 +482,6 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+V</string>
-   </property>
-   <property name="visible">
-    <bool>false</bool>
    </property>
   </action>
   <action name="actionRemove">

--- a/libs/librepcb/projecteditor/boardeditor/boardnetsegmentsplitter.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardnetsegmentsplitter.cpp
@@ -1,0 +1,164 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "boardnetsegmentsplitter.h"
+
+#include <librepcb/common/toolbox.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BoardNetSegmentSplitter::BoardNetSegmentSplitter() noexcept
+  : mJunctions(), mVias(), mTraces() {
+}
+
+BoardNetSegmentSplitter::~BoardNetSegmentSplitter() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BoardNetSegmentSplitter::replaceFootprintPadByJunctions(
+    const TraceAnchor& anchor, const Point& pos) noexcept {
+  mAnchorsToReplace[anchor] = pos;
+}
+
+void BoardNetSegmentSplitter::addJunction(const Junction& junction) noexcept {
+  mJunctions.append(std::make_shared<Junction>(junction));
+}
+
+void BoardNetSegmentSplitter::addVia(const Via& via,
+                                     bool       replaceByJunctions) noexcept {
+  if (replaceByJunctions) {
+    mAnchorsToReplace[TraceAnchor::via(via.getUuid())] = via.getPosition();
+  } else {
+    mVias.append(std::make_shared<Via>(via));
+  }
+}
+
+void BoardNetSegmentSplitter::addTrace(const Trace& trace) noexcept {
+  std::shared_ptr<Trace> copy = std::make_shared<Trace>(trace);
+  copy->setStartPoint(replaceAnchor(copy->getStartPoint(), copy->getLayer()));
+  copy->setEndPoint(replaceAnchor(copy->getEndPoint(), copy->getLayer()));
+  mTraces.append(copy);
+}
+
+QList<BoardNetSegmentSplitter::Segment>
+BoardNetSegmentSplitter::split() noexcept {
+  QList<Segment> segments;
+
+  // Split netsegment by anchors and lines
+  ViaList   availableVias   = mVias;
+  TraceList availableTraces = mTraces;
+  while (!availableTraces.isEmpty()) {
+    Segment segment;
+    findConnectedLinesAndPoints(availableTraces.first()->getStartPoint(),
+                                availableVias, availableTraces, segment);
+    segments.append(segment);
+  }
+  Q_ASSERT(availableTraces.isEmpty());
+
+  // Add remaining vias as separate segments
+  while (!availableVias.isEmpty()) {
+    Segment segment;
+    segment.vias.append(availableVias.take(0));
+    segments.append(segment);
+  }
+  Q_ASSERT(availableVias.isEmpty());
+
+  return segments;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+TraceAnchor BoardNetSegmentSplitter::replaceAnchor(
+    const TraceAnchor& anchor, const GraphicsLayerName& layer) noexcept {
+  if (mAnchorsToReplace.contains(anchor)) {
+    auto key = qMakePair(anchor, layer);
+    auto it  = mReplacedAnchors.find(key);
+    if (it == mReplacedAnchors.constEnd()) {
+      std::shared_ptr<Junction> newJunction = std::make_shared<Junction>(
+          Uuid::createRandom(), mAnchorsToReplace.value(anchor));
+      mJunctions.append(newJunction);
+      TraceAnchor newAnchor(TraceAnchor::junction(newJunction->getUuid()));
+      it = mReplacedAnchors.insert(key, newAnchor);
+    }
+    return *it;
+  } else {
+    return anchor;
+  }
+}
+
+void BoardNetSegmentSplitter::findConnectedLinesAndPoints(
+    const TraceAnchor& anchor, ViaList& availableVias,
+    TraceList& availableTraces, Segment& segment) noexcept {
+  if (tl::optional<Uuid> junctionUuid = anchor.tryGetJunction()) {
+    if (std::shared_ptr<Junction> junction = mJunctions.find(*junctionUuid)) {
+      if (!segment.junctions.contains(junction->getUuid())) {
+        segment.junctions.append(junction);
+      }
+    }
+  } else if (tl::optional<Uuid> viaUuid = anchor.tryGetVia()) {
+    if (std::shared_ptr<Via> via = mVias.find(*viaUuid)) {
+      if (availableVias.contains(via->getUuid())) {
+        segment.vias.append(via);
+        availableVias.remove(via->getUuid());
+      }
+    }
+  }
+  for (int i = 0; i < mTraces.count(); ++i) {
+    std::shared_ptr<Trace> trace = mTraces.value(i);
+    if (((trace->getStartPoint() == anchor) ||
+         (trace->getEndPoint() == anchor)) &&
+        availableTraces.contains(trace->getUuid()) &&
+        (!segment.traces.contains(trace->getUuid()))) {
+      segment.traces.append(trace);
+      availableTraces.remove(trace->getUuid());
+      findConnectedLinesAndPoints(trace->getStartPoint(), availableVias,
+                                  availableTraces, segment);
+      findConnectedLinesAndPoints(trace->getEndPoint(), availableVias,
+                                  availableTraces, segment);
+    }
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/boardeditor/boardnetsegmentsplitter.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardnetsegmentsplitter.h
@@ -1,0 +1,102 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_BOARDNETSEGMENTSPLITTER_H
+#define LIBREPCB_PROJECT_EDITOR_BOARDNETSEGMENTSPLITTER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/geometry/junction.h>
+#include <librepcb/common/geometry/trace.h>
+#include <librepcb/common/geometry/via.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class GraphicsLayer;
+
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Class BoardNetSegmentSplitter
+ ******************************************************************************/
+
+/**
+ * @brief The BoardNetSegmentSplitter class
+ */
+class BoardNetSegmentSplitter final {
+public:
+  // Types
+  struct Segment {
+    JunctionList junctions;
+    ViaList      vias;
+    TraceList    traces;
+  };
+
+  // Constructors / Destructor
+  BoardNetSegmentSplitter() noexcept;
+  BoardNetSegmentSplitter(const BoardNetSegmentSplitter& other) = delete;
+  ~BoardNetSegmentSplitter() noexcept;
+
+  // General Methods
+  void           replaceFootprintPadByJunctions(const TraceAnchor& anchor,
+                                                const Point&       pos) noexcept;
+  void           addJunction(const Junction& junction) noexcept;
+  void           addVia(const Via& via, bool replaceByJunctions) noexcept;
+  void           addTrace(const Trace& trace) noexcept;
+  QList<Segment> split() noexcept;
+
+  // Operator Overloadings
+  BoardNetSegmentSplitter& operator=(const BoardNetSegmentSplitter& rhs) =
+      delete;
+
+private:  // Methods
+  TraceAnchor replaceAnchor(const TraceAnchor&       anchor,
+                            const GraphicsLayerName& layer) noexcept;
+  void        findConnectedLinesAndPoints(const TraceAnchor& anchor,
+                                          ViaList&           availableVias,
+                                          TraceList& availableTraces, Segment& segment)
+
+      noexcept;
+
+private:  // Data
+  JunctionList mJunctions;
+  ViaList      mVias;
+  TraceList    mTraces;
+
+  QHash<TraceAnchor, Point>                                 mAnchorsToReplace;
+  QHash<QPair<TraceAnchor, GraphicsLayerName>, TraceAnchor> mReplacedAnchors;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.h
@@ -81,11 +81,15 @@ public:
 
   // Event Handlers
   virtual bool processSelectAll() noexcept override;
+  virtual bool processCut() noexcept override;
+  virtual bool processCopy() noexcept override;
+  virtual bool processPaste() noexcept override;
   virtual bool processRotateCw() noexcept override;
   virtual bool processRotateCcw() noexcept override;
   virtual bool processFlipHorizontal() noexcept override;
   virtual bool processFlipVertical() noexcept override;
   virtual bool processRemove() noexcept override;
+  virtual bool processAbortCommand() noexcept override;
   virtual bool processGraphicsSceneMouseMoved(
       QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processGraphicsSceneLeftMouseButtonPressed(
@@ -128,6 +132,9 @@ private:  // Methods
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool flipSelectedItems(Qt::Orientation orientation) noexcept;
   bool removeSelectedItems() noexcept;
+  bool copySelectedItemsToClipboard() noexcept;
+  bool pasteFromClipboard() noexcept;
+  bool abortCommand(bool showErrMsgBox) noexcept;
 
   /**
    * @brief Measure the length of the selected items.
@@ -168,7 +175,10 @@ private:  // Methods
       const ComponentInstance& cmpInst) const noexcept;
 
 private:  // Data
-  /// When moving items, this undo command will be active
+  /// An undo command will be active while dragging pasted items
+  bool mIsUndoCmdActive;
+
+  /// When dragging items, this undo command will be active
   QScopedPointer<CmdDragSelectedBoardItems> mSelectedItemsDragCommand;
   int                                       mCurrentSelectionIndex;
 };

--- a/libs/librepcb/projecteditor/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdpasteboarditems.cpp
@@ -1,0 +1,328 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdpasteboarditems.h"
+
+#include "../boardeditor/boardclipboarddata.h"
+#include "../boardeditor/boardnetsegmentsplitter.h"
+#include "cmdremoveboarditems.h"
+
+#include <librepcb/common/scopeguard.h>
+#include <librepcb/common/toolbox.h>
+#include <librepcb/library/dev/device.h>
+#include <librepcb/library/pkg/package.h>
+#include <librepcb/project/boards/boardlayerstack.h>
+#include <librepcb/project/boards/cmd/cmdboardholeadd.h>
+#include <librepcb/project/boards/cmd/cmdboardnetsegmentadd.h>
+#include <librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h>
+#include <librepcb/project/boards/cmd/cmdboardplaneadd.h>
+#include <librepcb/project/boards/cmd/cmdboardpolygonadd.h>
+#include <librepcb/project/boards/cmd/cmdboardstroketextadd.h>
+#include <librepcb/project/boards/cmd/cmddeviceinstanceadd.h>
+#include <librepcb/project/boards/items/bi_device.h>
+#include <librepcb/project/boards/items/bi_footprint.h>
+#include <librepcb/project/boards/items/bi_footprintpad.h>
+#include <librepcb/project/boards/items/bi_hole.h>
+#include <librepcb/project/boards/items/bi_netline.h>
+#include <librepcb/project/boards/items/bi_netpoint.h>
+#include <librepcb/project/boards/items/bi_netsegment.h>
+#include <librepcb/project/boards/items/bi_plane.h>
+#include <librepcb/project/boards/items/bi_polygon.h>
+#include <librepcb/project/boards/items/bi_stroketext.h>
+#include <librepcb/project/boards/items/bi_via.h>
+#include <librepcb/project/circuit/circuit.h>
+#include <librepcb/project/circuit/cmd/cmdnetclassadd.h>
+#include <librepcb/project/circuit/cmd/cmdnetsignaladd.h>
+#include <librepcb/project/circuit/netsignal.h>
+#include <librepcb/project/library/cmd/cmdprojectlibraryaddelement.h>
+#include <librepcb/project/library/projectlibrary.h>
+#include <librepcb/project/project.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdPasteBoardItems::CmdPasteBoardItems(Board& board,
+                                       std::unique_ptr<BoardClipboardData> data,
+                                       const Point& posOffset) noexcept
+  : UndoCommandGroup(tr("Paste Board Elements")),
+    mProject(board.getProject()),
+    mBoard(board),
+    mData(std::move(data)),
+    mPosOffset(posOffset) {
+  Q_ASSERT(mData);
+}
+
+CmdPasteBoardItems::~CmdPasteBoardItems() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdPasteBoardItems::performExecute() {
+  // if an error occurs, undo all already executed child commands
+  auto undoScopeGuard = scopeGuard([&]() { performUndo(); });
+
+  // Notes:
+  //
+  //  - Devices are only pasted if the corresponding component exists in the
+  //    circuit, and the device does not yet exist on the board (one cannot
+  //    paste a device if it is already added to the board).
+  //  - Netlines which were attached to a pad or via which was not copy/pasted
+  //    will be attached to newly created freestanding netpoints.
+  //  - The graphics items of the added elements are selected immediately to
+  //    allow dragging them afterwards.
+
+  // Paste devices which do not yet exist on the board
+  QSet<Uuid> pastedDevices;
+  for (const BoardClipboardData::Device& dev : mData->getDevices()) {
+    ComponentInstance* cmpInst =
+        mProject.getCircuit().getComponentInstanceByUuid(dev.componentUuid);
+    if (!cmpInst) {
+      continue;  // Corresponding component does not exist (anymore) in circuit.
+    }
+    BI_Device* devInst =
+        mBoard.getDeviceInstanceByComponentUuid(dev.componentUuid);
+    if (devInst) {
+      continue;  // Device already exist on the board.
+    }
+
+    // Copy new device to project library, if not existing already
+    tl::optional<Uuid> pgkUuid;
+    if (const library::Device* libDev =
+            mProject.getLibrary().getDevice(dev.libDeviceUuid)) {
+      pgkUuid = libDev->getPackageUuid();
+    } else {
+      QScopedPointer<library::Device> newLibDev(new library::Device(
+          mData->getDirectory("dev/" % dev.libDeviceUuid.toStr())));
+      pgkUuid = newLibDev->getPackageUuid();
+      execNewChildCmd(new CmdProjectLibraryAddElement<library::Device>(
+          mProject.getLibrary(), *newLibDev.take()));
+    }
+    Q_ASSERT(pgkUuid);
+
+    // Copy new package to project library, if not existing already
+    if (!mProject.getLibrary().getPackage(*pgkUuid)) {
+      QScopedPointer<library::Package> newLibPgk(
+          new library::Package(mData->getDirectory("pkg/" % pgkUuid->toStr())));
+      execNewChildCmd(new CmdProjectLibraryAddElement<library::Package>(
+          mProject.getLibrary(), *newLibPgk.take()));
+    }
+
+    // Add device instance to board
+    QScopedPointer<BI_Device> device(
+        new BI_Device(mBoard, *cmpInst, dev.libDeviceUuid, dev.libFootprintUuid,
+                      dev.position + mPosOffset, dev.rotation, dev.mirrored));
+    foreach (BI_StrokeText* text, device->getFootprint().getStrokeTexts()) {
+      device->getFootprint().removeStrokeText(*text);
+    }
+    for (const StrokeText& text : dev.strokeTexts) {
+      StrokeText copy(Uuid::createRandom(), text);        // assign new UUID
+      copy.setPosition(copy.getPosition() + mPosOffset);  // move
+      BI_StrokeText* item = new BI_StrokeText(mBoard, copy);
+      item->setSelected(true);
+      device->getFootprint().addStrokeText(*item);
+    }
+    device->setSelected(true);
+    execNewChildCmd(new CmdDeviceInstanceAdd(*device.take()));
+    pastedDevices.insert(dev.componentUuid);
+  }
+
+  // Paste net segments
+  for (const BoardClipboardData::NetSegment& seg : mData->getNetSegments()) {
+    BoardNetSegmentSplitter splitter;
+    for (auto it = mData->getPadPositions().constBegin();
+         it != mData->getPadPositions().constEnd(); ++it) {
+      const Uuid& device = it.key().first;
+      const Uuid& pad    = it.key().second;
+      if (!pastedDevices.contains(device)) {
+        // Device was not pasted, so we have to replace all pads by junctions
+        splitter.replaceFootprintPadByJunctions(TraceAnchor::pad(device, pad),
+                                                it.value());
+      }
+    }
+    for (const Via& v : seg.vias) {
+      splitter.addVia(v, false);
+    }
+    for (const Junction& junction : seg.junctions) {
+      splitter.addJunction(junction);
+    }
+    for (const Trace& trace : seg.traces) {
+      splitter.addTrace(trace);
+    }
+
+    foreach (const BoardNetSegmentSplitter::Segment& segment,
+             splitter.split()) {
+      // Add new segment
+      BI_NetSegment* copy =
+          new BI_NetSegment(mBoard, *getOrCreateNetSignal(*seg.netName));
+      copy->setSelected(true);
+      execNewChildCmd(new CmdBoardNetSegmentAdd(*copy));
+
+      // Add vias, netpoints and netlines
+      QScopedPointer<CmdBoardNetSegmentAddElements> cmdAddElements(
+          new CmdBoardNetSegmentAddElements(*copy));
+      QHash<Uuid, BI_Via*> viaMap;
+      for (const Via& v : segment.vias) {
+        BI_Via* via = cmdAddElements->addVia(
+            Via(Uuid::createRandom(), v.getPosition() + mPosOffset,
+                v.getShape(), v.getSize(), v.getDrillDiameter()));
+        via->setSelected(true);
+        viaMap.insert(v.getUuid(), via);
+      }
+      QHash<Uuid, BI_NetPoint*> netPointMap;
+      for (const Junction& junction : segment.junctions) {
+        BI_NetPoint* netpoint =
+            cmdAddElements->addNetPoint(junction.getPosition() + mPosOffset);
+        netpoint->setSelected(true);
+        netPointMap.insert(junction.getUuid(), netpoint);
+      }
+      for (const Trace& trace : segment.traces) {
+        BI_NetLineAnchor* start = nullptr;
+        if (tl::optional<Uuid> anchor =
+                trace.getStartPoint().tryGetJunction()) {
+          start = netPointMap[*anchor];
+        } else if (tl::optional<Uuid> anchor =
+                       trace.getStartPoint().tryGetVia()) {
+          start = viaMap[*anchor];
+        } else if (tl::optional<TraceAnchor::PadAnchor> anchor =
+                       trace.getStartPoint().tryGetPad()) {
+          Q_ASSERT(pastedDevices.contains(anchor->device));
+          BI_Device* device =
+              mBoard.getDeviceInstanceByComponentUuid(anchor->device);
+          start = device ? device->getFootprint().getPad(anchor->pad) : nullptr;
+        }
+        BI_NetLineAnchor* end = nullptr;
+        if (tl::optional<Uuid> anchor = trace.getEndPoint().tryGetJunction()) {
+          end = netPointMap[*anchor];
+        } else if (tl::optional<Uuid> anchor =
+                       trace.getEndPoint().tryGetVia()) {
+          end = viaMap[*anchor];
+        } else if (tl::optional<TraceAnchor::PadAnchor> anchor =
+                       trace.getEndPoint().tryGetPad()) {
+          Q_ASSERT(pastedDevices.contains(anchor->device));
+          BI_Device* device =
+              mBoard.getDeviceInstanceByComponentUuid(anchor->device);
+          end = device ? device->getFootprint().getPad(anchor->pad) : nullptr;
+        }
+        GraphicsLayer* layer =
+            mBoard.getLayerStack().getLayer(*trace.getLayer());
+        if ((!start) || (!end) || (!layer)) {
+          throw LogicError(__FILE__, __LINE__);
+        }
+        BI_NetLine* netline =
+            cmdAddElements->addNetLine(*start, *end, *layer, trace.getWidth());
+        netline->setSelected(true);
+      }
+      execNewChildCmd(cmdAddElements.take());
+    }
+  }
+
+  // Paste planes
+  for (const BoardClipboardData::Plane& plane : mData->getPlanes()) {
+    BI_Plane* copy = new BI_Plane(mBoard,
+                                  Uuid::createRandom(),  // assign new UUID
+                                  GraphicsLayerName(plane.layer),
+                                  *getOrCreateNetSignal(plane.netSignalName),
+                                  plane.outline.translated(mPosOffset)  // move
+    );
+    copy->setMinWidth(plane.minWidth);
+    copy->setMinClearance(plane.minClearance);
+    copy->setKeepOrphans(plane.keepOrphans);
+    copy->setPriority(plane.priority);
+    copy->setConnectStyle(plane.connectStyle);
+    copy->setSelected(true);
+    execNewChildCmd(new CmdBoardPlaneAdd(*copy));
+  }
+
+  // Paste polygons
+  for (const Polygon& polygon : mData->getPolygons()) {
+    Polygon copy(Uuid::createRandom(), polygon);          // assign new UUID
+    copy.setPath(copy.getPath().translated(mPosOffset));  // move
+    BI_Polygon* item = new BI_Polygon(mBoard, copy);
+    item->setSelected(true);
+    execNewChildCmd(new CmdBoardPolygonAdd(*item));
+  }
+
+  // Paste stroke texts
+  for (const StrokeText& text : mData->getStrokeTexts()) {
+    StrokeText copy(Uuid::createRandom(), text);        // assign new UUID
+    copy.setPosition(copy.getPosition() + mPosOffset);  // move
+    BI_StrokeText* item = new BI_StrokeText(mBoard, copy);
+    item->setSelected(true);
+    execNewChildCmd(new CmdBoardStrokeTextAdd(*item));
+  }
+
+  // Paste holes
+  for (const Hole& hole : mData->getHoles()) {
+    Hole copy(Uuid::createRandom(), hole);              // assign new UUID
+    copy.setPosition(copy.getPosition() + mPosOffset);  // move
+    BI_Hole* item = new BI_Hole(mBoard, copy);
+    item->setSelected(true);
+    execNewChildCmd(new CmdBoardHoleAdd(*item));
+  }
+
+  undoScopeGuard.dismiss();  // no undo required
+  return getChildCount() > 0;
+}
+
+NetSignal* CmdPasteBoardItems::getOrCreateNetSignal(const QString& name) {
+  NetSignal* netSignal = mProject.getCircuit().getNetSignalByName(name);
+  if (netSignal) {
+    return netSignal;
+  }
+
+  // Get or create netclass with the name "default"
+  NetClass* netclass =
+      mProject.getCircuit().getNetClassByName(ElementName("default"));
+  if (!netclass) {
+    CmdNetClassAdd* cmd =
+        new CmdNetClassAdd(mProject.getCircuit(), ElementName("default"));
+    execNewChildCmd(cmd);
+    netclass = cmd->getNetClass();
+    Q_ASSERT(netclass);
+  }
+
+  // Create new net signal
+  CmdNetSignalAdd* cmdAddNetSignal =
+      new CmdNetSignalAdd(mProject.getCircuit(), *netclass);
+  execNewChildCmd(cmdAddNetSignal);
+  return cmdAddNetSignal->getNetSignal();
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/cmd/cmdpasteboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdpasteboarditems.h
@@ -1,0 +1,87 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_CMDPASTEBOARDITEMS_H
+#define LIBREPCB_PROJECT_EDITOR_CMDPASTEBOARDITEMS_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/undocommandgroup.h>
+#include <librepcb/common/units/point.h>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+class Project;
+class Board;
+class NetSignal;
+
+namespace editor {
+
+class BoardClipboardData;
+
+/*******************************************************************************
+ *  Class CmdPasteBoardItems
+ ******************************************************************************/
+
+/**
+ * @brief The CmdPasteBoardItems class
+ */
+class CmdPasteBoardItems final : public UndoCommandGroup {
+public:
+  // Constructors / Destructor
+  CmdPasteBoardItems()                                = delete;
+  CmdPasteBoardItems(const CmdPasteBoardItems& other) = delete;
+  CmdPasteBoardItems(Board& board, std::unique_ptr<BoardClipboardData> data,
+                     const Point& posOffset) noexcept;
+  ~CmdPasteBoardItems() noexcept;
+
+  // Operator Overloadings
+  CmdPasteBoardItems& operator=(const CmdPasteBoardItems& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  bool performExecute() override;
+
+  NetSignal* getOrCreateNetSignal(const QString& name);
+
+private:  // Data
+  Project&                            mProject;
+  Board&                              mBoard;
+  std::unique_ptr<BoardClipboardData> mData;
+  Point                               mPosOffset;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/projecteditor/cmd/cmdpastefootprintitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdpastefootprintitems.cpp
@@ -1,0 +1,107 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdpastefootprintitems.h"
+
+#include <librepcb/libraryeditor/pkg/footprintclipboarddata.h>
+#include <librepcb/project/boards/board.h>
+#include <librepcb/project/boards/cmd/cmdboardholeadd.h>
+#include <librepcb/project/boards/cmd/cmdboardpolygonadd.h>
+#include <librepcb/project/boards/cmd/cmdboardstroketextadd.h>
+#include <librepcb/project/boards/items/bi_hole.h>
+#include <librepcb/project/boards/items/bi_polygon.h>
+#include <librepcb/project/boards/items/bi_stroketext.h>
+#include <librepcb/project/project.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdPasteFootprintItems::CmdPasteFootprintItems(
+    Board& board, std::unique_ptr<library::editor::FootprintClipboardData> data,
+    const Point& posOffset) noexcept
+  : UndoCommandGroup(tr("Paste Board Elements")),
+    mProject(board.getProject()),
+    mBoard(board),
+    mData(std::move(data)),
+    mPosOffset(posOffset) {
+}
+
+CmdPasteFootprintItems::~CmdPasteFootprintItems() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdPasteFootprintItems::performExecute() {
+  // Notes:
+  //
+  //  - The graphics items of the added elements are selected immediately to
+  //    allow dragging them afterwards.
+
+  // Paste polygons
+  for (const Polygon& polygon : mData->getPolygons()) {
+    Polygon copy(Uuid::createRandom(), polygon);          // assign new UUID
+    copy.setPath(copy.getPath().translated(mPosOffset));  // move
+    BI_Polygon* item = new BI_Polygon(mBoard, copy);
+    item->setSelected(true);
+    appendChild(new CmdBoardPolygonAdd(*item));
+  }
+
+  // Paste stroke texts
+  for (const StrokeText& text : mData->getStrokeTexts()) {
+    StrokeText copy(Uuid::createRandom(), text);        // assign new UUID
+    copy.setPosition(copy.getPosition() + mPosOffset);  // move
+    BI_StrokeText* item = new BI_StrokeText(mBoard, copy);
+    item->setSelected(true);
+    appendChild(new CmdBoardStrokeTextAdd(*item));
+  }
+
+  // Paste holes
+  for (const Hole& hole : mData->getHoles()) {
+    Hole copy(Uuid::createRandom(), hole);              // assign new UUID
+    copy.setPosition(copy.getPosition() + mPosOffset);  // move
+    BI_Hole* item = new BI_Hole(mBoard, copy);
+    item->setSelected(true);
+    appendChild(new CmdBoardHoleAdd(*item));
+  }
+
+  return UndoCommandGroup::performExecute();  // can throw
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/cmd/cmdpastefootprintitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdpastefootprintitems.h
@@ -1,0 +1,91 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_CMDPASTEFOOTPRINTITEMS_H
+#define LIBREPCB_PROJECT_EDITOR_CMDPASTEFOOTPRINTITEMS_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/undocommandgroup.h>
+#include <librepcb/common/units/point.h>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+namespace library {
+namespace editor {
+class FootprintClipboardData;
+}
+}  // namespace library
+
+namespace project {
+
+class Project;
+class Board;
+
+namespace editor {
+
+/*******************************************************************************
+ *  Class CmdPasteFootprintItems
+ ******************************************************************************/
+
+/**
+ * @brief The CmdPasteFootprintItems class
+ */
+class CmdPasteFootprintItems final : public UndoCommandGroup {
+public:
+  // Constructors / Destructor
+  CmdPasteFootprintItems()                                    = delete;
+  CmdPasteFootprintItems(const CmdPasteFootprintItems& other) = delete;
+  CmdPasteFootprintItems(
+      Board&                                                   board,
+      std::unique_ptr<library::editor::FootprintClipboardData> data,
+      const Point& posOffset) noexcept;
+  ~CmdPasteFootprintItems() noexcept;
+
+  // Operator Overloadings
+  CmdPasteFootprintItems& operator=(const CmdPasteFootprintItems& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc UndoCommand::performExecute()
+  bool performExecute() override;
+
+private:  // Data
+  Project&                                                 mProject;
+  Board&                                                   mBoard;
+  std::unique_ptr<library::editor::FootprintClipboardData> mData;
+  Point                                                    mPosOffset;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.h
@@ -39,11 +39,11 @@ class BI_NetSegment;
 class BI_Via;
 class BI_NetPoint;
 class BI_NetLine;
-class BI_NetLineAnchor;
 class BI_Plane;
 class BI_Polygon;
 class BI_StrokeText;
 class BI_Hole;
+class BI_FootprintPad;
 
 namespace editor {
 
@@ -58,9 +58,10 @@ class CmdRemoveBoardItems final : public UndoCommandGroup {
 private:
   // Private Types
   struct NetSegmentItems {
-    QSet<BI_Via*>      vias;
-    QSet<BI_NetPoint*> netpoints;
-    QSet<BI_NetLine*>  netlines;
+    QSet<BI_Via*>          vias;
+    QSet<BI_NetPoint*>     netpoints;
+    QSet<BI_NetLine*>      netlines;
+    QSet<BI_FootprintPad*> pads;
   };
   typedef QHash<BI_NetSegment*, NetSegmentItems> NetSegmentItemList;
 
@@ -116,17 +117,11 @@ private:  // Methods
   /// @copydoc UndoCommand::performExecute()
   bool performExecute() override;
 
-  void                     splitUpNetSegment(BI_NetSegment&         netsegment,
-                                             const NetSegmentItems& itemsToRemove);
-  void                     createNewSubNetSegment(BI_NetSegment&         netsegment,
-                                                  const NetSegmentItems& items);
-  QVector<NetSegmentItems> getNonCohesiveNetSegmentSubSegments(
-      BI_NetSegment& segment, const NetSegmentItems& removedItems) noexcept;
-  void findAllConnectedNetPointsAndNetLines(
-      BI_NetLineAnchor& anchor, QSet<BI_NetLineAnchor*>& processedAnchors,
-      QSet<BI_Via*>& vias, QSet<BI_NetPoint*>& netpoints,
-      QSet<BI_NetLine*>& netlines, QSet<BI_Via*>& availableVias,
-      QSet<BI_NetLine*>& availableNetLines) const noexcept;
+  void removeNetSegmentItems(BI_NetSegment&                netsegment,
+                             const QSet<BI_FootprintPad*>& padsToDisconnect,
+                             const QSet<BI_Via*>&          viasToRemove,
+                             const QSet<BI_NetPoint*>&     netpointsToRemove,
+                             const QSet<BI_NetLine*>&      netlinesToRemove);
 
 private:  // Data
   Board& mBoard;

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedboarditems.cpp
@@ -59,6 +59,7 @@ bool CmdRemoveSelectedBoardItems::performExecute() {
   query->addDeviceInstancesOfSelectedFootprints();
   query->addSelectedVias();
   query->addSelectedNetLines();
+  query->addNetPointsOfNetLines(true);
   query->addSelectedPlanes();
   query->addSelectedPolygons();
   query->addSelectedBoardStrokeTexts();

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -31,6 +31,7 @@ SOURCES += \
     boardeditor/boardeditor.cpp \
     boardeditor/boardlayersdock.cpp \
     boardeditor/boardlayerstacksetupdialog.cpp \
+    boardeditor/boardnetsegmentsplitter.cpp \
     boardeditor/boardpickplacegeneratordialog.cpp \
     boardeditor/boardplanepropertiesdialog.cpp \
     boardeditor/boardviapropertiesdialog.cpp \
@@ -99,6 +100,7 @@ HEADERS += \
     boardeditor/boardeditor.h \
     boardeditor/boardlayersdock.h \
     boardeditor/boardlayerstacksetupdialog.h \
+    boardeditor/boardnetsegmentsplitter.h \
     boardeditor/boardpickplacegeneratordialog.h \
     boardeditor/boardplanepropertiesdialog.h \
     boardeditor/boardviapropertiesdialog.h \

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -26,6 +26,8 @@ RESOURCES += \
     ../../../img/images.qrc \
 
 SOURCES += \
+    boardeditor/boardclipboarddata.cpp \
+    boardeditor/boardclipboarddatabuilder.cpp \
     boardeditor/boarddesignrulecheckdialog.cpp \
     boardeditor/boarddesignrulecheckmessagesdock.cpp \
     boardeditor/boardeditor.cpp \
@@ -60,6 +62,8 @@ SOURCES += \
     cmd/cmdflipselectedboarditems.cpp \
     cmd/cmdmirrorselectedschematicitems.cpp \
     cmd/cmdmoveselectedschematicitems.cpp \
+    cmd/cmdpasteboarditems.cpp \
+    cmd/cmdpastefootprintitems.cpp \
     cmd/cmdpasteschematicitems.cpp \
     cmd/cmdremoveboarditems.cpp \
     cmd/cmdremoveselectedboarditems.cpp \
@@ -95,6 +99,8 @@ SOURCES += \
     toolbars/searchtoolbar.cpp \
 
 HEADERS += \
+    boardeditor/boardclipboarddata.h \
+    boardeditor/boardclipboarddatabuilder.h \
     boardeditor/boarddesignrulecheckdialog.h \
     boardeditor/boarddesignrulecheckmessagesdock.h \
     boardeditor/boardeditor.h \
@@ -129,6 +135,8 @@ HEADERS += \
     cmd/cmdflipselectedboarditems.h \
     cmd/cmdmirrorselectedschematicitems.h \
     cmd/cmdmoveselectedschematicitems.h \
+    cmd/cmdpasteboarditems.h \
+    cmd/cmdpastefootprintitems.h \
     cmd/cmdpasteschematicitems.h \
     cmd/cmdremoveboarditems.h \
     cmd/cmdremoveselectedboarditems.h \


### PR DESCRIPTION
Allows to copy&paste board items (even between different projects). In addition, it's even possible to copy graphical objects of a footprint from the library editor into a board.

Limitations:
- Device instances cannot be copied since they would affect the netlist which currently can only be edited by the schematic editor.
- Footprint pads cannot be copied from the library editor into a board since a board can't contain "naked" pads.

Implemented very similar to #724.

ToDo:
- [x] Support cut+paste even for device instances, since this will not affect the netlist
- [x] More testing and bugfixing

Fixes #13 