### PR TITLE
Component editor: Remove checkbox text "required/optional"

### DIFF
--- a/libs/librepcb/libraryeditor/cmp/componentsignallistmodel.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallistmodel.cpp
@@ -175,14 +175,16 @@ QVariant ComponentSignalListModel::data(const QModelIndex& index,
       bool required = item ? item->isRequired() : mNewIsRequired;
       switch (role) {
         case Qt::DisplayRole:
-          return required ? tr("Required") : tr("Optional");
+          // See https://github.com/LibrePCB/LibrePCB/issues/475.
+          return QString();
         case Qt::CheckStateRole:
           return required ? Qt::Checked : Qt::Unchecked;
         case Qt::ToolTipRole:
-          return required ? tr("Leaving this signal unconnected in schematics "
-                               "produces an ERC error.")
-                          : tr("Leaving this signal unconnected in schematics "
-                               "is allowed.");
+          return tr("If checked, the signal needs to be connected in "
+                    "schematics, otherwise an ERC error is raised.") +
+              "\n" +
+              tr("If unchecked, it's allowed to leave the signal unconnected "
+                 "in schematics.");
         default:
           return QVariant();
       }
@@ -220,7 +222,7 @@ QVariant ComponentSignalListModel::headerData(int section,
         case COLUMN_NAME:
           return tr("Name");
         case COLUMN_ISREQUIRED:
-          return tr("Connection");
+          return tr("Required");
         case COLUMN_FORCEDNETNAME:
           return tr("Forced Net");
         default:


### PR DESCRIPTION
Removed the text of the component signal checkbox for choosing "required" or "optional" to avoid confusion what state the checkbox actually has. Instead, the column title "Connection" is now changed to "Required" and the tooltip is more descriptive.

![image](https://user-images.githubusercontent.com/5374821/110045833-9756cf00-7d4b-11eb-81fc-109e93992133.png)

It's a bit ugly now since the checkbox is not centered. I tried to center it but found no reliable, simple way to do so...

Fixes #475 