### PR TITLE
Save and restore board planes visibility

### DIFF
--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -304,6 +304,8 @@ Board::Board(Project& project,
       // Load all planes
       foreach (const SExpression& node, root.getChildren("plane")) {
         BI_Plane* plane = new BI_Plane(*this, node, fileFormat);
+        // load visibility from user settings
+        plane->setVisible(mUserSettings->getPlaneVisibility(plane->getUuid()));
         mPlanes.append(plane);
       }
 
@@ -883,6 +885,10 @@ void Board::save() {
                       brdDoc.toByteArray());  // can throw
 
     // save user settings
+    mUserSettings->resetPlanesVisibility();
+    foreach (BI_Plane* plane, mPlanes) {
+      mUserSettings->setPlaneVisibility(plane->getUuid(), plane->isVisible());
+    }
     SExpression usrDoc(mUserSettings->serializeToDomElement(
         "librepcb_board_user_settings"));  // can throw
     mDirectory->write("settings.user.lp", usrDoc.toByteArray());  // can throw

--- a/libs/librepcb/project/boards/boardusersettings.h
+++ b/libs/librepcb/project/boards/boardusersettings.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include <librepcb/common/fileio/serializableobject.h>
+#include <librepcb/common/uuid.h>
 
 #include <QtCore>
 
@@ -58,7 +59,18 @@ public:
                     const Version& fileFormat);
   ~BoardUserSettings() noexcept;
 
+  // Getters
+  bool getPlaneVisibility(const Uuid& uuid) const noexcept {
+    return mPlanesVisibility.value(uuid, true);
+  }
+
+  // Setters
+  void setPlaneVisibility(const Uuid& uuid, bool visible) noexcept {
+    mPlanesVisibility[uuid] = visible;
+  }
+
   // General Methods
+  void resetPlanesVisibility() noexcept { mPlanesVisibility.clear(); }
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -70,6 +82,7 @@ private:  // Methods
   // General
   Board& mBoard;
   QScopedPointer<GraphicsLayerStackAppearanceSettings> mLayerSettings;
+  QMap<Uuid, bool> mPlanesVisibility;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
The visibility of planes now gets stored in the board user settings file (`<PROJECT>/boards/<BOARD>/settings.user.lp`). Since this file usually is not put under version control, no noisy diff occurs when changing the visibility of planes.


Fixes #538