### PR TITLE
Schematic editor: Fix leaving tool with right click + move

### DIFF
--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -295,11 +295,15 @@ bool SchematicEditorState_AddComponent::
 bool SchematicEditorState_AddComponent::
     processGraphicsSceneRightMouseButtonReleased(
         QGraphicsSceneMouseEvent& e) noexcept {
-  if ((mIsUndoCmdActive) &&
-      (e.screenPos() == e.buttonDownScreenPos(Qt::RightButton))) {
-    // rotate symbol
-    mLastAngle += Angle::deg90();
-    mCurrentSymbolEditCommand->setRotation(mLastAngle, true);
+  if (mIsUndoCmdActive && mCurrentSymbolEditCommand) {
+    // Only rotate symbol if cursor was not moved during click
+    if (e.screenPos() == e.buttonDownScreenPos(Qt::RightButton)) {
+      mLastAngle += Angle::deg90();
+      mCurrentSymbolEditCommand->setRotation(mLastAngle, true);
+    }
+
+    // Always accept the event if we are placing a symbol! When ignoring the
+    // event, the state machine will abort the tool by a right click!
     return true;
   }
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
@@ -134,12 +134,14 @@ bool SchematicEditorState_AddNetLabel::
 bool SchematicEditorState_AddNetLabel::
     processGraphicsSceneRightMouseButtonReleased(
         QGraphicsSceneMouseEvent& e) noexcept {
-  Schematic* schematic = getActiveSchematic();
-  if (!schematic) return false;
+  if (mUndoCmdActive && mCurrentNetLabel && mEditCmd) {
+    // Only rotate net label if cursor was not moved during click
+    if (e.screenPos() == e.buttonDownScreenPos(Qt::RightButton)) {
+      mEditCmd->rotate(Angle::deg90(), mCurrentNetLabel->getPosition(), true);
+    }
 
-  if (mCurrentNetLabel && mUndoCmdActive &&
-      (e.screenPos() == e.buttonDownScreenPos(Qt::RightButton))) {
-    mEditCmd->rotate(Angle::deg90(), mCurrentNetLabel->getPosition(), true);
+    // Always accept the event if we are placing a net label! When ignoring the
+    // event, the state machine will abort the tool by a right click!
     return true;
   }
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
@@ -199,14 +199,18 @@ bool SchematicEditorState_DrawWire::
 bool SchematicEditorState_DrawWire::
     processGraphicsSceneRightMouseButtonReleased(
         QGraphicsSceneMouseEvent& e) noexcept {
-  if ((mSubState == SubState::POSITIONING_NETPOINT) &&
-      (e.screenPos() == e.buttonDownScreenPos(Qt::RightButton))) {
-    // switch to next wire mode
-    Point pos = Point::fromPx(e.scenePos()).mappedToGrid(getGridInterval());
-    mWireMode = static_cast<WireMode>(mWireMode + 1);
-    if (mWireMode == WireMode_COUNT) mWireMode = static_cast<WireMode>(0);
-    updateWireModeActionsCheckedState();
-    updateNetpointPositions(pos);
+  if (mSubState == SubState::POSITIONING_NETPOINT) {
+    // Only switch to next wire mode if cursor was not moved during click
+    if (e.screenPos() == e.buttonDownScreenPos(Qt::RightButton)) {
+      Point pos = Point::fromPx(e.scenePos()).mappedToGrid(getGridInterval());
+      mWireMode = static_cast<WireMode>(mWireMode + 1);
+      if (mWireMode == WireMode_COUNT) mWireMode = static_cast<WireMode>(0);
+      updateWireModeActionsCheckedState();
+      updateNetpointPositions(pos);
+    }
+
+    // Always accept the event if we are drawing a wire! When ignoring the
+    // event, the state machine will abort the tool by a right click!
     return true;
   }
 


### PR DESCRIPTION
When pressing the right mouse button while moving the cursor, each schematic editor tool unintentionally exited because the event was not handled by the tool. So the event was handled by the state machine, which switches to the last active tool by the right mouse button click.

Now the event is accepted by the corresponding tools to avoid this issue.

Fixes #343.