### PR TITLE
Give footprint pads an UUID and allow unconnected pads

### DIFF
--- a/libs/librepcb/eagleimport/packageconverter.cpp
+++ b/libs/librepcb/eagleimport/packageconverter.cpp
@@ -179,7 +179,7 @@ std::unique_ptr<library::Package> PackageConverter::generate() const {
     }
     Angle rot = Angle::fromDeg(pad.getRotation().getAngle());
     std::shared_ptr<library::FootprintPad> fptPad(new library::FootprintPad(
-        uuid, pos, rot, shape, width, height, drillDiameter,
+        uuid, uuid, pos, rot, shape, width, height, drillDiameter,
         library::FootprintPad::BoardSide::THT));
     footprint->getPads().append(fptPad);
   }
@@ -204,7 +204,7 @@ std::unique_ptr<library::Package> PackageConverter::generate() const {
     PositiveLength width(Length::fromMm(pad.getWidth()));  // can throw
     PositiveLength height(Length::fromMm(pad.getHeight()));  // can throw
     std::shared_ptr<library::FootprintPad> fptPad(new library::FootprintPad(
-        uuid, pos, rot, library::FootprintPad::Shape::RECT, width, height,
+        uuid, uuid, pos, rot, library::FootprintPad::Shape::RECT, width, height,
         UnsignedLength(0), side));
     footprint->getPads().append(fptPad);
   }

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.cpp
@@ -71,7 +71,7 @@ CmdFootprintPadEdit::~CmdFootprintPadEdit() noexcept {
  *  Setters
  ******************************************************************************/
 
-void CmdFootprintPadEdit::setPackagePadUuid(const Uuid& pad,
+void CmdFootprintPadEdit::setPackagePadUuid(const tl::optional<Uuid>& pad,
                                             bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewPackagePadUuid = pad;

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.h
@@ -51,7 +51,8 @@ public:
   ~CmdFootprintPadEdit() noexcept;
 
   // Setters
-  void setPackagePadUuid(const Uuid& pad, bool immediate) noexcept;
+  void setPackagePadUuid(const tl::optional<Uuid>& pad,
+                         bool immediate) noexcept;
   void setBoardSide(FootprintPad::BoardSide side, bool immediate) noexcept;
   void setShape(FootprintPad::Shape shape, bool immediate) noexcept;
   void setWidth(const PositiveLength& width, bool immediate) noexcept;
@@ -86,8 +87,8 @@ private:
   FootprintPad& mPad;
 
   // General Attributes
-  Uuid mOldPackagePadUuid;
-  Uuid mNewPackagePadUuid;
+  tl::optional<Uuid> mOldPackagePadUuid;
+  tl::optional<Uuid> mNewPackagePadUuid;
   FootprintPad::BoardSide mOldBoardSide;
   FootprintPad::BoardSide mNewBoardSide;
   FootprintPad::Shape mOldShape;

--- a/libs/librepcb/library/pkg/footprintpad.h
+++ b/libs/librepcb/library/pkg/footprintpad.h
@@ -59,6 +59,7 @@ public:
 
   // Signals
   enum class Event {
+    UuidChanged,
     PackagePadUuidChanged,
     PositionChanged,
     RotationChanged,
@@ -74,18 +75,19 @@ public:
   // Constructors / Destructor
   FootprintPad() = delete;
   FootprintPad(const FootprintPad& other) noexcept;
-  FootprintPad(const Uuid& padUuid, const Point& pos, const Angle& rot,
-               Shape shape, const PositiveLength& width,
-               const PositiveLength& height,
+  FootprintPad(const Uuid& uuid, const FootprintPad& other) noexcept;
+  FootprintPad(const Uuid& uuid, const tl::optional<Uuid>& pkgPadUuid,
+               const Point& pos, const Angle& rot, Shape shape,
+               const PositiveLength& width, const PositiveLength& height,
                const UnsignedLength& drillDiameter, BoardSide side) noexcept;
   FootprintPad(const SExpression& node, const Version& fileFormat);
   ~FootprintPad() noexcept;
 
   // Getters
-  const Uuid& getUuid() const noexcept {
-    return getPackagePadUuid();
-  }  // for SerializableObjectList
-  const Uuid& getPackagePadUuid() const noexcept { return mPackagePadUuid; }
+  const Uuid& getUuid() const noexcept { return mUuid; }
+  const tl::optional<Uuid>& getPackagePadUuid() const noexcept {
+    return mPackagePadUuid;
+  }
   const Point& getPosition() const noexcept { return mPosition; }
   const Angle& getRotation() const noexcept { return mRotation; }
   Shape getShape() const noexcept { return mShape; }
@@ -102,7 +104,7 @@ public:
       noexcept;
 
   // Setters
-  bool setPackagePadUuid(const Uuid& pad) noexcept;
+  bool setPackagePadUuid(const tl::optional<Uuid>& pad) noexcept;
   bool setPosition(const Point& pos) noexcept;
   bool setRotation(const Angle& rot) noexcept;
   bool setShape(Shape shape) noexcept;
@@ -126,7 +128,14 @@ public:
   FootprintPad& operator=(const FootprintPad& rhs) noexcept;
 
 protected:  // Data
-  Uuid mPackagePadUuid;
+  Uuid mUuid;
+
+  /// The connected package pad
+  ///
+  /// This is the UUID of the package pad where this footprint pad is
+  /// connected to. It can be tl::nullopt, which means that the footprint pad
+  /// is electrically not connected (e.g. for mechanical-only pads).
+  tl::optional<Uuid> mPackagePadUuid;
   Point mPosition;
   Angle mRotation;
   Shape mShape;

--- a/libs/librepcb/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpadgraphicsitem.cpp
@@ -105,10 +105,11 @@ void FootprintPadGraphicsItem::setLayerName(const QString& name) noexcept {
   mTextGraphicsItem->setLayer(mLayerProvider.getLayer(name));
 }
 
-void FootprintPadGraphicsItem::setPackagePadUuid(const Uuid& uuid) noexcept {
+void FootprintPadGraphicsItem::setPackagePadUuid(
+    const tl::optional<Uuid>& uuid) noexcept {
   QString name;
-  if (mPackagePadList) {
-    if (std::shared_ptr<const PackagePad> pad = mPackagePadList->find(uuid)) {
+  if (mPackagePadList && uuid) {
+    if (std::shared_ptr<const PackagePad> pad = mPackagePadList->find(*uuid)) {
       name = *pad->getName();
     }
   }

--- a/libs/librepcb/library/pkg/footprintpadgraphicsitem.h
+++ b/libs/librepcb/library/pkg/footprintpadgraphicsitem.h
@@ -69,7 +69,7 @@ public:
   void setRotation(const Angle& rot) noexcept;
   void setShape(const QPainterPath& shape) noexcept;
   void setLayerName(const QString& name) noexcept;
-  void setPackagePadUuid(const Uuid& uuid) noexcept;
+  void setPackagePadUuid(const tl::optional<Uuid>& uuid) noexcept;
   void setSelected(bool selected) noexcept;
 
   // Inherited from QGraphicsItem

--- a/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
+++ b/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.cpp
@@ -64,8 +64,9 @@ FootprintPreviewGraphicsItem::FootprintPreviewGraphicsItem(
 
   for (const FootprintPad& fptPad : footprint.getPads()) {
     const PackagePad* pkgPad = nullptr;
-    if (mPackage)
-      pkgPad = mPackage->getPads().find(fptPad.getPackagePadUuid()).get();
+    if (mPackage && fptPad.getPackagePadUuid()) {
+      pkgPad = mPackage->getPads().find(*fptPad.getPackagePadUuid()).get();
+    }
     FootprintPadPreviewGraphicsItem* item =
         new FootprintPadPreviewGraphicsItem(layerProvider, fptPad, pkgPad);
     item->setPos(fptPad.getPosition().toPxQPointF());

--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardcontext.cpp
@@ -194,7 +194,7 @@ void NewElementWizardContext::copyElement(ElementType type,
       const Package* package = dynamic_cast<Package*>(element.data());
       Q_ASSERT(package);
       // copy pads but generate new UUIDs
-      QHash<Uuid, Uuid> padUuidMap;
+      QHash<Uuid, tl::optional<Uuid>> padUuidMap;
       mPackagePads.clear();
       for (const PackagePad& pad : package->getPads()) {
         Uuid newUuid = Uuid::createRandom();
@@ -211,8 +211,12 @@ void NewElementWizardContext::copyElement(ElementType type,
             footprint.getDescriptions().getDefaultValue()));
         // copy pads but generate new UUIDs
         for (const FootprintPad& pad : footprint.getPads()) {
+          tl::optional<Uuid> pkgPad = pad.getPackagePadUuid();
+          if (pkgPad) {
+            pkgPad = padUuidMap.value(*pkgPad);  // Translate to new UUID
+          }
           newFootprint->getPads().append(std::make_shared<FootprintPad>(
-              *padUuidMap.find(pad.getUuid()), pad.getPosition(),
+              Uuid::createRandom(), pkgPad, pad.getPosition(),
               pad.getRotation(), pad.getShape(), pad.getWidth(),
               pad.getHeight(), pad.getDrillDiameter(), pad.getBoardSide()));
         }

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
@@ -40,9 +40,9 @@ namespace library {
 namespace editor {
 
 FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
-    const Package& pkg, const Footprint& fpt, FootprintPad& pad,
-    UndoStack& undoStack, const LengthUnit& lengthUnit,
-    const QString& settingsPrefix, QWidget* parent) noexcept
+    const Package& pkg, FootprintPad& pad, UndoStack& undoStack,
+    const LengthUnit& lengthUnit, const QString& settingsPrefix,
+    QWidget* parent) noexcept
   : QDialog(parent),
     mPad(pad),
     mUndoStack(undoStack),
@@ -67,12 +67,9 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   int currentPadIndex = 0;
   mUi->cbxPackagePad->addItem(tr("(not connected)"), "");
   for (const PackagePad& p : pkg.getPads()) {
-    if ((p.getUuid() == mPad.getUuid()) ||
-        (!fpt.getPads().contains(p.getUuid()))) {
-      mUi->cbxPackagePad->addItem(*p.getName(), p.getUuid().toStr());
-      if (mPad.getPackagePadUuid() == p.getUuid()) {
-        currentPadIndex = mUi->cbxPackagePad->count() - 1;
-      }
+    mUi->cbxPackagePad->addItem(*p.getName(), p.getUuid().toStr());
+    if (mPad.getPackagePadUuid() == p.getUuid()) {
+      currentPadIndex = mUi->cbxPackagePad->count() - 1;
     }
   }
   mUi->cbxPackagePad->setCurrentIndex(currentPadIndex);
@@ -147,8 +144,8 @@ void FootprintPadPropertiesDialog::on_buttonBox_clicked(
 bool FootprintPadPropertiesDialog::applyChanges() noexcept {
   try {
     QScopedPointer<CmdFootprintPadEdit> cmd(new CmdFootprintPadEdit(mPad));
-    Uuid pkgPad = Uuid::fromString(
-        mUi->cbxPackagePad->currentData().toString());  // can throw
+    tl::optional<Uuid> pkgPad =
+        Uuid::tryFromString(mUi->cbxPackagePad->currentData().toString());
     cmd->setPackagePadUuid(pkgPad, false);
     if (mUi->rbtnBoardSideTop->isChecked()) {
       cmd->setBoardSide(FootprintPad::BoardSide::TOP, false);

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
@@ -61,8 +61,8 @@ public:
   FootprintPadPropertiesDialog() = delete;
   FootprintPadPropertiesDialog(const FootprintPadPropertiesDialog& other) =
       delete;
-  FootprintPadPropertiesDialog(const Package& pkg, const Footprint& fpt,
-                               FootprintPad& pad, UndoStack& undoStack,
+  FootprintPadPropertiesDialog(const Package& pkg, FootprintPad& pad,
+                               UndoStack& undoStack,
                                const LengthUnit& lengthUnit,
                                const QString& settingsPrefix,
                                QWidget* parent = nullptr) noexcept;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
@@ -85,7 +85,8 @@ private:  // Methods
   bool startAddPad(const Point& pos) noexcept;
   bool finishAddPad(const Point& pos) noexcept;
   bool abortAddPad() noexcept;
-  void packagePadComboBoxCurrentPadChanged(PackagePad* pad) noexcept;
+  void selectNextFreePadInComboBox() noexcept;
+  void packagePadComboBoxCurrentPadChanged(tl::optional<Uuid> pad) noexcept;
   void boardSideSelectorCurrentSideChanged(
       FootprintPad::BoardSide side) noexcept;
   void shapeSelectorCurrentShapeChanged(FootprintPad::Shape shape) noexcept;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -479,8 +479,8 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
           dynamic_cast<FootprintPadGraphicsItem*>(item)) {
     Q_ASSERT(pad);
     FootprintPadPropertiesDialog dialog(
-        mContext.package, *mContext.currentFootprint, pad->getPad(),
-        mContext.undoStack, getDefaultLengthUnit(),
+        mContext.package, pad->getPad(), mContext.undoStack,
+        getDefaultLengthUnit(),
         "package_editor/footprint_pad_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();

--- a/libs/librepcb/libraryeditor/pkg/widgets/packagepadcombobox.h
+++ b/libs/librepcb/libraryeditor/pkg/widgets/packagepadcombobox.h
@@ -52,27 +52,23 @@ public:
   ~PackagePadComboBox() noexcept;
 
   // Getters
-  PackagePad* getCurrentPad() const noexcept;
+  tl::optional<Uuid> getCurrentPad() const noexcept;
 
   // Setters
-  void setPackage(Package* package, Footprint* footprint = nullptr) noexcept;
-  void setCurrentPad(PackagePad* pad) noexcept;
-
-  // General Methods
-  void updatePads() noexcept;
+  void setPads(const PackagePadList& pads) noexcept;
+  void setCurrentPad(tl::optional<Uuid> pad) noexcept;
 
   // Operator Overloadings
   PackagePadComboBox& operator=(const PackagePadComboBox& rhs) = delete;
 
 signals:
-  void currentPadChanged(PackagePad* pad);
+  void currentPadChanged(tl::optional<Uuid> pad);
 
 private:  // Methods
+  tl::optional<Uuid> getPadAtIndex(int index) const noexcept;
   void currentIndexChanged(int index) noexcept;
 
 private:  // Data
-  Package* mPackage;
-  Footprint* mFootprint;
   QComboBox* mComboBox;
 };
 
@@ -84,4 +80,4 @@ private:  // Data
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_EDITOR_PACKAGEPADCOMBOBOX_H
+#endif

--- a/libs/librepcb/project/boards/items/bi_footprintpad.h
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.h
@@ -107,19 +107,25 @@ public:
   // Operator Overloadings
   BI_FootprintPad& operator=(const BI_FootprintPad& rhs) = delete;
 
-private slots:
-
+private:  // Methods
   void footprintAttributesChanged();
   void componentSignalInstanceNetSignalChanged(NetSignal* from, NetSignal* to);
-
-private:
   void updateGraphicsItemTransform() noexcept;
 
-  // General
+private:  // Data
   BI_Footprint& mFootprint;
   const library::FootprintPad* mFootprintPad;
+
+  /// The package pad where this footprint pad is connected to
+  ///
+  /// @attention This is `nullptr` if the footprint pad is not connected!
   const library::PackagePad* mPackagePad;
+
+  /// The net signal where this footprint pad is connected to
+  ///
+  /// @attention This is `nullptr` if the footprint pad is not connected!
   ComponentSignalInstance* mComponentSignalInstance;
+
   QMetaObject::Connection mHighlightChangedConnection;
   QMetaObject::Connection mNetSignalNameChangedConnection;
 

--- a/tests/unittests/library/pkg/footprintpadtest.cpp
+++ b/tests/unittests/library/pkg/footprintpadtest.cpp
@@ -1,0 +1,155 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/common/application.h>
+#include <librepcb/library/pkg/footprintpad.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace library {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class FootprintPadTest : public ::testing::Test {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(FootprintPadTest, testConstructFromSExpressionV01) {
+  // Attention: Do NOT modify this string! It represents the freezed(!) file
+  // format V0.1 and even current versions of LibrePCB must be able to load it!
+  SExpression sexpr = SExpression::parse(
+      "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape rect)\n"
+      " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (drill 0.0)\n"
+      ")",
+      FilePath());
+  FootprintPad obj(sexpr, Version::fromString("0.1"));
+  EXPECT_EQ(Uuid::fromString("7040952d-7016-49cd-8c3e-6078ecca98b9"),
+            obj.getUuid());
+  EXPECT_EQ(Uuid::fromString("7040952d-7016-49cd-8c3e-6078ecca98b9"),
+            obj.getPackagePadUuid());
+  EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
+  EXPECT_EQ(Angle::deg45(), obj.getRotation());
+  EXPECT_EQ(FootprintPad::Shape::RECT, obj.getShape());
+  EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
+  EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
+  EXPECT_EQ(UnsignedLength(0), obj.getDrillDiameter());
+  EXPECT_EQ(FootprintPad::BoardSide::TOP, obj.getBoardSide());
+}
+
+TEST_F(FootprintPadTest, testConstructFromSExpressionV02Connected) {
+  // Attention: Do NOT modify this string after the file format v0.2 is freezed,
+  // i.e. after releasing LibrePCB 0.2.0! Even current versions of LibrePCB
+  // must be able to load the file format v0.2!
+  SExpression sexpr = SExpression::parse(
+      "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape rect)\n"
+      " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (drill 0.0)\n"
+      " (package_pad d48b8bd2-a46c-4495-87a5-662747034098)\n"
+      ")",
+      FilePath());
+  FootprintPad obj(sexpr, Version::fromString("0.2"));
+  EXPECT_EQ(Uuid::fromString("7040952d-7016-49cd-8c3e-6078ecca98b9"),
+            obj.getUuid());
+  EXPECT_EQ(Uuid::fromString("d48b8bd2-a46c-4495-87a5-662747034098"),
+            obj.getPackagePadUuid());
+  EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
+  EXPECT_EQ(Angle::deg45(), obj.getRotation());
+  EXPECT_EQ(FootprintPad::Shape::RECT, obj.getShape());
+  EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
+  EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
+  EXPECT_EQ(UnsignedLength(0), obj.getDrillDiameter());
+  EXPECT_EQ(FootprintPad::BoardSide::TOP, obj.getBoardSide());
+}
+
+TEST_F(FootprintPadTest, testConstructFromSExpressionV02Unconnected) {
+  // Attention: Do NOT modify this string after the file format v0.2 is freezed,
+  // i.e. after releasing LibrePCB 0.2.0! Even current versions of LibrePCB
+  // must be able to load the file format v0.2!
+  SExpression sexpr = SExpression::parse(
+      "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape rect)\n"
+      " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (drill 1.0)\n"
+      " (package_pad none)\n"
+      ")",
+      FilePath());
+  FootprintPad obj(sexpr, Version::fromString("0.2"));
+  EXPECT_EQ(Uuid::fromString("7040952d-7016-49cd-8c3e-6078ecca98b9"),
+            obj.getUuid());
+  EXPECT_EQ(tl::nullopt, obj.getPackagePadUuid());
+  EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
+  EXPECT_EQ(Angle::deg45(), obj.getRotation());
+  EXPECT_EQ(FootprintPad::Shape::RECT, obj.getShape());
+  EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
+  EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
+  EXPECT_EQ(UnsignedLength(1000000), obj.getDrillDiameter());
+  EXPECT_EQ(FootprintPad::BoardSide::TOP, obj.getBoardSide());
+}
+
+TEST_F(FootprintPadTest, testConstructFromSExpressionCurrentVersion) {
+  SExpression sexpr = SExpression::parse(
+      "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape rect)\n"
+      " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (drill 0.0)\n"
+      " (package_pad d48b8bd2-a46c-4495-87a5-662747034098)\n"
+      ")",
+      FilePath());
+  FootprintPad obj(sexpr, qApp->getFileFormatVersion());
+  EXPECT_EQ(Uuid::fromString("7040952d-7016-49cd-8c3e-6078ecca98b9"),
+            obj.getUuid());
+  EXPECT_EQ(Uuid::fromString("d48b8bd2-a46c-4495-87a5-662747034098"),
+            obj.getPackagePadUuid());
+  EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
+  EXPECT_EQ(Angle::deg45(), obj.getRotation());
+  EXPECT_EQ(FootprintPad::Shape::RECT, obj.getShape());
+  EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
+  EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
+  EXPECT_EQ(UnsignedLength(0), obj.getDrillDiameter());
+  EXPECT_EQ(FootprintPad::BoardSide::TOP, obj.getBoardSide());
+}
+
+TEST_F(FootprintPadTest, testSerializeAndDeserialize) {
+  FootprintPad obj1(Uuid::createRandom(), Uuid::createRandom(), Point(123, 567),
+                    Angle(789), FootprintPad::Shape::OCTAGON,
+                    PositiveLength(123), PositiveLength(456),
+                    UnsignedLength(100000), FootprintPad::BoardSide::THT);
+  SExpression sexpr1 = obj1.serializeToDomElement("pad");
+
+  FootprintPad obj2(sexpr1, qApp->getFileFormatVersion());
+  SExpression sexpr2 = obj2.serializeToDomElement("pad");
+
+  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace library
+}  // namespace librepcb

--- a/tests/unittests/libraryeditor/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/libraryeditor/pkg/footprintclipboarddatatest.cpp
@@ -83,14 +83,14 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       Uuid::createRandom(), CircuitIdentifier("pad2"));
 
   std::shared_ptr<FootprintPad> footprintPad1 = std::make_shared<FootprintPad>(
-      Uuid::createRandom(), Point(12, 34), Angle(56),
+      Uuid::createRandom(), packagePad1->getUuid(), Point(12, 34), Angle(56),
       FootprintPad::Shape::OCTAGON, PositiveLength(11), PositiveLength(22),
       UnsignedLength(0), FootprintPad::BoardSide::TOP);
 
   std::shared_ptr<FootprintPad> footprintPad2 = std::make_shared<FootprintPad>(
-      Uuid::createRandom(), Point(12, 34), Angle(56), FootprintPad::Shape::RECT,
-      PositiveLength(123), PositiveLength(456), UnsignedLength(789),
-      FootprintPad::BoardSide::THT);
+      Uuid::createRandom(), tl::nullopt, Point(12, 34), Angle(56),
+      FootprintPad::Shape::RECT, PositiveLength(123), PositiveLength(456),
+      UnsignedLength(789), FootprintPad::BoardSide::THT);
 
   std::shared_ptr<Polygon> polygon1 = std::make_shared<Polygon>(
       Uuid::createRandom(), GraphicsLayerName("foo"), UnsignedLength(1), false,

--- a/tests/unittests/unittests.pro
+++ b/tests/unittests/unittests.pro
@@ -127,6 +127,7 @@ SOURCES += \
     library/cmp/componentsymbolvariantitemsuffixtest.cpp \
     library/cmp/componentsymbolvariantitemtest.cpp \
     library/librarybaseelementtest.cpp \
+    library/pkg/footprintpadtest.cpp \
     library/sym/symbolpintest.cpp \
     libraryeditor/pkg/footprintclipboarddatatest.cpp \
     libraryeditor/sym/symbolclipboarddatatest.cpp \


### PR DESCRIPTION
Let footprint pads have their own UUID instead of using the UUID of the connected package pad.

When upgrading v0.1 package files to v0.2, the key `package_pad` gets added. Then the `pad` and `package_pad` both have the same value:

```scheme
(pad af3ead15-37a6-474d-8698-e4a22bd117de (side top) (shape rect)
 (position 1.4 0.0) (rotation 0.0) (size 1.6 1.8) (drill 0.0)
 (package_pad af3ead15-37a6-474d-8698-e4a22bd117de)
)
```
This way the file format upgrade is deterministic. When creating entirely new packages in LibrePCB v0.2.x, the footprint pad UUID is random, while the `package_pad` UUID is either a package pad UUID or `none` for unconnected pads.

This file format change allowed some new features which are also implemented in this PR:
- Allow footprint pads to be unconnected, i.e. not connected to any package pad (pure mechanical pads).
- Allow multiple footprint pads to be connected to the same package pad.
- Copy&paste pads in the footprint editor without restrictions.

Fixes #445, fixes #641.