### PR TITLE
Allow creating unconnected board net segments (traces/vias)

### DIFF
--- a/libs/librepcb/common/circuitidentifier.h
+++ b/libs/librepcb/common/circuitidentifier.h
@@ -26,6 +26,7 @@
 #include "fileio/sexpression.h"
 #include "toolbox.h"
 
+#include <optional/tl/optional.hpp>
 #include <type_safe/constrained_type.hpp>
 
 #include <QtCore>
@@ -128,6 +129,25 @@ inline CircuitIdentifier deserialize(const SExpression& sexpr,
                                      const Version& fileFormat) {
   Q_UNUSED(fileFormat);
   return CircuitIdentifier(sexpr.getValue());  // can throw
+}
+
+template <>
+inline SExpression serialize(const tl::optional<CircuitIdentifier>& obj) {
+  if (obj) {
+    return serialize(*obj);
+  } else {
+    return SExpression::createString("");
+  }
+}
+
+template <>
+inline tl::optional<CircuitIdentifier> deserialize(const SExpression& sexpr,
+                                                   const Version& fileFormat) {
+  if (sexpr.getValue().isEmpty()) {
+    return tl::nullopt;
+  } else {
+    return deserialize<CircuitIdentifier>(sexpr, fileFormat);  // can throw
+  }
 }
 
 inline QDataStream& operator<<(QDataStream& stream,

--- a/libs/librepcb/project/boards/board.cpp
+++ b/libs/librepcb/project/boards/board.cpp
@@ -494,7 +494,7 @@ QList<BI_Via*> Board::getViasAtScenePos(
     const Point& pos, const QSet<const NetSignal*>& netsignals) const noexcept {
   QList<BI_Via*> list;
   foreach (BI_NetSegment* segment, mNetSegments) {
-    if (netsignals.isEmpty() || netsignals.contains(&segment->getNetSignal())) {
+    if (netsignals.isEmpty() || netsignals.contains(segment->getNetSignal())) {
       segment->getViasAtScenePos(pos, list);
     }
   }
@@ -506,7 +506,7 @@ QList<BI_NetPoint*> Board::getNetPointsAtScenePos(
     const QSet<const NetSignal*>& netsignals) const noexcept {
   QList<BI_NetPoint*> list;
   foreach (BI_NetSegment* segment, mNetSegments) {
-    if (netsignals.isEmpty() || netsignals.contains(&segment->getNetSignal())) {
+    if (netsignals.isEmpty() || netsignals.contains(segment->getNetSignal())) {
       segment->getNetPointsAtScenePos(pos, layer, list);
     }
   }
@@ -518,7 +518,7 @@ QList<BI_NetLine*> Board::getNetLinesAtScenePos(
     const QSet<const NetSignal*>& netsignals) const noexcept {
   QList<BI_NetLine*> list;
   foreach (BI_NetSegment* segment, mNetSegments) {
-    if (netsignals.isEmpty() || netsignals.contains(&segment->getNetSignal())) {
+    if (netsignals.isEmpty() || netsignals.contains(segment->getNetSignal())) {
       segment->getNetLinesAtScenePos(pos, layer, list);
     }
   }
@@ -548,7 +548,7 @@ BI_NetPoint* Board::getNetPointNextToScenePos(
     const QSet<const NetSignal*>& netsignals) const {
   BI_NetPoint* bestMatch = nullptr;
   foreach (BI_NetSegment* segment, mNetSegments) {
-    if (netsignals.isEmpty() || netsignals.contains(&segment->getNetSignal())) {
+    if (netsignals.isEmpty() || netsignals.contains(segment->getNetSignal())) {
       BI_NetPoint* newMatch =
           segment->getNetPointNextToScenePos(pos, layer, maxDistance);
       if (newMatch) bestMatch = newMatch;
@@ -562,7 +562,7 @@ BI_Via* Board::getViaNextToScenePos(
     const QSet<const NetSignal*>& netsignals) const {
   BI_Via* bestMatch = nullptr;
   foreach (BI_NetSegment* segment, mNetSegments) {
-    if (netsignals.isEmpty() || netsignals.contains(&segment->getNetSignal())) {
+    if (netsignals.isEmpty() || netsignals.contains(segment->getNetSignal())) {
       BI_Via* newMatch = segment->getViaNextToScenePos(pos, maxDistance);
       if (newMatch) bestMatch = newMatch;
     }

--- a/libs/librepcb/project/boards/board.h
+++ b/libs/librepcb/project/boards/board.h
@@ -151,29 +151,30 @@ public:
   }
   bool isEmpty() const noexcept;
   QList<BI_Base*> getItemsAtScenePos(const Point& pos) const noexcept;
-  QList<BI_Via*> getViasAtScenePos(const Point& pos,
-                                   const NetSignal* netsignal = nullptr) const
+  QList<BI_Via*> getViasAtScenePos(
+      const Point& pos, const QSet<const NetSignal*>& netsignals = {}) const
       noexcept;
   QList<BI_NetPoint*> getNetPointsAtScenePos(
       const Point& pos, const GraphicsLayer* layer = nullptr,
-      const NetSignal* netsignal = nullptr) const noexcept;
+      const QSet<const NetSignal*>& netsignals = {}) const noexcept;
   QList<BI_NetLine*> getNetLinesAtScenePos(
       const Point& pos, const GraphicsLayer* layer = nullptr,
-      const NetSignal* netsignal = nullptr) const noexcept;
+      const QSet<const NetSignal*>& netsignals = {}) const noexcept;
   QList<BI_FootprintPad*> getPadsAtScenePos(
       const Point& pos, const GraphicsLayer* layer = nullptr,
-      const NetSignal* netsignal = nullptr) const noexcept;
+      const QSet<const NetSignal*>& netsignals = {}) const noexcept;
 
   BI_NetPoint* getNetPointNextToScenePos(
       const Point& pos, UnsignedLength& maxDistance,
       const GraphicsLayer* layer = nullptr,
-      const NetSignal* netsignal = nullptr) const;
-  BI_Via* getViaNextToScenePos(const Point& pos, UnsignedLength& maxDistance,
-                               const NetSignal* netsignal = nullptr) const;
+      const QSet<const NetSignal*>& netsignals = {}) const;
+  BI_Via* getViaNextToScenePos(
+      const Point& pos, UnsignedLength& maxDistance,
+      const QSet<const NetSignal*>& netsignals = {}) const;
   BI_FootprintPad* getPadNextToScenePos(
       const Point& pos, UnsignedLength& maxDistance,
       const GraphicsLayer* layer = nullptr,
-      const NetSignal* netsignal = nullptr) const;
+      const QSet<const NetSignal*>& netsignals = {}) const;
   QList<BI_Base*> getAllItems() const noexcept;
 
   // Setters: General

--- a/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/project/boards/boardplanefragmentsbuilder.cpp
@@ -184,7 +184,7 @@ void BoardPlaneFragmentsBuilder::subtractOtherObjects() {
            mPlane.getBoard().getNetSegments()) {
     // subtract vias
     foreach (const BI_Via* via, netsegment->getVias()) {
-      if (&netsegment->getNetSignal() == &mPlane.getNetSignal()) {
+      if (netsegment->getNetSignal() == &mPlane.getNetSignal()) {
         ClipperLib::Path path = ClipperHelpers::convert(
             via->getVia().getSceneOutline(), maxArcTolerance());
         mConnectedNetSignalAreas.push_back(path);
@@ -195,7 +195,7 @@ void BoardPlaneFragmentsBuilder::subtractOtherObjects() {
     // subtract netlines
     foreach (const BI_NetLine* netline, netsegment->getNetLines()) {
       if (netline->getLayer().getName() != mPlane.getLayerName()) continue;
-      if (&netsegment->getNetSignal() == &mPlane.getNetSignal()) {
+      if (netsegment->getNetSignal() == &mPlane.getNetSignal()) {
         ClipperLib::Path path = ClipperHelpers::convert(
             netline->getSceneOutline(), maxArcTolerance());
         mConnectedNetSignalAreas.push_back(path);
@@ -266,7 +266,7 @@ ClipperLib::Path BoardPlaneFragmentsBuilder::createPadCutOut(
 ClipperLib::Path BoardPlaneFragmentsBuilder::createViaCutOut(
     const BI_Via& via) const noexcept {
   bool differentNetSignal =
-      (&via.getNetSignalOfNetSegment() != &mPlane.getNetSignal());
+      (via.getNetSegment().getNetSignal() != &mPlane.getNetSignal());
   if ((mPlane.getConnectStyle() == BI_Plane::ConnectStyle::None) ||
       differentNetSignal) {
     return ClipperHelpers::convert(

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.cpp
@@ -45,7 +45,7 @@ CmdBoardNetSegmentAdd::CmdBoardNetSegmentAdd(BI_NetSegment& segment) noexcept
 }
 
 CmdBoardNetSegmentAdd::CmdBoardNetSegmentAdd(Board& board,
-                                             NetSignal& netsignal) noexcept
+                                             NetSignal* netsignal) noexcept
   : UndoCommand(tr("Add net segment")),
     mBoard(board),
     mNetSignal(netsignal),

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentadd.h
@@ -48,7 +48,7 @@ class CmdBoardNetSegmentAdd final : public UndoCommand {
 public:
   // Constructors / Destructor
   explicit CmdBoardNetSegmentAdd(BI_NetSegment& segment) noexcept;
-  CmdBoardNetSegmentAdd(Board& board, NetSignal& netsignal) noexcept;
+  CmdBoardNetSegmentAdd(Board& board, NetSignal* netsignal) noexcept;
   ~CmdBoardNetSegmentAdd() noexcept;
 
   // Getters
@@ -69,7 +69,7 @@ private:
   // Private Member Variables
 
   Board& mBoard;
-  NetSignal& mNetSignal;
+  NetSignal* mNetSignal;
   BI_NetSegment* mNetSegment;
 };
 

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.cpp
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.cpp
@@ -40,7 +40,7 @@ CmdBoardNetSegmentEdit::CmdBoardNetSegmentEdit(
     BI_NetSegment& netsegment) noexcept
   : UndoCommand(tr("Edit net segment")),
     mNetSegment(netsegment),
-    mOldNetSignal(&netsegment.getNetSignal()),
+    mOldNetSignal(netsegment.getNetSignal()),
     mNewNetSignal(mOldNetSignal) {
 }
 
@@ -51,9 +51,9 @@ CmdBoardNetSegmentEdit::~CmdBoardNetSegmentEdit() noexcept {
  *  Setters
  ******************************************************************************/
 
-void CmdBoardNetSegmentEdit::setNetSignal(NetSignal& netsignal) noexcept {
+void CmdBoardNetSegmentEdit::setNetSignal(NetSignal* netsignal) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewNetSignal = &netsignal;
+  mNewNetSignal = netsignal;
 }
 
 /*******************************************************************************
@@ -67,11 +67,11 @@ bool CmdBoardNetSegmentEdit::performExecute() {
 }
 
 void CmdBoardNetSegmentEdit::performUndo() {
-  mNetSegment.setNetSignal(*mOldNetSignal);  // can throw
+  mNetSegment.setNetSignal(mOldNetSignal);  // can throw
 }
 
 void CmdBoardNetSegmentEdit::performRedo() {
-  mNetSegment.setNetSignal(*mNewNetSignal);  // can throw
+  mNetSegment.setNetSignal(mNewNetSignal);  // can throw
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.h
+++ b/libs/librepcb/project/boards/cmd/cmdboardnetsegmentedit.h
@@ -50,7 +50,7 @@ public:
   ~CmdBoardNetSegmentEdit() noexcept;
 
   // Setters
-  void setNetSignal(NetSignal& netsignal) noexcept;
+  void setNetSignal(NetSignal* netsignal) noexcept;
 
 private:
   // Private Methods

--- a/libs/librepcb/project/boards/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/project/boards/drc/boardclipperpathgenerator.cpp
@@ -278,7 +278,7 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
 
   // net segment items
   foreach (const BI_NetSegment* netsegment, mBoard.getNetSegments()) {
-    if (&netsegment->getNetSignal() != netsignal) {
+    if (netsegment->getNetSignal() != netsignal) {
       continue;
     }
 

--- a/libs/librepcb/project/boards/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/project/boards/drc/boarddesignrulecheck.cpp
@@ -384,7 +384,7 @@ void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
       if (restring < *mOptions.minPthRestring) {
         QString msg = tr("Min. via restring ('%1'): %2",
                          "Placeholders are net name + restring width")
-                          .arg(*netsegment->getNetSignal().getName(),
+                          .arg(netsegment->getNetNameToDisplay(true),
                                formatLength(restring));
         PositiveLength diameter = via->getDrillDiameter() +
             mOptions.minPthRestring + mOptions.minPthRestring;
@@ -433,7 +433,7 @@ void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
       if (via->getDrillDiameter() < mOptions.minPthDrillDiameter) {
         QString msg = tr("Min. via drill diameter ('%1'): %2",
                          "Placeholders are net name + drill diameter")
-                          .arg(*netsegment->getNetSignal().getName(),
+                          .arg(netsegment->getNetNameToDisplay(true),
                                formatLength(*via->getDrillDiameter()));
         Path location = Path::circle(via->getDrillDiameter())
                             .translated(via->getPosition());

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netline.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netline.cpp
@@ -28,6 +28,7 @@
 #include "../boardlayerstack.h"
 #include "../items/bi_netline.h"
 #include "../items/bi_netpoint.h"
+#include "../items/bi_netsegment.h"
 
 #include <QPrinter>
 #include <QtCore>
@@ -64,7 +65,7 @@ bool BGI_NetLine::isSelectable() const noexcept {
  ******************************************************************************/
 
 void BGI_NetLine::updateCacheAndRepaint() noexcept {
-  setToolTip(*mNetLine.getNetSignalOfNetSegment().getName());
+  setToolTip(mNetLine.getNetSegment().getNetNameToDisplay(true));
 
   prepareGeometryChange();
 
@@ -101,8 +102,9 @@ void BGI_NetLine::paint(QPainter* painter,
   Q_UNUSED(option);
   Q_UNUSED(widget);
 
-  bool highlight = mNetLine.isSelected() ||
-      mNetLine.getNetSignalOfNetSegment().isHighlighted();
+  const NetSignal* netsignal = mNetLine.getNetSegment().getNetSignal();
+  bool highlight =
+      mNetLine.isSelected() || (netsignal && netsignal->isHighlighted());
 
   // draw line
   if (mLayer->isVisible()) {

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.cpp
@@ -27,6 +27,7 @@
 #include "../board.h"
 #include "../boardlayerstack.h"
 #include "../items/bi_netpoint.h"
+#include "../items/bi_netsegment.h"
 
 #include <QPrinter>
 #include <QtCore>
@@ -64,7 +65,7 @@ bool BGI_NetPoint::isSelectable() const noexcept {
  ******************************************************************************/
 
 void BGI_NetPoint::updateCacheAndRepaint() noexcept {
-  setToolTip(*mNetPoint.getNetSignalOfNetSegment().getName());
+  setToolTip(mNetPoint.getNetSegment().getNetNameToDisplay(true));
 
   prepareGeometryChange();
 
@@ -88,8 +89,9 @@ void BGI_NetPoint::paint(QPainter* painter,
   Q_UNUSED(option);
   Q_UNUSED(widget);
 
-  bool highlight = mNetPoint.isSelected() ||
-      mNetPoint.getNetSignalOfNetSegment().isHighlighted();
+  const NetSignal* netsignal = mNetPoint.getNetSegment().getNetSignal();
+  bool highlight =
+      mNetPoint.isSelected() || (netsignal && netsignal->isHighlighted());
 
 #ifdef QT_DEBUG
   GraphicsLayer* layer =

--- a/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_via.cpp
@@ -26,6 +26,7 @@
 #include "../../project.h"
 #include "../board.h"
 #include "../boardlayerstack.h"
+#include "../items/bi_netsegment.h"
 #include "../items/bi_via.h"
 
 #include <librepcb/common/application.h>
@@ -77,7 +78,7 @@ bool BGI_Via::isSelectable() const noexcept {
 void BGI_Via::updateCacheAndRepaint() noexcept {
   prepareGeometryChange();
 
-  setToolTip(*mVia.getNetSignalOfNetSegment().getName());
+  setToolTip(mVia.getNetSegment().getNetNameToDisplay(true));
 
   mViaLayer = getLayer(GraphicsLayer::sBoardViasTht);
   mTopStopMaskLayer = getLayer(GraphicsLayer::sTopStopMask);
@@ -107,8 +108,9 @@ void BGI_Via::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
   Q_UNUSED(option);
   Q_UNUSED(widget);
 
-  NetSignal& netsignal = mVia.getNetSignalOfNetSegment();
-  bool highlight = mVia.isSelected() || (netsignal.isHighlighted());
+  const NetSignal* netsignal = mVia.getNetSegment().getNetSignal();
+  bool highlight =
+      mVia.isSelected() || (netsignal && netsignal->isHighlighted());
 
   if (mDrawStopMask && mBottomStopMaskLayer &&
       mBottomStopMaskLayer->isVisible()) {
@@ -125,10 +127,12 @@ void BGI_Via::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
     painter->drawPath(mCopper);
 
     // draw netsignal name
-    painter->setFont(mFont);
-    painter->setPen(mViaLayer->getColor(highlight).lighter(150));
-    painter->drawText(mShape.boundingRect(), Qt::AlignCenter,
-                      *netsignal.getName());
+    if (netsignal) {
+      painter->setFont(mFont);
+      painter->setPen(mViaLayer->getColor(highlight).lighter(150));
+      painter->drawText(mShape.boundingRect(), Qt::AlignCenter,
+                        *netsignal->getName());
+    }
   }
 
   if (mDrawStopMask && mTopStopMaskLayer && mTopStopMaskLayer->isVisible()) {

--- a/libs/librepcb/project/boards/items/bi_footprintpad.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprintpad.cpp
@@ -27,6 +27,7 @@
 #include "../../circuit/netsignal.h"
 #include "bi_device.h"
 #include "bi_footprint.h"
+#include "bi_netsegment.h"
 
 #include <librepcb/common/graphics/graphicslayer.h>
 #include <librepcb/library/dev/device.h>
@@ -172,13 +173,13 @@ void BI_FootprintPad::registerNetLine(BI_NetLine& netline) {
       (netline.getBoard() != mBoard)) {
     throw LogicError(__FILE__, __LINE__);
   }
-  if (&netline.getNetSignalOfNetSegment() != getCompSigInstNetSignal()) {
+  if (netline.getNetSegment().getNetSignal() != getCompSigInstNetSignal()) {
     throw RuntimeError(
         __FILE__, __LINE__,
         QString("Trace of net \"%1\" is not allowed to be connected to "
                 "pad \"%2\" of device \"%3\" (%4) since it is connected to the "
                 "net \"%5\".")
-            .arg(*netline.getNetSignalOfNetSegment().getName(),
+            .arg(netline.getNetSegment().getNetNameToDisplay(),
                  getPadNameOrUuid(), getComponentInstanceName(),
                  getLibraryDeviceName(), getNetSignalName()));
   }

--- a/libs/librepcb/project/boards/items/bi_netline.h
+++ b/libs/librepcb/project/boards/items/bi_netline.h
@@ -99,7 +99,6 @@ public:
   BI_NetLineAnchor& getEndPoint() const noexcept { return *mEndPoint; }
   BI_NetLineAnchor* getOtherPoint(const BI_NetLineAnchor& firstPoint) const
       noexcept;
-  NetSignal& getNetSignalOfNetSegment() const noexcept;
   bool isSelectable() const noexcept override;
   Path getSceneOutline(const Length& expansion = Length(0)) const noexcept;
   UnsignedLength getLength() const noexcept;
@@ -135,7 +134,7 @@ private:
   Trace mTrace;
   QScopedPointer<BGI_NetLine> mGraphicsItem;
   Point mPosition;  ///< the center of startpoint and endpoint
-  QMetaObject::Connection mHighlightChangedConnection;
+  QVector<QMetaObject::Connection> mConnections;
 
   // References
   BI_NetLineAnchor* mStartPoint;

--- a/libs/librepcb/project/boards/items/bi_netpoint.h
+++ b/libs/librepcb/project/boards/items/bi_netpoint.h
@@ -66,7 +66,6 @@ public:
   const Uuid& getUuid() const noexcept { return mJunction.getUuid(); }
   const Junction& getJunction() const noexcept { return mJunction; }
   BI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
-  NetSignal& getNetSignalOfNetSegment() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
   GraphicsLayer* getLayerOfLines() const noexcept;
   bool isSelectable() const noexcept override;

--- a/libs/librepcb/project/boards/items/bi_netsegment.h
+++ b/libs/librepcb/project/boards/items/bi_netsegment.h
@@ -65,12 +65,33 @@ public:
                 const QHash<const BI_Device*, BI_Device*>& devMap);
   BI_NetSegment(Board& board, const SExpression& node,
                 const Version& fileFormat);
-  BI_NetSegment(Board& board, NetSignal& signal);
+  BI_NetSegment(Board& board, NetSignal* signal);
   ~BI_NetSegment() noexcept;
 
   // Getters
   const Uuid& getUuid() const noexcept { return mUuid; }
-  NetSignal& getNetSignal() const noexcept { return *mNetSignal; }
+
+  /// Get the net signal this segment belongs to
+  ///
+  /// @note If the net segment is not connected to any net (which is allowed),
+  ///       nullptr is returned.
+  ///
+  /// @return Pointer to the net signal (nullptr if unconnected)
+  NetSignal* getNetSignal() const noexcept { return mNetSignal; }
+
+  /// Get the net name to display
+  ///
+  /// If connected to a net, the net name is returned. Otherwise a fallback
+  /// string is returned (either an empty string, or something like "(no net)"
+  /// in the user's locale). This is just for convenience to avoid implementing
+  /// exactly the same logic in many different modules.
+  ///
+  /// @param fallback   If the segment has no net, this determines whether an
+  ///                   empty string should be returned (false, default) or
+  ///                   something like "(no net)".
+  /// @return The net name or the fallback.
+  QString getNetNameToDisplay(bool fallback = false) const noexcept;
+
   bool isUsed() const noexcept;
   int getViasAtScenePos(const Point& pos, QList<BI_Via*>& vias) const noexcept;
   int getNetPointsAtScenePos(const Point& pos, const GraphicsLayer* layer,
@@ -86,7 +107,7 @@ public:
                                UnsignedLength& maxDistance) const noexcept;
 
   // Setters
-  void setNetSignal(NetSignal& netsignal);
+  void setNetSignal(NetSignal* netsignal);
 
   // Via Methods
   const QList<BI_Via*>& getVias() const noexcept { return mVias; }
@@ -150,6 +171,10 @@ private:
 
   // Attributes
   Uuid mUuid;
+
+  /// The net signal this segment belongs to
+  ///
+  /// This is nullptr if not connected!
   NetSignal* mNetSignal;
 
   // Items

--- a/libs/librepcb/project/boards/items/bi_via.cpp
+++ b/libs/librepcb/project/boards/items/bi_via.cpp
@@ -66,11 +66,6 @@ void BI_Via::init() {
   // connect to the "attributes changed" signal of the board
   connect(&mBoard, &Board::attributesChanged, this,
           &BI_Via::boardOrNetAttributesChanged);
-
-  // Connect to the "name changed" signal of the net signal to enforce updating
-  // the displayed net signal name in the board.
-  connect(&getNetSignalOfNetSegment(), &NetSignal::nameChanged, this,
-          &BI_Via::boardOrNetAttributesChanged);
 }
 
 BI_Via::~BI_Via() noexcept {
@@ -80,10 +75,6 @@ BI_Via::~BI_Via() noexcept {
 /*******************************************************************************
  *  Getters
  ******************************************************************************/
-
-NetSignal& BI_Via::getNetSignalOfNetSegment() const noexcept {
-  return mNetSegment.getNetSignal();
-}
 
 bool BI_Via::isOnLayer(const QString& layerName) const noexcept {
   return GraphicsLayer::isCopperLayer(layerName);
@@ -103,7 +94,9 @@ void BI_Via::setPosition(const Point& position) noexcept {
     foreach (BI_NetLine* netline, mRegisteredNetLines) {
       netline->updateLine();
     }
-    mBoard.scheduleAirWiresRebuild(&getNetSignalOfNetSegment());
+    if (NetSignal* netsignal = mNetSegment.getNetSignal()) {
+      mBoard.scheduleAirWiresRebuild(netsignal);
+    }
   }
 }
 
@@ -133,20 +126,27 @@ void BI_Via::addToBoard() {
   if (isAddedToBoard() || isUsed()) {
     throw LogicError(__FILE__, __LINE__);
   }
-  mHighlightChangedConnection =
-      connect(&getNetSignalOfNetSegment(), &NetSignal::highlightedChanged,
-              [this]() { mGraphicsItem->update(); });
+  if (NetSignal* netsignal = mNetSegment.getNetSignal()) {
+    mConnections.append(connect(netsignal, &NetSignal::nameChanged, this,
+                                &BI_Via::boardOrNetAttributesChanged));
+    mConnections.append(connect(netsignal, &NetSignal::highlightedChanged,
+                                [this]() { mGraphicsItem->update(); }));
+    mBoard.scheduleAirWiresRebuild(netsignal);
+  }
   BI_Base::addToBoard(mGraphicsItem.data());
-  mBoard.scheduleAirWiresRebuild(&getNetSignalOfNetSegment());
 }
 
 void BI_Via::removeFromBoard() {
   if ((!isAddedToBoard()) || isUsed()) {
     throw LogicError(__FILE__, __LINE__);
   }
-  disconnect(mHighlightChangedConnection);
+  while (!mConnections.isEmpty()) {
+    disconnect(mConnections.takeLast());
+  }
+  if (NetSignal* netsignal = mNetSegment.getNetSignal()) {
+    mBoard.scheduleAirWiresRebuild(netsignal);
+  }
   BI_Base::removeFromBoard(mGraphicsItem.data());
-  mBoard.scheduleAirWiresRebuild(&getNetSignalOfNetSegment());
 }
 
 void BI_Via::registerNetLine(BI_NetLine& netline) {

--- a/libs/librepcb/project/boards/items/bi_via.h
+++ b/libs/librepcb/project/boards/items/bi_via.h
@@ -63,7 +63,6 @@ public:
 
   // Getters
   BI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
-  NetSignal& getNetSignalOfNetSegment() const noexcept;
   const Via& getVia() const noexcept { return mVia; }
   const Uuid& getUuid() const noexcept { return mVia.getUuid(); }
   Via::Shape getShape() const noexcept { return mVia.getShape(); }
@@ -118,7 +117,7 @@ private:
   Via mVia;
   BI_NetSegment& mNetSegment;
   QScopedPointer<BGI_Via> mGraphicsItem;
-  QMetaObject::Connection mHighlightChangedConnection;
+  QVector<QMetaObject::Connection> mConnections;
 
   // Registered Elements
   QSet<BI_NetLine*> mRegisteredNetLines;

--- a/libs/librepcb/projecteditor/boardeditor/boardclipboarddata.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardclipboarddata.h
@@ -124,18 +124,18 @@ public:
   struct NetSegment : public SerializableObject {
     static constexpr const char* tagname = "netsegment";
 
-    CircuitIdentifier netName;
+    tl::optional<CircuitIdentifier> netName;
     ViaList vias;
     JunctionList junctions;
     TraceList traces;
     Signal<NetSegment> onEdited;  ///< Dummy event, not used
 
-    explicit NetSegment(const CircuitIdentifier& netName)
+    explicit NetSegment(const tl::optional<CircuitIdentifier>& netName)
       : netName(netName), vias(), junctions(), traces(), onEdited(*this) {}
 
     NetSegment(const SExpression& node, const Version& fileFormat)
-      : netName(deserialize<CircuitIdentifier>(node.getChild("net/@0"),
-                                               fileFormat)),
+      : netName(deserialize<tl::optional<CircuitIdentifier>>(
+            node.getChild("net/@0"), fileFormat)),
         vias(node, fileFormat),
         junctions(node, fileFormat),
         traces(node, fileFormat),

--- a/libs/librepcb/projecteditor/boardeditor/boardclipboarddatabuilder.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardclipboarddatabuilder.cpp
@@ -147,9 +147,12 @@ std::unique_ptr<BoardClipboardData> BoardClipboardDataBuilder::generate(
 
     foreach (const BoardNetSegmentSplitter::Segment& segment,
              splitter.split()) {
+      tl::optional<CircuitIdentifier> netName;
+      if (const NetSignal* netsignal = it.key()->getNetSignal()) {
+        netName = netsignal->getName();
+      }
       std::shared_ptr<BoardClipboardData::NetSegment> newSegment =
-          std::make_shared<BoardClipboardData::NetSegment>(
-              it.key()->getNetSignal().getName());
+          std::make_shared<BoardClipboardData::NetSegment>(netName);
       newSegment->vias = segment.vias;
       newSegment->junctions = segment.junctions;
       newSegment->traces = segment.traces;

--- a/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardviapropertiesdialog.cpp
@@ -26,6 +26,7 @@
 
 #include <librepcb/common/undostack.h>
 #include <librepcb/project/boards/cmd/cmdboardviaedit.h>
+#include <librepcb/project/boards/items/bi_netsegment.h>
 #include <librepcb/project/boards/items/bi_via.h>
 #include <librepcb/project/circuit/netsignal.h>
 
@@ -80,8 +81,8 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(
   // drill diameter spinbox
   mUi->edtDrillDiameter->setValue(mVia.getDrillDiameter());
 
-  // netsignal combobox
-  mUi->lblNetSignal->setText(*mVia.getNetSignalOfNetSegment().getName());
+  // netsignal name
+  mUi->lblNetSignal->setText(mVia.getNetSegment().getNetNameToDisplay(true));
 }
 
 BoardViaPropertiesDialog::~BoardViaPropertiesDialog() noexcept {

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -340,7 +340,7 @@ bool BoardEditorState_AddVia::fixPosition(Board& board,
 
     // Find stuff at the via position
     QSet<BI_NetPoint*> otherNetAnchors = {};
-    if (BI_Via* via = findVia(board, pos, nullptr, {mCurrentViaToPlace})) {
+    if (BI_Via* via = findVia(board, pos, {}, {mCurrentViaToPlace})) {
       if (&via->getNetSignalOfNetSegment() != netsignal) {
         throw RuntimeError(__FILE__, __LINE__,
                            tr("Via of a different signal already present at "
@@ -533,29 +533,29 @@ QSet<NetSignal*> BoardEditorState_AddVia::getNetSignalsAtScenePos(
   return result;
 }
 
-BI_Via* BoardEditorState_AddVia::findVia(Board& board, const Point pos,
-                                         NetSignal* netsignal,
-                                         const QSet<BI_Via*>& except) const
-    noexcept {
-  QSet<BI_Via*> items = Toolbox::toSet(board.getViasAtScenePos(pos, netsignal));
+BI_Via* BoardEditorState_AddVia::findVia(
+    Board& board, const Point pos, const QSet<const NetSignal*>& netsignals,
+    const QSet<BI_Via*>& except) const noexcept {
+  QSet<BI_Via*> items =
+      Toolbox::toSet(board.getViasAtScenePos(pos, netsignals));
   items -= except;
   return items.count() > 0 ? *items.constBegin() : nullptr;
 }
 
 BI_FootprintPad* BoardEditorState_AddVia::findPad(
-    Board& board, const Point pos, NetSignal* netsignal,
+    Board& board, const Point pos, const QSet<const NetSignal*>& netsignals,
     const QSet<BI_FootprintPad*>& except) const noexcept {
   QSet<BI_FootprintPad*> items =
-      Toolbox::toSet(board.getPadsAtScenePos(pos, nullptr, netsignal));
+      Toolbox::toSet(board.getPadsAtScenePos(pos, nullptr, netsignals));
   items -= except;
   return items.count() > 0 ? *items.constBegin() : nullptr;
 }
 
-BI_NetLine* BoardEditorState_AddVia::findNetLine(Board& board, const Point pos,
-                                                 NetSignal* netsignal) const
-    noexcept {
+BI_NetLine* BoardEditorState_AddVia::findNetLine(
+    Board& board, const Point pos,
+    const QSet<const NetSignal*>& netsignals) const noexcept {
   QSet<BI_NetLine*> items =
-      Toolbox::toSet(board.getNetLinesAtScenePos(pos, nullptr, netsignal));
+      Toolbox::toSet(board.getNetLinesAtScenePos(pos, nullptr, netsignals));
   return items.count() > 0 ? *items.constBegin() : nullptr;
 }
 

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
@@ -26,6 +26,7 @@
 #include "boardeditorstate.h"
 
 #include <librepcb/project/boards/items/bi_via.h>
+#include <optional/tl/optional.hpp>
 
 #include <QtCore>
 
@@ -85,7 +86,9 @@ private:  // Methods
   void updateShapeActionsCheckedState() noexcept;
   void sizeEditValueChanged(const PositiveLength& value) noexcept;
   void drillDiameterEditValueChanged(const PositiveLength& value) noexcept;
-  NetSignal* getClosestNetSignal(Board& board, const Point& pos) noexcept;
+  void applySelectedNetSignal() noexcept;
+  void updateClosestNetSignal(Board& board, const Point& pos) noexcept;
+  NetSignal* getCurrentNetSignal() const noexcept;
   QSet<NetSignal*> getNetSignalsAtScenePos(Board& board, const Point& pos,
                                            QSet<BI_Base*> except = {}) const
       noexcept;
@@ -103,11 +106,16 @@ private:  // Methods
 private:  // Data
   // State
   bool mIsUndoCmdActive;
-  QString mAutoText;
-  bool mFindClosestNetSignal;
-  NetSignal* mLastClosestNetSignal;
   Via mLastViaProperties;
-  NetSignal* mLastNetSignal;
+
+  /// Whether the net signal is determined automatically or not
+  bool mUseAutoNetSignal;
+
+  /// The current net signal of the via
+  tl::optional<Uuid> mCurrentNetSignal;
+
+  /// Whether #mCurrentNetSignal contains an up-to-date closest net signal
+  bool mClosestNetSignalIsUpToDate;
 
   // Information about the current via to place. Only valid if
   // mIsUndoCmdActive == true.

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
@@ -89,14 +89,16 @@ private:  // Methods
   QSet<NetSignal*> getNetSignalsAtScenePos(Board& board, const Point& pos,
                                            QSet<BI_Base*> except = {}) const
       noexcept;
-  BI_Via* findVia(Board& board, const Point pos, NetSignal* netsignal = nullptr,
+  BI_Via* findVia(Board& board, const Point pos,
+                  const QSet<const NetSignal*>& netsignals = {},
                   const QSet<BI_Via*>& except = {}) const noexcept;
   BI_FootprintPad* findPad(Board& board, const Point pos,
-                           NetSignal* netsignal = nullptr,
+                           const QSet<const NetSignal*>& netsignals = {},
                            const QSet<BI_FootprintPad*>& except = {}) const
       noexcept;
   BI_NetLine* findNetLine(Board& board, const Point pos,
-                          NetSignal* netsignal = nullptr) const noexcept;
+                          const QSet<const NetSignal*>& netsignals = {}) const
+      noexcept;
 
 private:  // Data
   // State

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
@@ -144,14 +144,14 @@ private:
    * @brief Find a BI_Via at the given position on the board.
    * @param board The board on which to look.
    * @param pos The position at which to look.
-   * @param netsignal When specified only look for BI_Via which are part of that
-   * signal
+   * @param netsignals  When not empty, only look for vias which are part of
+   *                    one of these signals.
    * @param except A QSet of BI_Via that should be excluded when looking at the
    * target position.
    * @return A single BI_Via, if any. at the target position.
    */
   BI_Via* findVia(Board& board, const Point& pos,
-                  NetSignal* netsignal = nullptr,
+                  const QSet<const NetSignal*>& netsignals = {},
                   const QSet<BI_Via*>& except = {}) const noexcept;
 
   /**
@@ -160,13 +160,14 @@ private:
    * @param pos The position at which to look.
    * @param layer When specified only look for BI_FootprintPad which are on that
    * layer
-   * @param netsignal When specified only look for BI_FootprintPad which are
-   * part of that signal
+   * @param netsignals  When not empty, only look for pads which are part of
+   *                    one of these signals.
    * @return A single BI_FootprintPad, if any. at the target position.
    */
   BI_FootprintPad* findPad(Board& board, const Point& pos,
                            GraphicsLayer* layer = nullptr,
-                           NetSignal* netsignal = nullptr) const noexcept;
+                           const QSet<const NetSignal*>& netsignals = {}) const
+      noexcept;
 
   /**
    * @brief Find a BI_NetPoint at the given position on the board.
@@ -174,15 +175,15 @@ private:
    * @param pos The position at which to look.
    * @param layer When specified only look for BI_NetPoint which are on that
    * layer
-   * @param netsignal When specified only look for BI_NetPoint which are part of
-   * that signal
+   * @param netsignals  When not empty, only look for netpoints which are part
+   *                    of one of these signals.
    * @param except A QSet of BI_NetPoint that should be excluded when looking at
    * the target position.
    * @return A single BI_NetPoint, if any. at the target position.
    */
   BI_NetPoint* findNetPoint(Board& board, const Point& pos,
                             GraphicsLayer* layer = nullptr,
-                            NetSignal* netsignal = nullptr,
+                            const QSet<const NetSignal*>& netsignals = {},
                             const QSet<BI_NetPoint*>& except = {}) const
       noexcept;
 
@@ -192,22 +193,21 @@ private:
    * @param pos The position at which to look.
    * @param layer When specified only look for BI_NetLine which are on that
    * layer
-   * @param netsignal When specified only look for BI_NetLine which are part of
-   * that signal
+   * @param netsignals  When not empty, only look for netlines which are part
+   *                    of one of these signals.
    * @param except A QSet of BI_NetLine that should be excluded when looking at
    * the target position.
    * @return A single BI_NetLine, if any. at the target position.
    */
   BI_NetLine* findNetLine(Board& board, const Point& pos,
                           GraphicsLayer* layer = nullptr,
-                          NetSignal* netsignal = nullptr,
+                          const QSet<const NetSignal*>& netsignals = {},
                           const QSet<BI_NetLine*>& except = {}) const noexcept;
 
-  BI_NetLineAnchor* findAnchorNextTo(Board& board, const Point& pos,
-                                     const UnsignedLength& maxDistance,
-                                     GraphicsLayer* layer = nullptr,
-                                     NetSignal* netsignal = nullptr) const
-      noexcept;
+  BI_NetLineAnchor* findAnchorNextTo(
+      Board& board, const Point& pos, const UnsignedLength& maxDistance,
+      GraphicsLayer* layer = nullptr,
+      const QSet<const NetSignal*>& netsignals = {}) const noexcept;
 
   /**
    * @brief Update the currently active traces according

--- a/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineboardnetsegments.cpp
@@ -68,7 +68,7 @@ bool CmdCombineBoardNetSegments::performExecute() {
   if (&mOldSegment == &mNewSegment) throw LogicError(__FILE__, __LINE__);
   if (&mOldSegment.getBoard() != &mNewSegment.getBoard())
     throw LogicError(__FILE__, __LINE__);
-  if (&mOldSegment.getNetSignal() != &mNewSegment.getNetSignal())
+  if (mOldSegment.getNetSignal() != mNewSegment.getNetSignal())
     throw LogicError(__FILE__, __LINE__);
 
   // move all required vias/netpoints/netlines to the resulting netsegment

--- a/libs/librepcb/projecteditor/cmd/cmdcombinenetsignals.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombinenetsignals.cpp
@@ -105,7 +105,7 @@ bool CmdCombineNetSignals::performExecute() {
   // re-add all board netsegments
   foreach (BI_NetSegment* netsegment, boardNetSegments) {
     CmdBoardNetSegmentEdit* cmd = new CmdBoardNetSegmentEdit(*netsegment);
-    cmd->setNetSignal(mResultingNetSignal);
+    cmd->setNetSignal(&mResultingNetSignal);
     execNewChildCmd(cmd);  // can throw
     execNewChildCmd(new CmdBoardNetSegmentAdd(*netsegment));  // can throw
   }

--- a/libs/librepcb/projecteditor/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdpasteboarditems.cpp
@@ -183,8 +183,9 @@ bool CmdPasteBoardItems::performExecute() {
     foreach (const BoardNetSegmentSplitter::Segment& segment,
              splitter.split()) {
       // Add new segment
-      BI_NetSegment* copy =
-          new BI_NetSegment(mBoard, *getOrCreateNetSignal(*seg.netName));
+      NetSignal* netsignal =
+          seg.netName ? getOrCreateNetSignal(**seg.netName) : nullptr;
+      BI_NetSegment* copy = new BI_NetSegment(mBoard, netsignal);
       copy->setSelected(true);
       execNewChildCmd(new CmdBoardNetSegmentAdd(*copy));
 


### PR DESCRIPTION
This allows to create traces and vias which are not assigned to any net. The main purpose is to provide the ability to create plated through holes for mechanical purposes only. A positive side effect is that the "add via" tool in the board editor is no longer rejected if the schematic is empty (i.e. no nets available) - now this tool works as usual since it is able to create unconnected vias.

![librepcb-unconnected-netsegment](https://user-images.githubusercontent.com/5374821/107860803-cb705b80-6e41-11eb-9b53-787826de8998.gif)

Fixes #618.