### PR TITLE
Improve UI/UX

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.h
+++ b/apps/librepcb/controlpanel/controlpanel.h
@@ -131,6 +131,13 @@ private:
   void updateNoLibrariesWarningVisibility() noexcept;
   void showProjectReadmeInBrowser(const FilePath& projectFilePath) noexcept;
 
+  // add action to menu methods
+  QAction* addActionOpenProject(QMenu& menu, FilePath& fp) noexcept;
+  QAction* addActionCloseProject(QMenu& menu, FilePath& fp) noexcept;
+  QAction* addActionAddFavorite(QMenu& menu, FilePath& fp) noexcept;
+  QAction* addActionRemoveFavorite(QMenu& menu, FilePath& fp) noexcept;
+  QAction* addActionUpdateLibrary(QMenu& menu, FilePath& fp) noexcept;
+
   // Project Management
 
   project::editor::ProjectEditor* newProject(

--- a/apps/librepcb/controlpanel/controlpanel.ui
+++ b/apps/librepcb/controlpanel/controlpanel.ui
@@ -14,7 +14,7 @@
    <string>LibrePCB ControlPanel</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../../img/images.qrc">
     <normaloff>:/img/app/librepcb.png</normaloff>:/img/app/librepcb.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -168,7 +168,7 @@
               <string>New Project</string>
              </property>
              <property name="icon">
-              <iconset>
+              <iconset resource="../../../img/images.qrc">
                <normaloff>:/img/actions/new.png</normaloff>:/img/actions/new.png</iconset>
              </property>
              <property name="iconSize">
@@ -185,7 +185,7 @@
               <string>Open Project</string>
              </property>
              <property name="icon">
-              <iconset>
+              <iconset resource="../../../img/images.qrc">
                <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
              </property>
              <property name="iconSize">
@@ -202,7 +202,7 @@
               <string>Library Manager</string>
              </property>
              <property name="icon">
-              <iconset>
+              <iconset resource="../../../img/images.qrc">
                <normaloff>:/img/library/symbol.png</normaloff>:/img/library/symbol.png</iconset>
              </property>
              <property name="iconSize">
@@ -435,19 +435,19 @@ QListView::item
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">
-     <string>File</string>
+     <string>&amp;File</string>
     </property>
     <addaction name="actionNew_Project"/>
     <addaction name="actionOpen_Project"/>
-    <addaction name="actionClose_all_open_projects"/>
     <addaction name="separator"/>
     <addaction name="actionSwitch_Workspace"/>
     <addaction name="separator"/>
+    <addaction name="actionClose_all_open_projects"/>
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>Help</string>
+     <string>&amp;Help</string>
     </property>
     <addaction name="actionOnlineDocumentation"/>
     <addaction name="actionOpenWebsite"/>
@@ -456,7 +456,7 @@ QListView::item
    </widget>
    <widget class="QMenu" name="menuExtras">
     <property name="title">
-     <string>Extras</string>
+     <string>&amp;Extras</string>
     </property>
     <addaction name="actionRescanLibraries"/>
     <addaction name="actionOpen_Library_Manager"/>
@@ -470,11 +470,11 @@ QListView::item
   <widget class="librepcb::StatusBar" name="statusBar"/>
   <action name="actionQuit">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/quit.png</normaloff>:/img/actions/quit.png</iconset>
    </property>
    <property name="text">
-    <string>Quit</string>
+    <string>&amp;Quit</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Q</string>
@@ -485,7 +485,7 @@ QListView::item
   </action>
   <action name="actionAbout_Qt">
    <property name="text">
-    <string>About Qt</string>
+    <string>About &amp;Qt</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -496,11 +496,11 @@ QListView::item
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;About LibrePCB</string>
+    <string>About &amp;LibrePCB</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -511,43 +511,43 @@ QListView::item
   </action>
   <action name="actionNew_Project">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/new.png</normaloff>:/img/actions/new.png</iconset>
    </property>
    <property name="text">
-    <string>New Project</string>
+    <string>&amp;New Project</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+N</string>
    </property>
   </action>
   <action name="actionOpen_Project">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
    </property>
    <property name="text">
-    <string>Open Project</string>
+    <string>&amp;Open Project</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+O</string>
    </property>
   </action>
   <action name="actionSwitch_Workspace">
    <property name="text">
-    <string>Switch Workspace</string>
+    <string>&amp;Switch Workspace</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string>Ctrl+Alt+W</string>
    </property>
   </action>
   <action name="actionWorkspace_Settings">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
    </property>
    <property name="text">
-    <string>Workspace Settings</string>
+    <string>&amp;Workspace Settings</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -558,38 +558,38 @@ QListView::item
   </action>
   <action name="actionOpen_Library_Manager">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/library/symbol.png</normaloff>:/img/library/symbol.png</iconset>
    </property>
    <property name="text">
-    <string>Open Library Manager</string>
+    <string>&amp;Open Library Manager</string>
    </property>
    <property name="toolTip">
     <string>Open Library Manager</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+L</string>
    </property>
   </action>
   <action name="actionClose_all_open_projects">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
-    <string>Close all open projects</string>
+    <string>&amp;Close All Open Projects</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+W</string>
    </property>
   </action>
   <action name="actionRescanLibraries">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
-    <string>Rescan Libraries</string>
+    <string>&amp;Rescan Libraries</string>
    </property>
    <property name="shortcut">
     <string notr="true">F5</string>
@@ -597,11 +597,11 @@ QListView::item
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
-    <string>Online Documentation</string>
+    <string>&amp;Online Documentation</string>
    </property>
    <property name="shortcut">
     <string notr="true">F1</string>
@@ -609,11 +609,11 @@ QListView::item
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
-    <string>LibrePCB Website</string>
+    <string>LibrePCB &amp;Website</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -628,7 +628,17 @@ QListView::item
    <header location="global">librepcb/common/widgets/statusbar.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>newProjectButton</sender>

--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -256,11 +256,11 @@
   </widget>
   <action name="actionAbout">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;About LibrePCB</string>
+    <string>About &amp;LibrePCB</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -282,19 +282,19 @@
   </action>
   <action name="actionClose">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
     <string>&amp;Close Library Editor</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+W</string>
    </property>
   </action>
   <action name="actionNew">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/new_2.png</normaloff>:/img/actions/new_2.png</iconset>
    </property>
    <property name="text">
@@ -306,7 +306,7 @@
   </action>
   <action name="actionSave">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
    </property>
    <property name="text">
@@ -318,7 +318,7 @@
   </action>
   <action name="actionUndo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
    </property>
    <property name="text">
@@ -330,7 +330,7 @@
   </action>
   <action name="actionRedo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/redo.png</normaloff>:/img/actions/redo.png</iconset>
    </property>
    <property name="text">
@@ -342,7 +342,7 @@
   </action>
   <action name="actionAbortCommand">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/stop.png</normaloff>:/img/actions/stop.png</iconset>
    </property>
    <property name="text">
@@ -354,7 +354,7 @@
   </action>
   <action name="actionZoomIn">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_in.png</normaloff>:/img/actions/zoom_in.png</iconset>
    </property>
    <property name="text">
@@ -366,7 +366,7 @@
   </action>
   <action name="actionZoomOut">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_out.png</normaloff>:/img/actions/zoom_out.png</iconset>
    </property>
    <property name="text">
@@ -378,19 +378,19 @@
   </action>
   <action name="actionZoomAll">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_all.png</normaloff>:/img/actions/zoom_all.png</iconset>
    </property>
    <property name="text">
     <string>Zoo&amp;m All</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+0</string>
    </property>
   </action>
   <action name="actionRotateCcw">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_left.png</normaloff>:/img/actions/rotate_left.png</iconset>
    </property>
    <property name="text">
@@ -402,7 +402,7 @@
   </action>
   <action name="actionRotateCw">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_right.png</normaloff>:/img/actions/rotate_right.png</iconset>
    </property>
    <property name="text">
@@ -414,7 +414,7 @@
   </action>
   <action name="actionCopy">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -426,7 +426,7 @@
   </action>
   <action name="actionCut">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/cut.png</normaloff>:/img/actions/cut.png</iconset>
    </property>
    <property name="text">
@@ -438,7 +438,7 @@
   </action>
   <action name="actionPaste">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/paste.png</normaloff>:/img/actions/paste.png</iconset>
    </property>
    <property name="text">
@@ -450,7 +450,7 @@
   </action>
   <action name="actionRemove">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -462,7 +462,7 @@
   </action>
   <action name="actionToolSelect">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/select.png</normaloff>:/img/actions/select.png</iconset>
    </property>
    <property name="text">
@@ -474,7 +474,7 @@
   </action>
   <action name="actionAddSymbolPin">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/add_symbol_pin.png</normaloff>:/img/actions/add_symbol_pin.png</iconset>
    </property>
    <property name="text">
@@ -486,7 +486,7 @@
   </action>
   <action name="actionAddThtPad">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/add_tht_pad.png</normaloff>:/img/actions/add_tht_pad.png</iconset>
    </property>
    <property name="text">
@@ -498,7 +498,7 @@
   </action>
   <action name="actionAddSmtPad">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/add_smt_pad.png</normaloff>:/img/actions/add_smt_pad.png</iconset>
    </property>
    <property name="text">
@@ -510,19 +510,19 @@
   </action>
   <action name="actionDrawLine">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/draw_line.png</normaloff>:/img/actions/draw_line.png</iconset>
    </property>
    <property name="text">
     <string>&amp;Draw Line</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">L</string>
    </property>
   </action>
   <action name="actionAddText">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/add_text.png</normaloff>:/img/actions/add_text.png</iconset>
    </property>
    <property name="text">
@@ -534,7 +534,7 @@
   </action>
   <action name="actionDrawPolygon">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/draw_polygon.png</normaloff>:/img/actions/draw_polygon.png</iconset>
    </property>
    <property name="text">
@@ -546,7 +546,7 @@
   </action>
   <action name="actionDrawCircle">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/draw_circle.png</normaloff>:/img/actions/draw_circle.png</iconset>
    </property>
    <property name="text">
@@ -561,7 +561,7 @@
   </action>
   <action name="actionAddHole">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/add_hole.png</normaloff>:/img/actions/add_hole.png</iconset>
    </property>
    <property name="text">
@@ -573,7 +573,7 @@
   </action>
   <action name="actionGridProperties">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/grid.png</normaloff>:/img/actions/grid.png</iconset>
    </property>
    <property name="text">
@@ -585,7 +585,7 @@
   </action>
   <action name="actionDrawRect">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/draw_rectangle.png</normaloff>:/img/actions/draw_rectangle.png</iconset>
    </property>
    <property name="text">
@@ -597,7 +597,7 @@
   </action>
   <action name="actionRescanLibraries">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
@@ -609,7 +609,7 @@
   </action>
   <action name="actionRemoveElement">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -621,7 +621,7 @@
   </action>
   <action name="actionAddName">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/add_name.png</normaloff>:/img/actions/add_name.png</iconset>
    </property>
    <property name="text">
@@ -633,7 +633,7 @@
   </action>
   <action name="actionAddValue">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/add_value.png</normaloff>:/img/actions/add_value.png</iconset>
    </property>
    <property name="text">
@@ -645,7 +645,7 @@
   </action>
   <action name="actionShowElementInFileManager">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
    </property>
    <property name="text">
@@ -657,11 +657,11 @@
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
-    <string>Online Documentation</string>
+    <string>&amp;Online Documentation</string>
    </property>
    <property name="shortcut">
     <string notr="true">F1</string>
@@ -669,11 +669,11 @@
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
-    <string>LibrePCB Website</string>
+    <string>LibrePCB &amp;Website</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -681,7 +681,7 @@
   </action>
   <action name="actionMirror">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/flip_horizontal.png</normaloff>:/img/actions/flip_horizontal.png</iconset>
    </property>
    <property name="text">
@@ -693,7 +693,7 @@
   </action>
   <action name="actionFlip">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/swap.png</normaloff>:/img/actions/swap.png</iconset>
    </property>
    <property name="text">
@@ -705,7 +705,7 @@
   </action>
   <action name="actionSelectAll">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../img/images.qrc">
      <normaloff>:/img/actions/select_all.png</normaloff>:/img/actions/select_all.png</iconset>
    </property>
    <property name="text">
@@ -730,6 +730,15 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+  <include location="../../../img/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -58,7 +58,10 @@ namespace editor {
  ******************************************************************************/
 
 PackageEditorState_Select::PackageEditorState_Select(Context& context) noexcept
-  : PackageEditorState(context), mState(SubState::IDLE), mStartPos() {
+  : PackageEditorState(context),
+    mState(SubState::IDLE),
+    mStartPos(),
+    mCurrentSelectionIndex(0) {
 }
 
 PackageEditorState_Select::~PackageEditorState_Select() noexcept {
@@ -99,33 +102,14 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       // update start position of selection or movement
       mStartPos = Point::fromPx(e.scenePos());
       // get items under cursor
-      QList<QSharedPointer<FootprintPadGraphicsItem>> pads;
-      QList<QSharedPointer<CircleGraphicsItem>>       circles;
-      QList<QSharedPointer<PolygonGraphicsItem>>      polygons;
-      QList<QSharedPointer<StrokeTextGraphicsItem>>   texts;
-      QList<QSharedPointer<HoleGraphicsItem>>         holes;
-      int count = mContext.currentGraphicsItem->getItemsAtPosition(
-          mStartPos, &pads, &circles, &polygons, &texts, &holes);
-      if (count == 0) {
+      QList<QGraphicsItem*> items = findItemsAtPosition(mStartPos);
+      if (items.isEmpty()) {
         // start selecting
         clearSelectionRect(true);
         mState = SubState::SELECTING;
       } else {
         // check if the top most item under the cursor is already selected
-        QGraphicsItem* topMostItem = nullptr;
-        if (pads.count() > 0) {
-          topMostItem = pads.first().data();
-        } else if (texts.count() > 0) {
-          topMostItem = texts.first().data();
-        } else if (polygons.count() > 0) {
-          topMostItem = polygons.first().data();
-        } else if (circles.count() > 0) {
-          topMostItem = circles.first().data();
-        } else if (holes.count() > 0) {
-          topMostItem = holes.first().data();
-        } else {
-          Q_ASSERT(false);
-        }
+        QGraphicsItem* topMostItem = items.first();
         bool itemAlreadySelected = topMostItem->isSelected();
 
         if (e.modifiers().testFlag(Qt::ControlModifier)) {
@@ -136,6 +120,19 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
                 ->setSelected(!itemAlreadySelected);
           } else {
             topMostItem->setSelected(!itemAlreadySelected);
+          }
+        } else if (e.modifiers().testFlag(Qt::ShiftModifier)) {
+          // Cycle Selection, when holding shift
+          mCurrentSelectionIndex += 1;
+          mCurrentSelectionIndex %= items.count();
+          clearSelectionRect(true);
+          QGraphicsItem* item = items[mCurrentSelectionIndex];
+          if (dynamic_cast<FootprintPadGraphicsItem*>(item)) {
+            // workaround for selection of a SymbolPinGraphicsItem
+            dynamic_cast<FootprintPadGraphicsItem*>(item)
+                ->setSelected(true);
+          } else {
+            item->setSelected(true);
           }
         } else if (!itemAlreadySelected) {
           // Only select the topmost item when clicking an unselected item
@@ -369,103 +366,125 @@ bool PackageEditorState_Select::processAbortCommand() noexcept {
  *  Private Methods
  ******************************************************************************/
 
-bool PackageEditorState_Select::openContextMenuAtPos(
-    const Point& pos) noexcept {
+bool PackageEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
+  if (mState != SubState::IDLE) return false;
+
+  // handle item selection
+  QGraphicsItem* selectedItem = nullptr;
+  QList<QGraphicsItem*> items = findItemsAtPosition(pos);
+  if (items.isEmpty()) return false;
+  foreach (QGraphicsItem* item, items) {
+    if (item->isSelected()) {
+      selectedItem = item;
+    }
+  }
+  if (!selectedItem) {
+    clearSelectionRect(true);
+    selectedItem = items.first();
+    if (dynamic_cast<FootprintPadGraphicsItem*>(selectedItem)) {
+      // workaround for selection of a SymbolPinGraphicsItem
+      dynamic_cast<FootprintPadGraphicsItem*>(selectedItem)
+          ->setSelected(true);
+    } else {
+      selectedItem->setSelected(true);
+    }
+  }
+  Q_ASSERT(selectedItem);
+  Q_ASSERT(selectedItem->isSelected());
+
   // build the context menu
   QMenu    menu;
   QAction* aRotateCCW =
       menu.addAction(QIcon(":/img/actions/rotate_left.png"), tr("Rotate"));
+  connect(aRotateCCW, &QAction::triggered, [this](){
+    rotateSelectedItems(Angle::deg90());
+  });
   QAction* aMirrorH =
       menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), tr("Mirror"));
+  connect(aMirrorH, &QAction::triggered, [this](){
+    mirrorSelectedItems(Qt::Horizontal, false);
+  });
   QAction* aFlipH = menu.addAction(QIcon(":/img/actions/swap.png"), tr("Flip"));
+  connect(aFlipH, &QAction::triggered, [this](){
+    mirrorSelectedItems(Qt::Horizontal, true);
+  });
   QAction* aRemove =
       menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
+  connect(aRemove, &QAction::triggered, [this](){
+    removeSelectedItems();
+  });
   menu.addSeparator();
-  QAction* aProperties = menu.addAction(tr("Properties"));
+  QAction* aProperties =
+      menu.addAction(QIcon(":/img/actions/settings.png"), tr("Properties"));
+  connect(aProperties, &QAction::triggered, [this, &selectedItem](){
+    openPropertiesDialogOfItem(selectedItem);
+  });
 
   // execute the context menu
-  QAction* action = menu.exec(QCursor::pos());
-  if (action == aRotateCCW) {
-    return rotateSelectedItems(Angle::deg90());
-  } else if (action == aMirrorH) {
-    return mirrorSelectedItems(Qt::Horizontal, false);
-  } else if (action == aFlipH) {
-    return mirrorSelectedItems(Qt::Horizontal, true);
-  } else if (action == aRemove) {
-    return removeSelectedItems();
-  } else if (action == aProperties) {
-    return openPropertiesDialogOfItemAtPos(pos);
-  } else {
-    return false;
-  }
+  return menu.exec(QCursor::pos());
 }
 
-bool PackageEditorState_Select::openPropertiesDialogOfItemAtPos(
-    const Point& pos) noexcept {
-  QList<QSharedPointer<FootprintPadGraphicsItem>> pads;
-  QList<QSharedPointer<CircleGraphicsItem>>       circles;
-  QList<QSharedPointer<PolygonGraphicsItem>>      polygons;
-  QList<QSharedPointer<StrokeTextGraphicsItem>>   texts;
-  QList<QSharedPointer<HoleGraphicsItem>>         holes;
-  mContext.currentGraphicsItem->getItemsAtPosition(pos, &pads, &circles,
-                                                   &polygons, &texts, &holes);
+bool PackageEditorState_Select::openPropertiesDialogOfItem(
+    QGraphicsItem* item) noexcept {
+  if (!item) return false;
 
-  if (pads.count() > 0) {
-    FootprintPadGraphicsItem* item =
-        dynamic_cast<FootprintPadGraphicsItem*>(pads.first().data());
-    Q_ASSERT(item);
+  if (FootprintPadGraphicsItem* pad =
+      dynamic_cast<FootprintPadGraphicsItem*>(item)) {
+    Q_ASSERT(pad);
     FootprintPadPropertiesDialog dialog(
-        mContext.package, *mContext.currentFootprint, item->getPad(),
+        mContext.package, *mContext.currentFootprint, pad->getPad(),
         mContext.undoStack, getDefaultLengthUnit(),
         "package_editor/footprint_pad_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (texts.count() > 0) {
-    StrokeTextGraphicsItem* item =
-        dynamic_cast<StrokeTextGraphicsItem*>(texts.first().data());
-    Q_ASSERT(item);
+  } else if (StrokeTextGraphicsItem* text =
+             dynamic_cast<StrokeTextGraphicsItem*>(item)) {
+    Q_ASSERT(text);
     StrokeTextPropertiesDialog dialog(
-        item->getText(), mContext.undoStack,
+        text->getText(), mContext.undoStack,
         mContext.layerProvider.getBoardGeometryElementLayers(),
         getDefaultLengthUnit(), "package_editor/stroke_text_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (polygons.count() > 0) {
-    PolygonGraphicsItem* item =
-        dynamic_cast<PolygonGraphicsItem*>(polygons.first().data());
-    Q_ASSERT(item);
+  } else if (PolygonGraphicsItem* polygon =
+             dynamic_cast<PolygonGraphicsItem*>(item)) {
+    Q_ASSERT(polygon);
     PolygonPropertiesDialog dialog(
-        item->getPolygon(), mContext.undoStack,
+        polygon->getPolygon(), mContext.undoStack,
         mContext.layerProvider.getBoardGeometryElementLayers(),
         getDefaultLengthUnit(), "package_editor/polygon_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (circles.count() > 0) {
-    CircleGraphicsItem* item =
-        dynamic_cast<CircleGraphicsItem*>(circles.first().data());
-    Q_ASSERT(item);
+  } else if (CircleGraphicsItem* circle =
+             dynamic_cast<CircleGraphicsItem*>(item)) {
+    Q_ASSERT(circle);
     CirclePropertiesDialog dialog(
-        item->getCircle(), mContext.undoStack,
+        circle->getCircle(), mContext.undoStack,
         mContext.layerProvider.getBoardGeometryElementLayers(),
         getDefaultLengthUnit(), "package_editor/circle_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (holes.count() > 0) {
-    HoleGraphicsItem* item =
-        dynamic_cast<HoleGraphicsItem*>(holes.first().data());
-    Q_ASSERT(item);
+  } else if (HoleGraphicsItem* hole =
+             dynamic_cast<HoleGraphicsItem*>(item)) {
+    Q_ASSERT(hole);
     HolePropertiesDialog dialog(
-        item->getHole(), mContext.undoStack, getDefaultLengthUnit(),
+        hole->getHole(), mContext.undoStack, getDefaultLengthUnit(),
         "package_editor/hole_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else {
-    return false;
   }
+  return false;
+}
+
+bool PackageEditorState_Select::openPropertiesDialogOfItemAtPos(
+    const Point& pos) noexcept {
+  QList<QGraphicsItem*> items = findItemsAtPosition(pos);
+  if (items.isEmpty()) return false;
+  return openPropertiesDialogOfItem(items.first());
 }
 
 bool PackageEditorState_Select::copySelectedItemsToClipboard() noexcept {
@@ -612,6 +631,39 @@ void PackageEditorState_Select::clearSelectionRect(
   if (updateItemsSelectionState) {
     mContext.graphicsScene.setSelectionArea(QPainterPath());
   }
+}
+
+QList<QGraphicsItem*> PackageEditorState_Select::findItemsAtPosition(
+    const Point& pos) noexcept {
+  QList<QSharedPointer<FootprintPadGraphicsItem>> pads;
+  QList<QSharedPointer<CircleGraphicsItem>>       circles;
+  QList<QSharedPointer<PolygonGraphicsItem>>      polygons;
+  QList<QSharedPointer<StrokeTextGraphicsItem>>   texts;
+  QList<QSharedPointer<HoleGraphicsItem>>         holes;
+  int count = mContext.currentGraphicsItem->getItemsAtPosition(
+      pos, &pads, &circles, &polygons, &texts, &holes);
+  QList<QGraphicsItem*> result = {};
+  foreach (QSharedPointer<FootprintPadGraphicsItem> pad, pads) {
+    result.append(pad.data());
+  }
+  foreach (QSharedPointer<CircleGraphicsItem> cirlce, circles) {
+    result.append(cirlce.data());
+  }
+  foreach (QSharedPointer<PolygonGraphicsItem> polygon, polygons) {
+    result.append(polygon.data());
+  }
+  foreach (QSharedPointer<StrokeTextGraphicsItem> text, texts) {
+    result.append(text.data());
+  }
+  foreach (QSharedPointer<HoleGraphicsItem> hole, holes) {
+    result.append(hole.data());
+  }
+
+  Q_ASSERT(result.count() == (pads.count() + texts.count()
+                              + polygons.count() + circles.count()
+                              + holes.count()));
+  Q_ASSERT(result.count() == count);
+  return result;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
@@ -88,6 +88,7 @@ public:
 
 private:  // Methods
   bool openContextMenuAtPos(const Point& pos) noexcept;
+  bool openPropertiesDialogOfItem(QGraphicsItem* item) noexcept;
   bool openPropertiesDialogOfItemAtPos(const Point& pos) noexcept;
   bool copySelectedItemsToClipboard() noexcept;
   bool pasteFromClipboard() noexcept;
@@ -97,12 +98,14 @@ private:  // Methods
   bool removeSelectedItems() noexcept;
   void setSelectionRect(const Point& p1, const Point& p2) noexcept;
   void clearSelectionRect(bool updateItemsSelectionState) noexcept;
+  QList<QGraphicsItem*> findItemsAtPosition(const Point& pos) noexcept;
 
 private:  // Types / Data
   enum class SubState { IDLE, SELECTING, MOVING, PASTING };
   SubState                                      mState;
   Point                                         mStartPos;
   QScopedPointer<CmdDragSelectedFootprintItems> mCmdDragSelectedItems;
+  int mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
@@ -57,7 +57,10 @@ namespace editor {
 
 SymbolEditorState_Select::SymbolEditorState_Select(
     const Context& context) noexcept
-  : SymbolEditorState(context), mState(SubState::IDLE), mStartPos() {
+  : SymbolEditorState(context),
+    mState(SubState::IDLE),
+    mStartPos(),
+    mCurrentSelectionIndex(0) {
 }
 
 SymbolEditorState_Select::~SymbolEditorState_Select() noexcept {
@@ -97,32 +100,16 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       // update start position of selection or movement
       mStartPos = Point::fromPx(e.scenePos());
       // get items under cursor
-      QList<QSharedPointer<SymbolPinGraphicsItem>> pins;
-      QList<QSharedPointer<CircleGraphicsItem>>    circles;
-      QList<QSharedPointer<PolygonGraphicsItem>>   polygons;
-      QList<QSharedPointer<TextGraphicsItem>>      texts;
-      int count = mContext.symbolGraphicsItem.getItemsAtPosition(
-          mStartPos, &pins, &circles, &polygons, &texts);
-      if (count == 0) {
+      QList<QGraphicsItem*> items = findItemsAtPosition(mStartPos);
+      if (items.isEmpty()) {
         // start selecting
         clearSelectionRect(true);
         mState = SubState::SELECTING;
       } else {
         // check if the top most item under the cursor is already selected
-        QGraphicsItem* topMostItem = nullptr;
-        if (pins.count() > 0) {
-          topMostItem = pins.first().data();
-        } else if (texts.count() > 0) {
-          topMostItem = texts.first().data();
-        } else if (polygons.count() > 0) {
-          topMostItem = polygons.first().data();
-        } else if (circles.count() > 0) {
-          topMostItem = circles.first().data();
-        } else {
-          Q_ASSERT(false);
-        }
-        bool itemAlreadySelected = topMostItem->isSelected();
+        QGraphicsItem* topMostItem = items.first();
 
+        bool itemAlreadySelected = topMostItem->isSelected();
         if (e.modifiers().testFlag(Qt::ControlModifier)) {
           // Toggle selection when CTRL is pressed
           if (dynamic_cast<SymbolPinGraphicsItem*>(topMostItem)) {
@@ -131,6 +118,19 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
                 ->setSelected(!itemAlreadySelected);
           } else {
             topMostItem->setSelected(!itemAlreadySelected);
+          }
+        } else if (e.modifiers().testFlag(Qt::ShiftModifier)) {
+          // Cycle Selection, when holding shift
+          mCurrentSelectionIndex += 1;
+          mCurrentSelectionIndex %= items.count();
+          clearSelectionRect(true);
+          QGraphicsItem* item = items[mCurrentSelectionIndex];
+          if (dynamic_cast<SymbolPinGraphicsItem*>(item)) {
+            // workaround for selection of a SymbolPinGraphicsItem
+            dynamic_cast<SymbolPinGraphicsItem*>(item)
+                ->setSelected(true);
+          } else {
+            item->setSelected(true);
           }
         } else if (!itemAlreadySelected) {
           // Only select the topmost item when clicking an unselected item
@@ -347,86 +347,108 @@ bool SymbolEditorState_Select::processAbortCommand() noexcept {
  ******************************************************************************/
 
 bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
+  if (mState != SubState::IDLE) return false;
+
+  // handle item selection
+  QGraphicsItem* selectedItem = nullptr;
+  QList<QGraphicsItem*> items = findItemsAtPosition(pos);
+  if (items.isEmpty()) return false;
+  foreach (QGraphicsItem* item, items) {
+    if (item->isSelected()) {
+      selectedItem = item;
+    }
+  }
+  if (!selectedItem) {
+    clearSelectionRect(true);
+    selectedItem = items.first();
+    if (dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)) {
+      // workaround for selection of a SymbolPinGraphicsItem
+      dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)
+          ->setSelected(true);
+    } else {
+      selectedItem->setSelected(true);
+    }
+  }
+  Q_ASSERT(selectedItem);
+  Q_ASSERT(selectedItem->isSelected());
+
   // build the context menu
-  QMenu    menu;
+  QMenu menu;
   QAction* aRotateCCW =
-      menu.addAction(QIcon(":/img/actions/rotate_left.png"), tr("Rotate"));
+      menu.addAction(QIcon(":/img/actions/rotate_left.png"), tr("&Rotate"));
+  connect(aRotateCCW, &QAction::triggered, [this](){
+    rotateSelectedItems(Angle::deg90());
+  });
   QAction* aMirrorH =
-      menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), tr("Mirror"));
+      menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), tr("&Mirror"));
+  connect(aMirrorH, &QAction::triggered, [this](){
+    mirrorSelectedItems(Qt::Horizontal);
+  });
   QAction* aRemove =
-      menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
+      menu.addAction(QIcon(":/img/actions/delete.png"), tr("R&emove"));
+  connect(aRemove, &QAction::triggered, [this](){
+    removeSelectedItems();
+  });
   menu.addSeparator();
-  QAction* aProperties = menu.addAction(tr("Properties"));
+  QAction* aProperties = menu.addAction(QIcon(":/img/actions/settings.png"),
+                                        tr("&Properties"));
+  connect(aProperties, &QAction::triggered, [this, &selectedItem](){
+    openPropertiesDialogOfItem(selectedItem);
+  });
 
   // execute the context menu
-  QAction* action = menu.exec(QCursor::pos());
-  if (action == aRotateCCW) {
-    return rotateSelectedItems(Angle::deg90());
-  } else if (action == aMirrorH) {
-    return mirrorSelectedItems(Qt::Horizontal);
-  } else if (action == aRemove) {
-    return removeSelectedItems();
-  } else if (action == aProperties) {
-    return openPropertiesDialogOfItemAtPos(pos);
-  } else {
-    return false;
-  }
+  return menu.exec(QCursor::pos());
 }
 
-bool SymbolEditorState_Select::openPropertiesDialogOfItemAtPos(
-    const Point& pos) noexcept {
-  QList<QSharedPointer<SymbolPinGraphicsItem>> pins;
-  QList<QSharedPointer<CircleGraphicsItem>>    circles;
-  QList<QSharedPointer<PolygonGraphicsItem>>   polygons;
-  QList<QSharedPointer<TextGraphicsItem>>      texts;
-  mContext.symbolGraphicsItem.getItemsAtPosition(pos, &pins, &circles,
-                                                 &polygons, &texts);
+bool SymbolEditorState_Select::openPropertiesDialogOfItem(
+    QGraphicsItem* item) noexcept {
+  if (!item) return false;
 
-  if (pins.count() > 0) {
-    SymbolPinGraphicsItem* item =
-        dynamic_cast<SymbolPinGraphicsItem*>(pins.first().data());
-    Q_ASSERT(item);
+  if (SymbolPinGraphicsItem* pin = dynamic_cast<SymbolPinGraphicsItem*>(item)) {
+    Q_ASSERT(pin);
     SymbolPinPropertiesDialog dialog(
-        item->getPin(), mContext.undoStack, getDefaultLengthUnit(),
+        pin->getPin(), mContext.undoStack, getDefaultLengthUnit(),
         "symbol_editor/pin_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (texts.count() > 0) {
-    TextGraphicsItem* item =
-        dynamic_cast<TextGraphicsItem*>(texts.first().data());
-    Q_ASSERT(item);
+  } else if (TextGraphicsItem* text = dynamic_cast<TextGraphicsItem*>(item)) {
+    Q_ASSERT(text);
     TextPropertiesDialog dialog(
-        item->getText(), mContext.undoStack,
+        text->getText(), mContext.undoStack,
         mContext.layerProvider.getSchematicGeometryElementLayers(),
         getDefaultLengthUnit(), "symbol_editor/text_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (polygons.count() > 0) {
-    PolygonGraphicsItem* item =
-        dynamic_cast<PolygonGraphicsItem*>(polygons.first().data());
-    Q_ASSERT(item);
+  } else if (PolygonGraphicsItem* polygon =
+             dynamic_cast<PolygonGraphicsItem*>(item)) {
+    Q_ASSERT(polygon);
     PolygonPropertiesDialog dialog(
-        item->getPolygon(), mContext.undoStack,
+        polygon->getPolygon(), mContext.undoStack,
         mContext.layerProvider.getSchematicGeometryElementLayers(),
         getDefaultLengthUnit(), "symbol_editor/polygon_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (circles.count() > 0) {
-    CircleGraphicsItem* item =
-        dynamic_cast<CircleGraphicsItem*>(circles.first().data());
-    Q_ASSERT(item);
+  } else if (CircleGraphicsItem* circle =
+             dynamic_cast<CircleGraphicsItem*>(item)) {
+    Q_ASSERT(circle);
     CirclePropertiesDialog dialog(
-        item->getCircle(), mContext.undoStack,
+        circle->getCircle(), mContext.undoStack,
         mContext.layerProvider.getSchematicGeometryElementLayers(),
         getDefaultLengthUnit(), "symbol_editor/circle_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else {
-    return false;
   }
+  return false;
+}
+
+bool SymbolEditorState_Select::openPropertiesDialogOfItemAtPos(
+    const Point& pos) noexcept {
+  QList<QGraphicsItem*> items = findItemsAtPosition(pos);
+  if (items.isEmpty()) return false;
+  return openPropertiesDialogOfItem(items.first());
 }
 
 bool SymbolEditorState_Select::copySelectedItemsToClipboard() noexcept {
@@ -552,6 +574,34 @@ void SymbolEditorState_Select::clearSelectionRect(
   if (updateItemsSelectionState) {
     mContext.graphicsScene.setSelectionArea(QPainterPath());
   }
+}
+
+QList<QGraphicsItem*> SymbolEditorState_Select::findItemsAtPosition(
+    const Point& pos) noexcept {
+  QList<QSharedPointer<SymbolPinGraphicsItem>> pins;
+  QList<QSharedPointer<CircleGraphicsItem>>    circles;
+  QList<QSharedPointer<PolygonGraphicsItem>>   polygons;
+  QList<QSharedPointer<TextGraphicsItem>>      texts;
+  int count = mContext.symbolGraphicsItem.getItemsAtPosition(
+      pos, &pins, &circles, &polygons, &texts);
+  QList<QGraphicsItem*> result = {};
+  foreach (QSharedPointer<SymbolPinGraphicsItem> pin, pins) {
+    result.append(pin.data());
+  }
+  foreach (QSharedPointer<CircleGraphicsItem> cirlce, circles) {
+    result.append(cirlce.data());
+  }
+  foreach (QSharedPointer<PolygonGraphicsItem> polygon, polygons) {
+    result.append(polygon.data());
+  }
+  foreach (QSharedPointer<TextGraphicsItem> text, texts) {
+    result.append(text.data());
+  }
+
+  Q_ASSERT(result.count() == (pins.count() + texts.count()
+                             + polygons.count() + circles.count()));
+  Q_ASSERT(result.count() == count);
+  return result;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
@@ -87,6 +87,7 @@ public:
 
 private:  // Methods
   bool openContextMenuAtPos(const Point& pos) noexcept;
+  bool openPropertiesDialogOfItem(QGraphicsItem* item) noexcept;
   bool openPropertiesDialogOfItemAtPos(const Point& pos) noexcept;
   bool copySelectedItemsToClipboard() noexcept;
   bool pasteFromClipboard() noexcept;
@@ -95,12 +96,14 @@ private:  // Methods
   bool removeSelectedItems() noexcept;
   void setSelectionRect(const Point& p1, const Point& p2) noexcept;
   void clearSelectionRect(bool updateItemsSelectionState) noexcept;
+  QList<QGraphicsItem*> findItemsAtPosition(const Point& pos) noexcept;
 
 private:  // Types / Data
   enum class SubState { IDLE, SELECTING, MOVING, PASTING };
   SubState                                   mState;
   Point                                      mStartPos;
   QScopedPointer<CmdDragSelectedSymbolItems> mCmdDragSelectedItems;
+  int mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -149,6 +149,10 @@ private:
                                     mDrcMessages;  ///< Key: Board UUID
   QScopedPointer<QGraphicsPathItem> mDrcLocationGraphicsItem;
 
+  // Search Toolbar
+  QString mLastSearch;
+  int mNextDeviceIndex;
+
   // Misc
   QPointer<Board> mActiveBoard;
   QList<QAction*> mBoardListActions;

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -17,7 +17,7 @@
    <string>Board Editor</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../../../img/images.qrc">
     <normaloff>:/img/actions/board_editor.png</normaloff>:/img/actions/board_editor.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -77,10 +77,16 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menuExport">
+     <property name="title">
+      <string>&amp;Export As...</string>
+     </property>
+     <addaction name="actionExportLppz"/>
+     <addaction name="actionExportAsPdf"/>
+     <addaction name="actionExportAsSvg"/>
+    </widget>
     <addaction name="actionProjectSave"/>
-    <addaction name="actionExportLppz"/>
-    <addaction name="actionExportAsPdf"/>
-    <addaction name="actionExportAsSvg"/>
+    <addaction name="menuExport"/>
     <addaction name="actionGenerateBom"/>
     <addaction name="actionGenerateFabricationData"/>
     <addaction name="actionGeneratePickPlace"/>
@@ -113,18 +119,18 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <addaction name="actionGrid"/>
-    <addaction name="separator"/>
     <addaction name="actionHideAllPlanes"/>
     <addaction name="actionShowAllPlanes"/>
     <addaction name="separator"/>
     <addaction name="actionZoomIn"/>
     <addaction name="actionZoomOut"/>
     <addaction name="actionZoomAll"/>
+    <addaction name="separator"/>
+    <addaction name="actionGrid"/>
    </widget>
    <widget class="QMenu" name="menuProject">
     <property name="title">
-     <string>Pro&amp;ject</string>
+     <string>&amp;Project</string>
     </property>
     <addaction name="actionProjectProperties"/>
     <addaction name="actionProjectSettings"/>
@@ -215,6 +221,7 @@
    <addaction name="actionZoomIn"/>
    <addaction name="actionZoomOut"/>
    <addaction name="actionZoomAll"/>
+   <addaction name="actionGrid"/>
   </widget>
   <widget class="QToolBar" name="editToolbar">
    <property name="windowTitle">
@@ -235,18 +242,6 @@
    <addaction name="actionCopy"/>
    <addaction name="actionPaste"/>
    <addaction name="actionRemove"/>
-  </widget>
-  <widget class="QToolBar" name="viewToolbar">
-   <property name="windowTitle">
-    <string>View</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-   <addaction name="actionGrid"/>
   </widget>
   <widget class="librepcb::project::editor::SearchToolBar" name="searchToolbar">
    <property name="windowTitle">
@@ -291,10 +286,11 @@
     <bool>true</bool>
    </attribute>
    <addaction name="actionCommandAbort"/>
+   <addaction name="separator"/>
   </widget>
   <action name="actionProjectSave">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
    </property>
    <property name="text">
@@ -306,19 +302,19 @@
   </action>
   <action name="actionProjectClose">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
     <string>&amp;Close Project</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+W</string>
    </property>
   </action>
   <action name="actionPrint">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/print.png</normaloff>:/img/actions/print.png</iconset>
    </property>
    <property name="text">
@@ -330,7 +326,7 @@
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/quit.png</normaloff>:/img/actions/quit.png</iconset>
    </property>
    <property name="text">
@@ -342,11 +338,14 @@
   </action>
   <action name="actionExportAsPdf">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/pdf.png</normaloff>:/img/actions/pdf.png</iconset>
    </property>
    <property name="text">
-    <string>PDF &amp;Export</string>
+    <string>&amp;PDF</string>
+   </property>
+   <property name="toolTip">
+    <string>Export as PDF</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -354,7 +353,7 @@
   </action>
   <action name="actionShowControlPanel">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/home.png</normaloff>:/img/actions/home.png</iconset>
    </property>
    <property name="text">
@@ -366,19 +365,19 @@
   </action>
   <action name="actionShowSchematicEditor">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/schematic.png</normaloff>:/img/actions/schematic.png</iconset>
    </property>
    <property name="text">
     <string>Show Schematic Editor</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+Tab</string>
    </property>
   </action>
   <action name="actionUndo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
    </property>
    <property name="text">
@@ -390,7 +389,7 @@
   </action>
   <action name="actionRedo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/redo.png</normaloff>:/img/actions/redo.png</iconset>
    </property>
    <property name="text">
@@ -402,11 +401,11 @@
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
-    <string>Online Documentation</string>
+    <string>&amp;Online Documentation</string>
    </property>
    <property name="shortcut">
     <string notr="true">F1</string>
@@ -414,11 +413,11 @@
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
-    <string>LibrePCB Website</string>
+    <string>LibrePCB &amp;Website</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -426,7 +425,7 @@
   </action>
   <action name="actionRotate_CCW">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_left.png</normaloff>:/img/actions/rotate_left.png</iconset>
    </property>
    <property name="text">
@@ -438,7 +437,7 @@
   </action>
   <action name="actionRotate_CW">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_right.png</normaloff>:/img/actions/rotate_right.png</iconset>
    </property>
    <property name="text">
@@ -450,7 +449,7 @@
   </action>
   <action name="actionCopy">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -465,7 +464,7 @@
   </action>
   <action name="actionCut">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/cut.png</normaloff>:/img/actions/cut.png</iconset>
    </property>
    <property name="text">
@@ -480,7 +479,7 @@
   </action>
   <action name="actionPaste">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/paste.png</normaloff>:/img/actions/paste.png</iconset>
    </property>
    <property name="text">
@@ -495,7 +494,7 @@
   </action>
   <action name="actionRemove">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -507,7 +506,7 @@
   </action>
   <action name="actionGrid">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/grid.png</normaloff>:/img/actions/grid.png</iconset>
    </property>
    <property name="text">
@@ -519,11 +518,11 @@
   </action>
   <action name="actionZoomIn">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_in.png</normaloff>:/img/actions/zoom_in.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Zoom In</string>
+    <string>Zoom &amp;In</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl++</string>
@@ -531,7 +530,7 @@
   </action>
   <action name="actionZoomOut">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_out.png</normaloff>:/img/actions/zoom_out.png</iconset>
    </property>
    <property name="text">
@@ -543,14 +542,14 @@
   </action>
   <action name="actionZoomAll">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_all.png</normaloff>:/img/actions/zoom_all.png</iconset>
    </property>
    <property name="text">
-    <string>Zoo&amp;m All</string>
+    <string>Zoom &amp;All</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string>Ctrl+0</string>
    </property>
   </action>
   <action name="actionProjectProperties">
@@ -566,7 +565,7 @@
   </action>
   <action name="actionProjectSettings">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
    </property>
    <property name="text">
@@ -581,11 +580,11 @@
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;About LibrePCB</string>
+    <string>About &amp;LibrePCB</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -607,7 +606,7 @@
   </action>
   <action name="actionToolSelect">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/select.png</normaloff>:/img/actions/select.png</iconset>
    </property>
    <property name="text">
@@ -619,7 +618,7 @@
   </action>
   <action name="actionCommandAbort">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/stop.png</normaloff>:/img/actions/stop.png</iconset>
    </property>
    <property name="text">
@@ -631,7 +630,7 @@
   </action>
   <action name="actionNewBoard">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/new_2.png</normaloff>:/img/actions/new_2.png</iconset>
    </property>
    <property name="text">
@@ -651,11 +650,11 @@
   </action>
   <action name="actionFlipHorizontal">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/flip_horizontal.png</normaloff>:/img/actions/flip_horizontal.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Flip Horizontal</string>
+    <string>Flip &amp;Horizontal</string>
    </property>
    <property name="shortcut">
     <string notr="true">F</string>
@@ -663,7 +662,7 @@
   </action>
   <action name="actionFlipVertical">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/flip_vertical.png</normaloff>:/img/actions/flip_vertical.png</iconset>
    </property>
    <property name="text">
@@ -675,7 +674,7 @@
   </action>
   <action name="actionToolDrawTrace">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/draw_wire.png</normaloff>:/img/actions/draw_wire.png</iconset>
    </property>
    <property name="text">
@@ -687,7 +686,7 @@
   </action>
   <action name="actionToolAddVia">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_via.png</normaloff>:/img/actions/add_via.png</iconset>
    </property>
    <property name="text">
@@ -699,7 +698,7 @@
   </action>
   <action name="actionCopyBoard">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -711,7 +710,7 @@
   </action>
   <action name="actionGenerateFabricationData">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_gerber.png</normaloff>:/img/actions/export_gerber.png</iconset>
    </property>
    <property name="text">
@@ -742,11 +741,11 @@
   </action>
   <action name="actionRemoveBoard">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
-    <string>Remove &amp;Board</string>
+    <string>&amp;Remove Board</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -754,7 +753,7 @@
   </action>
   <action name="actionToolDrawPolygon">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/draw_polygon.png</normaloff>:/img/actions/draw_polygon.png</iconset>
    </property>
    <property name="text">
@@ -766,11 +765,11 @@
   </action>
   <action name="actionRebuildPlanes">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rebuild_plane.png</normaloff>:/img/actions/rebuild_plane.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Rebuild Planes</string>
+    <string>Rebuild &amp;Planes</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -778,7 +777,7 @@
   </action>
   <action name="actionToolAddPlane">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_plane.png</normaloff>:/img/actions/add_plane.png</iconset>
    </property>
    <property name="text">
@@ -790,11 +789,11 @@
   </action>
   <action name="actionToolAddText">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_text.png</normaloff>:/img/actions/add_text.png</iconset>
    </property>
    <property name="text">
-    <string>Add T&amp;ext</string>
+    <string>Add &amp;Text</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -802,7 +801,7 @@
   </action>
   <action name="actionToolAddHole">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_hole.png</normaloff>:/img/actions/add_hole.png</iconset>
    </property>
    <property name="text">
@@ -814,23 +813,23 @@
   </action>
   <action name="actionUpdateLibrary">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
-    <string>Update Library</string>
+    <string>&amp;Update Library</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">F5</string>
    </property>
   </action>
   <action name="actionExportLppz">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_zip.png</normaloff>:/img/actions/export_zip.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Export project to *.lppz</string>
+    <string>&amp;LPPZ</string>
    </property>
    <property name="toolTip">
     <string>Export project to *.lppz</string>
@@ -841,7 +840,7 @@
   </action>
   <action name="actionGenerateBom">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/generate_bom.png</normaloff>:/img/actions/generate_bom.png</iconset>
    </property>
    <property name="text">
@@ -856,11 +855,11 @@
   </action>
   <action name="actionShowAllPlanes">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/show_planes.png</normaloff>:/img/actions/show_planes.png</iconset>
    </property>
    <property name="text">
-    <string>Show All Planes</string>
+    <string>&amp;Show All Planes</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -868,11 +867,11 @@
   </action>
   <action name="actionHideAllPlanes">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/hide_planes.png</normaloff>:/img/actions/hide_planes.png</iconset>
    </property>
    <property name="text">
-    <string>Hide All Planes</string>
+    <string>&amp;Hide All Planes</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -880,7 +879,7 @@
   </action>
   <action name="actionDesignRuleCheck">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/drc.png</normaloff>:/img/actions/drc.png</iconset>
    </property>
    <property name="text">
@@ -892,7 +891,7 @@
   </action>
   <action name="actionGeneratePickPlace">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_pick_place_file.png</normaloff>:/img/actions/export_pick_place_file.png</iconset>
    </property>
    <property name="text">
@@ -904,11 +903,14 @@
   </action>
   <action name="actionExportAsSvg">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_svg.png</normaloff>:/img/actions/export_svg.png</iconset>
    </property>
    <property name="text">
-    <string>SVG Export</string>
+    <string>&amp;SVG</string>
+   </property>
+   <property name="toolTip">
+    <string>Export as SVG</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -916,14 +918,19 @@
   </action>
   <action name="actionSelectAll">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/select_all.png</normaloff>:/img/actions/select_all.png</iconset>
    </property>
    <property name="text">
-    <string>Select All</string>
+    <string>Select &amp;All</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+A</string>
+   </property>
+  </action>
+  <action name="actionTest">
+   <property name="text">
+    <string>Test</string>
    </property>
   </action>
  </widget>
@@ -944,6 +951,15 @@
    <header location="global">librepcb/projecteditor/toolbars/searchtoolbar.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
@@ -37,6 +37,7 @@ class Angle;
 
 namespace project {
 
+class SI_Base;
 class SI_Symbol;
 class SI_NetLabel;
 class Schematic;
@@ -90,19 +91,29 @@ public:
   virtual bool processSwitchToSchematicPage(int index) noexcept override;
 
   // Operator Overloadings
-  SchematicEditorState_Select& operator       =(
+  SchematicEditorState_Select& operator =(
       const SchematicEditorState_Select& rhs) = delete;
 
 private:  // Methods
-  bool startMovingSelectedItems(Schematic&   schematic,
+  bool startMovingSelectedItems(Schematic& schematic,
                                 const Point& startPos) noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems() noexcept;
   bool removeSelectedItems() noexcept;
   bool copySelectedItemsToClipboard() noexcept;
   bool pasteFromClipboard() noexcept;
+  void openPropertiesDialog(SI_Base* item) noexcept;
   void openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept;
   void openNetLabelPropertiesDialog(SI_NetLabel& netlabel) noexcept;
+
+  //Right Click Menu
+  QAction* addActionCut(QMenu& menu, const QString& text = tr("Cut")) noexcept;
+  QAction* addActionCopy(QMenu& menu, const QString& text = tr("Copy")) noexcept;
+  QAction* addActionRemove(QMenu& menu, const QString& text = tr("Remove")) noexcept;
+  QAction* addActionMirror(QMenu& menu, const QString& text = tr("Mirror")) noexcept;
+  QAction* addActionRotate(QMenu& menu, const QString& text = tr("Rotate")) noexcept;
+  QAction* addActionOpenProperties(QMenu& menu, SI_Base* item,
+                                   const QString& text = tr("Properties")) noexcept;
 
 private:  // Data
   /// enum for all possible substates
@@ -116,6 +127,7 @@ private:  // Data
   SubState mSubState;  ///< the current substate
   Point    mStartPos;
   QScopedPointer<CmdMoveSelectedSchematicItems> mSelectedItemsMoveCommand;
+  int mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -41,6 +41,7 @@ namespace project {
 
 class Project;
 class Schematic;
+class SI_Symbol;
 
 namespace editor {
 
@@ -130,6 +131,10 @@ private:
   QScopedPointer<ExclusiveActionGroup> mToolsActionGroup;
 
   int mActiveSchematicIndex;
+
+  // Search Function
+  QString mLastSearch;
+  int mNextSymbolIndex;
 
   // Docks
   SchematicPagesDock* mPagesDock;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -14,7 +14,7 @@
    <string>Schematic Editor</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../../../img/images.qrc">
     <normaloff>:/img/actions/schematic.png</normaloff>:/img/actions/schematic.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -46,11 +46,17 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menu_Export_As">
+     <property name="title">
+      <string>&amp;Export As...</string>
+     </property>
+     <addaction name="actionExportLppz"/>
+     <addaction name="actionPDF_Export"/>
+     <addaction name="actionExportAsSvg"/>
+    </widget>
     <addaction name="actionNew_Schematic_Page"/>
     <addaction name="actionSave_Project"/>
-    <addaction name="actionExportLppz"/>
-    <addaction name="actionPDF_Export"/>
-    <addaction name="actionExportAsSvg"/>
+    <addaction name="menu_Export_As"/>
     <addaction name="actionGenerateBom"/>
     <addaction name="actionPrint"/>
     <addaction name="separator"/>
@@ -92,11 +98,11 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <addaction name="actionGrid"/>
-    <addaction name="separator"/>
     <addaction name="actionZoom_In"/>
     <addaction name="actionZoom_Out"/>
     <addaction name="actionZoom_All"/>
+    <addaction name="separator"/>
+    <addaction name="actionGrid"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -109,7 +115,7 @@
    </widget>
    <widget class="QMenu" name="menuProject">
     <property name="title">
-     <string>Pro&amp;ject</string>
+     <string>&amp;Project</string>
     </property>
     <addaction name="actionProjectProperties"/>
     <addaction name="actionProjectSettings"/>
@@ -118,7 +124,7 @@
    </widget>
    <widget class="QMenu" name="menuSchematic">
     <property name="title">
-     <string>Schematic</string>
+     <string>&amp;Schematic</string>
     </property>
     <addaction name="actionRenameSheet"/>
    </widget>
@@ -173,6 +179,7 @@
    <addaction name="actionZoom_In"/>
    <addaction name="actionZoom_Out"/>
    <addaction name="actionZoom_All"/>
+   <addaction name="actionGrid"/>
   </widget>
   <widget class="QToolBar" name="editToolbar">
    <property name="windowTitle">
@@ -193,19 +200,8 @@
    <addaction name="actionCut"/>
    <addaction name="actionCopy"/>
    <addaction name="actionPaste"/>
+   <addaction name="separator"/>
    <addaction name="actionRemove"/>
-  </widget>
-  <widget class="QToolBar" name="viewToolbar">
-   <property name="windowTitle">
-    <string>View</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-   <addaction name="actionGrid"/>
   </widget>
   <widget class="librepcb::project::editor::SearchToolBar" name="searchToolbar">
    <property name="windowTitle">
@@ -271,7 +267,7 @@
   </widget>
   <action name="actionQuit">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/quit.png</normaloff>:/img/actions/quit.png</iconset>
    </property>
    <property name="text">
@@ -286,7 +282,7 @@
   </action>
   <action name="actionSave_Project">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
    </property>
    <property name="text">
@@ -298,11 +294,11 @@
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/info.png</normaloff>:/img/actions/info.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;About LibrePCB</string>
+    <string>About &amp;LibrePCB</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -324,7 +320,7 @@
   </action>
   <action name="actionPrint">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/print.png</normaloff>:/img/actions/print.png</iconset>
    </property>
    <property name="text">
@@ -336,11 +332,11 @@
   </action>
   <action name="actionPDF_Export">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/pdf.png</normaloff>:/img/actions/pdf.png</iconset>
    </property>
    <property name="text">
-    <string>Export schematics to &amp;PDF</string>
+    <string>&amp;PDF</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -351,7 +347,7 @@
   </action>
   <action name="actionShow_Control_Panel">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/home.png</normaloff>:/img/actions/home.png</iconset>
    </property>
    <property name="text">
@@ -363,7 +359,7 @@
   </action>
   <action name="actionShow_Board_Editor">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/board_editor.png</normaloff>:/img/actions/board_editor.png</iconset>
    </property>
    <property name="text">
@@ -375,7 +371,7 @@
   </action>
   <action name="actionUndo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/undo.png</normaloff>:/img/actions/undo.png</iconset>
    </property>
    <property name="text">
@@ -387,7 +383,7 @@
   </action>
   <action name="actionRedo">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/redo.png</normaloff>:/img/actions/redo.png</iconset>
    </property>
    <property name="text">
@@ -399,11 +395,11 @@
   </action>
   <action name="actionZoom_In">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_in.png</normaloff>:/img/actions/zoom_in.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Zoom In</string>
+    <string>Zoom &amp;In</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl++</string>
@@ -411,7 +407,7 @@
   </action>
   <action name="actionZoom_Out">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_out.png</normaloff>:/img/actions/zoom_out.png</iconset>
    </property>
    <property name="text">
@@ -423,23 +419,23 @@
   </action>
   <action name="actionZoom_All">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/zoom_all.png</normaloff>:/img/actions/zoom_all.png</iconset>
    </property>
    <property name="text">
-    <string>Zoo&amp;m All</string>
+    <string>Zoom &amp;All</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+0</string>
    </property>
   </action>
   <action name="actionOnlineDocumentation">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/help.png</normaloff>:/img/actions/help.png</iconset>
    </property>
    <property name="text">
-    <string>Online Documentation</string>
+    <string>&amp;Online Documentation</string>
    </property>
    <property name="shortcut">
     <string notr="true">F1</string>
@@ -447,11 +443,11 @@
   </action>
   <action name="actionOpenWebsite">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/open_browser.png</normaloff>:/img/actions/open_browser.png</iconset>
    </property>
    <property name="text">
-    <string>LibrePCB Website</string>
+    <string>LibrePCB &amp;Website</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -459,7 +455,7 @@
   </action>
   <action name="actionRotate_CCW">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_left.png</normaloff>:/img/actions/rotate_left.png</iconset>
    </property>
    <property name="text">
@@ -471,7 +467,7 @@
   </action>
   <action name="actionRotate_CW">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/rotate_right.png</normaloff>:/img/actions/rotate_right.png</iconset>
    </property>
    <property name="text">
@@ -483,11 +479,11 @@
   </action>
   <action name="actionMirror">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/flip_horizontal.png</normaloff>:/img/actions/flip_horizontal.png</iconset>
    </property>
    <property name="text">
-    <string>M&amp;irror</string>
+    <string>&amp;Mirror</string>
    </property>
    <property name="shortcut">
     <string notr="true">M</string>
@@ -495,7 +491,7 @@
   </action>
   <action name="actionCopy">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/copy.png</normaloff>:/img/actions/copy.png</iconset>
    </property>
    <property name="text">
@@ -507,11 +503,11 @@
   </action>
   <action name="actionCut">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/cut.png</normaloff>:/img/actions/cut.png</iconset>
    </property>
    <property name="text">
-    <string>Cut</string>
+    <string>Cu&amp;t</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+X</string>
@@ -519,7 +515,7 @@
   </action>
   <action name="actionPaste">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/paste.png</normaloff>:/img/actions/paste.png</iconset>
    </property>
    <property name="text">
@@ -531,7 +527,7 @@
   </action>
   <action name="actionRemove">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/delete.png</normaloff>:/img/actions/delete.png</iconset>
    </property>
    <property name="text">
@@ -543,19 +539,19 @@
   </action>
   <action name="actionClose_Project">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/close.png</normaloff>:/img/actions/close.png</iconset>
    </property>
    <property name="text">
     <string>&amp;Close Project</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string notr="true">Ctrl+W</string>
    </property>
   </action>
   <action name="actionToolSelect">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/select.png</normaloff>:/img/actions/select.png</iconset>
    </property>
    <property name="text">
@@ -567,7 +563,7 @@
   </action>
   <action name="actionToolAddComponent">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/add_component.png</normaloff>:/img/actions/add_component.png</iconset>
    </property>
    <property name="text">
@@ -579,7 +575,7 @@
   </action>
   <action name="actionToolDrawWire">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/draw_wire.png</normaloff>:/img/actions/draw_wire.png</iconset>
    </property>
    <property name="text">
@@ -591,7 +587,7 @@
   </action>
   <action name="actionCommandAbort">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/stop.png</normaloff>:/img/actions/stop.png</iconset>
    </property>
    <property name="text">
@@ -603,7 +599,7 @@
   </action>
   <action name="actionGrid">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/grid.png</normaloff>:/img/actions/grid.png</iconset>
    </property>
    <property name="text">
@@ -623,7 +619,7 @@
   </action>
   <action name="actionAddComp_Resistor">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/library/resistor_eu.png</normaloff>:/img/library/resistor_eu.png</iconset>
    </property>
    <property name="text">
@@ -635,7 +631,7 @@
   </action>
   <action name="actionAddComp_BipolarCapacitor">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/library/bipolar_capacitor_eu.png</normaloff>:/img/library/bipolar_capacitor_eu.png</iconset>
    </property>
    <property name="text">
@@ -650,7 +646,7 @@
   </action>
   <action name="actionAddComp_Inductor">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/library/inductor_eu.png</normaloff>:/img/library/inductor_eu.png</iconset>
    </property>
    <property name="text">
@@ -662,7 +658,7 @@
   </action>
   <action name="actionAddComp_gnd">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/library/gnd.png</normaloff>:/img/library/gnd.png</iconset>
    </property>
    <property name="text">
@@ -674,7 +670,7 @@
   </action>
   <action name="actionAddComp_vcc">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/library/vcc.png</normaloff>:/img/library/vcc.png</iconset>
    </property>
    <property name="text">
@@ -694,7 +690,7 @@
   </action>
   <action name="actionProjectSettings">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
    </property>
    <property name="text">
@@ -706,11 +702,11 @@
   </action>
   <action name="actionToolAddNetLabel">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/draw_netlabel.png</normaloff>:/img/actions/draw_netlabel.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Add Netlabel</string>
+    <string>Add &amp;Netlabel</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -718,7 +714,7 @@
   </action>
   <action name="actionAddComp_UnipolarCapacitor">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/library/unipolar_capacitor_eu.png</normaloff>:/img/library/unipolar_capacitor_eu.png</iconset>
    </property>
    <property name="text">
@@ -730,7 +726,7 @@
   </action>
   <action name="actionNew_Schematic_Page">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/new_2.png</normaloff>:/img/actions/new_2.png</iconset>
    </property>
    <property name="text">
@@ -742,11 +738,11 @@
   </action>
   <action name="actionUpdateLibrary">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
    </property>
    <property name="text">
-    <string>Update Library</string>
+    <string>&amp;Update Library</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -754,11 +750,11 @@
   </action>
   <action name="actionExportLppz">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_zip.png</normaloff>:/img/actions/export_zip.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Export project to *.lppz</string>
+    <string>&amp;LPPZ</string>
    </property>
    <property name="toolTip">
     <string>Export project to *.lppz</string>
@@ -769,11 +765,11 @@
   </action>
   <action name="actionGenerateBom">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/generate_bom.png</normaloff>:/img/actions/generate_bom.png</iconset>
    </property>
    <property name="text">
-    <string>Generate BOM</string>
+    <string>&amp;Generate BOM</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -781,7 +777,7 @@
   </action>
   <action name="actionRenameSheet">
    <property name="text">
-    <string>Rename Sheet</string>
+    <string>&amp;Rename Sheet</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -789,11 +785,11 @@
   </action>
   <action name="actionExportAsSvg">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/export_svg.png</normaloff>:/img/actions/export_svg.png</iconset>
    </property>
    <property name="text">
-    <string>Export sheet to SVG</string>
+    <string>&amp;SVG</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -801,11 +797,11 @@
   </action>
   <action name="actionSelectAll">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../../../img/images.qrc">
      <normaloff>:/img/actions/select_all.png</normaloff>:/img/actions/select_all.png</iconset>
    </property>
    <property name="text">
-    <string>Select All</string>
+    <string>Select &amp;All</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+A</string>
@@ -824,6 +820,15 @@
    <header location="global">librepcb/projecteditor/toolbars/searchtoolbar.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+  <include location="../../../../img/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/libs/librepcb/projecteditor/toolbars/searchtoolbar.cpp
+++ b/libs/librepcb/projecteditor/toolbars/searchtoolbar.cpp
@@ -37,10 +37,18 @@ namespace editor {
  ******************************************************************************/
 
 SearchToolBar::SearchToolBar(QWidget* parent) noexcept
-  : QToolBar(parent), mCompleterListFunction(), mLineEdit(new QLineEdit()) {
+  : QToolBar(parent),
+    mCompleterListFunction(),
+    mLineEdit(new QLineEdit()),
+    mShortcutFocus(nullptr) {
   mLineEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   mLineEdit->setMaxLength(30);             // avoid too large widget in toolbar
   mLineEdit->setClearButtonEnabled(true);  // to quickly clear the search term
+  mShortcutFocus = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_F), this);
+  connect(mShortcutFocus, &QShortcut::activated, this, [this](){
+    mLineEdit->setFocus();
+  });
+  mLineEdit->setFocus();
   connect(mLineEdit.data(), &QLineEdit::textEdited, this,
           &SearchToolBar::textEdited);
   connect(mLineEdit.data(), &QLineEdit::returnPressed, this,

--- a/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
+++ b/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
@@ -75,6 +75,7 @@ private:
 private:
   CompleterListFunction     mCompleterListFunction;
   QScopedPointer<QLineEdit> mLineEdit;
+  QShortcut* mShortcutFocus;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
# Unify User Interface
This PR improves the UI/UX by unifying the interface of the control panel and editors.

## Refactor ControlPanel
- Update Mnemonics
- Add Keyboard Shortcuts
- Unify context menu and use helper functions
- [ ] Open project with Enter key from the file list

## Refactor BoardEditor, Schematiceditor, LibraryEditor

## Other Changes
- Add Ctrl+F Shortcut to focus on the search toolbar
- [x] Change search behavior (#756 )
- [x] Improve context menu and item selection of editors (#757 )
- [ ] Reuse code for via/pad shape selection (#759) 

## Todo
- [x] Rename short fsm file names to long versions (like BES_* -> BoardEditorState_*)
- [ ] Create reusable menus (e.g. always the same help menu)
- [ ] Create a consistent, globally available shortcut manager and editor
  - [ ] Investigate impact single letter key shortcuts (e.g R for rotate)
  - [ ] Add keyboard shortcuts to librarymanager
  - [ ] Compile list of keyboard shortcuts
  - [ ] Add more keyboard shortcuts to libraryeditor