### PR TITLE
UuidGenerator: Add quazip build dependency

### DIFF
--- a/apps/UuidGenerator/UuidGenerator.pro
+++ b/apps/UuidGenerator/UuidGenerator.pro
@@ -46,6 +46,13 @@ HEADERS += \
 FORMS += \
     mainwindow.ui \
 
+# QuaZIP
+!contains(UNBUNDLE, quazip) {
+    LIBS += -lquazip -lz
+    INCLUDEPATH += ../../libs/quazip
+    DEPENDPATH += ../../libs/quazip
+}
+
 # polyclipping
 !contains(UNBUNDLE, polyclipping) {
     LIBS += -lpolyclipping


### PR DESCRIPTION
This dependency was missing, which caused dynamically linked builds to fail when not unbundling quazip.

Part of the fix for #785.

Note: Dynamic builds still won't work until https://github.com/LibrePCB/quazip/pull/2 is merged and the quazip submodule is updated.