### PR TITLE
Add support for text labels in schematics

### DIFF
--- a/libs/librepcb/common/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/common/graphics/primitivetextgraphicsitem.cpp
@@ -66,8 +66,10 @@ void PrimitiveTextGraphicsItem::setRotation(const Angle& rot) noexcept {
 }
 
 void PrimitiveTextGraphicsItem::setText(const QString& text) noexcept {
-  mText = text;
-  updateBoundingRectAndShape();
+  if (text != mText) {
+    mText = text;
+    updateBoundingRectAndShape();
+  }
 }
 
 void PrimitiveTextGraphicsItem::setHeight(

--- a/libs/librepcb/common/graphics/textgraphicsitem.h
+++ b/libs/librepcb/common/graphics/textgraphicsitem.h
@@ -36,6 +36,7 @@ namespace librepcb {
 
 class OriginCrossGraphicsItem;
 class IF_GraphicsLayerProvider;
+class AttributeProvider;
 
 /*******************************************************************************
  *  Class TextGraphicsItem
@@ -57,6 +58,10 @@ public:
   // Getters
   Text& getText() noexcept { return mText; }
 
+  // General Methods
+  void setAttributeProvider(const AttributeProvider* provider) noexcept;
+  void updateText() noexcept;
+
   // Operator Overloadings
   TextGraphicsItem& operator=(const TextGraphicsItem& rhs) = delete;
 
@@ -67,6 +72,9 @@ private:  // Data
   Text& mText;
   const IF_GraphicsLayerProvider& mLayerProvider;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
+
+  /// Object for substituting placeholders in text
+  const AttributeProvider* mAttributeProvider;
 
   // Slots
   Text::OnEditedSlot mOnEditedSlot;

--- a/libs/librepcb/project/project.pro
+++ b/libs/librepcb/project/project.pro
@@ -124,6 +124,8 @@ SOURCES += \
     schematics/cmd/cmdschematicnetsegmentremove.cpp \
     schematics/cmd/cmdschematicnetsegmentremoveelements.cpp \
     schematics/cmd/cmdschematicremove.cpp \
+    schematics/cmd/cmdschematictextadd.cpp \
+    schematics/cmd/cmdschematictextremove.cpp \
     schematics/cmd/cmdsymbolinstanceadd.cpp \
     schematics/cmd/cmdsymbolinstanceedit.cpp \
     schematics/cmd/cmdsymbolinstanceremove.cpp \
@@ -140,6 +142,7 @@ SOURCES += \
     schematics/items/si_netsegment.cpp \
     schematics/items/si_symbol.cpp \
     schematics/items/si_symbolpin.cpp \
+    schematics/items/si_text.cpp \
     schematics/schematic.cpp \
     schematics/schematiclayerprovider.cpp \
     schematics/schematicselectionquery.cpp \
@@ -246,6 +249,8 @@ HEADERS += \
     schematics/cmd/cmdschematicnetsegmentremove.h \
     schematics/cmd/cmdschematicnetsegmentremoveelements.h \
     schematics/cmd/cmdschematicremove.h \
+    schematics/cmd/cmdschematictextadd.h \
+    schematics/cmd/cmdschematictextremove.h \
     schematics/cmd/cmdsymbolinstanceadd.h \
     schematics/cmd/cmdsymbolinstanceedit.h \
     schematics/cmd/cmdsymbolinstanceremove.h \
@@ -262,6 +267,7 @@ HEADERS += \
     schematics/items/si_netsegment.h \
     schematics/items/si_symbol.h \
     schematics/items/si_symbolpin.h \
+    schematics/items/si_text.h \
     schematics/schematic.h \
     schematics/schematiclayerprovider.h \
     schematics/schematicselectionquery.h \

--- a/libs/librepcb/project/schematics/cmd/cmdschematictextadd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematictextadd.cpp
@@ -20,13 +20,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "si_base.h"
+#include "cmdschematictextadd.h"
 
-#include "../../project.h"
-#include "../graphicsitems/sgi_base.h"
+#include "../items/si_text.h"
 #include "../schematic.h"
-
-#include <librepcb/common/graphics/graphicsscene.h>
 
 #include <QtCore>
 
@@ -40,55 +37,28 @@ namespace project {
  *  Constructors / Destructor
  ******************************************************************************/
 
-SI_Base::SI_Base(Schematic& schematic) noexcept
-  : QObject(&schematic),
-    mSchematic(schematic),
-    mIsAddedToSchematic(false),
-    mIsSelected(false) {
+CmdSchematicTextAdd::CmdSchematicTextAdd(SI_Text& text) noexcept
+  : UndoCommand(tr("Add schematic text")), mText(text) {
 }
 
-SI_Base::~SI_Base() noexcept {
-  Q_ASSERT(!mIsAddedToSchematic);
+CmdSchematicTextAdd::~CmdSchematicTextAdd() noexcept {
 }
 
 /*******************************************************************************
- *  Getters
+ *  Inherited from UndoCommand
  ******************************************************************************/
 
-Project& SI_Base::getProject() const noexcept {
-  return mSchematic.getProject();
+bool CmdSchematicTextAdd::performExecute() {
+  performRedo();  // can throw
+  return true;
 }
 
-Circuit& SI_Base::getCircuit() const noexcept {
-  return mSchematic.getProject().getCircuit();
+void CmdSchematicTextAdd::performUndo() {
+  mText.getSchematic().removeText(mText);  // can throw
 }
 
-/*******************************************************************************
- *  Setters
- ******************************************************************************/
-
-void SI_Base::setSelected(bool selected) noexcept {
-  mIsSelected = selected;
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-void SI_Base::addToSchematic(QGraphicsItem* item) noexcept {
-  Q_ASSERT(!mIsAddedToSchematic);
-  if (item) {
-    mSchematic.getGraphicsScene().addItem(*item);
-  }
-  mIsAddedToSchematic = true;
-}
-
-void SI_Base::removeFromSchematic(QGraphicsItem* item) noexcept {
-  Q_ASSERT(mIsAddedToSchematic);
-  if (item) {
-    mSchematic.getGraphicsScene().removeItem(*item);
-  }
-  mIsAddedToSchematic = false;
+void CmdSchematicTextAdd::performRedo() {
+  mText.getSchematic().addText(mText);  // can throw
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematictextadd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematictextadd.h
@@ -1,0 +1,77 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICTEXTADD_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICTEXTADD_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/undocommand.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+class SI_Text;
+
+/*******************************************************************************
+ *  Class CmdSchematicTextAdd
+ ******************************************************************************/
+
+/**
+ * @brief The CmdSchematicTextAdd class
+ */
+class CmdSchematicTextAdd final : public UndoCommand {
+public:
+  // Constructors / Destructor
+  CmdSchematicTextAdd() = delete;
+  CmdSchematicTextAdd(const CmdSchematicTextAdd& other) = delete;
+  explicit CmdSchematicTextAdd(SI_Text& text) noexcept;
+  ~CmdSchematicTextAdd() noexcept;
+
+  // Operator Overloadings
+  CmdSchematicTextAdd& operator=(const CmdSchematicTextAdd& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc ::librepcb::UndoCommand::performExecute()
+  bool performExecute() override;
+
+  /// @copydoc ::librepcb::UndoCommand::performUndo()
+  void performUndo() override;
+
+  /// @copydoc ::librepcb::UndoCommand::performRedo()
+  void performRedo() override;
+
+private:  // Data
+  SI_Text& mText;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/project/schematics/cmd/cmdschematictextremove.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematictextremove.cpp
@@ -20,13 +20,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "si_base.h"
+#include "cmdschematictextremove.h"
 
-#include "../../project.h"
-#include "../graphicsitems/sgi_base.h"
+#include "../items/si_text.h"
 #include "../schematic.h"
-
-#include <librepcb/common/graphics/graphicsscene.h>
 
 #include <QtCore>
 
@@ -40,55 +37,29 @@ namespace project {
  *  Constructors / Destructor
  ******************************************************************************/
 
-SI_Base::SI_Base(Schematic& schematic) noexcept
-  : QObject(&schematic),
-    mSchematic(schematic),
-    mIsAddedToSchematic(false),
-    mIsSelected(false) {
+CmdSchematicTextRemove::CmdSchematicTextRemove(SI_Text& text) noexcept
+  : UndoCommand(tr("Remove schematic text")), mText(text) {
 }
 
-SI_Base::~SI_Base() noexcept {
-  Q_ASSERT(!mIsAddedToSchematic);
+CmdSchematicTextRemove::~CmdSchematicTextRemove() noexcept {
 }
 
 /*******************************************************************************
- *  Getters
+ *  Inherited from UndoCommand
  ******************************************************************************/
 
-Project& SI_Base::getProject() const noexcept {
-  return mSchematic.getProject();
+bool CmdSchematicTextRemove::performExecute() {
+  performRedo();  // can throw
+
+  return true;
 }
 
-Circuit& SI_Base::getCircuit() const noexcept {
-  return mSchematic.getProject().getCircuit();
+void CmdSchematicTextRemove::performUndo() {
+  mText.getSchematic().addText(mText);  // can throw
 }
 
-/*******************************************************************************
- *  Setters
- ******************************************************************************/
-
-void SI_Base::setSelected(bool selected) noexcept {
-  mIsSelected = selected;
-}
-
-/*******************************************************************************
- *  General Methods
- ******************************************************************************/
-
-void SI_Base::addToSchematic(QGraphicsItem* item) noexcept {
-  Q_ASSERT(!mIsAddedToSchematic);
-  if (item) {
-    mSchematic.getGraphicsScene().addItem(*item);
-  }
-  mIsAddedToSchematic = true;
-}
-
-void SI_Base::removeFromSchematic(QGraphicsItem* item) noexcept {
-  Q_ASSERT(mIsAddedToSchematic);
-  if (item) {
-    mSchematic.getGraphicsScene().removeItem(*item);
-  }
-  mIsAddedToSchematic = false;
+void CmdSchematicTextRemove::performRedo() {
+  mText.getSchematic().removeText(mText);  // can throw
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematictextremove.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematictextremove.h
@@ -1,0 +1,78 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_CMDSCHEMATICTEXTREMOVE_H
+#define LIBREPCB_PROJECT_CMDSCHEMATICTEXTREMOVE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/undocommand.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+
+class Schematic;
+class SI_Text;
+
+/*******************************************************************************
+ *  Class CmdSchematicTextRemove
+ ******************************************************************************/
+
+/**
+ * @brief The CmdSchematicTextRemove class
+ */
+class CmdSchematicTextRemove final : public UndoCommand {
+public:
+  // Constructors / Destructor
+  CmdSchematicTextRemove() = delete;
+  CmdSchematicTextRemove(const CmdSchematicTextRemove& other) = delete;
+  CmdSchematicTextRemove(SI_Text& text) noexcept;
+  ~CmdSchematicTextRemove() noexcept;
+
+  // Operator Overloadings
+  CmdSchematicTextRemove& operator=(const CmdSchematicTextRemove& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc ::librepcb::UndoCommand::performExecute()
+  bool performExecute() override;
+
+  /// @copydoc ::librepcb::UndoCommand::performUndo()
+  void performUndo() override;
+
+  /// @copydoc ::librepcb::UndoCommand::performRedo()
+  void performRedo() override;
+
+private:  // Data
+  SI_Text& mText;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/project/schematics/items/si_base.h
+++ b/libs/librepcb/project/schematics/items/si_base.h
@@ -40,7 +40,6 @@ namespace project {
 class Project;
 class Circuit;
 class Schematic;
-class SGI_Base;
 
 /*******************************************************************************
  *  Class SI_Base
@@ -61,6 +60,7 @@ public:
     NetLabel,  ///< ::librepcb::project::SI_NetLabel
     Symbol,  ///< ::librepcb::project::SI_Symbol
     SymbolPin,  ///< ::librepcb::project::SI_SymbolPin
+    Text,  ///< ::librepcb::project::SI_Text
   };
 
   // Constructors / Destructor
@@ -93,8 +93,8 @@ public:
 
 protected:
   // General Methods
-  void addToSchematic(SGI_Base* item) noexcept;
-  void removeFromSchematic(SGI_Base* item) noexcept;
+  void addToSchematic(QGraphicsItem* item) noexcept;
+  void removeFromSchematic(QGraphicsItem* item) noexcept;
 
 protected:
   Schematic& mSchematic;

--- a/libs/librepcb/project/schematics/items/si_text.h
+++ b/libs/librepcb/project/schematics/items/si_text.h
@@ -1,0 +1,102 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_SI_TEXT_H
+#define LIBREPCB_PROJECT_SI_TEXT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "si_base.h"
+
+#include <librepcb/common/geometry/text.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class TextGraphicsItem;
+
+namespace project {
+
+class Schematic;
+
+/*******************************************************************************
+ *  Class SI_Text
+ ******************************************************************************/
+
+/**
+ * @brief The SI_Text class represents a text label in a schematic
+ */
+class SI_Text final : public SI_Base, public SerializableObject {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  SI_Text() = delete;
+  SI_Text(const SI_Text& other) = delete;
+  SI_Text(Schematic& schematic, const SExpression& node,
+          const Version& fileFormat);
+  SI_Text(Schematic& schematic, const Text& text);
+  ~SI_Text() noexcept;
+
+  // Getters
+  const Uuid& getUuid() const noexcept { return mText.getUuid(); }
+  const Angle& getRotation() const noexcept { return mText.getRotation(); }
+  Text& getText() noexcept { return mText; }
+  const Text& getText() const noexcept { return mText; }
+
+  // General Methods
+  void addToSchematic() override;
+  void removeFromSchematic() override;
+
+  /// @copydoc librepcb::SerializableObject::serialize()
+  void serialize(SExpression& root) const override;
+
+  // Inherited from SI_Base
+  Type_t getType() const noexcept override { return SI_Base::Type_t::Text; }
+  const Point& getPosition() const noexcept override {
+    return mText.getPosition();
+  }
+  QPainterPath getGrabAreaScenePx() const noexcept override;
+  void setSelected(bool selected) noexcept override;
+
+  // Operator Overloadings
+  SI_Text& operator=(const SI_Text& rhs) = delete;
+
+private:  // Methods
+  void init();
+  void schematicAttributesChanged() noexcept;
+
+private:  // Attributes
+  Text mText;
+  QScopedPointer<TextGraphicsItem> mGraphicsItem;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/project/schematics/schematic.h
+++ b/libs/librepcb/project/schematics/schematic.h
@@ -58,6 +58,7 @@ class SI_NetSegment;
 class SI_NetPoint;
 class SI_NetLine;
 class SI_NetLabel;
+class SI_Text;
 class SchematicSelectionQuery;
 
 /*******************************************************************************
@@ -78,7 +79,7 @@ class SchematicSelectionQuery;
  *      - symbol pin:   ::librepcb::project::SI_SymbolPin
  *  - polygon:          TODO
  *  - circle:           TODO
- *  - text:             TODO
+ *  - text:             ::librepcb::project::SI_Text
  */
 class Schematic final : public QObject,
                         public AttributeProvider,
@@ -101,6 +102,7 @@ public:
   enum ItemZValue {
     ZValue_Default = 0,  ///< this is the default value (behind all other items)
     ZValue_Symbols,  ///< Z value for ::librepcb::project::SI_Symbol items
+    ZValue_Texts,  ///< Z value for ::librepcb::project::SI_Text items
     ZValue_NetLabels,  ///< Z value for ::librepcb::project::SI_NetLabel items
     ZValue_NetLines,  ///< Z value for ::librepcb::project::SI_NetLine items
     ZValue_HiddenNetPoints,  ///< Z value for hidden
@@ -130,6 +132,7 @@ public:
   QList<SI_NetLine*> getNetLinesAtScenePos(const Point& pos) const noexcept;
   QList<SI_NetLabel*> getNetLabelsAtScenePos(const Point& pos) const noexcept;
   QList<SI_SymbolPin*> getPinsAtScenePos(const Point& pos) const noexcept;
+  QList<SI_Text*> getTextsAtScenePos(const Point& pos) const noexcept;
 
   // Setters: General
   void setGridProperties(const GridProperties& grid) noexcept;
@@ -153,6 +156,12 @@ public:
   SI_NetSegment* getNetSegmentByUuid(const Uuid& uuid) const noexcept;
   void addNetSegment(SI_NetSegment& netsegment);
   void removeNetSegment(SI_NetSegment& netsegment);
+
+  // Text Methods
+  QList<SI_Text*> getTexts() const noexcept { return mTexts; }
+  SI_Text* getTextByUuid(const Uuid& uuid) const noexcept;
+  void addText(SI_Text& text);
+  void removeText(SI_Text& text);
 
   // General Methods
   void addToProject();
@@ -216,6 +225,7 @@ private:
 
   QList<SI_Symbol*> mSymbols;
   QList<SI_NetSegment*> mNetSegments;
+  QList<SI_Text*> mTexts;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/schematicselectionquery.cpp
+++ b/libs/librepcb/project/schematics/schematicselectionquery.cpp
@@ -28,6 +28,7 @@
 #include "items/si_netsegment.h"
 #include "items/si_symbol.h"
 #include "items/si_symbolpin.h"
+#include "items/si_text.h"
 #include "schematic.h"
 
 #include <QtCore>
@@ -44,8 +45,11 @@ namespace project {
 
 SchematicSelectionQuery::SchematicSelectionQuery(
     const QList<SI_Symbol*>& symbols, const QList<SI_NetSegment*>& netsegments,
-    QObject* parent)
-  : QObject(parent), mSymbols(symbols), mNetSegments(netsegments) {
+    const QList<SI_Text*>& texts, QObject* parent)
+  : QObject(parent),
+    mSymbols(symbols),
+    mNetSegments(netsegments),
+    mTexts(texts) {
 }
 
 SchematicSelectionQuery::~SchematicSelectionQuery() noexcept {
@@ -72,7 +76,7 @@ QHash<SI_NetSegment*, SchematicSelectionQuery::NetSegmentItems>
 
 int SchematicSelectionQuery::getResultCount() const noexcept {
   return mResultSymbols.count() + mResultNetPoints.count() +
-      mResultNetLines.count() + mResultNetLabels.count();
+      mResultNetLines.count() + mResultNetLabels.count() + mResultTexts.count();
 }
 
 /*******************************************************************************
@@ -113,6 +117,14 @@ void SchematicSelectionQuery::addSelectedNetLabels() noexcept {
       if (netlabel->isSelected()) {
         mResultNetLabels.insert(netlabel);
       }
+    }
+  }
+}
+
+void SchematicSelectionQuery::addSelectedTexts() noexcept {
+  foreach (SI_Text* text, mTexts) {
+    if (text->isSelected()) {
+      mResultTexts.insert(text);
     }
   }
 }

--- a/libs/librepcb/project/schematics/schematicselectionquery.h
+++ b/libs/librepcb/project/schematics/schematicselectionquery.h
@@ -39,6 +39,7 @@ class SI_NetSegment;
 class SI_NetLine;
 class SI_NetPoint;
 class SI_NetLabel;
+class SI_Text;
 
 /*******************************************************************************
  *  Class SchematicSelectionQuery
@@ -63,6 +64,7 @@ public:
   SchematicSelectionQuery(const SchematicSelectionQuery& other) = delete;
   SchematicSelectionQuery(const QList<SI_Symbol*>& symbols,
                           const QList<SI_NetSegment*>& netsegments,
+                          const QList<SI_Text*>& texts,
                           QObject* parent = nullptr);
   ~SchematicSelectionQuery() noexcept;
 
@@ -77,6 +79,7 @@ public:
   const QSet<SI_NetLabel*>& getNetLabels() const noexcept {
     return mResultNetLabels;
   }
+  const QSet<SI_Text*>& getTexts() const noexcept { return mResultTexts; }
 
   /**
    * @brief Get net points, net lines and net labels grouped by net segement
@@ -96,6 +99,7 @@ public:
   void addSelectedNetPoints() noexcept;
   void addSelectedNetLines() noexcept;
   void addSelectedNetLabels() noexcept;
+  void addSelectedTexts() noexcept;
   /**
    * @brief Add net points of the selected net lines
    *
@@ -116,12 +120,14 @@ private:
   // references to the Schematic object
   const QList<SI_Symbol*>& mSymbols;
   const QList<SI_NetSegment*>& mNetSegments;
+  const QList<SI_Text*>& mTexts;
 
   // query result
   QSet<SI_Symbol*> mResultSymbols;
   QSet<SI_NetPoint*> mResultNetPoints;
   QSet<SI_NetLine*> mResultNetLines;
   QSet<SI_NetLabel*> mResultNetLabels;
+  QSet<SI_Text*> mResultTexts;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "cmdmirrorselectedschematicitems.h"
 
+#include <librepcb/common/geometry/cmd/cmdtextedit.h>
 #include <librepcb/common/gridproperties.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.h>
@@ -33,6 +34,7 @@
 #include <librepcb/project/schematics/items/si_netpoint.h>
 #include <librepcb/project/schematics/items/si_symbol.h>
 #include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/items/si_text.h>
 #include <librepcb/project/schematics/schematic.h>
 #include <librepcb/project/schematics/schematicselectionquery.h>
 
@@ -71,6 +73,7 @@ bool CmdMirrorSelectedSchematicItems::performExecute() {
   query->addSelectedNetPoints();
   query->addNetPointsOfNetLines();
   query->addSelectedNetLabels();
+  query->addSelectedTexts();
 
   // find the center of all elements
   Point center = Point(0, 0);
@@ -85,6 +88,10 @@ bool CmdMirrorSelectedSchematicItems::performExecute() {
   }
   foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
     center += netlabel->getPosition();
+    ++count;
+  }
+  foreach (SI_Text* text, query->getTexts()) {
+    center += text->getPosition();
     ++count;
   }
   if (count > 0) {
@@ -122,6 +129,11 @@ bool CmdMirrorSelectedSchematicItems::performExecute() {
 
     CmdSchematicNetLabelEdit* cmd = new CmdSchematicNetLabelEdit(*netlabel);
     cmd->setPosition(newpos, false);
+    appendChild(cmd);
+  }
+  foreach (SI_Text* text, query->getTexts()) {
+    CmdTextEdit* cmd = new CmdTextEdit(text->getText());
+    cmd->mirror(mOrientation, center, false);
     appendChild(cmd);
   }
 

--- a/libs/librepcb/projecteditor/cmd/cmdmoveselectedschematicitems.h
+++ b/libs/librepcb/projecteditor/cmd/cmdmoveselectedschematicitems.h
@@ -32,6 +32,9 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class CmdTextEdit;
+
 namespace project {
 
 class Schematic;
@@ -73,6 +76,7 @@ private:
   QList<CmdSymbolInstanceEdit*> mSymbolEditCmds;
   QList<CmdSchematicNetPointEdit*> mNetPointEditCmds;
   QList<CmdSchematicNetLabelEdit*> mNetLabelEditCmds;
+  QList<CmdTextEdit*> mTextEditCmds;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
@@ -42,6 +42,7 @@
 #include <librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h>
+#include <librepcb/project/schematics/cmd/cmdschematictextadd.h>
 #include <librepcb/project/schematics/cmd/cmdsymbolinstanceadd.h>
 #include <librepcb/project/schematics/items/si_netlabel.h>
 #include <librepcb/project/schematics/items/si_netline.h>
@@ -49,6 +50,7 @@
 #include <librepcb/project/schematics/items/si_netsegment.h>
 #include <librepcb/project/schematics/items/si_symbol.h>
 #include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/items/si_text.h>
 #include <librepcb/project/schematics/schematic.h>
 #include <librepcb/project/settings/projectsettings.h>
 
@@ -277,6 +279,15 @@ bool CmdPasteSchematicItems::performExecute() {
         execNewChildCmd(cmd);
       }
     }
+  }
+
+  // Paste texts
+  for (const Text& text : mData->getTexts()) {
+    Text copy(Uuid::createRandom(), text);  // assign new UUID
+    copy.setPosition(copy.getPosition() + mPosOffset);  // move
+    SI_Text* item = new SI_Text(mSchematic, copy);
+    item->setSelected(true);
+    execNewChildCmd(new CmdSchematicTextAdd(*item));
   }
 
   undoScopeGuard.dismiss();  // no undo required

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
@@ -48,6 +48,7 @@
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentadd.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentaddelements.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetsegmentremove.h>
+#include <librepcb/project/schematics/cmd/cmdschematictextremove.h>
 #include <librepcb/project/schematics/cmd/cmdsymbolinstanceremove.h>
 #include <librepcb/project/schematics/items/si_netlabel.h>
 #include <librepcb/project/schematics/items/si_netline.h>
@@ -93,6 +94,7 @@ bool CmdRemoveSelectedSchematicItems::performExecute() {
   query->addSelectedSymbols();
   query->addSelectedNetLines();
   query->addSelectedNetLabels();
+  query->addSelectedTexts();
   query->addNetPointsOfNetLines(true);
   query->addNetLinesOfSymbolPins();
 
@@ -112,6 +114,11 @@ bool CmdRemoveSelectedSchematicItems::performExecute() {
   foreach (SI_Symbol* symbol, query->getSymbols()) {
     Q_ASSERT(symbol->isAddedToSchematic());
     removeSymbol(*symbol);  // can throw
+  }
+
+  // remove texts
+  foreach (SI_Text* text, query->getTexts()) {
+    execNewChildCmd(new CmdSchematicTextRemove(*text));  // can throw
   }
 
   // remove netsignals which are no longer required

--- a/libs/librepcb/projecteditor/cmd/cmdrotateselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdrotateselectedschematicitems.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "cmdrotateselectedschematicitems.h"
 
+#include <librepcb/common/geometry/cmd/cmdtextedit.h>
 #include <librepcb/common/gridproperties.h>
 #include <librepcb/project/project.h>
 #include <librepcb/project/schematics/cmd/cmdschematicnetlabelanchorsupdate.h>
@@ -33,6 +34,7 @@
 #include <librepcb/project/schematics/items/si_netpoint.h>
 #include <librepcb/project/schematics/items/si_symbol.h>
 #include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/items/si_text.h>
 #include <librepcb/project/schematics/schematic.h>
 #include <librepcb/project/schematics/schematicselectionquery.h>
 
@@ -71,6 +73,7 @@ bool CmdRotateSelectedSchematicItems::performExecute() {
   query->addSelectedNetPoints();
   query->addNetPointsOfNetLines();
   query->addSelectedNetLabels();
+  query->addSelectedTexts();
 
   // find the center of all elements
   Point center = Point(0, 0);
@@ -85,6 +88,10 @@ bool CmdRotateSelectedSchematicItems::performExecute() {
   }
   foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
     center += netlabel->getPosition();
+    ++count;
+  }
+  foreach (SI_Text* text, query->getTexts()) {
+    center += text->getPosition();
     ++count;
   }
   if (count > 0) {
@@ -108,6 +115,11 @@ bool CmdRotateSelectedSchematicItems::performExecute() {
   }
   foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
     CmdSchematicNetLabelEdit* cmd = new CmdSchematicNetLabelEdit(*netlabel);
+    cmd->rotate(mAngle, center, false);
+    appendChild(cmd);
+  }
+  foreach (SI_Text* text, query->getTexts()) {
+    CmdTextEdit* cmd = new CmdTextEdit(text->getText());
     cmd->rotate(mAngle, center, false);
     appendChild(cmd);
   }

--- a/libs/librepcb/projecteditor/projecteditor.pro
+++ b/libs/librepcb/projecteditor/projecteditor.pro
@@ -87,6 +87,7 @@ SOURCES += \
     schematiceditor/fsm/schematiceditorstate.cpp \
     schematiceditor/fsm/schematiceditorstate_addcomponent.cpp \
     schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp \
+    schematiceditor/fsm/schematiceditorstate_addtext.cpp \
     schematiceditor/fsm/schematiceditorstate_drawwire.cpp \
     schematiceditor/fsm/schematiceditorstate_select.cpp \
     schematiceditor/renamenetsegmentdialog.cpp \
@@ -160,6 +161,7 @@ HEADERS += \
     schematiceditor/fsm/schematiceditorstate.h \
     schematiceditor/fsm/schematiceditorstate_addcomponent.h \
     schematiceditor/fsm/schematiceditorstate_addnetlabel.h \
+    schematiceditor/fsm/schematiceditorstate_addtext.h \
     schematiceditor/fsm/schematiceditorstate_drawwire.h \
     schematiceditor/fsm/schematiceditorstate_select.h \
     schematiceditor/renamenetsegmentdialog.h \

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.cpp
@@ -24,6 +24,7 @@
 
 #include "schematiceditorstate_addcomponent.h"
 #include "schematiceditorstate_addnetlabel.h"
+#include "schematiceditorstate_addtext.h"
 #include "schematiceditorstate_drawwire.h"
 #include "schematiceditorstate_select.h"
 
@@ -53,6 +54,7 @@ SchematicEditorFsm::SchematicEditorFsm(const Context& context,
                  new SchematicEditorState_AddNetLabel(context));
   mStates.insert(State::ADD_COMPONENT,
                  new SchematicEditorState_AddComponent(context));
+  mStates.insert(State::ADD_TEXT, new SchematicEditorState_AddText(context));
   enterNextState(State::SELECT);
 }
 
@@ -101,6 +103,10 @@ bool SchematicEditorFsm::processAddComponent(const Uuid& cmp,
 
 bool SchematicEditorFsm::processAddNetLabel() noexcept {
   return setNextState(State::ADD_NETLABEL);
+}
+
+bool SchematicEditorFsm::processAddText() noexcept {
+  return setNextState(State::ADD_TEXT);
 }
 
 bool SchematicEditorFsm::processDrawWire() noexcept {

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.h
@@ -74,7 +74,9 @@ public:
     /// ::librepcb::project::editor::SchematicEditorState_AddNetLabel
     ADD_NETLABEL,
     /// ::librepcb::project::editor::SchematicEditorState_AddComponent
-    ADD_COMPONENT
+    ADD_COMPONENT,
+    /// ::librepcb::project::editor::SchematicEditorState_AddText
+    ADD_TEXT,
   };
 
   /// FSM Context
@@ -102,6 +104,7 @@ public:
   bool processAddComponent() noexcept;
   bool processAddComponent(const Uuid& cmp, const Uuid& symbVar) noexcept;
   bool processAddNetLabel() noexcept;
+  bool processAddText() noexcept;
   bool processDrawWire() noexcept;
   bool processAbortCommand() noexcept;
   bool processSelectAll() noexcept;

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addtext.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addtext.cpp
@@ -1,0 +1,345 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "schematiceditorstate_addtext.h"
+
+#include "../schematiceditor.h"
+#include "ui_schematiceditor.h"
+
+#include <librepcb/common/geometry/cmd/cmdtextedit.h>
+#include <librepcb/common/graphics/graphicslayer.h>
+#include <librepcb/common/graphics/graphicsview.h>
+#include <librepcb/common/undostack.h>
+#include <librepcb/common/widgets/graphicslayercombobox.h>
+#include <librepcb/common/widgets/positivelengthedit.h>
+#include <librepcb/project/project.h>
+#include <librepcb/project/schematics/cmd/cmdschematictextadd.h>
+#include <librepcb/project/schematics/items/si_text.h>
+#include <librepcb/project/schematics/schematic.h>
+#include <librepcb/project/schematics/schematiclayerprovider.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace project {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+SchematicEditorState_AddText::SchematicEditorState_AddText(
+    const Context& context) noexcept
+  : SchematicEditorState(context),
+    mIsUndoCmdActive(false),
+    mLastTextProperties(
+        Uuid::createRandom(),  // UUID is not relevant here
+        GraphicsLayerName(GraphicsLayer::sSchematicComments),  // Layer
+        "{{PROJECT}}",  // Text
+        Point(),  // Position is not relevant here
+        Angle::deg0(),  // Rotation
+        PositiveLength(1500000),  // Height
+        Alignment(HAlign::left(), VAlign::bottom())  // Alignment
+        ),
+    mCurrentTextToPlace(nullptr) {
+}
+
+SchematicEditorState_AddText::~SchematicEditorState_AddText() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+bool SchematicEditorState_AddText::entry() noexcept {
+  Q_ASSERT(mIsUndoCmdActive == false);
+
+  Schematic* schematic = getActiveSchematic();
+  if (!schematic) return false;
+
+  // Clear schematic selection because selection does not make sense in this
+  // state
+  schematic->clearSelection();
+
+  // Add a new stroke text
+  Point pos = mContext.editorGraphicsView.mapGlobalPosToScenePos(QCursor::pos(),
+                                                                 true, true);
+  if (!addText(*schematic, pos)) return false;
+
+  // Add the "Layer:" label to the toolbar
+  mLayerLabel.reset(new QLabel(tr("Layer:")));
+  mLayerLabel->setIndent(10);
+  mContext.editorUi.commandToolbar->addWidget(mLayerLabel.data());
+
+  // Add the layers combobox to the toolbar
+  mLayerComboBox.reset(new GraphicsLayerComboBox());
+  mLayerComboBox->setLayers(
+      mContext.project.getLayers().getSchematicGeometryElementLayers());
+  mLayerComboBox->setCurrentLayer(mLastTextProperties.getLayerName());
+  mContext.editorUi.commandToolbar->addWidget(mLayerComboBox.data());
+  connect(mLayerComboBox.data(), &GraphicsLayerComboBox::currentLayerChanged,
+          this, &SchematicEditorState_AddText::layerComboBoxLayerChanged);
+
+  // Add the "Text:" label to the toolbar
+  mTextLabel.reset(new QLabel(tr("Text:")));
+  mTextLabel->setIndent(10);
+  mContext.editorUi.commandToolbar->addWidget(mTextLabel.data());
+
+  // Add the text combobox to the toolbar
+  mTextComboBox.reset(new QComboBox());
+  mTextComboBox->setEditable(true);
+  mTextComboBox->setMinimumContentsLength(20);
+  mTextComboBox->addItem("{{SHEET}}");
+  mTextComboBox->addItem("{{PAGE_X_OF_Y}}");
+  mTextComboBox->addItem("{{PROJECT}}");
+  mTextComboBox->addItem("{{AUTHOR}}");
+  mTextComboBox->addItem("{{VERSION}}");
+  mTextComboBox->addItem("{{MODIFIED_DATE}}");
+  mTextComboBox->setCurrentIndex(
+      mTextComboBox->findText(mLastTextProperties.getText()));
+  mTextComboBox->setCurrentText(mLastTextProperties.getText());
+  connect(mTextComboBox.data(), &QComboBox::currentTextChanged, this,
+          &SchematicEditorState_AddText::textComboBoxValueChanged);
+  mContext.editorUi.commandToolbar->addWidget(mTextComboBox.data());
+
+  // Add the "Height:" label to the toolbar
+  mHeightLabel.reset(new QLabel(tr("Height:")));
+  mHeightLabel->setIndent(10);
+  mContext.editorUi.commandToolbar->addWidget(mHeightLabel.data());
+
+  // Add the height spinbox to the toolbar
+  mHeightEdit.reset(new PositiveLengthEdit());
+  mHeightEdit->setValue(mLastTextProperties.getHeight());
+  connect(mHeightEdit.data(), &PositiveLengthEdit::valueChanged, this,
+          &SchematicEditorState_AddText::heightEditValueChanged);
+  mContext.editorUi.commandToolbar->addWidget(mHeightEdit.data());
+
+  // Change the cursor
+  mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
+
+  // Set focus to text combobox to allow typing the text immediately
+  setFocusToTextEdit();
+
+  return true;
+}
+
+bool SchematicEditorState_AddText::exit() noexcept {
+  // Abort the currently active command
+  if (!abortCommand(true)) return false;
+
+  // Remove actions / widgets from the "command" toolbar
+  mHeightEdit.reset();
+  mHeightLabel.reset();
+  mTextComboBox.reset();
+  mTextLabel.reset();
+  mLayerComboBox.reset();
+  mLayerLabel.reset();
+
+  // Reset the cursor
+  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
+
+  return true;
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool SchematicEditorState_AddText::processRotateCw() noexcept {
+  return rotateText(-Angle::deg90());
+}
+
+bool SchematicEditorState_AddText::processRotateCcw() noexcept {
+  return rotateText(Angle::deg90());
+}
+
+bool SchematicEditorState_AddText::processGraphicsSceneMouseMoved(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  Point pos = Point::fromPx(e.scenePos()).mappedToGrid(getGridInterval());
+  return updatePosition(pos);
+}
+
+bool SchematicEditorState_AddText::processGraphicsSceneLeftMouseButtonPressed(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  Schematic* schematic = getActiveSchematic();
+  if (!schematic) return false;
+
+  Point pos = Point::fromPx(e.scenePos()).mappedToGrid(getGridInterval());
+  fixPosition(pos);
+  addText(*schematic, pos);
+  return true;
+}
+
+bool SchematicEditorState_AddText::
+    processGraphicsSceneLeftMouseButtonDoubleClicked(
+        QGraphicsSceneMouseEvent& e) noexcept {
+  return processGraphicsSceneLeftMouseButtonPressed(e);
+}
+
+bool SchematicEditorState_AddText::processGraphicsSceneRightMouseButtonReleased(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  // Only rotate if cursor was not moved during click
+  if (e.screenPos() == e.buttonDownScreenPos(Qt::RightButton)) {
+    rotateText(Angle::deg90());
+  }
+
+  // Always accept the event if we are placing a text! When ignoring the
+  // event, the state machine will abort the tool by a right click!
+  return mIsUndoCmdActive;
+}
+
+bool SchematicEditorState_AddText::processSwitchToSchematicPage(
+    int index) noexcept {
+  Q_UNUSED(index);
+  return !mIsUndoCmdActive;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+bool SchematicEditorState_AddText::addText(Schematic& schematic,
+                                           const Point& pos) noexcept {
+  Q_ASSERT(mIsUndoCmdActive == false);
+
+  try {
+    mContext.undoStack.beginCmdGroup(tr("Add text to schematic"));
+    mIsUndoCmdActive = true;
+    mLastTextProperties.setPosition(pos);
+    mCurrentTextToPlace =
+        new SI_Text(schematic, Text(Uuid::createRandom(), mLastTextProperties));
+    QScopedPointer<CmdSchematicTextAdd> cmdAdd(
+        new CmdSchematicTextAdd(*mCurrentTextToPlace));
+    mContext.undoStack.appendToCmdGroup(cmdAdd.take());
+    mCurrentTextEditCmd.reset(new CmdTextEdit(mCurrentTextToPlace->getText()));
+
+    // Set focus to text combobox to allow typing the text immediately
+    setFocusToTextEdit();
+
+    return true;
+  } catch (const Exception& e) {
+    QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
+    abortCommand(false);
+    return false;
+  }
+}
+
+bool SchematicEditorState_AddText::rotateText(const Angle& angle) noexcept {
+  if ((!mCurrentTextEditCmd) || (!mCurrentTextToPlace)) return false;
+
+  mCurrentTextEditCmd->rotate(angle, mCurrentTextToPlace->getPosition(), true);
+  mLastTextProperties = mCurrentTextToPlace->getText();
+
+  return true;  // Event handled
+}
+
+bool SchematicEditorState_AddText::updatePosition(const Point& pos) noexcept {
+  if (mCurrentTextEditCmd) {
+    mCurrentTextEditCmd->setPosition(pos, true);
+    return true;  // Event handled
+  } else {
+    return false;
+  }
+}
+
+bool SchematicEditorState_AddText::fixPosition(const Point& pos) noexcept {
+  Q_ASSERT(mIsUndoCmdActive == true);
+
+  try {
+    if (mCurrentTextEditCmd) {
+      mCurrentTextEditCmd->setPosition(pos, false);
+      mContext.undoStack.appendToCmdGroup(mCurrentTextEditCmd.take());
+    }
+    mContext.undoStack.commitCmdGroup();
+    mIsUndoCmdActive = false;
+    mCurrentTextToPlace = nullptr;
+    return true;
+  } catch (const Exception& e) {
+    QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
+    abortCommand(false);
+    return false;
+  }
+}
+
+bool SchematicEditorState_AddText::abortCommand(bool showErrMsgBox) noexcept {
+  try {
+    // Delete the current edit command
+    mCurrentTextEditCmd.reset();
+
+    // Abort the undo command
+    if (mIsUndoCmdActive) {
+      mContext.undoStack.abortCmdGroup();
+      mIsUndoCmdActive = false;
+    }
+
+    // Reset attributes, go back to idle state
+    mCurrentTextToPlace = nullptr;
+    return true;
+  } catch (const Exception& e) {
+    if (showErrMsgBox) {
+      QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
+    }
+    return false;
+  }
+}
+
+void SchematicEditorState_AddText::layerComboBoxLayerChanged(
+    const GraphicsLayerName& layerName) noexcept {
+  mLastTextProperties.setLayerName(layerName);
+  if (mCurrentTextEditCmd) {
+    mCurrentTextEditCmd->setLayerName(mLastTextProperties.getLayerName(), true);
+  }
+}
+
+void SchematicEditorState_AddText::textComboBoxValueChanged(
+    const QString& value) noexcept {
+  mLastTextProperties.setText(value.trimmed());
+  if (mCurrentTextEditCmd) {
+    mCurrentTextEditCmd->setText(mLastTextProperties.getText(), true);
+  }
+}
+
+void SchematicEditorState_AddText::heightEditValueChanged(
+    const PositiveLength& value) noexcept {
+  mLastTextProperties.setHeight(value);
+  if (mCurrentTextEditCmd) {
+    mCurrentTextEditCmd->setHeight(mLastTextProperties.getHeight(), true);
+  }
+}
+
+void SchematicEditorState_AddText::setFocusToTextEdit() noexcept {
+  if (mTextComboBox) {
+    mTextComboBox->lineEdit()->selectAll();
+    mTextComboBox->setFocus();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addtext.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addtext.h
@@ -1,0 +1,126 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_PROJECT_EDITOR_SCHEMATICEDITORSTATE_ADDTEXT_H
+#define LIBREPCB_PROJECT_EDITOR_SCHEMATICEDITORSTATE_ADDTEXT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "schematiceditorstate.h"
+
+#include <librepcb/common/geometry/text.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class CmdTextEdit;
+class PositiveLengthEdit;
+class GraphicsLayerComboBox;
+
+namespace project {
+
+class Schematic;
+class SI_Text;
+
+namespace editor {
+
+/*******************************************************************************
+ *  Class SchematicEditorState_AddText
+ ******************************************************************************/
+
+/**
+ * @brief The SchematicEditorState_AddText class
+ */
+class SchematicEditorState_AddText final : public SchematicEditorState {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  SchematicEditorState_AddText() = delete;
+  SchematicEditorState_AddText(const SchematicEditorState_AddText& other) =
+      delete;
+  explicit SchematicEditorState_AddText(const Context& context) noexcept;
+  virtual ~SchematicEditorState_AddText() noexcept;
+
+  // General Methods
+  virtual bool entry() noexcept override;
+  virtual bool exit() noexcept override;
+
+  // Event Handlers
+  virtual bool processRotateCw() noexcept override;
+  virtual bool processRotateCcw() noexcept override;
+  virtual bool processGraphicsSceneMouseMoved(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processGraphicsSceneLeftMouseButtonDoubleClicked(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processGraphicsSceneRightMouseButtonReleased(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processSwitchToSchematicPage(int index) noexcept override;
+
+  // Operator Overloadings
+  SchematicEditorState_AddText& operator=(
+      const SchematicEditorState_AddText& rhs) = delete;
+
+private:  // Methods
+  bool addText(Schematic& schematic, const Point& pos) noexcept;
+  bool rotateText(const Angle& angle) noexcept;
+  bool updatePosition(const Point& pos) noexcept;
+  bool fixPosition(const Point& pos) noexcept;
+  bool abortCommand(bool showErrMsgBox) noexcept;
+  void layerComboBoxLayerChanged(const GraphicsLayerName& layerName) noexcept;
+  void textComboBoxValueChanged(const QString& value) noexcept;
+  void heightEditValueChanged(const PositiveLength& value) noexcept;
+  void setFocusToTextEdit() noexcept;
+
+private:  // Data
+  // State
+  bool mIsUndoCmdActive;
+  Text mLastTextProperties;
+
+  // Information about the current text to place. Only valid if
+  // mIsUndoCmdActive == true.
+  SI_Text* mCurrentTextToPlace;
+  QScopedPointer<CmdTextEdit> mCurrentTextEditCmd;
+
+  // Widgets for the command toolbar
+  QScopedPointer<QLabel> mLayerLabel;
+  QScopedPointer<GraphicsLayerComboBox> mLayerComboBox;
+  QScopedPointer<QLabel> mTextLabel;
+  QScopedPointer<QComboBox> mTextComboBox;
+  QScopedPointer<QLabel> mHeightLabel;
+  QScopedPointer<PositiveLengthEdit> mHeightEdit;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace project
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -31,10 +31,14 @@
 #include "../schematicclipboarddatabuilder.h"
 #include "../symbolinstancepropertiesdialog.h"
 
+#include <librepcb/common/dialogs/textpropertiesdialog.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/undostack.h>
+#include <librepcb/project/project.h>
 #include <librepcb/project/schematics/items/si_netlabel.h>
 #include <librepcb/project/schematics/items/si_symbol.h>
+#include <librepcb/project/schematics/items/si_text.h>
+#include <librepcb/project/schematics/schematiclayerprovider.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -360,6 +364,21 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
       break;
     }
 
+    case SI_Base::Type_t::Text: {
+      SI_Text* text = dynamic_cast<SI_Text*>(selectedItem);
+      Q_ASSERT(text);
+
+      addActionCut(menu);
+      addActionCopy(menu);
+      addActionRemove(menu);
+      menu.addSeparator();
+      addActionRotate(menu);
+      addActionMirror(menu);
+      menu.addSeparator();
+      addActionOpenProperties(menu, selectedItem);
+      break;
+    }
+
     default:
       return false;
   }
@@ -521,6 +540,13 @@ void SchematicEditorState_Select::openPropertiesDialog(SI_Base* item) noexcept {
       break;
     }
 
+    case SI_Base::Type_t::Text: {
+      SI_Text* text = dynamic_cast<SI_Text*>(item);
+      Q_ASSERT(text);
+      openTextPropertiesDialog(*text);
+      break;
+    }
+
     default:
       break;
   }
@@ -540,6 +566,16 @@ void SchematicEditorState_Select::openNetLabelPropertiesDialog(
   RenameNetSegmentDialog dialog(mContext.undoStack, netlabel.getNetSegment(),
                                 parentWidget());
   dialog.exec();  // performs the rename, if needed
+}
+
+void SchematicEditorState_Select::openTextPropertiesDialog(
+    SI_Text& text) noexcept {
+  TextPropertiesDialog dialog(
+      text.getText(), mContext.undoStack,
+      mContext.project.getLayers().getSchematicGeometryElementLayers(),
+      getDefaultLengthUnit(), "schematic_editor/text_properties_dialog",
+      parentWidget());
+  dialog.exec();  // performs the modifications
 }
 
 QAction* SchematicEditorState_Select::addActionCut(

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.h
@@ -40,6 +40,7 @@ namespace project {
 class SI_Base;
 class SI_Symbol;
 class SI_NetLabel;
+class SI_Text;
 class Schematic;
 
 namespace editor {
@@ -105,6 +106,7 @@ private:  // Methods
   void openPropertiesDialog(SI_Base* item) noexcept;
   void openSymbolPropertiesDialog(SI_Symbol& symbol) noexcept;
   void openNetLabelPropertiesDialog(SI_NetLabel& netlabel) noexcept;
+  void openTextPropertiesDialog(SI_Text& text) noexcept;
 
   // Right Click Menu
   QAction* addActionCut(QMenu& menu, const QString& text = tr("Cut")) noexcept;

--- a/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddata.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddata.cpp
@@ -48,7 +48,8 @@ SchematicClipboardData::SchematicClipboardData(const Uuid& schematicUuid,
     mCursorPos(cursorPos),
     mComponentInstances(),
     mSymbolInstances(),
-    mNetSegments() {
+    mNetSegments(),
+    mTexts() {
 }
 
 SchematicClipboardData::SchematicClipboardData(const QByteArray& mimeData)
@@ -63,6 +64,7 @@ SchematicClipboardData::SchematicClipboardData(const QByteArray& mimeData)
   mComponentInstances.loadFromSExpression(root, fileFormat);
   mSymbolInstances.loadFromSExpression(root, fileFormat);
   mNetSegments.loadFromSExpression(root, fileFormat);
+  mTexts.loadFromSExpression(root, fileFormat);
 }
 
 SchematicClipboardData::~SchematicClipboardData() noexcept {
@@ -121,6 +123,7 @@ void SchematicClipboardData::serialize(SExpression& root) const {
   mComponentInstances.serialize(root);
   mSymbolInstances.serialize(root);
   mNetSegments.serialize(root);
+  mTexts.serialize(root);
 }
 
 QString SchematicClipboardData::getMimeType() noexcept {

--- a/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddata.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddata.h
@@ -28,6 +28,7 @@
 #include <librepcb/common/geometry/junction.h>
 #include <librepcb/common/geometry/netlabel.h>
 #include <librepcb/common/geometry/netline.h>
+#include <librepcb/common/geometry/text.h>
 #include <librepcb/project/circuit/componentinstance.h>
 
 #include <QtCore>
@@ -227,6 +228,7 @@ public:
   SerializableObjectList<NetSegment, NetSegment>& getNetSegments() noexcept {
     return mNetSegments;
   }
+  TextList& getTexts() noexcept { return mTexts; }
 
   // General Methods
   std::unique_ptr<QMimeData> toMimeData() const;
@@ -250,6 +252,7 @@ private:  // Data
       mComponentInstances;
   SerializableObjectList<SymbolInstance, SymbolInstance> mSymbolInstances;
   SerializableObjectList<NetSegment, NetSegment> mNetSegments;
+  TextList mTexts;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddatabuilder.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematicclipboarddatabuilder.cpp
@@ -37,6 +37,7 @@
 #include <librepcb/project/schematics/items/si_netsegment.h>
 #include <librepcb/project/schematics/items/si_symbol.h>
 #include <librepcb/project/schematics/items/si_symbolpin.h>
+#include <librepcb/project/schematics/items/si_text.h>
 #include <librepcb/project/schematics/schematic.h>
 #include <librepcb/project/schematics/schematicselectionquery.h>
 
@@ -77,6 +78,7 @@ std::unique_ptr<SchematicClipboardData> SchematicClipboardDataBuilder::generate(
   query->addSelectedSymbols();
   query->addSelectedNetLines();
   query->addSelectedNetLabels();
+  query->addSelectedTexts();
   query->addNetPointsOfNetLines();
 
   // Add components
@@ -144,6 +146,11 @@ std::unique_ptr<SchematicClipboardData> SchematicClipboardDataBuilder::generate(
       newSegment->labels = segment.netlabels;
       data->getNetSegments().append(newSegment);
     }
+  }
+
+  // Add texts
+  foreach (SI_Text* text, query->getTexts()) {
+    data->getTexts().append(std::make_shared<Text>(text->getText()));
   }
 
   return data;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -170,6 +170,8 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
                                mUi->actionToolAddNetLabel);
   mToolsActionGroup->addAction(SchematicEditorFsm::State::ADD_COMPONENT,
                                mUi->actionToolAddComponent);
+  mToolsActionGroup->addAction(SchematicEditorFsm::State::ADD_TEXT,
+                               mUi->actionToolAddText);
   mToolsActionGroup->setCurrentAction(mFsm->getCurrentState());
   connect(mFsm, &SchematicEditorFsm::stateChanged, mToolsActionGroup.data(),
           &ExclusiveActionGroup::setCurrentAction);
@@ -653,6 +655,9 @@ void SchematicEditor::toolActionGroupChangeTriggered(
       break;
     case SchematicEditorFsm::State::ADD_COMPONENT:
       mFsm->processAddComponent();
+      break;
+    case SchematicEditorFsm::State::ADD_TEXT:
+      mFsm->processAddText();
       break;
     default:
       Q_ASSERT(false);

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.ui
@@ -105,6 +105,7 @@
     <addaction name="actionToolSelect"/>
     <addaction name="actionToolDrawWire"/>
     <addaction name="actionToolAddNetLabel"/>
+    <addaction name="actionToolAddText"/>
     <addaction name="actionToolAddComponent"/>
    </widget>
    <widget class="QMenu" name="menuProject">
@@ -234,6 +235,7 @@
    <addaction name="actionToolSelect"/>
    <addaction name="actionToolDrawWire"/>
    <addaction name="actionToolAddNetLabel"/>
+   <addaction name="actionToolAddText"/>
    <addaction name="actionToolAddComponent"/>
   </widget>
   <widget class="QToolBar" name="commandToolbar">
@@ -808,7 +810,22 @@
     <string>Select All</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+A</string>
+    <string notr="true">Ctrl+A</string>
+   </property>
+  </action>
+  <action name="actionToolAddText">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/img/actions/add_text.png</normaloff>:/img/actions/add_text.png</iconset>
+   </property>
+   <property name="text">
+    <string>Add &amp;Text</string>
+   </property>
+   <property name="toolTip">
+    <string>Add Text</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
    </property>
   </action>
  </widget>

--- a/tests/unittests/projecteditor/schematiceditor/schematicclipboarddatatest.cpp
+++ b/tests/unittests/projecteditor/schematiceditor/schematicclipboarddatatest.cpp
@@ -140,6 +140,15 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
   netSegment2->labels.append(std::make_shared<NetLabel>(
       Uuid::createRandom(), Point(1230, 4560), Angle(7890)));
 
+  std::shared_ptr<Text> text1 = std::make_shared<Text>(
+      Uuid::createRandom(), GraphicsLayerName("foo"), "text 1", Point(1, 2),
+      Angle(3), PositiveLength(4), Alignment(HAlign::left(), VAlign::top()));
+
+  std::shared_ptr<Text> text2 = std::make_shared<Text>(
+      Uuid::createRandom(), GraphicsLayerName("bar"), "text 2", Point(10, 20),
+      Angle(30), PositiveLength(40),
+      Alignment(HAlign::center(), VAlign::bottom()));
+
   // Create object
   SchematicClipboardData obj1(uuid, pos);
   obj1.getComponentInstances().append(component1);
@@ -148,6 +157,8 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
   obj1.getSymbolInstances().append(symbol2);
   obj1.getNetSegments().append(netSegment1);
   obj1.getNetSegments().append(netSegment2);
+  obj1.getTexts().append(text1);
+  obj1.getTexts().append(text2);
 
   // Serialize to MIME data
   std::unique_ptr<QMimeData> mime1 = obj1.toMimeData();
@@ -160,6 +171,7 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
   EXPECT_EQ(obj1.getComponentInstances(), obj2->getComponentInstances());
   EXPECT_EQ(obj1.getNetSegments(), obj2->getNetSegments());
   EXPECT_EQ(obj1.getSymbolInstances(), obj2->getSymbolInstances());
+  EXPECT_EQ(obj1.getTexts(), obj2->getTexts());
 }
 
 /*******************************************************************************


### PR DESCRIPTION
The same text labels as already supported in the symbol editor can now be added to schematics as well:

![Peek 2020-11-17 19-29](https://user-images.githubusercontent.com/5374821/99431813-9ec4aa80-290b-11eb-91e1-51d48a4b6a14.gif)

Fixes #441