### PR TITLE
BoardDesignRules: Fix loading max. stopmask drill diameter

### DIFF
--- a/libs/librepcb/common/boarddesignrules.cpp
+++ b/libs/librepcb/common/boarddesignrules.cpp
@@ -79,7 +79,7 @@ BoardDesignRules::BoardDesignRules(const SExpression& node)
     mStopMaskClearanceMax = e->getValueOfFirstChild<UnsignedLength>();
   }
   if (const SExpression* e =
-          node.tryGetChildByPath("stopmask_max_via_diameter")) {
+          node.tryGetChildByPath("stopmask_max_via_drill_diameter")) {
     mStopMaskMaxViaDrillDiameter = e->getValueOfFirstChild<UnsignedLength>();
   }
   // cream mask

--- a/tests/unittests/common/boarddesignrulestest.cpp
+++ b/tests/unittests/common/boarddesignrulestest.cpp
@@ -1,0 +1,69 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/common/boarddesignrules.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class BoardDesignRulesTest : public ::testing::Test {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
+  BoardDesignRules obj1;
+  obj1.setName(ElementName("foo bar"));
+  obj1.setDescription("Foo Bar");
+  obj1.setStopMaskClearanceRatio(UnsignedRatio(Ratio(11)));
+  obj1.setStopMaskClearanceBounds(UnsignedLength(22), UnsignedLength(33));
+  obj1.setStopMaskMaxViaDiameter(UnsignedLength(44));
+  obj1.setCreamMaskClearanceRatio(UnsignedRatio(Ratio(55)));
+  obj1.setCreamMaskClearanceBounds(UnsignedLength(66), UnsignedLength(77));
+  obj1.setRestringPadRatio(UnsignedRatio(Ratio(88)));
+  obj1.setRestringPadBounds(UnsignedLength(99), UnsignedLength(111));
+  obj1.setRestringViaRatio(UnsignedRatio(Ratio(222)));
+  obj1.setRestringViaBounds(UnsignedLength(333), UnsignedLength(444));
+  SExpression sexpr1 = obj1.serializeToDomElement("rules");
+
+  BoardDesignRules obj2(sexpr1);
+  SExpression sexpr2 = obj2.serializeToDomElement("rules");
+
+  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -75,6 +75,7 @@ SOURCES += \
     common/applicationtest.cpp \
     common/attributes/attributekeytest.cpp \
     common/attributes/attributesubstitutortest.cpp \
+    common/boarddesignrulestest.cpp \
     common/circuitidentifiertest.cpp \
     common/fileio/csvfiletest.cpp \
     common/fileio/directorylocktest.cpp \


### PR DESCRIPTION
The maximum stopmask drill diameter was not loaded properly from the settings file. Instead, the default parameter was restored.

Now I added a unit test which checks serializing/deserializing of the design rules.