### PR TITLE
Fix possibly outdated displayed net names in boards

### DIFF
--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.cpp
@@ -59,8 +59,6 @@ BGI_FootprintPad::BGI_FootprintPad(BI_FootprintPad& pad) noexcept
     mBottomStopMaskLayer(nullptr),
     mTopCreamMaskLayer(nullptr),
     mBottomCreamMaskLayer(nullptr) {
-  setToolTip(mPad.getDisplayText());
-
   mFont = qApp->getDefaultSansSerifFont();
   mFont.setPixelSize(1);
 
@@ -84,6 +82,8 @@ bool BGI_FootprintPad::isSelectable() const noexcept {
 
 void BGI_FootprintPad::updateCacheAndRepaint() noexcept {
   prepareGeometryChange();
+
+  setToolTip(mPad.getDisplayText());
 
   // set Z value
   if ((mLibPad.getBoardSide() == library::FootprintPad::BoardSide::BOTTOM) !=

--- a/libs/librepcb/project/boards/items/bi_footprintpad.h
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.h
@@ -120,6 +120,7 @@ private:
   const library::PackagePad*   mPackagePad;
   ComponentSignalInstance*     mComponentSignalInstance;
   QMetaObject::Connection      mHighlightChangedConnection;
+  QMetaObject::Connection      mNetSignalNameChangedConnection;
 
   // Misc
   Point                            mPosition;

--- a/libs/librepcb/project/boards/items/bi_netline.cpp
+++ b/libs/librepcb/project/boards/items/bi_netline.cpp
@@ -159,6 +159,11 @@ void BI_NetLine::init() {
 
   mGraphicsItem.reset(new BGI_NetLine(*this));
   updateLine();
+
+  // Connect to the "name changed" signal of the net signal to enforce updating
+  // the displayed net signal name in the board.
+  connect(&getNetSignalOfNetSegment(), &NetSignal::nameChanged, this,
+          &BI_NetLine::updateLine);
 }
 
 BI_NetLine::~BI_NetLine() noexcept {

--- a/libs/librepcb/project/boards/items/bi_via.cpp
+++ b/libs/librepcb/project/boards/items/bi_via.cpp
@@ -79,7 +79,12 @@ void BI_Via::init() {
 
   // connect to the "attributes changed" signal of the board
   connect(&mBoard, &Board::attributesChanged, this,
-          &BI_Via::boardAttributesChanged);
+          &BI_Via::boardOrNetAttributesChanged);
+
+  // Connect to the "name changed" signal of the net signal to enforce updating
+  // the displayed net signal name in the board.
+  connect(&getNetSignalOfNetSegment(), &NetSignal::nameChanged, this,
+          &BI_Via::boardOrNetAttributesChanged);
 }
 
 BI_Via::~BI_Via() noexcept {
@@ -237,7 +242,7 @@ void BI_Via::setSelected(bool selected) noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void BI_Via::boardAttributesChanged() {
+void BI_Via::boardOrNetAttributesChanged() {
   mGraphicsItem->updateCacheAndRepaint();
 }
 

--- a/libs/librepcb/project/boards/items/bi_via.h
+++ b/libs/librepcb/project/boards/items/bi_via.h
@@ -115,7 +115,7 @@ public:
 
 private:
   void init();
-  void boardAttributesChanged();
+  void boardOrNetAttributesChanged();
 
   // General
   BI_NetSegment&          mNetSegment;


### PR DESCRIPTION
The displayed net names within vias and pads, and the net names within the hints of vias, pads and traces were not updated properly if a net signal was renamed. So the displayed net names in boards was wrong. Now the event of renaming a net signal is forwarded to vias, pads and traces to enforce updating the displayed texts and hints accordingly.

Fixes #712