### PR TITLE
Don't provide "Hidden Grab Areas" layer when not reasonable

### DIFF
--- a/libs/librepcb/common/graphics/graphicslayer.cpp
+++ b/libs/librepcb/common/graphics/graphicslayer.cpp
@@ -146,36 +146,6 @@ QString GraphicsLayer::getGrabAreaLayerName(
   }
 }
 
-const QStringList&
-    GraphicsLayer::getSchematicGeometryElementLayerNames() noexcept {
-  static QStringList names = {
-      sSymbolOutlines,    sSymbolHiddenGrabAreas, sSymbolNames,
-      sSymbolValues,      sSchematicSheetFrames,  sSchematicDocumentation,
-      sSchematicComments, sSchematicGuide,
-  };
-  return names;
-}
-
-const QStringList& GraphicsLayer::getBoardGeometryElementLayerNames() noexcept {
-  static QStringList names = {
-      sBoardSheetFrames, sBoardOutlines,
-      sBoardMillingPth,  sBoardMeasures,
-      sBoardAlignment,   sBoardDocumentation,
-      sBoardComments,    sBoardGuide,
-      sTopPlacement,     sTopHiddenGrabAreas,
-      sTopDocumentation, sTopNames,
-      sTopValues,        sTopCopper,
-      sTopCourtyard,     sTopGlue,
-      sTopSolderPaste,   sTopStopMask,
-      sBotPlacement,     sBotHiddenGrabAreas,
-      sBotDocumentation, sBotNames,
-      sBotValues,        sBotCopper,
-      sBotCourtyard,     sBotGlue,
-      sBotSolderPaste,   sBotStopMask,
-  };
-  return names;
-}
-
 void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr,
                                      QColor& color, QColor& colorHl,
                                      bool& visible) noexcept {

--- a/libs/librepcb/common/graphics/graphicslayer.h
+++ b/libs/librepcb/common/graphics/graphicslayer.h
@@ -197,8 +197,6 @@ public:
   static int getInnerLayerNumber(const QString& name) noexcept;
   static QString getMirroredLayerName(const QString& name) noexcept;
   static QString getGrabAreaLayerName(const QString& outlineLayerName) noexcept;
-  static const QStringList& getSchematicGeometryElementLayerNames() noexcept;
-  static const QStringList& getBoardGeometryElementLayerNames() noexcept;
   static void getDefaultValues(const QString& name, QString& nameTr,
                                QColor& color, QColor& colorHl,
                                bool& visible) noexcept;
@@ -234,14 +232,6 @@ public:
   GraphicsLayer* getGrabAreaLayer(const QString outlineLayerName) const
       noexcept {
     return getLayer(GraphicsLayer::getGrabAreaLayerName(outlineLayerName));
-  }
-
-  QList<GraphicsLayer*> getSchematicGeometryElementLayers() const noexcept {
-    return getLayers(GraphicsLayer::getSchematicGeometryElementLayerNames());
-  }
-
-  QList<GraphicsLayer*> getBoardGeometryElementLayers() const noexcept {
-    return getLayers(GraphicsLayer::getBoardGeometryElementLayerNames());
   }
 
   QList<GraphicsLayer*> getLayers(const QStringList& layerNames) const

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "packageeditorstate.h"
 
+#include <librepcb/common/graphics/graphicslayer.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/gridproperties.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
@@ -57,6 +58,60 @@ const PositiveLength& PackageEditorState::getGridInterval() const noexcept {
 
 const LengthUnit& PackageEditorState::getDefaultLengthUnit() const noexcept {
   return mContext.workspace.getSettings().defaultLengthUnit.get();
+}
+
+QList<GraphicsLayer*> PackageEditorState::getAllowedTextLayers() const
+    noexcept {
+  return mContext.layerProvider.getLayers({
+      GraphicsLayer::sBoardSheetFrames,
+      GraphicsLayer::sBoardOutlines,
+      GraphicsLayer::sBoardMillingPth,
+      GraphicsLayer::sBoardMeasures,
+      GraphicsLayer::sBoardAlignment,
+      GraphicsLayer::sBoardDocumentation,
+      GraphicsLayer::sBoardComments,
+      GraphicsLayer::sBoardGuide,
+      GraphicsLayer::sTopPlacement,
+      // GraphicsLayer::sTopHiddenGrabAreas, -> makes no sense for texts
+      GraphicsLayer::sTopDocumentation,
+      GraphicsLayer::sTopNames,
+      GraphicsLayer::sTopValues,
+      GraphicsLayer::sTopCopper,
+      GraphicsLayer::sTopCourtyard,
+      GraphicsLayer::sTopGlue,
+      GraphicsLayer::sTopSolderPaste,
+      GraphicsLayer::sTopStopMask,
+      GraphicsLayer::sBotPlacement,
+      // GraphicsLayer::sBotHiddenGrabAreas, -> makes no sense for texts
+      GraphicsLayer::sBotDocumentation,
+      GraphicsLayer::sBotNames,
+      GraphicsLayer::sBotValues,
+      GraphicsLayer::sBotCopper,
+      GraphicsLayer::sBotCourtyard,
+      GraphicsLayer::sBotGlue,
+      GraphicsLayer::sBotSolderPaste,
+      GraphicsLayer::sBotStopMask,
+  });
+}
+
+QList<GraphicsLayer*> PackageEditorState::getAllowedCircleAndPolygonLayers()
+    const noexcept {
+  return mContext.layerProvider.getLayers({
+      GraphicsLayer::sBoardSheetFrames, GraphicsLayer::sBoardOutlines,
+      GraphicsLayer::sBoardMillingPth,  GraphicsLayer::sBoardMeasures,
+      GraphicsLayer::sBoardAlignment,   GraphicsLayer::sBoardDocumentation,
+      GraphicsLayer::sBoardComments,    GraphicsLayer::sBoardGuide,
+      GraphicsLayer::sTopPlacement,     GraphicsLayer::sTopHiddenGrabAreas,
+      GraphicsLayer::sTopDocumentation, GraphicsLayer::sTopNames,
+      GraphicsLayer::sTopValues,        GraphicsLayer::sTopCopper,
+      GraphicsLayer::sTopCourtyard,     GraphicsLayer::sTopGlue,
+      GraphicsLayer::sTopSolderPaste,   GraphicsLayer::sTopStopMask,
+      GraphicsLayer::sBotPlacement,     GraphicsLayer::sBotHiddenGrabAreas,
+      GraphicsLayer::sBotDocumentation, GraphicsLayer::sBotNames,
+      GraphicsLayer::sBotValues,        GraphicsLayer::sBotCopper,
+      GraphicsLayer::sBotCourtyard,     GraphicsLayer::sBotGlue,
+      GraphicsLayer::sBotSolderPaste,   GraphicsLayer::sBotStopMask,
+  });
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate.h
@@ -35,6 +35,9 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class GraphicsLayer;
+
 namespace library {
 namespace editor {
 
@@ -105,6 +108,8 @@ public:
 protected:  // Methods
   const PositiveLength& getGridInterval() const noexcept;
   const LengthUnit& getDefaultLengthUnit() const noexcept;
+  QList<GraphicsLayer*> getAllowedTextLayers() const noexcept;
+  QList<GraphicsLayer*> getAllowedCircleAndPolygonLayers() const noexcept;
 
 protected:  // Data
   Context& mContext;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -78,8 +78,7 @@ bool PackageEditorState_DrawCircle::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Layer:"));
   std::unique_ptr<GraphicsLayerComboBox> layerComboBox(
       new GraphicsLayerComboBox());
-  layerComboBox->setLayers(
-      mContext.layerProvider.getBoardGeometryElementLayers());
+  layerComboBox->setLayers(getAllowedCircleAndPolygonLayers());
   layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &PackageEditorState_DrawCircle::layerComboBoxValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -82,8 +82,7 @@ bool PackageEditorState_DrawPolygonBase::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Layer:"));
   std::unique_ptr<GraphicsLayerComboBox> layerComboBox(
       new GraphicsLayerComboBox());
-  layerComboBox->setLayers(
-      mContext.layerProvider.getBoardGeometryElementLayers());
+  layerComboBox->setLayers(getAllowedCircleAndPolygonLayers());
   layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &PackageEditorState_DrawPolygonBase::layerComboBoxValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -84,8 +84,7 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
     mContext.commandToolBar.addLabel(tr("Layer:"));
     std::unique_ptr<GraphicsLayerComboBox> layerComboBox(
         new GraphicsLayerComboBox());
-    layerComboBox->setLayers(
-        mContext.layerProvider.getBoardGeometryElementLayers());
+    layerComboBox->setLayers(getAllowedTextLayers());
     layerComboBox->setCurrentLayer(mLastLayerName);
     connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
             this, &PackageEditorState_DrawTextBase::layerComboBoxValueChanged);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -489,8 +489,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
                  dynamic_cast<StrokeTextGraphicsItem*>(item)) {
     Q_ASSERT(text);
     StrokeTextPropertiesDialog dialog(
-        text->getText(), mContext.undoStack,
-        mContext.layerProvider.getBoardGeometryElementLayers(),
+        text->getText(), mContext.undoStack, getAllowedTextLayers(),
         getDefaultLengthUnit(), "package_editor/stroke_text_properties_dialog",
         &mContext.editorWidget);
     dialog.exec();
@@ -500,9 +499,8 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     Q_ASSERT(polygon);
     PolygonPropertiesDialog dialog(
         polygon->getPolygon(), mContext.undoStack,
-        mContext.layerProvider.getBoardGeometryElementLayers(),
-        getDefaultLengthUnit(), "package_editor/polygon_properties_dialog",
-        &mContext.editorWidget);
+        getAllowedCircleAndPolygonLayers(), getDefaultLengthUnit(),
+        "package_editor/polygon_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
   } else if (CircleGraphicsItem* circle =
@@ -510,9 +508,8 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     Q_ASSERT(circle);
     CirclePropertiesDialog dialog(
         circle->getCircle(), mContext.undoStack,
-        mContext.layerProvider.getBoardGeometryElementLayers(),
-        getDefaultLengthUnit(), "package_editor/circle_properties_dialog",
-        &mContext.editorWidget);
+        getAllowedCircleAndPolygonLayers(), getDefaultLengthUnit(),
+        "package_editor/circle_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
   } else if (HoleGraphicsItem* hole = dynamic_cast<HoleGraphicsItem*>(item)) {

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "symboleditorstate.h"
 
+#include <librepcb/common/graphics/graphicslayer.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/gridproperties.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
@@ -57,6 +58,33 @@ const PositiveLength& SymbolEditorState::getGridInterval() const noexcept {
 
 const LengthUnit& SymbolEditorState::getDefaultLengthUnit() const noexcept {
   return mContext.workspace.getSettings().defaultLengthUnit.get();
+}
+
+QList<GraphicsLayer*> SymbolEditorState::getAllowedTextLayers() const noexcept {
+  return mContext.layerProvider.getLayers({
+      GraphicsLayer::sSymbolOutlines,
+      // GraphicsLayer::sSymbolHiddenGrabAreas, -> makes no sense for texts
+      GraphicsLayer::sSymbolNames,
+      GraphicsLayer::sSymbolValues,
+      GraphicsLayer::sSchematicSheetFrames,
+      GraphicsLayer::sSchematicDocumentation,
+      GraphicsLayer::sSchematicComments,
+      GraphicsLayer::sSchematicGuide,
+  });
+}
+
+QList<GraphicsLayer*> SymbolEditorState::getAllowedCircleAndPolygonLayers()
+    const noexcept {
+  return mContext.layerProvider.getLayers({
+      GraphicsLayer::sSymbolOutlines,
+      GraphicsLayer::sSymbolHiddenGrabAreas,
+      GraphicsLayer::sSymbolNames,
+      GraphicsLayer::sSymbolValues,
+      GraphicsLayer::sSchematicSheetFrames,
+      GraphicsLayer::sSchematicDocumentation,
+      GraphicsLayer::sSchematicComments,
+      GraphicsLayer::sSchematicGuide,
+  });
 }
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate.h
@@ -35,6 +35,9 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class GraphicsLayer;
+
 namespace library {
 namespace editor {
 
@@ -104,6 +107,8 @@ public:
 protected:  // Methods
   const PositiveLength& getGridInterval() const noexcept;
   const LengthUnit& getDefaultLengthUnit() const noexcept;
+  QList<GraphicsLayer*> getAllowedTextLayers() const noexcept;
+  QList<GraphicsLayer*> getAllowedCircleAndPolygonLayers() const noexcept;
 
 protected:  // Data
   Context mContext;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -78,8 +78,7 @@ bool SymbolEditorState_DrawCircle::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Layer:"));
   std::unique_ptr<GraphicsLayerComboBox> layerComboBox(
       new GraphicsLayerComboBox());
-  layerComboBox->setLayers(
-      mContext.layerProvider.getSchematicGeometryElementLayers());
+  layerComboBox->setLayers(getAllowedCircleAndPolygonLayers());
   layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &SymbolEditorState_DrawCircle::layerComboBoxValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -82,8 +82,7 @@ bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
   mContext.commandToolBar.addLabel(tr("Layer:"));
   std::unique_ptr<GraphicsLayerComboBox> layerComboBox(
       new GraphicsLayerComboBox());
-  layerComboBox->setLayers(
-      mContext.layerProvider.getSchematicGeometryElementLayers());
+  layerComboBox->setLayers(getAllowedCircleAndPolygonLayers());
   layerComboBox->setCurrentLayer(mLastLayerName);
   connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &SymbolEditorState_DrawPolygonBase::layerComboBoxValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -78,8 +78,7 @@ bool SymbolEditorState_DrawTextBase::entry() noexcept {
     mContext.commandToolBar.addLabel(tr("Layer:"));
     std::unique_ptr<GraphicsLayerComboBox> layerComboBox(
         new GraphicsLayerComboBox());
-    layerComboBox->setLayers(
-        mContext.layerProvider.getSchematicGeometryElementLayers());
+    layerComboBox->setLayers(getAllowedTextLayers());
     layerComboBox->setCurrentLayer(mLastLayerName);
     connect(layerComboBox.get(), &GraphicsLayerComboBox::currentLayerChanged,
             this, &SymbolEditorState_DrawTextBase::layerComboBoxValueChanged);

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
@@ -463,11 +463,10 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (TextGraphicsItem* text = dynamic_cast<TextGraphicsItem*>(item)) {
     Q_ASSERT(text);
-    TextPropertiesDialog dialog(
-        text->getText(), mContext.undoStack,
-        mContext.layerProvider.getSchematicGeometryElementLayers(),
-        getDefaultLengthUnit(), "symbol_editor/text_properties_dialog",
-        &mContext.editorWidget);
+    TextPropertiesDialog dialog(text->getText(), mContext.undoStack,
+                                getAllowedTextLayers(), getDefaultLengthUnit(),
+                                "symbol_editor/text_properties_dialog",
+                                &mContext.editorWidget);
     dialog.exec();
     return true;
   } else if (PolygonGraphicsItem* polygon =
@@ -475,9 +474,8 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     Q_ASSERT(polygon);
     PolygonPropertiesDialog dialog(
         polygon->getPolygon(), mContext.undoStack,
-        mContext.layerProvider.getSchematicGeometryElementLayers(),
-        getDefaultLengthUnit(), "symbol_editor/polygon_properties_dialog",
-        &mContext.editorWidget);
+        getAllowedCircleAndPolygonLayers(), getDefaultLengthUnit(),
+        "symbol_editor/polygon_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
   } else if (CircleGraphicsItem* circle =
@@ -485,9 +483,8 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     Q_ASSERT(circle);
     CirclePropertiesDialog dialog(
         circle->getCircle(), mContext.undoStack,
-        mContext.layerProvider.getSchematicGeometryElementLayers(),
-        getDefaultLengthUnit(), "symbol_editor/circle_properties_dialog",
-        &mContext.editorWidget);
+        getAllowedCircleAndPolygonLayers(), getDefaultLengthUnit(),
+        "symbol_editor/circle_properties_dialog", &mContext.editorWidget);
     dialog.exec();
     return true;
   }

--- a/libs/librepcb/project/boards/boardlayerstack.cpp
+++ b/libs/librepcb/project/boards/boardlayerstack.cpp
@@ -82,40 +82,6 @@ BoardLayerStack::~BoardLayerStack() noexcept {
 }
 
 /*******************************************************************************
- *  Getters
- ******************************************************************************/
-
-QList<GraphicsLayer*> BoardLayerStack::getAllowedPolygonLayers() const
-    noexcept {
-  static QStringList names = {
-      GraphicsLayer::sBoardOutlines,
-      GraphicsLayer::sBoardMillingPth,
-      GraphicsLayer::sBoardDocumentation,
-      GraphicsLayer::sBoardComments,
-      GraphicsLayer::sBoardGuide,
-      GraphicsLayer::sTopCopper,
-      GraphicsLayer::sTopPlacement,
-      GraphicsLayer::sTopDocumentation,
-      GraphicsLayer::sTopNames,
-      GraphicsLayer::sTopValues,
-      GraphicsLayer::sTopCourtyard,
-      GraphicsLayer::sTopGlue,
-      GraphicsLayer::sTopSolderPaste,
-      GraphicsLayer::sTopStopMask,
-      GraphicsLayer::sBotCopper,
-      GraphicsLayer::sBotPlacement,
-      GraphicsLayer::sBotDocumentation,
-      GraphicsLayer::sBotNames,
-      GraphicsLayer::sBotValues,
-      GraphicsLayer::sBotCourtyard,
-      GraphicsLayer::sBotGlue,
-      GraphicsLayer::sBotSolderPaste,
-      GraphicsLayer::sBotStopMask,
-  };
-  return getLayers(names);
-}
-
-/*******************************************************************************
  *  Setters
  ******************************************************************************/
 

--- a/libs/librepcb/project/boards/boardlayerstack.h
+++ b/libs/librepcb/project/boards/boardlayerstack.h
@@ -63,7 +63,6 @@ public:
   // Getters
   Board& getBoard() const noexcept { return mBoard; }
   int getInnerLayerCount() const noexcept { return mInnerLayerCount; }
-  QList<GraphicsLayer*> getAllowedPolygonLayers() const noexcept;
 
   /// @copydoc ::librepcb::IF_GraphicsLayerProvider::getAllLayers()
   QList<GraphicsLayer*> getAllLayers() const noexcept override {

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate.cpp
@@ -24,9 +24,11 @@
 
 #include "../boardeditor.h"
 
+#include <librepcb/common/graphics/graphicslayer.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/gridproperties.h>
 #include <librepcb/common/undostack.h>
+#include <librepcb/project/boards/boardlayerstack.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
 #include <librepcb/workspace/workspace.h>
 
@@ -65,6 +67,40 @@ PositiveLength BoardEditorState::getGridInterval() const noexcept {
 
 const LengthUnit& BoardEditorState::getDefaultLengthUnit() const noexcept {
   return mContext.workspace.getSettings().defaultLengthUnit.get();
+}
+
+QList<GraphicsLayer*> BoardEditorState::getAllowedGeometryLayers(
+    const Board& board) const noexcept {
+  return board.getLayerStack().getLayers({
+      GraphicsLayer::sBoardSheetFrames,
+      GraphicsLayer::sBoardOutlines,
+      GraphicsLayer::sBoardMillingPth,
+      GraphicsLayer::sBoardMeasures,
+      GraphicsLayer::sBoardAlignment,
+      GraphicsLayer::sBoardDocumentation,
+      GraphicsLayer::sBoardComments,
+      GraphicsLayer::sBoardGuide,
+      GraphicsLayer::sTopPlacement,
+      // GraphicsLayer::sTopHiddenGrabAreas, -> makes no sense in boards
+      GraphicsLayer::sTopDocumentation,
+      GraphicsLayer::sTopNames,
+      GraphicsLayer::sTopValues,
+      GraphicsLayer::sTopCopper,
+      GraphicsLayer::sTopCourtyard,
+      GraphicsLayer::sTopGlue,
+      GraphicsLayer::sTopSolderPaste,
+      GraphicsLayer::sTopStopMask,
+      GraphicsLayer::sBotPlacement,
+      // GraphicsLayer::sBotHiddenGrabAreas, -> makes no sense in boards
+      GraphicsLayer::sBotDocumentation,
+      GraphicsLayer::sBotNames,
+      GraphicsLayer::sBotValues,
+      GraphicsLayer::sBotCopper,
+      GraphicsLayer::sBotCourtyard,
+      GraphicsLayer::sBotGlue,
+      GraphicsLayer::sBotSolderPaste,
+      GraphicsLayer::sBotStopMask,
+  });
 }
 
 bool BoardEditorState::execCmd(UndoCommand* cmd) {

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate.h
@@ -36,6 +36,7 @@
 namespace librepcb {
 
 class UndoCommand;
+class GraphicsLayer;
 
 namespace project {
 
@@ -140,6 +141,8 @@ protected:  // Methods
   Board* getActiveBoard() noexcept;
   PositiveLength getGridInterval() const noexcept;
   const LengthUnit& getDefaultLengthUnit() const noexcept;
+  QList<GraphicsLayer*> getAllowedGeometryLayers(const Board& board) const
+      noexcept;
   bool execCmd(UndoCommand* cmd);
   QWidget* parentWidget() noexcept;
 

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addstroketext.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addstroketext.cpp
@@ -99,8 +99,7 @@ bool BoardEditorState_AddStrokeText::entry() noexcept {
 
   // Add the layers combobox to the toolbar
   mLayerComboBox.reset(new GraphicsLayerComboBox());
-  mLayerComboBox->setLayers(
-      board->getLayerStack().getBoardGeometryElementLayers());
+  mLayerComboBox->setLayers(getAllowedGeometryLayers(*board));
   mLayerComboBox->setCurrentLayer(mLastStrokeTextProperties.getLayerName());
   mContext.editorUi.commandToolbar->addWidget(mLayerComboBox.data());
   connect(mLayerComboBox.data(), &GraphicsLayerComboBox::currentLayerChanged,

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
@@ -89,7 +89,7 @@ bool BoardEditorState_DrawPolygon::entry() noexcept {
 
   // Add the layers combobox to the toolbar
   mLayerComboBox.reset(new GraphicsLayerComboBox());
-  mLayerComboBox->setLayers(board->getLayerStack().getAllowedPolygonLayers());
+  mLayerComboBox->setLayers(getAllowedGeometryLayers(*board));
   mLayerComboBox->setCurrentLayer(mLastPolygonProperties.getLayerName());
   mContext.editorUi.commandToolbar->addWidget(mLayerComboBox.data());
   connect(mLayerComboBox.data(), &GraphicsLayerComboBox::currentLayerChanged,

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.cpp
@@ -46,7 +46,6 @@
 #include <librepcb/library/elements.h>
 #include <librepcb/libraryeditor/pkg/footprintclipboarddata.h>
 #include <librepcb/project/boards/board.h>
-#include <librepcb/project/boards/boardlayerstack.h>
 #include <librepcb/project/boards/boardselectionquery.h>
 #include <librepcb/project/boards/cmd/cmdboardplaneedit.h>
 #include <librepcb/project/boards/cmd/cmddeviceinstanceeditall.h>
@@ -1232,16 +1231,16 @@ void BoardEditorState_Select::openPlanePropertiesDialog(
 void BoardEditorState_Select::openPolygonPropertiesDialog(
     Board& board, Polygon& polygon) noexcept {
   PolygonPropertiesDialog dialog(
-      polygon, mContext.undoStack,
-      board.getLayerStack().getAllowedPolygonLayers(), getDefaultLengthUnit(),
-      "board_editor/polygon_properties_dialog", parentWidget());
+      polygon, mContext.undoStack, getAllowedGeometryLayers(board),
+      getDefaultLengthUnit(), "board_editor/polygon_properties_dialog",
+      parentWidget());
   dialog.exec();
 }
 
 void BoardEditorState_Select::openStrokeTextPropertiesDialog(
     Board& board, StrokeText& text) noexcept {
   StrokeTextPropertiesDialog dialog(
-      text, mContext.undoStack, board.getLayerStack().getAllowedPolygonLayers(),
+      text, mContext.undoStack, getAllowedGeometryLayers(board),
       getDefaultLengthUnit(), "board_editor/stroke_text_properties_dialog",
       parentWidget());
   dialog.exec();

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate.cpp
@@ -24,9 +24,12 @@
 
 #include "../schematiceditor.h"
 
+#include <librepcb/common/graphics/graphicslayer.h>
 #include <librepcb/common/graphics/graphicsview.h>
 #include <librepcb/common/gridproperties.h>
 #include <librepcb/common/undostack.h>
+#include <librepcb/project/project.h>
+#include <librepcb/project/schematics/schematiclayerprovider.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
 #include <librepcb/workspace/workspace.h>
 
@@ -65,6 +68,20 @@ PositiveLength SchematicEditorState::getGridInterval() const noexcept {
 
 const LengthUnit& SchematicEditorState::getDefaultLengthUnit() const noexcept {
   return mContext.workspace.getSettings().defaultLengthUnit.get();
+}
+
+QList<GraphicsLayer*> SchematicEditorState::getAllowedGeometryLayers() const
+    noexcept {
+  return mContext.project.getLayers().getLayers({
+      GraphicsLayer::sSymbolOutlines,
+      // GraphicsLayer::sSymbolHiddenGrabAreas, -> makes no sense in schematics
+      GraphicsLayer::sSymbolNames,
+      GraphicsLayer::sSymbolValues,
+      GraphicsLayer::sSchematicSheetFrames,
+      GraphicsLayer::sSchematicDocumentation,
+      GraphicsLayer::sSchematicComments,
+      GraphicsLayer::sSchematicGuide,
+  });
 }
 
 bool SchematicEditorState::execCmd(UndoCommand* cmd) {

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate.h
@@ -36,6 +36,7 @@
 namespace librepcb {
 
 class UndoCommand;
+class GraphicsLayer;
 
 namespace project {
 
@@ -121,6 +122,7 @@ protected:  // Methods
   Schematic* getActiveSchematic() noexcept;
   PositiveLength getGridInterval() const noexcept;
   const LengthUnit& getDefaultLengthUnit() const noexcept;
+  QList<GraphicsLayer*> getAllowedGeometryLayers() const noexcept;
   bool execCmd(UndoCommand* cmd);
   QWidget* parentWidget() noexcept;
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addtext.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addtext.cpp
@@ -35,7 +35,6 @@
 #include <librepcb/project/schematics/cmd/cmdschematictextadd.h>
 #include <librepcb/project/schematics/items/si_text.h>
 #include <librepcb/project/schematics/schematic.h>
-#include <librepcb/project/schematics/schematiclayerprovider.h>
 
 #include <QtCore>
 
@@ -95,8 +94,7 @@ bool SchematicEditorState_AddText::entry() noexcept {
 
   // Add the layers combobox to the toolbar
   mLayerComboBox.reset(new GraphicsLayerComboBox());
-  mLayerComboBox->setLayers(
-      mContext.project.getLayers().getSchematicGeometryElementLayers());
+  mLayerComboBox->setLayers(getAllowedGeometryLayers());
   mLayerComboBox->setCurrentLayer(mLastTextProperties.getLayerName());
   mContext.editorUi.commandToolbar->addWidget(mLayerComboBox.data());
   connect(mLayerComboBox.data(), &GraphicsLayerComboBox::currentLayerChanged,

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
@@ -35,7 +35,6 @@
 #include <librepcb/project/schematics/cmd/cmdschematicpolygonadd.h>
 #include <librepcb/project/schematics/items/si_polygon.h>
 #include <librepcb/project/schematics/schematic.h>
-#include <librepcb/project/schematics/schematiclayerprovider.h>
 
 #include <QtCore>
 
@@ -91,8 +90,7 @@ bool SchematicEditorState_DrawPolygon::entry() noexcept {
 
   // Add the layers combobox to the toolbar
   mLayerComboBox.reset(new GraphicsLayerComboBox());
-  mLayerComboBox->setLayers(
-      mContext.project.getLayers().getSchematicGeometryElementLayers());
+  mLayerComboBox->setLayers(getAllowedGeometryLayers());
   mLayerComboBox->setCurrentLayer(mLastPolygonProperties.getLayerName());
   mContext.editorUi.commandToolbar->addWidget(mLayerComboBox.data());
   connect(mLayerComboBox.data(), &GraphicsLayerComboBox::currentLayerChanged,

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -42,7 +42,6 @@
 #include <librepcb/project/schematics/items/si_polygon.h>
 #include <librepcb/project/schematics/items/si_symbol.h>
 #include <librepcb/project/schematics/items/si_text.h>
-#include <librepcb/project/schematics/schematiclayerprovider.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -709,8 +708,7 @@ void SchematicEditorState_Select::openNetLabelPropertiesDialog(
 void SchematicEditorState_Select::openPolygonPropertiesDialog(
     SI_Polygon& polygon) noexcept {
   PolygonPropertiesDialog dialog(
-      polygon.getPolygon(), mContext.undoStack,
-      mContext.project.getLayers().getSchematicGeometryElementLayers(),
+      polygon.getPolygon(), mContext.undoStack, getAllowedGeometryLayers(),
       getDefaultLengthUnit(), "schematic_editor/polygon_properties_dialog",
       parentWidget());
   dialog.exec();
@@ -719,8 +717,7 @@ void SchematicEditorState_Select::openPolygonPropertiesDialog(
 void SchematicEditorState_Select::openTextPropertiesDialog(
     SI_Text& text) noexcept {
   TextPropertiesDialog dialog(
-      text.getText(), mContext.undoStack,
-      mContext.project.getLayers().getSchematicGeometryElementLayers(),
+      text.getText(), mContext.undoStack, getAllowedGeometryLayers(),
       getDefaultLengthUnit(), "schematic_editor/text_properties_dialog",
       parentWidget());
   dialog.exec();  // performs the modifications


### PR DESCRIPTION
In all editors, the "Hidden Grab Areas" layers are removed from the dropdown lists where this layer makes no sense. See details in #808.

Fixes #808.