### PR TITLE
Factor out more geometry classes of schematics/boards

### DIFF
--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -94,6 +94,7 @@ SOURCES += \
     geometry/polygon.cpp \
     geometry/stroketext.cpp \
     geometry/text.cpp \
+    geometry/trace.cpp \
     geometry/vertex.cpp \
     geometry/via.cpp \
     graphics/circlegraphicsitem.cpp \
@@ -238,6 +239,7 @@ HEADERS += \
     geometry/polygon.h \
     geometry/stroketext.h \
     geometry/text.h \
+    geometry/trace.h \
     geometry/vertex.h \
     geometry/via.h \
     graphics/circlegraphicsitem.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -87,6 +87,7 @@ SOURCES += \
     geometry/cmd/cmdtextedit.cpp \
     geometry/hole.cpp \
     geometry/junction.cpp \
+    geometry/netline.cpp \
     geometry/path.cpp \
     geometry/pathmodel.cpp \
     geometry/polygon.cpp \
@@ -228,6 +229,7 @@ HEADERS += \
     geometry/cmd/cmdtextedit.h \
     geometry/hole.h \
     geometry/junction.h \
+    geometry/netline.h \
     geometry/path.h \
     geometry/pathmodel.h \
     geometry/polygon.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -95,6 +95,7 @@ SOURCES += \
     geometry/stroketext.cpp \
     geometry/text.cpp \
     geometry/vertex.cpp \
+    geometry/via.cpp \
     graphics/circlegraphicsitem.cpp \
     graphics/defaultgraphicslayerprovider.cpp \
     graphics/graphicslayer.cpp \
@@ -238,6 +239,7 @@ HEADERS += \
     geometry/stroketext.h \
     geometry/text.h \
     geometry/vertex.h \
+    geometry/via.h \
     graphics/circlegraphicsitem.h \
     graphics/defaultgraphicslayerprovider.h \
     graphics/graphicslayer.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -87,6 +87,7 @@ SOURCES += \
     geometry/cmd/cmdtextedit.cpp \
     geometry/hole.cpp \
     geometry/junction.cpp \
+    geometry/netlabel.cpp \
     geometry/netline.cpp \
     geometry/path.cpp \
     geometry/pathmodel.cpp \
@@ -229,6 +230,7 @@ HEADERS += \
     geometry/cmd/cmdtextedit.h \
     geometry/hole.h \
     geometry/junction.h \
+    geometry/netlabel.h \
     geometry/netline.h \
     geometry/path.h \
     geometry/pathmodel.h \

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -86,6 +86,7 @@ SOURCES += \
     geometry/cmd/cmdstroketextedit.cpp \
     geometry/cmd/cmdtextedit.cpp \
     geometry/hole.cpp \
+    geometry/junction.cpp \
     geometry/path.cpp \
     geometry/pathmodel.cpp \
     geometry/polygon.cpp \
@@ -226,6 +227,7 @@ HEADERS += \
     geometry/cmd/cmdstroketextedit.h \
     geometry/cmd/cmdtextedit.h \
     geometry/hole.h \
+    geometry/junction.h \
     geometry/path.h \
     geometry/pathmodel.h \
     geometry/polygon.h \

--- a/libs/librepcb/common/geometry/junction.cpp
+++ b/libs/librepcb/common/geometry/junction.cpp
@@ -1,0 +1,111 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "junction.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+Junction::Junction(const Junction& other) noexcept
+  : onEdited(*this), mUuid(other.mUuid), mPosition(other.mPosition) {
+}
+
+Junction::Junction(const Uuid& uuid, const Junction& other) noexcept
+  : Junction(other) {
+  mUuid = uuid;
+}
+
+Junction::Junction(const Uuid& uuid, const Point& position) noexcept
+  : onEdited(*this), mUuid(uuid), mPosition(position) {
+}
+
+Junction::Junction(const SExpression& node)
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+    mPosition(node.getChildByPath("position")) {
+}
+
+Junction::~Junction() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+bool Junction::setUuid(const Uuid& uuid) noexcept {
+  if (uuid == mUuid) {
+    return false;
+  }
+
+  mUuid = uuid;
+  onEdited.notify(Event::UuidChanged);
+  return true;
+}
+
+bool Junction::setPosition(const Point& position) noexcept {
+  if (position == mPosition) {
+    return false;
+  }
+
+  mPosition = position;
+  onEdited.notify(Event::PositionChanged);
+  return true;
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void Junction::serialize(SExpression& root) const {
+  root.appendChild(mUuid);
+  root.appendChild(mPosition.serializeToDomElement("position"), false);
+}
+
+/*******************************************************************************
+ *  Operator Overloadings
+ ******************************************************************************/
+
+bool Junction::operator==(const Junction& rhs) const noexcept {
+  if (mUuid != rhs.mUuid) return false;
+  if (mPosition != rhs.mPosition) return false;
+  return true;
+}
+
+Junction& Junction::operator=(const Junction& rhs) noexcept {
+  setUuid(rhs.mUuid);
+  setPosition(rhs.mPosition);
+  return *this;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/geometry/junction.h
+++ b/libs/librepcb/common/geometry/junction.h
@@ -1,0 +1,115 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_JUNCTION_H
+#define LIBREPCB_JUNCTION_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../fileio/cmd/cmdlistelementinsert.h"
+#include "../fileio/cmd/cmdlistelementremove.h"
+#include "../fileio/cmd/cmdlistelementsswap.h"
+#include "../fileio/serializableobjectlist.h"
+#include "../units/all_length_units.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class Junction
+ ******************************************************************************/
+
+/**
+ * @brief The Junction class represents the connection point between netlines
+ *        or traces
+ *
+ * The main purpose of this class is to serialize and deserialize junctions
+ * contained in schematics or boards.
+ */
+class Junction final : public SerializableObject {
+  Q_DECLARE_TR_FUNCTIONS(Junction)
+
+public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    PositionChanged,
+  };
+  Signal<Junction, Event>       onEdited;
+  typedef Slot<Junction, Event> OnEditedSlot;
+
+  // Constructors / Destructor
+  Junction() = delete;
+  Junction(const Junction& other) noexcept;
+  Junction(const Uuid& uuid, const Junction& other) noexcept;
+  Junction(const Uuid& uuid, const Point& position) noexcept;
+  explicit Junction(const SExpression& node);
+  ~Junction() noexcept;
+
+  // Getters
+  const Uuid&  getUuid() const noexcept { return mUuid; }
+  const Point& getPosition() const noexcept { return mPosition; }
+
+  // Setters
+  bool setUuid(const Uuid& uuid) noexcept;
+  bool setPosition(const Point& position) noexcept;
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Operator Overloadings
+  bool operator==(const Junction& rhs) const noexcept;
+  bool operator!=(const Junction& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+  Junction& operator=(const Junction& rhs) noexcept;
+
+private:  // Data
+  Uuid  mUuid;
+  Point mPosition;
+};
+
+/*******************************************************************************
+ *  Class JunctionList
+ ******************************************************************************/
+
+struct JunctionListNameProvider {
+  static constexpr const char* tagname = "junction";
+};
+using JunctionList =
+    SerializableObjectList<Junction, JunctionListNameProvider, Junction::Event>;
+using CmdJunctionInsert =
+    CmdListElementInsert<Junction, JunctionListNameProvider, Junction::Event>;
+using CmdJunctionRemove =
+    CmdListElementRemove<Junction, JunctionListNameProvider, Junction::Event>;
+using CmdJunctionsSwap =
+    CmdListElementsSwap<Junction, JunctionListNameProvider, Junction::Event>;
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/common/geometry/netlabel.cpp
+++ b/libs/librepcb/common/geometry/netlabel.cpp
@@ -1,0 +1,129 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "netlabel.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+NetLabel::NetLabel(const NetLabel& other) noexcept
+  : onEdited(*this),
+    mUuid(other.mUuid),
+    mPosition(other.mPosition),
+    mRotation(other.mRotation) {
+}
+
+NetLabel::NetLabel(const Uuid& uuid, const NetLabel& other) noexcept
+  : NetLabel(other) {
+  mUuid = uuid;
+}
+
+NetLabel::NetLabel(const Uuid& uuid, const Point& position,
+                   const Angle& rotation) noexcept
+  : onEdited(*this), mUuid(uuid), mPosition(position), mRotation(rotation) {
+}
+
+NetLabel::NetLabel(const SExpression& node)
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+    mPosition(node.getChildByPath("position")),
+    mRotation(node.getValueByPath<Angle>("rotation")) {
+}
+
+NetLabel::~NetLabel() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+bool NetLabel::setUuid(const Uuid& uuid) noexcept {
+  if (uuid == mUuid) {
+    return false;
+  }
+
+  mUuid = uuid;
+  onEdited.notify(Event::UuidChanged);
+  return true;
+}
+
+bool NetLabel::setPosition(const Point& position) noexcept {
+  if (position == mPosition) {
+    return false;
+  }
+
+  mPosition = position;
+  onEdited.notify(Event::PositionChanged);
+  return true;
+}
+
+bool NetLabel::setRotation(const Angle& rotation) noexcept {
+  if (rotation == mRotation) {
+    return false;
+  }
+
+  mRotation = rotation;
+  onEdited.notify(Event::RotationChanged);
+  return true;
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void NetLabel::serialize(SExpression& root) const {
+  root.appendChild(mUuid);
+  root.appendChild(mPosition.serializeToDomElement("position"), true);
+  root.appendChild("rotation", mRotation, false);
+}
+
+/*******************************************************************************
+ *  Operator Overloadings
+ ******************************************************************************/
+
+bool NetLabel::operator==(const NetLabel& rhs) const noexcept {
+  if (mUuid != rhs.mUuid) return false;
+  if (mPosition != rhs.mPosition) return false;
+  if (mRotation != rhs.mRotation) return false;
+  return true;
+}
+
+NetLabel& NetLabel::operator=(const NetLabel& rhs) noexcept {
+  setUuid(rhs.mUuid);
+  setPosition(rhs.mPosition);
+  setRotation(rhs.mRotation);
+  return *this;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/geometry/netlabel.h
+++ b/libs/librepcb/common/geometry/netlabel.h
@@ -1,0 +1,119 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_NETLABEL_H
+#define LIBREPCB_NETLABEL_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../fileio/cmd/cmdlistelementinsert.h"
+#include "../fileio/cmd/cmdlistelementremove.h"
+#include "../fileio/cmd/cmdlistelementsswap.h"
+#include "../fileio/serializableobjectlist.h"
+#include "../units/all_length_units.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class NetLabel
+ ******************************************************************************/
+
+/**
+ * @brief The NetLabel class represents a net text label of a schematic
+ *
+ * The main purpose of this class is to serialize and deserialize net labels
+ * contained in schematics.
+ */
+class NetLabel final : public SerializableObject {
+  Q_DECLARE_TR_FUNCTIONS(NetLabel)
+
+public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    PositionChanged,
+    RotationChanged,
+  };
+  Signal<NetLabel, Event>       onEdited;
+  typedef Slot<NetLabel, Event> OnEditedSlot;
+
+  // Constructors / Destructor
+  NetLabel() = delete;
+  NetLabel(const NetLabel& other) noexcept;
+  NetLabel(const Uuid& uuid, const NetLabel& other) noexcept;
+  NetLabel(const Uuid& uuid, const Point& position,
+           const Angle& rotation) noexcept;
+  explicit NetLabel(const SExpression& node);
+  ~NetLabel() noexcept;
+
+  // Getters
+  const Uuid&  getUuid() const noexcept { return mUuid; }
+  const Point& getPosition() const noexcept { return mPosition; }
+  const Angle& getRotation() const noexcept { return mRotation; }
+
+  // Setters
+  bool setUuid(const Uuid& uuid) noexcept;
+  bool setPosition(const Point& position) noexcept;
+  bool setRotation(const Angle& rotation) noexcept;
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Operator Overloadings
+  bool operator==(const NetLabel& rhs) const noexcept;
+  bool operator!=(const NetLabel& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+  NetLabel& operator=(const NetLabel& rhs) noexcept;
+
+private:  // Data
+  Uuid  mUuid;
+  Point mPosition;
+  Angle mRotation;
+};
+
+/*******************************************************************************
+ *  Class NetLabelList
+ ******************************************************************************/
+
+struct NetLabelListNameProvider {
+  static constexpr const char* tagname = "label";
+};
+using NetLabelList =
+    SerializableObjectList<NetLabel, NetLabelListNameProvider, NetLabel::Event>;
+using CmdNetLabelInsert =
+    CmdListElementInsert<NetLabel, NetLabelListNameProvider, NetLabel::Event>;
+using CmdNetLabelRemove =
+    CmdListElementRemove<NetLabel, NetLabelListNameProvider, NetLabel::Event>;
+using CmdNetLabelsSwap =
+    CmdListElementsSwap<NetLabel, NetLabelListNameProvider, NetLabel::Event>;
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/common/geometry/netline.cpp
+++ b/libs/librepcb/common/geometry/netline.cpp
@@ -1,0 +1,199 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "netline.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class NetLineAnchor
+ ******************************************************************************/
+
+NetLineAnchor::NetLineAnchor(const tl::optional<Uuid>&      junction,
+                             const tl::optional<PinAnchor>& pin) noexcept
+  : mJunction(junction), mPin(pin) {
+  Q_ASSERT(((junction) && (!pin)) || ((!junction) && (pin)));
+}
+
+NetLineAnchor::NetLineAnchor(const NetLineAnchor& other) noexcept
+  : mJunction(other.mJunction), mPin(other.mPin) {
+}
+
+NetLineAnchor::NetLineAnchor(const SExpression& node) {
+  if (const SExpression* junctionNode = node.tryGetChildByPath("junction")) {
+    mJunction = junctionNode->getValueOfFirstChild<Uuid>();
+  } else {
+    mPin = PinAnchor{node.getValueByPath<Uuid>("symbol"),
+                     node.getValueByPath<Uuid>("pin")};
+  }
+}
+
+NetLineAnchor::~NetLineAnchor() noexcept {
+}
+
+void NetLineAnchor::serialize(SExpression& root) const {
+  if (mJunction) {
+    root.appendChild("junction", *mJunction, false);
+  } else if (mPin) {
+    root.appendChild("symbol", mPin->symbol, false);
+    root.appendChild("pin", mPin->pin, false);
+  } else {
+    throw LogicError(__FILE__, __LINE__);
+  }
+}
+
+bool NetLineAnchor::operator==(const NetLineAnchor& rhs) const noexcept {
+  return (mJunction == rhs.mJunction) && (mPin == rhs.mPin);
+}
+
+NetLineAnchor& NetLineAnchor::operator=(const NetLineAnchor& rhs) noexcept {
+  mJunction = rhs.mJunction;
+  mPin      = rhs.mPin;
+  return *this;
+}
+
+NetLineAnchor NetLineAnchor::junction(const Uuid& junction) noexcept {
+  return NetLineAnchor(junction, tl::nullopt);
+}
+
+NetLineAnchor NetLineAnchor::pin(const Uuid& symbol, const Uuid& pin) noexcept {
+  return NetLineAnchor(tl::nullopt, PinAnchor{symbol, pin});
+}
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+NetLine::NetLine(const NetLine& other) noexcept
+  : onEdited(*this),
+    mUuid(other.mUuid),
+    mWidth(other.mWidth),
+    mStart(other.mStart),
+    mEnd(other.mEnd) {
+}
+
+NetLine::NetLine(const Uuid& uuid, const NetLine& other) noexcept
+  : NetLine(other) {
+  mUuid = uuid;
+}
+
+NetLine::NetLine(const Uuid& uuid, const UnsignedLength& width,
+                 const NetLineAnchor& start, const NetLineAnchor& end) noexcept
+  : onEdited(*this), mUuid(uuid), mWidth(width), mStart(start), mEnd(end) {
+}
+
+NetLine::NetLine(const SExpression& node)
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+    mWidth(node.getValueByPath<UnsignedLength>("width")),
+    mStart(node.getChildByPath("from")),
+    mEnd(node.getChildByPath("to")) {
+}
+
+NetLine::~NetLine() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+bool NetLine::setUuid(const Uuid& uuid) noexcept {
+  if (uuid == mUuid) {
+    return false;
+  }
+
+  mUuid = uuid;
+  onEdited.notify(Event::UuidChanged);
+  return true;
+}
+
+bool NetLine::setWidth(const UnsignedLength& width) noexcept {
+  if (width == mWidth) {
+    return false;
+  }
+
+  mWidth = width;
+  onEdited.notify(Event::WidthChanged);
+  return true;
+}
+
+bool NetLine::setStartPoint(const NetLineAnchor& start) noexcept {
+  if (start == mStart) {
+    return false;
+  }
+
+  mStart = start;
+  onEdited.notify(Event::StartPointChanged);
+  return true;
+}
+
+bool NetLine::setEndPoint(const NetLineAnchor& end) noexcept {
+  if (end == mEnd) {
+    return false;
+  }
+
+  mEnd = end;
+  onEdited.notify(Event::EndPointChanged);
+  return true;
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void NetLine::serialize(SExpression& root) const {
+  root.appendChild(mUuid);
+  root.appendChild("width", mWidth, false);
+  root.appendChild(mStart.serializeToDomElement("from"), true);
+  root.appendChild(mEnd.serializeToDomElement("to"), true);
+}
+
+/*******************************************************************************
+ *  Operator Overloadings
+ ******************************************************************************/
+
+bool NetLine::operator==(const NetLine& rhs) const noexcept {
+  if (mUuid != rhs.mUuid) return false;
+  if (mWidth != rhs.mWidth) return false;
+  if (mStart != rhs.mStart) return false;
+  if (mEnd != rhs.mEnd) return false;
+  return true;
+}
+
+NetLine& NetLine::operator=(const NetLine& rhs) noexcept {
+  setUuid(rhs.mUuid);
+  setWidth(rhs.mWidth);
+  setStartPoint(rhs.mStart);
+  setEndPoint(rhs.mEnd);
+  return *this;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/geometry/netline.h
+++ b/libs/librepcb/common/geometry/netline.h
@@ -1,0 +1,195 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_NETLINE_H
+#define LIBREPCB_NETLINE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../fileio/cmd/cmdlistelementinsert.h"
+#include "../fileio/cmd/cmdlistelementremove.h"
+#include "../fileio/cmd/cmdlistelementsswap.h"
+#include "../fileio/serializableobjectlist.h"
+#include "../units/all_length_units.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class NetLineAnchor
+ ******************************************************************************/
+
+/**
+ * @brief The NetLineAnchor class
+ */
+class NetLineAnchor final : public SerializableObject {
+  Q_DECLARE_TR_FUNCTIONS(NetLineAnchor)
+
+public:
+  // Types
+  struct PinAnchor {
+    Uuid symbol;
+    Uuid pin;
+
+    bool operator==(const PinAnchor& rhs) const noexcept {
+      return (symbol == rhs.symbol) && (pin == rhs.pin);
+    }
+  };
+
+  // Constructors / Destructor
+  NetLineAnchor() = delete;
+  NetLineAnchor(const NetLineAnchor& other) noexcept;
+  explicit NetLineAnchor(const SExpression& node);
+  ~NetLineAnchor() noexcept;
+
+  // Getters
+  const tl::optional<Uuid>& tryGetJunction() const noexcept {
+    return mJunction;
+  }
+  const tl::optional<PinAnchor>& tryGetPin() const noexcept { return mPin; }
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Operator Overloadings
+  bool operator==(const NetLineAnchor& rhs) const noexcept;
+  bool operator!=(const NetLineAnchor& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+  NetLineAnchor& operator=(const NetLineAnchor& rhs) noexcept;
+
+  // Static Methods
+  static NetLineAnchor junction(const Uuid& junction) noexcept;
+  static NetLineAnchor pin(const Uuid& symbol, const Uuid& pin) noexcept;
+
+private:  // Methods
+  NetLineAnchor(const tl::optional<Uuid>&      junction,
+                const tl::optional<PinAnchor>& pin) noexcept;
+
+private:  // Data
+  tl::optional<Uuid>      mJunction;
+  tl::optional<PinAnchor> mPin;
+};
+
+/*******************************************************************************
+ *  Class NetLine
+ ******************************************************************************/
+
+/**
+ * @brief The NetLine class represents a net line within a schematic
+ *
+ * The main purpose of this class is to serialize and deserialize schematic
+ * net lines.
+ */
+class NetLine final : public SerializableObject {
+  Q_DECLARE_TR_FUNCTIONS(NetLine)
+
+public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    WidthChanged,
+    StartPointChanged,
+    EndPointChanged,
+  };
+  Signal<NetLine, Event>       onEdited;
+  typedef Slot<NetLine, Event> OnEditedSlot;
+
+  // Constructors / Destructor
+  NetLine() = delete;
+  NetLine(const NetLine& other) noexcept;
+  NetLine(const Uuid& uuid, const NetLine& other) noexcept;
+  NetLine(const Uuid& uuid, const UnsignedLength& width,
+          const NetLineAnchor& start, const NetLineAnchor& end) noexcept;
+  explicit NetLine(const SExpression& node);
+  ~NetLine() noexcept;
+
+  // Getters
+  const Uuid&           getUuid() const noexcept { return mUuid; }
+  const UnsignedLength& getWidth() const noexcept { return mWidth; }
+  const NetLineAnchor&  getStartPoint() const noexcept { return mStart; }
+  const NetLineAnchor&  getEndPoint() const noexcept { return mEnd; }
+
+  // Setters
+  bool setUuid(const Uuid& uuid) noexcept;
+  bool setWidth(const UnsignedLength& width) noexcept;
+  bool setStartPoint(const NetLineAnchor& start) noexcept;
+  bool setEndPoint(const NetLineAnchor& end) noexcept;
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Operator Overloadings
+  bool operator==(const NetLine& rhs) const noexcept;
+  bool operator!=(const NetLine& rhs) const noexcept { return !(*this == rhs); }
+  NetLine& operator=(const NetLine& rhs) noexcept;
+
+private:  // Data
+  Uuid           mUuid;
+  UnsignedLength mWidth;
+  NetLineAnchor  mStart;
+  NetLineAnchor  mEnd;
+};
+
+/*******************************************************************************
+ *  Class NetLineList
+ ******************************************************************************/
+
+struct NetLineListNameProvider {
+  static constexpr const char* tagname = "line";
+};
+using NetLineList =
+    SerializableObjectList<NetLine, NetLineListNameProvider, NetLine::Event>;
+using CmdNetLineInsert =
+    CmdListElementInsert<NetLine, NetLineListNameProvider, NetLine::Event>;
+using CmdNetLineRemove =
+    CmdListElementRemove<NetLine, NetLineListNameProvider, NetLine::Event>;
+using CmdNetLinesSwap =
+    CmdListElementsSwap<NetLine, NetLineListNameProvider, NetLine::Event>;
+
+/*******************************************************************************
+ *  Non-Member Functions
+ ******************************************************************************/
+
+inline uint qHash(const NetLineAnchor& key, uint seed) noexcept {
+  QString s;
+  if (tl::optional<Uuid> anchor = key.tryGetJunction()) {
+    s += anchor->toStr();
+  }
+  if (tl::optional<NetLineAnchor::PinAnchor> anchor = key.tryGetPin()) {
+    s += anchor->symbol.toStr();
+    s += anchor->pin.toStr();
+  }
+  Q_ASSERT(!s.isEmpty());
+
+  return ::qHash(s, seed);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/common/geometry/trace.cpp
+++ b/libs/librepcb/common/geometry/trace.cpp
@@ -1,0 +1,232 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "trace.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class TraceAnchor
+ ******************************************************************************/
+
+TraceAnchor::TraceAnchor(const tl::optional<Uuid>&      junction,
+                         const tl::optional<Uuid>&      via,
+                         const tl::optional<PadAnchor>& pad) noexcept
+  : mJunction(junction), mVia(via), mPad(pad) {
+  Q_ASSERT(((junction) && (!via) && (!pad)) ||
+           ((!junction) && (via) && (!pad)) ||
+           ((!junction) && (!via) && (pad)));
+}
+
+TraceAnchor::TraceAnchor(const TraceAnchor& other) noexcept
+  : mJunction(other.mJunction), mVia(other.mVia), mPad(other.mPad) {
+}
+
+TraceAnchor::TraceAnchor(const SExpression& node) {
+  if (const SExpression* junctionNode = node.tryGetChildByPath("junction")) {
+    mJunction = junctionNode->getValueOfFirstChild<Uuid>();
+  } else if (const SExpression* viaNode = node.tryGetChildByPath("via")) {
+    mVia = viaNode->getValueOfFirstChild<Uuid>();
+  } else {
+    mPad = PadAnchor{node.getValueByPath<Uuid>("device"),
+                     node.getValueByPath<Uuid>("pad")};
+  }
+}
+
+TraceAnchor::~TraceAnchor() noexcept {
+}
+
+void TraceAnchor::serialize(SExpression& root) const {
+  if (mJunction) {
+    root.appendChild("junction", *mJunction, false);
+  } else if (mVia) {
+    root.appendChild("via", *mVia, false);
+  } else if (mPad) {
+    root.appendChild("device", mPad->device, false);
+    root.appendChild("pad", mPad->pad, false);
+  } else {
+    throw LogicError(__FILE__, __LINE__);
+  }
+}
+
+bool TraceAnchor::operator==(const TraceAnchor& rhs) const noexcept {
+  return (mJunction == rhs.mJunction) && (mVia == rhs.mVia) &&
+         (mPad == rhs.mPad);
+}
+
+TraceAnchor& TraceAnchor::operator=(const TraceAnchor& rhs) noexcept {
+  mJunction = rhs.mJunction;
+  mVia      = rhs.mVia;
+  mPad      = rhs.mPad;
+  return *this;
+}
+
+TraceAnchor TraceAnchor::junction(const Uuid& junction) noexcept {
+  return TraceAnchor(junction, tl::nullopt, tl::nullopt);
+}
+
+TraceAnchor TraceAnchor::via(const Uuid& via) noexcept {
+  return TraceAnchor(tl::nullopt, via, tl::nullopt);
+}
+
+TraceAnchor TraceAnchor::pad(const Uuid& device, const Uuid& pad) noexcept {
+  return TraceAnchor(tl::nullopt, tl::nullopt, PadAnchor{device, pad});
+}
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+Trace::Trace(const Trace& other) noexcept
+  : onEdited(*this),
+    mUuid(other.mUuid),
+    mLayer(other.mLayer),
+    mWidth(other.mWidth),
+    mStart(other.mStart),
+    mEnd(other.mEnd) {
+}
+
+Trace::Trace(const Uuid& uuid, const Trace& other) noexcept : Trace(other) {
+  mUuid = uuid;
+}
+
+Trace::Trace(const Uuid& uuid, const GraphicsLayerName& layer,
+             const PositiveLength& width, const TraceAnchor& start,
+             const TraceAnchor& end) noexcept
+  : onEdited(*this),
+    mUuid(uuid),
+    mLayer(layer),
+    mWidth(width),
+    mStart(start),
+    mEnd(end) {
+}
+
+Trace::Trace(const SExpression& node)
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+    mLayer(node.getValueByPath<GraphicsLayerName>("layer")),
+    mWidth(node.getValueByPath<PositiveLength>("width")),
+    mStart(node.getChildByPath("from")),
+    mEnd(node.getChildByPath("to")) {
+}
+
+Trace::~Trace() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+bool Trace::setUuid(const Uuid& uuid) noexcept {
+  if (uuid == mUuid) {
+    return false;
+  }
+
+  mUuid = uuid;
+  onEdited.notify(Event::UuidChanged);
+  return true;
+}
+
+bool Trace::setLayer(const GraphicsLayerName& layer) noexcept {
+  if (layer == mLayer) {
+    return false;
+  }
+
+  mLayer = layer;
+  onEdited.notify(Event::LayerChanged);
+  return true;
+}
+
+bool Trace::setWidth(const PositiveLength& width) noexcept {
+  if (width == mWidth) {
+    return false;
+  }
+
+  mWidth = width;
+  onEdited.notify(Event::WidthChanged);
+  return true;
+}
+
+bool Trace::setStartPoint(const TraceAnchor& start) noexcept {
+  if (start == mStart) {
+    return false;
+  }
+
+  mStart = start;
+  onEdited.notify(Event::StartPointChanged);
+  return true;
+}
+
+bool Trace::setEndPoint(const TraceAnchor& end) noexcept {
+  if (end == mEnd) {
+    return false;
+  }
+
+  mEnd = end;
+  onEdited.notify(Event::EndPointChanged);
+  return true;
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void Trace::serialize(SExpression& root) const {
+  root.appendChild(mUuid);
+  root.appendChild("layer", SExpression::createToken(*mLayer), false);
+  root.appendChild("width", mWidth, false);
+  root.appendChild(mStart.serializeToDomElement("from"), true);
+  root.appendChild(mEnd.serializeToDomElement("to"), true);
+}
+
+/*******************************************************************************
+ *  Operator Overloadings
+ ******************************************************************************/
+
+bool Trace::operator==(const Trace& rhs) const noexcept {
+  if (mUuid != rhs.mUuid) return false;
+  if (mLayer != rhs.mLayer) return false;
+  if (mWidth != rhs.mWidth) return false;
+  if (mStart != rhs.mStart) return false;
+  if (mEnd != rhs.mEnd) return false;
+  return true;
+}
+
+Trace& Trace::operator=(const Trace& rhs) noexcept {
+  setUuid(rhs.mUuid);
+  setLayer(rhs.mLayer);
+  setWidth(rhs.mWidth);
+  setStartPoint(rhs.mStart);
+  setEndPoint(rhs.mEnd);
+  return *this;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/geometry/trace.h
+++ b/libs/librepcb/common/geometry/trace.h
@@ -1,0 +1,206 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_TRACE_H
+#define LIBREPCB_TRACE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../fileio/cmd/cmdlistelementinsert.h"
+#include "../fileio/cmd/cmdlistelementremove.h"
+#include "../fileio/cmd/cmdlistelementsswap.h"
+#include "../fileio/serializableobjectlist.h"
+#include "../graphics/graphicslayername.h"
+#include "../units/all_length_units.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class TraceAnchor
+ ******************************************************************************/
+
+/**
+ * @brief The TraceAnchor class
+ */
+class TraceAnchor final : public SerializableObject {
+  Q_DECLARE_TR_FUNCTIONS(TraceAnchor)
+
+public:
+  // Types
+  struct PadAnchor {
+    Uuid device;
+    Uuid pad;
+
+    bool operator==(const PadAnchor& rhs) const noexcept {
+      return (device == rhs.device) && (pad == rhs.pad);
+    }
+  };
+
+  // Constructors / Destructor
+  TraceAnchor() = delete;
+  TraceAnchor(const TraceAnchor& other) noexcept;
+  explicit TraceAnchor(const SExpression& node);
+  ~TraceAnchor() noexcept;
+
+  // Getters
+  const tl::optional<Uuid>& tryGetJunction() const noexcept {
+    return mJunction;
+  }
+  const tl::optional<Uuid>&      tryGetVia() const noexcept { return mVia; }
+  const tl::optional<PadAnchor>& tryGetPad() const noexcept { return mPad; }
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Operator Overloadings
+  bool operator==(const TraceAnchor& rhs) const noexcept;
+  bool operator!=(const TraceAnchor& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+  TraceAnchor& operator=(const TraceAnchor& rhs) noexcept;
+
+  // Static Methods
+  static TraceAnchor junction(const Uuid& junction) noexcept;
+  static TraceAnchor via(const Uuid& via) noexcept;
+  static TraceAnchor pad(const Uuid& device, const Uuid& pad) noexcept;
+
+private:  // Methods
+  TraceAnchor(const tl::optional<Uuid>& junction, const tl::optional<Uuid>& via,
+              const tl::optional<PadAnchor>& pad) noexcept;
+
+private:  // Data
+  tl::optional<Uuid>      mJunction;
+  tl::optional<Uuid>      mVia;
+  tl::optional<PadAnchor> mPad;
+};
+
+/*******************************************************************************
+ *  Class Trace
+ ******************************************************************************/
+
+/**
+ * @brief The Trace class represents a trace within a board
+ *
+ * The main purpose of this class is to serialize and deserialize traces.
+ */
+class Trace final : public SerializableObject {
+  Q_DECLARE_TR_FUNCTIONS(Trace)
+
+public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    LayerChanged,
+    WidthChanged,
+    StartPointChanged,
+    EndPointChanged,
+  };
+  Signal<Trace, Event>       onEdited;
+  typedef Slot<Trace, Event> OnEditedSlot;
+
+  // Constructors / Destructor
+  Trace() = delete;
+  Trace(const Trace& other) noexcept;
+  Trace(const Uuid& uuid, const Trace& other) noexcept;
+  Trace(const Uuid& uuid, const GraphicsLayerName& layer,
+        const PositiveLength& width, const TraceAnchor& start,
+        const TraceAnchor& end) noexcept;
+  explicit Trace(const SExpression& node);
+  ~Trace() noexcept;
+
+  // Getters
+  const Uuid&              getUuid() const noexcept { return mUuid; }
+  const GraphicsLayerName& getLayer() const noexcept { return mLayer; }
+  const PositiveLength&    getWidth() const noexcept { return mWidth; }
+  const TraceAnchor&       getStartPoint() const noexcept { return mStart; }
+  const TraceAnchor&       getEndPoint() const noexcept { return mEnd; }
+
+  // Setters
+  bool setUuid(const Uuid& uuid) noexcept;
+  bool setLayer(const GraphicsLayerName& layer) noexcept;
+  bool setWidth(const PositiveLength& width) noexcept;
+  bool setStartPoint(const TraceAnchor& start) noexcept;
+  bool setEndPoint(const TraceAnchor& end) noexcept;
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Operator Overloadings
+  bool   operator==(const Trace& rhs) const noexcept;
+  bool   operator!=(const Trace& rhs) const noexcept { return !(*this == rhs); }
+  Trace& operator=(const Trace& rhs) noexcept;
+
+private:  // Data
+  Uuid              mUuid;
+  GraphicsLayerName mLayer;
+  PositiveLength    mWidth;
+  TraceAnchor       mStart;
+  TraceAnchor       mEnd;
+};
+
+/*******************************************************************************
+ *  Class TraceList
+ ******************************************************************************/
+
+struct TraceListNameProvider {
+  static constexpr const char* tagname = "trace";
+};
+using TraceList =
+    SerializableObjectList<Trace, TraceListNameProvider, Trace::Event>;
+using CmdTraceInsert =
+    CmdListElementInsert<Trace, TraceListNameProvider, Trace::Event>;
+using CmdTraceRemove =
+    CmdListElementRemove<Trace, TraceListNameProvider, Trace::Event>;
+using CmdTracesSwap =
+    CmdListElementsSwap<Trace, TraceListNameProvider, Trace::Event>;
+
+/*******************************************************************************
+ *  Non-Member Functions
+ ******************************************************************************/
+
+inline uint qHash(const TraceAnchor& key, uint seed) noexcept {
+  QString s;
+  if (tl::optional<Uuid> anchor = key.tryGetJunction()) {
+    s += anchor->toStr();
+  }
+  if (tl::optional<Uuid> anchor = key.tryGetVia()) {
+    s += anchor->toStr();
+  }
+  if (tl::optional<TraceAnchor::PadAnchor> anchor = key.tryGetPad()) {
+    s += anchor->device.toStr();
+    s += anchor->pad.toStr();
+  }
+  Q_ASSERT(!s.isEmpty());
+
+  return ::qHash(s, seed);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/common/geometry/via.cpp
+++ b/libs/librepcb/common/geometry/via.cpp
@@ -1,0 +1,199 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "via.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+Via::Via(const Via& other) noexcept
+  : onEdited(*this),
+    mUuid(other.mUuid),
+    mPosition(other.mPosition),
+    mShape(other.mShape),
+    mSize(other.mSize),
+    mDrillDiameter(other.mDrillDiameter) {
+}
+
+Via::Via(const Uuid& uuid, const Via& other) noexcept : Via(other) {
+  mUuid = uuid;
+}
+
+Via::Via(const Uuid& uuid, const Point& position, Shape shape,
+         const PositiveLength& size,
+         const PositiveLength& drillDiameter) noexcept
+  : onEdited(*this),
+    mUuid(uuid),
+    mPosition(position),
+    mShape(shape),
+    mSize(size),
+    mDrillDiameter(drillDiameter) {
+}
+
+Via::Via(const SExpression& node)
+  : onEdited(*this),
+    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
+    mPosition(node.getChildByPath("position")),
+    mShape(node.getValueByPath<Shape>("shape")),
+    mSize(node.getValueByPath<PositiveLength>("size")),
+    mDrillDiameter(node.getValueByPath<PositiveLength>("drill")) {
+}
+
+Via::~Via() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+Path Via::getOutline(const Length& expansion) const noexcept {
+  Length size = mSize + (expansion * 2);
+  if (size > 0) {
+    PositiveLength pSize(size);
+    switch (mShape) {
+      case Shape::Round:
+        return Path::circle(pSize);
+      case Shape::Square:
+        return Path::centeredRect(pSize, pSize);
+      case Shape::Octagon:
+        return Path::octagon(pSize, pSize);
+      default:
+        Q_ASSERT(false);
+        break;
+    }
+  }
+  return Path();
+}
+
+Path Via::getSceneOutline(const Length& expansion) const noexcept {
+  return getOutline(expansion).translated(mPosition);
+}
+
+QPainterPath Via::toQPainterPathPx(const Length& expansion) const noexcept {
+  QPainterPath p = getOutline(expansion).toQPainterPathPx();
+  p.setFillRule(Qt::OddEvenFill);  // important to subtract the hole!
+  p.addEllipse(QPointF(0, 0), mDrillDiameter->toPx() / 2,
+               mDrillDiameter->toPx() / 2);
+  return p;
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+bool Via::setUuid(const Uuid& uuid) noexcept {
+  if (uuid == mUuid) {
+    return false;
+  }
+
+  mUuid = uuid;
+  onEdited.notify(Event::UuidChanged);
+  return true;
+}
+
+bool Via::setPosition(const Point& position) noexcept {
+  if (position == mPosition) {
+    return false;
+  }
+
+  mPosition = position;
+  onEdited.notify(Event::PositionChanged);
+  return true;
+}
+
+bool Via::setShape(Shape shape) noexcept {
+  if (shape == mShape) {
+    return false;
+  }
+
+  mShape = shape;
+  onEdited.notify(Event::ShapeChanged);
+  return true;
+}
+
+bool Via::setSize(const PositiveLength& size) noexcept {
+  if (size == mSize) {
+    return false;
+  }
+
+  mSize = size;
+  onEdited.notify(Event::SizeChanged);
+  return true;
+}
+
+bool Via::setDrillDiameter(const PositiveLength& diameter) noexcept {
+  if (diameter == mDrillDiameter) {
+    return false;
+  }
+
+  mDrillDiameter = diameter;
+  onEdited.notify(Event::DrillDiameterChanged);
+  return true;
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void Via::serialize(SExpression& root) const {
+  root.appendChild(mUuid);
+  root.appendChild(mPosition.serializeToDomElement("position"), true);
+  root.appendChild("size", mSize, false);
+  root.appendChild("drill", mDrillDiameter, false);
+  root.appendChild("shape", mShape, false);
+}
+
+/*******************************************************************************
+ *  Operator Overloadings
+ ******************************************************************************/
+
+bool Via::operator==(const Via& rhs) const noexcept {
+  if (mUuid != rhs.mUuid) return false;
+  if (mPosition != rhs.mPosition) return false;
+  if (mShape != rhs.mShape) return false;
+  if (mSize != rhs.mSize) return false;
+  if (mDrillDiameter != rhs.mDrillDiameter) return false;
+  return true;
+}
+
+Via& Via::operator=(const Via& rhs) noexcept {
+  setUuid(rhs.mUuid);
+  setPosition(rhs.mPosition);
+  setShape(rhs.mShape);
+  setSize(rhs.mSize);
+  setDrillDiameter(rhs.mDrillDiameter);
+  return *this;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/geometry/via.h
+++ b/libs/librepcb/common/geometry/via.h
@@ -1,0 +1,164 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_VIA_H
+#define LIBREPCB_VIA_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../fileio/cmd/cmdlistelementinsert.h"
+#include "../fileio/cmd/cmdlistelementremove.h"
+#include "../fileio/cmd/cmdlistelementsswap.h"
+#include "../fileio/serializableobjectlist.h"
+#include "../units/all_length_units.h"
+#include "path.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class Via
+ ******************************************************************************/
+
+/**
+ * @brief The Via class represents a via of a board
+ *
+ * The main purpose of this class is to serialize and deserialize vias
+ * contained in boards.
+ */
+class Via final : public SerializableObject {
+  Q_DECLARE_TR_FUNCTIONS(Via)
+
+public:
+  // Signals
+  enum class Event {
+    UuidChanged,
+    PositionChanged,
+    ShapeChanged,
+    SizeChanged,
+    DrillDiameterChanged,
+  };
+  Signal<Via, Event>       onEdited;
+  typedef Slot<Via, Event> OnEditedSlot;
+
+  // Public Types
+  enum class Shape { Round, Square, Octagon };
+
+  // Constructors / Destructor
+  Via() = delete;
+  Via(const Via& other) noexcept;
+  Via(const Uuid& uuid, const Via& other) noexcept;
+  Via(const Uuid& uuid, const Point& position, Shape shape,
+      const PositiveLength& size, const PositiveLength& drillDiameter) noexcept;
+  explicit Via(const SExpression& node);
+  ~Via() noexcept;
+
+  // Getters
+  const Uuid&           getUuid() const noexcept { return mUuid; }
+  const Point&          getPosition() const noexcept { return mPosition; }
+  Shape                 getShape() const noexcept { return mShape; }
+  const PositiveLength& getSize() const noexcept { return mSize; }
+  const PositiveLength& getDrillDiameter() const noexcept {
+    return mDrillDiameter;
+  }
+  Path getOutline(const Length& expansion = Length(0)) const noexcept;
+  Path getSceneOutline(const Length& expansion = Length(0)) const noexcept;
+  QPainterPath toQPainterPathPx(const Length& expansion = Length(0)) const
+      noexcept;
+
+  // Setters
+  bool setUuid(const Uuid& uuid) noexcept;
+  bool setPosition(const Point& position) noexcept;
+  bool setShape(Shape shape) noexcept;
+  bool setSize(const PositiveLength& size) noexcept;
+  bool setDrillDiameter(const PositiveLength& diameter) noexcept;
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Operator Overloadings
+  bool operator==(const Via& rhs) const noexcept;
+  bool operator!=(const Via& rhs) const noexcept { return !(*this == rhs); }
+  Via& operator=(const Via& rhs) noexcept;
+
+private:  // Data
+  Uuid           mUuid;
+  Point          mPosition;
+  Shape          mShape;
+  PositiveLength mSize;
+  PositiveLength mDrillDiameter;
+};
+
+/*******************************************************************************
+ *  Class ViaList
+ ******************************************************************************/
+
+struct ViaListNameProvider {
+  static constexpr const char* tagname = "via";
+};
+using ViaList = SerializableObjectList<Via, ViaListNameProvider, Via::Event>;
+using CmdViaInsert = CmdListElementInsert<Via, ViaListNameProvider, Via::Event>;
+using CmdViaRemove = CmdListElementRemove<Via, ViaListNameProvider, Via::Event>;
+using CmdViasSwap  = CmdListElementsSwap<Via, ViaListNameProvider, Via::Event>;
+
+/*******************************************************************************
+ *  Non-Member Functions
+ ******************************************************************************/
+
+template <>
+inline SExpression serializeToSExpression(const Via::Shape& obj) {
+  switch (obj) {
+    case Via::Shape::Round:
+      return SExpression::createToken("round");
+    case Via::Shape::Square:
+      return SExpression::createToken("square");
+    case Via::Shape::Octagon:
+      return SExpression::createToken("octagon");
+    default:
+      throw LogicError(__FILE__, __LINE__);
+  }
+}
+
+template <>
+inline Via::Shape deserializeFromSExpression(const SExpression& sexpr,
+                                             bool               throwIfEmpty) {
+  QString str = sexpr.getStringOrToken(throwIfEmpty);
+  if (str == "round")
+    return Via::Shape::Round;
+  else if (str == "square")
+    return Via::Shape::Square;
+  else if (str == "octagon")
+    return Via::Shape::Octagon;
+  else
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString(Via::tr("Unknown via shape: \"%1\"")).arg(str));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/project/boards/boardgerberexport.cpp
+++ b/libs/librepcb/project/boards/boardgerberexport.cpp
@@ -428,16 +428,16 @@ void BoardGerberExport::drawVia(GerberGenerator& gen, const BI_Via& via,
           mBoard.getDesignRules().calcStopMaskClearance(*via.getSize()) * 2);
     }
     switch (via.getShape()) {
-      case BI_Via::Shape::Round: {
+      case Via::Shape::Round: {
         gen.flashCircle(via.getPosition(), outerDiameter, UnsignedLength(0));
         break;
       }
-      case BI_Via::Shape::Square: {
+      case Via::Shape::Square: {
         gen.flashRect(via.getPosition(), outerDiameter, outerDiameter,
                       Angle::deg0(), UnsignedLength(0));
         break;
       }
-      case BI_Via::Shape::Octagon: {
+      case Via::Shape::Octagon: {
         gen.flashRegularPolygon(via.getPosition(), outerDiameter, 8,
                                 Angle::deg0(), UnsignedLength(0));
         break;

--- a/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
@@ -185,8 +185,8 @@ void BoardPlaneFragmentsBuilder::subtractOtherObjects() {
     // subtract vias
     foreach (const BI_Via* via, netsegment->getVias()) {
       if (&netsegment->getNetSignal() == &mPlane.getNetSignal()) {
-        ClipperLib::Path path =
-            ClipperHelpers::convert(via->getSceneOutline(), maxArcTolerance());
+        ClipperLib::Path path = ClipperHelpers::convert(
+            via->getVia().getSceneOutline(), maxArcTolerance());
         mConnectedNetSignalAreas.push_back(path);
       }
       c.AddPath(createViaCutOut(*via), ClipperLib::ptClip, true);
@@ -270,7 +270,8 @@ ClipperLib::Path BoardPlaneFragmentsBuilder::createViaCutOut(
   if ((mPlane.getConnectStyle() == BI_Plane::ConnectStyle::None) ||
       differentNetSignal) {
     return ClipperHelpers::convert(
-        via.getSceneOutline(*mPlane.getMinClearance()), maxArcTolerance());
+        via.getVia().getSceneOutline(*mPlane.getMinClearance()),
+        maxArcTolerance());
   } else {
     return ClipperLib::Path();
   }

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.cpp
@@ -55,11 +55,9 @@ BI_Via* CmdBoardNetSegmentAddElements::addVia(BI_Via& via) {
   return &via;
 }
 
-BI_Via* CmdBoardNetSegmentAddElements::addVia(
-    const Point& position, BI_Via::Shape shape, const PositiveLength& size,
-    const PositiveLength& drillDiameter) {
-  BI_Via* via = new BI_Via(mNetSegment, position, shape, size, drillDiameter);
-  return addVia(*via);
+BI_Via* CmdBoardNetSegmentAddElements::addVia(const Via& via) {
+  BI_Via* v = new BI_Via(mNetSegment, via);
+  return addVia(*v);
 }
 
 BI_NetPoint* CmdBoardNetSegmentAddElements::addNetPoint(BI_NetPoint& netpoint) {

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentaddelements.h
@@ -56,9 +56,7 @@ public:
 
   // General Methods
   BI_Via*      addVia(BI_Via& via);
-  BI_Via*      addVia(const Point& position, BI_Via::Shape shape,
-                      const PositiveLength& size,
-                      const PositiveLength& drillDiameter);
+  BI_Via*      addVia(const Via& via);
   BI_NetPoint* addNetPoint(BI_NetPoint& netpoint);
   BI_NetPoint* addNetPoint(const Point& position);
   BI_NetLine*  addNetLine(BI_NetLine& netline);

--- a/libs/librepcb/project/boards/cmd/cmdboardviaedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardviaedit.cpp
@@ -82,7 +82,7 @@ void CmdBoardViaEdit::rotate(const Angle& angle, const Point& center,
   if (immediate) mVia.setPosition(mNewPos);
 }
 
-void CmdBoardViaEdit::setShape(BI_Via::Shape shape, bool immediate) noexcept {
+void CmdBoardViaEdit::setShape(Via::Shape shape, bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewShape = shape;
   if (immediate) mVia.setShape(mNewShape);

--- a/libs/librepcb/project/boards/cmd/cmdboardviaedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardviaedit.h
@@ -55,7 +55,7 @@ public:
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
-  void setShape(BI_Via::Shape shape, bool immediate) noexcept;
+  void setShape(Via::Shape shape, bool immediate) noexcept;
   void setSize(const PositiveLength& size, bool immediate) noexcept;
   void setDrillDiameter(const PositiveLength& diameter,
                         bool                  immediate) noexcept;
@@ -80,8 +80,8 @@ private:
   // General Attributes
   Point          mOldPos;
   Point          mNewPos;
-  BI_Via::Shape  mOldShape;
-  BI_Via::Shape  mNewShape;
+  Via::Shape     mOldShape;
+  Via::Shape     mNewShape;
   PositiveLength mOldSize;
   PositiveLength mNewSize;
   PositiveLength mOldDrillDiameter;

--- a/libs/librepcb/project/boards/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/project/boards/drc/boardclipperpathgenerator.cpp
@@ -286,8 +286,8 @@ void BoardClipperPathGenerator::addCopper(const QString&   layerName,
         continue;
       }
       ClipperHelpers::unite(
-          mPaths,
-          ClipperHelpers::convert(via->getSceneOutline(), mMaxArcTolerance));
+          mPaths, ClipperHelpers::convert(via->getVia().getSceneOutline(),
+                                          mMaxArcTolerance));
     }
 
     // netlines

--- a/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
@@ -90,9 +90,9 @@ void BGI_Via::updateCacheAndRepaint() noexcept {
       mVia.getBoard().getDesignRules().calcStopMaskClearance(*mVia.getSize());
 
   // set shapes and bounding rect
-  mShape        = mVia.getOutline().toQPainterPathPx();
-  mCopper       = mVia.toQPainterPathPx();
-  mStopMask     = mVia.getOutline(*stopMaskClearance).toQPainterPathPx();
+  mShape    = mVia.getVia().getOutline().toQPainterPathPx();
+  mCopper   = mVia.getVia().toQPainterPathPx();
+  mStopMask = mVia.getVia().getOutline(*stopMaskClearance).toQPainterPathPx();
   mBoundingRect = mStopMask.boundingRect();
 
   update();

--- a/libs/librepcb/project/boards/items/bi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.cpp
@@ -224,6 +224,12 @@ Path BI_FootprintPad::getSceneOutline(const Length& expansion) const noexcept {
   return getOutline(expansion).rotated(rotation).translated(mPosition);
 }
 
+TraceAnchor BI_FootprintPad::toTraceAnchor() const noexcept {
+  return TraceAnchor::pad(
+      mFootprint.getDeviceInstance().getComponentInstanceUuid(),
+      mPackagePad->getUuid());
+}
+
 /*******************************************************************************
  *  Private Slots
  ******************************************************************************/

--- a/libs/librepcb/project/boards/items/bi_footprintpad.h
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.h
@@ -81,6 +81,7 @@ public:
   bool isSelectable() const noexcept override;
   Path getOutline(const Length& expansion = Length(0)) const noexcept;
   Path getSceneOutline(const Length& expansion = Length(0)) const noexcept;
+  TraceAnchor toTraceAnchor() const noexcept override;
 
   // General Methods
   void addToBoard() override;

--- a/libs/librepcb/project/boards/items/bi_netline.h
+++ b/libs/librepcb/project/boards/items/bi_netline.h
@@ -28,7 +28,7 @@
 
 #include <librepcb/common/fileio/serializableobject.h>
 #include <librepcb/common/geometry/path.h>
-#include <librepcb/common/uuid.h>
+#include <librepcb/common/geometry/trace.h>
 
 #include <QtCore>
 
@@ -57,6 +57,8 @@ public:
   virtual void                     unregisterNetLine(BI_NetLine& netline) = 0;
   virtual const QSet<BI_NetLine*>& getNetLines() const noexcept           = 0;
   virtual const Point&             getPosition() const noexcept           = 0;
+
+  virtual TraceAnchor toTraceAnchor() const noexcept = 0;
 
   std::vector<PositiveLength> getLineWidths() const noexcept;
   UnsignedLength              getMaxLineWidth() const noexcept;
@@ -88,9 +90,10 @@ public:
 
   // Getters
   BI_NetSegment&        getNetSegment() const noexcept { return mNetSegment; }
-  const Uuid&           getUuid() const noexcept { return mUuid; }
+  const Trace&          getTrace() const noexcept { return mTrace; }
+  const Uuid&           getUuid() const noexcept { return mTrace.getUuid(); }
   GraphicsLayer&        getLayer() const noexcept { return *mLayer; }
-  const PositiveLength& getWidth() const noexcept { return mWidth; }
+  const PositiveLength& getWidth() const noexcept { return mTrace.getWidth(); }
   BI_NetLineAnchor&     getStartPoint() const noexcept { return *mStartPoint; }
   BI_NetLineAnchor&     getEndPoint() const noexcept { return *mEndPoint; }
   BI_NetLineAnchor*     getOtherPoint(const BI_NetLineAnchor& firstPoint) const
@@ -124,22 +127,19 @@ public:
 
 private:
   void              init();
-  BI_NetLineAnchor* deserializeAnchor(const SExpression& root,
-                                      const QString&     key) const;
-  void serializeAnchor(SExpression& root, BI_NetLineAnchor* anchor) const;
+  BI_NetLineAnchor* getAnchor(const TraceAnchor& anchor);
 
   // General
   BI_NetSegment&              mNetSegment;
+  Trace                       mTrace;
   QScopedPointer<BGI_NetLine> mGraphicsItem;
   Point                   mPosition;  ///< the center of startpoint and endpoint
   QMetaObject::Connection mHighlightChangedConnection;
 
-  // Attributes
-  Uuid              mUuid;
+  // References
   BI_NetLineAnchor* mStartPoint;
   BI_NetLineAnchor* mEndPoint;
   GraphicsLayer*    mLayer;
-  PositiveLength    mWidth;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/boards/items/bi_netpoint.cpp
+++ b/libs/librepcb/project/boards/items/bi_netpoint.cpp
@@ -38,42 +38,30 @@ namespace project {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BI_NetPoint::BI_NetPoint(BI_NetSegment& segment, const BI_NetPoint& other)
-  : BI_Base(segment.getBoard()),
-    mNetSegment(segment),
-    mUuid(Uuid::createRandom()),
-    mPosition(other.mPosition) {
-  init();
-}
-
 BI_NetPoint::BI_NetPoint(BI_NetSegment& segment, const SExpression& node)
-  : BI_Base(segment.getBoard()),
-    mNetSegment(segment),
-    mUuid(node.getChildByIndex(0).getValue<Uuid>()),
-    mPosition(node.getChildByPath("position")) {
+  : BI_Base(segment.getBoard()), mNetSegment(segment), mJunction(node) {
   init();
 }
 
 BI_NetPoint::BI_NetPoint(BI_NetSegment& segment, const Point& position)
   : BI_Base(segment.getBoard()),
     mNetSegment(segment),
-    mUuid(Uuid::createRandom()),
-    mPosition(position) {
+    mJunction(Uuid::createRandom(), position) {
   init();
 }
 
 void BI_NetPoint::init() {
   // create the graphics item
   mGraphicsItem.reset(new BGI_NetPoint(*this));
-  mGraphicsItem->setPos(mPosition.toPxQPointF());
+  mGraphicsItem->setPos(mJunction.getPosition().toPxQPointF());
 
   // create ERC messages
   mErcMsgDeadNetPoint.reset(new ErcMsg(mBoard.getProject(), *this,
-                                       mUuid.toStr(), "Dead",
+                                       mJunction.getUuid().toStr(), "Dead",
                                        ErcMsg::ErcMsgType_t::BoardError,
                                        tr("Dead net point in board \"%1\": %2")
                                            .arg(*mBoard.getName())
-                                           .arg(mUuid.toStr())));
+                                           .arg(mJunction.getUuid().toStr())));
 }
 
 BI_NetPoint::~BI_NetPoint() noexcept {
@@ -94,14 +82,17 @@ GraphicsLayer* BI_NetPoint::getLayerOfLines() const noexcept {
                                                 : nullptr;
 }
 
+TraceAnchor BI_NetPoint::toTraceAnchor() const noexcept {
+  return TraceAnchor::junction(mJunction.getUuid());
+}
+
 /*******************************************************************************
  *  Setters
  ******************************************************************************/
 
 void BI_NetPoint::setPosition(const Point& position) noexcept {
-  if (position != mPosition) {
-    mPosition = position;
-    mGraphicsItem->setPos(mPosition.toPxQPointF());
+  if (mJunction.setPosition(position)) {
+    mGraphicsItem->setPos(position.toPxQPointF());
     foreach (BI_NetLine* line, mRegisteredNetLines) { line->updateLine(); }
     mBoard.scheduleAirWiresRebuild(&getNetSignalOfNetSegment());
   }
@@ -140,11 +131,19 @@ void BI_NetPoint::removeFromBoard() {
 }
 
 void BI_NetPoint::registerNetLine(BI_NetLine& netline) {
-  if ((!isAddedToBoard()) || (mRegisteredNetLines.contains(&netline)) ||
-      (&netline.getNetSegment() != &mNetSegment) ||
-      ((mRegisteredNetLines.count() > 0) &&
-       (&netline.getLayer() != getLayerOfLines()))) {
-    throw LogicError(__FILE__, __LINE__);
+  if (!isAddedToBoard()) {
+    throw LogicError(__FILE__, __LINE__,
+                     "NetPoint is currently not added to the board.");
+  } else if (mRegisteredNetLines.contains(&netline)) {
+    throw LogicError(__FILE__, __LINE__,
+                     "NetLine is already registered to the NetPoint.");
+  } else if (&netline.getNetSegment() != &mNetSegment) {
+    throw LogicError(__FILE__, __LINE__,
+                     "NetLine has different NetSegment than the NetPoint.");
+  } else if ((mRegisteredNetLines.count() > 0) &&
+             (&netline.getLayer() != getLayerOfLines())) {
+    throw LogicError(__FILE__, __LINE__,
+                     "NetPoint already has NetLines on different layer.");
   }
   mRegisteredNetLines.insert(&netline);
   netline.updateLine();
@@ -165,8 +164,7 @@ void BI_NetPoint::unregisterNetLine(BI_NetLine& netline) {
 }
 
 void BI_NetPoint::serialize(SExpression& root) const {
-  root.appendChild(mUuid);
-  root.appendChild(mPosition.serializeToDomElement("position"), false);
+  mJunction.serialize(root);
 }
 
 /*******************************************************************************
@@ -174,7 +172,8 @@ void BI_NetPoint::serialize(SExpression& root) const {
  ******************************************************************************/
 
 QPainterPath BI_NetPoint::getGrabAreaScenePx() const noexcept {
-  return mGraphicsItem->shape().translated(mPosition.toPxQPointF());
+  return mGraphicsItem->shape().translated(
+      mJunction.getPosition().toPxQPointF());
 }
 
 bool BI_NetPoint::isSelectable() const noexcept {

--- a/libs/librepcb/project/boards/items/bi_netpoint.h
+++ b/libs/librepcb/project/boards/items/bi_netpoint.h
@@ -29,6 +29,7 @@
 #include "bi_base.h"
 
 #include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/geometry/junction.h>
 
 #include <QtCore>
 
@@ -56,18 +57,19 @@ public:
   // Constructors / Destructor
   BI_NetPoint()                         = delete;
   BI_NetPoint(const BI_NetPoint& other) = delete;
-  BI_NetPoint(BI_NetSegment& segment, const BI_NetPoint& other);
   BI_NetPoint(BI_NetSegment& segment, const SExpression& node);
   BI_NetPoint(BI_NetSegment& segment, const Point& position);
   ~BI_NetPoint() noexcept;
 
   // Getters
-  const Uuid&    getUuid() const noexcept { return mUuid; }
-  BI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
-  NetSignal&     getNetSignalOfNetSegment() const noexcept;
+  const Uuid&     getUuid() const noexcept { return mJunction.getUuid(); }
+  const Junction& getJunction() const noexcept { return mJunction; }
+  BI_NetSegment&  getNetSegment() const noexcept { return mNetSegment; }
+  NetSignal&      getNetSignalOfNetSegment() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
   GraphicsLayer* getLayerOfLines() const noexcept;
   bool           isSelectable() const noexcept override;
+  TraceAnchor    toTraceAnchor() const noexcept override;
 
   // Setters
   void setPosition(const Point& position) noexcept;
@@ -79,9 +81,11 @@ public:
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
 
-  // Inherited from SI_Base
+  // Inherited from BI_Base
   Type_t getType() const noexcept override { return BI_Base::Type_t::NetPoint; }
-  const Point& getPosition() const noexcept override { return mPosition; }
+  const Point& getPosition() const noexcept override {
+    return mJunction.getPosition();
+  }
   bool         getIsMirrored() const noexcept override { return false; }
   QPainterPath getGrabAreaScenePx() const noexcept override;
   void         setSelected(bool selected) noexcept override;
@@ -107,8 +111,7 @@ private:
 
   // Attributes
   BI_NetSegment& mNetSegment;
-  Uuid           mUuid;
-  Point          mPosition;
+  Junction       mJunction;
 
   // Registered Elements
   QSet<BI_NetLine*> mRegisteredNetLines;  ///< all registered netlines

--- a/libs/librepcb/project/boards/items/bi_netsegment.cpp
+++ b/libs/librepcb/project/boards/items/bi_netsegment.cpp
@@ -72,7 +72,7 @@ BI_NetSegment::BI_NetSegment(Board& board, const BI_NetSegment& other,
   }
   // copy netpoints
   foreach (const BI_NetPoint* netpoint, other.mNetPoints) {
-    BI_NetPoint* copy = new BI_NetPoint(*this, *netpoint);
+    BI_NetPoint* copy = new BI_NetPoint(*this, netpoint->getPosition());
     mNetPoints.append(copy);
     anchorsMap.insert(netpoint, copy);
   }

--- a/libs/librepcb/project/circuit/netsignal.cpp
+++ b/libs/librepcb/project/circuit/netsignal.cpp
@@ -179,10 +179,14 @@ void NetSignal::unregisterComponentSignal(ComponentSignalInstance& signal) {
 }
 
 void NetSignal::registerSchematicNetSegment(SI_NetSegment& netsegment) {
-  if ((!mIsAddedToCircuit) ||
-      (mRegisteredSchematicNetSegments.contains(&netsegment)) ||
-      (netsegment.getCircuit() != mCircuit)) {
-    throw LogicError(__FILE__, __LINE__);
+  if (!mIsAddedToCircuit) {
+    throw LogicError(__FILE__, __LINE__, "NetSignal is not added to circuit.");
+  }
+  if (mRegisteredSchematicNetSegments.contains(&netsegment)) {
+    throw LogicError(__FILE__, __LINE__, "NetSegment already in NetSignal.");
+  }
+  if (netsegment.getCircuit() != mCircuit) {
+    throw LogicError(__FILE__, __LINE__, "NetSegment is from other circuit.");
   }
   mRegisteredSchematicNetSegments.append(&netsegment);
   updateErcMessages();

--- a/libs/librepcb/project/schematics/items/si_netlabel.h
+++ b/libs/librepcb/project/schematics/items/si_netlabel.h
@@ -26,7 +26,7 @@
 #include "../graphicsitems/sgi_netlabel.h"
 #include "si_base.h"
 
-#include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/geometry/netlabel.h>
 
 #include <QtCore>
 
@@ -61,11 +61,12 @@ public:
   ~SI_NetLabel() noexcept;
 
   // Getters
-  const Uuid&    getUuid() const noexcept { return mUuid; }
-  const Angle&   getRotation() const noexcept { return mRotation; }
-  SI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
-  NetSignal&     getNetSignalOfNetSegment() const noexcept;
-  Length         getApproximateWidth() noexcept;
+  const Uuid&  getUuid() const noexcept { return mNetLabel.getUuid(); }
+  const Angle& getRotation() const noexcept { return mNetLabel.getRotation(); }
+  const NetLabel& getNetLabel() const noexcept { return mNetLabel; }
+  SI_NetSegment&  getNetSegment() const noexcept { return mNetSegment; }
+  NetSignal&      getNetSignalOfNetSegment() const noexcept;
+  Length          getApproximateWidth() noexcept;
 
   // Setters
   void setPosition(const Point& position) noexcept;
@@ -81,7 +82,9 @@ public:
 
   // Inherited from SI_Base
   Type_t getType() const noexcept override { return SI_Base::Type_t::NetLabel; }
-  const Point& getPosition() const noexcept override { return mPosition; }
+  const Point& getPosition() const noexcept override {
+    return mNetLabel.getPosition();
+  }
   QPainterPath getGrabAreaScenePx() const noexcept override;
   void         setSelected(bool selected) noexcept override;
 
@@ -98,9 +101,7 @@ private:
 
   // Attributes
   SI_NetSegment& mNetSegment;
-  Uuid           mUuid;
-  Point          mPosition;
-  Angle          mRotation;
+  NetLabel       mNetLabel;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/items/si_netline.h
+++ b/libs/librepcb/project/schematics/items/si_netline.h
@@ -26,7 +26,7 @@
 #include "../graphicsitems/sgi_netline.h"
 #include "si_base.h"
 
-#include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/geometry/netline.h>
 
 #include <QtCore>
 
@@ -52,6 +52,8 @@ public:
   virtual void                     unregisterNetLine(SI_NetLine& netline) = 0;
   virtual const QSet<SI_NetLine*>& getNetLines() const noexcept           = 0;
   virtual const Point&             getPosition() const noexcept           = 0;
+
+  virtual NetLineAnchor toNetLineAnchor() const noexcept = 0;
 };
 
 /*******************************************************************************
@@ -75,11 +77,14 @@ public:
 
   // Getters
   SI_NetSegment&        getNetSegment() const noexcept { return mNetSegment; }
-  const Uuid&           getUuid() const noexcept { return mUuid; }
-  const UnsignedLength& getWidth() const noexcept { return mWidth; }
-  SI_NetLineAnchor&     getStartPoint() const noexcept { return *mStartPoint; }
-  SI_NetLineAnchor&     getEndPoint() const noexcept { return *mEndPoint; }
-  SI_NetLineAnchor*     getOtherPoint(const SI_NetLineAnchor& firstPoint) const
+  const NetLine&        getNetLine() const noexcept { return mNetLine; }
+  const Uuid&           getUuid() const noexcept { return mNetLine.getUuid(); }
+  const UnsignedLength& getWidth() const noexcept {
+    return mNetLine.getWidth();
+  }
+  SI_NetLineAnchor& getStartPoint() const noexcept { return *mStartPoint; }
+  SI_NetLineAnchor& getEndPoint() const noexcept { return *mEndPoint; }
+  SI_NetLineAnchor* getOtherPoint(const SI_NetLineAnchor& firstPoint) const
       noexcept;
   NetSignal& getNetSignalOfNetSegment() const noexcept;
 
@@ -105,21 +110,18 @@ public:
 
 private:
   void              init();
-  SI_NetLineAnchor* deserializeAnchor(const SExpression& root,
-                                      const QString&     key) const;
-  void serializeAnchor(SExpression& root, SI_NetLineAnchor* anchor) const;
+  SI_NetLineAnchor* getAnchor(const NetLineAnchor& anchor);
 
   // General
   SI_NetSegment&              mNetSegment;
+  NetLine                     mNetLine;
   QScopedPointer<SGI_NetLine> mGraphicsItem;
   Point                   mPosition;  ///< the center of startpoint and endpoint
   QMetaObject::Connection mHighlightChangedConnection;
 
-  // Attributes
-  Uuid              mUuid;
+  // References
   SI_NetLineAnchor* mStartPoint;
   SI_NetLineAnchor* mEndPoint;
-  UnsignedLength    mWidth;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/items/si_netpoint.h
+++ b/libs/librepcb/project/schematics/items/si_netpoint.h
@@ -28,7 +28,7 @@
 #include "./si_netline.h"
 #include "si_base.h"
 
-#include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/geometry/junction.h>
 
 #include <QtCore>
 
@@ -62,12 +62,14 @@ public:
   ~SI_NetPoint() noexcept;
 
   // Getters
-  const Uuid&    getUuid() const noexcept { return mUuid; }
-  bool           isVisibleJunction() const noexcept;
-  bool           isOpenLineEnd() const noexcept;
-  SI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
-  NetSignal&     getNetSignalOfNetSegment() const noexcept;
+  const Uuid&     getUuid() const noexcept { return mJunction.getUuid(); }
+  const Junction& getJunction() const noexcept { return mJunction; }
+  bool            isVisibleJunction() const noexcept;
+  bool            isOpenLineEnd() const noexcept;
+  SI_NetSegment&  getNetSegment() const noexcept { return mNetSegment; }
+  NetSignal&      getNetSignalOfNetSegment() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
+  NetLineAnchor toNetLineAnchor() const noexcept override;
 
   // Setters
   void setPosition(const Point& position) noexcept;
@@ -81,7 +83,9 @@ public:
 
   // Inherited from SI_Base
   Type_t getType() const noexcept override { return SI_Base::Type_t::NetPoint; }
-  const Point& getPosition() const noexcept override { return mPosition; }
+  const Point& getPosition() const noexcept override {
+    return mJunction.getPosition();
+  }
   QPainterPath getGrabAreaScenePx() const noexcept override;
   void         setSelected(bool selected) noexcept override;
 
@@ -106,8 +110,7 @@ private:
 
   // Attributes
   SI_NetSegment& mNetSegment;
-  Uuid           mUuid;
-  Point          mPosition;
+  Junction       mJunction;
 
   // Registered Elements
   QSet<SI_NetLine*> mRegisteredNetLines;  ///< all registered netlines

--- a/libs/librepcb/project/schematics/items/si_symbolpin.cpp
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.cpp
@@ -140,6 +140,10 @@ bool SI_SymbolPin::isVisibleJunction() const noexcept {
   return (mRegisteredNetLines.count() > 1);
 }
 
+NetLineAnchor SI_SymbolPin::toNetLineAnchor() const noexcept {
+  return NetLineAnchor::pin(mSymbol.getUuid(), mSymbolPin->getUuid());
+}
+
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/

--- a/libs/librepcb/project/schematics/items/si_symbolpin.h
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.h
@@ -82,6 +82,7 @@ public:
   bool           isRequired() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
   bool isVisibleJunction() const noexcept;
+  NetLineAnchor toNetLineAnchor() const noexcept override;
 
   // General Methods
   void addToSchematic() override;

--- a/libs/librepcb/project/schematics/schematicselectionquery.cpp
+++ b/libs/librepcb/project/schematics/schematicselectionquery.cpp
@@ -55,6 +55,21 @@ SchematicSelectionQuery::~SchematicSelectionQuery() noexcept {
  *  Getters: General
  ******************************************************************************/
 
+QHash<SI_NetSegment*, SchematicSelectionQuery::NetSegmentItems>
+SchematicSelectionQuery::getNetSegmentItems() const noexcept {
+  QHash<SI_NetSegment*, NetSegmentItems> result;
+  foreach (SI_NetPoint* netpoint, mResultNetPoints) {
+    result[&netpoint->getNetSegment()].netpoints.insert(netpoint);
+  }
+  foreach (SI_NetLine* netline, mResultNetLines) {
+    result[&netline->getNetSegment()].netlines.insert(netline);
+  }
+  foreach (SI_NetLabel* netlabel, mResultNetLabels) {
+    result[&netlabel->getNetSegment()].netlabels.insert(netlabel);
+  }
+  return result;
+}
+
 int SchematicSelectionQuery::getResultCount() const noexcept {
   return mResultSymbols.count() + mResultNetPoints.count() +
          mResultNetLines.count() + mResultNetLabels.count();
@@ -102,12 +117,19 @@ void SchematicSelectionQuery::addSelectedNetLabels() noexcept {
   }
 }
 
-void SchematicSelectionQuery::addNetPointsOfNetLines() noexcept {
+void SchematicSelectionQuery::addNetPointsOfNetLines(
+    bool onlyIfAllNetLinesSelected) noexcept {
   foreach (SI_NetLine* netline, mResultNetLines) {
     SI_NetPoint* p1 = dynamic_cast<SI_NetPoint*>(&netline->getStartPoint());
     SI_NetPoint* p2 = dynamic_cast<SI_NetPoint*>(&netline->getEndPoint());
-    if (p1) mResultNetPoints.insert(p1);
-    if (p2) mResultNetPoints.insert(p2);
+    if (p1 && ((!onlyIfAllNetLinesSelected) ||
+               (mResultNetLines.contains(p1->getNetLines())))) {
+      mResultNetPoints.insert(p1);
+    }
+    if (p2 && ((!onlyIfAllNetLinesSelected) ||
+               (mResultNetLines.contains(p2->getNetLines())))) {
+      mResultNetPoints.insert(p2);
+    }
   }
 }
 

--- a/libs/librepcb/project/schematics/schematicselectionquery.h
+++ b/libs/librepcb/project/schematics/schematicselectionquery.h
@@ -51,6 +51,13 @@ class SchematicSelectionQuery final : public QObject {
   Q_OBJECT
 
 public:
+  // Types
+  struct NetSegmentItems {
+    QSet<SI_NetPoint*> netpoints;
+    QSet<SI_NetLine*>  netlines;
+    QSet<SI_NetLabel*> netlabels;
+  };
+
   // Constructors / Destructor
   SchematicSelectionQuery()                                     = delete;
   SchematicSelectionQuery(const SchematicSelectionQuery& other) = delete;
@@ -70,7 +77,18 @@ public:
   const QSet<SI_NetLabel*>& getNetLabels() const noexcept {
     return mResultNetLabels;
   }
-  int  getResultCount() const noexcept;
+
+  /**
+   * @brief Get net points, net lines and net labels grouped by net segement
+   *
+   * Same as #getNetPoints(), #getNetLines() and #getNetLabels(), but grouped
+   * by their corresponding net segments. Only net segments containing selected
+   * items are returned.
+   *
+   * @return List of net segments containing the selected items
+   */
+  QHash<SI_NetSegment*, NetSegmentItems> getNetSegmentItems() const noexcept;
+  int                                    getResultCount() const noexcept;
   bool isResultEmpty() const noexcept { return (getResultCount() == 0); }
 
   // General Methods
@@ -78,7 +96,16 @@ public:
   void addSelectedNetPoints() noexcept;
   void addSelectedNetLines() noexcept;
   void addSelectedNetLabels() noexcept;
-  void addNetPointsOfNetLines() noexcept;
+  /**
+   * @brief Add net points of the selected net lines
+   *
+   * @param onlyIfAllNetLinesSelected   If true, net points are added only if
+   *                                    *all* connected net lines are selected.
+   *                                    If false, net points are added if at
+   *                                    least one of the connected net lines
+   *                                    is selected.
+   */
+  void addNetPointsOfNetLines(bool onlyIfAllNetLinesSelected = false) noexcept;
   void addNetLinesOfSymbolPins() noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
@@ -64,10 +64,9 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(
                           settingsPrefix % "/pos_y");
 
   // shape combobox
-  mUi->cbxShape->addItem(tr("Round"), static_cast<int>(BI_Via::Shape::Round));
-  mUi->cbxShape->addItem(tr("Square"), static_cast<int>(BI_Via::Shape::Square));
-  mUi->cbxShape->addItem(tr("Octagon"),
-                         static_cast<int>(BI_Via::Shape::Octagon));
+  mUi->cbxShape->addItem(tr("Round"), static_cast<int>(Via::Shape::Round));
+  mUi->cbxShape->addItem(tr("Square"), static_cast<int>(Via::Shape::Square));
+  mUi->cbxShape->addItem(tr("Octagon"), static_cast<int>(Via::Shape::Octagon));
   mUi->cbxShape->setCurrentIndex(
       mUi->cbxShape->findData(static_cast<int>(mVia.getShape())));
 
@@ -116,9 +115,8 @@ void BoardViaPropertiesDialog::accept() {
 bool BoardViaPropertiesDialog::applyChanges() noexcept {
   try {
     QScopedPointer<CmdBoardViaEdit> cmd(new CmdBoardViaEdit(mVia));
-    cmd->setShape(
-        static_cast<BI_Via::Shape>(mUi->cbxShape->currentData().toInt()),
-        false);
+    cmd->setShape(static_cast<Via::Shape>(mUi->cbxShape->currentData().toInt()),
+                  false);
     cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
                      false);
     cmd->setSize(mUi->edtSize->getValue(), false);

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
@@ -100,14 +100,12 @@ private:  // Methods
 
 private:  // Data
   // State
-  bool           mIsUndoCmdActive;
-  QString        mAutoText;
-  bool           mFindClosestNetSignal;
-  NetSignal*     mLastClosestNetSignal;
-  BI_Via::Shape  mLastShape;
-  PositiveLength mLastSize;
-  PositiveLength mLastDrillDiameter;
-  NetSignal*     mLastNetSignal;
+  bool       mIsUndoCmdActive;
+  QString    mAutoText;
+  bool       mFindClosestNetSignal;
+  NetSignal* mLastClosestNetSignal;
+  Via        mLastViaProperties;
+  NetSignal* mLastNetSignal;
 
   // Information about the current via to place. Only valid if
   // mIsUndoCmdActive == true.

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.cpp
@@ -66,9 +66,12 @@ BoardEditorState_DrawTrace::BoardEditorState_DrawTrace(
     mCurrentLayerName(GraphicsLayer::sTopCopper),
     mAddVia(false),
     mTempVia(nullptr),
-    mCurrentViaShape(BI_Via::Shape::Round),
-    mCurrentViaSize(700000),
-    mCurrentViaDrillDiameter(300000),
+    mCurrentViaProperties(Uuid::createRandom(),  // UUID is not relevant here
+                          Point(),            // Position is not relevant here
+                          Via::Shape::Round,  // Default shape
+                          PositiveLength(700000),  // Default size
+                          PositiveLength(300000)   // Default drill diameter
+                          ),
     mViaLayerName(""),
     mTargetPos(),
     mCursorPos(),
@@ -170,14 +173,14 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
       this, &BoardEditorState_DrawTrace::layerComboBoxIndexChanged);
 
   // Add shape actions to the "command" toolbar
-  mShapeActions.insert(static_cast<int>(BI_Via::Shape::Round),
+  mShapeActions.insert(static_cast<int>(Via::Shape::Round),
                        mContext.editorUi.commandToolbar->addAction(
                            QIcon(":/img/command_toolbars/via_round.png"), ""));
-  mShapeActions.insert(static_cast<int>(BI_Via::Shape::Square),
+  mShapeActions.insert(static_cast<int>(Via::Shape::Square),
                        mContext.editorUi.commandToolbar->addAction(
                            QIcon(":/img/command_toolbars/via_square.png"), ""));
   mShapeActions.insert(
-      static_cast<int>(BI_Via::Shape::Octagon),
+      static_cast<int>(Via::Shape::Octagon),
       mContext.editorUi.commandToolbar->addAction(
           QIcon(":/img/command_toolbars/via_octagon.png"), ""));
   updateShapeActionsCheckedState();
@@ -185,7 +188,7 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
   // Connect the shape actions with the slot updateShapeActionsCheckedState()
   foreach (int shape, mShapeActions.keys()) {
     connect(mShapeActions.value(shape), &QAction::triggered, [this, shape]() {
-      mCurrentViaShape = static_cast<BI_Via::Shape>(shape);
+      mCurrentViaProperties.setShape(static_cast<Via::Shape>(shape));
       updateShapeActionsCheckedState();
     });
   }
@@ -197,7 +200,7 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
 
   // Add the size combobox to the toolbar
   mSizeEdit.reset(new PositiveLengthEdit());
-  mSizeEdit->setValue(mCurrentViaSize);
+  mSizeEdit->setValue(mCurrentViaProperties.getSize());
   mContext.editorUi.commandToolbar->addWidget(mSizeEdit.data());
   connect(mSizeEdit.data(), &PositiveLengthEdit::valueChanged, this,
           &BoardEditorState_DrawTrace::sizeEditValueChanged);
@@ -209,7 +212,7 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
 
   // Add the drill combobox to the toolbar
   mDrillEdit.reset(new PositiveLengthEdit());
-  mDrillEdit->setValue(mCurrentViaDrillDiameter);
+  mDrillEdit->setValue(mCurrentViaProperties.getDrillDiameter());
   mContext.editorUi.commandToolbar->addWidget(mDrillEdit.data());
   connect(mDrillEdit.data(), &PositiveLengthEdit::valueChanged, this,
           &BoardEditorState_DrawTrace::drillDiameterEditValueChanged);
@@ -301,15 +304,15 @@ bool BoardEditorState_DrawTrace::processKeyPressed(
       mDrillEdit->stepBy(-1);
       return true;
     case Qt::Key_4:
-      mCurrentViaShape = BI_Via::Shape::Round;
+      mCurrentViaProperties.setShape(Via::Shape::Round);
       updateShapeActionsCheckedState();
       return true;
     case Qt::Key_5:
-      mCurrentViaShape = BI_Via::Shape::Square;
+      mCurrentViaProperties.setShape(Via::Shape::Square);
       updateShapeActionsCheckedState();
       return true;
     case Qt::Key_6:
-      mCurrentViaShape = BI_Via::Shape::Octagon;
+      mCurrentViaProperties.setShape(Via::Shape::Octagon);
       updateShapeActionsCheckedState();
       return true;
     default:
@@ -890,9 +893,9 @@ void BoardEditorState_DrawTrace::showVia(bool isVisible) noexcept {
       cmdRemove->removeNetPoint(*mPositioningNetPoint2);
       CmdBoardNetSegmentAddElements* cmdAdd =
           new CmdBoardNetSegmentAddElements(*mCurrentNetSegment);
+      mCurrentViaProperties.setPosition(mPositioningNetPoint2->getPosition());
       mTempVia =
-          cmdAdd->addVia(mPositioningNetPoint2->getPosition(), mCurrentViaShape,
-                         mCurrentViaSize, mCurrentViaDrillDiameter);
+          cmdAdd->addVia(Via(Uuid::createRandom(), mCurrentViaProperties));
       Q_ASSERT(mTempVia);
       mPositioningNetLine2 = cmdAdd->addNetLine(
           *mPositioningNetPoint1, *mTempVia, mPositioningNetLine2->getLayer(),
@@ -916,9 +919,9 @@ void BoardEditorState_DrawTrace::showVia(bool isVisible) noexcept {
       mTempVia = nullptr;
     } else if (mTempVia) {
       mTempVia->setPosition(mTargetPos);
-      mTempVia->setSize(mCurrentViaSize);
-      mTempVia->setShape(mCurrentViaShape);
-      mTempVia->setDrillDiameter(mCurrentViaDrillDiameter);
+      mTempVia->setSize(mCurrentViaProperties.getSize());
+      mTempVia->setShape(mCurrentViaProperties.getShape());
+      mTempVia->setDrillDiameter(mCurrentViaProperties.getDrillDiameter());
     }
   } catch (const Exception& e) {
     QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
@@ -994,23 +997,23 @@ void BoardEditorState_DrawTrace::layerComboBoxIndexChanged(int index) noexcept {
 
 void BoardEditorState_DrawTrace::updateShapeActionsCheckedState() noexcept {
   foreach (int key, mShapeActions.keys()) {
-    mShapeActions.value(key)->setCheckable(key ==
-                                           static_cast<int>(mCurrentViaShape));
-    mShapeActions.value(key)->setChecked(key ==
-                                         static_cast<int>(mCurrentViaShape));
+    mShapeActions.value(key)->setCheckable(
+        key == static_cast<int>(mCurrentViaProperties.getShape()));
+    mShapeActions.value(key)->setChecked(
+        key == static_cast<int>(mCurrentViaProperties.getShape()));
   }
   updateNetpointPositions();
 }
 
 void BoardEditorState_DrawTrace::sizeEditValueChanged(
     const PositiveLength& value) noexcept {
-  mCurrentViaSize = value;
+  mCurrentViaProperties.setSize(value);
   updateNetpointPositions();
 }
 
 void BoardEditorState_DrawTrace::drillDiameterEditValueChanged(
     const PositiveLength& value) noexcept {
-  mCurrentViaDrillDiameter = value;
+  mCurrentViaProperties.setDrillDiameter(value);
   updateNetpointPositions();
 }
 

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
@@ -25,7 +25,7 @@
  ******************************************************************************/
 #include "boardeditorstate.h"
 
-#include <librepcb/project/boards/items/bi_via.h>
+#include <librepcb/common/geometry/via.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -45,6 +45,8 @@ class BI_FootprintPad;
 class BI_NetPoint;
 class BI_NetLine;
 class BI_NetLineAnchor;
+class BI_Via;
+class BI_NetSegment;
 
 namespace editor {
 
@@ -256,19 +258,17 @@ private:
       noexcept;
 
   // State
-  SubState       mSubState;          ///< the current substate
-  WireMode       mCurrentWireMode;   ///< the current wire mode
-  QString        mCurrentLayerName;  ///< the current board layer name
-  bool           mAddVia;            ///< whether a via add is requested
-  BI_Via*        mTempVia;
-  BI_Via::Shape  mCurrentViaShape;          ///< the current via shape
-  PositiveLength mCurrentViaSize;           ///< the current via size
-  PositiveLength mCurrentViaDrillDiameter;  ///< the current via drill
-                                            ///< diameter
-  QString mViaLayerName;  ///< the name of the layer where the via
-                          ///< was started
-  Point mTargetPos;       ///< the current target position of the
-                          ///< active trace
+  SubState mSubState;          ///< the current substate
+  WireMode mCurrentWireMode;   ///< the current wire mode
+  QString  mCurrentLayerName;  ///< the current board layer name
+  bool     mAddVia;            ///< whether a via add is requested
+  BI_Via*  mTempVia;
+  Via      mCurrentViaProperties;  ///< The current Via properties
+                                   ///< diameter
+  QString mViaLayerName;           ///< the name of the layer where the via
+                                   ///< was started
+  Point mTargetPos;                ///< the current target position of the
+                                   ///< active trace
 
   Point             mCursorPos;          ///< the current cursor position
   PositiveLength    mCurrentWidth;       ///< the current wire width

--- a/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.cpp
@@ -79,8 +79,7 @@ bool CmdCombineBoardNetSegments::performExecute() {
     if (via == &mOldAnchor) {
       anchorMap.insert(via, &mNewAnchor);
     } else {
-      BI_Via* newVia = cmdAdd->addVia(via->getPosition(), via->getShape(),
-                                      via->getSize(), via->getDrillDiameter());
+      BI_Via* newVia = cmdAdd->addVia(Via(Uuid::createRandom(), via->getVia()));
       anchorMap.insert(via, newVia);
     }
   }

--- a/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveboarditems.cpp
@@ -210,8 +210,7 @@ void CmdRemoveBoardItems::createNewSubNetSegment(BI_NetSegment& netsegment,
   QHash<const BI_NetLineAnchor*, BI_NetLineAnchor*> anchorMap;
   foreach (const BI_Via* via, items.vias) {
     BI_Via* newVia =
-        cmdAddElements->addVia(via->getPosition(), via->getShape(),
-                               via->getSize(), via->getDrillDiameter());
+        cmdAddElements->addVia(Via(Uuid::createRandom(), via->getVia()));
     Q_ASSERT(newVia);
     anchorMap.insert(via, newVia);
   }

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
@@ -31,7 +31,6 @@
 #include <librepcb/common/scopeguard.h>
 #include <librepcb/common/toolbox.h>
 #include <librepcb/project/boards/board.h>
-#include <librepcb/project/boards/cmd/cmddeviceinstanceremove.h>
 #include <librepcb/project/boards/items/bi_device.h>
 #include <librepcb/project/boards/items/bi_footprint.h>
 #include <librepcb/project/boards/items/bi_footprintpad.h>
@@ -41,20 +40,14 @@
 #include <librepcb/project/circuit/cmd/cmdcomponentinstanceremove.h>
 #include <librepcb/project/circuit/cmd/cmdcompsiginstsetnetsignal.h>
 #include <librepcb/project/circuit/cmd/cmdnetsignaladd.h>
-#include <librepcb/project/circuit/cmd/cmdnetsignalremove.h>
 #include <librepcb/project/circuit/componentinstance.h>
 #include <librepcb/project/circuit/componentsignalinstance.h>
 #include <librepcb/project/circuit/netsignal.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetlabelremove.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetpointedit.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentedit.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h>
-#include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremoveelements.h>
 #include <librepcb/project/schematics/cmd/cmdsymbolinstanceremove.h>
 #include <librepcb/project/schematics/items/si_netlabel.h>
 #include <librepcb/project/schematics/items/si_netline.h>
@@ -100,49 +93,19 @@ bool CmdRemoveSelectedSchematicItems::performExecute() {
   query->addSelectedSymbols();
   query->addSelectedNetLines();
   query->addSelectedNetLabels();
-  query->addNetPointsOfNetLines();
+  query->addNetPointsOfNetLines(true);
   query->addNetLinesOfSymbolPins();
 
   // clear selection because these items will be removed now
   mSchematic.clearSelection();
 
-  // determine all affected netsegments and their items
-  NetSegmentItemList netSegmentItems;
-  foreach (SI_NetPoint* netpoint, query->getNetPoints()) {
-    Q_ASSERT(netpoint->isAddedToSchematic());
-    netSegmentItems[&netpoint->getNetSegment()].netpoints.insert(netpoint);
-  }
-  foreach (SI_NetLine* netline, query->getNetLines()) {
-    Q_ASSERT(netline->isAddedToSchematic());
-    netSegmentItems[&netline->getNetSegment()].netlines.insert(netline);
-  }
-  foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
-    Q_ASSERT(netlabel->isAddedToSchematic());
-    netSegmentItems[&netlabel->getNetSegment()].netlabels.insert(netlabel);
-  }
-
   // remove netlines/netpoints/netlabels/netsegments
-  foreach (SI_NetSegment* netsegment, netSegmentItems.keys()) {
-    Q_ASSERT(netsegment->isAddedToSchematic());
-    const NetSegmentItems& items = netSegmentItems.value(netsegment);
-    if (items.netlines.count() == 0) {
-      // only netlabels of this netsegment are selected
-      Q_ASSERT(items.netpoints.count() == 0);
-      foreach (SI_NetLabel* netlabel, items.netlabels) {
-        Q_ASSERT(netlabel);
-        removeNetLabel(*netlabel);  // can throw
-      }
-    } else if (items.netlines.count() == netsegment->getNetLines().count()) {
-      // all lines of the netsegment are selected --> remove the whole
-      // netsegment
-      removeNetSegment(*netsegment);  // can throw
-    } else if (items.netlines.count() < netsegment->getNetLines().count()) {
-      // only some of the netsegment's lines are selected --> split up the
-      // netsegment
-      splitUpNetSegment(*netsegment, items);  // can throw
-    } else {
-      throw LogicError(__FILE__, __LINE__);
-    }
+  QHash<SI_NetSegment*, SchematicSelectionQuery::NetSegmentItems>
+      netSegmentItems = query->getNetSegmentItems();
+  for (auto it = netSegmentItems.constBegin(); it != netSegmentItems.constEnd();
+       ++it) {
+    removeNetSegmentItems(*it.key(), it.value().netpoints, it.value().netlines,
+                          it.value().netlabels);
   }
 
   // remove all symbols, devices and component instances
@@ -167,39 +130,35 @@ bool CmdRemoveSelectedSchematicItems::performExecute() {
   return (getChildCount() > 0);
 }
 
-void CmdRemoveSelectedSchematicItems::removeNetSegment(
-    SI_NetSegment& netsegment) {
-  // determine component signal instances to be disconnected
-  QSet<SI_SymbolPin*> pinsToBeDisconnected = netsegment.getAllConnectedPins();
-  QSet<ComponentSignalInstance*> cmpSigsToBeDisconnected;
-  foreach (SI_SymbolPin* pin, pinsToBeDisconnected) {
-    ComponentSignalInstance* cmpSig = pin->getComponentSignalInstance();
-    Q_ASSERT(cmpSig);
-    if (pinsToBeDisconnected.contains(
-            Toolbox::toSet(cmpSig->getRegisteredSymbolPins()))) {
-      cmpSigsToBeDisconnected.insert(cmpSig);
+void CmdRemoveSelectedSchematicItems::removeNetSegmentItems(
+    SI_NetSegment& netsegment, const QSet<SI_NetPoint*>& netpointsToRemove,
+    const QSet<SI_NetLine*>&  netlinesToRemove,
+    const QSet<SI_NetLabel*>& netlabelsToRemove) {
+  // Determine resulting sub-netsegments
+  SchematicNetSegmentSplitter splitter;
+  foreach (SI_SymbolPin* pin, netsegment.getAllConnectedPins()) {
+    splitter.addSymbolPin(pin->toNetLineAnchor(), pin->getPosition());
+  }
+  foreach (SI_NetPoint* netpoint, netsegment.getNetPoints()) {
+    if (!netpointsToRemove.contains(netpoint)) {
+      splitter.addJunction(netpoint->getJunction());
+    }
+  }
+  foreach (SI_NetLine* netline, netsegment.getNetLines()) {
+    if (!netlinesToRemove.contains(netline)) {
+      splitter.addNetLine(netline->getNetLine());
+    }
+  }
+  foreach (SI_NetLabel* netlabel, netsegment.getNetLabels()) {
+    if (!netlabelsToRemove.contains(netlabel)) {
+      splitter.addNetLabel(netlabel->getNetLabel());
     }
   }
 
-  // remove netsegment
-  execNewChildCmd(new CmdSchematicNetSegmentRemove(netsegment));  // can throw
-
-  // disconnect component signal instances
-  foreach (ComponentSignalInstance* cmpSig, cmpSigsToBeDisconnected) {
-    disconnectComponentSignalInstance(*cmpSig);  // can throw
-  }
-}
-
-void CmdRemoveSelectedSchematicItems::splitUpNetSegment(
-    SI_NetSegment& netsegment, const NetSegmentItems& selectedItems) {
-  // determine all resulting sub-netsegments
-  QList<NetSegmentItems> subsegments =
-      getNonCohesiveNetSegmentSubSegments(netsegment, selectedItems);
-
-  // determine component signal instances to be disconnected
+  // Determine component signal instances to be disconnected
   QSet<SI_SymbolPin*> pinsToBeDisconnected;
   foreach (SI_SymbolPin* pin, netsegment.getAllConnectedPins()) {
-    if (selectedItems.netlines.contains(pin->getNetLines())) {
+    if (netlinesToRemove.contains(pin->getNetLines())) {
       pinsToBeDisconnected.insert(pin);
     }
   }
@@ -213,127 +172,102 @@ void CmdRemoveSelectedSchematicItems::splitUpNetSegment(
     }
   }
 
-  // remove the whole netsegment
-  execNewChildCmd(new CmdSchematicNetSegmentRemove(netsegment));
+  // Remove whole netsegment
+  execNewChildCmd(new CmdSchematicNetSegmentRemove(netsegment));  // can throw
 
-  // disconnect component signal instances
+  // Disconnect component signal instances
   foreach (ComponentSignalInstance* cmpSig, cmpSigsToBeDisconnected) {
     disconnectComponentSignalInstance(*cmpSig);  // can throw
   }
 
-  // create new sub-netsegments
-  QList<SI_NetSegment*> newSubsegments;
-  foreach (const NetSegmentItems& subsegment, subsegments) {
-    newSubsegments.append(
-        createNewSubNetSegment(netsegment, subsegment));  // can throw
+  // Create new sub-netsegments
+  QVector<SI_NetSegment*> newNetSegments;
+  foreach (const SchematicNetSegmentSplitter::Segment& segment,
+           splitter.split()) {
+    // Add new netsegment
+    CmdSchematicNetSegmentAdd* cmdAddNetSegment = new CmdSchematicNetSegmentAdd(
+        netsegment.getSchematic(), netsegment.getNetSignal());
+    execNewChildCmd(cmdAddNetSegment);  // can throw
+    SI_NetSegment* newNetSegment = cmdAddNetSegment->getNetSegment();
+    Q_ASSERT(newNetSegment);
+    newNetSegments.append(newNetSegment);
+
+    // Add new netpoints and netlines
+    CmdSchematicNetSegmentAddElements* cmdAddElements =
+        new CmdSchematicNetSegmentAddElements(*newNetSegment);
+    QHash<Uuid, SI_NetLineAnchor*> junctionMap;
+    for (const Junction& junction : segment.junctions) {
+      SI_NetPoint* newNetPoint =
+          cmdAddElements->addNetPoint(junction.getPosition());
+      junctionMap.insert(junction.getUuid(), newNetPoint);
+    }
+    for (const NetLine& netline : segment.netlines) {
+      SI_NetLineAnchor* start = nullptr;
+      if (tl::optional<Uuid> anchor =
+              netline.getStartPoint().tryGetJunction()) {
+        start = junctionMap[*anchor];
+      } else if (tl::optional<NetLineAnchor::PinAnchor> anchor =
+                     netline.getStartPoint().tryGetPin()) {
+        SI_Symbol* symbol = mSchematic.getSymbolByUuid(anchor->symbol);
+        start             = symbol ? symbol->getPin(anchor->pin) : nullptr;
+      }
+      SI_NetLineAnchor* end = nullptr;
+      if (tl::optional<Uuid> anchor = netline.getEndPoint().tryGetJunction()) {
+        end = junctionMap[*anchor];
+      } else if (tl::optional<NetLineAnchor::PinAnchor> anchor =
+                     netline.getEndPoint().tryGetPin()) {
+        SI_Symbol* symbol = mSchematic.getSymbolByUuid(anchor->symbol);
+        end               = symbol ? symbol->getPin(anchor->pin) : nullptr;
+      }
+      if ((!start) || (!end)) {
+        throw LogicError(__FILE__, __LINE__);
+      }
+      SI_NetLine* newNetLine = cmdAddElements->addNetLine(*start, *end);
+      Q_ASSERT(newNetLine);
+    }
+    execNewChildCmd(cmdAddElements);  // can throw
+
+    // Add new netlabels
+    for (const NetLabel& netlabel : segment.netlabels) {
+      execNewChildCmd(new CmdSchematicNetLabelAdd(
+          *newNetSegment, netlabel.getPosition(), netlabel.getRotation()));
+    }
   }
 
-  // assign new netsignal to each subsegment (with some exceptions)
-  foreach (SI_NetSegment* subsegment, newSubsegments) {
+  // Assign proper net signals to new net segments. Must be done *after* all
+  // net segments were added, otherwise net signals might be deleted too early.
+  foreach (SI_NetSegment* newNetSegment, newNetSegments) {
     NetSignal* newNetSignal = nullptr;
-    QString    forcedName   = subsegment->getForcedNetName();
+    QString    forcedName   = newNetSegment->getForcedNetName();
     if (!forcedName.isEmpty()) {
-      // set netsignal to forced name
-      if (subsegment->getNetSignal().getName() != forcedName) {
+      // Set netsignal to forced name
+      if (newNetSegment->getNetSignal().getName() != forcedName) {
         newNetSignal =
             mSchematic.getProject().getCircuit().getNetSignalByName(forcedName);
         if (!newNetSignal) {
-          // create new netsignal
+          // Create new netsignal
           CmdNetSignalAdd* cmdAddNetSignal =
-              new CmdNetSignalAdd(subsegment->getCircuit(),
-                                  subsegment->getNetSignal().getNetClass(),
+              new CmdNetSignalAdd(newNetSegment->getCircuit(),
+                                  newNetSegment->getNetSignal().getNetClass(),
                                   CircuitIdentifier(forcedName));  // can throw
           execNewChildCmd(cmdAddNetSignal);                        // can throw
           newNetSignal = cmdAddNetSignal->getNetSignal();
           Q_ASSERT(newNetSignal);
         }
       }
-    } else if (subsegment->getNetLabels().isEmpty()) {
-      // create new netsignal with auto-name
-      CmdNetSignalAdd* cmdAddNetSignal = new CmdNetSignalAdd(
-          subsegment->getCircuit(), subsegment->getNetSignal().getNetClass());
+    } else if (newNetSegment->getNetLabels().isEmpty()) {
+      // Create new netsignal with auto-name
+      CmdNetSignalAdd* cmdAddNetSignal =
+          new CmdNetSignalAdd(newNetSegment->getCircuit(),
+                              newNetSegment->getNetSignal().getNetClass());
       execNewChildCmd(cmdAddNetSignal);  // can throw
       newNetSignal = cmdAddNetSignal->getNetSignal();
       Q_ASSERT(newNetSignal);
     }
     if (newNetSignal) {
       execNewChildCmd(new CmdChangeNetSignalOfSchematicNetSegment(
-          *subsegment, *newNetSignal));
+          *newNetSegment, *newNetSignal));
     }
-  }
-}
-
-SI_NetSegment* CmdRemoveSelectedSchematicItems::createNewSubNetSegment(
-    SI_NetSegment& netsegment, const NetSegmentItems& items) {
-  // create new netsegment
-  CmdSchematicNetSegmentAdd* cmdAddNetSegment = new CmdSchematicNetSegmentAdd(
-      netsegment.getSchematic(), netsegment.getNetSignal());
-  execNewChildCmd(cmdAddNetSegment);  // can throw
-  SI_NetSegment* newNetSegment = cmdAddNetSegment->getNetSegment();
-  Q_ASSERT(newNetSegment);
-
-  // create new netpoints and netlines
-  CmdSchematicNetSegmentAddElements* cmdAddElements =
-      new CmdSchematicNetSegmentAddElements(*newNetSegment);
-  QHash<const SI_NetLineAnchor*, SI_NetLineAnchor*> netPointMap;
-  foreach (const SI_NetPoint* netpoint, items.netpoints) {
-    SI_NetPoint* newNetPoint =
-        cmdAddElements->addNetPoint(netpoint->getPosition());
-    netPointMap.insert(netpoint, newNetPoint);
-  }
-  foreach (const SI_NetLine* netline, items.netlines) {
-    SI_NetLineAnchor* p1 =
-        netPointMap.value(&netline->getStartPoint(), &netline->getStartPoint());
-    SI_NetLineAnchor* p2 =
-        netPointMap.value(&netline->getEndPoint(), &netline->getEndPoint());
-    SI_NetLine* newNetLine = cmdAddElements->addNetLine(*p1, *p2);
-    Q_ASSERT(newNetLine);
-  }
-  execNewChildCmd(cmdAddElements);  // can throw
-
-  // create new netlabels
-  foreach (const SI_NetLabel* netlabel, items.netlabels) {
-    CmdSchematicNetLabelAdd* cmdAdd = new CmdSchematicNetLabelAdd(
-        *newNetSegment, netlabel->getPosition(), netlabel->getRotation());
-    execNewChildCmd(cmdAdd);
-    CmdSchematicNetLabelEdit* cmdEdit =
-        new CmdSchematicNetLabelEdit(*cmdAdd->getNetLabel());
-    cmdEdit->setRotation(netlabel->getRotation(), false);
-    execNewChildCmd(cmdEdit);
-  }
-
-  return newNetSegment;
-}
-
-void CmdRemoveSelectedSchematicItems::removeNetLabel(SI_NetLabel& netlabel) {
-  // remove the netlabel
-  execNewChildCmd(new CmdSchematicNetLabelRemove(netlabel));  // can throw
-
-  // was this the last label of the netsegment?
-  if (netlabel.getNetSegment().getNetLabels().isEmpty()) {
-    // are there any forced net names of the net segment?
-    CmdNetSignalAdd* cmd;
-    NetClass&     netclass = netlabel.getNetSignalOfNetSegment().getNetClass();
-    QSet<QString> names    = netlabel.getNetSegment().getForcedNetNames();
-    if (names.isEmpty()) {
-      // create new netsignal with auto-name
-      cmd = new CmdNetSignalAdd(mSchematic.getProject().getCircuit(), netclass);
-    } else if (names.values().first() !=
-               netlabel.getNetSignalOfNetSegment().getName()) {
-      // create new netsignal with (first) forced name
-      cmd = new CmdNetSignalAdd(
-          mSchematic.getProject().getCircuit(), netclass,
-          CircuitIdentifier(names.values().first()));  // can throw
-    } else {
-      // keep current name, as it is forced anyway
-      return;
-    }
-    execNewChildCmd(cmd);  // can throw
-    NetSignal* netsignal = cmd->getNetSignal();
-    Q_ASSERT(netsignal);
-    // change the netsignal of the netsegment
-    execNewChildCmd(new CmdChangeNetSignalOfSchematicNetSegment(
-        netlabel.getNetSegment(), *netsignal));  // can throw
   }
 }
 
@@ -379,36 +313,6 @@ void CmdRemoveSelectedSchematicItems::disconnectComponentSignalInstance(
   // disconnect the component signal instance from the net signal
   execNewChildCmd(
       new CmdCompSigInstSetNetSignal(signal, nullptr));  // can throw
-}
-
-QList<CmdRemoveSelectedSchematicItems::NetSegmentItems>
-CmdRemoveSelectedSchematicItems::getNonCohesiveNetSegmentSubSegments(
-    SI_NetSegment& segment, const NetSegmentItems& removedItems) noexcept {
-  SchematicNetSegmentSplitter splitter;
-  foreach (SI_NetLine* netline, segment.getNetLines()) {
-    if (!removedItems.netlines.contains(netline)) {
-      splitter.addNetLine(netline);
-    }
-  }
-  foreach (SI_NetLabel* netlabel, segment.getNetLabels()) {
-    if (!removedItems.netlabels.contains(netlabel)) {
-      splitter.addNetLabel(netlabel);
-    }
-  }
-  QList<NetSegmentItems> segments;
-  foreach (const SchematicNetSegmentSplitter::Segment& seg, splitter.split()) {
-    NetSegmentItems items;
-    foreach (SI_NetLineAnchor* anchor, seg.anchors) {
-      if (SI_NetPoint* netpoint = dynamic_cast<SI_NetPoint*>(anchor)) {
-        items.netpoints.insert(netpoint);
-      }
-    }
-    items.netlines  = Toolbox::toSet(seg.netlines);
-    items.netlabels = Toolbox::toSet(seg.netlabels);
-    segments.append(items);
-  }
-
-  return segments;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.h
@@ -24,7 +24,6 @@
  *  Includes
  ******************************************************************************/
 #include <librepcb/common/undocommandgroup.h>
-#include <librepcb/common/units/all_length_units.h>
 
 #include <QtCore>
 
@@ -40,9 +39,6 @@ class SI_NetPoint;
 class SI_NetLine;
 class SI_NetLabel;
 class SI_Symbol;
-class SI_SymbolPin;
-class BI_Device;
-class SI_NetLineAnchor;
 class ComponentSignalInstance;
 
 namespace editor {
@@ -55,15 +51,6 @@ namespace editor {
  * @brief The CmdRemoveSelectedSchematicItems class
  */
 class CmdRemoveSelectedSchematicItems final : public UndoCommandGroup {
-private:
-  // Private Types
-  struct NetSegmentItems {
-    QSet<SI_NetPoint*> netpoints;
-    QSet<SI_NetLine*>  netlines;
-    QSet<SI_NetLabel*> netlabels;
-  };
-  typedef QHash<SI_NetSegment*, NetSegmentItems> NetSegmentItemList;
-
 public:
   // Constructors / Destructor
   explicit CmdRemoveSelectedSchematicItems(Schematic& schematic) noexcept;
@@ -75,26 +62,12 @@ private:
   /// @copydoc UndoCommand::performExecute()
   bool performExecute() override;
 
-  void           removeNetSegment(SI_NetSegment& netsegment);
-  void           splitUpNetSegment(SI_NetSegment&         netsegment,
-                                   const NetSegmentItems& selectedItems);
-  SI_NetSegment* createNewSubNetSegment(SI_NetSegment&         netsegment,
-                                        const NetSegmentItems& items);
-  void           removeNetLabel(SI_NetLabel& netlabel);
-  void           removeSymbol(SI_Symbol& symbol);
+  void removeNetSegmentItems(SI_NetSegment&            netsegment,
+                             const QSet<SI_NetPoint*>& netpointsToRemove,
+                             const QSet<SI_NetLine*>&  netlinesToRemove,
+                             const QSet<SI_NetLabel*>& netlabelsToRemove);
+  void removeSymbol(SI_Symbol& symbol);
   void disconnectComponentSignalInstance(ComponentSignalInstance& signal);
-  QList<NetSegmentItems> getNonCohesiveNetSegmentSubSegments(
-      SI_NetSegment& segment, const NetSegmentItems& removedItems) noexcept;
-  void findAllConnectedNetPointsAndNetLines(
-      SI_NetLineAnchor& anchor, QSet<SI_NetLineAnchor*>& processedAnchors,
-      QSet<SI_NetPoint*>& netpoints, QSet<SI_NetLine*>& netlines,
-      QSet<SI_NetLine*>& availableNetLines) const noexcept;
-  int getNearestNetSegmentOfNetLabel(
-      const SI_NetLabel& netlabel, const QList<NetSegmentItems>& segments) const
-      noexcept;
-  Length getDistanceBetweenNetLabelAndNetSegment(
-      const SI_NetLabel& netlabel, const NetSegmentItems& netsegment) const
-      noexcept;
 
   // Attributes from the constructor
   Schematic& mSchematic;

--- a/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddata.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddata.cpp
@@ -24,10 +24,7 @@
 
 #include <librepcb/common/fileio/transactionaldirectory.h>
 #include <librepcb/common/fileio/transactionalfilesystem.h>
-#include <librepcb/library/cmp/component.h>
 #include <librepcb/library/librarybaseelement.h>
-#include <librepcb/library/sym/symbol.h>
-#include <librepcb/project/circuit/netsignal.h>
 
 #include <QtCore>
 #include <QtWidgets>


### PR DESCRIPTION
## Creating new classes `Junction`, `NetLine`, `NetLabel`, `Via` and `Trace`

This allows to share the serialization/deserialization code of these geometry objects between different use cases. In particular, this avoids code duplication in `SchematicClipboardData` and in the upcoming class `BoardClipboardData`.

I added them to libs/librepcb/common/ because the other geometry classes are located there too, but I'm not sure if it would be better to move them to libs/librepcb/project/ since actually they are used only in project related classes...

## Use these classes in the project classes `SI_NetLine`, `BI_Via`, `SchematicClipboardData` etc. for serialization/deserialization

As explained above.

## Refactor `SchematicNetSegmentSplitter` by using these new classes

Using e.g. `NetLine` instead of `SI_NetLine` makes the class more flexible and improves testability since now it can be tested without instantiating a whole project. Not used yet, but we might add some tests in future.

## Notes

- There should be no change in the behavior of LibrePCB, it's only a code refactoring.
- Mainly I made these changes as a preparation for #754 since it will be much easier after this refactoring.
- There is still some code duplication of serialization/deserialization within `SchematicClipboardData` - for now I factored out only the most important classes, but we could factor our the other things too some day.