### PR TITLE
Support mirroring alignment of schematic net labels

### DIFF
--- a/libs/librepcb/common/geometry/netlabel.cpp
+++ b/libs/librepcb/common/geometry/netlabel.cpp
@@ -46,15 +46,16 @@ NetLabel::NetLabel(const Uuid& uuid, const NetLabel& other) noexcept
 }
 
 NetLabel::NetLabel(const Uuid& uuid, const Point& position,
-                   const Angle& rotation) noexcept
-  : onEdited(*this), mUuid(uuid), mPosition(position), mRotation(rotation) {
+                   const Angle& rotation, const Alignment& alignment) noexcept
+  : onEdited(*this), mUuid(uuid), mPosition(position), mRotation(rotation), mAlignment(alignment) {
 }
 
 NetLabel::NetLabel(const SExpression& node, const Version& fileFormat)
   : onEdited(*this),
     mUuid(deserialize<Uuid>(node.getChild("@0"), fileFormat)),
     mPosition(node.getChild("position"), fileFormat),
-    mRotation(deserialize<Angle>(node.getChild("rotation/@0"), fileFormat)) {
+    mRotation(deserialize<Angle>(node.getChild("rotation/@0"), fileFormat)),
+    mAlignment(node.getChild("alignment"), fileFormat) {
 }
 
 NetLabel::~NetLabel() noexcept {
@@ -94,6 +95,16 @@ bool NetLabel::setRotation(const Angle& rotation) noexcept {
   return true;
 }
 
+bool NetLabel::setAlignment(const Alignment &alignment) noexcept {
+  if (alignment == mAlignment) {
+    return false;
+  }
+
+  mAlignment = alignment;
+  onEdited.notify(Event::AlignmentChanged);
+  return true;
+}
+
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
@@ -102,6 +113,7 @@ void NetLabel::serialize(SExpression& root) const {
   root.appendChild(mUuid);
   root.appendChild(mPosition.serializeToDomElement("position"), true);
   root.appendChild("rotation", mRotation, false);
+  root.appendChild(mAlignment.serializeToDomElement("alignment"), false);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/geometry/netlabel.cpp
+++ b/libs/librepcb/common/geometry/netlabel.cpp
@@ -37,7 +37,8 @@ NetLabel::NetLabel(const NetLabel& other) noexcept
   : onEdited(*this),
     mUuid(other.mUuid),
     mPosition(other.mPosition),
-    mRotation(other.mRotation) {
+    mRotation(other.mRotation),
+    mAlignment(other.mAlignment) {
 }
 
 NetLabel::NetLabel(const Uuid& uuid, const NetLabel& other) noexcept
@@ -47,7 +48,11 @@ NetLabel::NetLabel(const Uuid& uuid, const NetLabel& other) noexcept
 
 NetLabel::NetLabel(const Uuid& uuid, const Point& position,
                    const Angle& rotation, const Alignment& alignment) noexcept
-  : onEdited(*this), mUuid(uuid), mPosition(position), mRotation(rotation), mAlignment(alignment) {
+  : onEdited(*this),
+    mUuid(uuid),
+    mPosition(position),
+    mRotation(rotation),
+    mAlignment(alignment) {
 }
 
 NetLabel::NetLabel(const SExpression& node, const Version& fileFormat)
@@ -55,7 +60,12 @@ NetLabel::NetLabel(const SExpression& node, const Version& fileFormat)
     mUuid(deserialize<Uuid>(node.getChild("@0"), fileFormat)),
     mPosition(node.getChild("position"), fileFormat),
     mRotation(deserialize<Angle>(node.getChild("rotation/@0"), fileFormat)),
-    mAlignment(node.getChild("alignment"), fileFormat) {
+    mAlignment() {
+  auto parsedAlignment = node.tryGetChild("alignment");
+  if (parsedAlignment) {
+    Alignment tempAligment(*parsedAlignment, fileFormat);
+    mAlignment = tempAligment;
+  }
 }
 
 NetLabel::~NetLabel() noexcept {
@@ -95,7 +105,7 @@ bool NetLabel::setRotation(const Angle& rotation) noexcept {
   return true;
 }
 
-bool NetLabel::setAlignment(const Alignment &alignment) noexcept {
+bool NetLabel::setAlignment(const Alignment& alignment) noexcept {
   if (alignment == mAlignment) {
     return false;
   }
@@ -124,6 +134,7 @@ bool NetLabel::operator==(const NetLabel& rhs) const noexcept {
   if (mUuid != rhs.mUuid) return false;
   if (mPosition != rhs.mPosition) return false;
   if (mRotation != rhs.mRotation) return false;
+  if (mAlignment != rhs.mAlignment) return false;
   return true;
 }
 
@@ -131,6 +142,7 @@ NetLabel& NetLabel::operator=(const NetLabel& rhs) noexcept {
   setUuid(rhs.mUuid);
   setPosition(rhs.mPosition);
   setRotation(rhs.mRotation);
+  setAlignment(rhs.mAlignment);
   return *this;
 }
 

--- a/libs/librepcb/common/geometry/netlabel.cpp
+++ b/libs/librepcb/common/geometry/netlabel.cpp
@@ -24,6 +24,8 @@
 
 #include <QtCore>
 
+#include <version.h>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -61,9 +63,8 @@ NetLabel::NetLabel(const SExpression& node, const Version& fileFormat)
     mPosition(node.getChild("position"), fileFormat),
     mRotation(deserialize<Angle>(node.getChild("rotation/@0"), fileFormat)),
     mAlignment() {
-  auto parsedAlignment = node.tryGetChild("alignment");
-  if (parsedAlignment) {
-    Alignment tempAligment(*parsedAlignment, fileFormat);
+  if (fileFormat >= Version::fromString("0.2")) {
+    Alignment tempAligment(node.getChild("alignment"), fileFormat);
     mAlignment = tempAligment;
   }
 }

--- a/libs/librepcb/common/geometry/netlabel.cpp
+++ b/libs/librepcb/common/geometry/netlabel.cpp
@@ -63,7 +63,7 @@ NetLabel::NetLabel(const SExpression& node, const Version& fileFormat)
     mPosition(node.getChild("position"), fileFormat),
     mRotation(deserialize<Angle>(node.getChild("rotation/@0"), fileFormat)),
     mMirrored(false) {
-  if (fileFormat >= Version::fromString("0.2.1")) {
+  if (fileFormat >= Version::fromString("0.2")) {
     mMirrored = deserialize<bool>(node.getChild("mirror/@0"), fileFormat);
   }
 }

--- a/libs/librepcb/common/geometry/netlabel.h
+++ b/libs/librepcb/common/geometry/netlabel.h
@@ -23,12 +23,12 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../alignment.h"
 #include "../fileio/cmd/cmdlistelementinsert.h"
 #include "../fileio/cmd/cmdlistelementremove.h"
 #include "../fileio/cmd/cmdlistelementsswap.h"
 #include "../fileio/serializableobjectlist.h"
 #include "../units/all_length_units.h"
-#include "../alignment.h"
 
 #include <QtCore>
 
@@ -65,8 +65,8 @@ public:
   NetLabel() = delete;
   NetLabel(const NetLabel& other) noexcept;
   NetLabel(const Uuid& uuid, const NetLabel& other) noexcept;
-  NetLabel(const Uuid& uuid, const Point& position,
-           const Angle& rotation, const Alignment& alignment) noexcept;
+  NetLabel(const Uuid& uuid, const Point& position, const Angle& rotation,
+           const Alignment& alignment) noexcept;
   NetLabel(const SExpression& node, const Version& fileFormat);
   ~NetLabel() noexcept;
 

--- a/libs/librepcb/common/geometry/netlabel.h
+++ b/libs/librepcb/common/geometry/netlabel.h
@@ -23,7 +23,6 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../alignment.h"
 #include "../fileio/cmd/cmdlistelementinsert.h"
 #include "../fileio/cmd/cmdlistelementremove.h"
 #include "../fileio/cmd/cmdlistelementsswap.h"
@@ -56,7 +55,7 @@ public:
     UuidChanged,
     PositionChanged,
     RotationChanged,
-    AlignmentChanged,
+    MirroredChanged,
   };
   Signal<NetLabel, Event> onEdited;
   typedef Slot<NetLabel, Event> OnEditedSlot;
@@ -66,7 +65,7 @@ public:
   NetLabel(const NetLabel& other) noexcept;
   NetLabel(const Uuid& uuid, const NetLabel& other) noexcept;
   NetLabel(const Uuid& uuid, const Point& position, const Angle& rotation,
-           const Alignment& alignment) noexcept;
+           bool mirrored) noexcept;
   NetLabel(const SExpression& node, const Version& fileFormat);
   ~NetLabel() noexcept;
 
@@ -74,13 +73,13 @@ public:
   const Uuid& getUuid() const noexcept { return mUuid; }
   const Point& getPosition() const noexcept { return mPosition; }
   const Angle& getRotation() const noexcept { return mRotation; }
-  const Alignment& getAlignment() const noexcept { return mAlignment; }
+  bool getMirrored() const noexcept { return mMirrored; }
 
   // Setters
   bool setUuid(const Uuid& uuid) noexcept;
   bool setPosition(const Point& position) noexcept;
   bool setRotation(const Angle& rotation) noexcept;
-  bool setAlignment(const Alignment& alignment) noexcept;
+  bool setMirrored(const bool mirrored) noexcept;
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -96,7 +95,7 @@ private:  // Data
   Uuid mUuid;
   Point mPosition;
   Angle mRotation;
-  Alignment mAlignment;
+  bool mMirrored;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/geometry/netlabel.h
+++ b/libs/librepcb/common/geometry/netlabel.h
@@ -28,6 +28,7 @@
 #include "../fileio/cmd/cmdlistelementsswap.h"
 #include "../fileio/serializableobjectlist.h"
 #include "../units/all_length_units.h"
+#include "../alignment.h"
 
 #include <QtCore>
 
@@ -55,6 +56,7 @@ public:
     UuidChanged,
     PositionChanged,
     RotationChanged,
+    AlignmentChanged,
   };
   Signal<NetLabel, Event> onEdited;
   typedef Slot<NetLabel, Event> OnEditedSlot;
@@ -64,7 +66,7 @@ public:
   NetLabel(const NetLabel& other) noexcept;
   NetLabel(const Uuid& uuid, const NetLabel& other) noexcept;
   NetLabel(const Uuid& uuid, const Point& position,
-           const Angle& rotation) noexcept;
+           const Angle& rotation, const Alignment& alignment) noexcept;
   NetLabel(const SExpression& node, const Version& fileFormat);
   ~NetLabel() noexcept;
 
@@ -72,11 +74,13 @@ public:
   const Uuid& getUuid() const noexcept { return mUuid; }
   const Point& getPosition() const noexcept { return mPosition; }
   const Angle& getRotation() const noexcept { return mRotation; }
+  const Alignment& getAlignment() const noexcept { return mAlignment; }
 
   // Setters
   bool setUuid(const Uuid& uuid) noexcept;
   bool setPosition(const Point& position) noexcept;
   bool setRotation(const Angle& rotation) noexcept;
+  bool setAlignment(const Alignment& alignment) noexcept;
 
   /// @copydoc librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -92,6 +96,7 @@ private:  // Data
   Uuid mUuid;
   Point mPosition;
   Angle mRotation;
+  Alignment mAlignment;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
@@ -40,11 +40,13 @@ namespace project {
 
 CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(SI_NetSegment& segment,
                                                  const Point& position,
-                                                 const Angle& rotation) noexcept
+                                                 const Angle& rotation,
+                                                 const Alignment& alignment) noexcept
   : UndoCommand(tr("Add netlabel")),
     mNetSegment(segment),
     mPosition(position),
     mRotation(rotation),
+    mAlignment(alignment),
     mNetLabel(nullptr) {
 }
 
@@ -56,7 +58,7 @@ CmdSchematicNetLabelAdd::~CmdSchematicNetLabelAdd() noexcept {
  ******************************************************************************/
 
 bool CmdSchematicNetLabelAdd::performExecute() {
-  mNetLabel = new SI_NetLabel(mNetSegment, mPosition, mRotation);  // can throw
+  mNetLabel = new SI_NetLabel(mNetSegment, mPosition, mRotation, mAlignment);  // can throw
 
   performRedo();  // can throw
 

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
@@ -38,10 +38,9 @@ namespace project {
  *  Constructors / Destructor
  ******************************************************************************/
 
-CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(SI_NetSegment& segment,
-                                                 const Point& position,
-                                                 const Angle& rotation,
-                                                 const Alignment& alignment) noexcept
+CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(
+    SI_NetSegment& segment, const Point& position, const Angle& rotation,
+    const Alignment& alignment) noexcept
   : UndoCommand(tr("Add netlabel")),
     mNetSegment(segment),
     mPosition(position),
@@ -58,7 +57,8 @@ CmdSchematicNetLabelAdd::~CmdSchematicNetLabelAdd() noexcept {
  ******************************************************************************/
 
 bool CmdSchematicNetLabelAdd::performExecute() {
-  mNetLabel = new SI_NetLabel(mNetSegment, mPosition, mRotation, mAlignment);  // can throw
+  mNetLabel = new SI_NetLabel(mNetSegment, mPosition, mRotation,
+                              mAlignment);  // can throw
 
   performRedo();  // can throw
 

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.cpp
@@ -38,14 +38,15 @@ namespace project {
  *  Constructors / Destructor
  ******************************************************************************/
 
-CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(
-    SI_NetSegment& segment, const Point& position, const Angle& rotation,
-    const Alignment& alignment) noexcept
+CmdSchematicNetLabelAdd::CmdSchematicNetLabelAdd(SI_NetSegment& segment,
+                                                 const Point& position,
+                                                 const Angle& rotation,
+                                                 const bool mirrored) noexcept
   : UndoCommand(tr("Add netlabel")),
     mNetSegment(segment),
     mPosition(position),
     mRotation(rotation),
-    mAlignment(alignment),
+    mMirrored(mirrored),
     mNetLabel(nullptr) {
 }
 
@@ -58,7 +59,7 @@ CmdSchematicNetLabelAdd::~CmdSchematicNetLabelAdd() noexcept {
 
 bool CmdSchematicNetLabelAdd::performExecute() {
   mNetLabel = new SI_NetLabel(mNetSegment, mPosition, mRotation,
-                              mAlignment);  // can throw
+                              mMirrored);  // can throw
 
   performRedo();  // can throw
 

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/common/alignment.h>
 #include <librepcb/common/undocommand.h>
 #include <librepcb/common/units/all_length_units.h>
 
@@ -50,7 +51,7 @@ class CmdSchematicNetLabelAdd final : public UndoCommand {
 public:
   // Constructors / Destructor
   CmdSchematicNetLabelAdd(SI_NetSegment& segment, const Point& position,
-                          const Angle& rotation) noexcept;
+                          const Angle& rotation, const Alignment& alignment) noexcept;
   ~CmdSchematicNetLabelAdd() noexcept;
 
   // Getters
@@ -73,6 +74,7 @@ private:
   SI_NetSegment& mNetSegment;
   Point mPosition;
   Angle mRotation;
+  Alignment mAlignment;
   SI_NetLabel* mNetLabel;
 };
 

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
@@ -51,7 +51,8 @@ class CmdSchematicNetLabelAdd final : public UndoCommand {
 public:
   // Constructors / Destructor
   CmdSchematicNetLabelAdd(SI_NetSegment& segment, const Point& position,
-                          const Angle& rotation, const Alignment& alignment) noexcept;
+                          const Angle& rotation,
+                          const Alignment& alignment) noexcept;
   ~CmdSchematicNetLabelAdd() noexcept;
 
   // Getters

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeladd.h
@@ -23,7 +23,6 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/common/alignment.h>
 #include <librepcb/common/undocommand.h>
 #include <librepcb/common/units/all_length_units.h>
 
@@ -51,8 +50,7 @@ class CmdSchematicNetLabelAdd final : public UndoCommand {
 public:
   // Constructors / Destructor
   CmdSchematicNetLabelAdd(SI_NetSegment& segment, const Point& position,
-                          const Angle& rotation,
-                          const Alignment& alignment) noexcept;
+                          const Angle& rotation, const bool mirrored) noexcept;
   ~CmdSchematicNetLabelAdd() noexcept;
 
   // Getters
@@ -75,7 +73,7 @@ private:
   SI_NetSegment& mNetSegment;
   Point mPosition;
   Angle mRotation;
-  Alignment mAlignment;
+  bool mMirrored;
   SI_NetLabel* mNetLabel;
 };
 

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
@@ -40,8 +40,8 @@ CmdSchematicNetLabelEdit::CmdSchematicNetLabelEdit(
     SI_NetLabel& netlabel) noexcept
   : UndoCommand(tr("Edit netlabel")),
     mNetLabel(netlabel),
-    mOldAlignment(netlabel.getAlignment()),
-    mNewAlignment(mOldAlignment),
+    mOldMirrored(netlabel.getMirrored()),
+    mNewMirrored(mOldMirrored),
     mOldPos(netlabel.getPosition()),
     mNewPos(mOldPos),
     mOldRotation(netlabel.getRotation()),
@@ -51,6 +51,7 @@ CmdSchematicNetLabelEdit::CmdSchematicNetLabelEdit(
 CmdSchematicNetLabelEdit::~CmdSchematicNetLabelEdit() noexcept {
   if (!wasEverExecuted()) {
     // revert temporary changes
+    mNetLabel.setMirrored(mOldMirrored);
     mNetLabel.setPosition(mOldPos);
     mNetLabel.setRotation(mOldRotation);
   }
@@ -94,8 +95,8 @@ void CmdSchematicNetLabelEdit::rotate(const Angle& angle, const Point& center,
 
 void CmdSchematicNetLabelEdit::mirror(bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewAlignment.mirrorH();
-  if (immediate) mNetLabel.setAlignment(mNewAlignment);
+  mNewMirrored = !mNewMirrored;
+  if (immediate) mNetLabel.setMirrored(mNewMirrored);
 }
 
 /*******************************************************************************
@@ -111,13 +112,13 @@ bool CmdSchematicNetLabelEdit::performExecute() {
 void CmdSchematicNetLabelEdit::performUndo() {
   mNetLabel.setPosition(mOldPos);
   mNetLabel.setRotation(mOldRotation);
-  mNetLabel.setAlignment(mOldAlignment);
+  mNetLabel.setMirrored(mOldMirrored);
 }
 
 void CmdSchematicNetLabelEdit::performRedo() {
   mNetLabel.setPosition(mNewPos);
   mNetLabel.setRotation(mNewRotation);
-  mNetLabel.setAlignment(mNewAlignment);
+  mNetLabel.setMirrored(mNewMirrored);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
@@ -92,11 +92,10 @@ void CmdSchematicNetLabelEdit::rotate(const Angle& angle, const Point& center,
   }
 }
 
-void CmdSchematicNetLabelEdit::mirror(bool immediate) noexcept{
+void CmdSchematicNetLabelEdit::mirror(bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewAlignment.mirrorH();
-  if (immediate)
-      mNetLabel.setAlignment(mNewAlignment);
+  if (immediate) mNetLabel.setAlignment(mNewAlignment);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.cpp
@@ -40,6 +40,8 @@ CmdSchematicNetLabelEdit::CmdSchematicNetLabelEdit(
     SI_NetLabel& netlabel) noexcept
   : UndoCommand(tr("Edit netlabel")),
     mNetLabel(netlabel),
+    mOldAlignment(netlabel.getAlignment()),
+    mNewAlignment(mOldAlignment),
     mOldPos(netlabel.getPosition()),
     mNewPos(mOldPos),
     mOldRotation(netlabel.getRotation()),
@@ -90,6 +92,13 @@ void CmdSchematicNetLabelEdit::rotate(const Angle& angle, const Point& center,
   }
 }
 
+void CmdSchematicNetLabelEdit::mirror(bool immediate) noexcept{
+  Q_ASSERT(!wasEverExecuted());
+  mNewAlignment.mirrorH();
+  if (immediate)
+      mNetLabel.setAlignment(mNewAlignment);
+}
+
 /*******************************************************************************
  *  Inherited from UndoCommand
  ******************************************************************************/
@@ -103,11 +112,13 @@ bool CmdSchematicNetLabelEdit::performExecute() {
 void CmdSchematicNetLabelEdit::performUndo() {
   mNetLabel.setPosition(mOldPos);
   mNetLabel.setRotation(mOldRotation);
+  mNetLabel.setAlignment(mOldAlignment);
 }
 
 void CmdSchematicNetLabelEdit::performRedo() {
   mNetLabel.setPosition(mNewPos);
   mNetLabel.setRotation(mNewRotation);
+  mNetLabel.setAlignment(mNewAlignment);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
@@ -23,7 +23,6 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/common/alignment.h>
 #include <librepcb/common/undocommand.h>
 #include <librepcb/common/units/all_length_units.h>
 
@@ -76,8 +75,8 @@ private:
   SI_NetLabel& mNetLabel;
 
   // Misc
-  Alignment mOldAlignment;
-  Alignment mNewAlignment;
+  bool mOldMirrored;
+  bool mNewMirrored;
   Point mOldPos;
   Point mNewPos;
   Angle mOldRotation;

--- a/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
+++ b/libs/librepcb/project/schematics/cmd/cmdschematicnetlabeledit.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/common/alignment.h>
 #include <librepcb/common/undocommand.h>
 #include <librepcb/common/units/all_length_units.h>
 
@@ -55,6 +56,7 @@ public:
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
+  void mirror(bool immediate) noexcept;
 
 private:
   // Private Methods
@@ -74,6 +76,8 @@ private:
   SI_NetLabel& mNetLabel;
 
   // Misc
+  Alignment mOldAlignment;
+  Alignment mNewAlignment;
   Point mOldPos;
   Point mNewPos;
   Angle mOldRotation;

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -101,6 +101,9 @@ void SGI_NetLabel::updateCacheAndRepaint() noexcept {
   QRectF rect =
       QRectF(0, 0, mStaticText.size().width(), -mStaticText.size().height())
           .normalized();
+
+  if (mNetLabel.getMirrored()) rect.moveLeft(-mStaticText.size().width());
+
   qreal len = sOriginCrossLines[0].length();
   mBoundingRect =
       rect.united(QRectF(-len / 2, -len / 2, len, len)).normalized();

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -87,7 +87,13 @@ void SGI_NetLabel::updateCacheAndRepaint() noexcept {
 
   mStaticText.setText(*mNetLabel.getNetSignalOfNetSegment().getName());
   mStaticText.prepare(QTransform(), mFont);
-  mTextOrigin.setX(mRotate180 ? -mStaticText.size().width() : 0);
+  // mTextOrigin.setX(mRotate180 ? -mStaticText.size().width() : 0);
+  if(mNetLabel.getAlignment().getH() == HAlign::right()){
+      mTextOrigin.setX(-mStaticText.size().width());
+  }
+  else{
+      mTextOrigin.setX(0);
+  }
   mTextOrigin.setY(mRotate180 ? 0 : -mStaticText.size().height());
   mStaticText.prepare(QTransform()
                           .rotate(mRotate180 ? 180 : 0)

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -87,7 +87,7 @@ void SGI_NetLabel::updateCacheAndRepaint() noexcept {
 
   mStaticText.setText(*mNetLabel.getNetSignalOfNetSegment().getName());
   mStaticText.prepare(QTransform(), mFont);
-  if ((mNetLabel.getAlignment().getH() == HAlign::right()) ^ mRotate180) {
+  if (mNetLabel.getMirrored() ^ mRotate180) {
     mTextOrigin.setX(-mStaticText.size().width());
   } else {
     mTextOrigin.setX(0);

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -87,7 +87,6 @@ void SGI_NetLabel::updateCacheAndRepaint() noexcept {
 
   mStaticText.setText(*mNetLabel.getNetSignalOfNetSegment().getName());
   mStaticText.prepare(QTransform(), mFont);
-  // mTextOrigin.setX(mRotate180 ? -mStaticText.size().width() : 0);
   if ((mNetLabel.getAlignment().getH() == HAlign::right()) ^ mRotate180) {
     mTextOrigin.setX(-mStaticText.size().width());
   } else {

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.cpp
@@ -88,11 +88,10 @@ void SGI_NetLabel::updateCacheAndRepaint() noexcept {
   mStaticText.setText(*mNetLabel.getNetSignalOfNetSegment().getName());
   mStaticText.prepare(QTransform(), mFont);
   // mTextOrigin.setX(mRotate180 ? -mStaticText.size().width() : 0);
-  if(mNetLabel.getAlignment().getH() == HAlign::right()){
-      mTextOrigin.setX(-mStaticText.size().width());
-  }
-  else{
-      mTextOrigin.setX(0);
+  if ((mNetLabel.getAlignment().getH() == HAlign::right()) ^ mRotate180) {
+    mTextOrigin.setX(-mStaticText.size().width());
+  } else {
+    mTextOrigin.setX(0);
   }
   mTextOrigin.setY(mRotate180 ? 0 : -mStaticText.size().height());
   mStaticText.prepare(QTransform()

--- a/libs/librepcb/project/schematics/items/si_netlabel.cpp
+++ b/libs/librepcb/project/schematics/items/si_netlabel.cpp
@@ -52,10 +52,10 @@ SI_NetLabel::SI_NetLabel(SI_NetSegment& segment, const SExpression& node,
 }
 
 SI_NetLabel::SI_NetLabel(SI_NetSegment& segment, const Point& position,
-                         const Angle& rotation, const Alignment& alignment)
+                         const Angle& rotation, const bool mirrored)
   : SI_Base(segment.getSchematic()),
     mNetSegment(segment),
-    mNetLabel(Uuid::createRandom(), position, rotation, alignment) {
+    mNetLabel(Uuid::createRandom(), position, rotation, mirrored) {
   init();
 }
 
@@ -101,8 +101,8 @@ void SI_NetLabel::setRotation(const Angle& rotation) noexcept {
   }
 }
 
-void SI_NetLabel::setAlignment(const Alignment& alignment) noexcept {
-  if (mNetLabel.setAlignment(alignment)) {
+void SI_NetLabel::setMirrored(const bool mirrored) noexcept {
+  if (mNetLabel.setMirrored(mirrored)) {
     mGraphicsItem->updateCacheAndRepaint();
   }
 }

--- a/libs/librepcb/project/schematics/items/si_netlabel.cpp
+++ b/libs/librepcb/project/schematics/items/si_netlabel.cpp
@@ -101,7 +101,7 @@ void SI_NetLabel::setRotation(const Angle& rotation) noexcept {
   }
 }
 
-void SI_NetLabel::setAlignment(const Alignment &alignment) noexcept {
+void SI_NetLabel::setAlignment(const Alignment& alignment) noexcept {
   if (mNetLabel.setAlignment(alignment)) {
     mGraphicsItem->updateCacheAndRepaint();
   }

--- a/libs/librepcb/project/schematics/items/si_netlabel.cpp
+++ b/libs/librepcb/project/schematics/items/si_netlabel.cpp
@@ -52,10 +52,10 @@ SI_NetLabel::SI_NetLabel(SI_NetSegment& segment, const SExpression& node,
 }
 
 SI_NetLabel::SI_NetLabel(SI_NetSegment& segment, const Point& position,
-                         const Angle& rotation)
+                         const Angle& rotation, const Alignment& alignment)
   : SI_Base(segment.getSchematic()),
     mNetSegment(segment),
-    mNetLabel(Uuid::createRandom(), position, rotation) {
+    mNetLabel(Uuid::createRandom(), position, rotation, alignment) {
   init();
 }
 
@@ -98,6 +98,12 @@ void SI_NetLabel::setRotation(const Angle& rotation) noexcept {
     mGraphicsItem->setRotation(-rotation.toDeg());
     mGraphicsItem->updateCacheAndRepaint();
     updateAnchor();
+  }
+}
+
+void SI_NetLabel::setAlignment(const Alignment &alignment) noexcept {
+  if (mNetLabel.setAlignment(alignment)) {
+    mGraphicsItem->updateCacheAndRepaint();
   }
 }
 

--- a/libs/librepcb/project/schematics/items/si_netlabel.h
+++ b/libs/librepcb/project/schematics/items/si_netlabel.h
@@ -58,15 +58,13 @@ public:
   SI_NetLabel(SI_NetSegment& segment, const SExpression& node,
               const Version& fileFormat);
   explicit SI_NetLabel(SI_NetSegment& segment, const Point& position,
-                       const Angle& rotation, const Alignment& alignment);
+                       const Angle& rotation, const bool mirrored);
   ~SI_NetLabel() noexcept;
 
   // Getters
   const Uuid& getUuid() const noexcept { return mNetLabel.getUuid(); }
   const Angle& getRotation() const noexcept { return mNetLabel.getRotation(); }
-  const Alignment& getAlignment() const noexcept {
-    return mNetLabel.getAlignment();
-  }
+  bool getMirrored() const noexcept { return mNetLabel.getMirrored(); }
   const NetLabel& getNetLabel() const noexcept { return mNetLabel; }
   SI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
   NetSignal& getNetSignalOfNetSegment() const noexcept;
@@ -75,7 +73,7 @@ public:
   // Setters
   void setPosition(const Point& position) noexcept;
   void setRotation(const Angle& rotation) noexcept;
-  void setAlignment(const Alignment& alignment) noexcept;
+  void setMirrored(const bool mirrored) noexcept;
 
   // General Methods
   void updateAnchor() noexcept;

--- a/libs/librepcb/project/schematics/items/si_netlabel.h
+++ b/libs/librepcb/project/schematics/items/si_netlabel.h
@@ -58,12 +58,13 @@ public:
   SI_NetLabel(SI_NetSegment& segment, const SExpression& node,
               const Version& fileFormat);
   explicit SI_NetLabel(SI_NetSegment& segment, const Point& position,
-                       const Angle& rotation);
+                       const Angle& rotation, const Alignment& alignment);
   ~SI_NetLabel() noexcept;
 
   // Getters
   const Uuid& getUuid() const noexcept { return mNetLabel.getUuid(); }
   const Angle& getRotation() const noexcept { return mNetLabel.getRotation(); }
+  const Alignment& getAlignment() const noexcept { return mNetLabel.getAlignment(); }
   const NetLabel& getNetLabel() const noexcept { return mNetLabel; }
   SI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
   NetSignal& getNetSignalOfNetSegment() const noexcept;
@@ -72,6 +73,7 @@ public:
   // Setters
   void setPosition(const Point& position) noexcept;
   void setRotation(const Angle& rotation) noexcept;
+  void setAlignment(const Alignment& alignment) noexcept;
 
   // General Methods
   void updateAnchor() noexcept;

--- a/libs/librepcb/project/schematics/items/si_netlabel.h
+++ b/libs/librepcb/project/schematics/items/si_netlabel.h
@@ -64,7 +64,9 @@ public:
   // Getters
   const Uuid& getUuid() const noexcept { return mNetLabel.getUuid(); }
   const Angle& getRotation() const noexcept { return mNetLabel.getRotation(); }
-  const Alignment& getAlignment() const noexcept { return mNetLabel.getAlignment(); }
+  const Alignment& getAlignment() const noexcept {
+    return mNetLabel.getAlignment();
+  }
   const NetLabel& getNetLabel() const noexcept { return mNetLabel; }
   SI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
   NetSignal& getNetSignalOfNetSegment() const noexcept;

--- a/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
@@ -104,7 +104,7 @@ bool CmdCombineSchematicNetSegments::performExecute() {
   // copy net labels
   foreach (SI_NetLabel* netlabel, mOldSegment.getNetLabels()) {
     QScopedPointer<CmdSchematicNetLabelAdd> cmd(new CmdSchematicNetLabelAdd(
-        mNewSegment, netlabel->getPosition(), netlabel->getRotation()));
+        mNewSegment, netlabel->getPosition(), netlabel->getRotation(), netlabel->getAlignment()));
     execNewChildCmd(cmd.take());  // can throw
   }
 

--- a/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
@@ -104,7 +104,8 @@ bool CmdCombineSchematicNetSegments::performExecute() {
   // copy net labels
   foreach (SI_NetLabel* netlabel, mOldSegment.getNetLabels()) {
     QScopedPointer<CmdSchematicNetLabelAdd> cmd(new CmdSchematicNetLabelAdd(
-        mNewSegment, netlabel->getPosition(), netlabel->getRotation(), netlabel->getAlignment()));
+        mNewSegment, netlabel->getPosition(), netlabel->getRotation(),
+        netlabel->getAlignment()));
     execNewChildCmd(cmd.take());  // can throw
   }
 

--- a/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdcombineschematicnetsegments.cpp
@@ -105,7 +105,7 @@ bool CmdCombineSchematicNetSegments::performExecute() {
   foreach (SI_NetLabel* netlabel, mOldSegment.getNetLabels()) {
     QScopedPointer<CmdSchematicNetLabelAdd> cmd(new CmdSchematicNetLabelAdd(
         mNewSegment, netlabel->getPosition(), netlabel->getRotation(),
-        netlabel->getAlignment()));
+        netlabel->getMirrored()));
     execNewChildCmd(cmd.take());  // can throw
   }
 

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
@@ -127,18 +127,9 @@ bool CmdMirrorSelectedSchematicItems::performExecute() {
   foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
     Point newpos = netlabel->getPosition().mirrored(mOrientation, center);
 
-    // Compensate offset only for horizontal positioning
-    Angle labelRotation = netlabel->getRotation().mappedTo0_360deg();
-    if (labelRotation == Angle::deg0() || labelRotation == Angle::deg180()) {
-      // Since there is no right alignment (yet), coordinates need to be
-      // re-adjusted to accommodate left shift.
-      // New position = mirrored old position - label width
-      newpos.setX(newpos.getX() - netlabel->getApproximateWidth());
-      newpos.mapToGrid(mSchematic.getGridProperties().getInterval());
-    }
-
     CmdSchematicNetLabelEdit* cmd = new CmdSchematicNetLabelEdit(*netlabel);
     cmd->setPosition(newpos, false);
+    cmd->mirror(false);
     appendChild(cmd);
   }
   foreach (SI_Polygon* polygon, query->getPolygons()) {

--- a/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdmirrorselectedschematicitems.cpp
@@ -126,10 +126,14 @@ bool CmdMirrorSelectedSchematicItems::performExecute() {
   }
   foreach (SI_NetLabel* netlabel, query->getNetLabels()) {
     Point newpos = netlabel->getPosition().mirrored(mOrientation, center);
+    Angle rotation = netlabel->getRotation().mappedTo0_360deg();
 
     CmdSchematicNetLabelEdit* cmd = new CmdSchematicNetLabelEdit(*netlabel);
     cmd->setPosition(newpos, false);
     cmd->mirror(false);
+    if ((rotation == Angle::deg90()) || (rotation == Angle::deg270())) {
+      cmd->rotate(Angle::deg180(), newpos, false);
+    }
     appendChild(cmd);
   }
   foreach (SI_Polygon* polygon, query->getPolygons()) {

--- a/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
@@ -254,8 +254,9 @@ bool CmdPasteSchematicItems::performExecute() {
 
     // Add netlabels
     for (const NetLabel& nl : seg.labels) {
-      CmdSchematicNetLabelAdd* cmd = new CmdSchematicNetLabelAdd(
-          *copy, nl.getPosition() + mPosOffset, nl.getRotation(), nl.getAlignment());
+      CmdSchematicNetLabelAdd* cmd =
+          new CmdSchematicNetLabelAdd(*copy, nl.getPosition() + mPosOffset,
+                                      nl.getRotation(), nl.getAlignment());
       execNewChildCmd(cmd);
       cmd->getNetLabel()->setSelected(true);
       if (!forcedNetName) {

--- a/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
@@ -255,7 +255,7 @@ bool CmdPasteSchematicItems::performExecute() {
     // Add netlabels
     for (const NetLabel& nl : seg.labels) {
       CmdSchematicNetLabelAdd* cmd = new CmdSchematicNetLabelAdd(
-          *copy, nl.getPosition() + mPosOffset, nl.getRotation());
+          *copy, nl.getPosition() + mPosOffset, nl.getRotation(), nl.getAlignment());
       execNewChildCmd(cmd);
       cmd->getNetLabel()->setSelected(true);
       if (!forcedNetName) {

--- a/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdpasteschematicitems.cpp
@@ -256,7 +256,7 @@ bool CmdPasteSchematicItems::performExecute() {
     for (const NetLabel& nl : seg.labels) {
       CmdSchematicNetLabelAdd* cmd =
           new CmdSchematicNetLabelAdd(*copy, nl.getPosition() + mPosOffset,
-                                      nl.getRotation(), nl.getAlignment());
+                                      nl.getRotation(), nl.getMirrored());
       execNewChildCmd(cmd);
       cmd->getNetLabel()->setSelected(true);
       if (!forcedNetName) {

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
@@ -245,7 +245,7 @@ void CmdRemoveSelectedSchematicItems::removeNetSegmentItems(
     // Add new netlabels
     for (const NetLabel& netlabel : segment.netlabels) {
       execNewChildCmd(new CmdSchematicNetLabelAdd(
-          *newNetSegment, netlabel.getPosition(), netlabel.getRotation()));
+          *newNetSegment, netlabel.getPosition(), netlabel.getRotation(), netlabel.getAlignment()));
     }
   }
 

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
@@ -246,7 +246,7 @@ void CmdRemoveSelectedSchematicItems::removeNetSegmentItems(
     for (const NetLabel& netlabel : segment.netlabels) {
       execNewChildCmd(new CmdSchematicNetLabelAdd(
           *newNetSegment, netlabel.getPosition(), netlabel.getRotation(),
-          netlabel.getAlignment()));
+          netlabel.getMirrored()));
     }
   }
 

--- a/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/projecteditor/cmd/cmdremoveselectedschematicitems.cpp
@@ -245,7 +245,8 @@ void CmdRemoveSelectedSchematicItems::removeNetSegmentItems(
     // Add new netlabels
     for (const NetLabel& netlabel : segment.netlabels) {
       execNewChildCmd(new CmdSchematicNetLabelAdd(
-          *newNetSegment, netlabel.getPosition(), netlabel.getRotation(), netlabel.getAlignment()));
+          *newNetSegment, netlabel.getPosition(), netlabel.getRotation(),
+          netlabel.getAlignment()));
     }
   }
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
@@ -171,8 +171,7 @@ bool SchematicEditorState_AddNetLabel::addLabel(Schematic& schematic,
     mContext.undoStack.beginCmdGroup(tr("Add net label to schematic"));
     mUndoCmdActive = true;
     CmdSchematicNetLabelAdd* cmdAdd = new CmdSchematicNetLabelAdd(
-        netsegment, pos.mappedToGrid(getGridInterval()), Angle::deg0(),
-        Alignment());
+        netsegment, pos.mappedToGrid(getGridInterval()), Angle::deg0(), false);
     mContext.undoStack.appendToCmdGroup(cmdAdd);
     mCurrentNetLabel = cmdAdd->getNetLabel();
     mEditCmd = new CmdSchematicNetLabelEdit(*mCurrentNetLabel);

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
@@ -171,7 +171,7 @@ bool SchematicEditorState_AddNetLabel::addLabel(Schematic& schematic,
     mContext.undoStack.beginCmdGroup(tr("Add net label to schematic"));
     mUndoCmdActive = true;
     CmdSchematicNetLabelAdd* cmdAdd = new CmdSchematicNetLabelAdd(
-        netsegment, pos.mappedToGrid(getGridInterval()), Angle::deg0());
+        netsegment, pos.mappedToGrid(getGridInterval()), Angle::deg0(), Alignment());
     mContext.undoStack.appendToCmdGroup(cmdAdd);
     mCurrentNetLabel = cmdAdd->getNetLabel();
     mEditCmd = new CmdSchematicNetLabelEdit(*mCurrentNetLabel);

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
@@ -171,7 +171,8 @@ bool SchematicEditorState_AddNetLabel::addLabel(Schematic& schematic,
     mContext.undoStack.beginCmdGroup(tr("Add net label to schematic"));
     mUndoCmdActive = true;
     CmdSchematicNetLabelAdd* cmdAdd = new CmdSchematicNetLabelAdd(
-        netsegment, pos.mappedToGrid(getGridInterval()), Angle::deg0(), Alignment());
+        netsegment, pos.mappedToGrid(getGridInterval()), Angle::deg0(),
+        Alignment());
     mContext.undoStack.appendToCmdGroup(cmdAdd);
     mCurrentNetLabel = cmdAdd->getNetLabel();
     mEditCmd = new CmdSchematicNetLabelEdit(*mCurrentNetLabel);

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
@@ -154,6 +154,15 @@ bool SchematicEditorState_AddNetLabel::processSwitchToSchematicPage(
   return !mUndoCmdActive;
 }
 
+bool SchematicEditorState_AddNetLabel::processMirror() noexcept {
+  if (mUndoCmdActive && mCurrentNetLabel && mEditCmd) {
+    mEditCmd->mirror(true);
+    return true;
+  }
+
+  return false;
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.h
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addnetlabel.h
@@ -72,6 +72,7 @@ public:
   virtual bool processGraphicsSceneRightMouseButtonReleased(
       QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processSwitchToSchematicPage(int index) noexcept override;
+  virtual bool processMirror() noexcept override;
 
   // Operator Overloadings
   SchematicEditorState_AddNetLabel& operator=(

--- a/tests/unittests/projecteditor/schematiceditor/schematicclipboarddatatest.cpp
+++ b/tests/unittests/projecteditor/schematiceditor/schematicclipboarddatatest.cpp
@@ -118,9 +118,9 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
       NetLineAnchor::junction(Uuid::createRandom()),
       NetLineAnchor::pin(Uuid::createRandom(), Uuid::createRandom())));
   netSegment1->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(12, 34), Angle(56)));
+      Uuid::createRandom(), Point(12, 34), Angle(56), Alignment()));
   netSegment1->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(123, 456), Angle(789)));
+      Uuid::createRandom(), Point(123, 456), Angle(789), Alignment()));
 
   std::shared_ptr<SchematicClipboardData::NetSegment> netSegment2 =
       std::make_shared<SchematicClipboardData::NetSegment>(
@@ -138,9 +138,9 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
       NetLineAnchor::junction(Uuid::createRandom()),
       NetLineAnchor::pin(Uuid::createRandom(), Uuid::createRandom())));
   netSegment2->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(120, 340), Angle(560)));
+      Uuid::createRandom(), Point(120, 340), Angle(560), Alignment()));
   netSegment2->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(1230, 4560), Angle(7890)));
+      Uuid::createRandom(), Point(1230, 4560), Angle(7890), Alignment()));
 
   std::shared_ptr<Polygon> polygon1 = std::make_shared<Polygon>(
       Uuid::createRandom(), GraphicsLayerName("foo"), UnsignedLength(1), false,

--- a/tests/unittests/projecteditor/schematiceditor/schematicclipboarddatatest.cpp
+++ b/tests/unittests/projecteditor/schematiceditor/schematicclipboarddatatest.cpp
@@ -118,9 +118,9 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
       NetLineAnchor::junction(Uuid::createRandom()),
       NetLineAnchor::pin(Uuid::createRandom(), Uuid::createRandom())));
   netSegment1->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(12, 34), Angle(56), Alignment()));
+      Uuid::createRandom(), Point(12, 34), Angle(56), false));
   netSegment1->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(123, 456), Angle(789), Alignment()));
+      Uuid::createRandom(), Point(123, 456), Angle(789), false));
 
   std::shared_ptr<SchematicClipboardData::NetSegment> netSegment2 =
       std::make_shared<SchematicClipboardData::NetSegment>(
@@ -138,9 +138,9 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
       NetLineAnchor::junction(Uuid::createRandom()),
       NetLineAnchor::pin(Uuid::createRandom(), Uuid::createRandom())));
   netSegment2->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(120, 340), Angle(560), Alignment()));
+      Uuid::createRandom(), Point(120, 340), Angle(560), false));
   netSegment2->labels.append(std::make_shared<NetLabel>(
-      Uuid::createRandom(), Point(1230, 4560), Angle(7890), Alignment()));
+      Uuid::createRandom(), Point(1230, 4560), Angle(7890), false));
 
   std::shared_ptr<Polygon> polygon1 = std::make_shared<Polygon>(
       Uuid::createRandom(), GraphicsLayerName("foo"), UnsignedLength(1), false,


### PR DESCRIPTION
Allow the NetLabel(s) to be aligned based on the standard 9 position Alignment.
Works with the CmdMirrorSelectedSchematicItems command.