### PR TITLE
Remove linking output message in qmake project file

### DIFF
--- a/librepcb.pro
+++ b/librepcb.pro
@@ -12,10 +12,3 @@ apps.depends = libs
 tests.depends = libs
 
 TRANSLATIONS = ./i18n/librepcb.ts
-
-# Print information about current linking configuration
-isEmpty(UNBUNDLE) {
-    message("Link statically")
-} else {
-    message("Link dynamically")
-}


### PR DESCRIPTION
The message() causes the QtCreator (at least sometimes) to switch to a different output pane, which is quite annoying. And in colored console output it might be confusing too since it it the only output on stderr. Thus I'd say let's remove it.

@dbrgn is that fine for you? :slightly_smiling_face: 