### PR TITLE
Library Editor: Duplicate all categories

### DIFF
--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.h
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.h
@@ -129,7 +129,7 @@ public:  // Data
   QString                   mElementKeywords;
   QString                   mElementAuthor;
   tl::optional<Version>     mElementVersion;
-  tl::optional<Uuid>        mElementCategoryUuid;
+  QSet<Uuid>                mElementCategoryUuids;
 
   // symbol
   SymbolPinList mSymbolPins;

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.cpp
@@ -152,16 +152,24 @@ void NewElementWizardPage_EnterMetadata::btnChooseCategoryClicked() noexcept {
       return;
     }
   }
-  mContext.mElementCategoryUuid = categoryUuid;
+  mContext.mElementCategoryUuids.clear();
+  if (categoryUuid.has_value()) {
+    mContext.mElementCategoryUuids.insert(*categoryUuid);
+  }
   updateCategoryTreeLabel();
 }
 
 void NewElementWizardPage_EnterMetadata::btnResetCategoryClicked() noexcept {
-  mContext.mElementCategoryUuid = tl::nullopt;
+  mContext.mElementCategoryUuids.clear();
   updateCategoryTreeLabel();
 }
 
 void NewElementWizardPage_EnterMetadata::updateCategoryTreeLabel() noexcept {
+  tl::optional<Uuid> rootCategoryUuid = tl::nullopt;
+  if (mContext.mElementCategoryUuids.count()) {
+    rootCategoryUuid = mContext.mElementCategoryUuids.values().first();
+  }
+
   switch (mContext.mElementType) {
     case NewElementWizardContext::ElementType::ComponentCategory:
     case NewElementWizardContext::ElementType::Symbol:
@@ -173,7 +181,7 @@ void NewElementWizardPage_EnterMetadata::updateCategoryTreeLabel() noexcept {
           *mUi->lblCategoryTree);
       builder.setHighlightLastLine(true);
       builder.setOneLine(true);
-      builder.updateText(mContext.mElementCategoryUuid);
+      builder.updateText(rootCategoryUuid);
       break;
     }
     case NewElementWizardContext::ElementType::PackageCategory:
@@ -184,13 +192,19 @@ void NewElementWizardPage_EnterMetadata::updateCategoryTreeLabel() noexcept {
           *mUi->lblCategoryTree);
       builder.setHighlightLastLine(true);
       builder.setOneLine(true);
-      builder.updateText(mContext.mElementCategoryUuid);
+      builder.updateText(rootCategoryUuid);
       break;
     }
     default: {
       mUi->lblCategoryTree->setText(tr("Root category"));
       break;
     }
+  }
+  if (mContext.mElementCategoryUuids.count() > 1) {
+    mUi->lblMoreCategories->setText(
+        tr("... and %1 more.").arg(mContext.mElementCategoryUuids.count() - 1));
+  } else {
+    mUi->lblMoreCategories->setText(QString());
   }
 }
 

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_entermetadata.ui
@@ -122,6 +122,22 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="lblMoreCategories">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true">... and X more.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QToolButton" name="btnChooseCategory">
        <property name="minimumSize">
         <size>


### PR DESCRIPTION
Copy all categories to when duplicating a symbol/device/... in a library.

- NewElementWizardContext holds a list of all categories of the original item
- duplicate/new element wizard
  - add "and x more" label to signify more "hidden" categories. 
  - reset clears the complete list
  - change replaces *all* categories with the newly selected one
  - the wizard cannot assign multiple categories. This has to be done as usual in the editor
- fixes #696