### PR TITLE
LibraryDownload: Remove destination ZIP before starting download

### DIFF
--- a/libs/librepcb/librarymanager/librarydownload.h
+++ b/libs/librepcb/librarymanager/librarydownload.h
@@ -102,6 +102,7 @@ private:  // Data
   QScopedPointer<FileDownload> mFileDownload;
   FilePath mDestDir;
   FilePath mTempDestDir;
+  FilePath mTempZipFile;
 };
 
 /*******************************************************************************

--- a/tests/unittests/librarymanager/librarydownloadtest.cpp
+++ b/tests/unittests/librarymanager/librarydownloadtest.cpp
@@ -1,0 +1,227 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/fileio/fileutils.h>
+#include <librepcb/common/fileio/transactionalfilesystem.h>
+#include <librepcb/common/network/networkaccessmanager.h>
+#include <librepcb/librarymanager/librarydownload.h>
+
+#include <QSignalSpy>
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+namespace manager {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class LibraryDownloadTest : public ::testing::Test {
+public:
+  static void SetUpTestCase() { sDownloadManager = new NetworkAccessManager(); }
+
+  static void TearDownTestCase() { delete sDownloadManager; }
+
+  static void createZip(const FilePath& dir, const FilePath& zip) {
+    std::shared_ptr<TransactionalFileSystem> fs =
+        TransactionalFileSystem::openRO(dir);
+    fs->exportToZip(zip);
+  }
+
+protected:
+  static NetworkAccessManager* sDownloadManager;
+};
+
+NetworkAccessManager* LibraryDownloadTest::sDownloadManager = nullptr;
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(LibraryDownloadTest, testDownloadInvalidLibrary) {
+  // create temporary directory
+  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstLibDir = dstDir.getPathTo("my library");
+  FileUtils::makePath(dstDir);
+
+  // prepare library ZIP
+  FilePath srcLibZip = dstDir.getPathTo("lib.zip");
+  createZip(dstDir, srcLibZip);
+
+  // start the file download
+  LibraryDownload* dl =
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+  QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
+  dl->start();
+
+  // wait until download finished (with timeout)
+  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
+  auto currentTime = []() {
+    return QDateTime::currentDateTime().toMSecsSinceEpoch();
+  };
+  while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
+    QThread::msleep(100);
+    qApp->processEvents();
+  }
+
+  // check count and parameters of emited signals
+  EXPECT_EQ(1, spyFinished.count());
+  EXPECT_FALSE(spyFinished.first()[0].toBool());  // success
+  EXPECT_FALSE(spyFinished.first()[1].toString().isEmpty())
+      << spyFinished.first()[1].toString().toStdString();  // error message
+  EXPECT_FALSE(dstLibDir.isExistingDir());
+}
+
+TEST_F(LibraryDownloadTest, testDownloadValidLibrary) {
+  // create temporary directory
+  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstLibDir = dstDir.getPathTo("my library");
+  FileUtils::makePath(dstDir);
+
+  // prepare library ZIP
+  FilePath srcLibDir(TEST_DATA_DIR "/libraries/Populated Library.lplib");
+  FilePath srcLibZip = dstDir.getPathTo("lib.zip");
+  createZip(srcLibDir, srcLibZip);
+
+  // start the file download
+  LibraryDownload* dl =
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+  QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
+  dl->start();
+
+  // wait until download finished (with timeout)
+  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
+  auto currentTime = []() {
+    return QDateTime::currentDateTime().toMSecsSinceEpoch();
+  };
+  while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
+    QThread::msleep(100);
+    qApp->processEvents();
+  }
+
+  // check count and parameters of emited signals
+  EXPECT_EQ(1, spyFinished.count());
+  EXPECT_TRUE(spyFinished.first()[0].toBool());  // success
+  EXPECT_TRUE(spyFinished.first()[1].toString().isNull())
+      << spyFinished.first()[1].toString().toStdString();  // error message
+  EXPECT_TRUE(dstLibDir.isExistingDir());
+  EXPECT_TRUE(dstLibDir.getPathTo(".librepcb-lib").isExistingFile());
+}
+
+TEST_F(LibraryDownloadTest, testDownloadValidNestedLibrary) {
+  // create temporary directory
+  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstLibDir = dstDir.getPathTo("my library");
+  FileUtils::makePath(dstDir);
+
+  // prepare library ZIP
+  FilePath srcLibDir(TEST_DATA_DIR "/libraries/Populated Library.lplib");
+  FilePath tmpLibDir = dstDir.getPathTo("temp dir");
+  FileUtils::copyDirRecursively(srcLibDir, tmpLibDir);
+  FilePath srcLibZip = dstDir.getPathTo("lib.zip");
+  createZip(dstDir, srcLibZip);
+
+  // start the file download
+  LibraryDownload* dl =
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+  QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
+  dl->start();
+
+  // wait until download finished (with timeout)
+  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
+  auto currentTime = []() {
+    return QDateTime::currentDateTime().toMSecsSinceEpoch();
+  };
+  while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
+    QThread::msleep(100);
+    qApp->processEvents();
+  }
+
+  // check count and parameters of emited signals
+  EXPECT_EQ(1, spyFinished.count());
+  EXPECT_TRUE(spyFinished.first()[0].toBool());  // success
+  EXPECT_TRUE(spyFinished.first()[1].toString().isNull())
+      << spyFinished.first()[1].toString().toStdString();  // error message
+  EXPECT_TRUE(dstLibDir.isExistingDir());
+  EXPECT_TRUE(dstLibDir.getPathTo(".librepcb-lib").isExistingFile());
+}
+
+TEST_F(LibraryDownloadTest, testDownloadValidLibraryDestinationAlreadyExists) {
+  // create temporary directory
+  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstLibDir = dstDir.getPathTo("my library");
+  FileUtils::makePath(dstDir);
+
+  // prepare library ZIP
+  FilePath srcLibDir(TEST_DATA_DIR "/libraries/Populated Library.lplib");
+  FilePath srcLibZip = dstDir.getPathTo("lib.zip");
+  createZip(srcLibDir, srcLibZip);
+
+  // create destination directory, temporary destination directory, and ZIP
+  // to check if the library download overwrites them all
+  FilePath dstTmpDir = FilePath(dstLibDir.toStr() % ".tmp");
+  FilePath dstZip = FilePath(dstLibDir.toStr() % ".zip");
+  FileUtils::makePath(dstLibDir);
+  FileUtils::makePath(dstTmpDir);
+  FileUtils::writeFile(dstZip, QByteArray());
+
+  // start the file download
+  LibraryDownload* dl =
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+  QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
+  dl->start();
+
+  // wait until download finished (with timeout)
+  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
+  auto currentTime = []() {
+    return QDateTime::currentDateTime().toMSecsSinceEpoch();
+  };
+  while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
+    QThread::msleep(100);
+    qApp->processEvents();
+  }
+
+  // check count and parameters of emited signals
+  EXPECT_EQ(1, spyFinished.count());
+  EXPECT_TRUE(spyFinished.first()[0].toBool());  // success
+  EXPECT_TRUE(spyFinished.first()[1].toString().isNull())
+      << spyFinished.first()[1].toString().toStdString();  // error message
+  EXPECT_TRUE(dstLibDir.isExistingDir());
+  EXPECT_TRUE(dstLibDir.getPathTo(".librepcb-lib").isExistingFile());
+  EXPECT_FALSE(dstTmpDir.isExistingDir());
+  EXPECT_FALSE(dstZip.isExistingFile());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace manager
+}  // namespace library
+}  // namespace librepcb

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -19,6 +19,7 @@ CONFIG -= app_bundle
 LIBS += \
     -L$${DESTDIR} \
     -lgoogletest \
+    -llibrepcblibrarymanager \
     -llibrepcbeagleimport \
     -llibrepcbworkspace \
     -llibrepcbproject \
@@ -40,6 +41,7 @@ INCLUDEPATH += \
     ../../libs/type_safe/external/debug_assert \
 
 DEPENDPATH += \
+    ../../libs/librepcb/librarymanager \
     ../../libs/librepcb/eagleimport \
     ../../libs/librepcb/workspace \
     ../../libs/librepcb/project \
@@ -57,6 +59,7 @@ PRE_TARGETDEPS += \
 isEmpty(UNBUNDLE) {
     # These libraries will only be linked statically when not unbundling
     PRE_TARGETDEPS += \
+        $${DESTDIR}/liblibrepcblibrarymanager.a \
         $${DESTDIR}/liblibrepcbeagleimport.a \
         $${DESTDIR}/liblibrepcbworkspace.a \
         $${DESTDIR}/liblibrepcbproject.a \
@@ -110,6 +113,7 @@ SOURCES += \
     library/cmp/componentsymbolvariantitemsuffixtest.cpp \
     library/cmp/componentsymbolvariantitemtest.cpp \
     library/librarybaseelementtest.cpp \
+    librarymanager/librarydownloadtest.cpp \
     main.cpp \
     project/boards/boardgerberexporttest.cpp \
     project/boards/boardpickplacegeneratortest.cpp \


### PR DESCRIPTION
Affects downloading libraries with the library manager:

If the temporary ZIP file already exists before starting to download a library, the download failed with a "file already exists" error. This can happen for example when closing LibrePCB while a library download was in progress. Afterwards, it was not possible anymore to download the library with the library manager.

Now the ZIP file will be removed before starting the download.

Fixes #657.