### PR TITLE
Saveas feature

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -208,6 +208,8 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   // connect some actions which are created with the Qt Designer
   connect(mUi->actionProjectSave, &QAction::triggered, &mProjectEditor,
           &ProjectEditor::saveProject);
+    connect(mUi->actionProjectSaveAs, &QAction::triggered,
+          [this]() { mProjectEditor.saveProjectAs(this); });
   connect(mUi->actionQuit, &QAction::triggered, this, &BoardEditor::close);
   connect(mUi->actionOpenWebsite, &QAction::triggered,
           []() { QDesktopServices::openUrl(QUrl("https://librepcb.org")); });

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.ui
@@ -78,6 +78,7 @@
      <string>&amp;File</string>
     </property>
     <addaction name="actionProjectSave"/>
+    <addaction name="actionProjectSaveAs"/>
     <addaction name="actionExportLppz"/>
     <addaction name="actionExportAsPdf"/>
     <addaction name="actionExportAsSvg"/>
@@ -302,6 +303,15 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionProjectSaveAs">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Save Project</string>
    </property>
   </action>
   <action name="actionProjectClose">

--- a/libs/librepcb/projecteditor/projecteditor.cpp
+++ b/libs/librepcb/projecteditor/projecteditor.cpp
@@ -211,6 +211,46 @@ bool ProjectEditor::saveProject() noexcept {
   }
 }
 
+bool ProjectEditor::saveProjectAs(QWidget* parent) noexcept {
+  try {
+    qDebug() << "Saving project as...";
+
+    FilePath defaultDirectory = mProject.getPath().getParentDir(); // can throw
+    QString directoryName = FileDialog::getSaveFileName(
+        parent, tr("Save project as *"), defaultDirectory.toStr(), "*");
+    if (directoryName.isEmpty()) return false;
+
+    // Copy project directory to 'directoryName' directory
+    // create file system
+    FilePath chosenDir = FilePath(directoryName);
+    std::shared_ptr<TransactionalFileSystem> fs = TransactionalFileSystem::openRW(
+      chosenDir);
+    TransactionalDirectory transdir(fs);
+
+    // Create a new project
+    Project* project = Project::create(
+        std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(fs)), 
+        directoryName);
+
+    // Save project to its own transactional directory, and then copies it to the
+    // newly created transactional directory
+    mProject.save();
+    mProject.getDirectory().copyTo(transdir);
+
+    project->save();
+    fs->save();
+
+    // Do not clean the undo stack for saving as copy, could be useful?
+
+    qDebug() << "Project successfully saved";
+    return true;
+  } catch (Exception& exc) {
+      QMessageBox::critical(0, tr("Error while saving the project"),
+                            exc.getMsg());
+      return false;
+    }
+}
+
 bool ProjectEditor::autosaveProject() noexcept {
   if (mUndoStack->isClean())
     return false;  // do not save if there are no changes

--- a/libs/librepcb/projecteditor/projecteditor.h
+++ b/libs/librepcb/projecteditor/projecteditor.h
@@ -169,6 +169,17 @@ public slots:
   bool saveProject() noexcept;
 
   /**
+   * @brief Save the whole project as a copy to the harddisc
+   *
+   * @note The whole save procedere is described in @ref doc_project_save.
+   *
+   * @param parent    parent widget of the dialog (optional)
+   *
+   * @return true on success, false on failure
+   */
+  bool saveProjectAs(QWidget* parent = nullptr) noexcept;
+
+  /**
    * @brief Make a automatic backup of the project (save to temporary files)
    *
    * @note The whole save procedere is described in @ref doc_project_save.

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -122,6 +122,8 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
           &SchematicEditor::addSchematic);
   connect(mUi->actionSave_Project, &QAction::triggered, &mProjectEditor,
           &ProjectEditor::saveProject);
+  connect(mUi->actionSave_Project_As, &QAction::triggered,
+          [this]() { mProjectEditor.saveProjectAs(this); });
   connect(mUi->actionQuit, &QAction::triggered, this, &SchematicEditor::close);
   connect(mUi->actionOpenWebsite, &QAction::triggered,
           []() { QDesktopServices::openUrl(QUrl("https://librepcb.org")); });

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -48,6 +48,7 @@
     </property>
     <addaction name="actionNew_Schematic_Page"/>
     <addaction name="actionSave_Project"/>
+    <addaction name="actionSave_Project_As"/>
     <addaction name="actionExportLppz"/>
     <addaction name="actionPDF_Export"/>
     <addaction name="actionExportAsSvg"/>
@@ -294,6 +295,15 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionSave_Project_As">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/img/actions/save.png</normaloff>:/img/actions/save.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Save Project As</string>
    </property>
   </action>
   <action name="actionAbout">


### PR DESCRIPTION
My implementation of the feature suggested in #741 

Works for the most part, missing 2 features:
- By default, the save dialog window requires all files to end in .lpp. This does not make sense for a folder. How should the dialog be called instead?
- The .lpp file doesn't get renamed to the same name as the new project, as the project files get strictly copied.