### PR TITLE
Allow opening locked workspace/project/library in some cases

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -413,6 +413,8 @@ void ControlPanel::openLibraryEditor(const FilePath& libDir) noexcept {
       connect(editor, &LibraryEditor::destroyed, this,
               &ControlPanel::libraryEditorDestroyed);
       mOpenLibraryEditors.insert(libDir, editor);
+    } catch (const UserCanceled& e) {
+      // User requested to abort -> do nothing.
     } catch (const Exception& e) {
       QMessageBox::critical(this, tr("Error"), e.getMsg());
     }

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -29,6 +29,7 @@
 
 #include <librepcb/common/application.h>
 #include <librepcb/common/dialogs/aboutdialog.h>
+#include <librepcb/common/dialogs/directorylockhandlerdialog.h>
 #include <librepcb/common/dialogs/filedialog.h>
 #include <librepcb/common/fileio/fileutils.h>
 #include <librepcb/common/fileio/transactionalfilesystem.h>
@@ -313,8 +314,9 @@ ProjectEditor* ControlPanel::openProject(const FilePath& filepath) noexcept {
     ProjectEditor* editor = getOpenProject(filepath);
     if (!editor) {
       std::shared_ptr<TransactionalFileSystem> fs =
-          TransactionalFileSystem::openRW(filepath.getParentDir(),
-                                          &askForRestoringBackup);
+          TransactionalFileSystem::openRW(
+              filepath.getParentDir(), &askForRestoringBackup,
+              DirectoryLockHandlerDialog::createDirectoryLockCallback());
       Project* project = new Project(std::unique_ptr<TransactionalDirectory>(
                                          new TransactionalDirectory(fs)),
                                      filepath.getFilename());

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -26,6 +26,7 @@
 
 #include <librepcb/common/application.h>
 #include <librepcb/common/debug.h>
+#include <librepcb/common/dialogs/directorylockhandlerdialog.h>
 #include <librepcb/common/exceptions.h>
 #include <librepcb/common/network/networkaccessmanager.h>
 #include <librepcb/workspace/settings/workspacesettings.h>
@@ -246,7 +247,10 @@ static int openWorkspace(const FilePath& path) noexcept {
       }
     }
 
-    Workspace ws(path);  // can throw
+    // Open the workspace (can throw). If it is locked, a dialog will show
+    // an error and possibly provides an option to override the lock.
+    Workspace ws(path,
+                 DirectoryLockHandlerDialog::createDirectoryLockCallback());
 
     // Now since workspace settings are loaded, switch to the locale defined
     // there (until now, the system locale was used).

--- a/libs/librepcb/common/common.pro
+++ b/libs/librepcb/common/common.pro
@@ -60,6 +60,7 @@ SOURCES += \
     dialogs/aboutdialog.cpp \
     dialogs/boarddesignrulesdialog.cpp \
     dialogs/circlepropertiesdialog.cpp \
+    dialogs/directorylockhandlerdialog.cpp \
     dialogs/filedialog.cpp \
     dialogs/gridsettingsdialog.cpp \
     dialogs/holepropertiesdialog.cpp \
@@ -197,6 +198,7 @@ HEADERS += \
     dialogs/aboutdialog.h \
     dialogs/boarddesignrulesdialog.h \
     dialogs/circlepropertiesdialog.h \
+    dialogs/directorylockhandlerdialog.h \
     dialogs/filedialog.h \
     dialogs/gridsettingsdialog.h \
     dialogs/holepropertiesdialog.h \
@@ -323,6 +325,7 @@ FORMS += \
     dialogs/aboutdialog.ui \
     dialogs/boarddesignrulesdialog.ui \
     dialogs/circlepropertiesdialog.ui \
+    dialogs/directorylockhandlerdialog.ui \
     dialogs/gridsettingsdialog.ui \
     dialogs/holepropertiesdialog.ui \
     dialogs/polygonpropertiesdialog.ui \

--- a/libs/librepcb/common/dialogs/directorylockhandlerdialog.cpp
+++ b/libs/librepcb/common/dialogs/directorylockhandlerdialog.cpp
@@ -1,0 +1,92 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "directorylockhandlerdialog.h"
+
+#include "ui_directorylockhandlerdialog.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+DirectoryLockHandlerDialog::DirectoryLockHandlerDialog(
+    const FilePath& directory, const QString& user, bool allowOverrideLock,
+    QWidget* parent) noexcept
+  : QDialog(parent), mUi(new Ui::DirectoryLockHandlerDialog) {
+  mUi->setupUi(this);
+  mUi->lblDescription->setText(
+      mUi->lblDescription->text().arg(directory.toNative(), user));
+  mUi->lblDisclaimer->setVisible(allowOverrideLock);
+
+  if (allowOverrideLock) {
+    // Add "accept risk" checkbox to buttonbox.
+    QCheckBox* cbxAcceptRisk = new QCheckBox(tr("I accept the risk."), this);
+    mUi->buttonBox->addButton(cbxAcceptRisk, QDialogButtonBox::ActionRole);
+
+    // Add "override lock" button to buttonbox.
+    QPushButton* btnOverride = mUi->buttonBox->addButton(
+        tr("Open anyway"), QDialogButtonBox::DestructiveRole);
+    btnOverride->setEnabled(false);
+    connect(btnOverride, &QPushButton::clicked, this, &QDialog::accept);
+    connect(cbxAcceptRisk, &QCheckBox::toggled, btnOverride,
+            &QPushButton::setEnabled);
+  }
+
+  adjustSize();
+}
+
+DirectoryLockHandlerDialog::~DirectoryLockHandlerDialog() noexcept {
+}
+
+/*******************************************************************************
+ *  Public Methods
+ ******************************************************************************/
+
+DirectoryLock::LockHandlerCallback
+    DirectoryLockHandlerDialog::createDirectoryLockCallback(
+        QWidget* parent) noexcept {
+  return [parent](const FilePath& p, DirectoryLock::LockStatus status,
+                  const QString& user) {
+    bool allowOverride =
+        (status == DirectoryLock::LockStatus::LockedByOtherUser) ||
+        (status == DirectoryLock::LockStatus::LockedByUnknownApp);
+    DirectoryLockHandlerDialog dialog(p, user, allowOverride, parent);
+    if (dialog.exec() == QDialog::Accepted) {
+      return true;
+    }
+    throw UserCanceled(__FILE__, __LINE__);
+  };
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/common/dialogs/directorylockhandlerdialog.h
+++ b/libs/librepcb/common/dialogs/directorylockhandlerdialog.h
@@ -1,0 +1,76 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_DIRECTORYLOCKHANDLERDIALOG_H
+#define LIBREPCB_DIRECTORYLOCKHANDLERDIALOG_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/common/fileio/directorylock.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+namespace Ui {
+class DirectoryLockHandlerDialog;
+}
+
+/*******************************************************************************
+ *  Class DirectoryLockHandlerDialog
+ ******************************************************************************/
+
+/**
+ * @brief The DirectoryLockHandlerDialog class
+ */
+class DirectoryLockHandlerDialog final : public QDialog {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  DirectoryLockHandlerDialog() = delete;
+  DirectoryLockHandlerDialog(const DirectoryLockHandlerDialog& other) = delete;
+  DirectoryLockHandlerDialog(const FilePath& directory, const QString& user,
+                             bool allowOverrideLock,
+                             QWidget* parent = nullptr) noexcept;
+  ~DirectoryLockHandlerDialog() noexcept;
+
+  // Operator Overloadings
+  DirectoryLockHandlerDialog& operator=(const DirectoryLockHandlerDialog& rhs) =
+      delete;
+
+  static DirectoryLock::LockHandlerCallback createDirectoryLockCallback(
+      QWidget* parent = nullptr) noexcept;
+
+private:  // Data
+  QScopedPointer<Ui::DirectoryLockHandlerDialog> mUi;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/common/dialogs/directorylockhandlerdialog.ui
+++ b/libs/librepcb/common/dialogs/directorylockhandlerdialog.ui
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::DirectoryLockHandlerDialog</class>
+ <widget class="QDialog" name="librepcb::DirectoryLockHandlerDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>523</width>
+    <height>209</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Directory is locked</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="pixmap">
+        <pixmap>:/img/status/dialog_warning.png</pixmap>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblDescription">
+       <property name="text">
+        <string extracomment="%2 is something like &quot;sername@computername&quot;.">Could not open the directory &quot;%1&quot; because it is already opened by &quot;%2&quot;. Close any application accessing this directory and try again.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblDisclaimer">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>If you're absolutely sure that the directory is not accessed by any other application instance anymore, you could discard the current lock and open this directory anyway. But if the directory is still accessed by another application instance, this could lead in corrupt files, so use this option very carefully!</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>librepcb::DirectoryLockHandlerDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>librepcb::DirectoryLockHandlerDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/libs/librepcb/common/fileio/directorylock.cpp
+++ b/libs/librepcb/common/fileio/directorylock.cpp
@@ -146,21 +146,27 @@ DirectoryLock::LockStatus DirectoryLock::getStatus(
  *  General Methods
  ******************************************************************************/
 
-void DirectoryLock::tryLock(bool* wasStale) {
-  LockStatus status = getStatus();  // can throw
-  if (wasStale) {
-    *wasStale = (status == LockStatus::StaleLock);
-  }
+void DirectoryLock::tryLock(LockHandlerCallback lockHandler) {
+  QString user;
+  LockStatus status = getStatus(&user);  // can throw
   switch (status) {
-    case LockStatus::Unlocked:
     case LockStatus::StaleLock:
+      qWarning() << "Overriding stale lock on directory:" << mDirToLock;
+      // fallthrough
+    case LockStatus::Unlocked:
       lock();  // can throw
       break;
     default:  // Locked!
+      if (lockHandler && lockHandler(mDirToLock, status, user)) {
+        qInfo() << "Overriding lock on directory:" << mDirToLock;
+        lock();  // can throw
+        break;
+      }
       throw RuntimeError(__FILE__, __LINE__,
-                         tr("The directory is locked, "
-                            "check if it is already opened elsewhere: %1")
-                             .arg(mDirToLock.toNative()));
+                         tr("Could not lock the directory \"%1\" because it is "
+                            "already locked by \"%2\". Close any application "
+                            "accessing this directory and try again.")
+                             .arg(mDirToLock.toNative(), user));
   }
 }
 

--- a/libs/librepcb/common/fileio/directorylock.h
+++ b/libs/librepcb/common/fileio/directorylock.h
@@ -28,6 +28,8 @@
 
 #include <QtCore>
 
+#include <functional>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -174,6 +176,23 @@ public:
     LockedByUnknownApp,
   };
 
+  /**
+   * @brief Callback type used to determine whether a lock should be overridden
+   *        or not
+   *
+   * @param dir     The directory to be locked.
+   * @param status  The current status of the lock (see #getStatus()).
+   * @param user    Name of the user which currently holds the lock.
+   *
+   * @retval true   Override lock.
+   * @retval false  Do not override lock.
+   *
+   * @throw ::librepcb::UserCanceled to abort locking the directory.
+   */
+  typedef std::function<bool(const FilePath& dir, LockStatus status,
+                             const QString& user)>
+      LockHandlerCallback;
+
   // Constructors / Destructor
 
   /**
@@ -261,12 +280,14 @@ public:
    * - StaleLock: Set "wasStale = true" and get the lock (calling #lock())
    * - Locked:    Throw exception (something like "Directory already locked")
    *
-   * @param wasStale  This variable will be set to true if there was a stale
-   * lock, and to false if not (if a valid pointer was passed).
+   *@param lockHandler  If supplied and the directory is already locked, this
+   *                    callback gets called to determine whether the lock
+   *                    should be overridden or not. If not supplied and the
+   *                    directory is locked, an exception will be thrown.
    *
    * @throw   Exception on error (e.g. already locked, no access rights, ...)
    */
-  void tryLock(bool* wasStale = nullptr);
+  void tryLock(LockHandlerCallback lockHandler = nullptr);
 
   /**
    * @brief Unlock the specified directory if it was locked by this object

--- a/libs/librepcb/common/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.cpp
@@ -47,7 +47,7 @@ namespace librepcb {
 
 TransactionalFileSystem::TransactionalFileSystem(
     const FilePath& filepath, bool writable, RestoreCallback restoreCallback,
-    QObject* parent)
+    DirectoryLock::LockHandlerCallback lockCallback, QObject* parent)
   : FileSystem(parent),
     mFilePath(filepath),
     mIsWritable(writable),
@@ -63,7 +63,7 @@ TransactionalFileSystem::TransactionalFileSystem(
   // Lock directory if the file system is opened in R/W mode.
   if (mIsWritable) {
     FileUtils::makePath(mFilePath);  // can throw
-    mLock.tryLock();  // can throw
+    mLock.tryLock(lockCallback);  // can throw
   }
 
   // If there is an autosave backup, load it according the restore mode.

--- a/libs/librepcb/common/fileio/transactionalfilesystem.h
+++ b/libs/librepcb/common/fileio/transactionalfilesystem.h
@@ -127,9 +127,11 @@ public:
 
   // Constructors / Destructor
   TransactionalFileSystem() = delete;
-  TransactionalFileSystem(const FilePath& filepath, bool writable = false,
-                          RestoreCallback restoreCallback = RestoreCallback(),
-                          QObject* parent = nullptr);
+  TransactionalFileSystem(
+      const FilePath& filepath, bool writable = false,
+      RestoreCallback restoreCallback = RestoreCallback(),
+      DirectoryLock::LockHandlerCallback lockCallback = nullptr,
+      QObject* parent = nullptr);
   TransactionalFileSystem(const TransactionalFileSystem& other) = delete;
   virtual ~TransactionalFileSystem() noexcept;
 
@@ -163,21 +165,23 @@ public:
   static std::shared_ptr<TransactionalFileSystem> open(
       const FilePath& filepath, bool writable,
       RestoreCallback restoreCallback = &RestoreMode::no,
+      DirectoryLock::LockHandlerCallback lockCallback = nullptr,
       QObject* parent = nullptr) {
-    return std::make_shared<TransactionalFileSystem>(filepath, writable,
-                                                     restoreCallback, parent);
+    return std::make_shared<TransactionalFileSystem>(
+        filepath, writable, restoreCallback, lockCallback, parent);
   }
   static std::shared_ptr<TransactionalFileSystem> openRO(
       const FilePath& filepath,
       RestoreCallback restoreCallback = &RestoreMode::no,
       QObject* parent = nullptr) {
-    return open(filepath, false, restoreCallback, parent);
+    return open(filepath, false, restoreCallback, nullptr, parent);
   }
   static std::shared_ptr<TransactionalFileSystem> openRW(
       const FilePath& filepath,
       RestoreCallback restoreCallback = &RestoreMode::no,
+      DirectoryLock::LockHandlerCallback lockCallback = nullptr,
       QObject* parent = nullptr) {
-    return open(filepath, true, restoreCallback, parent);
+    return open(filepath, true, restoreCallback, lockCallback, parent);
   }
   static QString cleanPath(QString path) noexcept;
 

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "editorwidgetbase.h"
 
+#include <librepcb/common/dialogs/directorylockhandlerdialog.h>
 #include <librepcb/common/undostack.h>
 #include <librepcb/common/utils/exclusiveactiongroup.h>
 #include <librepcb/common/utils/toolbarproxy.h>
@@ -49,9 +50,10 @@ EditorWidgetBase::EditorWidgetBase(const Context& context, const FilePath& fp,
   : QWidget(parent),
     mContext(context),
     mFilePath(fp),
-    mFileSystem(
-        TransactionalFileSystem::open(fp, !context.readOnly,
-                                      &askForRestoringBackup)),  // can throw
+    mFileSystem(TransactionalFileSystem::open(
+        fp, !context.readOnly, &askForRestoringBackup,
+        DirectoryLockHandlerDialog::createDirectoryLockCallback())),  // can
+                                                                      // throw
     mUndoStackActionGroup(nullptr),
     mToolsActionGroup(nullptr),
     mStatusBar(nullptr),

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.cpp
@@ -51,7 +51,7 @@ namespace editor {
 
 LibraryOverviewWidget::LibraryOverviewWidget(const Context& context,
                                              const FilePath& fp,
-                                             QWidget* parent) noexcept
+                                             QWidget* parent)
   : EditorWidgetBase(context, fp, parent),
     mUi(new Ui::LibraryOverviewWidget),
     mCurrentFilter() {

--- a/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/libraryeditor/lib/libraryoverviewwidget.h
@@ -65,7 +65,7 @@ public:
   LibraryOverviewWidget() = delete;
   LibraryOverviewWidget(const LibraryOverviewWidget& other) = delete;
   LibraryOverviewWidget(const Context& context, const FilePath& fp,
-                        QWidget* parent = nullptr) noexcept;
+                        QWidget* parent = nullptr);
   ~LibraryOverviewWidget() noexcept;
 
   // Setters

--- a/libs/librepcb/libraryeditor/libraryeditor.cpp
+++ b/libs/librepcb/libraryeditor/libraryeditor.cpp
@@ -559,6 +559,8 @@ void LibraryEditor::editLibraryElementTriggered(const FilePath& fp,
     int index = mUi->tabWidget->addTab(widget, widget->windowIcon(),
                                        widget->windowTitle());
     mUi->tabWidget->setCurrentIndex(index);
+  } catch (const UserCanceled& e) {
+    // User requested to abort -> do nothing.
   } catch (const Exception& e) {
     QMessageBox::critical(this, tr("Failed to open category"), e.getMsg());
   }

--- a/libs/librepcb/workspace/workspace.cpp
+++ b/libs/librepcb/workspace/workspace.cpp
@@ -85,26 +85,22 @@ Workspace::Workspace(const FilePath& wsPath)
   FileUtils::makePath(mLibrariesPath);  // can throw
 
   // Check if the workspace is locked (already open or application crashed).
-  switch (mLock.getStatus())  // can throw
-  {
+  switch (mLock.getStatus()) {  // can throw
     case DirectoryLock::LockStatus::Unlocked: {
       // nothing to do here (the workspace will be locked later)
       break;
-    }
-    case DirectoryLock::LockStatus::Locked: {
-      // the workspace is locked by another application instance
-      throw RuntimeError(__FILE__, __LINE__,
-                         tr("The workspace is already "
-                            "opened by another application instance or user!"));
     }
     case DirectoryLock::LockStatus::StaleLock: {
       // ignore stale lock as there is nothing to restore
       qWarning() << "There was a stale lock on the workspace:" << mPath;
       break;
     }
-    default:
-      Q_ASSERT(false);
-      throw LogicError(__FILE__, __LINE__);
+    default: {
+      // the workspace is locked by another application instance
+      throw RuntimeError(__FILE__, __LINE__,
+                         tr("The workspace is already "
+                            "opened by another application instance or user!"));
+    }
   }
 
   // the workspace can be opened by this application, so we will lock it

--- a/libs/librepcb/workspace/workspace.h
+++ b/libs/librepcb/workspace/workspace.h
@@ -70,12 +70,16 @@ public:
   /**
    * @brief Constructor to open an existing workspace
    *
-   * @param wsPath    The filepath to the workspace directory
+   * @param wsPath        The filepath to the workspace directory
+   * @param lockCallback  A callback which gets called if the workspace
+   *                      directory is locked, to decide what to do in this
+   *                      case.
    *
    * @throw Exception If the workspace could not be opened, this constructor
    * throws an exception.
    */
-  explicit Workspace(const FilePath& wsPath);
+  explicit Workspace(const FilePath& wsPath,
+                     DirectoryLock::LockHandlerCallback lockCallback = nullptr);
 
   /**
    * The destructor

--- a/tests/unittests/common/fileio/directorylocktest.cpp
+++ b/tests/unittests/common/fileio/directorylocktest.cpp
@@ -186,7 +186,7 @@ TEST_F(DirectoryLockTest, testSingleStatusLockUnlock) {
 
   // get lock
   lock.lock();
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock.getStatus());
   EXPECT_TRUE(mTempLockFilePath.isExistingFile());
 
   // release lock
@@ -203,14 +203,14 @@ TEST_F(DirectoryLockTest, testMultipleStatusLockUnlock) {
 
   // get lock1
   lock1.lock();
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock1.getStatus());
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock2.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock1.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock2.getStatus());
   EXPECT_TRUE(mTempLockFilePath.isExistingFile());
 
   // get lock2 (steals the lock from lock1)
   lock2.lock();
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock1.getStatus());
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock2.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock1.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock2.getStatus());
   EXPECT_TRUE(mTempLockFilePath.isExistingFile());
 
   // release lock2
@@ -223,14 +223,14 @@ TEST_F(DirectoryLockTest, testMultipleStatusLockUnlock) {
 TEST_F(DirectoryLockTest, testTryLockWithoutArgument) {
   DirectoryLock lock(mTempDir);
   lock.tryLock();
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock.getStatus());
 }
 
 TEST_F(DirectoryLockTest, testTryLockUnlockedDir) {
   bool wasStale = true;
   DirectoryLock lock(mTempDir);
   lock.tryLock(&wasStale);
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock.getStatus());
   EXPECT_FALSE(wasStale);
 }
 
@@ -239,7 +239,7 @@ TEST_F(DirectoryLockTest, testTryLockLockedDir) {
   DirectoryLock lock1(mTempDir);
   DirectoryLock lock2(mTempDir);
   lock1.tryLock(&wasStale);
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock1.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock1.getStatus());
   EXPECT_THROW(lock2.tryLock(), Exception);
   EXPECT_FALSE(wasStale);
 }
@@ -254,7 +254,7 @@ TEST_F(DirectoryLockTest, testUnlockIfLockedOnUnlockedDir) {
 TEST_F(DirectoryLockTest, testUnlockIfLockedOnLockedDir) {
   DirectoryLock lock(mTempDir);
   lock.lock();
-  EXPECT_EQ(DirectoryLock::LockStatus::Locked, lock.getStatus());
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByThisApp, lock.getStatus());
   EXPECT_TRUE(lock.unlockIfLocked());
   EXPECT_EQ(DirectoryLock::LockStatus::Unlocked, lock.getStatus());
 }
@@ -290,6 +290,77 @@ TEST_F(DirectoryLockTest, testStaleLock) {
   ASSERT_TRUE(wasStale);
 }
 #endif
+
+#if (QT_VERSION >= \
+     QT_VERSION_CHECK(5, 3, 0))  // QProcess::processId() requires Qt>=5.3
+TEST_F(DirectoryLockTest, testLockedByOtherApp) {
+  // Run a new process.
+  QProcess process;
+  process.start(getTestProcessExePath().toStr());
+  bool success = process.waitForStarted();
+  ASSERT_TRUE(success) << qPrintable(process.errorString());
+
+  // Get the lock, read the lock file content and release the lock.
+  DirectoryLock lock(mTempDir);
+  lock.lock();
+  QStringList lines =
+      QString(FileUtils::readFile(mTempLockFilePath)).split('\n');
+  lock.unlock();
+
+  // Create a lock file with the PID/name of the other process.
+  lines[3] = QString::number(process.processId());
+  lines[4] = SystemInfo::getProcessNameByPid(process.processId());
+  FileUtils::writeFile(mTempLockFilePath, lines.join('\n').toUtf8());
+
+  // Check lock status.
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByOtherApp, lock.getStatus());
+
+  // Try to get the lock. Should fail since the directory is already locked.
+  EXPECT_THROW(lock.tryLock(), Exception);
+
+  // Exit the other process.
+  process.kill();
+  success = process.waitForFinished();
+  ASSERT_TRUE(success) << qPrintable(process.errorString());
+}
+#endif
+
+TEST_F(DirectoryLockTest, testLockedByOtherUser) {
+  // Get the lock, read the lock file content and release the lock.
+  DirectoryLock lock(mTempDir);
+  lock.lock();
+  QStringList lines =
+      QString(FileUtils::readFile(mTempLockFilePath)).split('\n');
+  lock.unlock();
+
+  // Create a lock file with another user name.
+  lines[1] = "DirectoryLockTest_testLockedByOtherUser";
+  FileUtils::writeFile(mTempLockFilePath, lines.join('\n').toUtf8());
+
+  // Check lock status.
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByOtherUser, lock.getStatus());
+
+  // Try to get the lock. Should fail since the directory is already locked.
+  EXPECT_THROW(lock.tryLock(), Exception);
+}
+
+TEST_F(DirectoryLockTest, testLockedByUnknownApp) {
+  // Create a lock file, memorize its content and release the lock.
+  DirectoryLock lock(mTempDir);
+  lock.lock();
+  QByteArray content = FileUtils::readFile(mTempLockFilePath);
+  lock.unlock();
+
+  // Now create the lock file with the same content as before. So it looke like
+  // the lock is coming from this application instance, but it doesn't.
+  FileUtils::writeFile(mTempLockFilePath, content);
+
+  // Check lock status.
+  EXPECT_EQ(DirectoryLock::LockStatus::LockedByUnknownApp, lock.getStatus());
+
+  // Try to get the lock. Should fail since the path is considered as locked.
+  EXPECT_THROW(lock.tryLock(), Exception);
+}
 
 TEST_F(DirectoryLockTest, testLockFileContent) {
   // get the lock


### PR DESCRIPTION
If a workspace, project or library directory is locked by a `.lock` file but we are not 100% sure if the lock is still valid, the error message dialog now provides the ability to discard the lock and open the directory anyway:

![image](https://user-images.githubusercontent.com/5374821/109435248-d28a9280-7a19-11eb-9f19-274217a5ff84.png)

This is especially useful when running LibrePCB as a Flatpak since due to PID namespacing we are not able to check if the application holding a lock is still running or not.

But if we are absolutely sure the lock is still valid, this option is not available since generally it could be dangerous to discard file locks.

Fixes #734