### PR TITLE
Board editor: Do not reject placing vias on top of other items

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -286,51 +286,26 @@ bool BoardEditorState_AddVia::fixPosition(Board& board,
       mCurrentViaEditCmd->setPosition(pos, false);
     }
 
-    // Find stuff at the via position
+    // Find stuff at the via position to determine what should be connected.
+    // Note: Do not reject placing the via if there are items of other net
+    // signals at the cursor position. It could be annoying usability if the
+    // tool rejects to place a via. Simply ignore all items of other net
+    // signals here. The DRC will raise an error if the user created a short
+    // circuit with this via.
     NetSignal* netsignal = mCurrentViaToPlace->getNetSegment().getNetSignal();
-    QSet<BI_NetPoint*> otherNetAnchors = {};
-    if (BI_Via* via = findVia(board, pos, {}, {mCurrentViaToPlace})) {
-      if (via->getNetSegment().getNetSignal() != netsignal) {
-        throw RuntimeError(__FILE__, __LINE__,
-                           tr("Via of a different signal already present at "
-                              "target position."));
-      } else {
-        abortCommand(false);
-        return true;
-      }
-    } else if (BI_FootprintPad* pad = findPad(board, pos)) {
-      if (pad->getCompSigInstNetSignal() != netsignal) {
-        throw RuntimeError(__FILE__, __LINE__,
-                           tr("Pad of a different signal already present at "
-                              "target position."));
-      } else {
-        abortCommand(false);
-        return true;
-      }
-    }
-    foreach (BI_NetPoint* netpoint, board.getNetPointsAtScenePos(pos)) {
-      if (netpoint->getNetSegment().getNetSignal() != netsignal) {
-        throw RuntimeError(__FILE__, __LINE__,
-                           tr("Netpoint of a different signal already present "
-                              "at target position."));
-      } else {
-        otherNetAnchors.insert(netpoint);
-      }
-    }
-    foreach (BI_NetLine* netline, board.getNetLinesAtScenePos(pos)) {
-      if (netline->getNetSegment().getNetSignal() != netsignal) {
-        throw RuntimeError(__FILE__, __LINE__,
-                           tr("Netline of a different signal already present "
-                              "at target position."));
-      } else if (!otherNetAnchors.contains(
-                     dynamic_cast<BI_NetPoint*>(&netline->getStartPoint())) &&
-                 !otherNetAnchors.contains(
-                     dynamic_cast<BI_NetPoint*>(&netline->getEndPoint()))) {
-        // TODO(5n8ke) is this the best way to check whtether the NetLine should
-        // be split?
+    QList<BI_NetPoint*> otherNetAnchors =
+        board.getNetPointsAtScenePos(pos, nullptr, {netsignal});
+    foreach (BI_NetLine* netline,
+             board.getNetLinesAtScenePos(pos, nullptr, {netsignal})) {
+      if (!otherNetAnchors.contains(
+              dynamic_cast<BI_NetPoint*>(&netline->getStartPoint())) &&
+          !otherNetAnchors.contains(
+              dynamic_cast<BI_NetPoint*>(&netline->getEndPoint()))) {
+        // TODO(5n8ke) is this the best way to check whtether the NetLine
+        // should be split?
         QScopedPointer<CmdBoardSplitNetLine> cmdSplit(
             new CmdBoardSplitNetLine(*netline, pos));
-        otherNetAnchors.insert(cmdSplit->getSplitPoint());
+        otherNetAnchors.append(cmdSplit->getSplitPoint());
         mContext.undoStack.appendToCmdGroup(cmdSplit.take());
       }
     }

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_addvia.h
@@ -89,9 +89,6 @@ private:  // Methods
   void applySelectedNetSignal() noexcept;
   void updateClosestNetSignal(Board& board, const Point& pos) noexcept;
   NetSignal* getCurrentNetSignal() const noexcept;
-  QSet<NetSignal*> getNetSignalsAtScenePos(Board& board, const Point& pos,
-                                           QSet<BI_Base*> except = {}) const
-      noexcept;
   BI_Via* findVia(Board& board, const Point pos,
                   const QSet<const NetSignal*>& netsignals = {},
                   const QSet<BI_Via*>& except = {}) const noexcept;


### PR DESCRIPTION
In the "add via" tool, do not reject placing the via anymore if there are pads or vias at the cursor position, or traces of other net signals. It could be annoying usability if the tool rejects to place a via in some situations. For example placing a via in a high density area might not be possible without creating short circuits. But often you still want to place the via (temporarily creating a short circuit) and move traces away afterwards. The tool should not reject you from doing this. If you do it and don't realize that you created a short circuit, the DRC will raise an error anyway when running the next time.

In addition, I made another change related to this feature: When placing a via with the "auto net" feature, so far only traces were taken into account to determine the net at the cursor position. Now vias and pads at the cursor position are taken into account as well. This is especially useful when placing a via within a thermal pad.

Fixes #866.