### PR TITLE
Functional tests: Revert marking failed tests on macOS with xfail

### DIFF
--- a/tests/funq/librarymanager/test_create_local_library.py
+++ b/tests/funq/librarymanager/test_create_local_library.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pytest
-import sys
-
 """
 Test creating local libraries with the library manager
 """
 
 
-@pytest.mark.xfail(sys.platform == "darwin",
-                   reason="Test fails on macOS for an unknown reason.")
 def test(librepcb, helpers):
     """
     Create new local library

--- a/tests/funq/librarymanager/test_download_manually.py
+++ b/tests/funq/librarymanager/test_download_manually.py
@@ -2,16 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import os
-import pytest
-import sys
 
 """
 Test manually downloading libraries with the library manager
 """
 
 
-@pytest.mark.xfail(sys.platform == "darwin",
-                   reason="Test fails on macOS for an unknown reason.")
 def test(librepcb, helpers):
     """
     Download library by URL

--- a/tests/funq/librarymanager/test_install_remote_libraries.py
+++ b/tests/funq/librarymanager/test_install_remote_libraries.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pytest
-import sys
-
 """
 Test installing remote libraries with the library manager
 """
 
 
-@pytest.mark.xfail(sys.platform == "darwin",
-                   reason="Test fails on macOS for an unknown reason.")
 def test(librepcb, helpers):
     """
     Install some remote libraries


### PR DESCRIPTION
This reverts commit feea5c1ef115d83a8090132f7fbdf40c1a41db65 which was added in #716. It seems that the problem was "automatically" solved when macOS updated Qt to 5.15.1 :wink:

Fixes #718