### PR TITLE
Allow to modify polygons graphically

### DIFF
--- a/libs/librepcb/common/graphics/polygongraphicsitem.h
+++ b/libs/librepcb/common/graphics/polygongraphicsitem.h
@@ -55,16 +55,39 @@ public:
   // Getters
   Polygon& getPolygon() noexcept { return mPolygon; }
 
+  /// Get the line segment at a specific position
+  ///
+  /// @param pos    The position to check for lines.
+  /// @return       The index of the vertex *after* the line under the cursor.
+  ///               So for the first line segment, index 1 is returned. If no
+  ///               line is located under the specified position, -1 is
+  ///               returned.
+  int getLineIndexAtPosition(const Point& pos) const noexcept;
+
+  /// Get the vertices at a specific position
+  ///
+  /// @param pos    The position to check for vertices.
+  /// @return       All indices of the vertices at the specified position.
+  QVector<int> getVertexIndicesAtPosition(const Point& pos) const noexcept;
+
+  // Inherited Methods
+  QVariant itemChange(GraphicsItemChange change,
+                      const QVariant& value) noexcept override;
+
   // Operator Overloadings
   PolygonGraphicsItem& operator=(const PolygonGraphicsItem& rhs) = delete;
 
 private:  // Methods
   void polygonEdited(const Polygon& polygon, Polygon::Event event) noexcept;
   void updateFillLayer() noexcept;
+  void updateVertexGraphicsItems() noexcept;
 
 private:  // Data
   Polygon& mPolygon;
   const IF_GraphicsLayerProvider& mLayerProvider;
+
+  /// The square graphics items to drag each vertex
+  QList<std::shared_ptr<PrimitivePathGraphicsItem>> mVertexGraphicsItems;
 
   // Slots
   Polygon::OnEditedSlot mOnEditedSlot;

--- a/libs/librepcb/common/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivepathgraphicsitem.cpp
@@ -42,6 +42,7 @@ PrimitivePathGraphicsItem::PrimitivePathGraphicsItem(
   : QGraphicsItem(parent),
     mLineLayer(nullptr),
     mFillLayer(nullptr),
+    mShapeMode(ShapeMode::STROKE_AND_AREA_BY_LAYER),
     mOnLayerEditedSlot(*this, &PrimitivePathGraphicsItem::layerEdited) {
   mPen.setCapStyle(Qt::RoundCap);
   mPenHighlighted.setCapStyle(Qt::RoundCap);
@@ -107,6 +108,11 @@ void PrimitivePathGraphicsItem::setFillLayer(
   updateColors();
   updateVisibility();
   updateBoundingRectAndShape();  // grab area may have changed
+}
+
+void PrimitivePathGraphicsItem::setShapeMode(ShapeMode mode) noexcept {
+  mShapeMode = mode;
+  updateBoundingRectAndShape();
 }
 
 /*******************************************************************************
@@ -192,8 +198,12 @@ void PrimitivePathGraphicsItem::updateColors() noexcept {
 
 void PrimitivePathGraphicsItem::updateBoundingRectAndShape() noexcept {
   prepareGeometryChange();
-  mShape = Toolbox::shapeFromPath(mPainterPath, mPen, mBrush,
-                                  UnsignedLength(200000));
+  if (mShapeMode == ShapeMode::FILLED_OUTLINE) {
+    mShape = mPainterPath;
+  } else {
+    mShape = Toolbox::shapeFromPath(mPainterPath, mPen, mBrush,
+                                    UnsignedLength(200000));
+  }
   mBoundingRect = mShape.controlPointRect();
   update();
 }

--- a/libs/librepcb/common/graphics/primitivepathgraphicsitem.h
+++ b/libs/librepcb/common/graphics/primitivepathgraphicsitem.h
@@ -43,6 +43,16 @@ namespace librepcb {
  */
 class PrimitivePathGraphicsItem : public QGraphicsItem {
 public:
+  // Types
+  enum class ShapeMode {
+    /// Both the line stroke (with its specified width) and the filled area
+    /// are used as shape, if the corresponding layers are set and visible.
+    STROKE_AND_AREA_BY_LAYER,
+
+    /// Only the area within the painter path is used as shape.
+    FILLED_OUTLINE,
+  };
+
   // Constructors / Destructor
   // PrimitivePathGraphicsItem() = delete;
   PrimitivePathGraphicsItem(const PrimitivePathGraphicsItem& other) = delete;
@@ -56,6 +66,7 @@ public:
   void setLineWidth(const UnsignedLength& width) noexcept;
   void setLineLayer(const GraphicsLayer* layer) noexcept;
   void setFillLayer(const GraphicsLayer* layer) noexcept;
+  void setShapeMode(ShapeMode mode) noexcept;
 
   // Inherited from QGraphicsItem
   QRectF boundingRect() const noexcept override { return mBoundingRect; }
@@ -74,9 +85,10 @@ private:  // Methods
   void updateBoundingRectAndShape() noexcept;
   void updateVisibility() noexcept;
 
-private:  // Data
+protected:  // Data
   const GraphicsLayer* mLineLayer;
   const GraphicsLayer* mFillLayer;
+  ShapeMode mShapeMode;
   QPen mPen;
   QPen mPenHighlighted;
   QBrush mBrush;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
@@ -32,6 +32,10 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class Polygon;
+class CmdPolygonEdit;
+
 namespace library {
 namespace editor {
 
@@ -96,16 +100,34 @@ private:  // Methods
   bool mirrorSelectedItems(Qt::Orientation orientation,
                            bool flipLayers) noexcept;
   bool removeSelectedItems() noexcept;
+  void removeSelectedPolygonVertices() noexcept;
+  void startAddingPolygonVertex(Polygon& polygon, int vertex,
+                                const Point& pos) noexcept;
   void setSelectionRect(const Point& p1, const Point& p2) noexcept;
   void clearSelectionRect(bool updateItemsSelectionState) noexcept;
   QList<QGraphicsItem*> findItemsAtPosition(const Point& pos) noexcept;
+  bool findPolygonVerticesAtPosition(const Point& pos) noexcept;
 
 private:  // Types / Data
-  enum class SubState { IDLE, SELECTING, MOVING, PASTING };
+  enum class SubState {
+    IDLE,
+    SELECTING,
+    MOVING,
+    PASTING,
+    MOVING_POLYGON_VERTEX
+  };
+
   SubState mState;
   Point mStartPos;
   QScopedPointer<CmdDragSelectedFootprintItems> mCmdDragSelectedItems;
   int mCurrentSelectionIndex;
+
+  /// The current polygon selected for editing (nullptr if none)
+  Polygon* mSelectedPolygon;
+  /// The polygon vertex indices selected for editing (empty if none)
+  QVector<int> mSelectedPolygonVertices;
+  /// The polygon edit command (nullptr if not editing)
+  QScopedPointer<CmdPolygonEdit> mCmdPolygonEdit;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
@@ -32,6 +32,7 @@
 #include <librepcb/common/dialogs/circlepropertiesdialog.h>
 #include <librepcb/common/dialogs/polygonpropertiesdialog.h>
 #include <librepcb/common/dialogs/textpropertiesdialog.h>
+#include <librepcb/common/geometry/cmd/cmdpolygonedit.h>
 #include <librepcb/common/graphics/circlegraphicsitem.h>
 #include <librepcb/common/graphics/graphicsscene.h>
 #include <librepcb/common/graphics/graphicsview.h>
@@ -60,7 +61,10 @@ SymbolEditorState_Select::SymbolEditorState_Select(
   : SymbolEditorState(context),
     mState(SubState::IDLE),
     mStartPos(),
-    mCurrentSelectionIndex(0) {
+    mCurrentSelectionIndex(0),
+    mSelectedPolygon(nullptr),
+    mSelectedPolygonVertices(),
+    mCmdPolygonEdit() {
 }
 
 SymbolEditorState_Select::~SymbolEditorState_Select() noexcept {
@@ -89,6 +93,22 @@ bool SymbolEditorState_Select::processGraphicsSceneMouseMoved(
       mCmdDragSelectedItems->setDeltaToStartPos(delta);
       return true;
     }
+    case SubState::MOVING_POLYGON_VERTEX: {
+      if (!mSelectedPolygon) {
+        return false;
+      }
+      if (!mCmdPolygonEdit) {
+        mCmdPolygonEdit.reset(new CmdPolygonEdit(*mSelectedPolygon));
+      }
+      QVector<Vertex> vertices = mSelectedPolygon->getPath().getVertices();
+      foreach (int i, mSelectedPolygonVertices) {
+        if ((i >= 0) && (i < vertices.count())) {
+          vertices[i].setPos(currentPos.mappedToGrid(getGridInterval()));
+        }
+      }
+      mCmdPolygonEdit->setPath(Path(vertices), true);
+      return true;
+    }
     default: { return false; }
   }
 }
@@ -101,7 +121,9 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       mStartPos = Point::fromPx(e.scenePos());
       // get items under cursor
       QList<QGraphicsItem*> items = findItemsAtPosition(mStartPos);
-      if (items.isEmpty()) {
+      if (findPolygonVerticesAtPosition(mStartPos)) {
+        mState = SubState::MOVING_POLYGON_VERTEX;
+      } else if (items.isEmpty()) {
         // start selecting
         clearSelectionRect(true);
         mState = SubState::SELECTING;
@@ -179,6 +201,18 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
       if (mCmdDragSelectedItems) {
         try {
           mContext.undoStack.execCmd(mCmdDragSelectedItems.take());
+        } catch (const Exception& e) {
+          QMessageBox::critical(&mContext.editorWidget, tr("Error"),
+                                e.getMsg());
+        }
+      }
+      mState = SubState::IDLE;
+      return true;
+    }
+    case SubState::MOVING_POLYGON_VERTEX: {
+      if (mCmdPolygonEdit) {
+        try {
+          mContext.undoStack.execCmd(mCmdPolygonEdit.take());
         } catch (const Exception& e) {
           QMessageBox::critical(&mContext.editorWidget, tr("Error"),
                                 e.getMsg());
@@ -268,15 +302,36 @@ bool SymbolEditorState_Select::processPaste() noexcept {
 }
 
 bool SymbolEditorState_Select::processRotateCw() noexcept {
-  return rotateSelectedItems(-Angle::deg90());
+  switch (mState) {
+    case SubState::IDLE:
+    case SubState::MOVING:
+    case SubState::PASTING: {
+      return rotateSelectedItems(-Angle::deg90());
+    }
+    default: { return false; }
+  }
 }
 
 bool SymbolEditorState_Select::processRotateCcw() noexcept {
-  return rotateSelectedItems(Angle::deg90());
+  switch (mState) {
+    case SubState::IDLE:
+    case SubState::MOVING:
+    case SubState::PASTING: {
+      return rotateSelectedItems(Angle::deg90());
+    }
+    default: { return false; }
+  }
 }
 
 bool SymbolEditorState_Select::processMirror() noexcept {
-  return mirrorSelectedItems(Qt::Horizontal);
+  switch (mState) {
+    case SubState::IDLE:
+    case SubState::MOVING:
+    case SubState::PASTING: {
+      return mirrorSelectedItems(Qt::Horizontal);
+    }
+    default: { return false; }
+  }
 }
 
 bool SymbolEditorState_Select::processRemove() noexcept {
@@ -292,6 +347,11 @@ bool SymbolEditorState_Select::processAbortCommand() noexcept {
   switch (mState) {
     case SubState::MOVING: {
       mCmdDragSelectedItems.reset();
+      mState = SubState::IDLE;
+      return true;
+    }
+    case SubState::MOVING_POLYGON_VERTEX: {
+      mCmdPolygonEdit.reset();
       mState = SubState::IDLE;
       return true;
     }
@@ -317,47 +377,73 @@ bool SymbolEditorState_Select::processAbortCommand() noexcept {
 bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
   if (mState != SubState::IDLE) return false;
 
-  // handle item selection
-  QGraphicsItem* selectedItem = nullptr;
-  QList<QGraphicsItem*> items = findItemsAtPosition(pos);
-  if (items.isEmpty()) return false;
-  foreach (QGraphicsItem* item, items) {
-    if (item->isSelected()) {
-      selectedItem = item;
-    }
-  }
-  if (!selectedItem) {
-    clearSelectionRect(true);
-    selectedItem = items.first();
-    if (dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)) {
-      // workaround for selection of a SymbolPinGraphicsItem
-      dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)->setSelected(true);
-    } else {
-      selectedItem->setSelected(true);
-    }
-  }
-  Q_ASSERT(selectedItem);
-  Q_ASSERT(selectedItem->isSelected());
-
-  // build the context menu
   QMenu menu;
-  QAction* aRotateCCW =
-      menu.addAction(QIcon(":/img/actions/rotate_left.png"), tr("&Rotate"));
-  connect(aRotateCCW, &QAction::triggered,
-          [this]() { rotateSelectedItems(Angle::deg90()); });
-  QAction* aMirrorH =
-      menu.addAction(QIcon(":/img/actions/flip_horizontal.png"), tr("&Mirror"));
-  connect(aMirrorH, &QAction::triggered,
-          [this]() { mirrorSelectedItems(Qt::Horizontal); });
-  QAction* aRemove =
-      menu.addAction(QIcon(":/img/actions/delete.png"), tr("R&emove"));
-  connect(aRemove, &QAction::triggered, [this]() { removeSelectedItems(); });
-  menu.addSeparator();
-  QAction* aProperties =
-      menu.addAction(QIcon(":/img/actions/settings.png"), tr("&Properties"));
-  connect(aProperties, &QAction::triggered, [this, &selectedItem]() {
-    openPropertiesDialogOfItem(selectedItem);
-  });
+  if (findPolygonVerticesAtPosition(pos)) {
+    // special menu for polygon vertices
+    QAction* aRemove =
+        menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove Vertex"));
+    connect(aRemove, &QAction::triggered,
+            [this]() { removeSelectedPolygonVertices(); });
+    int remainingVertices = mSelectedPolygon->getPath().getVertices().count() -
+        mSelectedPolygonVertices.count();
+    aRemove->setEnabled(remainingVertices >= 2);
+  } else {
+    // handle item selection
+    QGraphicsItem* selectedItem = nullptr;
+    QList<QGraphicsItem*> items = findItemsAtPosition(pos);
+    if (items.isEmpty()) return false;
+    foreach (QGraphicsItem* item, items) {
+      if (item->isSelected()) {
+        selectedItem = item;
+      }
+    }
+    if (!selectedItem) {
+      clearSelectionRect(true);
+      selectedItem = items.first();
+      if (dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)) {
+        // workaround for selection of a SymbolPinGraphicsItem
+        dynamic_cast<SymbolPinGraphicsItem*>(selectedItem)->setSelected(true);
+      } else {
+        selectedItem->setSelected(true);
+      }
+    }
+    Q_ASSERT(selectedItem);
+    Q_ASSERT(selectedItem->isSelected());
+
+    // if a polygon line is under the cursor, add the "Add Vertex" menu item
+    if (PolygonGraphicsItem* i =
+            dynamic_cast<PolygonGraphicsItem*>(selectedItem)) {
+      Polygon* polygon = &i->getPolygon();
+      int index = i->getLineIndexAtPosition(pos);
+      if (index >= 0) {
+        QAction* aAddVertex =
+            menu.addAction(QIcon(":/img/actions/add.png"), tr("Add Vertex"));
+        connect(aAddVertex, &QAction::triggered,
+                [=]() { startAddingPolygonVertex(*polygon, index, pos); });
+        menu.addSeparator();
+      }
+    }
+
+    // build the context menu
+    QMenu menu;
+    QAction* aRotateCCW =
+        menu.addAction(QIcon(":/img/actions/rotate_left.png"), tr("&Rotate"));
+    connect(aRotateCCW, &QAction::triggered,
+            [this]() { rotateSelectedItems(Angle::deg90()); });
+    QAction* aMirrorH = menu.addAction(
+        QIcon(":/img/actions/flip_horizontal.png"), tr("&Mirror"));
+    connect(aMirrorH, &QAction::triggered,
+            [this]() { mirrorSelectedItems(Qt::Horizontal); });
+    QAction* aRemove =
+        menu.addAction(QIcon(":/img/actions/delete.png"), tr("R&emove"));
+    connect(aRemove, &QAction::triggered, [this]() { removeSelectedItems(); });
+    menu.addSeparator();
+    QAction* aProperties =
+        menu.addAction(QIcon(":/img/actions/settings.png"), tr("&Properties"));
+    connect(aProperties, &QAction::triggered, [this, &selectedItem]() {
+      openPropertiesDialogOfItem(selectedItem);
+    });
+  }
 
   // execute the context menu
   menu.exec(QCursor::pos());
@@ -533,6 +619,57 @@ bool SymbolEditorState_Select::removeSelectedItems() noexcept {
   return true;  // TODO: return false if no items were selected
 }
 
+void SymbolEditorState_Select::removeSelectedPolygonVertices() noexcept {
+  if ((!mSelectedPolygon) || mSelectedPolygonVertices.isEmpty()) {
+    return;
+  }
+
+  try {
+    Path path;
+    for (int i = 0; i < mSelectedPolygon->getPath().getVertices().count();
+         ++i) {
+      if (!mSelectedPolygonVertices.contains(i)) {
+        path.getVertices().append(mSelectedPolygon->getPath().getVertices()[i]);
+      }
+    }
+    if (mSelectedPolygon->getPath().isClosed() &&
+        path.getVertices().count() > 2) {
+      path.close();
+    }
+    if (path.isClosed() && (path.getVertices().count() == 3)) {
+      path.getVertices().removeLast();  // Avoid overlapping lines
+    }
+    if (path.getVertices().count() < 2) {
+      return;  // Do not allow to create invalid polygons!
+    }
+    QScopedPointer<CmdPolygonEdit> cmd(new CmdPolygonEdit(*mSelectedPolygon));
+    cmd->setPath(path, false);
+    mContext.undoStack.execCmd(cmd.take());
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+  }
+}
+
+void SymbolEditorState_Select::startAddingPolygonVertex(
+    Polygon& polygon, int vertex, const Point& pos) noexcept {
+  try {
+    Q_ASSERT(vertex > 0);  // it must be the vertex *after* the clicked line
+    Path path = polygon.getPath();
+    Point newPos = pos.mappedToGrid(getGridInterval());
+    Angle newAngle = path.getVertices()[vertex - 1].getAngle();
+    path.getVertices().insert(vertex, Vertex(newPos, newAngle));
+    mCmdPolygonEdit.reset(new CmdPolygonEdit(polygon));
+    mCmdPolygonEdit->setPath(path, true);
+
+    mSelectedPolygon = &polygon;
+    mSelectedPolygonVertices = {vertex};
+    mStartPos = pos;
+    mState = SubState::MOVING_POLYGON_VERTEX;
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+  }
+}
+
 void SymbolEditorState_Select::setSelectionRect(const Point& p1,
                                                 const Point& p2) noexcept {
   mContext.graphicsScene.setSelectionRect(p1, p2);
@@ -574,6 +711,25 @@ QList<QGraphicsItem*> SymbolEditorState_Select::findItemsAtPosition(
            (pins.count() + texts.count() + polygons.count() + circles.count()));
   Q_ASSERT(result.count() == count);
   return result;
+}
+
+bool SymbolEditorState_Select::findPolygonVerticesAtPosition(
+    const Point& pos) noexcept {
+  for (Polygon& p : mContext.symbol.getPolygons()) {
+    PolygonGraphicsItem* i =
+        mContext.symbolGraphicsItem.getPolygonGraphicsItem(p);
+    if (i && i->isSelected()) {
+      mSelectedPolygonVertices = i->getVertexIndicesAtPosition(pos);
+      if (!mSelectedPolygonVertices.isEmpty()) {
+        mSelectedPolygon = &p;
+        return true;
+      }
+    }
+  }
+
+  mSelectedPolygon = nullptr;
+  mSelectedPolygonVertices.clear();
+  return false;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
@@ -32,6 +32,10 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class Polygon;
+class CmdPolygonEdit;
+
 namespace library {
 namespace editor {
 
@@ -94,16 +98,34 @@ private:  // Methods
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems(Qt::Orientation orientation) noexcept;
   bool removeSelectedItems() noexcept;
+  void removeSelectedPolygonVertices() noexcept;
+  void startAddingPolygonVertex(Polygon& polygon, int vertex,
+                                const Point& pos) noexcept;
   void setSelectionRect(const Point& p1, const Point& p2) noexcept;
   void clearSelectionRect(bool updateItemsSelectionState) noexcept;
   QList<QGraphicsItem*> findItemsAtPosition(const Point& pos) noexcept;
+  bool findPolygonVerticesAtPosition(const Point& pos) noexcept;
 
 private:  // Types / Data
-  enum class SubState { IDLE, SELECTING, MOVING, PASTING };
+  enum class SubState {
+    IDLE,
+    SELECTING,
+    MOVING,
+    PASTING,
+    MOVING_POLYGON_VERTEX
+  };
+
   SubState mState;
   Point mStartPos;
   QScopedPointer<CmdDragSelectedSymbolItems> mCmdDragSelectedItems;
   int mCurrentSelectionIndex;
+
+  /// The current polygon selected for editing (nullptr if none)
+  Polygon* mSelectedPolygon;
+  /// The polygon vertex indices selected for editing (empty if none)
+  QVector<int> mSelectedPolygonVertices;
+  /// The polygon edit command (nullptr if not editing)
+  QScopedPointer<CmdPolygonEdit> mCmdPolygonEdit;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/boards/items/bi_polygon.h
+++ b/libs/librepcb/project/boards/items/bi_polygon.h
@@ -73,6 +73,7 @@ public:
   const Polygon& getPolygon() const noexcept { return *mPolygon; }
   const Uuid& getUuid() const
       noexcept;  // convenience function, e.g. for template usage
+  PolygonGraphicsItem& getGraphicsItem() noexcept { return *mGraphicsItem; }
   bool isSelectable() const noexcept override;
 
   // General Methods

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.h
@@ -35,6 +35,7 @@
 namespace librepcb {
 
 class UndoCommandGroup;
+class CmdPolygonEdit;
 class Polygon;
 class StrokeText;
 class Hole;
@@ -47,6 +48,7 @@ class BI_Via;
 class BI_Plane;
 class BI_NetSegment;
 class BI_NetLine;
+class BI_Polygon;
 
 namespace editor {
 
@@ -107,7 +109,7 @@ public:
       delete;
 
 private:  // Methods
-          // Menu Helpers
+  // Menu Helpers
   void addActionRotate(QMenu& menu,
                        const QString& text = tr("Rotate")) noexcept;
   void addActionFlip(QMenu& menu, const QString& text = tr("Flip")) noexcept;
@@ -116,6 +118,11 @@ private:  // Methods
   void addActionDeleteAll(
       QMenu& menu, BI_NetSegment& netsegment,
       const QString& text = tr("Remove Whole Trace")) noexcept;
+  void addActionRemoveVertex(
+      QMenu& menu, BI_Polygon& polygon, const QVector<int>& verticesToRemove,
+      const QString& text = tr("Remove Vertex")) noexcept;
+  bool addActionAddVertex(QMenu& menu, BI_Polygon& polygon, const Point& pos,
+                          const QString& text = tr("Add Vertex")) noexcept;
   void addActionMeasure(
       QMenu& menu, BI_NetLine& netline,
       const QString& text = tr("Measure Selected Segments Length")) noexcept;
@@ -132,9 +139,13 @@ private:  // Methods
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool flipSelectedItems(Qt::Orientation orientation) noexcept;
   bool removeSelectedItems() noexcept;
+  void removeSelectedPolygonVertices() noexcept;
+  void startAddingPolygonVertex(BI_Polygon& polygon, int vertex,
+                                const Point& pos) noexcept;
   bool copySelectedItemsToClipboard() noexcept;
   bool pasteFromClipboard() noexcept;
   bool abortCommand(bool showErrMsgBox) noexcept;
+  bool findPolygonVerticesAtPosition(const Point& pos) noexcept;
 
   /**
    * @brief Measure the length of the selected items.
@@ -181,6 +192,13 @@ private:  // Data
   /// When dragging items, this undo command will be active
   QScopedPointer<CmdDragSelectedBoardItems> mSelectedItemsDragCommand;
   int mCurrentSelectionIndex;
+
+  /// The current polygon selected for editing (nullptr if none)
+  BI_Polygon* mSelectedPolygon;
+  /// The polygon vertex indices selected for editing (empty if none)
+  QVector<int> mSelectedPolygonVertices;
+  /// The polygon edit command (nullptr if not editing)
+  QScopedPointer<CmdPolygonEdit> mCmdPolygonEdit;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
Within the package-, symbol- and board editors, polygons can now be edited graphically:
- Dragging vertices of selected polygons
- Removing vertices by context menu on vertices
- Inserting vertices by context menu of line segments

![librepcb_polygons](https://user-images.githubusercontent.com/5374821/94342382-05ff6600-0011-11eb-928e-8d541438bfae.gif)
