### PR TITLE
Improve search behavior in board- and schematic editor

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -104,7 +104,7 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   if (!mProject.getDirectory().isWritable()) {
     filenameStr.append(QStringLiteral(" [Read-Only]"));
   }
-  setWindowTitle(QString("%1 - LibrePCB Board Editor").arg(filenameStr));
+  setWindowTitle(tr("%1 - LibrePCB Board Editor").arg(filenameStr));
 
   // Add Dock Widgets
   mUnplacedComponentsDock = new UnplacedComponentsDock(mProjectEditor);
@@ -443,7 +443,7 @@ void BoardEditor::on_actionCopyBoard_triggered() {
   bool    ok   = false;
   QString name = QInputDialog::getText(
       this, tr("Copy Board"), tr("Choose a name:"), QLineEdit::Normal,
-      QString(tr("copy_of_%1")).arg(*board->getName()), &ok);
+      tr("copy_of_%1").arg(*board->getName()), &ok);
   if (!ok) return;
 
   try {
@@ -462,8 +462,7 @@ void BoardEditor::on_actionRemoveBoard_triggered() {
 
   QMessageBox::StandardButton btn = QMessageBox::question(
       this, tr("Remove board"),
-      QString(tr("Are you really sure to remove the board \"%1\"?"))
-          .arg(*board->getName()));
+      tr("Are you really sure to remove the board \"%1\"?").arg(*board->getName()));
   if (btn != QMessageBox::Yes) return;
 
   try {
@@ -849,30 +848,49 @@ void BoardEditor::clearDrcMarker() noexcept {
   mGraphicsView->setSceneRectMarker(QRectF());
 }
 
+QList<BI_Device*> BoardEditor::getSearchCandidates() noexcept {
+  QList<BI_Device*> candidates = {};
+  if (Board* board = getActiveBoard()) {
+    candidates += board->getDeviceInstances().values();
+    std::sort(candidates.begin(), candidates.end(),
+              [](BI_Device* a, BI_Device* b){
+      return a->getComponentInstance().getName()
+          < b->getComponentInstance().getName();
+    });
+  }
+  return candidates;
+}
+
 QStringList BoardEditor::getSearchToolBarCompleterList() noexcept {
   QStringList list;
-  if (Board* board = getActiveBoard()) {
-    foreach (const BI_Device* device, board->getDeviceInstances()) {
-      list.append(*device->getComponentInstance().getName());
-    }
+  foreach (const BI_Device* device, getSearchCandidates()) {
+    list.append(*device->getComponentInstance().getName());
   }
   return list;
 }
 
-void BoardEditor::goToDevice(const QString& name) noexcept {
-  if (Board* board = getActiveBoard()) {
-    foreach (BI_Device* device, board->getDeviceInstances()) {
-      if (device->getComponentInstance().getName()->toLower() ==
-          name.toLower()) {
-        board->clearSelection();
-        device->setSelected(true);
-        QRectF rect   = device->getFootprint().getBoundingRect();
-        qreal  margin = Length(1000000).toPx();
-        rect.adjust(-margin, -margin, margin, margin);
-        mGraphicsView->zoomToRect(rect);
-        return;
-      }
+void BoardEditor::goToDevice(const QString& name, unsigned int index) noexcept {
+  QList<BI_Device*> deviceCandidates = {};
+  foreach (BI_Device* device, getSearchCandidates()) {
+    if (device->getComponentInstance().getName()
+        ->startsWith(name, Qt::CaseInsensitive)) {
+      deviceCandidates.append(device);
     }
+  }
+
+  if (deviceCandidates.count()) {
+    index %= deviceCandidates.count();
+    BI_Device* device = deviceCandidates[index];
+    Board* board = getActiveBoard();
+    Q_ASSERT(board);
+    board->clearSelection();
+    device->setSelected(true);
+    QRectF rect = device->getFootprint().getBoundingRect();
+    // Zoom to a rectangle relative to the maximum device dimension. The
+    // device is 1/4th of the screen.
+    qreal margin = 1.5f*std::max(rect.size().width(), rect.size().height());
+    rect.adjust(-margin, -margin, margin, margin);
+    mGraphicsView->zoomToRect(rect);
   }
 }
 

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -132,8 +132,9 @@ private:
   void        highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,
                                   bool                               zoomTo) noexcept;
   void        clearDrcMarker() noexcept;
+  QList<BI_Device*> getSearchCandidates() noexcept;
   QStringList getSearchToolBarCompleterList() noexcept;
-  void        goToDevice(const QString& name) noexcept;
+  void        goToDevice(const QString& name, unsigned int index) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -88,7 +88,7 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   if (!mProject.getDirectory().isWritable()) {
     filenameStr.append(QStringLiteral(" [Read-Only]"));
   }
-  setWindowTitle(QString("%1 - LibrePCB Schematic Editor").arg(filenameStr));
+  setWindowTitle(tr("%1 - LibrePCB Schematic Editor").arg(filenameStr));
 
   // Add Dock Widgets
   mPagesDock = new SchematicPagesDock(mProject, this);
@@ -696,31 +696,49 @@ void SchematicEditor::renameSchematic(int index) noexcept {
   }
 }
 
+QList<SI_Symbol*> SchematicEditor::getSearchCandidates() noexcept {
+  QList<SI_Symbol*> candidates = {};
+  foreach (const Schematic* schematic, mProject.getSchematics()) {
+    Q_ASSERT(schematic);
+    candidates += schematic->getSymbols();
+  }
+  std::sort(candidates.begin(), candidates.end(),
+            [](SI_Symbol* a, SI_Symbol* b){
+    return a->getName() < b->getName();
+  });
+  return candidates;
+}
+
 QStringList SchematicEditor::getSearchToolBarCompleterList() noexcept {
   QStringList list;
-  foreach (const Schematic* schematic, mProject.getSchematics()) {
-    foreach (const SI_Symbol* symbol, schematic->getSymbols()) {
-      list.append(symbol->getName());
-    }
+  foreach (SI_Symbol* symbol, getSearchCandidates()) {
+    list.append(symbol->getName());
   }
   return list;
 }
 
-void SchematicEditor::goToSymbol(const QString& name) noexcept {
-  for (int i = 0; i < mProject.getSchematics().count(); ++i) {
-    const Schematic* schematic = mProject.getSchematicByIndex(i);
-    Q_ASSERT(schematic);
-    foreach (SI_Symbol* symbol, schematic->getSymbols()) {
-      if (symbol->getName().toLower() == name.toLower()) {
-        setActiveSchematicIndex(i);
-        schematic->clearSelection();
-        symbol->setSelected(true);
-        QRectF rect   = symbol->getBoundingRect();
-        qreal  margin = Length(1000000).toPx();
-        rect.adjust(-margin, -margin, margin, margin);
-        mGraphicsView->zoomToRect(rect);
-        return;
-      }
+void SchematicEditor::goToSymbol(const QString& name,
+                                 unsigned int index) noexcept {
+  QList<SI_Symbol*> symbolCandidates = {};
+  foreach (SI_Symbol* symbol, getSearchCandidates()) {
+    if (symbol->getName().startsWith(name, Qt::CaseInsensitive)) {
+      symbolCandidates.append(symbol);
+    }
+  }
+
+  if (symbolCandidates.count()) {
+    index %= symbolCandidates.count();
+    SI_Symbol* symbol = symbolCandidates[index];
+    Schematic& schematic = symbol->getSchematic();
+    if (setActiveSchematicIndex(mProject.getSchematics().indexOf(&schematic))) {
+      schematic.clearSelection();
+      symbol->setSelected(true);
+      QRectF rect = symbol->getBoundingRect();
+      // Zoom to a rectangle relative to the maximum symbol dimension. The
+      // symbol is 1/4th of the screen.
+      qreal margin = 1.5f*std::max(rect.size().width(), rect.size().height());
+      rect.adjust(-margin, -margin, margin, margin);
+      mGraphicsView->zoomToRect(rect);
     }
   }
 }

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -41,6 +41,7 @@ namespace project {
 
 class Project;
 class Schematic;
+class SI_Symbol;
 
 namespace editor {
 
@@ -118,8 +119,9 @@ private:
   void        addSchematic() noexcept;
   void        removeSchematic(int index) noexcept;
   void        renameSchematic(int index) noexcept;
+  QList<SI_Symbol*> getSearchCandidates() noexcept;
   QStringList getSearchToolBarCompleterList() noexcept;
-  void        goToSymbol(const QString& name) noexcept;
+  void        goToSymbol(const QString& name, unsigned int index) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/toolbars/searchtoolbar.cpp
+++ b/libs/librepcb/projecteditor/toolbars/searchtoolbar.cpp
@@ -37,7 +37,10 @@ namespace editor {
  ******************************************************************************/
 
 SearchToolBar::SearchToolBar(QWidget* parent) noexcept
-  : QToolBar(parent), mCompleterListFunction(), mLineEdit(new QLineEdit()) {
+  : QToolBar(parent),
+    mCompleterListFunction(),
+    mLineEdit(new QLineEdit()),
+    mIndex(0) {
   mLineEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   mLineEdit->setMaxLength(30);             // avoid too large widget in toolbar
   mLineEdit->setClearButtonEnabled(true);  // to quickly clear the search term
@@ -76,10 +79,11 @@ void SearchToolBar::updateCompleter() noexcept {
 void SearchToolBar::textEdited(const QString& text) noexcept {
   Q_UNUSED(text);
   updateCompleter();
+  mIndex = 0;
 }
 
 void SearchToolBar::enterPressed() noexcept {
-  emit goToTriggered(mLineEdit->text().trimmed());
+  emit goToTriggered(mLineEdit->text().trimmed(), mIndex++);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
+++ b/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
@@ -65,7 +65,7 @@ public:
   SearchToolBar& operator=(const SearchToolBar& rhs) = delete;
 
 signals:
-  void goToTriggered(const QString& name);
+  void goToTriggered(const QString& name, unsigned int index = 0);
 
 private:
   void updateCompleter() noexcept;
@@ -75,6 +75,7 @@ private:
 private:
   CompleterListFunction     mCompleterListFunction;
   QScopedPointer<QLineEdit> mLineEdit;
+  unsigned int mIndex; ///< Number of searches with the current search term
 };
 
 /*******************************************************************************


### PR DESCRIPTION
- Allow cycling through results beginning with the current search term
- Zoom depending on the symbol/device size, and showing the maximum dimension as 1/4 of the screen