### PR TITLE
SQLiteDatabaseTest: Simplify flaky concurrency test case

### DIFF
--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -62,7 +62,7 @@ jobs:
     displayName: Run LibrePCB Unittests
   - bash: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -v --librepcb-executable="build/install/opt/bin/librepcb-cli" ./tests/cli
     displayName: Run LibrePCB-CLI Functional Tests
-  - bash: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -v --librepcb-executable="build/install/opt/bin/librepcb" ./tests/funq
+  - bash: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -v --librepcb-executable="build/install/opt/bin/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
     displayName: Run LibrePCB Functional Tests
   - bash: ./ci/upload_artifacts.sh
     displayName: Upload Artifacts

--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -27,7 +27,7 @@ jobs:
     displayName: Run LibrePCB Unittests
   - bash: pytest -v --librepcb-executable="build/install/opt/librepcb-cli.app/Contents/MacOS/librepcb-cli" ./tests/cli
     displayName: Run LibrePCB-CLI Functional Tests
-  - bash: pytest -v --librepcb-executable="build/install/opt/librepcb.app/Contents/MacOS/librepcb" ./tests/funq
+  - bash: pytest -v --librepcb-executable="build/install/opt/librepcb.app/Contents/MacOS/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
     displayName: Run LibrePCB Functional Tests
   - bash: ./ci/upload_artifacts.sh
     displayName: Upload Artifacts

--- a/ci/azure-jobs-windows.yml
+++ b/ci/azure-jobs-windows.yml
@@ -40,7 +40,7 @@ jobs:
       displayName: Run LibrePCB Unittests
     - script: pytest -v --librepcb-executable="build/install/opt/bin/librepcb-cli.exe" ./tests/cli
       displayName: Run LibrePCB-CLI Functional Tests
-    - script: pytest -v --librepcb-executable="build/install/opt/bin/librepcb.exe" ./tests/funq
+    - script: pytest -v --librepcb-executable="build/install/opt/bin/librepcb.exe" --reruns 5 --reruns-delay 10 ./tests/funq
       displayName: Run LibrePCB Functional Tests
     - bash: ./ci/upload_artifacts.sh
       displayName: Upload Artifacts

--- a/tests/funq/requirements.txt
+++ b/tests/funq/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/parkouss/funq.git@811a8b4fa510e5256b0a14fe93f5c331fd9dd6be#egg=funq-server&subdirectory=server
 git+https://github.com/parkouss/funq.git@811a8b4fa510e5256b0a14fe93f5c331fd9dd6be#egg=funq&subdirectory=client
-pytest~=3.6.3
+pytest~=3.10
+pytest-rerunfailures~=7.0


### PR DESCRIPTION
After several years of annoying issues with this unit test on Windows (because Windows cannot reliably remove files, run multiple threads at the same time, and because Windows is incredibly slow), I have no more nerves to maintain this unittest. So I heavily simplified it to use only a single thread in addition to the main thread. This is actually the main use-case for SQLiteDatabase, so I think we don't loose a lot of important test coverage.

I really hope this finally fixes the constantly failing CI pipelines. It is a huge pain to have so many CI failures.