### PR TITLE
CI: Work around broken macOS builds

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -39,10 +39,10 @@ then
   brew link --force qt5
 
   # Install Python packages
-  pip2 install --user future "flake8==3.7.7"
-  pip2 install --user -r ./tests/cli/requirements.txt
-  pip2 install --user -r ./tests/funq/requirements.txt
-  export PATH="$PATH:`python2 -m site --user-base`/bin"
+  pip3 install --user future "flake8==3.7.7"
+  pip3 install --user -r ./tests/cli/requirements.txt
+  pip3 install --user -r ./tests/funq/requirements.txt
+  export PATH="$PATH:`python3 -m site --user-base`/bin"
 
   # Qt Installer Framework
   wget -cq "$QTIFW_URL_BASE/QtInstallerFramework-mac-x64.dmg"

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -21,11 +21,24 @@ then
 elif [ "$OS" = "mac" ]
 then
 
-  brew update
+  # MacOS resp. homebrew needs workarounds to make it less unstable.
+  # See https://github.com/actions/virtual-environments/issues/1811
+  brew uninstall openssl@1.0.2t || true
+  brew uninstall python@2.7.17 || true
+  brew untap local/openssl || true
+  brew untap local/python2 || true
+
+  # Update homebrow to avoid issues due to outdated package database. But
+  # because even the update sometimes fails, let's ignore any errors with
+  # "|| true" (Apple-style error handling). Maybe this way we get succussful
+  # builds even if homebrow failed, which saves a lot of time and nerves.
+  brew update || true
+
+  # Install Qt
   brew install qt5
   brew link --force qt5
 
-  # python packages
+  # Install Python packages
   pip2 install --user future "flake8==3.7.7"
   pip2 install --user -r ./tests/cli/requirements.txt
   pip2 install --user -r ./tests/funq/requirements.txt


### PR DESCRIPTION
MacOS builds on CI are broken since a few days (as usual every few months.... seems to be a damn unstable OS).

I applied the workaround as suggested in https://github.com/actions/virtual-environments/issues/1811#issuecomment-708480190 to fix the failure. But I suspect some day these new commands will suddenly fail when Apple and/or homebrew change the behavior again. So I applied Apple-style error handling for prevention: Just ignoring any error :wink:

I'm not sure, but I suspect someone even suddenly removed Python 2 from macOS?! Therefore I switched the functional tests to Python 3, fortunately that was an easy task...