### PR TITLE
Board editor: Fix staying in the "place device" tool

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorfsm.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorfsm.cpp
@@ -61,6 +61,14 @@ BoardEditorFsm::BoardEditorFsm(const Context& context, QObject* parent) noexcept
   mStates.insert(State::DRAW_PLANE, new BoardEditorState_DrawPlane(context));
   mStates.insert(State::DRAW_TRACE, new BoardEditorState_DrawTrace(context));
   enterNextState(State::SELECT);
+
+  // Connect the requestLeavingState() signal of all states to the
+  // processSelect() method to leave the state. Using a queued connection to
+  // avoid complex nested call stacks of two different states at the same time.
+  foreach (BoardEditorState* state, mStates) {
+    connect(state, &BoardEditorState::requestLeavingState, this,
+            &BoardEditorFsm::processSelect, Qt::QueuedConnection);
+  }
 }
 
 BoardEditorFsm::~BoardEditorFsm() noexcept {

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate.h
@@ -127,6 +127,15 @@ public:
   // Operator Overloadings
   BoardEditorState& operator=(const BoardEditorState& rhs) = delete;
 
+signals:
+  /**
+   * @brief Signal to indicate that the current tool should be exited
+   *
+   * This signal can be emitted by each state to signalize the FSM to leave
+   * the current state and entering the select tool.
+   */
+  void requestLeavingState();
+
 protected:  // Methods
   Board* getActiveBoard() noexcept;
   PositiveLength getGridInterval() const noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_adddevice.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_adddevice.cpp
@@ -123,6 +123,9 @@ bool BoardEditorState_AddDevice::processGraphicsSceneLeftMouseButtonPressed(
     }
     mContext.undoStack.commitCmdGroup();
     mIsUndoCmdActive = false;
+
+    // Placing finished, leave tool now.
+    emit requestLeavingState();
   } catch (const Exception& e) {
     QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
     abortCommand(false);


### PR DESCRIPTION
After a device has been placed on the board, the "place device" tool was not left automatically. So the user had to manually click on the "select" tool button to be able to select and move items. Now the "select" tool is automatically entered after placing a device.

The bug was probably introduced by the last board editor FSM refactoring.

Fixes #787