### PR TITLE
Fix crash after adding a device to a board failed

### DIFF
--- a/libs/librepcb/project/boards/items/bi_footprint.cpp
+++ b/libs/librepcb/project/boards/items/bi_footprint.cpp
@@ -51,25 +51,40 @@ namespace project {
 
 BI_Footprint::BI_Footprint(BI_Device& device, const BI_Footprint& other)
   : BI_Base(device.getBoard()), mDevice(device) {
-  foreach (const BI_StrokeText* text, other.mStrokeTexts) {
-    addStrokeText(*new BI_StrokeText(mBoard, *text));
+  try {
+    foreach (const BI_StrokeText* text, other.mStrokeTexts) {
+      addStrokeText(*new BI_StrokeText(mBoard, *text));
+    }
+    init();
+  } catch (...) {
+    deinit();
+    throw;
   }
-  init();
 }
 
 BI_Footprint::BI_Footprint(BI_Device& device, const SExpression& node,
                            const Version& fileFormat)
   : BI_Base(device.getBoard()), mDevice(device) {
-  foreach (const SExpression& node, node.getChildren("stroke_text")) {
-    addStrokeText(*new BI_StrokeText(mBoard, node, fileFormat));  // can throw
+  try {
+    foreach (const SExpression& node, node.getChildren("stroke_text")) {
+      addStrokeText(*new BI_StrokeText(mBoard, node, fileFormat));  // can throw
+    }
+    init();
+  } catch (...) {
+    deinit();
+    throw;
   }
-  init();
 }
 
 BI_Footprint::BI_Footprint(BI_Device& device)
   : BI_Base(device.getBoard()), mDevice(device) {
-  resetStrokeTextsToLibraryFootprint();
-  init();
+  try {
+    resetStrokeTextsToLibraryFootprint();
+    init();
+  } catch (...) {
+    deinit();
+    throw;
+  }
 }
 
 void BI_Footprint::init() {
@@ -118,12 +133,16 @@ void BI_Footprint::init() {
           &BI_Footprint::deviceInstanceMirrored);
 }
 
-BI_Footprint::~BI_Footprint() noexcept {
+void BI_Footprint::deinit() noexcept {
   qDeleteAll(mPads);
   mPads.clear();
   qDeleteAll(mStrokeTexts);
   mStrokeTexts.clear();
   mGraphicsItem.reset();
+}
+
+BI_Footprint::~BI_Footprint() noexcept {
+  deinit();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/boards/items/bi_footprint.h
+++ b/libs/librepcb/project/boards/items/bi_footprint.h
@@ -130,6 +130,7 @@ signals:
 
 private:
   void init();
+  void deinit() noexcept;
   void updateGraphicsItemTransform() noexcept;
 
   // General


### PR DESCRIPTION
When adding a new device to a board failed (for example due to invalid library elements), some objects were not cleaned up properly which caused a segfault some time later (for example when saving the project). Now these objects are cleaned up to fix this issue.

Fixes #840