### PR TITLE
Editors: Improve context menu handling

### DIFF
--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
@@ -88,6 +88,7 @@ public:
 
 private:  // Methods
   bool openContextMenuAtPos(const Point& pos) noexcept;
+  bool openPropertiesDialogOfItem(QGraphicsItem* item) noexcept;
   bool openPropertiesDialogOfItemAtPos(const Point& pos) noexcept;
   bool copySelectedItemsToClipboard() noexcept;
   bool pasteFromClipboard() noexcept;
@@ -97,12 +98,14 @@ private:  // Methods
   bool removeSelectedItems() noexcept;
   void setSelectionRect(const Point& p1, const Point& p2) noexcept;
   void clearSelectionRect(bool updateItemsSelectionState) noexcept;
+  QList<QGraphicsItem*> findItemsAtPosition(const Point& pos) noexcept;
 
 private:  // Types / Data
   enum class SubState { IDLE, SELECTING, MOVING, PASTING };
   SubState                                      mState;
   Point                                         mStartPos;
   QScopedPointer<CmdDragSelectedFootprintItems> mCmdDragSelectedItems;
+  int mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
@@ -87,6 +87,7 @@ public:
 
 private:  // Methods
   bool openContextMenuAtPos(const Point& pos) noexcept;
+  bool openPropertiesDialogOfItem(QGraphicsItem* item) noexcept;
   bool openPropertiesDialogOfItemAtPos(const Point& pos) noexcept;
   bool copySelectedItemsToClipboard() noexcept;
   bool pasteFromClipboard() noexcept;
@@ -95,12 +96,14 @@ private:  // Methods
   bool removeSelectedItems() noexcept;
   void setSelectionRect(const Point& p1, const Point& p2) noexcept;
   void clearSelectionRect(bool updateItemsSelectionState) noexcept;
+  QList<QGraphicsItem*> findItemsAtPosition(const Point& pos) noexcept;
 
 private:  // Types / Data
   enum class SubState { IDLE, SELECTING, MOVING, PASTING };
   SubState                                   mState;
   Point                                      mStartPos;
   QScopedPointer<CmdDragSelectedSymbolItems> mCmdDragSelectedItems;
+  int mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -52,7 +52,9 @@ namespace editor {
 
 SchematicEditorState_Select::SchematicEditorState_Select(
     const Context& context) noexcept
-  : SchematicEditorState(context), mSubState(SubState::IDLE) {
+  : SchematicEditorState(context),
+    mSubState(SubState::IDLE),
+    mCurrentSelectionIndex(0) {
 }
 
 SchematicEditorState_Select::~SchematicEditorState_Select() noexcept {
@@ -194,13 +196,13 @@ bool SchematicEditorState_Select::processGraphicsSceneMouseMoved(
 }
 
 bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
-    QGraphicsSceneMouseEvent& e) noexcept {
+    QGraphicsSceneMouseEvent& mouseEvent) noexcept {
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
   if (mSubState == SubState::IDLE) {
     // handle items selection
-    Point           pos   = Point::fromPx(e.scenePos());
+    Point           pos   = Point::fromPx(mouseEvent.scenePos());
     QList<SI_Base*> items = schematic->getItemsAtScenePos(pos);
     if (items.isEmpty()) {
       // no items under mouse --> start drawing a selection rectangle
@@ -212,9 +214,15 @@ bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
 
     bool itemAlreadySelected = items.first()->isSelected();
 
-    if ((e.modifiers() & Qt::ControlModifier)) {
+    if (mouseEvent.modifiers() & Qt::ControlModifier) {
       // Toggle selection when CTRL is pressed
       items.first()->setSelected(!itemAlreadySelected);
+    } else if (mouseEvent.modifiers() & Qt::ShiftModifier) {
+        // Cycle Selection, when holding shift
+        mCurrentSelectionIndex += 1;
+        mCurrentSelectionIndex %= items.count();
+        schematic->clearSelection();
+        items[mCurrentSelectionIndex]->setSelected(true);
     } else if (!itemAlreadySelected) {
       // Only select the topmost item when clicking an unselected item
       // without CTRL
@@ -222,13 +230,14 @@ bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       items.first()->setSelected(true);
     }
 
-    if (startMovingSelectedItems(*schematic, Point::fromPx(e.scenePos()))) {
+    if (startMovingSelectedItems(*schematic,
+                                 Point::fromPx(mouseEvent.scenePos()))) {
       return true;
     }
   } else if (mSubState == SubState::PASTING) {
     // stop moving items (set position of all selected elements permanent)
     Q_ASSERT(!mSelectedItemsMoveCommand.isNull());
-    Point pos = Point::fromPx(e.scenePos());
+    Point pos = Point::fromPx(mouseEvent.scenePos());
     mSelectedItemsMoveCommand->setCurrentPosition(pos);
     try {
       mContext.undoStack.appendToCmdGroup(
@@ -292,24 +301,7 @@ bool SchematicEditorState_Select::
     if (items.isEmpty()) return false;
 
     // open the properties editor dialog of the top most item
-    switch (items.first()->getType()) {
-      case SI_Base::Type_t::Symbol: {
-        SI_Symbol* symbol = dynamic_cast<SI_Symbol*>(items.first());
-        Q_ASSERT(symbol);
-        openSymbolPropertiesDialog(*symbol);
-        return true;
-      }
-
-      case SI_Base::Type_t::NetLabel: {
-        SI_NetLabel* netlabel = dynamic_cast<SI_NetLabel*>(items.first());
-        Q_ASSERT(netlabel);
-        openNetLabelPropertiesDialog(*netlabel);
-        return true;
-      }
-
-      default:
-        break;
-    }
+    openPropertiesDialog(items.first());
   }
 
   return false;
@@ -319,85 +311,61 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
     QGraphicsSceneMouseEvent& e) noexcept {
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
+  if (mSubState != SubState::IDLE) return false;
 
-  if (mSubState == SubState::IDLE) {
-    // handle item selection
-    QList<SI_Base*> items =
-        schematic->getItemsAtScenePos(Point::fromPx(e.scenePos()));
-    if (items.isEmpty()) return false;
-    schematic->clearSelection();
-    items.first()->setSelected(true);
-
-    // build and execute the context menu
-    QMenu menu;
-    switch (items.first()->getType()) {
-      case SI_Base::Type_t::Symbol: {
-        SI_Symbol* symbol = dynamic_cast<SI_Symbol*>(items.first());
-        Q_ASSERT(symbol);
-
-        // build the context menu
-        QAction* aCut =
-            menu.addAction(QIcon(":/img/actions/cut.png"), tr("Cut"));
-        QAction* aCopy =
-            menu.addAction(QIcon(":/img/actions/copy.png"), tr("Copy"));
-        QAction* aRotateCCW = menu.addAction(
-            QIcon(":/img/actions/rotate_left.png"), tr("Rotate"));
-        QAction* aMirror = menu.addAction(
-            QIcon(":/img/actions/flip_horizontal.png"), tr("Mirror"));
-        QAction* aRemoveSymbol = menu.addAction(
-            QIcon(":/img/actions/delete.png"), tr("Remove Symbol"));
-        menu.addSeparator();
-        QAction* aProperties = menu.addAction(tr("Properties"));
-
-        // execute the context menu
-        QAction* action = menu.exec(e.screenPos());
-        if (action == aCut) {
-          copySelectedItemsToClipboard();
-          removeSelectedItems();
-        } else if (action == aCopy) {
-          copySelectedItemsToClipboard();
-        } else if (action == aRotateCCW) {
-          rotateSelectedItems(Angle::deg90());
-        } else if (action == aMirror) {
-          mirrorSelectedItems();
-        } else if (action == aRemoveSymbol) {
-          removeSelectedItems();
-        } else if (action == aProperties) {
-          openSymbolPropertiesDialog(*symbol);
-        }
-        return true;
-      }
-
-      case SI_Base::Type_t::NetLabel: {
-        SI_NetLabel* netlabel = dynamic_cast<SI_NetLabel*>(items.first());
-        Q_ASSERT(netlabel);
-
-        // build the context menu
-        QAction* aRotateCCW = menu.addAction(
-            QIcon(":/img/actions/rotate_left.png"), tr("Rotate"));
-        QAction* aRemove = menu.addAction(QIcon(":/img/actions/delete.png"),
-                                          tr("Remove Net Label"));
-        menu.addSeparator();
-        QAction* aRenameNetSegment = menu.addAction(tr("Rename Net Segment"));
-
-        // execute the context menu
-        QAction* action = menu.exec(e.screenPos());
-        if (action == aRotateCCW) {
-          rotateSelectedItems(Angle::deg90());
-        } else if (action == aRemove) {
-          removeSelectedItems();
-        } else if (action == aRenameNetSegment) {
-          openNetLabelPropertiesDialog(*netlabel);
-        }
-        return true;
-      }
-
-      default:
-        break;
+  // handle item selection
+  QList<SI_Base*> items =
+      schematic->getItemsAtScenePos(Point::fromPx(e.scenePos()));
+  if (items.isEmpty()) return false;
+  SI_Base* selectedItem = nullptr;
+  foreach (SI_Base* item, items) {
+    if (item->isSelected()) {
+      selectedItem = item;
     }
   }
+  if (!selectedItem) {
+    schematic->clearSelection();
+    selectedItem = items.first();
+    selectedItem->setSelected(true);
+  }
+  Q_ASSERT(selectedItem);
+  Q_ASSERT(selectedItem->isSelected());
 
-  return false;
+  // build the context menu
+  QMenu menu;
+  switch (selectedItem->getType()) {
+    case SI_Base::Type_t::Symbol: {
+      SI_Symbol* symbol = dynamic_cast<SI_Symbol*>(selectedItem);
+      Q_ASSERT(symbol);
+
+      addActionCut(menu);
+      addActionCopy(menu);
+      addActionRemove(menu, tr("Remove Symbol"));
+      menu.addSeparator();
+      addActionRotate(menu);
+      addActionMirror(menu);
+      menu.addSeparator();
+      addActionOpenProperties(menu, selectedItem);
+      break;
+    }
+
+    case SI_Base::Type_t::NetLabel: {
+      SI_NetLabel* netlabel = dynamic_cast<SI_NetLabel*>(selectedItem);
+      Q_ASSERT(netlabel);
+
+      addActionRotate(menu);
+      addActionRemove(menu, tr("Remove Net Label"));
+      menu.addSeparator();
+      addActionOpenProperties(menu, selectedItem, tr("Rename Net Segment"));
+      break;
+    }
+
+    default:
+      return false;
+  }
+  // execute the context menu
+  menu.exec(e.screenPos());
+  return true;
 }
 
 bool SchematicEditorState_Select::processSwitchToSchematicPage(
@@ -536,6 +504,28 @@ bool SchematicEditorState_Select::pasteFromClipboard() noexcept {
   return false;
 }
 
+void SchematicEditorState_Select::openPropertiesDialog(SI_Base* item) noexcept {
+  if (!item) return;
+  switch (item->getType()) {
+    case SI_Base::Type_t::Symbol: {
+      SI_Symbol* symbol = dynamic_cast<SI_Symbol*>(item);
+      Q_ASSERT(symbol);
+      openSymbolPropertiesDialog(*symbol);
+      break;
+    }
+
+    case SI_Base::Type_t::NetLabel: {
+      SI_NetLabel* netlabel = dynamic_cast<SI_NetLabel*>(item);
+      Q_ASSERT(netlabel);
+      openNetLabelPropertiesDialog(*netlabel);
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
 void SchematicEditorState_Select::openSymbolPropertiesDialog(
     SI_Symbol& symbol) noexcept {
   SymbolInstancePropertiesDialog dialog(
@@ -550,6 +540,61 @@ void SchematicEditorState_Select::openNetLabelPropertiesDialog(
   RenameNetSegmentDialog dialog(mContext.undoStack, netlabel.getNetSegment(),
                                 parentWidget());
   dialog.exec();  // performs the rename, if needed
+}
+
+QAction* SchematicEditorState_Select::addActionCut(
+    QMenu &menu, const QString &text) noexcept {
+  QAction* action = menu.addAction(QIcon(":/img/actions/cut.png"), text);
+  connect(action, &QAction::triggered, [this](){
+    copySelectedItemsToClipboard();
+    removeSelectedItems();
+  });
+  return action;
+}
+
+QAction* SchematicEditorState_Select::addActionCopy(
+    QMenu &menu, const QString &text) noexcept {
+  QAction* action = menu.addAction(QIcon(":/img/actions/copy.png"), text);
+  connect(action, &QAction::triggered, [this](){
+    copySelectedItemsToClipboard();
+  });
+  return action;
+}
+
+QAction* SchematicEditorState_Select::addActionRemove(
+    QMenu &menu, const QString &text) noexcept {
+  QAction* action = menu.addAction(QIcon(":/img/actions/delete.png"), text);
+  connect(action, &QAction::triggered, [this](){
+    removeSelectedItems();
+  });
+  return action;
+}
+
+QAction* SchematicEditorState_Select::addActionMirror(
+    QMenu &menu, const QString &text) noexcept {
+  QAction* action = menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), text);
+  connect(action, &QAction::triggered, [this](){
+    mirrorSelectedItems();
+  });
+  return action;
+}
+
+QAction* SchematicEditorState_Select::addActionRotate(
+    QMenu &menu, const QString &text) noexcept {
+  QAction* action = menu.addAction(QIcon(":/img/actions/rotate_left.png"), text);
+  connect(action, &QAction::triggered, [this](){
+    rotateSelectedItems(Angle::deg90());
+  });
+  return action;
+}
+
+QAction* SchematicEditorState_Select::addActionOpenProperties(
+    QMenu &menu, SI_Base* item, const QString &text) noexcept {
+  QAction* action = menu.addAction(QIcon(":/img/actions/settings.png"), text);
+  connect(action, &QAction::triggered, [this, item](){
+    openPropertiesDialog(item);
+  });
+  return action;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
@@ -37,6 +37,7 @@ class Angle;
 
 namespace project {
 
+class SI_Base;
 class SI_Symbol;
 class SI_NetLabel;
 class Schematic;
@@ -90,19 +91,29 @@ public:
   virtual bool processSwitchToSchematicPage(int index) noexcept override;
 
   // Operator Overloadings
-  SchematicEditorState_Select& operator       =(
+  SchematicEditorState_Select& operator =(
       const SchematicEditorState_Select& rhs) = delete;
 
 private:  // Methods
-  bool startMovingSelectedItems(Schematic&   schematic,
+  bool startMovingSelectedItems(Schematic& schematic,
                                 const Point& startPos) noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems() noexcept;
   bool removeSelectedItems() noexcept;
   bool copySelectedItemsToClipboard() noexcept;
   bool pasteFromClipboard() noexcept;
+  void openPropertiesDialog(SI_Base* item) noexcept;
   void openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept;
   void openNetLabelPropertiesDialog(SI_NetLabel& netlabel) noexcept;
+
+  //Right Click Menu
+  QAction* addActionCut(QMenu& menu, const QString& text = tr("Cut")) noexcept;
+  QAction* addActionCopy(QMenu& menu, const QString& text = tr("Copy")) noexcept;
+  QAction* addActionRemove(QMenu& menu, const QString& text = tr("Remove")) noexcept;
+  QAction* addActionMirror(QMenu& menu, const QString& text = tr("Mirror")) noexcept;
+  QAction* addActionRotate(QMenu& menu, const QString& text = tr("Rotate")) noexcept;
+  QAction* addActionOpenProperties(QMenu& menu, SI_Base* item,
+                                   const QString& text = tr("Properties")) noexcept;
 
 private:  // Data
   /// enum for all possible substates
@@ -116,6 +127,7 @@ private:  // Data
   SubState mSubState;  ///< the current substate
   Point    mStartPos;
   QScopedPointer<CmdMoveSelectedSchematicItems> mSelectedItemsMoveCommand;
+  int mCurrentSelectionIndex;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
Improve context menu handling for the symbol, package, and schematic editor.

- Implement improvements as done in #748
- Implement findItemsAtPosition function where necessary
- Allow cycling through items while holding the shift key
- Fixes #536