### PR TITLE
Fix missing holes in footprint previews

### DIFF
--- a/libs/librepcb/common/graphics/holegraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/holegraphicsitem.cpp
@@ -37,7 +37,7 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-HoleGraphicsItem::HoleGraphicsItem(Hole& hole,
+HoleGraphicsItem::HoleGraphicsItem(const Hole& hole,
                                    const IF_GraphicsLayerProvider& lp,
                                    QGraphicsItem* parent) noexcept
   : PrimitiveCircleGraphicsItem(parent),

--- a/libs/librepcb/common/graphics/holegraphicsitem.h
+++ b/libs/librepcb/common/graphics/holegraphicsitem.h
@@ -50,12 +50,12 @@ public:
   // Constructors / Destructor
   HoleGraphicsItem() = delete;
   HoleGraphicsItem(const HoleGraphicsItem& other) = delete;
-  HoleGraphicsItem(Hole& hole, const IF_GraphicsLayerProvider& lp,
+  HoleGraphicsItem(const Hole& hole, const IF_GraphicsLayerProvider& lp,
                    QGraphicsItem* parent = nullptr) noexcept;
   ~HoleGraphicsItem() noexcept;
 
   // Getters
-  Hole& getHole() noexcept { return mHole; }
+  const Hole& getHole() noexcept { return mHole; }
 
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;
@@ -69,7 +69,7 @@ private:  // Methods
                       const QVariant& value) noexcept override;
 
 private:  // Data
-  Hole& mHole;
+  const Hole& mHole;
   const IF_GraphicsLayerProvider& mLayerProvider;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
 

--- a/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
@@ -30,6 +30,7 @@
 #include <librepcb/common/application.h>
 #include <librepcb/common/attributes/attributesubstitutor.h>
 #include <librepcb/common/graphics/graphicslayer.h>
+#include <librepcb/common/graphics/holegraphicsitem.h>
 #include <librepcb/common/graphics/stroketextgraphicsitem.h>
 
 #include <QPrinter>
@@ -80,6 +81,11 @@ FootprintPreviewGraphicsItem::FootprintPreviewGraphicsItem(
     text.setAttributeProvider(this);
     StrokeTextGraphicsItem* item =
         new StrokeTextGraphicsItem(text, layerProvider);
+    item->setParentItem(this);
+  }
+
+  for (const Hole& hole : footprint.getHoles()) {
+    HoleGraphicsItem* item = new HoleGraphicsItem(hole, layerProvider);
     item->setParentItem(this);
   }
 }

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmddragselectedfootprintitems.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmddragselectedfootprintitems.cpp
@@ -105,7 +105,9 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
       context.currentGraphicsItem->getSelectedHoles();
   foreach (const QSharedPointer<HoleGraphicsItem>& hole, holes) {
     Q_ASSERT(hole);
-    mHoleEditCmds.append(new CmdHoleEdit(hole->getHole()));
+    // Note: The const_cast<> is a bit ugly, but it was by far the easiest
+    // way and is safe since here we know that we're allowed to modify the hole.
+    mHoleEditCmds.append(new CmdHoleEdit(const_cast<Hole&>(hole->getHole())));
     mCenterPos += hole->getHole().getPosition();
     ++count;
   }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -517,9 +517,12 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (HoleGraphicsItem* hole = dynamic_cast<HoleGraphicsItem*>(item)) {
     Q_ASSERT(hole);
-    HolePropertiesDialog dialog(
-        hole->getHole(), mContext.undoStack, getDefaultLengthUnit(),
-        "package_editor/hole_properties_dialog", &mContext.editorWidget);
+    // Note: The const_cast<> is a bit ugly, but it was by far the easiest
+    // way and is safe since here we know that we're allowed to modify the hole.
+    HolePropertiesDialog dialog(const_cast<Hole&>(hole->getHole()),
+                                mContext.undoStack, getDefaultLengthUnit(),
+                                "package_editor/hole_properties_dialog",
+                                &mContext.editorWidget);
     dialog.exec();
     return true;
   }


### PR DESCRIPTION
At some places where footprint previews are shown (e.g. device editor, component chooser dialog, place devices dock), the holes of the footprint were not visible. Now the holes are shown properly.

Fixes #784