### PR TITLE
Format & clean up source files

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -91,26 +91,26 @@ int CommandLineInterface::execute() noexcept {
          "report failure (exit code = 1) if there are non-approved messages."));
   QCommandLineOption exportSchematicsOption(
       "export-schematics",
-      QString(tr("Export schematics to given file(s). Existing files will be "
-                 "overwritten. Supported file extensions: %1"))
+      tr("Export schematics to given file(s). Existing files will be "
+         "overwritten. Supported file extensions: %1")
           .arg("pdf"),
       tr("file"));
   QCommandLineOption exportBomOption(
       "export-bom",
-      QString(tr("Export generic BOM to given file(s). Existing files will be "
-                 "overwritten. Supported file extensions: %1"))
+      tr("Export generic BOM to given file(s). Existing files will be "
+         "overwritten. Supported file extensions: %1")
           .arg("csv"),
       tr("file"));
   QCommandLineOption exportBoardBomOption(
       "export-board-bom",
-      QString(tr("Export board-specific BOM to given file(s). Existing files "
-                 "will be overwritten. Supported file extensions: %1"))
+      tr("Export board-specific BOM to given file(s). Existing files "
+         "will be overwritten. Supported file extensions: %1")
           .arg("csv"),
       tr("file"));
   QCommandLineOption bomAttributesOption(
       "bom-attributes",
-      QString(tr("Comma-separated list of additional attributes to be exported "
-                 "to the BOM. Example: \"%1\""))
+      tr("Comma-separated list of additional attributes to be exported "
+         "to the BOM. Example: \"%1\"")
           .arg("MANUFACTURER, MPN"),
       tr("attributes"));
   QCommandLineOption exportPcbFabricationDataOption(
@@ -185,7 +185,7 @@ int CommandLineInterface::execute() noexcept {
     parser.addOption(libSaveOption);
     parser.addOption(libStrictOption);
   } else if (!command.isEmpty()) {
-    printErr(QString(tr("Unknown command '%1'.")).arg(command), 2);
+    printErr(tr("Unknown command '%1'.").arg(command), 2);
     print(parser.helpText(), 0);
     return 1;
   }
@@ -199,13 +199,11 @@ int CommandLineInterface::execute() noexcept {
 
   // --version
   if (parser.isSet(versionOption)) {
-    print(
-        QString(tr("LibrePCB CLI Version %1")).arg(mApp.applicationVersion()));
-    print(QString(tr("Git Revision %1")).arg(mApp.getGitRevision()));
-    print(QString(tr("Qt Version %1 (compiled against %2)"))
+    print(tr("LibrePCB CLI Version %1").arg(mApp.applicationVersion()));
+    print(tr("Git Revision %1").arg(mApp.getGitRevision()));
+    print(tr("Qt Version %1 (compiled against %2)")
               .arg(qVersion(), QT_VERSION_STR));
-    print(QString(tr("Built at %1"))
-              .arg(mApp.getBuildDate().toString(Qt::LocalDate)));
+    print(tr("Built at %1").arg(mApp.getBuildDate().toString(Qt::LocalDate)));
     return 0;
   }
 
@@ -286,8 +284,7 @@ bool CommandLineInterface::openProject(
 
     // Open project
     FilePath projectFp(QFileInfo(projectFile).absoluteFilePath());
-    print(QString(tr("Open project '%1'..."))
-              .arg(prettyPath(projectFp, projectFile)));
+    print(tr("Open project '%1'...").arg(prettyPath(projectFp, projectFile)));
     std::shared_ptr<TransactionalFileSystem> projectFs;
     QString                                  projectFileName;
     if (projectFp.getSuffix() == "lppz") {
@@ -357,9 +354,8 @@ bool CommandLineInterface::openProject(
               QString("    - [%1] %2").arg(severity, msg->getMsg()));
         }
       }
-      print("  " % QString(tr("Approved messages: %1")).arg(approvedMsgCount));
-      print("  " %
-            QString(tr("Non-approved messages: %1")).arg(messages.count()));
+      print("  " % tr("Approved messages: %1").arg(approvedMsgCount));
+      print("  " % tr("Non-approved messages: %1").arg(messages.count()));
       // sort messages to increases readability of console output
       std::sort(messages.begin(), messages.end());
       foreach (const QString& msg, messages) { printErr(msg); }
@@ -370,7 +366,7 @@ bool CommandLineInterface::openProject(
 
     // Export schematics
     foreach (const QString& destStr, exportSchematicsFiles) {
-      print(QString(tr("Export schematics to '%1'...")).arg(destStr));
+      print(tr("Export schematics to '%1'...").arg(destStr));
       QString suffix = destStr.split('.').last().toLower();
       if (suffix == "pdf") {
         QString destPathStr = AttributeSubstitutor::substitute(
@@ -383,8 +379,7 @@ bool CommandLineInterface::openProject(
         print(QString("  => '%1'").arg(prettyPath(destPath, destPathStr)));
         writtenFilesCounter[destPath]++;
       } else {
-        printErr("  " %
-                 QString(tr("ERROR: Unknown extension '%1'.")).arg(suffix));
+        printErr("  " % tr("ERROR: Unknown extension '%1'.").arg(suffix));
         success = false;
       }
     }
@@ -401,8 +396,8 @@ bool CommandLineInterface::openProject(
         if (board) {
           boardList.append(board);
         } else {
-          printErr(QString(tr("ERROR: No board with the name '%1' found."))
-                       .arg(boardName));
+          printErr(
+              tr("ERROR: No board with the name '%1' found.").arg(boardName));
           success = false;
         }
       }
@@ -426,10 +421,9 @@ bool CommandLineInterface::openProject(
         const QString& destStr       = job.first;
         bool           boardSpecific = job.second;
         if (boardSpecific) {
-          print(
-              QString(tr("Export board-specific BOM to '%1'...")).arg(destStr));
+          print(tr("Export board-specific BOM to '%1'...").arg(destStr));
         } else {
-          print(QString(tr("Export generic BOM to '%1'...")).arg(destStr));
+          print(tr("Export generic BOM to '%1'...").arg(destStr));
         }
         QList<Board*> boards =
             boardSpecific ? boardList : QList<Board*>{nullptr};
@@ -460,8 +454,7 @@ bool CommandLineInterface::openProject(
             csv->saveToFile(fp);                                  // can throw
             writtenFilesCounter[fp]++;
           } else {
-            printErr("  " %
-                     QString(tr("ERROR: Unknown extension '%1'.")).arg(suffix));
+            printErr("  " % tr("ERROR: Unknown extension '%1'.").arg(suffix));
             success = false;
           }
         }
@@ -480,14 +473,14 @@ bool CommandLineInterface::openProject(
           customSettings = BoardFabricationOutputSettings(
               SExpression::parse(FileUtils::readFile(fp), fp));  // can throw
         } catch (const Exception& e) {
-          printErr(QString(tr("ERROR: Failed to load custom settings: %1"))
-                       .arg(e.getMsg()));
+          printErr(
+              tr("ERROR: Failed to load custom settings: %1").arg(e.getMsg()));
           success = false;
           boardList.clear();  // avoid exporting any boards
         }
       }
       foreach (const Board* board, boardList) {
-        print("  " % QString(tr("Board '%1':")).arg(*board->getName()));
+        print("  " % tr("Board '%1':").arg(*board->getName()));
         BoardGerberExport grbExport(
             *board, customSettings ? *customSettings
                                    : board->getFabricationOutputSettings());
@@ -521,23 +514,23 @@ bool CommandLineInterface::openProject(
       writtenFilesIterator.next();
       if (writtenFilesIterator.value() > 1) {
         filesOverwritten = true;
-        printErr(QString(tr("ERROR: The file %1 was written multiple times!"))
+        printErr(tr("ERROR: The file %1 was written multiple times!")
                      .arg(prettyPath(writtenFilesIterator.key(), projectFile)));
       }
     }
     if (filesOverwritten) {
-      printErr(QString(tr("NOTE: To avoid writing files multiple times, make "
-                          "sure to pass unique filepaths to all export "
-                          "functions. For board output files, you could either "
-                          "add the placeholder '%1' to the path or specify the "
-                          "boards to export with the '%2' argument."))
+      printErr(tr("NOTE: To avoid writing files multiple times, make "
+                  "sure to pass unique filepaths to all export "
+                  "functions. For board output files, you could either "
+                  "add the placeholder '%1' to the path or specify the "
+                  "boards to export with the '%2' argument.")
                    .arg("'{{BOARD}}'", "--board"));
       success = false;
     }
 
     return success;
   } catch (const Exception& e) {
-    printErr(QString(tr("ERROR: %1")).arg(e.getMsg()));
+    printErr(tr("ERROR: %1").arg(e.getMsg()));
     return false;
   }
 }
@@ -549,7 +542,7 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
 
     // Open library
     FilePath libFp(QFileInfo(libDir).absoluteFilePath());
-    print(QString(tr("Open library '%1'...")).arg(prettyPath(libFp, libDir)));
+    print(tr("Open library '%1'...").arg(prettyPath(libFp, libDir)));
 
     std::shared_ptr<TransactionalFileSystem> libFs =
         TransactionalFileSystem::open(libFp, save);  // can throw
@@ -561,11 +554,10 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     // Open all component categories
     if (all) {
       QStringList elements = lib.searchForElements<ComponentCategory>();
-      print(QString(tr("Process %1 component categories..."))
-                .arg(elements.count()));
+      print(tr("Process %1 component categories...").arg(elements.count()));
       foreach (const QString& dir, elements) {
         FilePath fp = libFp.getPathTo(dir);
-        qInfo() << QString(tr("Open '%1'...")).arg(prettyPath(fp, libDir));
+        qInfo() << tr("Open '%1'...").arg(prettyPath(fp, libDir));
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         ComponentCategory element(std::unique_ptr<TransactionalDirectory>(
@@ -578,11 +570,10 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     // Open all package categories
     if (all) {
       QStringList elements = lib.searchForElements<PackageCategory>();
-      print(QString(tr("Process %1 package categories..."))
-                .arg(elements.count()));
+      print(tr("Process %1 package categories...").arg(elements.count()));
       foreach (const QString& dir, elements) {
         FilePath fp = libFp.getPathTo(dir);
-        qInfo() << QString(tr("Open '%1'...")).arg(prettyPath(fp, libDir));
+        qInfo() << tr("Open '%1'...").arg(prettyPath(fp, libDir));
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         PackageCategory element(std::unique_ptr<TransactionalDirectory>(
@@ -595,10 +586,10 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     // Open all symbols
     if (all) {
       QStringList elements = lib.searchForElements<Symbol>();
-      print(QString(tr("Process %1 symbols...")).arg(elements.count()));
+      print(tr("Process %1 symbols...").arg(elements.count()));
       foreach (const QString& dir, elements) {
         FilePath fp = libFp.getPathTo(dir);
-        qInfo() << QString(tr("Open '%1'...")).arg(prettyPath(fp, libDir));
+        qInfo() << tr("Open '%1'...").arg(prettyPath(fp, libDir));
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Symbol element(std::unique_ptr<TransactionalDirectory>(
@@ -611,10 +602,10 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     // Open all packages
     if (all) {
       QStringList elements = lib.searchForElements<Package>();
-      print(QString(tr("Process %1 packages...")).arg(elements.count()));
+      print(tr("Process %1 packages...").arg(elements.count()));
       foreach (const QString& dir, elements) {
         FilePath fp = libFp.getPathTo(dir);
-        qInfo() << QString(tr("Open '%1'...")).arg(prettyPath(fp, libDir));
+        qInfo() << tr("Open '%1'...").arg(prettyPath(fp, libDir));
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Package element(std::unique_ptr<TransactionalDirectory>(
@@ -627,10 +618,10 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     // Open all components
     if (all) {
       QStringList elements = lib.searchForElements<Component>();
-      print(QString(tr("Process %1 components...")).arg(elements.count()));
+      print(tr("Process %1 components...").arg(elements.count()));
       foreach (const QString& dir, elements) {
         FilePath fp = libFp.getPathTo(dir);
-        qInfo() << QString(tr("Open '%1'...")).arg(prettyPath(fp, libDir));
+        qInfo() << tr("Open '%1'...").arg(prettyPath(fp, libDir));
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Component element(std::unique_ptr<TransactionalDirectory>(
@@ -643,10 +634,10 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
     // Open all devices
     if (all) {
       QStringList elements = lib.searchForElements<Device>();
-      print(QString(tr("Process %1 devices...")).arg(elements.count()));
+      print(tr("Process %1 devices...").arg(elements.count()));
       foreach (const QString& dir, elements) {
         FilePath fp = libFp.getPathTo(dir);
-        qInfo() << QString(tr("Open '%1'...")).arg(prettyPath(fp, libDir));
+        qInfo() << tr("Open '%1'...").arg(prettyPath(fp, libDir));
         std::shared_ptr<TransactionalFileSystem> fs =
             TransactionalFileSystem::open(fp, save);  // can throw
         Device element(std::unique_ptr<TransactionalDirectory>(
@@ -658,7 +649,7 @@ bool CommandLineInterface::openLibrary(const QString& libDir, bool all,
 
     return success;
   } catch (const Exception& e) {
-    printErr(QString(tr("ERROR: %1")).arg(e.getMsg()));
+    printErr(tr("ERROR: %1").arg(e.getMsg()));
     return false;
   }
 }
@@ -675,7 +666,7 @@ void CommandLineInterface::processLibraryElement(const QString& libDir,
 
   // Check for non-canonical files (strict mode)
   if (strict) {
-    qInfo() << QString(tr("Check '%1' for non-canonical files..."))
+    qInfo() << tr("Check '%1' for non-canonical files...")
                    .arg(prettyPath(fs.getPath(), libDir));
 
     QStringList paths = fs.checkForModifications();  // can throw
@@ -692,8 +683,7 @@ void CommandLineInterface::processLibraryElement(const QString& libDir,
 
   // Save element to file system, if needed
   if (save) {
-    qInfo()
-        << QString(tr("Save '%1'...")).arg(prettyPath(fs.getPath(), libDir));
+    qInfo() << tr("Save '%1'...").arg(prettyPath(fs.getPath(), libDir));
     if (failIfFileFormatUnstable()) {
       success = false;
     } else {

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -71,12 +71,12 @@ ControlPanel::ControlPanel(Workspace& workspace)
     mLibraryManager(new LibraryManager(mWorkspace, this)) {
   mUi->setupUi(this);
 
-  setWindowTitle(QString(tr("Control Panel - LibrePCB %1"))
-                     .arg(qApp->applicationVersion()));
+  setWindowTitle(
+      tr("Control Panel - LibrePCB %1").arg(qApp->applicationVersion()));
 
   // show workspace path in status bar
   QString wsPath         = mWorkspace.getPath().toNative();
-  QLabel* statusBarLabel = new QLabel(QString(tr("Workspace: %1")).arg(wsPath));
+  QLabel* statusBarLabel = new QLabel(tr("Workspace: %1").arg(wsPath));
   mUi->statusBar->addWidget(statusBarLabel, 1);
 
   // initialize status bar
@@ -656,9 +656,9 @@ void ControlPanel::on_projectTreeView_customContextMenuRequested(
     case Remove: {
       QMessageBox::StandardButton btn = QMessageBox::question(
           this, tr("Remove"),
-          QString(tr("Are you really sure to remove following file or "
-                     "directory?\n\n"
-                     "%1\n\nWarning: This cannot be undone!"))
+          tr("Are you really sure to remove following file or "
+             "directory?\n\n"
+             "%1\n\nWarning: This cannot be undone!")
               .arg(fp.toNative()));
       if (btn == QMessageBox::Yes) {
         try {

--- a/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
+++ b/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
@@ -112,18 +112,16 @@ void ProjectLibraryUpdater::btnUpdateClicked() {
 
       // check whether project can still be opened of if we broke something
       try {
-        log(QString(tr("Open project %1..."))
-                .arg(prettyPath(mProjectFilePath)));
+        log(tr("Open project %1...").arg(prettyPath(mProjectFilePath)));
         Project project(std::unique_ptr<TransactionalDirectory>(
                             new TransactionalDirectory(fs)),
                         mProjectFilePath.getFilename());
-        log(QString(tr("Save project %1..."))
-                .arg(prettyPath(mProjectFilePath)));
+        log(tr("Save project %1...").arg(prettyPath(mProjectFilePath)));
         project.save();  // force updating library elements file format
         fs->save();      // can throw
       } catch (const Exception& e) {
         // something is broken -> discard modifications in file system
-        log(QString(tr("[ERROR] %1")).arg(e.getMsg()));
+        log(tr("[ERROR] %1").arg(e.getMsg()));
         throw RuntimeError(__FILE__, __LINE__,
                            tr("Failed to update library elements! Probably "
                               "there were breaking "
@@ -131,7 +129,7 @@ void ProjectLibraryUpdater::btnUpdateClicked() {
       }
       log(tr("[SUCCESS] All library elements updated."));
     } catch (const Exception& e) {
-      log(QString(tr("[ERROR] %1")).arg(e.getMsg()));
+      log(tr("[ERROR] %1").arg(e.getMsg()));
     }
 
     // re-open project if it was previously open
@@ -173,14 +171,14 @@ void ProjectLibraryUpdater::updateElements(
     QString                dst = dirpath % "/" % dirname;
     TransactionalDirectory dstDir(fs, dst);
     if (src.isValid() && (!dstDir.getFiles().isEmpty())) {
-      log(QString(tr("Update %1...")).arg(dst));
+      log(tr("Update %1...").arg(dst));
       std::shared_ptr<TransactionalFileSystem> srcFs =
           TransactionalFileSystem::openRO(src);
       TransactionalDirectory srcDir(srcFs);
       fs->removeDirRecursively(dst);
       srcDir.saveTo(dstDir);
     } else {
-      log(QString(tr("Skip %1...")).arg(dst));
+      log(tr("Skip %1...").arg(dst));
     }
   }
 }

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -55,7 +55,7 @@ if [ "$DOCKER" == "--docker" ]; then
   fi
 
   echo "[Re-running format_code.sh inside Docker container]"
-  $DOCKER_CMD run --rm -t -i --user "$(id -u):$(id -g)" \
+  $DOCKER_CMD run --rm -t --user "$(id -u):$(id -g)" \
     -v "$REPO_ROOT:/code" \
     $DOCKER_IMAGE \
     /bin/bash -c "cd /code && dev/format_code.sh $ALL"

--- a/libs/librepcb/common/attributes/attributelistmodel.cpp
+++ b/libs/librepcb/common/attributes/attributelistmodel.cpp
@@ -433,8 +433,7 @@ AttributeKey AttributeListModel::validateKeyOrThrow(const QString& key) const {
   if (mAttributeList && mAttributeList->contains(key)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already an attribute with the key \"%1\"."))
-            .arg(key));
+        tr("There is already an attribute with the key \"%1\".").arg(key));
   }
   return AttributeKey(key);  // can throw
 }

--- a/libs/librepcb/common/attributes/attributetype.cpp
+++ b/libs/librepcb/common/attributes/attributetype.cpp
@@ -72,8 +72,7 @@ const AttributeUnit* AttributeType::getUnitFromString(
 
   throw RuntimeError(
       __FILE__, __LINE__,
-      QString(tr("Unknown unit of attribute type \"%1\": \"%2\""))
-          .arg(mTypeName, unit));
+      tr("Unknown unit of attribute type \"%1\": \"%2\"").arg(mTypeName, unit));
 }
 
 bool AttributeType::isUnitAvailable(const AttributeUnit* unit) const noexcept {
@@ -120,7 +119,7 @@ const AttributeType& AttributeType::fromString(const QString& type) {
     if (t->getName() == type) return *t;
   }
   throw RuntimeError(__FILE__, __LINE__,
-                     QString(tr("Invalid attribute type: \"%1\"")).arg(type));
+                     tr("Invalid attribute type: \"%1\"").arg(type));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/boarddesignrules.cpp
+++ b/libs/librepcb/common/boarddesignrules.cpp
@@ -123,7 +123,7 @@ BoardDesignRules::BoardDesignRules(const SExpression& node)
     setRestringViaBounds(mRestringViaMin, mRestringViaMax);
   } catch (const Exception& e) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Invalid design rules: %1")).arg(e.getMsg()));
+                       tr("Invalid design rules: %1").arg(e.getMsg()));
   }
 }
 

--- a/libs/librepcb/common/cam/gerbergenerator.cpp
+++ b/libs/librepcb/common/cam/gerbergenerator.cpp
@@ -250,25 +250,27 @@ void GerberGenerator::circularInterpolateToPosition(const Point& start,
                            diff.getX().toNmString(), diff.getY().toNmString()));
 }
 
-void GerberGenerator::interpolateBetween(const Vertex& from, const Vertex& to) noexcept {
-    if (from.getAngle() == 0) {
-      // linear segment
-      linearInterpolateToPosition(to.getPos());
+void GerberGenerator::interpolateBetween(const Vertex& from,
+                                         const Vertex& to) noexcept {
+  if (from.getAngle() == 0) {
+    // linear segment
+    linearInterpolateToPosition(to.getPos());
+  } else {
+    // arc segment
+    // note: due to buggy clients when using single quadrant mode,
+    // we always use multi quadrant mode.
+    // see https://github.com/LibrePCB/LibrePCB/issues/247
+    setMultiQuadrantArcModeOn();
+    if (from.getAngle() < 0) {
+      switchToCircularCwInterpolationModeG02();
     } else {
-      // arc segment
-      // note: due to buggy clients when using single quadrant mode,
-      // we always use multi quadrant mode.
-      // see https://github.com/LibrePCB/LibrePCB/issues/247
-      setMultiQuadrantArcModeOn();
-      if (from.getAngle() < 0) {
-        switchToCircularCwInterpolationModeG02();
-      } else {
-        switchToCircularCcwInterpolationModeG03();
-      }
-      Point center = Toolbox::arcCenter(from.getPos(), to.getPos(), from.getAngle());
-      circularInterpolateToPosition(from.getPos(), center, to.getPos());
-      switchToLinearInterpolationModeG01();
+      switchToCircularCcwInterpolationModeG03();
     }
+    Point center =
+        Toolbox::arcCenter(from.getPos(), to.getPos(), from.getAngle());
+    circularInterpolateToPosition(from.getPos(), center, to.getPos());
+    switchToLinearInterpolationModeG01();
+  }
 }
 
 void GerberGenerator::flashAtPosition(const Point& pos) noexcept {

--- a/libs/librepcb/common/exceptions.h
+++ b/libs/librepcb/common/exceptions.h
@@ -61,21 +61,18 @@ class FilePath;
  * Example how to use exceptions:
  *
  * @code
- * void foo(int i)
- * {
- *     if (i < 0) {
- *         throw Exception(__FILE__, __LINE__, QString(tr("Invalid argument:
- * %1")).arg(i));
- *     }
+ * void foo(int i) {
+ *   if (i < 0) {
+ *     throw Exception(__FILE__, __LINE__, tr("Invalid argument: %1").arg(i));
+ *   }
  * }
  *
- * void bar() noexcept
- * {
- *     try {
- *         foo(-5);
- *     } catch (const Exception& e) {
- *         QMessageBox::critical(0, tr("Error"), e.getMsg());
- *     }
+ * void bar() noexcept {
+ *   try {
+ *     foo(-5);
+ *   } catch (const Exception& e) {
+ *     QMessageBox::critical(0, tr("Error"), e.getMsg());
+ *   }
  * }
  * @endcode
  *

--- a/libs/librepcb/common/fileio/asynccopyoperation.cpp
+++ b/libs/librepcb/common/fileio/asynccopyoperation.cpp
@@ -60,13 +60,13 @@ void AsyncCopyOperation::run() noexcept {
   try {
     // if (!mSource.isExistingDir()) {
     //  throw LogicError(__FILE__, __LINE__,
-    //                   QString(tr("The directory \"%1\" does not exist."))
+    //                   tr("The directory \"%1\" does not exist.")
     //                       .arg(mSource.toNative()));
     //}
     // if (mDestination.isExistingFile() || mDestination.isExistingDir()) {
     //  throw LogicError(
     //      __FILE__, __LINE__,
-    //      QString(tr("The file or directory \"%1\" exists already."))
+    //      tr("The file or directory \"%1\" exists already.")
     //          .arg(mDestination.toNative()));
     //}
 

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementinsert.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementinsert.h
@@ -49,7 +49,7 @@ public:
   CmdListElementInsert(SerializableObjectList<T, P, OnEditedArgs...>& list,
                        const std::shared_ptr<T>&                      element,
                        int index = -1) noexcept
-    : UndoCommand(QString(tr("Add %1")).arg(P::tagname)),
+    : UndoCommand(tr("Add %1").arg(P::tagname)),
       mList(list),
       mElement(element),
       mIndex(index) {}

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementremove.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementremove.h
@@ -48,7 +48,7 @@ public:
   CmdListElementRemove(const CmdListElementRemove& other) = delete;
   CmdListElementRemove(SerializableObjectList<T, P, OnEditedArgs...>& list,
                        const T* element) noexcept
-    : UndoCommand(QString(tr("Remove %1")).arg(P::tagname)),
+    : UndoCommand(tr("Remove %1").arg(P::tagname)),
       mList(list),
       mElement(element),
       mIndex(-1) {}

--- a/libs/librepcb/common/fileio/cmd/cmdlistelementsswap.h
+++ b/libs/librepcb/common/fileio/cmd/cmdlistelementsswap.h
@@ -48,10 +48,7 @@ public:
   CmdListElementsSwap(const CmdListElementsSwap& other) = delete;
   CmdListElementsSwap(SerializableObjectList<T, P, OnEditedArgs...>& list,
                       int i, int j) noexcept
-    : UndoCommand(QString(tr("Move %1")).arg(P::tagname)),
-      mList(list),
-      mI(i),
-      mJ(j) {}
+    : UndoCommand(tr("Move %1").arg(P::tagname)), mList(list), mI(i), mJ(j) {}
   ~CmdListElementsSwap() noexcept {}
 
   // Operator Overloadings

--- a/libs/librepcb/common/fileio/directorylock.cpp
+++ b/libs/librepcb/common/fileio/directorylock.cpp
@@ -71,9 +71,9 @@ void DirectoryLock::setDirToLock(const FilePath& dir) noexcept {
 DirectoryLock::LockStatus DirectoryLock::getStatus() const {
   // check if the directory to lock does exist
   if (!mDirToLock.isExistingDir()) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The directory \"%1\" does not exist."))
-                           .arg(mDirToLock.toNative()));
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        tr("The directory \"%1\" does not exist.").arg(mDirToLock.toNative()));
   }
 
   // when the directory is valid, the lock filepath must be valid too
@@ -91,7 +91,7 @@ DirectoryLock::LockStatus DirectoryLock::getStatus() const {
   // check count of lines
   if (lines.count() < 6) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The lock file \"%1\" has too few lines."))
+                       tr("The lock file \"%1\" has too few lines.")
                            .arg(mLockFilePath.toNative()));
   }
   // read lock metadata
@@ -141,11 +141,10 @@ void DirectoryLock::tryLock(bool* wasStale) {
       lock();  // can throw
       break;
     case LockStatus::Locked:
-      throw RuntimeError(
-          __FILE__, __LINE__,
-          QString(tr("The directory is locked, "
-                     "check if it is already opened elsewhere: %1"))
-              .arg(mDirToLock.toNative()));
+      throw RuntimeError(__FILE__, __LINE__,
+                         tr("The directory is locked, "
+                            "check if it is already opened elsewhere: %1")
+                             .arg(mDirToLock.toNative()));
     default:
       Q_ASSERT(false);
       throw LogicError(__FILE__, __LINE__);
@@ -164,9 +163,9 @@ bool DirectoryLock::unlockIfLocked() {
 void DirectoryLock::lock() {
   // check if the directory to lock does exist
   if (!mDirToLock.isExistingDir()) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The directory \"%1\" does not exist."))
-                           .arg(mDirToLock.toNative()));
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        tr("The directory \"%1\" does not exist.").arg(mDirToLock.toNative()));
   }
 
   // when the directory is valid, the lock filepath must be valid too

--- a/libs/librepcb/common/fileio/fileutils.cpp
+++ b/libs/librepcb/common/fileio/fileutils.cpp
@@ -37,15 +37,15 @@ namespace librepcb {
 
 QByteArray FileUtils::readFile(const FilePath& filepath) {
   if (!filepath.isExistingFile()) {
-    throw LogicError(__FILE__, __LINE__,
-                     QString(tr("The file \"%1\" does not exist."))
-                         .arg(filepath.toNative()));
+    throw LogicError(
+        __FILE__, __LINE__,
+        tr("The file \"%1\" does not exist.").arg(filepath.toNative()));
   }
   QFile file(filepath.toStr());
   if (!file.open(QIODevice::ReadOnly)) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Cannot "
-                                  "open file \"%1\": %2"))
+                       tr("Cannot "
+                          "open file \"%1\": %2")
                            .arg(filepath.toNative(), file.errorString()));
   }
   return file.readAll();
@@ -56,20 +56,20 @@ void FileUtils::writeFile(const FilePath& filepath, const QByteArray& content) {
   QSaveFile file(filepath.toStr());
   if (!file.open(QIODevice::WriteOnly)) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Could not open or create file \"%1\": %2"))
+                       tr("Could not open or create file \"%1\": %2")
                            .arg(filepath.toNative(), file.errorString()));
   }
   qint64 written = file.write(content);
   if (written != content.size()) {
     qDebug() << "only" << written << "of" << content.size() << "bytes written";
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Could not write to file \"%1\": %2"))
+                       tr("Could not write to file \"%1\": %2")
                            .arg(filepath.toNative(), file.errorString()));
   }
   if (!file.commit()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Could not write to "
-                                  "file \"%1\": %2"))
+                       tr("Could not write to "
+                          "file \"%1\": %2")
                            .arg(filepath.toNative(), file.errorString()));
   }
 }
@@ -78,16 +78,16 @@ void FileUtils::copyFile(const FilePath& source, const FilePath& dest) {
   if (!source.isExistingFile()) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("The file \"%1\" does not exist.")).arg(source.toNative()));
+        tr("The file \"%1\" does not exist.").arg(source.toNative()));
   }
   if (dest.isExistingFile() || dest.isExistingDir()) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("The file or directory \"%1\" exists already."))
+                     tr("The file or directory \"%1\" exists already.")
                          .arg(dest.toNative()));
   }
   if (!QFile::copy(source.toStr(), dest.toStr())) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Could not copy file \"%1\" to \"%2\"."))
+                       tr("Could not copy file \"%1\" to \"%2\".")
                            .arg(source.toNative(), dest.toNative()));
   }
 }
@@ -95,13 +95,13 @@ void FileUtils::copyFile(const FilePath& source, const FilePath& dest) {
 void FileUtils::copyDirRecursively(const FilePath& source,
                                    const FilePath& dest) {
   if (!source.isExistingDir()) {
-    throw LogicError(__FILE__, __LINE__,
-                     QString(tr("The directory \"%1\" does not exist."))
-                         .arg(source.toNative()));
+    throw LogicError(
+        __FILE__, __LINE__,
+        tr("The directory \"%1\" does not exist.").arg(source.toNative()));
   }
   if (dest.isExistingFile() || dest.isExistingDir()) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("The file or directory \"%1\" exists already."))
+                     tr("The file or directory \"%1\" exists already.")
                          .arg(dest.toNative()));
   }
   makePath(dest);  // can throw
@@ -119,19 +119,19 @@ void FileUtils::copyDirRecursively(const FilePath& source,
 void FileUtils::move(const FilePath& source, const FilePath& dest) {
   if ((!source.isExistingFile()) && (!source.isExistingDir())) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("The file or directory \"%1\" does not exist."))
+                     tr("The file or directory \"%1\" does not exist.")
                          .arg(source.toNative()));
   }
   if (dest.isExistingFile() || dest.isExistingDir()) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("The file or directory \"%1\" exists already."))
+                     tr("The file or directory \"%1\" exists already.")
                          .arg(dest.toNative()));
   }
   // Note: QDir::rename() fails if the parent directory does not yet exist
   makePath(dest.getParentDir());
   if (!QDir().rename(source.toStr(), dest.toStr())) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Could not move \"%1\" to \"%2\"."))
+                       tr("Could not move \"%1\" to \"%2\".")
                            .arg(source.toNative(), dest.toNative()));
   }
 }
@@ -140,7 +140,7 @@ void FileUtils::removeFile(const FilePath& file) {
   if (!QFile::remove(file.toStr())) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Could not remove file \"%1\".")).arg(file.toNative()));
+        tr("Could not remove file \"%1\".").arg(file.toNative()));
   }
 }
 
@@ -148,15 +148,15 @@ void FileUtils::removeDirRecursively(const FilePath& dir) {
   if (!QDir(dir.toStr()).removeRecursively()) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Could not remove directory \"%1\".")).arg(dir.toNative()));
+        tr("Could not remove directory \"%1\".").arg(dir.toNative()));
   }
 }
 
 void FileUtils::makePath(const FilePath& path) {
   if (!QDir().mkpath(path.toStr())) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Could not create directory or path \"%1\"."))
-                           .arg(path.toNative()));
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        tr("Could not create directory or path \"%1\".").arg(path.toNative()));
   }
 }
 
@@ -164,9 +164,9 @@ QList<FilePath> FileUtils::getFilesInDirectory(const FilePath&    dir,
                                                const QStringList& filters,
                                                bool               recursive) {
   if (!dir.isExistingDir()) {
-    throw LogicError(__FILE__, __LINE__,
-                     QString(tr("The directory \"%1\" does not exist."))
-                         .arg(dir.toNative()));
+    throw LogicError(
+        __FILE__, __LINE__,
+        tr("The directory \"%1\" does not exist.").arg(dir.toNative()));
   }
 
   QList<FilePath> files;

--- a/libs/librepcb/common/fileio/serializablekeyvaluemap.h
+++ b/libs/librepcb/common/fileio/serializablekeyvaluemap.h
@@ -86,16 +86,15 @@ public:
         value = child.getChildByIndex(0);
       }
       if (mValues.contains(key)) {
-        throw RuntimeError(
-            __FILE__, __LINE__,
-            QString(tr("Key \"%1\" defined multiple times.")).arg(key));
+        throw RuntimeError(__FILE__, __LINE__,
+                           tr("Key \"%1\" defined multiple times.").arg(key));
       }
       mValues.insert(key, deserializeFromSExpression<typename T::ValueType>(
                               value, false));  // can throw
     }
     if (!mValues.contains(QString(""))) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("No default %1 defined.")).arg(T::tagname));
+                         tr("No default %1 defined.").arg(T::tagname));
     }
   }
   ~SerializableKeyValueMap() noexcept {}

--- a/libs/librepcb/common/fileio/sexpression.cpp
+++ b/libs/librepcb/common/fileio/sexpression.cpp
@@ -124,7 +124,7 @@ QList<SExpression> SExpression::getChildren(const QString& name) const
 const SExpression& SExpression::getChildByIndex(int index) const {
   if ((index < 0) || index >= mChildren.count()) {
     throw FileParseError(__FILE__, __LINE__, mFilePath, -1, -1, QString(),
-                         QString(tr("Child not found: %1")).arg(index));
+                         tr("Child not found: %1").arg(index));
   }
   return mChildren.at(index);
 }
@@ -153,7 +153,7 @@ const SExpression& SExpression::getChildByPath(const QString& path) const {
     return *child;
   } else {
     throw FileParseError(__FILE__, __LINE__, mFilePath, -1, -1, QString(),
-                         QString(tr("Child not found: %1")).arg(path));
+                         tr("Child not found: %1").arg(path));
   }
 }
 
@@ -226,9 +226,8 @@ bool SExpression::isValidToken(const QString& token) const noexcept {
 QString SExpression::toString(int indent) const {
   if (mType == Type::List) {
     if (!isValidListName(mValue)) {
-      throw LogicError(
-          __FILE__, __LINE__,
-          QString(tr("Invalid S-Expression list name: %1")).arg(mValue));
+      throw LogicError(__FILE__, __LINE__,
+                       tr("Invalid S-Expression list name: %1").arg(mValue));
     }
     QString str = '(' + mValue;
     for (int i = 0; i < mChildren.count(); ++i) {
@@ -255,9 +254,8 @@ QString SExpression::toString(int indent) const {
     return str + ')';
   } else if (mType == Type::Token) {
     if (!isValidToken(mValue)) {
-      throw LogicError(
-          __FILE__, __LINE__,
-          QString(tr("Invalid S-Expression token: %1")).arg(mValue));
+      throw LogicError(__FILE__, __LINE__,
+                       tr("Invalid S-Expression token: %1").arg(mValue));
     }
     return mValue;
   } else if (mType == Type::String) {

--- a/libs/librepcb/common/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.cpp
@@ -176,7 +176,7 @@ QByteArray TransactionalFileSystem::read(const QString& path) const {
     return FileUtils::readFile(mFilePath.getPathTo(cleanedPath));  // can throw
   } else {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("File '%1' does not exist."))
+                       tr("File '%1' does not exist.")
                            .arg(mFilePath.getPathTo(cleanedPath).toNative()));
   }
 }
@@ -234,7 +234,7 @@ void TransactionalFileSystem::loadFromZip(const FilePath& fp) {
   if (!zip.open(QuaZip::mdUnzip)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Failed to open the ZIP file '%1'.")).arg(fp.toNative()));
+        tr("Failed to open the ZIP file '%1'.").arg(fp.toNative()));
   }
   QuaZipFile file(&zip);
   for (bool f = zip.goToFirstFile(); f; f = zip.goToNextFile()) {
@@ -270,7 +270,7 @@ void TransactionalFileSystem::exportToZip(const FilePath& fp) const {
   if (!zip.open(QuaZip::mdCreate)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Failed to create the ZIP file '%1'.")).arg(fp.toNative()));
+        tr("Failed to create the ZIP file '%1'.").arg(fp.toNative()));
   }
   try {
     QuaZipFile file(&zip);
@@ -432,7 +432,7 @@ void TransactionalFileSystem::exportDirToZip(QuaZipFile&     file,
     file.close();
     if (bytesWritten != content.length()) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("Failed to write file '%1' to '%2'."))
+                         tr("Failed to write file '%1' to '%2'.")
                              .arg(filepath, zipFp.toNative()));
     }
   }

--- a/libs/librepcb/common/font/strokefontpool.cpp
+++ b/libs/librepcb/common/font/strokefontpool.cpp
@@ -64,8 +64,7 @@ const StrokeFont& StrokeFontPool::getFont(const QString& filename) const {
   } else {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("The font \"%1\" does not exist in the font pool."))
-            .arg(filename));
+        tr("The font \"%1\" does not exist in the font pool.").arg(filename));
   }
 }
 

--- a/libs/librepcb/common/graphics/graphicslayer.cpp
+++ b/libs/librepcb/common/graphics/graphicslayer.cpp
@@ -250,7 +250,7 @@ void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr,
     h.insert(sBotCopper,                {tr("Bot Copper"),            QColor("#964578CC"),        QColor("#C00A66FC"),        true});
     // clang-format on
     for (int i = 1; i <= getInnerLayerCount(); ++i) {
-      QString nameTr = QString(tr("Inner Copper %1")).arg(i);
+      QString nameTr = tr("Inner Copper %1").arg(i);
       QColor  color;
       QColor  hlColor;
       switch ((i - 1) % 6) {

--- a/libs/librepcb/common/graphics/graphicsview.cpp
+++ b/libs/librepcb/common/graphics/graphicsview.cpp
@@ -305,8 +305,8 @@ bool GraphicsView::eventFilter(QObject* obj, QEvent* event) {
     case QEvent::GraphicsSceneContextMenu:
     case QEvent::KeyRelease:
     case QEvent::KeyPress: {
-      if (mEventHandlerObject
-          && mEventHandlerObject->graphicsViewEventHandler(event)) {
+      if (mEventHandlerObject &&
+          mEventHandlerObject->graphicsViewEventHandler(event)) {
         return true;
       }
       break;

--- a/libs/librepcb/common/network/filedownload.cpp
+++ b/libs/librepcb/common/network/filedownload.cpp
@@ -109,7 +109,7 @@ void FileDownload::finalizeRequest() {
   // save to destination file
   if (!mFile->commit()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Error while writing file \"%1\": %2"))
+                       tr("Error while writing file \"%1\": %2")
                            .arg(mDestination.toNative(), mFile->errorString()));
   }
 
@@ -122,7 +122,7 @@ void FileDownload::finalizeRequest() {
     QFile file(mDestination.toStr());
     if (!file.open(QFile::ReadOnly)) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("Error while readback file \"%1\": %2"))
+                         tr("Error while readback file \"%1\": %2")
                              .arg(mDestination.toNative(), file.errorString()));
     }
     QCryptographicHash hash(mHashAlgorithm);
@@ -145,10 +145,9 @@ void FileDownload::finalizeRequest() {
     QStringList files =
         JlCompress::extractDir(mDestination.toStr(), mExtractZipToDir.toStr());
     if (files.isEmpty()) {
-      throw RuntimeError(
-          __FILE__, __LINE__,
-          QString(tr("Error while extracting the ZIP file \"%1\"."))
-              .arg(mDestination.toNative()));
+      throw RuntimeError(__FILE__, __LINE__,
+                         tr("Error while extracting the ZIP file \"%1\".")
+                             .arg(mDestination.toNative()));
     }
   } else {
     // do NOT remove the downloaded file

--- a/libs/librepcb/common/network/networkrequestbase.cpp
+++ b/libs/librepcb/common/network/networkrequestbase.cpp
@@ -165,7 +165,7 @@ void NetworkRequestBase::replyErrorSlot(
     QNetworkReply::NetworkError code) noexcept {
   Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
   mErrored = true;
-  finalize(QString(tr("%1 (%2)")).arg(mReply->errorString()).arg(code));
+  finalize(tr("%1 (%2)").arg(mReply->errorString()).arg(code));
 }
 
 void NetworkRequestBase::replySslErrorsSlot(
@@ -174,7 +174,7 @@ void NetworkRequestBase::replySslErrorsSlot(
   mErrored = true;
   QStringList errorsList;
   foreach (const QSslError& e, errors) { errorsList.append(e.errorString()); }
-  finalize(QString(tr("SSL errors occurred:\n\n%1")).arg(errorsList.join("\n")));
+  finalize(tr("SSL errors occurred:\n\n%1").arg(errorsList.join("\n")));
 }
 
 void NetworkRequestBase::replyDownloadProgressSlot(qint64 bytesReceived,
@@ -190,8 +190,7 @@ void NetworkRequestBase::replyDownloadProgressSlot(qint64 bytesReceived,
   }
   int estimatedPercent =
       (100 * bytesReceived) / qMax(estimatedTotal, qint64(1));
-  emit progressState(
-      QString(tr("Receive data: %1")).arg(formatFileSize(bytesReceived)));
+  emit progressState(tr("Receive data: %1").arg(formatFileSize(bytesReceived)));
   emit progressPercent(estimatedPercent);
   emit progress(bytesReceived, bytesTotal, estimatedPercent);
 }
@@ -225,8 +224,7 @@ void NetworkRequestBase::replyFinishedSlot() noexcept {
       // follow redirection
       qDebug() << "Redirect from" << mUrl.toString() << "to"
                << redirectUrl.toString();
-      emit progressState(
-          QString(tr("Redirect to %1...")).arg(redirectUrl.toString()));
+      emit progressState(tr("Redirect to %1...").arg(redirectUrl.toString()));
       mReply.take()->deleteLater();
       mRedirectedUrls.append(mUrl);
       mUrl = redirectUrl;
@@ -237,8 +235,7 @@ void NetworkRequestBase::replyFinishedSlot() noexcept {
 
   // check for download error
   if (mReply->error() != QNetworkReply::NoError) {
-    finalize(
-        QString(tr("%1 (%2)")).arg(mReply->errorString()).arg(mReply->error()));
+    finalize(tr("%1 (%2)").arg(mReply->errorString()).arg(mReply->error()));
     return;
   }
 
@@ -271,7 +268,7 @@ void NetworkRequestBase::finalize(const QString& errorMsg) noexcept {
   } else {
     qDebug() << "Request failed:" << mUrl.toString();
     qDebug() << "Network error:" << errorMsg;
-    emit progressState(QString(tr("Request failed: %1")).arg(errorMsg));
+    emit progressState(tr("Request failed: %1").arg(errorMsg));
     emit errored(errorMsg);
     emit finished(false);
   }

--- a/libs/librepcb/common/sqlitedatabase.cpp
+++ b/libs/librepcb/common/sqlitedatabase.cpp
@@ -68,16 +68,15 @@ SQLiteDatabase::SQLiteDatabase(const FilePath& filepath)
 
   // check if database is valid
   if (!mDb.isValid()) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("Invalid database: \"%1\"")).arg(filepath.toNative()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Invalid database: \"%1\"").arg(filepath.toNative()));
   }
 
   // open the database
   if (!mDb.open()) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Could not open database: \"%1\""))
-                           .arg(filepath.toNative()));
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        tr("Could not open database: \"%1\"").arg(filepath.toNative()));
   }
 
   // set SQLite options
@@ -153,9 +152,8 @@ QSqlQuery SQLiteDatabase::prepareQuery(const QString& query) const {
   if (!q.prepare(query)) {
     qDebug() << q.lastError().databaseText();
     qDebug() << q.lastError().driverText();
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("Error while preparing SQL query: %1")).arg(query));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Error while preparing SQL query: %1").arg(query));
   }
   return q;
 }
@@ -183,9 +181,9 @@ int SQLiteDatabase::insert(QSqlQuery& query) {
   if (ok) {
     return id;
   } else {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Error while executing SQL query: %1"))
-                           .arg(query.lastQuery()));
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        tr("Error while executing SQL query: %1").arg(query.lastQuery()));
   }
 }
 
@@ -193,9 +191,9 @@ void SQLiteDatabase::exec(QSqlQuery& query) {
   if (!query.exec()) {
     qDebug() << query.lastError().databaseText();
     qDebug() << query.lastError().driverText();
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Error while executing SQL query: %1"))
-                           .arg(query.lastQuery()));
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        tr("Error while executing SQL query: %1").arg(query.lastQuery()));
   }
 }
 
@@ -216,8 +214,7 @@ void SQLiteDatabase::enableSqliteWriteAheadLogging() {
   if ((!success) || (result != "wal")) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("Could not enable SQLite Write-Ahead Logging: \"%1\""))
-            .arg(result));
+        tr("Could not enable SQLite Write-Ahead Logging: \"%1\"").arg(result));
   }
 }
 

--- a/libs/librepcb/common/systeminfo.cpp
+++ b/libs/librepcb/common/systeminfo.cpp
@@ -220,9 +220,8 @@ QString SystemInfo::getProcessNameByPid(qint64 pid) {
              (errno == static_cast<int>(std::errc::no_such_process))) {
     return QString();  // process not running
   } else {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("proc_name() failed with error %1.")).arg(errno));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("proc_name() failed with error %1.").arg(errno));
   }
 #elif defined(Q_OS_FREEBSD)
   char exePath[64];
@@ -270,17 +269,16 @@ QString SystemInfo::getProcessNameByPid(qint64 pid) {
   } else if (!hProcess) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("OpenProcess() failed with error %1.")).arg(GetLastError()));
+        tr("OpenProcess() failed with error %1.").arg(GetLastError()));
   }
   wchar_t buf[MAX_PATH];
   DWORD   length  = MAX_PATH;
   BOOL    success = QueryFullProcessImageNameW(hProcess, 0, buf, &length);
   CloseHandle(hProcess);
   if ((!success) || (!length)) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("QueryFullProcessImageNameW() failed with error %1."))
-            .arg(GetLastError()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("QueryFullProcessImageNameW() failed with error %1.")
+                           .arg(GetLastError()));
   }
   processName = QString::fromWCharArray(buf, length);
   int i       = processName.lastIndexOf(QLatin1Char('\\'));

--- a/libs/librepcb/common/systeminfo.cpp
+++ b/libs/librepcb/common/systeminfo.cpp
@@ -287,8 +287,9 @@ QString SystemInfo::getProcessNameByPid(qint64 pid) {
   if (i >= 0) processName.truncate(i);
 #elif defined(Q_OS_SOLARIS)
   // https://illumos.org/man/3proc/
-  // NOTE: This will only return the first PRFNSZ (16) bytes of the process name.
-  // If someone finds a way to get the full process name, feel free to improve this.
+  // NOTE: This will only return the first PRFNSZ (16) bytes of the process
+  // name. If someone finds a way to get the full process name, feel free to
+  // improve this.
   psinfo_t psinfo;
   if (proc_get_psinfo(pid, &psinfo) != 0) {
     return QString();  // process not running

--- a/libs/librepcb/common/toolbox.h
+++ b/libs/librepcb/common/toolbox.h
@@ -534,7 +534,7 @@ public:
     if (!ok) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("Invalid fixed point number string: \"%1\"")).arg(str));
+          tr("Invalid fixed point number string: \"%1\"").arg(str));
     }
     return result;
   }

--- a/libs/librepcb/common/undostack.cpp
+++ b/libs/librepcb/common/undostack.cpp
@@ -90,14 +90,14 @@ UndoStack::~UndoStack() noexcept {
 
 QString UndoStack::getUndoText() const noexcept {
   if (canUndo())
-    return QString(tr("Undo: %1")).arg(mCommands[mCurrentIndex - 1]->getText());
+    return tr("Undo: %1").arg(mCommands[mCurrentIndex - 1]->getText());
   else
     return tr("Undo");
 }
 
 QString UndoStack::getRedoText() const noexcept {
   if (canRedo())
-    return QString(tr("Redo: %1")).arg(mCommands[mCurrentIndex]->getText());
+    return tr("Redo: %1").arg(mCommands[mCurrentIndex]->getText());
   else
     return tr("Redo");
 }
@@ -168,7 +168,7 @@ bool UndoStack::execCmd(UndoCommand* cmd, bool forceKeepCmd) {
     mCurrentIndex++;
 
     // emit signals
-    emit undoTextChanged(QString(tr("Undo: %1")).arg(cmd->getText()));
+    emit undoTextChanged(tr("Undo: %1").arg(cmd->getText()));
     emit redoTextChanged(tr("Redo"));
     emit canUndoChanged(true);
     emit canRedoChanged(false);

--- a/libs/librepcb/common/utils/clipperhelpers.cpp
+++ b/libs/librepcb/common/utils/clipperhelpers.cpp
@@ -41,7 +41,7 @@ void ClipperHelpers::unite(ClipperLib::Paths& paths) {
               ClipperLib::pftEvenOdd);
   } catch (const std::exception& e) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("Failed to unite paths: %1")).arg(e.what()));
+                     tr("Failed to unite paths: %1").arg(e.what()));
   }
 }
 
@@ -55,7 +55,7 @@ void ClipperHelpers::unite(ClipperLib::Paths&      subject,
               ClipperLib::pftEvenOdd);
   } catch (const std::exception& e) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("Failed to unite paths: %1")).arg(e.what()));
+                     tr("Failed to unite paths: %1").arg(e.what()));
   }
 }
 
@@ -69,7 +69,7 @@ void ClipperHelpers::unite(ClipperLib::Paths&       subject,
               ClipperLib::pftEvenOdd);
   } catch (const std::exception& e) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("Failed to unite paths: %1")).arg(e.what()));
+                     tr("Failed to unite paths: %1").arg(e.what()));
   }
 }
 
@@ -86,9 +86,8 @@ std::unique_ptr<ClipperLib::PolyTree> ClipperHelpers::intersect(
               ClipperLib::pftEvenOdd);
     return result;
   } catch (const std::exception& e) {
-    throw LogicError(
-        __FILE__, __LINE__,
-        QString(tr("Failed to intersect paths: %1")).arg(e.what()));
+    throw LogicError(__FILE__, __LINE__,
+                     tr("Failed to intersect paths: %1").arg(e.what()));
   }
 }
 
@@ -102,7 +101,7 @@ void ClipperHelpers::subtract(ClipperLib::Paths&       subject,
               ClipperLib::pftNonZero);
   } catch (const std::exception& e) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("Failed to subtract paths: %1")).arg(e.what()));
+                     tr("Failed to subtract paths: %1").arg(e.what()));
   }
 }
 
@@ -114,7 +113,7 @@ void ClipperHelpers::offset(ClipperLib::Paths& paths, const Length& offset,
     o.Execute(paths, offset.toNm());
   } catch (const std::exception& e) {
     throw LogicError(__FILE__, __LINE__,
-                     QString(tr("Failed to offset a path: %1")).arg(e.what()));
+                     tr("Failed to offset a path: %1").arg(e.what()));
   }
 }
 

--- a/libs/librepcb/common/uuid.cpp
+++ b/libs/librepcb/common/uuid.cpp
@@ -107,9 +107,8 @@ Uuid Uuid::fromString(const QString& str) {
   if (isValid(str)) {
     return Uuid(str);
   } else {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("String is not a valid UUID: \"%1\"")).arg(str));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("String is not a valid UUID: \"%1\"").arg(str));
   }
 }
 

--- a/libs/librepcb/library/cmp/msg/msgduplicatesignalname.cpp
+++ b/libs/librepcb/library/cmp/msg/msgduplicatesignalname.cpp
@@ -38,7 +38,7 @@ MsgDuplicateSignalName::MsgDuplicateSignalName(
     const ComponentSignal& signal) noexcept
   : LibraryElementCheckMessage(
         Severity::Error,
-        QString(tr("Duplicate signal name: '%1'")).arg(*signal.getName()),
+        tr("Duplicate signal name: '%1'").arg(*signal.getName()),
         tr("All component signals must have unique names, otherwise they "
            "cannot be distinguished later in the device editor. If your part "
            "has several pins which are electrically exactly equal (e.g. "

--- a/libs/librepcb/library/cmp/msg/msgmissingcomponentdefaultvalue.cpp
+++ b/libs/librepcb/library/cmp/msg/msgmissingcomponentdefaultvalue.cpp
@@ -35,14 +35,14 @@ namespace library {
 MsgMissingComponentDefaultValue::MsgMissingComponentDefaultValue() noexcept
   : LibraryElementCheckMessage(
         Severity::Warning, tr("No default value set"),
-        QString(tr("Most components should have a default value set. The "
-                   "default value becomes the component's value when adding it "
-                   "to a schematic. It can also contain placeholders which are "
-                   "substituted later in the schematic. Commonly used default "
-                   "values are:\n\n"
-                   "Generic parts (e.g. a diode): %1\n"
-                   "Specific parts (e.g. a microcontroller): %2\n"
-                   "Passive parts: Using an attribute, e.g. %3"))
+        tr("Most components should have a default value set. The "
+           "default value becomes the component's value when adding it "
+           "to a schematic. It can also contain placeholders which are "
+           "substituted later in the schematic. Commonly used default "
+           "values are:\n\n"
+           "Generic parts (e.g. a diode): %1\n"
+           "Specific parts (e.g. a microcontroller): %2\n"
+           "Passive parts: Using an attribute, e.g. %3")
             .arg("'{{PARTNUMBER or DEVICE}}'",
                  "'{{PARTNUMBER or DEVICE or COMPONENT}}'",
                  "'{{RESISTANCE}}'")) {

--- a/libs/librepcb/library/cmp/msg/msgmissingsymbolvariantitem.cpp
+++ b/libs/librepcb/library/cmp/msg/msgmissingsymbolvariantitem.cpp
@@ -38,7 +38,7 @@ MsgMissingSymbolVariantItem::MsgMissingSymbolVariantItem(
     std::shared_ptr<const ComponentSymbolVariant> symbVar) noexcept
   : LibraryElementCheckMessage(
         Severity::Error,
-        QString(tr("Symbol variant '%1' has no items"))
+        tr("Symbol variant '%1' has no items")
             .arg(*symbVar->getNames().getDefaultValue()),
         tr("Every symbol variant requires at least one symbol item, otherwise "
            "it can't be added to schematics.")),

--- a/libs/librepcb/library/library.cpp
+++ b/libs/librepcb/library/library.cpp
@@ -60,8 +60,8 @@ Library::Library(std::unique_ptr<TransactionalDirectory> directory)
   // check directory suffix
   if (mDirectory->getAbsPath().getSuffix() != "lplib") {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The library directory does not have the "
-                                  "suffix '.lplib':\n\n%1"))
+                       tr("The library directory does not have the "
+                          "suffix '.lplib':\n\n%1")
                            .arg(mDirectory->getAbsPath().toNative()));
   }
 
@@ -134,7 +134,7 @@ void Library::moveTo(TransactionalDirectory& dest) {
     qDebug() << dest.getAbsPath().toNative();
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("A library directory name must have the suffix '.lplib'.")));
+        tr("A library directory name must have the suffix '.lplib'."));
   }
 
   // move the element

--- a/libs/librepcb/library/librarybaseelement.cpp
+++ b/libs/librepcb/library/librarybaseelement.cpp
@@ -83,7 +83,7 @@ LibraryBaseElement::LibraryBaseElement(
   if (!mDirectory->fileExists(versionFileName)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Directory is not a library element of type %1: \"%2\""))
+        tr("Directory is not a library element of type %1: \"%2\"")
             .arg(mLongElementName, mDirectory->getAbsPath().toNative()));
   }
 
@@ -91,7 +91,7 @@ LibraryBaseElement::LibraryBaseElement(
   QString dirUuidStr = mDirectory->getAbsPath().getFilename();
   if (mDirectoryNameMustBeUuid && (!Uuid::isValid(dirUuidStr))) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Directory name is not a valid UUID: \"%1\""))
+                       tr("Directory name is not a valid UUID: \"%1\"")
                            .arg(mDirectory->getAbsPath().toNative()));
   }
 

--- a/libs/librepcb/library/msg/msgnamenottitlecase.cpp
+++ b/libs/librepcb/library/msg/msgnamenottitlecase.cpp
@@ -34,7 +34,7 @@ namespace library {
 
 MsgNameNotTitleCase::MsgNameNotTitleCase(const ElementName& name) noexcept
   : LibraryElementCheckMessage(
-        Severity::Hint, QString(tr("Name not title case: '%1'")).arg(*name),
+        Severity::Hint, tr("Name not title case: '%1'").arg(*name),
         tr("Generally the library element name should be written in title case "
            "(for consistency). As the current name has words starting with a "
            "lowercase character, it seems that it is not title cases. If this "

--- a/libs/librepcb/library/pkg/msg/msgduplicatepadname.cpp
+++ b/libs/librepcb/library/pkg/msg/msgduplicatepadname.cpp
@@ -36,8 +36,7 @@ namespace library {
 
 MsgDuplicatePadName::MsgDuplicatePadName(const PackagePad& pad) noexcept
   : LibraryElementCheckMessage(
-        Severity::Error,
-        QString(tr("Duplicate pad name: '%1'")).arg(*pad.getName()),
+        Severity::Error, tr("Duplicate pad name: '%1'").arg(*pad.getName()),
         tr("All package pads must have unique names, otherwise they cannot be "
            "distinguished later in the device editor. If your part has several "
            "leads with same functionality (e.g. multiple GND leads), you can "

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprintname.cpp
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprintname.cpp
@@ -38,7 +38,7 @@ MsgMissingFootprintName::MsgMissingFootprintName(
     std::shared_ptr<const Footprint> footprint) noexcept
   : LibraryElementCheckMessage(
         Severity::Warning,
-        QString(tr("Missing text '%1' in footprint '%2'"))
+        tr("Missing text '%1' in footprint '%2'")
             .arg("{{NAME}}", *footprint->getNames().getDefaultValue()),
         tr("Most footprints should have a text element for the component's "
            "name, otherwise you won't see that name on the PCB (e.g. on "

--- a/libs/librepcb/library/pkg/msg/msgmissingfootprintvalue.cpp
+++ b/libs/librepcb/library/pkg/msg/msgmissingfootprintvalue.cpp
@@ -38,7 +38,7 @@ MsgMissingFootprintValue::MsgMissingFootprintValue(
     std::shared_ptr<const Footprint> footprint) noexcept
   : LibraryElementCheckMessage(
         Severity::Warning,
-        QString(tr("Missing text '%1' in footprint '%2'"))
+        tr("Missing text '%1' in footprint '%2'")
             .arg("{{VALUE}}", *footprint->getNames().getDefaultValue()),
         tr("Most footprints should have a text element for the component's "
            "value, otherwise you won't see that value on the PCB (e.g. on "

--- a/libs/librepcb/library/pkg/msg/msgpadoverlapswithplacement.cpp
+++ b/libs/librepcb/library/pkg/msg/msgpadoverlapswithplacement.cpp
@@ -40,11 +40,11 @@ MsgPadOverlapsWithPlacement::MsgPadOverlapsWithPlacement(
     const Length& clearance) noexcept
   : LibraryElementCheckMessage(
         Severity::Warning,
-        QString(tr("Clearance of pad '%1' in '%2' to placement layer"))
+        tr("Clearance of pad '%1' in '%2' to placement layer")
             .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
-        QString(tr("Pads should have at least %1 clearance to the outlines "
-                   "layer because outlines are drawn on silkscreen which will "
-                   "be cropped for Gerber export."))
+        tr("Pads should have at least %1 clearance to the outlines "
+           "layer because outlines are drawn on silkscreen which will "
+           "be cropped for Gerber export.")
             .arg(QString::number(clearance.toMm() * 1000) % "μm")),
     mFootprint(footprint),
     mPad(pad) {

--- a/libs/librepcb/library/pkg/msg/msgwrongfootprinttextlayer.cpp
+++ b/libs/librepcb/library/pkg/msg/msgwrongfootprinttextlayer.cpp
@@ -43,10 +43,10 @@ MsgWrongFootprintTextLayer::MsgWrongFootprintTextLayer(
     const QString&                    expectedLayerName) noexcept
   : LibraryElementCheckMessage(
         Severity::Warning,
-        QString(tr("Layer of '%1' in '%2' is not '%3'"))
+        tr("Layer of '%1' in '%2' is not '%3'")
             .arg(text->getText(), *footprint->getNames().getDefaultValue(),
                  GraphicsLayer(expectedLayerName).getNameTr()),
-        QString(tr("The text element '%1' should normally be on layer '%2'."))
+        tr("The text element '%1' should normally be on layer '%2'.")
             .arg(text->getText(),
                  GraphicsLayer(expectedLayerName).getNameTr())),
     mFootprint(footprint),

--- a/libs/librepcb/library/sym/msg/msgduplicatepinname.cpp
+++ b/libs/librepcb/library/sym/msg/msgduplicatepinname.cpp
@@ -36,8 +36,7 @@ namespace library {
 
 MsgDuplicatePinName::MsgDuplicatePinName(const SymbolPin& pin) noexcept
   : LibraryElementCheckMessage(
-        Severity::Error,
-        QString(tr("Duplicate pin name: '%1'")).arg(*pin.getName()),
+        Severity::Error, tr("Duplicate pin name: '%1'").arg(*pin.getName()),
         tr("All symbol pins must have unique names, otherwise they cannot be "
            "distinguished later in the component editor. If your part has "
            "several pins with same functionality (e.g. multiple GND pins), you "

--- a/libs/librepcb/library/sym/msg/msgmissingsymbolname.cpp
+++ b/libs/librepcb/library/sym/msg/msgmissingsymbolname.cpp
@@ -34,7 +34,7 @@ namespace library {
 
 MsgMissingSymbolName::MsgMissingSymbolName() noexcept
   : LibraryElementCheckMessage(
-        Severity::Warning, QString(tr("Missing text: '%1'")).arg("{{NAME}}"),
+        Severity::Warning, tr("Missing text: '%1'").arg("{{NAME}}"),
         tr("Most symbols should have a text element for the component's name, "
            "otherwise you won't see that name in the schematics. There are "
            "only a few exceptions (e.g. a schematic frame) which don't need a "

--- a/libs/librepcb/library/sym/msg/msgmissingsymbolvalue.cpp
+++ b/libs/librepcb/library/sym/msg/msgmissingsymbolvalue.cpp
@@ -34,7 +34,7 @@ namespace library {
 
 MsgMissingSymbolValue::MsgMissingSymbolValue() noexcept
   : LibraryElementCheckMessage(
-        Severity::Warning, QString(tr("Missing text: '%1'")).arg("{{VALUE}}"),
+        Severity::Warning, tr("Missing text: '%1'").arg("{{VALUE}}"),
         tr("Most symbols should have a text element for the component's value, "
            "otherwise you won't see that value in the schematics. There are "
            "only a few exceptions (e.g. a schematic frame) which don't need a "

--- a/libs/librepcb/library/sym/msg/msgoverlappingsymbolpins.cpp
+++ b/libs/librepcb/library/sym/msg/msgoverlappingsymbolpins.cpp
@@ -60,7 +60,7 @@ QString MsgOverlappingSymbolPins::buildMessage(
     pinNames.append("'" % pin->getName() % "'");
   }
   std::sort(pinNames.begin(), pinNames.end());
-  return QString(tr("Overlapping pins: %1")).arg(pinNames.join(", "));
+  return tr("Overlapping pins: %1").arg(pinNames.join(", "));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/library/sym/msg/msgsymbolpinnotongrid.cpp
+++ b/libs/librepcb/library/sym/msg/msgsymbolpinnotongrid.cpp
@@ -39,10 +39,10 @@ MsgSymbolPinNotOnGrid::MsgSymbolPinNotOnGrid(
     const PositiveLength&            gridInterval) noexcept
   : LibraryElementCheckMessage(
         Severity::Error,
-        QString(tr("Pin not on %1mm grid: '%2'"))
+        tr("Pin not on %1mm grid: '%2'")
             .arg(gridInterval->toMmString(), *pin->getName()),
-        QString(tr("Every pin must be placed exactly on the %1mm grid, "
-                   "otherwise it cannot be connected in the schematic editor."))
+        tr("Every pin must be placed exactly on the %1mm grid, "
+           "otherwise it cannot be connected in the schematic editor.")
             .arg(gridInterval->toMmString())),
     mPin(pin),
     mGridInterval(gridInterval) {

--- a/libs/librepcb/library/sym/msg/msgwrongsymboltextlayer.cpp
+++ b/libs/librepcb/library/sym/msg/msgwrongsymboltextlayer.cpp
@@ -39,9 +39,9 @@ MsgWrongSymbolTextLayer::MsgWrongSymbolTextLayer(
     std::shared_ptr<const Text> text, const QString& expectedLayerName) noexcept
   : LibraryElementCheckMessage(
         Severity::Warning,
-        QString(tr("Layer of '%1' is not '%2'"))
+        tr("Layer of '%1' is not '%2'")
             .arg(text->getText(), GraphicsLayer(expectedLayerName).getNameTr()),
-        QString(tr("The text element '%1' should normally be on layer '%2'."))
+        tr("The text element '%1' should normally be on layer '%2'.")
             .arg(text->getText(),
                  GraphicsLayer(expectedLayerName).getNameTr())),
     mText(text),

--- a/libs/librepcb/libraryeditor/cmp/componentsignallistmodel.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallistmodel.cpp
@@ -358,8 +358,7 @@ CircuitIdentifier ComponentSignalListModel::validateNameOrThrow(
   if (mSignalList && mSignalList->contains(name)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a signal with the name \"%1\"."))
-            .arg(name));
+        tr("There is already a signal with the name \"%1\".").arg(name));
   }
   return CircuitIdentifier(name);  // can throw
 }

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlistmodel.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlistmodel.cpp
@@ -109,10 +109,9 @@ void ComponentSymbolVariantItemListModel::addItem(
     std::shared_ptr<const Symbol> symbol =
         mSymbolsCache->getSymbol(*mNewSymbolUuid);
     if (!symbol) {
-      throw RuntimeError(
-          __FILE__, __LINE__,
-          QString(tr("Symbol '%1' not found in workspace library!"))
-              .arg(mNewSymbolUuid->toStr()));
+      throw RuntimeError(__FILE__, __LINE__,
+                         tr("Symbol '%1' not found in workspace library!")
+                             .arg(mNewSymbolUuid->toStr()));
     }
     std::shared_ptr<ComponentSymbolVariantItem> item =
         std::make_shared<ComponentSymbolVariantItem>(
@@ -186,10 +185,9 @@ void ComponentSymbolVariantItemListModel::changeSymbol(
   try {
     std::shared_ptr<const Symbol> sym = mSymbolsCache->getSymbol(symbol);
     if (!sym) {
-      throw RuntimeError(
-          __FILE__, __LINE__,
-          QString(tr("Symbol '%1' not found in workspace library!"))
-              .arg(symbol.toStr()));
+      throw RuntimeError(__FILE__, __LINE__,
+                         tr("Symbol '%1' not found in workspace library!")
+                             .arg(symbol.toStr()));
     }
     tl::optional<Uuid> uuid = Uuid::tryFromString(editData.toString());
     if (uuid) {

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistmodel.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistmodel.cpp
@@ -402,7 +402,7 @@ ElementName ComponentSymbolVariantListModel::validateNameOrThrow(
   if (mSymbolVariantList && mSymbolVariantList->contains(name)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a symbol variant with the name \"%1\"."))
+        tr("There is already a symbol variant with the name \"%1\".")
             .arg(name));
   }
   return ElementName(name);  // can throw

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -134,7 +134,7 @@ LibraryEditor::LibraryEditor(workspace::Workspace& ws, const FilePath& libFp,
       mWorkspace.getSettings().libraryLocaleOrder.get();
   QString libName = *mLibrary->getNames().value(localeOrder);
   if (readOnly) libName.append(tr(" [Read-Only]"));
-  setWindowTitle(QString(tr("%1 - LibrePCB Library Editor")).arg(libName));
+  setWindowTitle(tr("%1 - LibrePCB Library Editor").arg(libName));
   setWindowIcon(mLibrary->getIconAsPixmap());
 
   // setup "filter" toolbar
@@ -737,7 +737,7 @@ void LibraryEditor::updateTabTitles() noexcept {
   if (mCurrentEditorWidget) {
     mUi->actionSave->setEnabled(true);
     mUi->actionSave->setText(
-        QString(tr("&Save '%1'")).arg(mCurrentEditorWidget->windowTitle()));
+        tr("&Save '%1'").arg(mCurrentEditorWidget->windowTitle()));
   } else {
     mUi->actionSave->setEnabled(false);
   }

--- a/libs/librepcb/libraryeditor/pkg/footprintlistmodel.cpp
+++ b/libs/librepcb/libraryeditor/pkg/footprintlistmodel.cpp
@@ -347,8 +347,7 @@ ElementName FootprintListModel::validateNameOrThrow(const QString& name) const {
       if (footprint.getNames().getDefaultValue() == name) {
         throw RuntimeError(
             __FILE__, __LINE__,
-            QString(tr("There is already a footprint with the name \"%1\"."))
-                .arg(name));
+            tr("There is already a footprint with the name \"%1\".").arg(name));
       }
     }
   }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -109,8 +109,8 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
         mState = SubState::SELECTING;
       } else {
         // check if the top most item under the cursor is already selected
-        QGraphicsItem* topMostItem = items.first();
-        bool itemAlreadySelected = topMostItem->isSelected();
+        QGraphicsItem* topMostItem         = items.first();
+        bool           itemAlreadySelected = topMostItem->isSelected();
 
         if (e.modifiers().testFlag(Qt::ControlModifier)) {
           // Toggle selection when CTRL is pressed
@@ -129,8 +129,7 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
           QGraphicsItem* item = items[mCurrentSelectionIndex];
           if (dynamic_cast<FootprintPadGraphicsItem*>(item)) {
             // workaround for selection of a SymbolPinGraphicsItem
-            dynamic_cast<FootprintPadGraphicsItem*>(item)
-                ->setSelected(true);
+            dynamic_cast<FootprintPadGraphicsItem*>(item)->setSelected(true);
           } else {
             item->setSelected(true);
           }
@@ -366,12 +365,13 @@ bool PackageEditorState_Select::processAbortCommand() noexcept {
  *  Private Methods
  ******************************************************************************/
 
-bool PackageEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
+bool PackageEditorState_Select::openContextMenuAtPos(
+    const Point& pos) noexcept {
   if (mState != SubState::IDLE) return false;
 
   // handle item selection
-  QGraphicsItem* selectedItem = nullptr;
-  QList<QGraphicsItem*> items = findItemsAtPosition(pos);
+  QGraphicsItem*        selectedItem = nullptr;
+  QList<QGraphicsItem*> items        = findItemsAtPosition(pos);
   if (items.isEmpty()) return false;
   foreach (QGraphicsItem* item, items) {
     if (item->isSelected()) {
@@ -383,8 +383,7 @@ bool PackageEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept 
     selectedItem = items.first();
     if (dynamic_cast<FootprintPadGraphicsItem*>(selectedItem)) {
       // workaround for selection of a SymbolPinGraphicsItem
-      dynamic_cast<FootprintPadGraphicsItem*>(selectedItem)
-          ->setSelected(true);
+      dynamic_cast<FootprintPadGraphicsItem*>(selectedItem)->setSelected(true);
     } else {
       selectedItem->setSelected(true);
     }
@@ -396,27 +395,22 @@ bool PackageEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept 
   QMenu    menu;
   QAction* aRotateCCW =
       menu.addAction(QIcon(":/img/actions/rotate_left.png"), tr("Rotate"));
-  connect(aRotateCCW, &QAction::triggered, [this](){
-    rotateSelectedItems(Angle::deg90());
-  });
+  connect(aRotateCCW, &QAction::triggered,
+          [this]() { rotateSelectedItems(Angle::deg90()); });
   QAction* aMirrorH =
       menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), tr("Mirror"));
-  connect(aMirrorH, &QAction::triggered, [this](){
-    mirrorSelectedItems(Qt::Horizontal, false);
-  });
+  connect(aMirrorH, &QAction::triggered,
+          [this]() { mirrorSelectedItems(Qt::Horizontal, false); });
   QAction* aFlipH = menu.addAction(QIcon(":/img/actions/swap.png"), tr("Flip"));
-  connect(aFlipH, &QAction::triggered, [this](){
-    mirrorSelectedItems(Qt::Horizontal, true);
-  });
+  connect(aFlipH, &QAction::triggered,
+          [this]() { mirrorSelectedItems(Qt::Horizontal, true); });
   QAction* aRemove =
       menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
-  connect(aRemove, &QAction::triggered, [this](){
-    removeSelectedItems();
-  });
+  connect(aRemove, &QAction::triggered, [this]() { removeSelectedItems(); });
   menu.addSeparator();
   QAction* aProperties =
       menu.addAction(QIcon(":/img/actions/settings.png"), tr("Properties"));
-  connect(aProperties, &QAction::triggered, [this, &selectedItem](){
+  connect(aProperties, &QAction::triggered, [this, &selectedItem]() {
     openPropertiesDialogOfItem(selectedItem);
   });
 
@@ -430,7 +424,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
   if (!item) return false;
 
   if (FootprintPadGraphicsItem* pad =
-      dynamic_cast<FootprintPadGraphicsItem*>(item)) {
+          dynamic_cast<FootprintPadGraphicsItem*>(item)) {
     Q_ASSERT(pad);
     FootprintPadPropertiesDialog dialog(
         mContext.package, *mContext.currentFootprint, pad->getPad(),
@@ -440,7 +434,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     dialog.exec();
     return true;
   } else if (StrokeTextGraphicsItem* text =
-             dynamic_cast<StrokeTextGraphicsItem*>(item)) {
+                 dynamic_cast<StrokeTextGraphicsItem*>(item)) {
     Q_ASSERT(text);
     StrokeTextPropertiesDialog dialog(
         text->getText(), mContext.undoStack,
@@ -450,7 +444,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     dialog.exec();
     return true;
   } else if (PolygonGraphicsItem* polygon =
-             dynamic_cast<PolygonGraphicsItem*>(item)) {
+                 dynamic_cast<PolygonGraphicsItem*>(item)) {
     Q_ASSERT(polygon);
     PolygonPropertiesDialog dialog(
         polygon->getPolygon(), mContext.undoStack,
@@ -460,7 +454,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     dialog.exec();
     return true;
   } else if (CircleGraphicsItem* circle =
-             dynamic_cast<CircleGraphicsItem*>(item)) {
+                 dynamic_cast<CircleGraphicsItem*>(item)) {
     Q_ASSERT(circle);
     CirclePropertiesDialog dialog(
         circle->getCircle(), mContext.undoStack,
@@ -469,8 +463,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
         &mContext.editorWidget);
     dialog.exec();
     return true;
-  } else if (HoleGraphicsItem* hole =
-             dynamic_cast<HoleGraphicsItem*>(item)) {
+  } else if (HoleGraphicsItem* hole = dynamic_cast<HoleGraphicsItem*>(item)) {
     Q_ASSERT(hole);
     HolePropertiesDialog dialog(
         hole->getHole(), mContext.undoStack, getDefaultLengthUnit(),
@@ -660,9 +653,8 @@ QList<QGraphicsItem*> PackageEditorState_Select::findItemsAtPosition(
     result.append(hole.data());
   }
 
-  Q_ASSERT(result.count() == (pads.count() + texts.count()
-                              + polygons.count() + circles.count()
-                              + holes.count()));
+  Q_ASSERT(result.count() == (pads.count() + texts.count() + polygons.count() +
+                              circles.count() + holes.count()));
   Q_ASSERT(result.count() == count);
   return result;
 }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
@@ -105,7 +105,7 @@ private:  // Types / Data
   SubState                                      mState;
   Point                                         mStartPos;
   QScopedPointer<CmdDragSelectedFootprintItems> mCmdDragSelectedItems;
-  int mCurrentSelectionIndex;
+  int                                           mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkg/packagepadlistmodel.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlistmodel.cpp
@@ -306,7 +306,7 @@ CircuitIdentifier PackagePadListModel::validateNameOrThrow(
   if (mPadList && mPadList->contains(name)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a pad with the name \"%1\".")).arg(name));
+        tr("There is already a pad with the name \"%1\".").arg(name));
   }
   return CircuitIdentifier(name);  // can throw
 }

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
@@ -127,8 +127,7 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
           QGraphicsItem* item = items[mCurrentSelectionIndex];
           if (dynamic_cast<SymbolPinGraphicsItem*>(item)) {
             // workaround for selection of a SymbolPinGraphicsItem
-            dynamic_cast<SymbolPinGraphicsItem*>(item)
-                ->setSelected(true);
+            dynamic_cast<SymbolPinGraphicsItem*>(item)->setSelected(true);
           } else {
             item->setSelected(true);
           }
@@ -350,8 +349,8 @@ bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
   if (mState != SubState::IDLE) return false;
 
   // handle item selection
-  QGraphicsItem* selectedItem = nullptr;
-  QList<QGraphicsItem*> items = findItemsAtPosition(pos);
+  QGraphicsItem*        selectedItem = nullptr;
+  QList<QGraphicsItem*> items        = findItemsAtPosition(pos);
   if (items.isEmpty()) return false;
   foreach (QGraphicsItem* item, items) {
     if (item->isSelected()) {
@@ -363,8 +362,7 @@ bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
     selectedItem = items.first();
     if (dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)) {
       // workaround for selection of a SymbolPinGraphicsItem
-      dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)
-          ->setSelected(true);
+      dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)->setSelected(true);
     } else {
       selectedItem->setSelected(true);
     }
@@ -373,26 +371,22 @@ bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
   Q_ASSERT(selectedItem->isSelected());
 
   // build the context menu
-  QMenu menu;
+  QMenu    menu;
   QAction* aRotateCCW =
       menu.addAction(QIcon(":/img/actions/rotate_left.png"), tr("&Rotate"));
-  connect(aRotateCCW, &QAction::triggered, [this](){
-    rotateSelectedItems(Angle::deg90());
-  });
+  connect(aRotateCCW, &QAction::triggered,
+          [this]() { rotateSelectedItems(Angle::deg90()); });
   QAction* aMirrorH =
       menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), tr("&Mirror"));
-  connect(aMirrorH, &QAction::triggered, [this](){
-    mirrorSelectedItems(Qt::Horizontal);
-  });
+  connect(aMirrorH, &QAction::triggered,
+          [this]() { mirrorSelectedItems(Qt::Horizontal); });
   QAction* aRemove =
       menu.addAction(QIcon(":/img/actions/delete.png"), tr("R&emove"));
-  connect(aRemove, &QAction::triggered, [this](){
-    removeSelectedItems();
-  });
+  connect(aRemove, &QAction::triggered, [this]() { removeSelectedItems(); });
   menu.addSeparator();
-  QAction* aProperties = menu.addAction(QIcon(":/img/actions/settings.png"),
-                                        tr("&Properties"));
-  connect(aProperties, &QAction::triggered, [this, &selectedItem](){
+  QAction* aProperties =
+      menu.addAction(QIcon(":/img/actions/settings.png"), tr("&Properties"));
+  connect(aProperties, &QAction::triggered, [this, &selectedItem]() {
     openPropertiesDialogOfItem(selectedItem);
   });
 
@@ -422,7 +416,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     dialog.exec();
     return true;
   } else if (PolygonGraphicsItem* polygon =
-             dynamic_cast<PolygonGraphicsItem*>(item)) {
+                 dynamic_cast<PolygonGraphicsItem*>(item)) {
     Q_ASSERT(polygon);
     PolygonPropertiesDialog dialog(
         polygon->getPolygon(), mContext.undoStack,
@@ -432,7 +426,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     dialog.exec();
     return true;
   } else if (CircleGraphicsItem* circle =
-             dynamic_cast<CircleGraphicsItem*>(item)) {
+                 dynamic_cast<CircleGraphicsItem*>(item)) {
     Q_ASSERT(circle);
     CirclePropertiesDialog dialog(
         circle->getCircle(), mContext.undoStack,
@@ -599,8 +593,8 @@ QList<QGraphicsItem*> SymbolEditorState_Select::findItemsAtPosition(
     result.append(text.data());
   }
 
-  Q_ASSERT(result.count() == (pins.count() + texts.count()
-                             + polygons.count() + circles.count()));
+  Q_ASSERT(result.count() ==
+           (pins.count() + texts.count() + polygons.count() + circles.count()));
   Q_ASSERT(result.count() == count);
   return result;
 }

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
@@ -103,7 +103,7 @@ private:  // Types / Data
   SubState                                   mState;
   Point                                      mStartPos;
   QScopedPointer<CmdDragSelectedSymbolItems> mCmdDragSelectedItems;
-  int mCurrentSelectionIndex;
+  int                                        mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/librarymanager/addlibrarywidget.cpp
@@ -302,7 +302,7 @@ void AddLibraryWidget::downloadZippedLibraryButtonClicked() noexcept {
   }
   if (extractToDir.isExistingFile() || extractToDir.isExistingDir()) {
     QMessageBox::critical(this, tr("Directory exists already"),
-                          QString(tr("The directory \"%1\" exists already."))
+                          tr("The directory \"%1\" exists already.")
                               .arg(extractToDir.toNative()));
     return;
   }

--- a/libs/librepcb/librarymanager/libraryinfowidget.cpp
+++ b/libs/librepcb/librarymanager/libraryinfowidget.cpp
@@ -123,10 +123,9 @@ void LibraryInfoWidget::btnOpenLibraryEditorClicked() noexcept {
 
 void LibraryInfoWidget::btnRemoveLibraryClicked() noexcept {
   QString title = tr("Remove Library");
-  QString text =
-      QString(tr("Attention! This will remove the whole library directory:"
-                 "\n\n%1\n\nAre you really sure to remove \"%2\"?"))
-          .arg(mLibDir.toNative(), mUi->lblName->text());
+  QString text  = tr("Attention! This will remove the whole library directory:"
+                    "\n\n%1\n\nAre you really sure to remove \"%2\"?")
+                     .arg(mLibDir.toNative(), mUi->lblName->text());
 
   int res = QMessageBox::question(this, title, text,
                                   QMessageBox::Yes | QMessageBox::No);

--- a/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -206,7 +206,7 @@ void RepositoryLibraryListWidgetItem::updateInstalledStatus() noexcept {
     if (installedVersion) {
       if (installedVersion < mVersion) {
         mUi->lblInstalledVersion->setText(
-            QString(tr("v%1")).arg(installedVersion->toStr()));
+            tr("v%1").arg(installedVersion->toStr()));
         mUi->lblInstalledVersion->setStyleSheet("QLabel {color: red;}");
         mUi->cbxDownload->setText(tr("Update") % ":");
         mUi->cbxDownload->setVisible(true);

--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -148,23 +148,20 @@ public:
       noexcept {
     return *mFabricationOutputSettings;
   }
-  bool                isEmpty() const noexcept;
-  QList<BI_Base*>     getItemsAtScenePos(const Point& pos) const noexcept;
-  QList<BI_Via*>      getViasAtScenePos(const Point&     pos,
-                                        const NetSignal* netsignal = nullptr)
-                                        const noexcept;
-  QList<BI_NetPoint*> getNetPointsAtScenePos(const Point&         pos,
-                                           const GraphicsLayer* layer = nullptr,
-                                           const NetSignal* netsignal = nullptr)
-                                           const noexcept;
-  QList<BI_NetLine*> getNetLinesAtScenePos(const Point&         pos,
-                                           const GraphicsLayer* layer = nullptr,
-                                           const NetSignal* netsignal = nullptr)
-                                           const noexcept;
-  QList<BI_FootprintPad*> getPadsAtScenePos(const Point&         pos,
-                                          const GraphicsLayer* layer = nullptr,
-                                          const NetSignal* netsignal = nullptr)
-                                          const noexcept;
+  bool            isEmpty() const noexcept;
+  QList<BI_Base*> getItemsAtScenePos(const Point& pos) const noexcept;
+  QList<BI_Via*>  getViasAtScenePos(const Point&     pos,
+                                    const NetSignal* netsignal = nullptr) const
+      noexcept;
+  QList<BI_NetPoint*> getNetPointsAtScenePos(
+      const Point& pos, const GraphicsLayer* layer = nullptr,
+      const NetSignal* netsignal = nullptr) const noexcept;
+  QList<BI_NetLine*> getNetLinesAtScenePos(
+      const Point& pos, const GraphicsLayer* layer = nullptr,
+      const NetSignal* netsignal = nullptr) const noexcept;
+  QList<BI_FootprintPad*> getPadsAtScenePos(
+      const Point& pos, const GraphicsLayer* layer = nullptr,
+      const NetSignal* netsignal = nullptr) const noexcept;
   QList<BI_Base*> getAllItems() const noexcept;
 
   // Setters: General

--- a/libs/librepcb/project/boards/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/project/boards/boardplanefragmentsbuilder.h
@@ -23,8 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <polyclipping/clipper.hpp>
 #include <librepcb/common/geometry/path.h>
+#include <polyclipping/clipper.hpp>
 
 #include <QtCore>
 

--- a/libs/librepcb/project/boards/drc/boardclipperpathgenerator.h
+++ b/libs/librepcb/project/boards/drc/boardclipperpathgenerator.h
@@ -23,8 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <polyclipping/clipper.hpp>
 #include <librepcb/common/units/length.h>
+#include <polyclipping/clipper.hpp>
 
 #include <QtCore>
 

--- a/libs/librepcb/project/boards/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/project/boards/drc/boarddesignrulecheck.cpp
@@ -87,9 +87,9 @@ void BoardDesignRuleCheck::execute() {
   checkCourtyardClearances(78, 88);
   checkForMissingConnections(88, 90);
 
-  emit progressStatus(QString(tr("Finished with %1 message(s)!",
-                                 "Count of messages", mMessages.count()))
-                          .arg(mMessages.count()));
+  emit progressStatus(
+      tr("Finished with %1 message(s)!", "Count of messages", mMessages.count())
+          .arg(mMessages.count()));
   emit progressPercent(100);
   emit finished();
 }
@@ -114,9 +114,8 @@ void BoardDesignRuleCheck::checkForMissingConnections(int progressStart,
   // instead.
   mBoard.forceAirWiresRebuild();
   foreach (const BI_AirWire* airwire, mBoard.getAirWires()) {
-    QString msg =
-        QString(tr("Missing connection: '%1'", "Placeholder is net name"))
-            .arg(*airwire->getNetSignal().getName());
+    QString msg = tr("Missing connection: '%1'", "Placeholder is net name")
+                      .arg(*airwire->getNetSignal().getName());
     Path location = Path::obround(airwire->getP1(), airwire->getP2(),
                                   PositiveLength(50000));
     addMessage(BoardDesignRuleCheckMessage(msg, location));
@@ -168,8 +167,8 @@ void BoardDesignRuleCheck::checkCopperBoardClearances(int progressStart,
       for (const ClipperLib::Path& path :
            ClipperHelpers::flattenTree(*intersections)) {
         QString name1 = netsignals[i] ? *netsignals[i]->getName() : "";
-        QString msg   = QString(tr("Clearance (%1): '%2' <-> Board Outline",
-                                 "Placeholders are layer name + net name"))
+        QString msg   = tr("Clearance (%1): '%2' <-> Board Outline",
+                         "Placeholders are layer name + net name")
                           .arg(layer->getNameTr(), name1);
         Path location = ClipperHelpers::convert(path);
         addMessage(BoardDesignRuleCheckMessage(msg, location));
@@ -214,8 +213,8 @@ void BoardDesignRuleCheck::checkCopperCopperClearances(int progressStart,
              ClipperHelpers::flattenTree(*intersections)) {
           QString name1 = netsignals[i] ? *netsignals[i]->getName() : "";
           QString name2 = netsignals[k] ? *netsignals[k]->getName() : "";
-          QString msg   = QString(tr("Clearance (%1): '%2' <-> '%3'",
-                                   "Placeholders are layer name + net names"))
+          QString msg   = tr("Clearance (%1): '%2' <-> '%3'",
+                           "Placeholders are layer name + net names")
                             .arg(layer->getNameTr(), name1, name2);
           Path location = ClipperHelpers::convert(path);
           addMessage(BoardDesignRuleCheckMessage(msg, location));
@@ -261,10 +260,9 @@ void BoardDesignRuleCheck::checkCourtyardClearances(int progressStart,
              ClipperHelpers::flattenTree(*intersections)) {
           QString name1 = *dev1->getComponentInstance().getName();
           QString name2 = *dev2->getComponentInstance().getName();
-          QString msg =
-              QString(tr("Clearance (%1): '%2' <-> '%3'",
-                         "Placeholders are layer name + component names"))
-                  .arg(layer->getNameTr(), name1, name2);
+          QString msg   = tr("Clearance (%1): '%2' <-> '%3'",
+                           "Placeholders are layer name + component names")
+                            .arg(layer->getNameTr(), name1, name2);
           Path location = ClipperHelpers::convert(path);
           addMessage(BoardDesignRuleCheckMessage(msg, location));
         }
@@ -288,8 +286,8 @@ void BoardDesignRuleCheck::checkMinimumCopperWidth(int progressStart,
       continue;
     }
     if (text->getText().getStrokeWidth() < mOptions.minCopperWidth) {
-      QString msg = QString(tr("Min. copper width (%1) of text: %2",
-                               "Placeholders are layer name + width"))
+      QString msg = tr("Min. copper width (%1) of text: %2",
+                       "Placeholders are layer name + width")
                         .arg(layer->getNameTr(),
                              formatLength(*text->getText().getStrokeWidth()));
       QVector<Path> locations;
@@ -313,8 +311,8 @@ void BoardDesignRuleCheck::checkMinimumCopperWidth(int progressStart,
     }
     if (plane->getMinWidth() < mOptions.minCopperWidth) {
       QString msg =
-          QString(tr("Min. copper width (%1) of plane: %2",
-                     "Placeholders are layer name + width"))
+          tr("Min. copper width (%1) of plane: %2",
+             "Placeholders are layer name + width")
               .arg(layer->getNameTr(), formatLength(*plane->getMinWidth()));
       QVector<Path> locations =
           plane->getOutline().toClosedPath().toOutlineStrokes(
@@ -334,8 +332,8 @@ void BoardDesignRuleCheck::checkMinimumCopperWidth(int progressStart,
         continue;
       }
       if (text->getText().getStrokeWidth() < mOptions.minCopperWidth) {
-        QString msg = QString(tr("Min. copper width (%1) of text: %2",
-                                 "Placeholders are layer name + width"))
+        QString msg = tr("Min. copper width (%1) of text: %2",
+                         "Placeholders are layer name + width")
                           .arg(layer->getNameTr(),
                                formatLength(*text->getText().getStrokeWidth()));
         QVector<Path> locations;
@@ -359,8 +357,8 @@ void BoardDesignRuleCheck::checkMinimumCopperWidth(int progressStart,
         continue;
       }
       if (netline->getWidth() < mOptions.minCopperWidth) {
-        QString msg = QString(tr("Min. copper width (%1) of trace: %2",
-                                 "Placeholders are layer name + width"))
+        QString msg = tr("Min. copper width (%1) of trace: %2",
+                         "Placeholders are layer name + width")
                           .arg(netline->getLayer().getNameTr(),
                                formatLength(*netline->getWidth()));
         Path location = Path::obround(netline->getStartPoint().getPosition(),
@@ -384,8 +382,8 @@ void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
     foreach (const BI_Via* via, netsegment->getVias()) {
       Length restring = (*via->getSize() - *via->getDrillDiameter() + 1) / 2;
       if (restring < *mOptions.minPthRestring) {
-        QString msg = QString(tr("Min. via restring ('%1'): %2",
-                                 "Placeholders are net name + restring width"))
+        QString msg = tr("Min. via restring ('%1'): %2",
+                         "Placeholders are net name + restring width")
                           .arg(*netsegment->getNetSignal().getName(),
                                formatLength(restring));
         PositiveLength diameter = via->getDrillDiameter() +
@@ -409,8 +407,8 @@ void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
           qMin(pad->getLibPad().getWidth(), pad->getLibPad().getHeight());
       Length restring = (*size - *pad->getLibPad().getDrillDiameter() + 1) / 2;
       if (restring < *mOptions.minPthRestring) {
-        QString msg = QString(tr("Min. pad restring ('%1'): %2",
-                                 "Placeholders are pad name + restring width"))
+        QString msg = tr("Min. pad restring ('%1'): %2",
+                         "Placeholders are pad name + restring width")
                           .arg(pad->getDisplayText().simplified(),
                                formatLength(restring));
         PositiveLength diameter =
@@ -434,8 +432,8 @@ void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
   foreach (const BI_NetSegment* netsegment, mBoard.getNetSegments()) {
     foreach (const BI_Via* via, netsegment->getVias()) {
       if (via->getDrillDiameter() < mOptions.minPthDrillDiameter) {
-        QString msg = QString(tr("Min. via drill diameter ('%1'): %2",
-                                 "Placeholders are net name + drill diameter"))
+        QString msg = tr("Min. via drill diameter ('%1'): %2",
+                         "Placeholders are net name + drill diameter")
                           .arg(*netsegment->getNetSignal().getName(),
                                formatLength(*via->getDrillDiameter()));
         Path location = Path::circle(via->getDrillDiameter())
@@ -455,8 +453,8 @@ void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
       }
       if (pad->getLibPad().getDrillDiameter() < *mOptions.minPthDrillDiameter) {
         QString msg =
-            QString(tr("Min. pad drill diameter ('%1'): %2",
-                       "Placeholders are pad name + drill diameter"))
+            tr("Min. pad drill diameter ('%1'): %2",
+               "Placeholders are pad name + drill diameter")
                 .arg(pad->getDisplayText().simplified(),
                      formatLength(*pad->getLibPad().getDrillDiameter()));
         PositiveLength diameter(

--- a/libs/librepcb/project/boards/items/bi_device.cpp
+++ b/libs/librepcb/project/boards/items/bi_device.cpp
@@ -126,8 +126,8 @@ void BI_Device::initDeviceAndPackageAndFootprint(const Uuid& deviceUuid,
   if (!mLibDevice) {
     qDebug() << mCompInstance->getUuid();
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("No device with the UUID \"%1\" found in the "
-                                  "project's library."))
+                       tr("No device with the UUID \"%1\" found in the "
+                          "project's library.")
                            .arg(deviceUuid.toStr()));
   }
   // check if the device matches with the component
@@ -146,8 +146,8 @@ void BI_Device::initDeviceAndPackageAndFootprint(const Uuid& deviceUuid,
   if (!mLibPackage) {
     qDebug() << mCompInstance->getUuid();
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("No package with the UUID \"%1\" found in "
-                                  "the project's library."))
+                       tr("No package with the UUID \"%1\" found in "
+                          "the project's library.")
                            .arg(packageUuid.toStr()));
   }
   // get footprint from package

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -68,12 +68,12 @@ void BI_NetPoint::init() {
   mGraphicsItem->setPos(mPosition.toPxQPointF());
 
   // create ERC messages
-  mErcMsgDeadNetPoint.reset(
-      new ErcMsg(mBoard.getProject(), *this, mUuid.toStr(), "Dead",
-                 ErcMsg::ErcMsgType_t::BoardError,
-                 QString(tr("Dead net point in board \"%1\": %2"))
-                     .arg(*mBoard.getName())
-                     .arg(mUuid.toStr())));
+  mErcMsgDeadNetPoint.reset(new ErcMsg(mBoard.getProject(), *this,
+                                       mUuid.toStr(), "Dead",
+                                       ErcMsg::ErcMsgType_t::BoardError,
+                                       tr("Dead net point in board \"%1\": %2")
+                                           .arg(*mBoard.getName())
+                                           .arg(mUuid.toStr())));
 }
 
 BI_NetPoint::~BI_NetPoint() noexcept {
@@ -116,8 +116,7 @@ void BI_NetPoint::addToBoard() {
     throw LogicError(__FILE__, __LINE__,
                      "NetPoint is currently already added to the board.");
   } else if (isUsed()) {
-    throw LogicError(__FILE__, __LINE__,
-                     "NetPoint is currently in use.");
+    throw LogicError(__FILE__, __LINE__, "NetPoint is currently in use.");
   }
   mHighlightChangedConnection =
       connect(&getNetSignalOfNetSegment(), &NetSignal::highlightedChanged,
@@ -132,8 +131,7 @@ void BI_NetPoint::removeFromBoard() {
     throw LogicError(__FILE__, __LINE__,
                      "NetPoint is currently not added to the board.");
   } else if (isUsed()) {
-    throw LogicError(__FILE__, __LINE__,
-                     "NetPoint is currently in use.");
+    throw LogicError(__FILE__, __LINE__, "NetPoint is currently in use.");
   }
   disconnect(mHighlightChangedConnection);
   mErcMsgDeadNetPoint->setVisible(false);

--- a/libs/librepcb/project/boards/items/bi_plane.cpp
+++ b/libs/librepcb/project/boards/items/bi_plane.cpp
@@ -81,9 +81,9 @@ BI_Plane::BI_Plane(Board& board, const SExpression& node)
   mNetSignal =
       mBoard.getProject().getCircuit().getNetSignalByUuid(netSignalUuid);
   if (!mNetSignal) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Invalid net signal UUID: \"%1\""))
-                           .arg(netSignalUuid.toStr()));
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        tr("Invalid net signal UUID: \"%1\"").arg(netSignalUuid.toStr()));
   }
   mOutline = Path(node);
   init();

--- a/libs/librepcb/project/circuit/circuit.cpp
+++ b/libs/librepcb/project/circuit/circuit.cpp
@@ -160,10 +160,9 @@ void Circuit::addNetClass(NetClass& netclass) {
   }
   // check if there is no netclass with the same name in the list
   if (getNetClassByName(netclass.getName())) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There is already a net class with the name \"%1\"!"))
-            .arg(*netclass.getName()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("There is already a net class with the name \"%1\"!")
+                           .arg(*netclass.getName()));
   }
   // add netclass to circuit
   netclass.addToCircuit();  // can throw
@@ -191,8 +190,7 @@ void Circuit::setNetClassName(NetClass& netclass, const ElementName& newName) {
   if (getNetClassByName(newName)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a net class with the name \"%1\"!"))
-            .arg(*newName));
+        tr("There is already a net class with the name \"%1\"!").arg(*newName));
   }
   // apply the new name
   netclass.setName(newName);  // can throw
@@ -248,10 +246,9 @@ void Circuit::addNetSignal(NetSignal& netsignal) {
   }
   // check if there is no netsignal with the same name in the list
   if (getNetSignalByName(*netsignal.getName())) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There is already a net signal with the name \"%1\"!"))
-            .arg(*netsignal.getName()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("There is already a net signal with the name \"%1\"!")
+                           .arg(*netsignal.getName()));
   }
   // add netsignal to circuit
   netsignal.addToCircuit();  // can throw
@@ -279,10 +276,9 @@ void Circuit::setNetSignalName(NetSignal&               netsignal,
   }
   // check if there is no netsignal with the same name in the list
   if (getNetSignalByName(*newName)) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There is already a net signal with the name \"%1\"!"))
-            .arg(*newName));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("There is already a net signal with the name \"%1\"!")
+                           .arg(*newName));
   }
   // apply the new name
   netsignal.setName(newName, isAutoName);  // can throw
@@ -335,10 +331,9 @@ void Circuit::addComponentInstance(ComponentInstance& cmp) {
   }
   // check if there is no component with the same name in the list
   if (getComponentInstanceByName(*cmp.getName())) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There is already a component with the name \"%1\"!"))
-            .arg(*cmp.getName()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("There is already a component with the name \"%1\"!")
+                           .arg(*cmp.getName()));
   }
   // add to circuit
   cmp.addToCircuit();  // can throw
@@ -367,8 +362,7 @@ void Circuit::setComponentInstanceName(ComponentInstance&       cmp,
   if ((newName != cmp.getName()) && getComponentInstanceByName(*newName)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("There is already a component with the name \"%1\"!"))
-            .arg(*newName));
+        tr("There is already a component with the name \"%1\"!").arg(*newName));
   }
   // apply the new name
   cmp.setName(newName);  // can throw

--- a/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.cpp
+++ b/libs/librepcb/project/circuit/cmd/cmdcomponentinstanceadd.cpp
@@ -77,8 +77,8 @@ bool CmdComponentInstanceAdd::performExecute() {
     if (!cmp) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The component with the UUID \"%1\" does not exist in the "
-                     "project's library!"))
+          tr("The component with the UUID \"%1\" does not exist in the "
+             "project's library!")
               .arg(mComponentUuid.toStr()));
     }
     const QStringList& normOrder =

--- a/libs/librepcb/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/project/circuit/componentinstance.cpp
@@ -64,8 +64,8 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node)
   if (!mLibComponent) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("The component with the UUID \"%1\" does not exist in the "
-                   "project's library!"))
+        tr("The component with the UUID \"%1\" does not exist in the "
+           "project's library!")
             .arg(cmpUuid.toStr()));
   }
   Uuid symbVarUuid = node.getValueByPath<Uuid>("lib_variant");
@@ -274,8 +274,8 @@ void ComponentInstance::removeFromCircuit() {
   }
   if (isUsed()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The component \"%1\" cannot be removed "
-                                  "because it is still in use!"))
+                       tr("The component \"%1\" cannot be removed "
+                          "because it is still in use!")
                            .arg(*mName));
   }
   ScopeGuardList sgl(mSignals.count());
@@ -412,11 +412,11 @@ void ComponentInstance::updateErcMessages() noexcept {
   int required = getUnplacedRequiredSymbolsCount();
   int optional = getUnplacedOptionalSymbolsCount();
   mErcMsgUnplacedRequiredSymbols->setMsg(
-      QString(tr("Unplaced required symbols of component \"%1\": %2"))
+      tr("Unplaced required symbols of component \"%1\": %2")
           .arg(*mName)
           .arg(required));
   mErcMsgUnplacedOptionalSymbols->setMsg(
-      QString(tr("Unplaced optional symbols of component \"%1\": %2"))
+      tr("Unplaced optional symbols of component \"%1\": %2")
           .arg(*mName)
           .arg(optional));
   mErcMsgUnplacedRequiredSymbols->setVisible((mIsAddedToCircuit) &&

--- a/libs/librepcb/project/circuit/componentsignalinstance.cpp
+++ b/libs/librepcb/project/circuit/componentsignalinstance.cpp
@@ -173,8 +173,8 @@ void ComponentSignalInstance::setNetSignal(NetSignal* netsignal) {
   if (arePinsOrPadsUsed()) {
     throw LogicError(
         __FILE__, __LINE__,
-        QString(tr("The net signal of the component signal \"%1:%2\" cannot be "
-                   "changed because it is still in use!"))
+        tr("The net signal of the component signal \"%1:%2\" cannot be "
+           "changed because it is still in use!")
             .arg(*mComponentInstance.getName(), *mComponentSignal->getName()));
   }
   ScopeGuardList sgl;
@@ -226,8 +226,8 @@ void ComponentSignalInstance::removeFromCircuit() {
   }
   if (isUsed()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The component \"%1\" cannot be removed "
-                                  "because it is still in use!"))
+                       tr("The component \"%1\" cannot be removed "
+                          "because it is still in use!")
                            .arg(*mComponentInstance.getName()));
   }
   if (mNetSignal) {
@@ -298,11 +298,11 @@ void ComponentSignalInstance::netSignalNameChanged(
 
 void ComponentSignalInstance::updateErcMessages() noexcept {
   mErcMsgUnconnectedRequiredSignal->setMsg(
-      QString(tr("Unconnected component signal: \"%1\" from \"%2\""))
+      tr("Unconnected component signal: \"%1\" from \"%2\"")
           .arg(*mComponentSignal->getName())
           .arg(*mComponentInstance.getName()));
   mErcMsgForcedNetSignalNameConflict->setMsg(
-      QString(tr("Signal name conflict: \"%1\" != \"%2\" (\"%3\" from \"%4\")"))
+      tr("Signal name conflict: \"%1\" != \"%2\" (\"%3\" from \"%4\")")
           .arg((mNetSignal ? *mNetSignal->getName() : QString()),
                getForcedNetSignalName(), *mComponentSignal->getName(),
                *mComponentInstance.getName()));

--- a/libs/librepcb/project/circuit/componentsignalinstance.h
+++ b/libs/librepcb/project/circuit/componentsignalinstance.h
@@ -82,12 +82,12 @@ public:
   const library::ComponentSignal& getCompSignal() const noexcept {
     return *mComponentSignal;
   }
-  NetSignal* getNetSignal() const noexcept { return mNetSignal; }
+  NetSignal*         getNetSignal() const noexcept { return mNetSignal; }
   ComponentInstance& getComponentInstance() const noexcept {
     return mComponentInstance;
   }
-  bool       isNetSignalNameForced() const noexcept;
-  QString    getForcedNetSignalName() const noexcept;
+  bool                        isNetSignalNameForced() const noexcept;
+  QString                     getForcedNetSignalName() const noexcept;
   const QList<SI_SymbolPin*>& getRegisteredSymbolPins() const noexcept {
     return mRegisteredSymbolPins;
   }

--- a/libs/librepcb/project/circuit/netclass.cpp
+++ b/libs/librepcb/project/circuit/netclass.cpp
@@ -91,8 +91,8 @@ void NetClass::removeFromCircuit() {
   }
   if (isUsed()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The net class \"%1\" cannot be removed "
-                                  "because it is still in use!"))
+                       tr("The net class \"%1\" cannot be removed "
+                          "because it is still in use!")
                            .arg(*mName));
   }
   mIsAddedToCircuit = false;
@@ -134,8 +134,7 @@ void NetClass::updateErcMessages() noexcept {
           new ErcMsg(mCircuit.getProject(), *this, mUuid.toStr(), "Unused",
                      ErcMsg::ErcMsgType_t::CircuitWarning));
     }
-    mErcMsgUnusedNetClass->setMsg(
-        QString(tr("Unused net class: \"%1\"")).arg(*mName));
+    mErcMsgUnusedNetClass->setMsg(tr("Unused net class: \"%1\"").arg(*mName));
     mErcMsgUnusedNetClass->setVisible(true);
   } else if (mErcMsgUnusedNetClass) {
     mErcMsgUnusedNetClass.reset();

--- a/libs/librepcb/project/circuit/netsignal.cpp
+++ b/libs/librepcb/project/circuit/netsignal.cpp
@@ -31,8 +31,8 @@
 #include "componentsignalinstance.h"
 #include "netclass.h"
 
-#include <librepcb/library/cmp/component.h>
 #include <librepcb/common/exceptions.h>
+#include <librepcb/library/cmp/component.h>
 
 #include <QtCore>
 
@@ -151,8 +151,8 @@ void NetSignal::removeFromCircuit() {
   }
   if (isUsed()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The net signal \"%1\" cannot be removed "
-                                  "because it is still in use!"))
+                       tr("The net signal \"%1\" cannot be removed "
+                          "because it is still in use!")
                            .arg(*mName));
   }
   mNetClass->unregisterNetSignal(*this);  // can throw
@@ -258,8 +258,7 @@ void NetSignal::updateErcMessages() noexcept {
           new ErcMsg(mCircuit.getProject(), *this, mUuid.toStr(), "Unused",
                      ErcMsg::ErcMsgType_t::CircuitError, QString()));
     }
-    mErcMsgUnusedNetSignal->setMsg(
-        QString(tr("Unused net signal: \"%1\"")).arg(*mName));
+    mErcMsgUnusedNetSignal->setMsg(tr("Unused net signal: \"%1\"").arg(*mName));
     mErcMsgUnusedNetSignal->setVisible(true);
   } else if (mErcMsgUnusedNetSignal) {
     mErcMsgUnusedNetSignal.reset();
@@ -282,8 +281,7 @@ void NetSignal::updateErcMessages() noexcept {
           "ConnectedToLessThanTwoPins", ErcMsg::ErcMsgType_t::CircuitWarning));
     }
     mErcMsgConnectedToLessThanTwoPins->setMsg(
-        QString(tr("Net signal connected to less than two pins: \"%1\""))
-            .arg(*mName));
+        tr("Net signal connected to less than two pins: \"%1\"").arg(*mName));
     mErcMsgConnectedToLessThanTwoPins->setVisible(true);
   } else if (mErcMsgConnectedToLessThanTwoPins) {
     mErcMsgConnectedToLessThanTwoPins.reset();

--- a/libs/librepcb/project/project.cpp
+++ b/libs/librepcb/project/project.cpp
@@ -87,9 +87,9 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
               .arg(getPath().toNative()));
     }
     if (!mDirectory->fileExists(mFilename)) {
-      throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("The file \"%1\" does not exist."))
-                             .arg(getFilepath().toNative()));
+      throw RuntimeError(
+          __FILE__, __LINE__,
+          tr("The file \"%1\" does not exist.").arg(getFilepath().toNative()));
     }
     // check the project's file format version
     Version version =
@@ -267,15 +267,14 @@ Schematic* Project::createSchematic(const ElementName& name) {
   QString dirname = FilePath::cleanFileName(
       *name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
   if (dirname.isEmpty()) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("Invalid schematic name: \"%1\"")).arg(*name));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Invalid schematic name: \"%1\"").arg(*name));
   }
   std::unique_ptr<TransactionalDirectory> dir(
       new TransactionalDirectory(*mDirectory, "schematics/" % dirname));
   if (dir->fileExists("schematic.lp")) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The schematic exists already: \"%1\""))
+                       tr("The schematic exists already: \"%1\"")
                            .arg(dir->getAbsPath().toNative()));
   }
   return Schematic::create(*this, std::move(dir), name);
@@ -292,10 +291,9 @@ void Project::addSchematic(Schematic& schematic, int newIndex) {
             .arg(schematic.getUuid().toStr()));
   }
   if (getSchematicByName(*schematic.getName())) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There is already a schematic with the name \"%1\"!"))
-            .arg(*schematic.getName()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("There is already a schematic with the name \"%1\"!")
+                           .arg(*schematic.getName()));
   }
 
   if ((newIndex < 0) || (newIndex > mSchematics.count())) {
@@ -319,10 +317,9 @@ void Project::removeSchematic(Schematic& schematic, bool deleteSchematic) {
     throw LogicError(__FILE__, __LINE__);
   }
   if ((!deleteSchematic) && (!schematic.isEmpty())) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There are still elements in the schematic \"%1\"!"))
-            .arg(*schematic.getName()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("There are still elements in the schematic \"%1\"!")
+                           .arg(*schematic.getName()));
   }
 
   int index = getSchematicIndex(schematic);
@@ -370,8 +367,7 @@ void Project::printSchematicPages(QPrinter& printer, QList<int>& pages) {
     if (!schematic) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("No schematic page with the index %1 found."))
-              .arg(pages[i]));
+          tr("No schematic page with the index %1 found.").arg(pages[i]));
     }
     schematic->clearSelection();
     schematic->renderToQPainter(painter);
@@ -412,13 +408,13 @@ Board* Project::createBoard(const ElementName& name) {
       *name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
   if (dirname.isEmpty()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Invalid board name: \"%1\"")).arg(*name));
+                       tr("Invalid board name: \"%1\"").arg(*name));
   }
   std::unique_ptr<TransactionalDirectory> dir(
       new TransactionalDirectory(*mDirectory, "boards/" % dirname));
   if (dir->fileExists("board.lp")) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The board exists already: \"%1\""))
+                       tr("The board exists already: \"%1\"")
                            .arg(dir->getAbsPath().toNative()));
   }
   return Board::create(*this, std::move(dir), name);
@@ -429,13 +425,13 @@ Board* Project::createBoard(const Board& other, const ElementName& name) {
       *name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
   if (dirname.isEmpty()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Invalid board name: \"%1\"")).arg(*name));
+                       tr("Invalid board name: \"%1\"").arg(*name));
   }
   std::unique_ptr<TransactionalDirectory> dir(
       new TransactionalDirectory(*mDirectory, "boards/" % dirname));
   if (dir->fileExists("board.lp")) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The board exists already: \"%1\""))
+                       tr("The board exists already: \"%1\"")
                            .arg(dir->getAbsPath().toNative()));
   }
   return new Board(other, std::move(dir), name);
@@ -451,10 +447,9 @@ void Project::addBoard(Board& board, int newIndex) {
                            .arg(board.getUuid().toStr()));
   }
   if (getBoardByName(*board.getName())) {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("There is already a board with the name \"%1\"!"))
-            .arg(*board.getName()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("There is already a board with the name \"%1\"!")
+                           .arg(*board.getName()));
   }
 
   if ((newIndex < 0) || (newIndex > mBoards.count())) {

--- a/libs/librepcb/project/schematics/items/si_netpoint.cpp
+++ b/libs/librepcb/project/schematics/items/si_netpoint.cpp
@@ -63,7 +63,7 @@ void SI_NetPoint::init() {
   mErcMsgDeadNetPoint.reset(
       new ErcMsg(mSchematic.getProject(), *this, mUuid.toStr(), "Dead",
                  ErcMsg::ErcMsgType_t::SchematicError,
-                 QString(tr("Dead net point in schematic page \"%1\": %2"))
+                 tr("Dead net point in schematic page \"%1\": %2")
                      .arg(*mSchematic.getName())
                      .arg(mUuid.toStr())));
 }

--- a/libs/librepcb/project/schematics/items/si_symbol.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbol.cpp
@@ -91,8 +91,8 @@ void SI_Symbol::init(const Uuid& symbVarItemUuid) {
       mSymbVarItem->getSymbolUuid());
   if (!mSymbol) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("No symbol with the UUID \"%1\" found in the "
-                                  "project's library."))
+                       tr("No symbol with the UUID \"%1\" found in the "
+                          "project's library.")
                            .arg(mSymbVarItem->getSymbolUuid().toStr()));
   }
 

--- a/libs/librepcb/project/schematics/items/si_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.cpp
@@ -232,7 +232,7 @@ void SI_SymbolPin::setSelected(bool selected) noexcept {
 
 void SI_SymbolPin::updateErcMessages() noexcept {
   mErcMsgUnconnectedRequiredPin->setMsg(
-      QString(tr("Unconnected pin: \"%1\" of symbol \"%2\""))
+      tr("Unconnected pin: \"%1\" of symbol \"%2\"")
           .arg(getDisplayText(true, true))
           .arg(mSymbol.getName()));
 

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckmessagesdock.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckmessagesdock.cpp
@@ -69,8 +69,7 @@ void BoardDesignRuleCheckMessagesDock::setMessages(
   }
   mUi->listWidget->blockSignals(signalsBlocked);
 
-  setWindowTitle(
-      QString(tr("DRC [%1]", "Number of messages")).arg(mMessages.count()));
+  setWindowTitle(tr("DRC [%1]", "Number of messages").arg(mMessages.count()));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -462,7 +462,8 @@ void BoardEditor::on_actionRemoveBoard_triggered() {
 
   QMessageBox::StandardButton btn = QMessageBox::question(
       this, tr("Remove board"),
-      tr("Are you really sure to remove the board \"%1\"?").arg(*board->getName()));
+      tr("Are you really sure to remove the board \"%1\"?")
+          .arg(*board->getName()));
   if (btn != QMessageBox::Yes) return;
 
   try {
@@ -549,15 +550,14 @@ void BoardEditor::on_actionExportAsPdf_triggered() {
       board->print(printer);  // can throw
     }
 
-
     // Open PDF
     {
       namespace ws = ::librepcb::workspace;
       const ws::WorkspaceSettings& workspaceSettings =
           mProjectEditor.getWorkspace().getSettings();
 
-      ws::WorkspaceSettings::PdfOpenBehavior bhv
-          = workspaceSettings.pdfOpenBehavior.get();
+      ws::WorkspaceSettings::PdfOpenBehavior bhv =
+          workspaceSettings.pdfOpenBehavior.get();
 
       if (bhv == ws::WorkspaceSettings::PdfOpenBehavior::NEVER) {
         // do nothing
@@ -568,12 +568,10 @@ void BoardEditor::on_actionExportAsPdf_triggered() {
         bool doOpenPdf = true;
         if (bhv == ws::WorkspaceSettings::PdfOpenBehavior::ASK) {
           int openPdf = QMessageBox::information(
-                          this, tr("PDF Export"),
-                          tr("PDF exported successfully"),
-                          QMessageBox::Ok | QMessageBox::Open);
+              this, tr("PDF Export"), tr("PDF exported successfully"),
+              QMessageBox::Ok | QMessageBox::Open);
 
-          if (openPdf == QMessageBox::Ok)
-            doOpenPdf = false;
+          if (openPdf == QMessageBox::Ok) doOpenPdf = false;
         } else if (bhv != ws::WorkspaceSettings::PdfOpenBehavior::ALWAYS) {
           // this is the last possible state, otherwise there is an error
           throw LogicError(__FILE__, __LINE__);
@@ -584,8 +582,8 @@ void BoardEditor::on_actionExportAsPdf_triggered() {
             QString pdfCmd = workspaceSettings.pdfReaderCommand.get();
             // TODO: make it smarter to detect or insert quotes for path
             //        containing spaces
-            QProcess::startDetached(pdfCmd.replace(
-                                      "{{FILEPATH}}", filepath.toNative()));
+            QProcess::startDetached(
+                pdfCmd.replace("{{FILEPATH}}", filepath.toNative()));
           } else {
             QDesktopServices::openUrl(QUrl::fromLocalFile(filepath.toNative()));
           }
@@ -853,10 +851,10 @@ QList<BI_Device*> BoardEditor::getSearchCandidates() noexcept {
   if (Board* board = getActiveBoard()) {
     candidates += board->getDeviceInstances().values();
     std::sort(candidates.begin(), candidates.end(),
-              [](BI_Device* a, BI_Device* b){
-      return a->getComponentInstance().getName()
-          < b->getComponentInstance().getName();
-    });
+              [](BI_Device* a, BI_Device* b) {
+                return a->getComponentInstance().getName() <
+                       b->getComponentInstance().getName();
+              });
   }
   return candidates;
 }
@@ -872,8 +870,8 @@ QStringList BoardEditor::getSearchToolBarCompleterList() noexcept {
 void BoardEditor::goToDevice(const QString& name, unsigned int index) noexcept {
   QList<BI_Device*> deviceCandidates = {};
   foreach (BI_Device* device, getSearchCandidates()) {
-    if (device->getComponentInstance().getName()
-        ->startsWith(name, Qt::CaseInsensitive)) {
+    if (device->getComponentInstance().getName()->startsWith(
+            name, Qt::CaseInsensitive)) {
       deviceCandidates.append(device);
     }
   }
@@ -881,14 +879,14 @@ void BoardEditor::goToDevice(const QString& name, unsigned int index) noexcept {
   if (deviceCandidates.count()) {
     index %= deviceCandidates.count();
     BI_Device* device = deviceCandidates[index];
-    Board* board = getActiveBoard();
+    Board*     board  = getActiveBoard();
     Q_ASSERT(board);
     board->clearSelection();
     device->setSelected(true);
     QRectF rect = device->getFootprint().getBoundingRect();
     // Zoom to a rectangle relative to the maximum device dimension. The
     // device is 1/4th of the screen.
-    qreal margin = 1.5f*std::max(rect.size().width(), rect.size().height());
+    qreal margin = 1.5f * std::max(rect.size().width(), rect.size().height());
     rect.adjust(-margin, -margin, margin, margin);
     mGraphicsView->zoomToRect(rect);
   }

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -126,15 +126,15 @@ private:
   BoardEditor& operator=(const BoardEditor& rhs) = delete;
 
   // Private Methods
-  bool        graphicsViewEventHandler(QEvent* event);
-  void        toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
-  void        unplacedComponentsCountChanged(int count) noexcept;
-  void        highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,
-                                  bool                               zoomTo) noexcept;
-  void        clearDrcMarker() noexcept;
+  bool graphicsViewEventHandler(QEvent* event);
+  void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void unplacedComponentsCountChanged(int count) noexcept;
+  void highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,
+                           bool                               zoomTo) noexcept;
+  void clearDrcMarker() noexcept;
   QList<BI_Device*> getSearchCandidates() noexcept;
-  QStringList getSearchToolBarCompleterList() noexcept;
-  void        goToDevice(const QString& name, unsigned int index) noexcept;
+  QStringList       getSearchToolBarCompleterList() noexcept;
+  void goToDevice(const QString& name, unsigned int index) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/deviceinstancepropertiesdialog.cpp
@@ -66,8 +66,8 @@ DeviceInstancePropertiesDialog::DeviceInstancePropertiesDialog(
   mUi->edtRotation->setSingleStep(90.0);  // [°]
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &DeviceInstancePropertiesDialog::buttonBoxClicked);
-  setWindowTitle(QString(tr("Properties of %1"))
-                     .arg(*mDevice.getComponentInstance().getName()));
+  setWindowTitle(
+      tr("Properties of %1").arg(*mDevice.getComponentInstance().getName()));
 
   // Component Instance Attributes
   ComponentInstance& cmp = mDevice.getComponentInstance();
@@ -158,7 +158,7 @@ void DeviceInstancePropertiesDialog::accept() noexcept {
 bool DeviceInstancePropertiesDialog::applyChanges() noexcept {
   try {
     UndoStackTransaction transaction(
-        mUndoStack, QString(tr("Change properties of %1"))
+        mUndoStack, tr("Change properties of %1")
                         .arg(*mDevice.getComponentInstance().getName()));
 
     // Component Instance

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_adddevice.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_adddevice.cpp
@@ -113,9 +113,8 @@ bool BES_AddDevice::entry(BEE_Base* event) noexcept {
     startAddingDevice(e->getComponentInstance(), e->getDeviceUuid(),
                       e->getFootprintUuid());
   } catch (Exception& exc) {
-    QMessageBox::critical(
-        &mEditor, tr("Error"),
-        QString(tr("Could not add device:\n\n%1")).arg(exc.getMsg()));
+    QMessageBox::critical(&mEditor, tr("Error"),
+                          tr("Could not add device:\n\n%1").arg(exc.getMsg()));
     if (mIsUndoCmdActive) abortCommand(false);
     return false;
   }

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_addvia.h
@@ -76,27 +76,30 @@ private:
 
   // Private Methods
   ProcRetVal processSceneEvent(BEE_Base* event) noexcept;
-  bool addVia(Board& board) noexcept;
-  bool updateVia(Board& board, const Point& pos) noexcept;
-  bool fixVia(Board& board, const Point& pos) noexcept;
-  void updateShapeActionsCheckedState() noexcept;
-  void sizeEditValueChanged(const PositiveLength& value) noexcept;
+  bool       addVia(Board& board) noexcept;
+  bool       updateVia(Board& board, const Point& pos) noexcept;
+  bool       fixVia(Board& board, const Point& pos) noexcept;
+  void       updateShapeActionsCheckedState() noexcept;
+  void       sizeEditValueChanged(const PositiveLength& value) noexcept;
   void drillDiameterEditValueChanged(const PositiveLength& value) noexcept;
   void setNetSignal(NetSignal* netsignal) noexcept;
-  NetSignal* getClosestNetSignal(Board& board, const Point& pos) noexcept;
+  NetSignal*       getClosestNetSignal(Board& board, const Point& pos) noexcept;
   QSet<NetSignal*> getNetSignalsAtScenePos(Board& board, const Point& pos,
-                                    QSet<BI_Base*> except = {}) const noexcept;
+                                           QSet<BI_Base*> except = {}) const
+      noexcept;
   BI_Via* findVia(Board& board, const Point pos, NetSignal* netsignal = nullptr,
                   const QSet<BI_Via*>& except = {}) const noexcept;
   BI_FootprintPad* findPad(Board& board, const Point pos,
-                  NetSignal* netsignal = nullptr,
-                  const QSet<BI_FootprintPad*>& except = {}) const noexcept;
+                           NetSignal*                    netsignal = nullptr,
+                           const QSet<BI_FootprintPad*>& except    = {}) const
+      noexcept;
   BI_NetPoint* findNetPoint(Board& board, const Point pos,
-                  NetSignal* netsignal = nullptr,
-                  const QSet<BI_NetPoint*>& except = {}) const noexcept;
+                            NetSignal*                netsignal = nullptr,
+                            const QSet<BI_NetPoint*>& except    = {}) const
+      noexcept;
   BI_NetLine* findNetLine(Board& board, const Point pos,
-                  NetSignal* netsignal = nullptr) const noexcept;
-  void abortPlacement(const bool showErrorMessage = false) noexcept;
+                          NetSignal* netsignal = nullptr) const noexcept;
+  void        abortPlacement(const bool showErrorMessage = false) noexcept;
 
   // General Attributes
   SubState                        mSubState;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_drawtrace.h
@@ -95,31 +95,31 @@ private:
   };
 
   // Private Methods
-  ProcRetVal       processSubStateIdle(BEE_Base* event) noexcept;
-  ProcRetVal       processSubStatePositioning(BEE_Base* event) noexcept;
-  ProcRetVal       processIdleSceneEvent(BEE_Base* event) noexcept;
-  ProcRetVal       processPositioningSceneEvent(BEE_Base* event) noexcept;
+  ProcRetVal processSubStateIdle(BEE_Base* event) noexcept;
+  ProcRetVal processSubStatePositioning(BEE_Base* event) noexcept;
+  ProcRetVal processIdleSceneEvent(BEE_Base* event) noexcept;
+  ProcRetVal processPositioningSceneEvent(BEE_Base* event) noexcept;
 
   /**
-  * @brief Begin drawing the next BI_NetLine
-  *
-  * @param board On which board the new traces are drawn.
-  * @param pos The position, where the tracing should begin. If necessary a new
-  * BI_NetPoint is created.
-  * @param fixedPoint the BI_NetPoint used as the start anchor, when beginning a
-  * new trace
-  * @return True, when the tracing is successfully started.
-  */
+   * @brief Begin drawing the next BI_NetLine
+   *
+   * @param board On which board the new traces are drawn.
+   * @param pos The position, where the tracing should begin. If necessary a new
+   * BI_NetPoint is created.
+   * @param fixedPoint the BI_NetPoint used as the start anchor, when beginning
+   * a new trace
+   * @return True, when the tracing is successfully started.
+   */
   bool startPositioning(Board& board, const Point& pos,
-                                    BI_NetPoint* fixedPoint = nullptr) noexcept;
+                        BI_NetPoint* fixedPoint = nullptr) noexcept;
 
   /**
    * @brief Finalize the BI_NetLines and connect them to other
    * existing traces if necessary.
    * @param board On which board the drawing is finalized.
    * @return True, when the trace is succesfully drawn. When the trace is
-   * continued, return the result of startPositioning(). False when canceled or an
-   * error occured
+   * continued, return the result of startPositioning(). False when canceled or
+   * an error occured
    */
   bool addNextNetPoint(Board& board) noexcept;
 
@@ -140,8 +140,8 @@ private:
    * @return A single BI_Via, if any. at the target position.
    */
   BI_Via* findVia(Board& board, const Point& pos,
-                  NetSignal* netsignal = nullptr,
-                  const QSet<BI_Via*>& except = {}) const noexcept;
+                  NetSignal*           netsignal = nullptr,
+                  const QSet<BI_Via*>& except    = {}) const noexcept;
 
   /**
    * @brief Find a BI_FootprintPad at the given position on the board.
@@ -154,8 +154,8 @@ private:
    * @return A single BI_FootprintPad, if any. at the target position.
    */
   BI_FootprintPad* findPad(Board& board, const Point& pos,
-                           GraphicsLayer* layer = nullptr,
-                           NetSignal* netsignal = nullptr) const noexcept;
+                           GraphicsLayer* layer     = nullptr,
+                           NetSignal*     netsignal = nullptr) const noexcept;
 
   /**
    * @brief Find a BI_NetPoint at the given position on the board.
@@ -170,10 +170,10 @@ private:
    * @return A single BI_NetPoint, if any. at the target position.
    */
   BI_NetPoint* findNetPoint(Board& board, const Point& pos,
-                            GraphicsLayer* layer = nullptr,
-                            NetSignal* netsignal = nullptr,
-                            const QSet<BI_NetPoint*>& except = {})
-                                    const noexcept;
+                            GraphicsLayer*            layer     = nullptr,
+                            NetSignal*                netsignal = nullptr,
+                            const QSet<BI_NetPoint*>& except    = {}) const
+      noexcept;
 
   /**
    * @brief Find a BI_NetLine at the given position on the board.
@@ -188,8 +188,8 @@ private:
    * @return A single BI_NetLine, if any. at the target position.
    */
   BI_NetLine* findNetLine(Board& board, const Point& pos,
-                          GraphicsLayer* layer = nullptr,
-                          NetSignal* netsignal = nullptr,
+                          GraphicsLayer*           layer     = nullptr,
+                          NetSignal*               netsignal = nullptr,
                           const QSet<BI_NetLine*>& except = {}) const noexcept;
   /**
    * @brief Update the currently active traces according
@@ -240,34 +240,34 @@ private:
       noexcept;
 
   // General Attributes
-  SubState          mSubState;          ///< the current substate
-  WireMode          mCurrentWireMode;   ///< the current wire mode
-  QString           mCurrentLayerName;  ///< the current board layer name
-  bool              mAddVia;            ///< whether a via add is requested
-  BI_Via*           mTempVia;
-  BI_Via::Shape     mCurrentViaShape;   ///< the current via shape
-  PositiveLength    mCurrentViaSize;    ///< the current via size
-  PositiveLength    mCurrentViaDrillDiameter; ///< the current via drill
-                                        ///< diameter
-  QString           mViaLayerName;      ///< the name of the layer where the via
-                                        ///< was started
-  Point             mTargetPos;         ///< the current target position of the
-                                        ///< active trace
+  SubState       mSubState;          ///< the current substate
+  WireMode       mCurrentWireMode;   ///< the current wire mode
+  QString        mCurrentLayerName;  ///< the current board layer name
+  bool           mAddVia;            ///< whether a via add is requested
+  BI_Via*        mTempVia;
+  BI_Via::Shape  mCurrentViaShape;          ///< the current via shape
+  PositiveLength mCurrentViaSize;           ///< the current via size
+  PositiveLength mCurrentViaDrillDiameter;  ///< the current via drill
+                                            ///< diameter
+  QString mViaLayerName;  ///< the name of the layer where the via
+                          ///< was started
+  Point mTargetPos;       ///< the current target position of the
+                          ///< active trace
 
-  Point             mCursorPos;         ///< the current cursor position
-  PositiveLength    mCurrentWidth;      ///< the current wire width
-  bool              mCurrentAutoWidth;  ///< automatically adjust wire width
-  bool              mCurrentSnapActive; ///< the current active snap to target
-  BI_NetLineAnchor* mFixedStartAnchor;  ///< the fixed netline anchor (start
-                                        ///< point of the line)
-  BI_NetSegment* mCurrentNetSegment;    ///< the net segment that is currently
-                                        ///< edited
-  NetSignal*   mCurrentNetSignal;       ///< the net signal that is currently
-                                        ///< edited
-  BI_NetLine*  mPositioningNetLine1;    ///< line between fixed point and p1
-  BI_NetPoint* mPositioningNetPoint1;   ///< the first netpoint to place
-  BI_NetLine*  mPositioningNetLine2;    ///< line between p1 and p2
-  BI_NetPoint* mPositioningNetPoint2;   ///< the second netpoint to place
+  Point             mCursorPos;          ///< the current cursor position
+  PositiveLength    mCurrentWidth;       ///< the current wire width
+  bool              mCurrentAutoWidth;   ///< automatically adjust wire width
+  bool              mCurrentSnapActive;  ///< the current active snap to target
+  BI_NetLineAnchor* mFixedStartAnchor;   ///< the fixed netline anchor (start
+                                         ///< point of the line)
+  BI_NetSegment* mCurrentNetSegment;     ///< the net segment that is currently
+                                         ///< edited
+  NetSignal* mCurrentNetSignal;          ///< the net signal that is currently
+                                         ///< edited
+  BI_NetLine*  mPositioningNetLine1;     ///< line between fixed point and p1
+  BI_NetPoint* mPositioningNetPoint1;    ///< the first netpoint to place
+  BI_NetLine*  mPositioningNetLine2;     ///< line between p1 and p2
+  BI_NetPoint* mPositioningNetPoint2;    ///< the second netpoint to place
 
   // Widgets for the command toolbar
   QHash<WireMode, QAction*> mWireModeActions;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.cpp
@@ -296,9 +296,9 @@ BES_Base::ProcRetVal BES_Select::processIdleSceneRightMouseButtonReleased(
       addActionDelete(menu, tr("Remove %1").arg(*cmpInst.getName()));
       menu.addSeparator();
       addActionSnap(menu, devInst.getPosition(), board, *selectedItem);
-      QAction* aResetTexts =
-        menu.addAction(QIcon(":/img/actions/undo.png"), tr("Reset all texts"));
-      connect(aResetTexts, &QAction::triggered, [this, footprint](){
+      QAction* aResetTexts = menu.addAction(QIcon(":/img/actions/undo.png"),
+                                            tr("Reset all texts"));
+      connect(aResetTexts, &QAction::triggered, [this, footprint]() {
         try {
           mUndoStack.execCmd(new CmdFootprintStrokeTextsReset(*footprint));
         } catch (Exception& e) {
@@ -317,7 +317,7 @@ BES_Base::ProcRetVal BES_Select::processIdleSceneRightMouseButtonReleased(
           a->setChecked(true);
           a->setEnabled(false);
         } else {
-          connect(a, &QAction::triggered, [this, &board, &devInst, item](){
+          connect(a, &QAction::triggered, [this, &board, &devInst, item]() {
             try {
               CmdReplaceDevice* cmd = new CmdReplaceDevice(
                   mWorkspace, board, devInst, item.uuid, tl::optional<Uuid>());
@@ -344,16 +344,18 @@ BES_Base::ProcRetVal BES_Select::processIdleSceneRightMouseButtonReleased(
           a->setChecked(true);
           a->setEnabled(false);
         } else {
-          connect(a, &QAction::triggered, [this, &board, &devInst, &footprint](){
-            try {
-              Uuid deviceUuid = devInst.getLibDevice().getUuid();
-              CmdReplaceDevice* cmd = new CmdReplaceDevice(
-                  mWorkspace, board, devInst, deviceUuid, footprint.getUuid());
-              mUndoStack.execCmd(cmd);
-            } catch (Exception& e) {
-              QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
-            }
-          });
+          connect(a, &QAction::triggered,
+                  [this, &board, &devInst, &footprint]() {
+                    try {
+                      Uuid deviceUuid = devInst.getLibDevice().getUuid();
+                      CmdReplaceDevice* cmd =
+                          new CmdReplaceDevice(mWorkspace, board, devInst,
+                                               deviceUuid, footprint.getUuid());
+                      mUndoStack.execCmd(cmd);
+                    } catch (Exception& e) {
+                      QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
+                    }
+                  });
         }
       }
       aChangeFootprintMenu->setEnabled(!aChangeFootprintMenu->isEmpty());
@@ -416,7 +418,7 @@ BES_Base::ProcRetVal BES_Select::processIdleSceneRightMouseButtonReleased(
       QAction* aIsVisible = menu.addAction(tr("Visible"));
       aIsVisible->setCheckable(true);
       aIsVisible->setChecked(plane->isVisible());
-      connect(aIsVisible, &QAction::triggered, [plane, aIsVisible](){
+      connect(aIsVisible, &QAction::triggered, [plane, aIsVisible]() {
         // Visibility is not saved, thus no undo command is needed here.
         plane->setVisible(aIsVisible->isChecked());
       });
@@ -576,30 +578,28 @@ BES_Base::ProcRetVal BES_Select::processSubStateMovingSceneEvent(
 }
 
 void BES_Select::addActionRotate(QMenu& menu, const QString& text) noexcept {
-  QAction* action = menu.addAction(QIcon(":/img/actions/rotate_left.png"), text);
-  connect(action, &QAction::triggered, [this](){
-    rotateSelectedItems(Angle::deg90());
-  });
+  QAction* action =
+      menu.addAction(QIcon(":/img/actions/rotate_left.png"), text);
+  connect(action, &QAction::triggered,
+          [this]() { rotateSelectedItems(Angle::deg90()); });
 }
 
 void BES_Select::addActionFlip(QMenu& menu, const QString& text) noexcept {
-  QAction* action =  menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), text);
-  connect(action, &QAction::triggered, [this](){
-    flipSelectedItems(Qt::Horizontal);
-  });
+  QAction* action =
+      menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), text);
+  connect(action, &QAction::triggered,
+          [this]() { flipSelectedItems(Qt::Horizontal); });
 }
 
 void BES_Select::addActionDelete(QMenu& menu, const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/delete.png"), text);
-  connect(action, &QAction::triggered, [this]() {
-    removeSelectedItems();
-  });
+  connect(action, &QAction::triggered, [this]() { removeSelectedItems(); });
 }
 
 void BES_Select::addActionDeleteAll(QMenu& menu, BI_NetSegment& netsegment,
                                     const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/minus.png"), text);
-  connect(action, &QAction::triggered, [this, &netsegment](){
+  connect(action, &QAction::triggered, [this, &netsegment]() {
     netsegment.setSelected(true);
     removeSelectedItems();
   });
@@ -608,7 +608,7 @@ void BES_Select::addActionDeleteAll(QMenu& menu, BI_NetSegment& netsegment,
 void BES_Select::addActionMeasure(QMenu& menu, BI_NetLine& netline,
                                   const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/ruler.png"), text);
-  connect(action, &QAction::triggered, [this, &netline](){
+  connect(action, &QAction::triggered, [this, &netline]() {
     netline.setSelected(true);
     measureSelectedItems(netline);
   });
@@ -617,21 +617,22 @@ void BES_Select::addActionMeasure(QMenu& menu, BI_NetLine& netline,
 void BES_Select::addActionProperties(QMenu& menu, Board& board, BI_Base& item,
                                      const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/settings.png"), text);
-  connect(action, &QAction::triggered, [this, &board, &item](){
-    openPropertiesDialog(board, &item);
-  });
+  connect(action, &QAction::triggered,
+          [this, &board, &item]() { openPropertiesDialog(board, &item); });
 }
 
 void BES_Select::addActionSnap(QMenu& menu, const Point pos, Board& board,
                                BI_Base& item, const QString& text) noexcept {
   if (!pos.isOnGrid(board.getGridProperties().getInterval())) {
     QAction* action = menu.addAction(QIcon(":/img/actions/grid.png"), text);
-    connect(action, &QAction::triggered, [this, &board, &item](){
-      try  {
+    connect(action, &QAction::triggered, [this, &board, &item]() {
+      try {
         QScopedPointer<CmdDragSelectedBoardItems> cmdMove(
-              new CmdDragSelectedBoardItems(board, item.getPosition()));
-        cmdMove->setCurrentPosition(item.getPosition().mappedToGrid(
-                                board.getGridProperties().getInterval()), false);
+            new CmdDragSelectedBoardItems(board, item.getPosition()));
+        cmdMove->setCurrentPosition(
+            item.getPosition().mappedToGrid(
+                board.getGridProperties().getInterval()),
+            false);
         mUndoStack.execCmd(cmdMove.take());
       } catch (Exception& e) {
         QMessageBox::critical(&mEditor, tr("Error"), e.getMsg());
@@ -643,9 +644,8 @@ void BES_Select::addActionSnap(QMenu& menu, const Point pos, Board& board,
 void BES_Select::addActionSelectAll(QMenu& menu, BI_NetSegment& netsegment,
                                     const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/bookmark.png"), text);
-  connect(action, &QAction::triggered, [&netsegment](){
-    netsegment.setSelected(true);
-  });
+  connect(action, &QAction::triggered,
+          [&netsegment]() { netsegment.setSelected(true); });
 }
 
 bool BES_Select::startMovingSelectedItems(Board&       board,
@@ -793,7 +793,7 @@ void BES_Select::measureLengthInDirection(bool              directionBackwards,
   }
 }
 
-bool BES_Select::openPropertiesDialog(Board &board, BI_Base *item) {
+bool BES_Select::openPropertiesDialog(Board& board, BI_Base* item) {
   switch (item->getType()) {
     case BI_Base::Type_t::Footprint: {
       BI_Footprint* footprint = dynamic_cast<BI_Footprint*>(item);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/bes_select.h
@@ -88,19 +88,24 @@ private:
                                          Board* board) noexcept;
 
   // Menu Helpers
-  void addActionRotate(QMenu& menu, const QString& text = tr("Rotate")) noexcept;
+  void addActionRotate(QMenu&         menu,
+                       const QString& text = tr("Rotate")) noexcept;
   void addActionFlip(QMenu& menu, const QString& text = tr("Flip")) noexcept;
-  void addActionDelete(QMenu& menu,const QString& text = tr("Remove")) noexcept;
-  void addActionDeleteAll(QMenu& menu, BI_NetSegment& netsegment,
-                const QString& text = tr("Remove Whole Trace")) noexcept;
-  void addActionMeasure(QMenu& menu, BI_NetLine& netline,
-                const QString& text = tr("Measure Selected Segments Length")) noexcept;
+  void addActionDelete(QMenu&         menu,
+                       const QString& text = tr("Remove")) noexcept;
+  void addActionDeleteAll(
+      QMenu& menu, BI_NetSegment& netsegment,
+      const QString& text = tr("Remove Whole Trace")) noexcept;
+  void addActionMeasure(
+      QMenu& menu, BI_NetLine& netline,
+      const QString& text = tr("Measure Selected Segments Length")) noexcept;
   void addActionProperties(QMenu& menu, Board& board, BI_Base& item,
-                const QString& text = tr("Properties")) noexcept;
+                           const QString& text = tr("Properties")) noexcept;
   void addActionSnap(QMenu& menu, const Point pos, Board& board, BI_Base& item,
-                const QString& text = tr("Snap To Grid")) noexcept;
-  void addActionSelectAll(QMenu& menu, BI_NetSegment& netsegment,
-                const QString& text = tr("Select Whole Trace")) noexcept;
+                     const QString& text = tr("Snap To Grid")) noexcept;
+  void addActionSelectAll(
+      QMenu& menu, BI_NetSegment& netsegment,
+      const QString& text = tr("Select Whole Trace")) noexcept;
 
   bool startMovingSelectedItems(Board& board, const Point& startPos) noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
@@ -155,7 +160,7 @@ private:
   // Attributes
   SubState mSubState;  ///< the current substate
   QScopedPointer<CmdDragSelectedBoardItems> mSelectedItemsDragCommand;
-  int mCurrentSelectionIndex;
+  int                                       mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.cpp
@@ -318,8 +318,8 @@ void UnplacedComponentsDock::updateComponentsList() noexcept {
     }
   }
 
-  setWindowTitle(QString(tr("Place Devices [%1]"))
-                     .arg(mUi->lstUnplacedComponents->count()));
+  setWindowTitle(
+      tr("Place Devices [%1]").arg(mUi->lstUnplacedComponents->count()));
   emit unplacedComponentsCountChanged(getUnplacedComponentsCount());
 }
 

--- a/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdaddcomponenttocircuit.cpp
@@ -82,8 +82,8 @@ bool CmdAddComponentToCircuit::performExecute() {
     if (!cmpFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The component with the UUID \"%1\" does not exist in the "
-                     "workspace library!"))
+          tr("The component with the UUID \"%1\" does not exist in the "
+             "workspace library!")
               .arg(mComponentUuid.toStr()));
     }
     library::Component* cmp = new library::Component(

--- a/libs/librepcb/projecteditor/cmd/cmdadddevicetoboard.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdadddevicetoboard.cpp
@@ -87,8 +87,8 @@ bool CmdAddDeviceToBoard::performExecute() {
     if (!devFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The device with the UUID \"%1\" does not exist in the "
-                     "workspace library!"))
+          tr("The device with the UUID \"%1\" does not exist in the "
+             "workspace library!")
               .arg(mDeviceUuid.toStr()));
     }
     dev = new library::Device(std::unique_ptr<TransactionalDirectory>(
@@ -109,8 +109,8 @@ bool CmdAddDeviceToBoard::performExecute() {
     if (!pkgFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The package with the UUID \"%1\" does not exist in the "
-                     "workspace library!"))
+          tr("The package with the UUID \"%1\" does not exist in the "
+             "workspace library!")
               .arg(pkgUuid.toStr()));
     }
     pkg = new library::Package(std::unique_ptr<TransactionalDirectory>(
@@ -128,7 +128,7 @@ bool CmdAddDeviceToBoard::performExecute() {
   }
   if (!mFootprintUuid) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("Package does not have any footprints: %1"))
+                       tr("Package does not have any footprints: %1")
                            .arg(pkg->getUuid().toStr()));
   }
 

--- a/libs/librepcb/projecteditor/cmd/cmdaddsymboltoschematic.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdaddsymboltoschematic.cpp
@@ -87,8 +87,8 @@ bool CmdAddSymbolToSchematic::performExecute() {
     if (!symFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,
-          QString(tr("The symbol with the UUID \"%1\" does not exist in the "
-                     "workspace library!"))
+          tr("The symbol with the UUID \"%1\" does not exist in the "
+             "workspace library!")
               .arg(symbolUuid.toStr()));
     }
     library::Symbol* sym = new library::Symbol(

--- a/libs/librepcb/projecteditor/cmd/cmdboardsplitnetline.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdboardsplitnetline.cpp
@@ -38,9 +38,9 @@ namespace librepcb {
 namespace project {
 namespace editor {
 
-CmdBoardSplitNetLine::CmdBoardSplitNetLine(BI_NetLine& netline, const Point& pos)
-  noexcept : UndoCommandGroup(tr("Split trace")),
-  mOldNetLine(netline) {
+CmdBoardSplitNetLine::CmdBoardSplitNetLine(BI_NetLine&  netline,
+                                           const Point& pos) noexcept
+  : UndoCommandGroup(tr("Split trace")), mOldNetLine(netline) {
   mSplitPoint = new BI_NetPoint(mOldNetLine.getNetSegment(), pos);
 }
 
@@ -52,15 +52,15 @@ CmdBoardSplitNetLine::~CmdBoardSplitNetLine() noexcept {
  ******************************************************************************/
 
 bool CmdBoardSplitNetLine::performExecute() {
-  QScopedPointer<CmdBoardNetSegmentAddElements>
-      cmdAdd(new CmdBoardNetSegmentAddElements(mOldNetLine.getNetSegment()));
+  QScopedPointer<CmdBoardNetSegmentAddElements> cmdAdd(
+      new CmdBoardNetSegmentAddElements(mOldNetLine.getNetSegment()));
   cmdAdd->addNetPoint(*mSplitPoint);
   cmdAdd->addNetLine(*mSplitPoint, mOldNetLine.getStartPoint(),
                      mOldNetLine.getLayer(), mOldNetLine.getWidth());
   cmdAdd->addNetLine(*mSplitPoint, mOldNetLine.getEndPoint(),
                      mOldNetLine.getLayer(), mOldNetLine.getWidth());
   QScopedPointer<CmdBoardNetSegmentRemoveElements> cmdRemove(
-        new CmdBoardNetSegmentRemoveElements(mOldNetLine.getNetSegment()));
+      new CmdBoardNetSegmentRemoveElements(mOldNetLine.getNetSegment()));
   cmdRemove->removeNetLine(mOldNetLine);
   appendChild(cmdAdd.take());
   appendChild(cmdRemove.take());

--- a/libs/librepcb/projecteditor/cmd/cmdboardsplitnetline.h
+++ b/libs/librepcb/projecteditor/cmd/cmdboardsplitnetline.h
@@ -61,14 +61,13 @@ public:
 
   BI_NetPoint* getSplitPoint() noexcept { return mSplitPoint; };
 
-private: // Methods
-
+private:  // Methods
   /// @copydoc UndoCommand::performExecute()
   bool performExecute() override;
 
   // Private Member Variables
-  BI_NetLine& mOldNetLine;  ///< The BI_NetLine to be split
-  BI_NetPoint* mSplitPoint; ///< The new BI_NetPoint at the split position
+  BI_NetLine&  mOldNetLine;  ///< The BI_NetLine to be split
+  BI_NetPoint* mSplitPoint;  ///< The new BI_NetPoint at the split position
 };
 
 /*******************************************************************************
@@ -79,4 +78,4 @@ private: // Methods
 }  // namespace project
 }  // namespace librepcb
 
-#endif // LIBREPCB_PROJECT_CMDSPLITNETLINE_H
+#endif  // LIBREPCB_PROJECT_CMDSPLITNETLINE_H

--- a/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.cpp
@@ -149,8 +149,8 @@ CmdDragSelectedBoardItems::~CmdDragSelectedBoardItems() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void CmdDragSelectedBoardItems::setCurrentPosition(const Point& pos,
-                                            const bool gridIncrement) noexcept {
+void CmdDragSelectedBoardItems::setCurrentPosition(
+    const Point& pos, const bool gridIncrement) noexcept {
   Point delta = pos - mStartPos;
   if (gridIncrement) {
     delta.mapToGrid(mBoard.getGridProperties().getInterval());

--- a/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.h
+++ b/libs/librepcb/projecteditor/cmd/cmddragselectedboarditems.h
@@ -62,8 +62,8 @@ public:
   ~CmdDragSelectedBoardItems() noexcept;
 
   // General Methods
-  void setCurrentPosition(const Point& pos, const bool gridIncrement = true)
-    noexcept;
+  void setCurrentPosition(const Point& pos,
+                          const bool   gridIncrement = true) noexcept;
   void rotate(const Angle& angle, bool aroundItemsCenter = false) noexcept;
 
 private:

--- a/libs/librepcb/projecteditor/cmd/cmdreplacedevice.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdreplacedevice.cpp
@@ -27,13 +27,13 @@
 
 #include <librepcb/common/scopeguard.h>
 #include <librepcb/project/boards/board.h>
-#include <librepcb/project/boards/cmd/cmddeviceinstanceremove.h>
 #include <librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h>
+#include <librepcb/project/boards/cmd/cmddeviceinstanceremove.h>
 #include <librepcb/project/boards/items/bi_device.h>
 #include <librepcb/project/boards/items/bi_footprint.h>
 #include <librepcb/project/boards/items/bi_footprintpad.h>
-#include <librepcb/project/boards/items/bi_netsegment.h>
 #include <librepcb/project/boards/items/bi_netpoint.h>
+#include <librepcb/project/boards/items/bi_netsegment.h>
 
 #include <QtCore>
 
@@ -76,9 +76,9 @@ bool CmdReplaceDevice::performExecute() {
     BI_NetSegment* netsegment = pad->getNetSegmentOfLines();
     if (netsegment) {
       QScopedPointer<CmdBoardNetSegmentAddElements> cmdAdd(
-            new CmdBoardNetSegmentAddElements(*netsegment));
-      QMap<GraphicsLayer*, BI_NetPoint*> newNetPoints = {};
-      QSet<BI_NetLine*> connectedNetLines = pad->getNetLines();
+          new CmdBoardNetSegmentAddElements(*netsegment));
+      QMap<GraphicsLayer*, BI_NetPoint*> newNetPoints      = {};
+      QSet<BI_NetLine*>                  connectedNetLines = pad->getNetLines();
       if (connectedNetLines.count() > 1) {
         foreach (BI_NetLine* netline, connectedNetLines) {
           auto it = newNetPoints.find(&netline->getLayer());
@@ -92,9 +92,9 @@ bool CmdReplaceDevice::performExecute() {
       }
       execNewChildCmd(cmdAdd.take());
       QScopedPointer<CmdRemoveBoardItems> cmdRemove(
-            new CmdRemoveBoardItems(netsegment->getBoard()));
+          new CmdRemoveBoardItems(netsegment->getBoard()));
       cmdRemove->removeNetLines(pad->getNetLines());
-      execNewChildCmd(cmdRemove.take()); // can throw
+      execNewChildCmd(cmdRemove.take());  // can throw
     }
   }
 

--- a/libs/librepcb/projecteditor/docks/ercmsgdock.cpp
+++ b/libs/librepcb/projecteditor/docks/ercmsgdock.cpp
@@ -214,31 +214,28 @@ void ErcMsgDock::updateTopLevelItemTexts() noexcept {
   int              countOfNonIgnoredErcMessages = 0;
   QTreeWidgetItem* item;
   item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::CircuitError)];
-  item->setText(0, QString(tr("Circuit Errors (%1)")).arg(item->childCount()));
+  item->setText(0, tr("Circuit Errors (%1)").arg(item->childCount()));
   countOfNonIgnoredErcMessages += item->childCount();
   item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::CircuitWarning)];
-  item->setText(0,
-                QString(tr("Circuit Warnings (%1)")).arg(item->childCount()));
+  item->setText(0, tr("Circuit Warnings (%1)").arg(item->childCount()));
   countOfNonIgnoredErcMessages += item->childCount();
   item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::SchematicError)];
-  item->setText(0,
-                QString(tr("Schematic Errors (%1)")).arg(item->childCount()));
+  item->setText(0, tr("Schematic Errors (%1)").arg(item->childCount()));
   countOfNonIgnoredErcMessages += item->childCount();
   item =
       mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::SchematicWarning)];
-  item->setText(0,
-                QString(tr("Schematic Warnings (%1)")).arg(item->childCount()));
+  item->setText(0, tr("Schematic Warnings (%1)").arg(item->childCount()));
   countOfNonIgnoredErcMessages += item->childCount();
   item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardError)];
-  item->setText(0, QString(tr("Board Errors (%1)")).arg(item->childCount()));
+  item->setText(0, tr("Board Errors (%1)").arg(item->childCount()));
   countOfNonIgnoredErcMessages += item->childCount();
   item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardWarning)];
-  item->setText(0, QString(tr("Board Warnings (%1)")).arg(item->childCount()));
+  item->setText(0, tr("Board Warnings (%1)").arg(item->childCount()));
   countOfNonIgnoredErcMessages += item->childCount();
   item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::_Count)];
-  item->setText(0, QString(tr("Approved (%1)")).arg(item->childCount()));
+  item->setText(0, tr("Approved (%1)").arg(item->childCount()));
 
-  setWindowTitle(QString(tr("ERC [%1]")).arg(countOfNonIgnoredErcMessages));
+  setWindowTitle(tr("ERC [%1]").arg(countOfNonIgnoredErcMessages));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -371,8 +371,8 @@ void SchematicEditorState_AddComponent::startAddingComponent(
             .get();
     if (!currentSymbVarItem) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("The component with the UUID \"%1\" does "
-                                    "not have any symbol."))
+                         tr("The component with the UUID \"%1\" does "
+                            "not have any symbol.")
                              .arg(mCurrentComponent->getUuid().toStr()));
     }
     Point pos = mContext.editorGraphicsView.mapGlobalPosToScenePos(

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
@@ -254,8 +254,8 @@ bool SchematicEditorState_DrawWire::startPositioning(
         } catch (const Exception& e) {
           QMessageBox::warning(
               parentWidget(), tr("Invalid net name"),
-              QString(tr("Could not apply the forced net name because '%1' is "
-                         "not a valid net name."))
+              tr("Could not apply the forced net name because '%1' is "
+                 "not a valid net name.")
                   .arg(name));
         }
       }

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -218,11 +218,11 @@ bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       // Toggle selection when CTRL is pressed
       items.first()->setSelected(!itemAlreadySelected);
     } else if (mouseEvent.modifiers() & Qt::ShiftModifier) {
-        // Cycle Selection, when holding shift
-        mCurrentSelectionIndex += 1;
-        mCurrentSelectionIndex %= items.count();
-        schematic->clearSelection();
-        items[mCurrentSelectionIndex]->setSelected(true);
+      // Cycle Selection, when holding shift
+      mCurrentSelectionIndex += 1;
+      mCurrentSelectionIndex %= items.count();
+      schematic->clearSelection();
+      items[mCurrentSelectionIndex]->setSelected(true);
     } else if (!itemAlreadySelected) {
       // Only select the topmost item when clicking an unselected item
       // without CTRL
@@ -543,9 +543,9 @@ void SchematicEditorState_Select::openNetLabelPropertiesDialog(
 }
 
 QAction* SchematicEditorState_Select::addActionCut(
-    QMenu &menu, const QString &text) noexcept {
+    QMenu& menu, const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/cut.png"), text);
-  connect(action, &QAction::triggered, [this](){
+  connect(action, &QAction::triggered, [this]() {
     copySelectedItemsToClipboard();
     removeSelectedItems();
   });
@@ -553,47 +553,42 @@ QAction* SchematicEditorState_Select::addActionCut(
 }
 
 QAction* SchematicEditorState_Select::addActionCopy(
-    QMenu &menu, const QString &text) noexcept {
+    QMenu& menu, const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/copy.png"), text);
-  connect(action, &QAction::triggered, [this](){
-    copySelectedItemsToClipboard();
-  });
+  connect(action, &QAction::triggered,
+          [this]() { copySelectedItemsToClipboard(); });
   return action;
 }
 
 QAction* SchematicEditorState_Select::addActionRemove(
-    QMenu &menu, const QString &text) noexcept {
+    QMenu& menu, const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/delete.png"), text);
-  connect(action, &QAction::triggered, [this](){
-    removeSelectedItems();
-  });
+  connect(action, &QAction::triggered, [this]() { removeSelectedItems(); });
   return action;
 }
 
 QAction* SchematicEditorState_Select::addActionMirror(
-    QMenu &menu, const QString &text) noexcept {
-  QAction* action = menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), text);
-  connect(action, &QAction::triggered, [this](){
-    mirrorSelectedItems();
-  });
+    QMenu& menu, const QString& text) noexcept {
+  QAction* action =
+      menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), text);
+  connect(action, &QAction::triggered, [this]() { mirrorSelectedItems(); });
   return action;
 }
 
 QAction* SchematicEditorState_Select::addActionRotate(
-    QMenu &menu, const QString &text) noexcept {
-  QAction* action = menu.addAction(QIcon(":/img/actions/rotate_left.png"), text);
-  connect(action, &QAction::triggered, [this](){
-    rotateSelectedItems(Angle::deg90());
-  });
+    QMenu& menu, const QString& text) noexcept {
+  QAction* action =
+      menu.addAction(QIcon(":/img/actions/rotate_left.png"), text);
+  connect(action, &QAction::triggered,
+          [this]() { rotateSelectedItems(Angle::deg90()); });
   return action;
 }
 
 QAction* SchematicEditorState_Select::addActionOpenProperties(
-    QMenu &menu, SI_Base* item, const QString &text) noexcept {
+    QMenu& menu, SI_Base* item, const QString& text) noexcept {
   QAction* action = menu.addAction(QIcon(":/img/actions/settings.png"), text);
-  connect(action, &QAction::triggered, [this, item](){
-    openPropertiesDialog(item);
-  });
+  connect(action, &QAction::triggered,
+          [this, item]() { openPropertiesDialog(item); });
   return action;
 }
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
@@ -91,11 +91,11 @@ public:
   virtual bool processSwitchToSchematicPage(int index) noexcept override;
 
   // Operator Overloadings
-  SchematicEditorState_Select& operator =(
+  SchematicEditorState_Select& operator       =(
       const SchematicEditorState_Select& rhs) = delete;
 
 private:  // Methods
-  bool startMovingSelectedItems(Schematic& schematic,
+  bool startMovingSelectedItems(Schematic&   schematic,
                                 const Point& startPos) noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems() noexcept;
@@ -106,14 +106,19 @@ private:  // Methods
   void openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept;
   void openNetLabelPropertiesDialog(SI_NetLabel& netlabel) noexcept;
 
-  //Right Click Menu
+  // Right Click Menu
   QAction* addActionCut(QMenu& menu, const QString& text = tr("Cut")) noexcept;
-  QAction* addActionCopy(QMenu& menu, const QString& text = tr("Copy")) noexcept;
-  QAction* addActionRemove(QMenu& menu, const QString& text = tr("Remove")) noexcept;
-  QAction* addActionMirror(QMenu& menu, const QString& text = tr("Mirror")) noexcept;
-  QAction* addActionRotate(QMenu& menu, const QString& text = tr("Rotate")) noexcept;
-  QAction* addActionOpenProperties(QMenu& menu, SI_Base* item,
-                                   const QString& text = tr("Properties")) noexcept;
+  QAction* addActionCopy(QMenu&         menu,
+                         const QString& text = tr("Copy")) noexcept;
+  QAction* addActionRemove(QMenu&         menu,
+                           const QString& text = tr("Remove")) noexcept;
+  QAction* addActionMirror(QMenu&         menu,
+                           const QString& text = tr("Mirror")) noexcept;
+  QAction* addActionRotate(QMenu&         menu,
+                           const QString& text = tr("Rotate")) noexcept;
+  QAction* addActionOpenProperties(
+      QMenu& menu, SI_Base* item,
+      const QString& text = tr("Properties")) noexcept;
 
 private:  // Data
   /// enum for all possible substates
@@ -127,7 +132,7 @@ private:  // Data
   SubState mSubState;  ///< the current substate
   Point    mStartPos;
   QScopedPointer<CmdMoveSelectedSchematicItems> mSelectedItemsMoveCommand;
-  int mCurrentSelectionIndex;
+  int                                           mCurrentSelectionIndex;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/renamenetsegmentdialog.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/renamenetsegmentdialog.cpp
@@ -178,20 +178,20 @@ void RenameNetSegmentDialog::updateAction() noexcept {
       desc    = tr("No change is made.");
     } else if (renameWholeNet && (mNewNetSignal)) {
       mAction = Action::MERGE_NETSIGNALS;
-      desc = QString(tr("The whole net '%1' will be merged into the net '%2'."))
+      desc    = tr("The whole net '%1' will be merged into the net '%2'.")
                  .arg(*mNetSegment.getNetSignal().getName(), mNewNetName);
     } else if (renameWholeNet && (!mNewNetSignal)) {
       mAction = Action::RENAME_NETSIGNAL;
-      desc    = QString(tr("The whole net '%1' will be renamed to '%2'."))
+      desc    = tr("The whole net '%1' will be renamed to '%2'.")
                  .arg(*mNetSegment.getNetSignal().getName(), mNewNetName);
     } else if ((!renameWholeNet) && (mNewNetSignal)) {
       mAction = Action::MOVE_NETSEGMENT_TO_EXISTING_NET;
-      desc = QString(tr("The segment will be moved to the existing net '%1'."))
+      desc    = tr("The segment will be moved to the existing net '%1'.")
                  .arg(mNewNetName);
     } else if ((!renameWholeNet) && (!mNewNetSignal)) {
       mAction = Action::MOVE_NETSEGMENT_TO_NEW_NET;
-      desc    = QString(tr("The segment will be moved to the new net '%1'."))
-                 .arg(mNewNetName);
+      desc =
+          tr("The segment will be moved to the new net '%1'.").arg(mNewNetName);
     } else {
       mAction = Action::INVALID_NAME;  // Not correct, but sufficient
       desc    = "UNKNOWN ERROR";

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -702,10 +702,9 @@ QList<SI_Symbol*> SchematicEditor::getSearchCandidates() noexcept {
     Q_ASSERT(schematic);
     candidates += schematic->getSymbols();
   }
-  std::sort(candidates.begin(), candidates.end(),
-            [](SI_Symbol* a, SI_Symbol* b){
-    return a->getName() < b->getName();
-  });
+  std::sort(
+      candidates.begin(), candidates.end(),
+      [](SI_Symbol* a, SI_Symbol* b) { return a->getName() < b->getName(); });
   return candidates;
 }
 
@@ -718,7 +717,7 @@ QStringList SchematicEditor::getSearchToolBarCompleterList() noexcept {
 }
 
 void SchematicEditor::goToSymbol(const QString& name,
-                                 unsigned int index) noexcept {
+                                 unsigned int   index) noexcept {
   QList<SI_Symbol*> symbolCandidates = {};
   foreach (SI_Symbol* symbol, getSearchCandidates()) {
     if (symbol->getName().startsWith(name, Qt::CaseInsensitive)) {
@@ -728,7 +727,7 @@ void SchematicEditor::goToSymbol(const QString& name,
 
   if (symbolCandidates.count()) {
     index %= symbolCandidates.count();
-    SI_Symbol* symbol = symbolCandidates[index];
+    SI_Symbol* symbol    = symbolCandidates[index];
     Schematic& schematic = symbol->getSchematic();
     if (setActiveSchematicIndex(mProject.getSchematics().indexOf(&schematic))) {
       schematic.clearSelection();
@@ -736,7 +735,7 @@ void SchematicEditor::goToSymbol(const QString& name,
       QRectF rect = symbol->getBoundingRect();
       // Zoom to a rectangle relative to the maximum symbol dimension. The
       // symbol is 1/4th of the screen.
-      qreal margin = 1.5f*std::max(rect.size().width(), rect.size().height());
+      qreal margin = 1.5f * std::max(rect.size().width(), rect.size().height());
       rect.adjust(-margin, -margin, margin, margin);
       mGraphicsView->zoomToRect(rect);
     }

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -114,14 +114,14 @@ private:
   SchematicEditor& operator=(const SchematicEditor& rhs);
 
   // Private Methods
-  bool        graphicsViewEventHandler(QEvent* event);
-  void        toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
-  void        addSchematic() noexcept;
-  void        removeSchematic(int index) noexcept;
-  void        renameSchematic(int index) noexcept;
+  bool graphicsViewEventHandler(QEvent* event);
+  void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void addSchematic() noexcept;
+  void removeSchematic(int index) noexcept;
+  void renameSchematic(int index) noexcept;
   QList<SI_Symbol*> getSearchCandidates() noexcept;
-  QStringList getSearchToolBarCompleterList() noexcept;
-  void        goToSymbol(const QString& name, unsigned int index) noexcept;
+  QStringList       getSearchToolBarCompleterList() noexcept;
+  void goToSymbol(const QString& name, unsigned int index) noexcept;
 
   // General Attributes
   ProjectEditor&                       mProjectEditor;

--- a/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -74,7 +74,7 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
   mUi->edtSymbInstPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
                                   settingsPrefix % "/pos_y");
   mUi->edtSymbInstRotation->setSingleStep(90.0);  // [°]
-  setWindowTitle(QString(tr("Properties of %1")).arg(mSymbol.getName()));
+  setWindowTitle(tr("Properties of %1").arg(mSymbol.getName()));
 
   // Component Instance Attributes
   mUi->edtCompInstName->setText(*mComponentInstance.getName());
@@ -94,7 +94,7 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
               .toString(),
           *mComponentInstance.getLibComponent().getNames().value(localeOrder)) +
       " (" +
-      QString(tr("symbol variant \"%1\""))
+      tr("symbol variant \"%1\"")
           .arg(*mComponentInstance.getSymbolVariant().getNames().value(
               localeOrder)) +
       ")");
@@ -199,8 +199,7 @@ void SymbolInstancePropertiesDialog::accept() {
 bool SymbolInstancePropertiesDialog::applyChanges() noexcept {
   try {
     UndoStackTransaction transaction(
-        mUndoStack,
-        QString(tr("Change properties of %1")).arg(mSymbol.getName()));
+        mUndoStack, tr("Change properties of %1").arg(mSymbol.getName()));
 
     // Component Instance
     QScopedPointer<CmdComponentInstanceEdit> cmdCmp(

--- a/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
+++ b/libs/librepcb/projecteditor/toolbars/searchtoolbar.h
@@ -75,7 +75,7 @@ private:
 private:
   CompleterListFunction     mCompleterListFunction;
   QScopedPointer<QLineEdit> mLineEdit;
-  unsigned int mIndex; ///< Number of searches with the current search term
+  unsigned int mIndex;  ///< Number of searches with the current search term
 };
 
 /*******************************************************************************

--- a/libs/librepcb/workspace/library/workspacelibrarydb.cpp
+++ b/libs/librepcb/workspace/library/workspacelibrarydb.cpp
@@ -396,10 +396,9 @@ void WorkspaceLibraryDb::getLibraryMetadata(const FilePath libDir,
     QByteArray blob = query.value(0).toByteArray();
     if (icon) icon->loadFromData(blob, "png");
   } else {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("Library not found in workspace library: \"%1\""))
-            .arg(libDir.toNative()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Library not found in workspace library: \"%1\"")
+                           .arg(libDir.toNative()));
   }
 }
 
@@ -418,10 +417,9 @@ void WorkspaceLibraryDb::getDeviceMetadata(const FilePath& devDir,
     uuid = Uuid::fromString(query.value(1).toString());  // can throw
     if (cmpUuid) *cmpUuid = uuid;
   } else {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("Device not found in workspace library: \"%1\""))
-            .arg(devDir.toNative()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Device not found in workspace library: \"%1\"")
+                           .arg(devDir.toNative()));
   }
 }
 
@@ -628,8 +626,8 @@ QList<Uuid> WorkspaceLibraryDb::getCategoryParents(const QString& tablename,
   while ((optCategory = getCategoryParent(tablename, *optCategory))) {
     if (parentUuids.contains(*optCategory)) {
       throw RuntimeError(__FILE__, __LINE__,
-                         QString(tr("Endless loop "
-                                    "in category parentship detected (%1)."))
+                         tr("Endless loop "
+                            "in category parentship detected (%1).")
                              .arg(optCategory->toStr()));
     } else {
       parentUuids.append(*optCategory);
@@ -653,11 +651,10 @@ tl::optional<Uuid> WorkspaceLibraryDb::getCategoryParent(
       return tl::nullopt;
     }
   } else {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("The category "
-                   "\"%1\" does not exist in the library database."))
-            .arg(category.toStr()));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("The category "
+                          "\"%1\" does not exist in the library database.")
+                           .arg(category.toStr()));
   }
 }
 
@@ -737,11 +734,10 @@ int WorkspaceLibraryDb::getLibraryId(const FilePath& lib) const {
     if (!ok) throw LogicError(__FILE__, __LINE__);
     return id;
   } else {
-    throw RuntimeError(
-        __FILE__, __LINE__,
-        QString(tr("The library "
-                   "\"%1\" does not exist in the library database."))
-            .arg(relativeLibraryPath));
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("The library "
+                          "\"%1\" does not exist in the library database.")
+                           .arg(relativeLibraryPath));
   }
 }
 

--- a/libs/librepcb/workspace/settings/workspacesettings.h
+++ b/libs/librepcb/workspace/settings/workspacesettings.h
@@ -65,7 +65,9 @@ public:
   // The underlying type int is needed to map QButtonGroup IDs
   // to values in this enum. See for ex. WorkspaceSettingsDialog::loadSettings()
   enum class PdfOpenBehavior : int {
-    ALWAYS, NEVER, ASK,
+    ALWAYS,
+    NEVER,
+    ASK,
   };
 
   // Constructors / Destructor
@@ -210,7 +212,7 @@ public:
 }  // namespace workspace
 
 // Serialize settings values
-template<>
+template <>
 inline SExpression serializeToSExpression(
     const workspace::WorkspaceSettings::PdfOpenBehavior& b) {
   using namespace workspace;
@@ -226,10 +228,9 @@ inline SExpression serializeToSExpression(
   };
 }
 
-template<>
-inline workspace::WorkspaceSettings::PdfOpenBehavior
-  deserializeFromSExpression(const SExpression& sexpr, bool throwIfEmpty) {
-
+template <>
+inline workspace::WorkspaceSettings::PdfOpenBehavior deserializeFromSExpression(
+    const SExpression& sexpr, bool throwIfEmpty) {
   using namespace workspace;
   QString str = sexpr.getStringOrToken(throwIfEmpty);
   if (str == QLatin1String("always"))

--- a/libs/librepcb/workspace/settings/workspacesettingsdialog.cpp
+++ b/libs/librepcb/workspace/settings/workspacesettingsdialog.cpp
@@ -150,16 +150,16 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(WorkspaceSettings& settings,
     // PDF Reader
     // match IDs with enum values
     mUi->pdfOpenGroup->setId(
-          mUi->pdfOpenAlwaysRadio,
-          static_cast<int>(WorkspaceSettings::PdfOpenBehavior::ALWAYS));
+        mUi->pdfOpenAlwaysRadio,
+        static_cast<int>(WorkspaceSettings::PdfOpenBehavior::ALWAYS));
 
     mUi->pdfOpenGroup->setId(
-          mUi->pdfOpenNeverRadio,
-          static_cast<int>(WorkspaceSettings::PdfOpenBehavior::NEVER));
+        mUi->pdfOpenNeverRadio,
+        static_cast<int>(WorkspaceSettings::PdfOpenBehavior::NEVER));
 
     mUi->pdfOpenGroup->setId(
-          mUi->pdfOpenAskRadio,
-          static_cast<int>(WorkspaceSettings::PdfOpenBehavior::ASK));
+        mUi->pdfOpenAskRadio,
+        static_cast<int>(WorkspaceSettings::PdfOpenBehavior::ASK));
 
     // File picker
     connect(mUi->pdfCustomCmdPickBtn, &QToolButton::clicked, [&]() {
@@ -171,8 +171,8 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(WorkspaceSettings& settings,
       fileDialog.setDirectory(QDir::home());
 
       if (fileDialog.exec()) {
-        mUi->pdfCustomCmdEdit->setText(fileDialog.selectedFiles().first()
-                                       + " \"{{FILEPATH}}\"");
+        mUi->pdfCustomCmdEdit->setText(fileDialog.selectedFiles().first() +
+                                       " \"{{FILEPATH}}\"");
       }
     });
   }
@@ -284,8 +284,8 @@ void WorkspaceSettingsDialog::loadSettings() noexcept {
   mUi->pdfCustomRadioBtn->setChecked(mSettings.useCustomPdfReader.get());
 
   // External PDF reader behaviour
-  mUi->pdfOpenGroup->button(
-        static_cast<int>(mSettings.pdfOpenBehavior.get()))->setChecked(true);
+  mUi->pdfOpenGroup->button(static_cast<int>(mSettings.pdfOpenBehavior.get()))
+      ->setChecked(true);
 }
 
 void WorkspaceSettingsDialog::saveSettings() noexcept {
@@ -327,7 +327,7 @@ void WorkspaceSettingsDialog::saveSettings() noexcept {
 
     // External PDF reader behaviour
     mSettings.pdfOpenBehavior.set(
-          static_cast<WorkspaceSettings::PdfOpenBehavior>(
+        static_cast<WorkspaceSettings::PdfOpenBehavior>(
             mUi->pdfOpenGroup->checkedId()));
 
     mSettings.saveToFile();  // can throw

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -66,7 +66,7 @@ Workspace::Workspace(const FilePath& wsPath)
   if (!isValidWorkspacePath(mPath)) {
     throw RuntimeError(
         __FILE__, __LINE__,
-        QString(tr("Invalid workspace path: \"%1\"")).arg(mPath.toNative()));
+        tr("Invalid workspace path: \"%1\"").arg(mPath.toNative()));
   }
   FilePath    versionFp = mPath.getPathTo(".librepcb-workspace");
   QByteArray  versionRaw(FileUtils::readFile(versionFp));  // can throw
@@ -74,8 +74,8 @@ Workspace::Workspace(const FilePath& wsPath)
       VersionFile::fromByteArray(versionRaw);  // can throw
   if (wsVersionFile.getVersion() != FILE_FORMAT_VERSION()) {
     throw RuntimeError(__FILE__, __LINE__,
-                       QString(tr("The workspace version %1 is not compatible "
-                                  "with this application version."))
+                       tr("The workspace version %1 is not compatible "
+                          "with this application version.")
                            .arg(wsVersionFile.getVersion().toStr()));
   }
 

--- a/tests/unittests/common/alignmenttest.cpp
+++ b/tests/unittests/common/alignmenttest.cpp
@@ -85,7 +85,7 @@ TEST_P(AlignmentTest, testMirrored) {
   const AlignmentTestData& data = GetParam();
 
   if (data.valid) {
-    Alignment alignment = Alignment(data.origHAling, data.origVAling);
+    Alignment alignment         = Alignment(data.origHAling, data.origVAling);
     Alignment alignmentMirrored = alignment.mirrored();
     EXPECT_EQ(alignment, Alignment(data.origHAling, data.origVAling));
     EXPECT_EQ(alignmentMirrored, Alignment(data.mirrHAling, data.mirrVAling));
@@ -96,7 +96,7 @@ TEST_P(AlignmentTest, testMirroredH) {
   const AlignmentTestData& data = GetParam();
 
   if (data.valid) {
-    Alignment alignment = Alignment(data.origHAling, data.origVAling);
+    Alignment alignment          = Alignment(data.origHAling, data.origVAling);
     Alignment alignmentMirroredH = alignment.mirroredH();
     EXPECT_EQ(alignment, Alignment(data.origHAling, data.origVAling));
     EXPECT_EQ(alignmentMirroredH, Alignment(data.mirrHAling, data.origVAling));
@@ -107,7 +107,7 @@ TEST_P(AlignmentTest, testMirroredV) {
   const AlignmentTestData& data = GetParam();
 
   if (data.valid) {
-    Alignment alignment = Alignment(data.origHAling, data.origVAling);
+    Alignment alignment          = Alignment(data.origHAling, data.origVAling);
     Alignment alignmentMirroredV = alignment.mirroredV();
     EXPECT_EQ(alignment, Alignment(data.origHAling, data.origVAling));
     EXPECT_EQ(alignmentMirroredV, Alignment(data.origHAling, data.mirrVAling));


### PR DESCRIPTION
## Make `./dev/format_code.sh` running even without tty

The script did not work when running from a recent QtCreator because it had no tty attached. Now it runs both, with and without tty.

## Remove unnecessary QString() wrappers around tr()

Just to clean up the code.

## Format all source files with `./dev/format_code.sh --all`

To fix all style inconsistencies.