### PR TITLE
Only set QUAZIP_STATIC for static builds

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -69,6 +69,6 @@ contains(UNBUNDLE, all) {
 # QuaZIP configuration
 contains(UNBUNDLE, quazip) {
     DEFINES += SYSTEM_QUAZIP
-} else {
+} else:isEmpty(UNBUNDLE) {
     DEFINES += QUAZIP_STATIC
 }


### PR DESCRIPTION
It was accidentally set even for dynamic builds where the vendored quazip was being used (e.g. `UNBUNDLE+=polyclipping`).