### PR TITLE
librepcb-cli: Log fatal messages to stderr

### DIFF
--- a/apps/librepcb-cli/main.cpp
+++ b/apps/librepcb-cli/main.cpp
@@ -41,7 +41,11 @@ int main(int argc, char* argv[]) {
   // done as early as possible.
   Debug::instance();
 
-  // Silence debug output, it's a command line tool
+  // Silence logging output, it's a command line tool where logging messages
+  // could lead to issues when parsing the CLI output. Real errors will be
+  // printed to stderr explicitly and logging output can optionally be enabled
+  // with the "--verbose" flag. But still print fatal errors since this is the
+  // only way to print any error to stderr before the application gets aborted.
   Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::Fatal);
 
   // Create Application instance

--- a/apps/librepcb-cli/main.cpp
+++ b/apps/librepcb-cli/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
   Debug::instance();
 
   // Silence debug output, it's a command line tool
-  Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::Nothing);
+  Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::Fatal);
 
   // Create Application instance
   Application app(argc, argv);


### PR DESCRIPTION
These messages should always be visible on stderr, not just in the
logfile (which may not have been initialized properly if a fatal error
occurs).