### PR TITLE
Drop support for Qt < 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ the AUR. The package clones and builds the latest (unstable!) version of the
 To compile LibrePCB, you need the following software components:
 
 - g++ >= 4.8, MinGW >= 4.8, or Clang >= 3.3 (C++11 support is required)
-- [Qt](http://www.qt.io/download-open-source/) >= 5.2
+- [Qt](http://www.qt.io/download-open-source/) >= 5.5
 - [zlib](http://www.zlib.net/)
 - [OpenSSL](https://www.openssl.org/)
 

--- a/apps/librepcb/controlpanel/controlpanel.cpp
+++ b/apps/librepcb/controlpanel/controlpanel.cpp
@@ -133,11 +133,7 @@ ControlPanel::ControlPanel(Workspace& workspace)
 
   // slightly delay opening projects to make sure the control panel window goes
   // to background (schematic editor should be the top most window)
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
   QTimer::singleShot(10, this, &ControlPanel::openProjectsPassedByCommandLine);
-#else
-  QTimer::singleShot(10, this, SLOT(openProjectsPassedByCommandLine()));
-#endif
 
   // start scanning the workspace library (asynchronously)
   mWorkspace.getLibraryDb().startLibraryRescan();

--- a/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
+++ b/apps/librepcb/projectlibraryupdater/projectlibraryupdater.cpp
@@ -137,13 +137,8 @@ void ProjectLibraryUpdater::btnUpdateClicked() {
       mControlPanel.openProject(mProjectFilePath);
       // bring this window to front again (with some delay to make it working
       // properly)
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
       QTimer::singleShot(500, this, &QMainWindow::raise);
       QTimer::singleShot(500, this, &QMainWindow::activateWindow);
-#else
-      QTimer::singleShot(500, this, SLOT(raise()));
-      // QTimer::singleShot(500, this, SLOT(activateWindow()));
-#endif
     }
   }
 

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -7,8 +7,6 @@ jobs:
     ARCH: 'x86_64'
   strategy:
     matrix:
-      Ubuntu_1404_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-14.04-3
       Ubuntu_1604_GCC:
         IMAGE: librepcb/librepcb-dev:ubuntu-16.04-3
       Ubuntu_1604_Qt_5_14_2_GCC:

--- a/common.pri
+++ b/common.pri
@@ -13,10 +13,10 @@ SHARE_DIR_ABS = $$absolute_path("share", $${PWD})
 
 # is qt version sufficient
 lessThan(QT_MAJOR_VERSION, 5) {
-    error("Qt version $$[QT_VERSION] is too old, should be version 5.2 or newer!")
+    error("Qt version $$[QT_VERSION] is too old, should be version 5.5 or newer!")
 } else {
-    lessThan(QT_MINOR_VERSION, 2) {
-        error("Qt version $$[QT_VERSION] is too old, should be version 5.2 or newer!")
+    lessThan(QT_MINOR_VERSION, 5) {
+        error("Qt version $$[QT_VERSION] is too old, should be version 5.5 or newer!")
     }
 }
 

--- a/common.pri
+++ b/common.pri
@@ -20,22 +20,6 @@ lessThan(QT_MAJOR_VERSION, 5) {
     }
 }
 
-# redirect qInfo to qDebug for Qt < 5.5 because qInfo was not yet available
-# https://doc.qt.io/qt-5/qtglobal.html#qInfo
-lessThan(QT_MINOR_VERSION, 5) {
-    DEFINES += qInfo=qDebug
-}
-
-# do not allow to use -Werror in release mode on Qt < 5.5 because Q_ASSERT() would lead
-# to warnings (resp. errors) if the argument of Q_ASSERT() is not used elsewhere.
-#   --> see: http://code.qt.io/cgit/qt/qtbase.git/tree/dist/changes-5.5.0
-CONFIG(release, debug|release) {
-    lessThan(QT_MINOR_VERSION, 5) {
-        QMAKE_CFLAGS -= -Werror
-        QMAKE_CXXFLAGS -= -Werror
-    }
-}
-
 # In Qt 5.15, a lot of things were marked as deprecated, without providing
 # alternatives available in previous Qt versions. It would require a lot of
 # preprocessor conditionals to avoid these deprecation warnings, so let's just

--- a/dev/doxygen/pages/code_style_guide.md
+++ b/dev/doxygen/pages/code_style_guide.md
@@ -25,7 +25,7 @@ This page describes the code style guide for LibrePCB developers.
 
 # General {#doc_code_style_guide_general}
 
-- Qt >= 5.2
+- Qt >= 5.5
 - C++11
 - Use strongly typed enums (`enum class`, C++11) whenever reasonable
 - Use `nullptr` instead of `NULL` or `0`

--- a/libs/librepcb/common/debug.cpp
+++ b/libs/librepcb/common/debug.cpp
@@ -175,11 +175,9 @@ void Debug::messageHandler(QtMsgType type, const QMessageLogContext& context,
       instance()->print(DebugLevel_t::DebugMsg, msg, context.file,
                         context.line);
       break;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
     case QtInfoMsg:
       instance()->print(DebugLevel_t::Info, msg, context.file, context.line);
       break;
-#endif
     case QtWarningMsg:
       instance()->print(DebugLevel_t::Warning, msg, context.file, context.line);
       break;

--- a/libs/librepcb/common/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/common/dialogs/aboutdialog.cpp
@@ -98,10 +98,8 @@ AboutDialog::AboutDialog(QWidget* parent) noexcept
   details << "Linking type:     " + qApp->getLinkingType();
   details << "Unbundled libs:   " + qApp->getUnbundledLibs();
   details << "Qt Version:       " + qt;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
   details << "CPU Architecture: " + QSysInfo::currentCpuArchitecture();
   details << "Operating System: " + QSysInfo::prettyProductName();
-#endif
   details << "Platform Plugin:  " + qApp->platformName();
   mUi->txtDetails->setPlainText(details.join("\n"));
 }

--- a/libs/librepcb/common/geometry/path.h
+++ b/libs/librepcb/common/geometry/path.h
@@ -148,17 +148,7 @@ private:  // Data
  ******************************************************************************/
 
 inline uint qHash(const Path& key, uint seed = 0) noexcept {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
   return qHashRange(key.getVertices().begin(), key.getVertices().end(), seed);
-#else
-  uint hash = seed;
-  foreach (const Vertex& v, key.getVertices()) {
-    // from
-    // https://code.woboq.org/qt5/qtbase/src/corelib/tools/qhashfunctions.h.html
-    hash += seed ^ (qHash(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
-  }
-  return hash;
-#endif
 }
 
 /*******************************************************************************

--- a/libs/librepcb/common/graphics/graphicsview.cpp
+++ b/libs/librepcb/common/graphics/graphicsview.cpp
@@ -87,7 +87,6 @@ QRectF GraphicsView::getVisibleSceneRect() const noexcept {
 void GraphicsView::setUseOpenGl(bool useOpenGl) noexcept {
   if (useOpenGl != mUseOpenGl) {
     if (useOpenGl) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
       // Try to make schematics/boards looking good by choosing reasonable
       // format options (with default options, it looks ugly).
       QSurfaceFormat format = QSurfaceFormat::defaultFormat();
@@ -98,10 +97,6 @@ void GraphicsView::setUseOpenGl(bool useOpenGl) noexcept {
       QOpenGLWidget* viewport = new QOpenGLWidget();
       viewport->setFormat(format);
       setViewport(viewport);
-#else
-      setViewport(new QGLWidget(QGLFormat(
-          QGL::DoubleBuffer | QGL::AlphaChannel | QGL::SampleBuffers)));
-#endif
     } else {
       setViewport(nullptr);
     }
@@ -231,10 +226,8 @@ void GraphicsView::zoomAnimationValueChanged(const QVariant& value) noexcept {
  *  Inherited from QGraphicsView
  ******************************************************************************/
 
-// In Qt<5.5, do not specially handle trackpad events.
 // It is not possible to process the wheel event in the `eventFilter` because
 // `QGraphicsSceneWheelEvent` does not track the source of the wheel event.
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
 void GraphicsView::wheelEvent(QWheelEvent* event) {
   if (event->source() == Qt::MouseEventSynthesizedBySystem) {
     QAbstractScrollArea::wheelEvent(event);
@@ -242,11 +235,6 @@ void GraphicsView::wheelEvent(QWheelEvent* event) {
     QGraphicsView::wheelEvent(event);
   }
 }
-#else
-void GraphicsView::wheelEvent(QWheelEvent* event) {
-  QGraphicsView::wheelEvent(event);
-}
-#endif
 
 bool GraphicsView::eventFilter(QObject* obj, QEvent* event) {
   switch (event->type()) {

--- a/libs/librepcb/common/network/networkrequestbase.cpp
+++ b/libs/librepcb/common/network/networkrequestbase.cpp
@@ -296,10 +296,8 @@ QString NetworkRequestBase::getUserAgent() noexcept {
   static QString userAgent;
   if (userAgent.isEmpty()) {
     QStringList details;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
     details << QSysInfo::prettyProductName();
     details << QSysInfo::currentCpuArchitecture();
-#endif
     details << QLocale::system().name();
     userAgent =
         QString("LibrePCB/%1 (%2) Qt/%3")

--- a/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
+++ b/libs/librepcb/libraryeditor/common/editorwidgetbase.cpp
@@ -255,11 +255,7 @@ void EditorWidgetBase::scheduleLibraryElementChecks() noexcept {
   // results. Instead, just delay checks for some time to get more stable
   // messages. But also don't wait too long, otherwise it would feel like a
   // lagging user interface.
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
   QTimer::singleShot(50, this, &EditorWidgetBase::updateCheckMessages);
-#else
-  QTimer::singleShot(50, this, SLOT(updateCheckMessages()));
-#endif
 }
 
 void EditorWidgetBase::updateCheckMessages() noexcept {

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorstate_select.cpp
@@ -230,14 +230,6 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
 bool PackageEditorState_Select::
     processGraphicsSceneLeftMouseButtonDoubleClicked(
         QGraphicsSceneMouseEvent& e) noexcept {
-#if (QT_VERSION < QT_VERSION_CHECK(5, 3, 0))
-  // abort moving and handle double click
-  if (mState == SubState::MOVING) {
-    mCmdDragSelectedItems.reset();
-    mState = SubState::IDLE;
-  }
-#endif
-
   if (mState == SubState::IDLE) {
     return openPropertiesDialogOfItemAtPos(Point::fromPx(e.scenePos()));
   } else {

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorstate_select.cpp
@@ -227,14 +227,6 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
 
 bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonDoubleClicked(
     QGraphicsSceneMouseEvent& e) noexcept {
-#if (QT_VERSION < QT_VERSION_CHECK(5, 3, 0))
-  // abort moving and handle double click
-  if (mState == SubState::MOVING) {
-    mCmdDragSelectedItems.reset();
-    mState = SubState::IDLE;
-  }
-#endif
-
   if (mState == SubState::IDLE) {
     return openPropertiesDialogOfItemAtPos(Point::fromPx(e.scenePos()));
   } else {

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -271,11 +271,7 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
 
   // mGraphicsView->zoomAll(); does not work properly here, should be executed
   // later in the event loop (ugly, but seems to work...)
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
   QTimer::singleShot(200, mGraphicsView, &GraphicsView::zoomAll);
-#else
-  QTimer::singleShot(200, mGraphicsView, SLOT(zoomAll()));
-#endif
 }
 
 BoardEditor::~BoardEditor() {

--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_select.cpp
@@ -370,13 +370,6 @@ bool BoardEditorState_Select::processGraphicsSceneLeftMouseButtonDoubleClicked(
   Board* board = getActiveBoard();
   if (!board) return false;
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 3, 0))
-  if (mSelectedItemsDragCommand) {
-    // Abort moving and handle double click
-    abortCommand(false);
-  }
-#endif
-
   if ((!mSelectedItemsDragCommand) && (!mCmdPolygonEdit) && (!mCmdPlaneEdit)) {
     // Check if there is an element under the mouse
     QList<BI_Base*> items =

--- a/libs/librepcb/projecteditor/projecteditor.cpp
+++ b/libs/librepcb/projecteditor/projecteditor.cpp
@@ -218,11 +218,7 @@ bool ProjectEditor::autosaveProject() noexcept {
   if (mUndoStack->isCommandGroupActive()) {
     // the user is executing a command at the moment, so we should not save now,
     // try it a few seconds later instead...
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
     QTimer::singleShot(10000, this, &ProjectEditor::autosaveProject);
-#else
-    QTimer::singleShot(10000, this, SLOT(autosaveProject()));
-#endif
     return false;
   }
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -524,14 +524,9 @@ void SchematicEditorState_AddComponent::setFocusToToolbar() noexcept {
   }
   if (widget) {
     // Slightly delay it to make it working properly...
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
     QTimer::singleShot(0, widget, &QLineEdit::selectAll);
     QTimer::singleShot(
         0, widget, static_cast<void (QLineEdit::*)()>(&QLineEdit::setFocus));
-#else
-    QTimer::singleShot(0, widget, SLOT(selectAll()));
-    QTimer::singleShot(0, widget, SLOT(setFocus()));
-#endif
   }
 }
 

--- a/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -328,14 +328,6 @@ bool SchematicEditorState_Select::
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
-  // if in moving state, abort moving and handle double click (only needed
-  // on older qt versions)
-  if ((mSubState == SubState::MOVING) &&
-      (QT_VERSION < QT_VERSION_CHECK(5, 3, 0))) {
-    mSelectedItemsMoveCommand.reset();
-    mSubState = SubState::IDLE;
-  }
-
   if (mSubState == SubState::IDLE) {
     // check if there is an element under the mouse
     QList<SI_Base*> items =

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -241,11 +241,7 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
 
   // mGraphicsView->zoomAll(); does not work properly here, should be executed
   // later in the event loop (ugly, but seems to work...)
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
   QTimer::singleShot(200, mGraphicsView, &GraphicsView::zoomAll);
-#else
-  QTimer::singleShot(200, mGraphicsView, SLOT(zoomAll()));
-#endif
 }
 
 SchematicEditor::~SchematicEditor() {

--- a/tests/unittests/common/fileio/directorylocktest.cpp
+++ b/tests/unittests/common/fileio/directorylocktest.cpp
@@ -281,8 +281,6 @@ TEST_F(DirectoryLockTest, testUnlockIfLockedOnLockedDir) {
   EXPECT_EQ(DirectoryLock::LockStatus::Unlocked, lock.getStatus());
 }
 
-#if (QT_VERSION >= \
-     QT_VERSION_CHECK(5, 3, 0))  // QProcess::processId() requires Qt>=5.3
 TEST_F(DirectoryLockTest, testStaleLock) {
   QProcess process;
   process.start(getTestProcessExePath().toStr());
@@ -309,10 +307,7 @@ TEST_F(DirectoryLockTest, testStaleLock) {
   // try to get the lock
   lock.tryLock();
 }
-#endif
 
-#if (QT_VERSION >= \
-     QT_VERSION_CHECK(5, 3, 0))  // QProcess::processId() requires Qt>=5.3
 TEST_F(DirectoryLockTest, testLockedByOtherApp) {
   // Run a new process.
   QProcess process;
@@ -343,7 +338,6 @@ TEST_F(DirectoryLockTest, testLockedByOtherApp) {
   success = process.waitForFinished();
   ASSERT_TRUE(success) << qPrintable(process.errorString());
 }
-#endif
 
 TEST_F(DirectoryLockTest, testLockedByOtherUser) {
   // Get the lock, read the lock file content and release the lock.

--- a/tests/unittests/common/systeminfotest.cpp
+++ b/tests/unittests/common/systeminfotest.cpp
@@ -99,8 +99,6 @@ TEST_F(SystemInfoTest, testIsProcessRunning) {
   { EXPECT_TRUE(SystemInfo::isProcessRunning(qApp->applicationPid())); }
 
   // check another running process
-#if (QT_VERSION >= \
-     QT_VERSION_CHECK(5, 3, 0))  // QProcess::processId() requires Qt>=5.3
   {
     QProcess process;
     process.start(getTestProcessExePath().toStr());
@@ -113,7 +111,6 @@ TEST_F(SystemInfoTest, testIsProcessRunning) {
     ASSERT_TRUE(success) << qPrintable(process.errorString());
     EXPECT_FALSE(SystemInfo::isProcessRunning(pid));
   }
-#endif
 
   // check an invalid process
   { EXPECT_FALSE(SystemInfo::isProcessRunning(999999)); }
@@ -128,8 +125,6 @@ TEST_F(SystemInfoTest, testGetProcessNameByPid) {
   }
 
   // check another running process
-#if (QT_VERSION >= \
-     QT_VERSION_CHECK(5, 3, 0))  // QProcess::processId() requires Qt>=5.3
   {
     QProcess process;
     process.start(getTestProcessExePath().toStr());
@@ -153,7 +148,6 @@ TEST_F(SystemInfoTest, testGetProcessNameByPid) {
     processName = SystemInfo::getProcessNameByPid(pid);
     EXPECT_EQ(QString(), processName) << qPrintable(processName);
   }
-#endif
 
   // check an invalid process
   {


### PR DESCRIPTION
Now it seems to be time to get rid of the Ubuntu 14.04 CI job since it suddenly stopped working due to https://github.com/pypa/pypi-support/issues/978 :wink:

As explained in #766, both Ubuntu and Debian do no longer provide support for distributions shipping a Qt version older than 5.5, so it should be totally fine to drop support for Qt 5.2, 5.3 and 5.4.

This might even make @rnestler happy! :smiley: However, probably he now wants to drop support for Qt5.5 as well...