### PR TITLE
CI: Update to latest runners and Docker images

### DIFF
--- a/ci/azure-jobs-doxygen.yml
+++ b/ci/azure-jobs-doxygen.yml
@@ -1,8 +1,8 @@
 jobs:
 - job: Doxygen
   pool:
-    vmImage: 'ubuntu-16.04'
-  container: librepcb/librepcb-dev:ubuntu-18.04-2
+    vmImage: 'ubuntu-20.04'
+  container: librepcb/librepcb-dev:ubuntu-18.04-3
   steps:
   - bash: ./ci/build_doxygen.sh
     displayName: Build Doxygen Documentation

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -1,28 +1,28 @@
 jobs:
 - job: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   variables:
     OS: 'linux'
     ARCH: 'x86_64'
   strategy:
     matrix:
       Ubuntu_1404_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-14.04-2
+        IMAGE: librepcb/librepcb-dev:ubuntu-14.04-3
       Ubuntu_1604_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-2
+        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-3
       Ubuntu_1604_Qt_5_14_2_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.14.2-1
+        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.14.2-2
         DEPLOY: true
         NO_HOEDOWN: true
       Ubuntu_1804_Clang:
-        IMAGE: librepcb/librepcb-dev:ubuntu-18.04-2
+        IMAGE: librepcb/librepcb-dev:ubuntu-18.04-3
         CC: clang
         CXX: clang++
       Ubuntu_2004_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-3
+        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-4
       Ubuntu_2004_Unbundled:
-        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-3
+        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-4
         UNBUNDLE: "quazip polyclipping"
         LD_LIBRARY_PATH: $(Build.Repository.LocalPath)/build/install/opt/lib
   container: $[ variables['IMAGE'] ]

--- a/ci/azure-jobs-stylecheck.yml
+++ b/ci/azure-jobs-stylecheck.yml
@@ -1,8 +1,8 @@
 jobs:
 - job: Stylecheck
   pool:
-    vmImage: 'ubuntu-16.04'
-  container: librepcb/librepcb-dev:ubuntu-18.04-2
+    vmImage: 'ubuntu-20.04'
+  container: librepcb/librepcb-dev:ubuntu-18.04-3
   steps:
   - bash: ./ci/stylecheck.sh
     displayName: Run Stylecheck

--- a/ci/azure-jobs-windows.yml
+++ b/ci/azure-jobs-windows.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         Qt_5_15_0_MinGW_32bit:
-          IMAGE: librepcb/librepcb-dev:windowsservercore-ltsc2019-qt5.15.0-32bit-1
+          IMAGE: librepcb/librepcb-dev:windowsservercore-ltsc2019-qt5.15.2-32bit-1
           DEPLOY: true
     container: $[ variables['IMAGE'] ]
     steps:


### PR DESCRIPTION
To make sure LibrePCB compiles with the latest Qt version 5.15.2 (at least on Windows), and to have CMake available which we need for #798. On Ubuntu 16.04, Qt 5.15.2 unfortunately doesn't work for us since it is missing SSL support, thus we stick with Qt 5.14.2 for now.
