### PR TITLE
Package editor: Stop rejecting but warn about overlapping pads

### DIFF
--- a/libs/librepcb/library/library.pro
+++ b/libs/librepcb/library/library.pro
@@ -78,6 +78,7 @@ SOURCES += \
     pkg/msg/msgmissingfootprint.cpp \
     pkg/msg/msgmissingfootprintname.cpp \
     pkg/msg/msgmissingfootprintvalue.cpp \
+    pkg/msg/msgpadclearanceviolation.cpp \
     pkg/msg/msgpadoverlapswithplacement.cpp \
     pkg/msg/msgwrongfootprinttextlayer.cpp \
     pkg/package.cpp \
@@ -154,6 +155,7 @@ HEADERS += \
     pkg/msg/msgmissingfootprint.h \
     pkg/msg/msgmissingfootprintname.h \
     pkg/msg/msgmissingfootprintvalue.h \
+    pkg/msg/msgpadclearanceviolation.h \
     pkg/msg/msgpadoverlapswithplacement.h \
     pkg/msg/msgwrongfootprinttextlayer.h \
     pkg/package.h \

--- a/libs/librepcb/library/pkg/msg/msgpadclearanceviolation.cpp
+++ b/libs/librepcb/library/pkg/msg/msgpadclearanceviolation.cpp
@@ -17,56 +17,45 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_PACKAGECHECK_H
-#define LIBREPCB_LIBRARY_PACKAGECHECK_H
-
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "libraryelementcheck.h"
+#include "msgpadclearanceviolation.h"
 
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ******************************************************************************/
 namespace librepcb {
 namespace library {
 
-class Package;
-
 /*******************************************************************************
- *  Class PackageCheck
+ *  Constructors / Destructor
  ******************************************************************************/
 
-/**
- * @brief The PackageCheck class
- */
-class PackageCheck : public LibraryElementCheck {
-public:
-  // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+MsgPadClearanceViolation::MsgPadClearanceViolation(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad1, const QString& pkgPad1Name,
+    std::shared_ptr<const FootprintPad> pad2, const QString& pkgPad2Name,
+    const Length& clearance) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        tr("Clearance of pad '%1' to pad '%2' in '%3'")
+            .arg(pkgPad1Name, pkgPad2Name,
+                 *footprint->getNames().getDefaultValue()),
+        tr("Pads should have at least %1 clearance between each other. In some "
+           "situations it might be needed to use smaller clearances but not "
+           "all PCB manufacturers are able to reliably produce such small "
+           "clearances, so usually this should be avoided.")
+            .arg(QString::number(clearance.toMm() * 1000) % "μm")),
+    mFootprint(footprint),
+    mPad1(pad1),
+    mPad2(pad2) {
+}
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
-
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
-};
+MsgPadClearanceViolation::~MsgPadClearanceViolation() noexcept {
+}
 
 /*******************************************************************************
  *  End of File
@@ -74,5 +63,3 @@ private:  // Data
 
 }  // namespace library
 }  // namespace librepcb
-
-#endif  // LIBREPCB_LIBRARY_PACKAGECHECK_H

--- a/libs/librepcb/library/pkg/msg/msgpadclearanceviolation.h
+++ b/libs/librepcb/library/pkg/msg/msgpadclearanceviolation.h
@@ -17,13 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_LIBRARY_PACKAGECHECK_H
-#define LIBREPCB_LIBRARY_PACKAGECHECK_H
+#ifndef LIBREPCB_LIBRARY_MSGPADCLEARANCEVIOLATION_H
+#define LIBREPCB_LIBRARY_MSGPADCLEARANCEVIOLATION_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "libraryelementcheck.h"
+#include "../../msg/libraryelementcheckmessage.h"
+
+#include <librepcb/common/units/length.h>
 
 #include <QtCore>
 
@@ -33,39 +35,46 @@
 namespace librepcb {
 namespace library {
 
-class Package;
+class Footprint;
+class FootprintPad;
 
 /*******************************************************************************
- *  Class PackageCheck
+ *  Class MsgPadClearanceViolation
  ******************************************************************************/
 
 /**
- * @brief The PackageCheck class
+ * @brief The MsgPadClearanceViolation class
  */
-class PackageCheck : public LibraryElementCheck {
+class MsgPadClearanceViolation final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadClearanceViolation)
+
 public:
   // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+  MsgPadClearanceViolation() = delete;
+  MsgPadClearanceViolation(std::shared_ptr<const Footprint> footprint,
+                           std::shared_ptr<const FootprintPad> pad1,
+                           const QString& pkgPad1Name,
+                           std::shared_ptr<const FootprintPad> pad2,
+                           const QString& pkgPad2Name,
+                           const Length& clearance) noexcept;
+  MsgPadClearanceViolation(const MsgPadClearanceViolation& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mPad1(other.mPad1),
+      mPad2(other.mPad2) {}
+  virtual ~MsgPadClearanceViolation() noexcept;
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad1() const noexcept { return mPad1; }
+  std::shared_ptr<const FootprintPad> getPad2() const noexcept { return mPad2; }
 
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad1;
+  std::shared_ptr<const FootprintPad> mPad2;
 };
 
 /*******************************************************************************
@@ -75,4 +84,4 @@ private:  // Data
 }  // namespace library
 }  // namespace librepcb
 
-#endif  // LIBREPCB_LIBRARY_PACKAGECHECK_H
+#endif

--- a/libs/librepcb/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/library/pkg/packagecheck.cpp
@@ -26,6 +26,7 @@
 #include "msg/msgmissingfootprint.h"
 #include "msg/msgmissingfootprintname.h"
 #include "msg/msgmissingfootprintvalue.h"
+#include "msg/msgpadclearanceviolation.h"
 #include "msg/msgpadoverlapswithplacement.h"
 #include "msg/msgwrongfootprinttextlayer.h"
 #include "package.h"
@@ -62,7 +63,8 @@ LibraryElementCheckMessageList PackageCheck::runChecks() const {
   checkMissingFootprint(msgs);
   checkMissingTexts(msgs);
   checkWrongTextLayers(msgs);
-  checkPadsOverlapWithPlacement(msgs);
+  checkPadsClearanceToPads(msgs);
+  checkPadsClearanceToPlacement(msgs);
   return msgs;
 }
 
@@ -123,7 +125,61 @@ void PackageCheck::checkWrongTextLayers(MsgList& msgs) const {
   }
 }
 
-void PackageCheck::checkPadsOverlapWithPlacement(MsgList& msgs) const {
+void PackageCheck::checkPadsClearanceToPads(MsgList& msgs) const {
+  Length clearance(200000);  // 200 µm
+  Length tolerance(10);  // 0.01 µm, to avoid rounding issues
+
+  // Check all footprints.
+  for (auto itFtp = mPackage.getFootprints().begin();
+       itFtp != mPackage.getFootprints().end(); ++itFtp) {
+    std::shared_ptr<const Footprint> footprint = itFtp.ptr();
+
+    // Check all pads.
+    for (auto itPad1 = (*itFtp).getPads().begin();
+         itPad1 != (*itFtp).getPads().end(); ++itPad1) {
+      std::shared_ptr<const FootprintPad> pad1 = itPad1.ptr();
+      std::shared_ptr<const PackagePad> pkgPad1 = pad1->getPackagePadUuid()
+          ? mPackage.getPads().find(*pad1->getPackagePadUuid())
+          : nullptr;
+      Path pad1Path = pad1->getOutline(clearance - tolerance);
+      pad1Path.rotate(pad1->getRotation()).translate(pad1->getPosition());
+      const QPainterPath pad1PathPx = pad1Path.toQPainterPathPx();
+
+      // Compare with all pads *after* pad1 to avoid duplicate messages!
+      // So, don't initialize the iterator with begin() but with pad1 + 1.
+      auto itPad2 = itPad1;
+      for (++itPad2; itPad2 != (*itFtp).getPads().end(); ++itPad2) {
+        std::shared_ptr<const FootprintPad> pad2 = itPad2.ptr();
+        std::shared_ptr<const PackagePad> pkgPad2 = pad2->getPackagePadUuid()
+            ? mPackage.getPads().find(*pad2->getPackagePadUuid())
+            : nullptr;
+        Path pad2Path = pad2->getOutline();
+        pad2Path.rotate(pad2->getRotation()).translate(pad2->getPosition());
+        const QPainterPath pad2PathPx = pad2Path.toQPainterPathPx();
+
+        // Only warn if both pads have copper on the same board side.
+        if ((pad1->getBoardSide() == pad2->getBoardSide()) ||
+            (pad1->getBoardSide() == FootprintPad::BoardSide::THT) ||
+            (pad2->getBoardSide() == FootprintPad::BoardSide::THT)) {
+          // Only warn if both pads have different net signal, or one of them
+          // is unconnected (an unconnected pad is considered as a different
+          // net signal).
+          if ((pad1->getPackagePadUuid() != pad2->getPackagePadUuid()) ||
+              (!pad1->getPackagePadUuid()) || (!pad2->getPackagePadUuid())) {
+            // Now check if the clearance is really too small.
+            if (pad1PathPx.intersects(pad2PathPx)) {
+              msgs.append(std::make_shared<MsgPadClearanceViolation>(
+                  footprint, pad1, pkgPad1 ? *pkgPad1->getName() : QString(),
+                  pad2, pkgPad2 ? *pkgPad2->getName() : QString(), clearance));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+void PackageCheck::checkPadsClearanceToPlacement(MsgList& msgs) const {
   for (auto itFtp = mPackage.getFootprints().begin();
        itFtp != mPackage.getFootprints().end(); ++itFtp) {
     std::shared_ptr<const Footprint> footprint = itFtp.ptr();
@@ -152,8 +208,9 @@ void PackageCheck::checkPadsOverlapWithPlacement(MsgList& msgs) const {
     for (auto it = (*itFtp).getPads().begin(); it != (*itFtp).getPads().end();
          ++it) {
       std::shared_ptr<const FootprintPad> pad = it.ptr();
-      std::shared_ptr<const PackagePad> pkgPad =
-          mPackage.getPads().find(pad->getUuid());
+      std::shared_ptr<const PackagePad> pkgPad = pad->getPackagePadUuid()
+          ? mPackage.getPads().find(*pad->getPackagePadUuid())
+          : nullptr;
       Length clearance(150000);  // 150 µm
       Length tolerance(10);  // 0.01 µm, to avoid rounding issues
       Path stopMaskPath = pad->getOutline(clearance - tolerance);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.cpp
@@ -131,7 +131,6 @@ bool PackageEditorState_AddHoles::processGraphicsSceneLeftMouseButtonPressed(
 
 bool PackageEditorState_AddHoles::startAddHole(const Point& pos) noexcept {
   try {
-    mStartPos = pos;
     mContext.undoStack.beginCmdGroup(tr("Add hole"));
     mCurrentHole = new Hole(Uuid::createRandom(), pos, mLastDiameter);
     mContext.undoStack.appendToCmdGroup(
@@ -153,10 +152,6 @@ bool PackageEditorState_AddHoles::startAddHole(const Point& pos) noexcept {
 }
 
 bool PackageEditorState_AddHoles::finishAddHole(const Point& pos) noexcept {
-  if (pos == mStartPos) {
-    return abortAddHole();
-  }
-
   try {
     mEditCmd->setPosition(pos, true);
     mCurrentGraphicsItem->setSelected(false);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addholes.h
@@ -80,7 +80,6 @@ private:  // Methods
   void diameterEditValueChanged(const PositiveLength& value) noexcept;
 
 private:  // Data
-  Point mStartPos;
   QScopedPointer<CmdHoleEdit> mEditCmd;
   Hole* mCurrentHole;
   HoleGraphicsItem* mCurrentGraphicsItem;

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.cpp
@@ -231,7 +231,6 @@ bool PackageEditorState_AddPads::processRotateCcw() noexcept {
 
 bool PackageEditorState_AddPads::startAddPad(const Point& pos) noexcept {
   try {
-    mStartPos = pos;
     mContext.undoStack.beginCmdGroup(tr("Add footprint pad"));
     mLastPad.setPosition(pos);
     mCurrentPad.reset(new FootprintPad(Uuid::createRandom(), mLastPad));
@@ -253,10 +252,6 @@ bool PackageEditorState_AddPads::startAddPad(const Point& pos) noexcept {
 }
 
 bool PackageEditorState_AddPads::finishAddPad(const Point& pos) noexcept {
-  if (pos == mStartPos) {
-    return abortAddPad();
-  }
-
   try {
     mEditCmd->setPosition(pos, true);
     mCurrentGraphicsItem->setSelected(false);

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_addpads.h
@@ -96,7 +96,6 @@ private:  // Methods
 
 private:  // Types / Data
   PadType mPadType;
-  Point mStartPos;
   QScopedPointer<CmdFootprintPadEdit> mEditCmd;
   std::shared_ptr<FootprintPad> mCurrentPad;
   FootprintPadGraphicsItem* mCurrentGraphicsItem;


### PR DESCRIPTION
In the package editor, it was not possible to place two consecutive pads at the same position, see #836. This was strange behavior since after leaving and re-entering the "place pad" tool it was possible. The same applied to the "add hole" tool. To fix this strange behavior, I removed this limitation, so it is now possible to place to consecutive pads or holes at the same position.

However, now it's easier to accidentally place multiple pads at the same position without realizing it. Thus I implemented a package check which shows a warning if the clearance between two pads is <200um (so it also warns about overlapping pads). For holes I didn't implement such a warning since there might be situations where this is intended, and overlapping holes cannot lead in short circuits, in contrast to pads.

Fixes #836.