### PR TITLE
Improve error messages when project library update fails

### DIFF
--- a/libs/librepcb/project/boards/items/bi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.cpp
@@ -169,14 +169,36 @@ void BI_FootprintPad::removeFromBoard() {
 
 void BI_FootprintPad::registerNetLine(BI_NetLine& netline) {
   if ((!isAddedToBoard()) || (mRegisteredNetLines.contains(&netline)) ||
-      (netline.getBoard() != mBoard) ||
-      (&netline.getNetSignalOfNetSegment() != getCompSigInstNetSignal()) ||
-      (!isOnLayer(netline.getLayer().getName()))) {
+      (netline.getBoard() != mBoard)) {
     throw LogicError(__FILE__, __LINE__);
+  }
+  if (&netline.getNetSignalOfNetSegment() != getCompSigInstNetSignal()) {
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        QString("Trace of net \"%1\" is not allowed to be connected to "
+                "pad \"%2\" of device \"%3\" (%4) since it is connected to the "
+                "net \"%5\".")
+            .arg(*netline.getNetSignalOfNetSegment().getName(),
+                 getPadNameOrUuid(), getComponentInstanceName(),
+                 getLibraryDeviceName(), getNetSignalName()));
+  }
+  if (!isOnLayer(netline.getLayer().getName())) {
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        QString("Trace on layer \"%1\" cannot be connected to the pad \"%2\" "
+                "of device \"%3\" (%4) since it is on layer \"%5\".")
+            .arg(netline.getLayer().getName(), getPadNameOrUuid(),
+                 getComponentInstanceName(), getLibraryDeviceName(),
+                 getLayerName()));
   }
   foreach (const BI_NetLine* l, mRegisteredNetLines) {
     if (&l->getNetSegment() != &netline.getNetSegment()) {
-      throw LogicError(__FILE__, __LINE__);
+      throw RuntimeError(
+          __FILE__, __LINE__,
+          QString("There are traces from multiple net segments connected to "
+                  "the pad \"%1\" of device \"%2\" (%3).")
+              .arg(getPadNameOrUuid(), getComponentInstanceName(),
+                   getLibraryDeviceName()));
     }
   }
   mRegisteredNetLines.insert(&netline);
@@ -276,6 +298,30 @@ void BI_FootprintPad::updateGraphicsItemTransform() noexcept {
   if (mFootprint.getIsMirrored()) t.scale(qreal(-1), qreal(1));
   t.rotate(-mRotation.toDeg());
   mGraphicsItem->setTransform(t);
+}
+
+QString BI_FootprintPad::getLibraryDeviceName() const noexcept {
+  return *mFootprint.getDeviceInstance()
+              .getLibDevice()
+              .getNames()
+              .getDefaultValue();
+}
+
+QString BI_FootprintPad::getComponentInstanceName() const noexcept {
+  return *mFootprint.getDeviceInstance().getComponentInstance().getName();
+}
+
+QString BI_FootprintPad::getPadNameOrUuid() const noexcept {
+  return mPackagePad ? *mPackagePad->getName()
+                     : mFootprintPad->getUuid().toStr();
+}
+
+QString BI_FootprintPad::getNetSignalName() const noexcept {
+  if (const NetSignal* signal = getCompSigInstNetSignal()) {
+    return *signal->getName();
+  } else {
+    return QString();
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/boards/items/bi_footprintpad.h
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.h
@@ -111,6 +111,10 @@ private:  // Methods
   void footprintAttributesChanged();
   void componentSignalInstanceNetSignalChanged(NetSignal* from, NetSignal* to);
   void updateGraphicsItemTransform() noexcept;
+  QString getLibraryDeviceName() const noexcept;
+  QString getComponentInstanceName() const noexcept;
+  QString getPadNameOrUuid() const noexcept;
+  QString getNetSignalName() const noexcept;
 
 private:  // Data
   BI_Footprint& mFootprint;

--- a/libs/librepcb/project/schematics/items/si_symbolpin.h
+++ b/libs/librepcb/project/schematics/items/si_symbolpin.h
@@ -113,6 +113,9 @@ private slots:
 
 private:
   void updateGraphicsItemTransform() noexcept;
+  QString getLibraryComponentName() const noexcept;
+  QString getComponentSignalNameOrPinUuid() const noexcept;
+  QString getNetSignalName() const noexcept;
 
   // General
   SI_Symbol& mSymbol;


### PR DESCRIPTION
If the pinout of a device or component was changed after adding such elements to a project, the project library updater might fail due to invalid connections when running the next time. This is expected behavior (thus a warning appears in the library editor), but now the user at least gets a much more expressive error message. This way it's easier to determine which library element caused the error.

Since these are still pretty low level error messages, I didn't made them translatable, as decided in https://librepcb.discourse.group/t/119.

Fixes https://librepcb.discourse.group/t/project-update-library-fail-error-source-identification/344.