### PR TITLE
Library editor: Provide "snap to grid" context menu item

### DIFF
--- a/libs/librepcb/common/geometry/cmd/cmdcircleedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdcircleedit.cpp
@@ -107,6 +107,11 @@ void CmdCircleEdit::translate(const Point& deltaPos, bool immediate) noexcept {
   if (immediate) mCircle.setCenter(mNewCenter);
 }
 
+void CmdCircleEdit::snapToGrid(const PositiveLength& gridInterval,
+                               bool immediate) noexcept {
+  setCenter(mNewCenter.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdCircleEdit::rotate(const Angle& angle, const Point& center,
                            bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/common/geometry/cmd/cmdcircleedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdcircleedit.h
@@ -56,6 +56,7 @@ public:
   void setDiameter(const PositiveLength& dia, bool immediate) noexcept;
   void setCenter(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirrorGeometry(Qt::Orientation orientation, const Point& center,
                       bool immediate) noexcept;

--- a/libs/librepcb/common/geometry/cmd/cmdholeedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdholeedit.cpp
@@ -66,6 +66,11 @@ void CmdHoleEdit::translate(const Point& deltaPos, bool immediate) noexcept {
   if (immediate) mHole.setPosition(mNewPosition);
 }
 
+void CmdHoleEdit::snapToGrid(const PositiveLength& gridInterval,
+                             bool immediate) noexcept {
+  setPosition(mNewPosition.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdHoleEdit::rotate(const Angle& angle, const Point& center,
                          bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/common/geometry/cmd/cmdholeedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdholeedit.h
@@ -53,6 +53,7 @@ public:
   // Setters
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirror(Qt::Orientation orientation, const Point& center,
               bool immediate) noexcept;

--- a/libs/librepcb/common/geometry/cmd/cmdpolygonedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdpolygonedit.cpp
@@ -96,6 +96,11 @@ void CmdPolygonEdit::translate(const Point& deltaPos, bool immediate) noexcept {
   setPath(mNewPath.translated(deltaPos), immediate);
 }
 
+void CmdPolygonEdit::snapToGrid(const PositiveLength& gridInterval,
+                                bool immediate) noexcept {
+  setPath(mNewPath.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdPolygonEdit::rotate(const Angle& angle, const Point& center,
                             bool immediate) noexcept {
   setPath(mNewPath.rotated(angle, center), immediate);

--- a/libs/librepcb/common/geometry/cmd/cmdpolygonedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdpolygonedit.h
@@ -55,6 +55,7 @@ public:
   void setIsGrabArea(bool grabArea, bool immediate) noexcept;
   void setPath(const Path& path, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirrorGeometry(Qt::Orientation orientation, const Point& center,
                       bool immediate) noexcept;

--- a/libs/librepcb/common/geometry/cmd/cmdstroketextedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdstroketextedit.cpp
@@ -132,6 +132,11 @@ void CmdStrokeTextEdit::translate(const Point& delta, bool immediate) noexcept {
   if (immediate) mText.setPosition(mNewPosition);
 }
 
+void CmdStrokeTextEdit::snapToGrid(const PositiveLength& gridInterval,
+                                   bool immediate) noexcept {
+  setPosition(mNewPosition.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdStrokeTextEdit::setRotation(const Angle& angle,
                                     bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/common/geometry/cmd/cmdstroketextedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdstroketextedit.h
@@ -63,6 +63,7 @@ public:
   void setAlignment(const Alignment& align, bool immediate) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& delta, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void setMirrored(bool mirrored, bool immediate) noexcept;

--- a/libs/librepcb/common/geometry/cmd/cmdtextedit.cpp
+++ b/libs/librepcb/common/geometry/cmd/cmdtextedit.cpp
@@ -99,6 +99,11 @@ void CmdTextEdit::translate(const Point& deltaPos, bool immediate) noexcept {
   if (immediate) mText.setPosition(mNewPosition);
 }
 
+void CmdTextEdit::snapToGrid(const PositiveLength& gridInterval,
+                             bool immediate) noexcept {
+  setPosition(mNewPosition.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdTextEdit::setRotation(const Angle& angle, bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewRotation = angle;

--- a/libs/librepcb/common/geometry/cmd/cmdtextedit.h
+++ b/libs/librepcb/common/geometry/cmd/cmdtextedit.h
@@ -55,6 +55,7 @@ public:
   void setAlignment(const Alignment& align, bool immediate) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirror(Qt::Orientation orientation, const Point& center,

--- a/libs/librepcb/common/geometry/path.cpp
+++ b/libs/librepcb/common/geometry/path.cpp
@@ -126,6 +126,18 @@ Path Path::translated(const Point& offset) const noexcept {
   return Path(*this).translate(offset);
 }
 
+Path& Path::mapToGrid(const PositiveLength& gridInterval) noexcept {
+  for (Vertex& vertex : mVertices) {
+    vertex.setPos(vertex.getPos().mappedToGrid(gridInterval));
+  }
+  invalidatePainterPath();
+  return *this;
+}
+
+Path Path::mappedToGrid(const PositiveLength& gridInterval) const noexcept {
+  return Path(*this).mapToGrid(gridInterval);
+}
+
 Path& Path::rotate(const Angle& angle, const Point& center) noexcept {
   for (Vertex& vertex : mVertices) {
     vertex.setPos(vertex.getPos().rotated(angle, center));

--- a/libs/librepcb/common/geometry/path.h
+++ b/libs/librepcb/common/geometry/path.h
@@ -74,6 +74,8 @@ public:
   // Transformations
   Path& translate(const Point& offset) noexcept;
   Path translated(const Point& offset) const noexcept;
+  Path& mapToGrid(const PositiveLength& gridInterval) noexcept;
+  Path mappedToGrid(const PositiveLength& gridInterval) const noexcept;
   Path& rotate(const Angle& angle, const Point& center = Point(0, 0)) noexcept;
   Path rotated(const Angle& angle, const Point& center = Point(0, 0)) const
       noexcept;

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.cpp
@@ -127,6 +127,11 @@ void CmdFootprintPadEdit::translate(const Point& deltaPos,
   if (immediate) mPad.setPosition(mNewPos);
 }
 
+void CmdFootprintPadEdit::snapToGrid(const PositiveLength& gridInterval,
+                                     bool immediate) noexcept {
+  setPosition(mNewPos.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdFootprintPadEdit::setRotation(const Angle& angle,
                                       bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/library/pkg/cmd/cmdfootprintpadedit.h
@@ -60,6 +60,7 @@ public:
   void setDrillDiameter(const UnsignedLength& dia, bool immediate) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirrorGeometry(Qt::Orientation orientation, const Point& center,

--- a/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.cpp
+++ b/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.cpp
@@ -88,6 +88,11 @@ void CmdSymbolPinEdit::translate(const Point& deltaPos,
   if (immediate) mPin.setPosition(mNewPos);
 }
 
+void CmdSymbolPinEdit::snapToGrid(const PositiveLength& gridInterval,
+                                  bool immediate) noexcept {
+  setPosition(mNewPos.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdSymbolPinEdit::setRotation(const Angle& angle,
                                    bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.h
+++ b/libs/librepcb/library/sym/cmd/cmdsymbolpinedit.h
@@ -55,6 +55,7 @@ public:
   void setLength(const UnsignedLength& length, bool immediate) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirror(Qt::Orientation orientation, const Point& center,

--- a/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmddragselectedfootprintitems.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/cmd/cmddragselectedfootprintitems.h
@@ -63,7 +63,11 @@ public:
       const PackageEditorState::Context& context) noexcept;
   ~CmdDragSelectedFootprintItems() noexcept;
 
+  // Getters
+  bool hasOffTheGridElements() const noexcept { return mHasOffTheGridElements; }
+
   // General Methods
+  void snapToGrid() noexcept;
   void setDeltaToStartPos(const Point& delta) noexcept;
   void translate(const Point& deltaPos) noexcept;
   void rotate(const Angle& angle) noexcept;
@@ -89,6 +93,8 @@ private:
   Angle mDeltaRot;
   bool mMirroredGeometry;
   bool mMirroredLayer;
+  bool mSnappedToGrid;
+  bool mHasOffTheGridElements;
 
   // Move commands
   QList<CmdFootprintPadEdit*> mPadEditCmds;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -459,6 +459,13 @@ bool PackageEditorState_Select::openContextMenuAtPos(
         menu.addAction(QIcon(":/img/actions/delete.png"), tr("Remove"));
     connect(aRemove, &QAction::triggered, [this]() { removeSelectedItems(); });
     menu.addSeparator();
+    if (CmdDragSelectedFootprintItems(mContext).hasOffTheGridElements()) {
+      QAction* aSnapToGrid =
+          menu.addAction(QIcon(":/img/actions/grid.png"), tr("Snap To Grid"));
+      connect(aSnapToGrid, &QAction::triggered, this,
+              &PackageEditorState_Select::snapSelectedItemsToGrid);
+      menu.addSeparator();
+    }
     QAction* aProperties =
         menu.addAction(QIcon(":/img/actions/settings.png"), tr("Properties"));
     connect(aProperties, &QAction::triggered, [this, &selectedItem]() {
@@ -660,6 +667,18 @@ bool PackageEditorState_Select::mirrorSelectedItems(Qt::Orientation orientation,
       }
       mContext.undoStack.execCmd(cmd.take());
     }
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+  }
+  return true;  // TODO: return false if no items were selected
+}
+
+bool PackageEditorState_Select::snapSelectedItemsToGrid() noexcept {
+  try {
+    QScopedPointer<CmdDragSelectedFootprintItems> cmdMove(
+        new CmdDragSelectedFootprintItems(mContext));
+    cmdMove->snapToGrid();
+    mContext.undoStack.execCmd(cmdMove.take());
   } catch (const Exception& e) {
     QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
   }

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.h
@@ -99,6 +99,7 @@ private:  // Methods
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems(Qt::Orientation orientation,
                            bool flipLayers) noexcept;
+  bool snapSelectedItemsToGrid() noexcept;
   bool removeSelectedItems() noexcept;
   void removeSelectedPolygonVertices() noexcept;
   void startAddingPolygonVertex(Polygon& polygon, int vertex,

--- a/libs/librepcb/libraryeditor/sym/fsm/cmd/cmddragselectedsymbolitems.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/cmd/cmddragselectedsymbolitems.h
@@ -61,7 +61,11 @@ public:
       const SymbolEditorState::Context& context) noexcept;
   ~CmdDragSelectedSymbolItems() noexcept;
 
+  // Getters
+  bool hasOffTheGridElements() const noexcept { return mHasOffTheGridElements; }
+
   // General Methods
+  void snapToGrid() noexcept;
   void setDeltaToStartPos(const Point& delta) noexcept;
   void translate(const Point& deltaPos) noexcept;
   void rotate(const Angle& angle) noexcept;
@@ -85,6 +89,8 @@ private:
   Point mDeltaPos;
   Angle mDeltaRot;
   bool mMirrored;
+  bool mSnappedToGrid;
+  bool mHasOffTheGridElements;
 
   // Move commands
   QList<CmdSymbolPinEdit*> mPinEditCmds;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.h
@@ -97,6 +97,7 @@ private:  // Methods
   bool pasteFromClipboard() noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems(Qt::Orientation orientation) noexcept;
+  bool snapSelectedItemsToGrid() noexcept;
   bool removeSelectedItems() noexcept;
   void removeSelectedPolygonVertices() noexcept;
   void startAddingPolygonVertex(Polygon& polygon, int vertex,


### PR DESCRIPTION
In the package- and symbol editors, provide a "snap to grid" context menu item when selecting elements which are not aligned to the grid (if aligned, the menu item is not shown since it would do nothing). Just like already present in the board editor.

Fixes #860.