### PR TITLE
Schematic editor: Snap wires to pins/junctions off the grid

### DIFF
--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.cpp
@@ -203,6 +203,24 @@ bool SchematicEditorFsm::processRemove() noexcept {
   return false;
 }
 
+bool SchematicEditorFsm::processKeyPressed(const QKeyEvent& e) noexcept {
+  if (SchematicEditorState* state = getCurrentStateObj()) {
+    if (state->processKeyPressed(e)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool SchematicEditorFsm::processKeyReleased(const QKeyEvent& e) noexcept {
+  if (SchematicEditorState* state = getCurrentStateObj()) {
+    if (state->processKeyReleased(e)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool SchematicEditorFsm::processGraphicsSceneMouseMoved(
     QGraphicsSceneMouseEvent& e) noexcept {
   if (SchematicEditorState* state = getCurrentStateObj()) {

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorfsm.h
@@ -118,6 +118,8 @@ public:
   bool processRotateCcw() noexcept;
   bool processMirror() noexcept;
   bool processRemove() noexcept;
+  bool processKeyPressed(const QKeyEvent& e) noexcept;
+  bool processKeyReleased(const QKeyEvent& e) noexcept;
   bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept;
   bool processGraphicsSceneLeftMouseButtonPressed(
       QGraphicsSceneMouseEvent& e) noexcept;

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate.h
@@ -85,6 +85,14 @@ public:
   virtual bool processMirror() noexcept { return false; }
   virtual bool processRemove() noexcept { return false; }
   virtual bool processAbortCommand() noexcept { return false; }
+  virtual bool processKeyPressed(const QKeyEvent& e) noexcept {
+    Q_UNUSED(e);
+    return false;
+  }
+  virtual bool processKeyReleased(const QKeyEvent& e) noexcept {
+    Q_UNUSED(e);
+    return false;
+  }
   virtual bool processGraphicsSceneMouseMoved(
       QGraphicsSceneMouseEvent& e) noexcept {
     Q_UNUSED(e);

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawwire.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_drawwire.h
@@ -86,6 +86,8 @@ public:
 
   // Event Handlers
   virtual bool processAbortCommand() noexcept override;
+  virtual bool processKeyPressed(const QKeyEvent& e) noexcept override;
+  virtual bool processKeyReleased(const QKeyEvent& e) noexcept override;
   virtual bool processGraphicsSceneMouseMoved(
       QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processGraphicsSceneLeftMouseButtonPressed(
@@ -101,9 +103,9 @@ public:
       const SchematicEditorState_DrawWire& rhs) = delete;
 
 private:  //  Methods
-  bool startPositioning(Schematic& schematic, const Point& pos,
+  bool startPositioning(Schematic& schematic, bool snap,
                         SI_NetPoint* fixedPoint = nullptr) noexcept;
-  bool addNextNetPoint(Schematic& schematic, const Point& pos) noexcept;
+  bool addNextNetPoint(Schematic& schematic, bool snap) noexcept;
   bool abortPositioning(bool showErrMsgBox) noexcept;
   SI_SymbolPin* findSymbolPin(Schematic& schematic, const Point& pos) const
       noexcept;
@@ -111,7 +113,7 @@ private:  //  Methods
                             SI_NetPoint* except = nullptr) const noexcept;
   SI_NetLine* findNetLine(Schematic& schematic, const Point& pos,
                           SI_NetLine* except = nullptr) const noexcept;
-  void updateNetpointPositions(const Point& cursorPos) noexcept;
+  Point updateNetpointPositions(Schematic& schematic, bool snap) noexcept;
   void updateWireModeActionsCheckedState() noexcept;
   Point calcMiddlePointPos(const Point& p1, const Point p2, WireMode mode) const
       noexcept;
@@ -120,6 +122,7 @@ private:  // Data
   Circuit& mCircuit;
   SubState mSubState;  ///< the current substate
   WireMode mWireMode;  ///< the current wire mode
+  Point mCursorPos;  ///< the current cursor position
   SI_NetLineAnchor*
       mFixedStartAnchor;  ///< the fixed anchor (start point of the line)
   SI_NetLine* mPositioningNetLine1;  ///< line between fixed point and p1

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -629,6 +629,21 @@ bool SchematicEditor::graphicsViewEventHandler(QEvent* event) {
       }
       break;
     }
+
+    case QEvent::KeyPress: {
+      auto* e = dynamic_cast<QKeyEvent*>(event);
+      Q_ASSERT(e);
+      mFsm->processKeyPressed(*e);
+      break;
+    }
+
+    case QEvent::KeyRelease: {
+      auto* e = dynamic_cast<QKeyEvent*>(event);
+      Q_ASSERT(e);
+      mFsm->processKeyReleased(*e);
+      break;
+    }
+
     default: { break; }
   }
 


### PR DESCRIPTION
When drawing wires in the schematic editor, snap the wire even to symbol pins or junctions not located on the grid. When pressing the SHIFT key while drawing, snapping is temporarily disabled.

Fixes #371.