### PR TITLE
SystemInfo: Add support for OpenBSD

### DIFF
--- a/tests/unittests/common/systeminfotest.cpp
+++ b/tests/unittests/common/systeminfotest.cpp
@@ -55,8 +55,11 @@ protected:
 
   QString getOwnProcessExeName() const noexcept {
 #if defined(Q_OS_SOLARIS)
-    // Note: Solaris limits process names to 16 bytes
+    // Note: Solaris limits process names to 15 bytes
     return QString("librepcb-unitte");
+#elif defined(Q_OS_OPENBSD)
+    // Note: OpenBSD limits process names to 16 bytes
+    return QString("librepcb-unittes");
 #else
     return QString("librepcb-unittests");
 #endif


### PR DESCRIPTION
See https://librepcb.discourse.group/t/building-on-openbsd/320.

Now it compiles successfully and all unittests are passing. Tested on OpenBSD 6.8.

![image](https://user-images.githubusercontent.com/5374821/99265583-259d5880-2822-11eb-81ae-acdda2de8ca7.png)
