### PR TITLE
Replace sexpresso library with own implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "libs/parseagle"]
     path = libs/parseagle
     url = https://github.com/LibrePCB/parseagle.git
-[submodule "libs/sexpresso"]
-    path = libs/sexpresso
-    url = https://github.com/LibrePCB/sexpresso.git
 [submodule "libs/fontobene"]
     path = libs/fontobene-qt5
     url = https://github.com/fontobene/fontobene-qt5.git

--- a/apps/EagleImport/EagleImport.pro
+++ b/apps/EagleImport/EagleImport.pro
@@ -19,7 +19,6 @@ LIBS += \
     -llibrepcblibrary \
     -llibrepcbcommon \
     -lparseagle \
-    -lsexpresso \
     -lmuparser \
 
 # Solaris based systems need to link against libproc
@@ -36,7 +35,6 @@ DEPENDPATH += \
     ../../libs/librepcb/library \
     ../../libs/librepcb/common \
     ../../libs/parseagle \
-    ../../libs/sexpresso \
 
 isEmpty(UNBUNDLE) {
     # These libraries will only be linked statically when not unbundling
@@ -49,7 +47,6 @@ isEmpty(UNBUNDLE) {
 
 PRE_TARGETDEPS += \
     $${DESTDIR}/libparseagle.a \
-    $${DESTDIR}/libsexpresso.a \
 
 RESOURCES += \
     ../../img/images.qrc \

--- a/apps/UuidGenerator/UuidGenerator.pro
+++ b/apps/UuidGenerator/UuidGenerator.pro
@@ -13,7 +13,6 @@ QT += core widgets
 LIBS += \
     -L$${DESTDIR} \
     -llibrepcbcommon \
-    -lsexpresso \
     -lmuparser \
 
 # Solaris based systems need to link against libproc

--- a/apps/librepcb-cli/librepcb-cli.pro
+++ b/apps/librepcb-cli/librepcb-cli.pro
@@ -29,7 +29,6 @@ LIBS += \
     -llibrepcblibrary \
     -llibrepcbcommon \
     -lmuparser \
-    -lsexpresso \
 
 # Solaris based systems need to link against libproc
 solaris:LIBS += -lproc
@@ -47,11 +46,9 @@ DEPENDPATH += \
     ../../libs/librepcb/project \
     ../../libs/librepcb/library \
     ../../libs/librepcb/common \
-    ../../libs/sexpresso \
     ../../libs/muparser \
 
 PRE_TARGETDEPS += \
-    $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libmuparser.a \
 
 isEmpty(UNBUNDLE) {

--- a/apps/librepcb/librepcb.pro
+++ b/apps/librepcb/librepcb.pro
@@ -43,7 +43,6 @@ LIBS += \
     -llibrepcblibrary \
     -llibrepcbcommon \
     -lmuparser \
-    -lsexpresso \
 
 # Solaris based systems need to link against libproc
 solaris:LIBS += -lproc
@@ -61,11 +60,9 @@ DEPENDPATH += \
     ../../libs/librepcb/project \
     ../../libs/librepcb/library \
     ../../libs/librepcb/common \
-    ../../libs/sexpresso \
     ../../libs/muparser \
 
 PRE_TARGETDEPS += \
-    $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libmuparser.a \
 
 isEmpty(UNBUNDLE) {

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -24,7 +24,6 @@ isEmpty(UNBUNDLE) {
 
 INCLUDEPATH += \
     ../../ \
-    ../../sexpresso \
     ../../type_safe/include \
     ../../type_safe/external/debug_assert \
     ../../muparser/include \

--- a/libs/librepcb/common/fileio/sexpression.h
+++ b/libs/librepcb/common/fileio/sexpression.h
@@ -32,10 +32,6 @@
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
-namespace sexpresso {
-struct Sexp;
-}
-
 namespace librepcb {
 
 class SExpression;
@@ -140,11 +136,19 @@ public:
 
 private:  // Methods
   SExpression(Type type, const QString& value);
-  SExpression(sexpresso::Sexp& sexp, const FilePath& filePath);
 
-  QString escapeString(const QString& string) const noexcept;
-  bool isValidListName(const QString& name) const noexcept;
-  bool isValidToken(const QString& token) const noexcept;
+  static SExpression parse(const QString& content, int& index,
+                           const FilePath& filePath);
+  static SExpression parseList(const QString& content, int& index,
+                               const FilePath& filePath);
+  static QString parseToken(const QString& content, int& index,
+                            const FilePath& filePath);
+  static QString parseString(const QString& content, int& index,
+                             const FilePath& filePath);
+  static void skipWhitespaceAndComments(const QString& content, int& index);
+  static QString escapeString(const QString& string) noexcept;
+  static bool isValidToken(const QString& token) noexcept;
+  static bool isValidTokenChar(const QChar& c) noexcept;
   QString toString(int indent) const;
 
 private:  // Data

--- a/libs/libs.pro
+++ b/libs/libs.pro
@@ -10,14 +10,12 @@ SUBDIRS = \
     muparser \
     optional \
     parseagle \
-    sexpresso \
 
 librepcb.depends = \
     delaunay-triangulation \
     muparser \
     optional \
     parseagle \
-    sexpresso \
 
 # Hoedown is only needed for Qt <5.14
 equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 14) {

--- a/tests/unittests/common/fileio/sexpressiontest.cpp
+++ b/tests/unittests/common/fileio/sexpressiontest.cpp
@@ -1,0 +1,163 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/common/fileio/sexpression.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class SExpressionTest : public ::testing::Test {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST(SExpressionTest, testParseEmptyBytearray) {
+  EXPECT_THROW(SExpression::parse("", FilePath()), RuntimeError);
+}
+
+TEST(SExpressionTest, testParseEmptyBraces) {
+  EXPECT_THROW(SExpression::parse("()", FilePath()), RuntimeError);
+}
+
+TEST(SExpressionTest, testParseMissingClosingBrace) {
+  EXPECT_THROW(SExpression::parse("(test", FilePath()), RuntimeError);
+}
+
+TEST(SExpressionTest, testParseTooFewClosingBraces) {
+  EXPECT_THROW(SExpression::parse("(test (foo bar)", FilePath()), RuntimeError);
+}
+
+TEST(SExpressionTest, testParseTooManyClosingBraces) {
+  EXPECT_THROW(SExpression::parse("(test (foo bar)))", FilePath()),
+               RuntimeError);
+}
+
+TEST(SExpressionTest, testParseEmptyList) {
+  SExpression s = SExpression::parse("(test)", FilePath());
+  EXPECT_TRUE(s.isList());
+}
+
+TEST(SExpressionTest, testParseStringWithMissingEndQuote) {
+  EXPECT_THROW(SExpression::parse("(test \"foo)", FilePath()), RuntimeError);
+}
+
+TEST(SExpressionTest, testParseString) {
+  SExpression s = SExpression::parse("(test \"foo bar\")", FilePath());
+  EXPECT_TRUE(s.isList());
+  EXPECT_EQ(1, s.getChildren().count());
+  EXPECT_EQ("foo bar", s.getChildByIndex(0).getStringOrToken());
+}
+
+TEST(SExpressionTest, testParseStringWithQuotes) {
+  SExpression s = SExpression::parse("(test \"foo \\\"bar\\\"\")", FilePath());
+  EXPECT_TRUE(s.isList());
+  EXPECT_EQ(1, s.getChildren().count());
+  EXPECT_EQ("foo \"bar\"", s.getChildByIndex(0).getStringOrToken());
+}
+
+TEST(SExpressionTest, testParseStringWithNewlines) {
+  SExpression s = SExpression::parse("(test \"foo\\nbar\")", FilePath());
+  EXPECT_TRUE(s.isList());
+  EXPECT_EQ(1, s.getChildren().count());
+  EXPECT_EQ("foo\nbar", s.getChildByIndex(0).getStringOrToken());
+}
+
+TEST(SExpressionTest, testParseStringWithBackslash) {
+  SExpression s = SExpression::parse("(test \"foo\\\\bar\")", FilePath());
+  EXPECT_TRUE(s.isList());
+  EXPECT_EQ(1, s.getChildren().count());
+  EXPECT_EQ("foo\\bar", s.getChildByIndex(0).getStringOrToken());
+}
+
+TEST(SExpressionTest, testParseExpressionWithChildrenAndComments) {
+  QByteArray input =
+      "; (This whole line is a comment with CRLF line ending)\r\n"
+      "(librepcb_board 71762d7e-e7f1-403c-8020-db9670c01e9b\n"
+      " (default_font \"newstroke.bene\")\n"
+      " (grid (type lines) (interval 0.15875) (unit millimeters))\n"
+      " (fabrication_output_settings ; \"Just a comment\"\n"
+      "  (base_path \"./output/{{VERSION}}/gerber/{{PROJECT}}\")\n"
+      "  (outlines (suffix \"\"))\n"
+      "  (silkscreen_top (suffix \".gto\")\n"
+      "   (layers top_placement top_names)\n"
+      "  )\n"
+      " )\n"
+      ")\n";
+  SExpression s = SExpression::parse(input, FilePath());
+  EXPECT_EQ("newstroke.bene", s.getValueByPath<QString>("default_font"));
+  EXPECT_EQ("0.15875", s.getValueByPath<QString>("grid/interval"));
+  EXPECT_EQ("./output/{{VERSION}}/gerber/{{PROJECT}}",
+            s.getValueByPath<QString>("fabrication_output_settings/base_path"));
+  EXPECT_EQ(
+      "",
+      s.getValueByPath<QString>("fabrication_output_settings/outlines/suffix"));
+  EXPECT_EQ(".gto",
+            s.getValueByPath<QString>(
+                "fabrication_output_settings/silkscreen_top/suffix"));
+}
+
+TEST(SExpressionTest, testParsePartialExpression) {
+  QByteArray input =
+      "(librepcb_board 71762d7e-e7f1-403c-8020-db9670c01e9b\n"
+      " (default_font \"newstroke.bene\")\n"
+      " (grid (type lines) (interval 0.15875) (unit millimeters))\n"
+      " (fabrication_output_settings ; \"Just a comment\"\n"
+      "  (base_path \"./output/{{VERSION}}/gerber/{{PROJECT}}\")\n"
+      "  (outlines (suffix \"\"))\n"
+      "  (silkscreen_top (suffix \".gto\")\n"
+      "   (layers top_placement top_names)\n"
+      "  )\n"
+      " )\n"
+      ")";  // final newline omitted
+
+  // Check if parsing fails at *any* character boundary of the input string.
+  // This test is mainly there to check if the application does not crash due
+  // to index out of bounds string access.
+  for (int i = 0; i < input.length(); ++i) {
+    EXPECT_THROW(SExpression::parse(input.left(i), FilePath()), RuntimeError);
+    EXPECT_THROW(SExpression::parse(input.right(i), FilePath()), RuntimeError);
+  }
+}
+
+TEST(SExpressionTest, testSerializeStringWithEscaping) {
+  SExpression s = SExpression::createString("Foo\n \r\n \" \\ Bar");
+  EXPECT_EQ("\"Foo\\n \\r\\n \\\" \\\\ Bar\"\n", s.toByteArray());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -25,7 +25,6 @@ LIBS += \
     -llibrepcbproject \
     -llibrepcblibrary \    # Note: The order of the libraries is very important for the linker!
     -llibrepcbcommon \     # Another order could end up in "undefined reference" errors!
-    -lsexpresso \
     -lmuparser \
     -lparseagle \
 
@@ -48,12 +47,10 @@ DEPENDPATH += \
     ../../libs/librepcb/library \
     ../../libs/librepcb/common \
     ../../libs/parseagle \
-    ../../libs/sexpresso \
     ../../libs/muparser \
 
 PRE_TARGETDEPS += \
     $${DESTDIR}/libgoogletest.a \
-    $${DESTDIR}/libsexpresso.a \
     $${DESTDIR}/libmuparser.a \
 
 isEmpty(UNBUNDLE) {

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -81,6 +81,7 @@ SOURCES += \
     common/fileio/directorylocktest.cpp \
     common/fileio/filepathtest.cpp \
     common/fileio/serializableobjectlisttest.cpp \
+    common/fileio/sexpressiontest.cpp \
     common/fileio/transactionaldirectorytest.cpp \
     common/fileio/transactionalfilesystemtest.cpp \
     common/geometry/pathmodeltest.cpp \


### PR DESCRIPTION
Replacing `sexpresso::parse()` with our own parser in the `SExpression` class. See #783 for the motivation behind this change.

Because we also used `sexpresso::escape()` to escape characters in strings to be serialized, I also had to replace this by our own implementation. Then I saw that `sexpresso::escape()` even replaced `?` by `\?`, `'` by `\'` and the _audible bell_ by `\a` (wtf?), which doesn't make sense to me :wink: So I removed these replacements, but only for LibrePCB 0.2.x to keep the 0.1.x file format as-is.

Positive side effect of the own implementation: It seems to be much faster than `sexpresso::parse()` :smiley: Not an accurate measurement, but on my computer the background library scan now takes ~25% less time than before (tested only in debug mode).

I just hope there are no critical bugs :see_no_evil: I added some unit tests and tested manually by opening/saving whole projects, at least so far it seems to work properly...

- Fixes #783.
- Useful for #792 since sexpresso no longer needs to be unbundled