### PR TITLE
Fix possibly outdated texts of devices in boards

### DIFF
--- a/libs/librepcb/project/boards/items/bi_device.cpp
+++ b/libs/librepcb/project/boards/items/bi_device.cpp
@@ -168,8 +168,11 @@ void BI_Device::init() {
     }
   }
 
-  // emit the "attributesChanged" signal when the board has emited it
+  // Emit the "attributesChanged" signal when the board or component instance
+  // has emited it.
   connect(&mBoard, &Board::attributesChanged, this,
+          &BI_Device::attributesChanged);
+  connect(mCompInstance, &ComponentInstance::attributesChanged, this,
           &BI_Device::attributesChanged);
 
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);

--- a/libs/librepcb/project/boards/items/bi_stroketext.cpp
+++ b/libs/librepcb/project/boards/items/bi_stroketext.cpp
@@ -82,7 +82,7 @@ void BI_StrokeText::init() {
 
   // connect to the "attributes changed" signal of the board
   connect(&mBoard, &Board::attributesChanged, this,
-          &BI_StrokeText::boardAttributesChanged);
+          &BI_StrokeText::boardOrFootprintAttributesChanged);
 }
 
 BI_StrokeText::~BI_StrokeText() noexcept {
@@ -93,8 +93,19 @@ BI_StrokeText::~BI_StrokeText() noexcept {
  ******************************************************************************/
 
 void BI_StrokeText::setFootprint(BI_Footprint* footprint) noexcept {
+  if (mFootprint) {
+    disconnect(mFootprint, &BI_Footprint::attributesChanged, this,
+               &BI_StrokeText::boardOrFootprintAttributesChanged);
+  }
+
   mFootprint = footprint;
   updateGraphicsItems();
+
+  // Text might need to be updated if footprint attributes have changed.
+  if (mFootprint) {
+    connect(mFootprint, &BI_Footprint::attributesChanged, this,
+            &BI_StrokeText::boardOrFootprintAttributesChanged);
+  }
 }
 
 void BI_StrokeText::updateGraphicsItems() noexcept {
@@ -171,7 +182,7 @@ void BI_StrokeText::setSelected(bool selected) noexcept {
  *  Private Slots
  ******************************************************************************/
 
-void BI_StrokeText::boardAttributesChanged() {
+void BI_StrokeText::boardOrFootprintAttributesChanged() {
   mText->updatePaths();
 }
 

--- a/libs/librepcb/project/boards/items/bi_stroketext.h
+++ b/libs/librepcb/project/boards/items/bi_stroketext.h
@@ -95,7 +95,7 @@ public:
   BI_StrokeText& operator=(const BI_StrokeText& rhs) = delete;
 
 private slots:
-  void boardAttributesChanged();
+  void boardOrFootprintAttributesChanged();
 
 private:  // Methods
   void init();


### PR DESCRIPTION
Device texts like "{{NAME}}" or "{{VALUE}}" in boards were not updated after modifying these properties of a component (either in the schematic- or board editor). So the displayed texts were wrong after such modifications. Now they are updated immediately when changing component properties.

Fixes #730