### PR TITLE
Use built-in markdown support when using Qt >=5.14

### DIFF
--- a/apps/librepcb-cli/librepcb-cli.pro
+++ b/apps/librepcb-cli/librepcb-cli.pro
@@ -28,7 +28,6 @@ LIBS += \
     -llibrepcbproject \
     -llibrepcblibrary \
     -llibrepcbcommon \
-    -lhoedown \
     -lmuparser \
     -lsexpresso \
 
@@ -41,7 +40,6 @@ INCLUDEPATH += \
     ../../libs/type_safe/external/debug_assert \
 
 DEPENDPATH += \
-    ../../libs/hoedown \
     ../../libs/librepcb/librarymanager \
     ../../libs/librepcb/projecteditor \
     ../../libs/librepcb/libraryeditor \
@@ -53,7 +51,6 @@ DEPENDPATH += \
     ../../libs/muparser \
 
 PRE_TARGETDEPS += \
-    $${DESTDIR}/libhoedown.a \
     $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libmuparser.a \
 
@@ -80,6 +77,13 @@ SOURCES += \
 
 HEADERS += \
     commandlineinterface.h \
+
+# Hoedown is only needed for Qt <5.14
+equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 14) {
+    LIBS += -lhoedown
+    DEPENDPATH += ../../libs/hoedown
+    PRE_TARGETDEPS += $${DESTDIR}/libhoedown.a
+}
 
 # QuaZIP
 !contains(UNBUNDLE, quazip) {

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -42,7 +42,6 @@ LIBS += \
     -llibrepcbproject \
     -llibrepcblibrary \
     -llibrepcbcommon \
-    -lhoedown \
     -lmuparser \
     -lsexpresso \
 
@@ -55,7 +54,6 @@ INCLUDEPATH += \
     ../../libs/type_safe/external/debug_assert \
 
 DEPENDPATH += \
-    ../../libs/hoedown \
     ../../libs/librepcb/librarymanager \
     ../../libs/librepcb/projecteditor \
     ../../libs/librepcb/libraryeditor \
@@ -67,7 +65,6 @@ DEPENDPATH += \
     ../../libs/muparser \
 
 PRE_TARGETDEPS += \
-    $${DESTDIR}/libhoedown.a \
     $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libmuparser.a \
 
@@ -125,6 +122,13 @@ FORMS += \
     initializeworkspacewizard/initializeworkspacewizard_choosesettings.ui \
     initializeworkspacewizard/initializeworkspacewizard_finalizeimport.ui \
     projectlibraryupdater/projectlibraryupdater.ui \
+
+# Hoedown and markdownconverter are only needed for Qt <5.14
+equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 14) {
+    LIBS += -lhoedown
+    DEPENDPATH += ../../libs/hoedown
+    PRE_TARGETDEPS += $${DESTDIR}/libhoedown.a
+}
 
 # QuaZIP
 !contains(UNBUNDLE, quazip) {

--- a/apps/librepcb/markdown/markdownconverter.cpp
+++ b/apps/librepcb/markdown/markdownconverter.cpp
@@ -94,7 +94,7 @@ QString MarkdownConverter::convertMarkdownToHtml(
   // now (rendering README files in the project manager) this is fine, because
   // it makes the API simpler (QString in, QString out).
   QTextDocument document;
-  document.setMarkdown(markdown, QTextDocument::MarkdownDialectCommonMark);
+  document.setMarkdown(markdown, QTextDocument::MarkdownDialectGitHub);
   return document.toHtml();
 }
 #endif

--- a/apps/librepcb/markdown/markdownconverter.cpp
+++ b/apps/librepcb/markdown/markdownconverter.cpp
@@ -24,9 +24,13 @@
 
 #include <QtCore>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#include <qtextdocument.h>
+#else
 extern "C" {
 #include <hoedown/src/html.h>
 }
+#endif
 
 /*******************************************************************************
  *  Namespace
@@ -48,6 +52,7 @@ QString MarkdownConverter::convertMarkdownToHtml(
   }
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
 QString MarkdownConverter::convertMarkdownToHtml(
     const QString& markdown) noexcept {
   // create HTML renderer
@@ -78,6 +83,21 @@ QString MarkdownConverter::convertMarkdownToHtml(
 
   return html;
 }
+#endif
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+QString MarkdownConverter::convertMarkdownToHtml(
+    const QString& markdown) noexcept {
+  // Use a temporary QTextDocument to convert markdown to HTML.
+  // This is not terribly efficient (we could return a QTextDocument instead),
+  // but since this method is only used in non-performance-sensitive code right
+  // now (rendering README files in the project manager) this is fine, because
+  // it makes the API simpler (QString in, QString out).
+  QTextDocument document;
+  document.setMarkdown(markdown, QTextDocument::MarkdownDialectCommonMark);
+  return document.toHtml();
+}
+#endif
 
 /*******************************************************************************
  *  End of File

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -14,6 +14,7 @@ jobs:
       Ubuntu_1604_Qt_5_14_2_GCC:
         IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.14.2-1
         DEPLOY: true
+        NO_HOEDOWN: true
       Ubuntu_1804_Clang:
         IMAGE: librepcb/librepcb-dev:ubuntu-18.04-2
         CC: clang
@@ -40,6 +41,9 @@ jobs:
   - bash: rm -rf libs/polyclipping
     displayName: Remove bundled polyclipping lib
     condition: and(succeeded(), contains(variables['UNBUNDLE'], 'polyclipping'))
+  - bash: rm -rf libs/hoedown
+    displayName: Remove bundled hoedown lib
+    condition: and(succeeded(), eq(variables['NO_HOEDOWN'], 'true'))
   - bash: ./ci/build_librepcb.sh
     displayName: Build LibrePCB
   - bash: ./ci/build_linux_appimage.sh

--- a/libs/libs.pro
+++ b/libs/libs.pro
@@ -5,7 +5,6 @@ include(../common.pri)
 
 SUBDIRS = \
     delaunay-triangulation \
-    hoedown \
     googletest \
     librepcb \
     muparser \
@@ -18,8 +17,13 @@ librepcb.depends = \
     muparser \
     optional \
     parseagle \
-    hoedown \
     sexpresso \
+
+# Hoedown is only needed for Qt <5.14
+equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 14) {
+    SUBDIRS += hoedown
+    librepcb.depends += hoedown
+}
 
 !contains(UNBUNDLE, quazip) {
     SUBDIRS += quazip


### PR DESCRIPTION
As discussed in the development chat: Instead of replacing hoedown with cmark (see #777), we can use Qt's built-in markdown support in Qt >=5.14. The rendering is slightly different than with hoedown (using the CommonMark standard), but since the binary releases are using a recent Qt version and up-to date distros should also ship a recent Qt version, most users will already be using the new rendering logic.

With this change, there will be one less vendored library for distro package maintainers to package (see #385).

Closes #777.