### PR TITLE
Replace private marked copy operations with = delete

### DIFF
--- a/apps/librepcb/controlpanel/controlpanel.h
+++ b/apps/librepcb/controlpanel/controlpanel.h
@@ -82,8 +82,13 @@ class ControlPanel final : public QMainWindow {
 
 public:
   // Constructors / Destructor
+  ControlPanel() = delete;
+  ControlPanel(const ControlPanel& other) = delete;
   explicit ControlPanel(workspace::Workspace& workspace);
   ~ControlPanel();
+
+  // Operator Overloadings
+  ControlPanel& operator=(const ControlPanel& rhs) = delete;
 
 public slots:
 
@@ -120,11 +125,6 @@ private slots:
   void on_actionRescanLibraries_triggered();
 
 private:
-  // make some methods inaccessible...
-  ControlPanel();
-  ControlPanel(const ControlPanel& other);
-  ControlPanel& operator=(const ControlPanel& rhs);
-
   // General private methods
   void saveSettings();
   void loadSettings();

--- a/libs/librepcb/common/attributes/attributetype.h
+++ b/libs/librepcb/common/attributes/attributetype.h
@@ -59,6 +59,8 @@ public:
   };
 
   // Constructors / Destructor
+  AttributeType() = delete;
+  AttributeType(const AttributeType& other) = delete;
   AttributeType(Type_t type, const QString& typeName,
                 const QString& typeNameTr) noexcept;
   virtual ~AttributeType() noexcept;
@@ -84,12 +86,10 @@ public:
   static QList<const AttributeType*> getAllTypes() noexcept;
   static const AttributeType& fromString(const QString& type);
 
-protected:
-  // make some methods inaccessible...
-  AttributeType() = delete;
-  AttributeType(const AttributeType& other) = delete;
+  // Operator Overloadings
   AttributeType& operator=(const AttributeType& rhs) = delete;
 
+protected:
   // General Attributes
   Type_t mType;
   QString mTypeName;

--- a/libs/librepcb/common/attributes/attributeunit.h
+++ b/libs/librepcb/common/attributes/attributeunit.h
@@ -42,6 +42,8 @@ namespace librepcb {
 class AttributeUnit final {
 public:
   // Constructors / Destructor
+  AttributeUnit() = delete;
+  AttributeUnit(const AttributeUnit& other) = delete;
   explicit AttributeUnit(const QString& name, const QString& symbolTr,
                          const QStringList& userInputSuffixes) noexcept;
   ~AttributeUnit() noexcept;
@@ -53,12 +55,10 @@ public:
     return mUserInputSuffixes;
   }
 
-private:
-  // make some methods inaccessible...
-  AttributeUnit() = delete;
-  AttributeUnit(const AttributeUnit& other) = delete;
+  // Operator Overloadings
   AttributeUnit& operator=(const AttributeUnit& rhs) = delete;
 
+private:
   // General Attributes
   QString mName;  ///< to convert from/to string, e.g. "millivolt"
   QString mSymbolTr;  ///< e.g. "mV"

--- a/libs/librepcb/common/attributes/attrtypecapacitance.h
+++ b/libs/librepcb/common/attributes/attrtypecapacitance.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypeCapacitance final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypeCapacitance(const AttrTypeCapacitance& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypeCapacitance(const AttrTypeCapacitance& other) = delete;
+  // Operator Overloadings
   AttrTypeCapacitance& operator=(const AttrTypeCapacitance& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypeCapacitance() noexcept;
   ~AttrTypeCapacitance() noexcept;

--- a/libs/librepcb/common/attributes/attrtypecurrent.h
+++ b/libs/librepcb/common/attributes/attrtypecurrent.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypeCurrent final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypeCurrent(const AttrTypeCurrent& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypeCurrent(const AttrTypeCurrent& other) = delete;
+  // Operator Overloadings
   AttrTypeCurrent& operator=(const AttrTypeCurrent& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypeCurrent() noexcept;
   ~AttrTypeCurrent() noexcept;

--- a/libs/librepcb/common/attributes/attrtypefrequency.h
+++ b/libs/librepcb/common/attributes/attrtypefrequency.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypeFrequency final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypeFrequency(const AttrTypeFrequency& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypeFrequency(const AttrTypeFrequency& other) = delete;
+  // Operator Overloadings
   AttrTypeFrequency& operator=(const AttrTypeFrequency& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypeFrequency() noexcept;
   ~AttrTypeFrequency() noexcept;

--- a/libs/librepcb/common/attributes/attrtypeinductance.h
+++ b/libs/librepcb/common/attributes/attrtypeinductance.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypeInductance final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypeInductance(const AttrTypeInductance& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypeInductance(const AttrTypeInductance& other) = delete;
+  // Operator Overloadings
   AttrTypeInductance& operator=(const AttrTypeInductance& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypeInductance() noexcept;
   ~AttrTypeInductance() noexcept;

--- a/libs/librepcb/common/attributes/attrtypepower.h
+++ b/libs/librepcb/common/attributes/attrtypepower.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypePower final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypePower(const AttrTypePower& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypePower(const AttrTypePower& other) = delete;
+  // Operator Overloadings
   AttrTypePower& operator=(const AttrTypePower& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypePower() noexcept;
   ~AttrTypePower() noexcept;

--- a/libs/librepcb/common/attributes/attrtyperesistance.h
+++ b/libs/librepcb/common/attributes/attrtyperesistance.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypeResistance final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypeResistance(const AttrTypeResistance& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypeResistance(const AttrTypeResistance& other) = delete;
+  // Operator Overloadings
   AttrTypeResistance& operator=(const AttrTypeResistance& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypeResistance() noexcept;
   ~AttrTypeResistance() noexcept;

--- a/libs/librepcb/common/attributes/attrtypestring.h
+++ b/libs/librepcb/common/attributes/attrtypestring.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypeString final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypeString(const AttrTypeString& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypeString(const AttrTypeString& other) = delete;
+  // Operator Overloadings
   AttrTypeString& operator=(const AttrTypeString& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypeString() noexcept;
   ~AttrTypeString() noexcept;

--- a/libs/librepcb/common/attributes/attrtypevoltage.h
+++ b/libs/librepcb/common/attributes/attrtypevoltage.h
@@ -41,6 +41,9 @@ namespace librepcb {
  */
 class AttrTypeVoltage final : public AttributeType {
 public:
+  // Constructors / Destructor
+  AttrTypeVoltage(const AttrTypeVoltage& other) = delete;
+
   bool isValueValid(const QString& value) const noexcept;
   QString valueFromTr(const QString& value) const noexcept;
   QString printableValueTr(const QString& value,
@@ -50,11 +53,10 @@ public:
     return x;
   }
 
-private:
-  // make some methods inaccessible...
-  AttrTypeVoltage(const AttrTypeVoltage& other) = delete;
+  // Operator Overloadings
   AttrTypeVoltage& operator=(const AttrTypeVoltage& rhs) = delete;
 
+private:
   // Constructors / Destructor
   AttrTypeVoltage() noexcept;
   ~AttrTypeVoltage() noexcept;

--- a/libs/librepcb/common/debug.h
+++ b/libs/librepcb/common/debug.h
@@ -76,6 +76,9 @@ public:
     All = 100,  ///< all
   };
 
+  // Constructors / Destructor
+  Debug(const Debug& other) = delete;
+
   // General methods
 
   /**
@@ -152,12 +155,13 @@ public:
     return &dbg;
   }
 
+  // Operator Overloadings
+  Debug& operator=(const Debug& rhs) = delete;
+
 private:
-  // make some methods inaccessible...
+  // Constructors / Destructor
   Debug();
-  Debug(const Debug& other);
   ~Debug();
-  Debug& operator=(const Debug& rhs);
 
   /**
    * @brief The message handler for qDebug(), qWarning(), qCritical() and

--- a/libs/librepcb/common/graphics/graphicsview.h
+++ b/libs/librepcb/common/graphics/graphicsview.h
@@ -49,6 +49,7 @@ class GraphicsView final : public QGraphicsView {
 
 public:
   // Constructors / Destructor
+  GraphicsView(const GraphicsView& other) = delete;
   explicit GraphicsView(
       QWidget* parent = nullptr,
       IF_GraphicsViewEventHandler* eventHandler = nullptr) noexcept;
@@ -87,6 +88,9 @@ public:
                                bool mapToGrid) const noexcept;
   void handleMouseWheelEvent(QGraphicsSceneWheelEvent* event) noexcept;
 
+  // Operator Overloadings
+  GraphicsView& operator=(const GraphicsView& rhs) = delete;
+
 public slots:
 
   // Public Slots
@@ -109,10 +113,6 @@ private slots:
   void zoomAnimationValueChanged(const QVariant& value) noexcept;
 
 private:
-  // make some methods inaccessible...
-  GraphicsView(const GraphicsView& other) = delete;
-  GraphicsView& operator=(const GraphicsView& rhs) = delete;
-
   // Inherited Methods
   void wheelEvent(QWheelEvent* event);
   bool eventFilter(QObject* obj, QEvent* event);

--- a/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.h
+++ b/libs/librepcb/library/pkg/footprintpadpreviewgraphicsitem.h
@@ -49,6 +49,9 @@ class FootprintPad;
 class FootprintPadPreviewGraphicsItem final : public QGraphicsItem {
 public:
   // Constructors / Destructor
+  FootprintPadPreviewGraphicsItem() = delete;
+  FootprintPadPreviewGraphicsItem(
+      const FootprintPadPreviewGraphicsItem& other) = delete;
   explicit FootprintPadPreviewGraphicsItem(
       const IF_GraphicsLayerProvider& layerProvider, const FootprintPad& fptPad,
       const PackagePad* pkgPad = nullptr) noexcept;
@@ -66,14 +69,11 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0) noexcept override;
 
-private:
-  // make some methods inaccessible...
-  FootprintPadPreviewGraphicsItem() = delete;
-  FootprintPadPreviewGraphicsItem(
-      const FootprintPadPreviewGraphicsItem& other) = delete;
+  // Operator Overloadings
   FootprintPadPreviewGraphicsItem& operator=(
       const FootprintPadPreviewGraphicsItem& rhs) = delete;
 
+private:
   // General Attributes
   const FootprintPad& mFootprintPad;
   const PackagePad* mPackagePad;

--- a/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.h
+++ b/libs/librepcb/library/pkg/footprintpreviewgraphicsitem.h
@@ -56,6 +56,9 @@ class FootprintPreviewGraphicsItem final : public QGraphicsItem,
                                            public AttributeProvider {
 public:
   // Constructors / Destructor
+  FootprintPreviewGraphicsItem() = delete;
+  FootprintPreviewGraphicsItem(const FootprintPreviewGraphicsItem& other) =
+      delete;
   explicit FootprintPreviewGraphicsItem(
       const IF_GraphicsLayerProvider& layerProvider,
       const QStringList& localeOrder, const Footprint& footprint,
@@ -76,19 +79,16 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0) noexcept override;
 
+  // Operator Overloadings
+  FootprintPreviewGraphicsItem& operator=(
+      const FootprintPreviewGraphicsItem& rhs) = delete;
+
 signals:
 
   /// @copydoc AttributeProvider::attributesChanged()
   void attributesChanged() override {}
 
 private:
-  // make some methods inaccessible...
-  FootprintPreviewGraphicsItem() = delete;
-  FootprintPreviewGraphicsItem(const FootprintPreviewGraphicsItem& other) =
-      delete;
-  FootprintPreviewGraphicsItem& operator=(
-      const FootprintPreviewGraphicsItem& rhs) = delete;
-
   // Inherited from AttributeProvider
   /// @copydoc librepcb::AttributeProvider::getBuiltInAttributeValue()
   QString getBuiltInAttributeValue(const QString& key) const noexcept override;

--- a/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.h
+++ b/libs/librepcb/library/sym/symbolpinpreviewgraphicsitem.h
@@ -51,6 +51,9 @@ class ComponentSignal;
 class SymbolPinPreviewGraphicsItem final : public QGraphicsItem {
 public:
   // Constructors / Destructor
+  SymbolPinPreviewGraphicsItem() = delete;
+  SymbolPinPreviewGraphicsItem(const SymbolPinPreviewGraphicsItem& other) =
+      delete;
   explicit SymbolPinPreviewGraphicsItem(
       const IF_GraphicsLayerProvider& layerProvider, const SymbolPin& pin,
       const ComponentSignal* compSignal,
@@ -69,14 +72,11 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0) noexcept override;
 
-private:
-  // make some methods inaccessible...
-  SymbolPinPreviewGraphicsItem() = delete;
-  SymbolPinPreviewGraphicsItem(const SymbolPinPreviewGraphicsItem& other) =
-      delete;
+  // Operator Overloadings
   SymbolPinPreviewGraphicsItem& operator=(
       const SymbolPinPreviewGraphicsItem& rhs) = delete;
 
+private:
   // General Attributes
   const SymbolPin& mPin;
   const ComponentSignal* mComponentSignal;

--- a/libs/librepcb/library/sym/symbolpreviewgraphicsitem.h
+++ b/libs/librepcb/library/sym/symbolpreviewgraphicsitem.h
@@ -55,6 +55,8 @@ class SymbolPreviewGraphicsItem final : public QGraphicsItem,
                                         public AttributeProvider {
 public:
   // Constructors / Destructor
+  SymbolPreviewGraphicsItem() = delete;
+  SymbolPreviewGraphicsItem(const SymbolPreviewGraphicsItem& other) = delete;
   explicit SymbolPreviewGraphicsItem(
       const IF_GraphicsLayerProvider& layerProvider,
       const QStringList& localeOrder, const Symbol& symbol,
@@ -75,18 +77,16 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0) noexcept override;
 
+  // Operator Overloadings
+  SymbolPreviewGraphicsItem& operator=(const SymbolPreviewGraphicsItem& rhs) =
+      delete;
+
 signals:
 
   /// @copydoc AttributeProvider::attributesChanged()
   void attributesChanged() override {}
 
 private:
-  // make some methods inaccessible...
-  SymbolPreviewGraphicsItem() = delete;
-  SymbolPreviewGraphicsItem(const SymbolPreviewGraphicsItem& other) = delete;
-  SymbolPreviewGraphicsItem& operator=(const SymbolPreviewGraphicsItem& rhs) =
-      delete;
-
   // Inherited from AttributeProvider
   /// @copydoc librepcb::AttributeProvider::getBuiltInAttributeValue()
   QString getBuiltInAttributeValue(const QString& key) const noexcept override;

--- a/libs/librepcb/project/boards/graphicsitems/bgi_airwire.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_airwire.h
@@ -49,6 +49,8 @@ class BI_AirWire;
 class BGI_AirWire final : public BGI_Base {
 public:
   // Constructors / Destructor
+  BGI_AirWire() = delete;
+  BGI_AirWire(const BGI_AirWire& other) = delete;
   explicit BGI_AirWire(BI_AirWire& airwire) noexcept;
   ~BGI_AirWire() noexcept;
 
@@ -64,12 +66,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget);
 
-private:
-  // make some methods inaccessible...
-  BGI_AirWire() = delete;
-  BGI_AirWire(const BGI_AirWire& other) = delete;
+  // Operator Overloadings
   BGI_AirWire& operator=(const BGI_AirWire& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/boards/graphicsitems/bgi_base.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_base.h
@@ -45,16 +45,14 @@ class BGI_Base : public QGraphicsItem {
 public:
   // Constructors / Destructor
   explicit BGI_Base() noexcept;
+  BGI_Base(const BGI_Base& other) = delete;
   virtual ~BGI_Base() noexcept;
+
+  // Operator Overloadings
+  BGI_Base& operator=(const BGI_Base& rhs) = delete;
 
 protected:
   static qreal getZValueOfCopperLayer(const QString& name) noexcept;
-
-private:
-  // make some methods inaccessible...
-  // BGI_Base() = delete;
-  BGI_Base(const BGI_Base& other) = delete;
-  BGI_Base& operator=(const BGI_Base& rhs) = delete;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprint.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprint.h
@@ -54,6 +54,8 @@ class BI_Footprint;
 class BGI_Footprint final : public BGI_Base {
 public:
   // Constructors / Destructor
+  BGI_Footprint() = delete;
+  BGI_Footprint(const BGI_Footprint& other) = delete;
   explicit BGI_Footprint(BI_Footprint& footprint) noexcept;
   ~BGI_Footprint() noexcept;
 
@@ -69,12 +71,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0);
 
-private:
-  // make some methods inaccessible...
-  BGI_Footprint() = delete;
-  BGI_Footprint(const BGI_Footprint& other) = delete;
+  // Operator Overloadings
   BGI_Footprint& operator=(const BGI_Footprint& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(QString name) const noexcept;
 

--- a/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_footprintpad.h
@@ -54,6 +54,8 @@ class BI_FootprintPad;
 class BGI_FootprintPad final : public BGI_Base {
 public:
   // Constructors / Destructor
+  BGI_FootprintPad() = delete;
+  BGI_FootprintPad(const BGI_FootprintPad& other) = delete;
   explicit BGI_FootprintPad(BI_FootprintPad& pad) noexcept;
   ~BGI_FootprintPad() noexcept;
 
@@ -69,12 +71,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0);
 
-private:
-  // make some methods inaccessible...
-  BGI_FootprintPad() = delete;
-  BGI_FootprintPad(const BGI_FootprintPad& other) = delete;
+  // Operator Overloadings
   BGI_FootprintPad& operator=(const BGI_FootprintPad& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(QString name) const noexcept;
 

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netline.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netline.h
@@ -49,6 +49,8 @@ class BI_NetLine;
 class BGI_NetLine final : public BGI_Base {
 public:
   // Constructors / Destructor
+  BGI_NetLine() = delete;
+  BGI_NetLine(const BGI_NetLine& other) = delete;
   explicit BGI_NetLine(BI_NetLine& netline) noexcept;
   ~BGI_NetLine() noexcept;
 
@@ -64,12 +66,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget);
 
-private:
-  // make some methods inaccessible...
-  BGI_NetLine() = delete;
-  BGI_NetLine(const BGI_NetLine& other) = delete;
+  // Operator Overloadings
   BGI_NetLine& operator=(const BGI_NetLine& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_netpoint.h
@@ -49,6 +49,8 @@ class BI_NetPoint;
 class BGI_NetPoint final : public BGI_Base {
 public:
   // Constructors / Destructor
+  BGI_NetPoint() = delete;
+  BGI_NetPoint(const BGI_NetPoint& other) = delete;
   explicit BGI_NetPoint(BI_NetPoint& netpoint) noexcept;
   ~BGI_NetPoint() noexcept;
 
@@ -63,12 +65,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget);
 
-private:
-  // make some methods inaccessible...
-  BGI_NetPoint() = delete;
-  BGI_NetPoint(const BGI_NetPoint& other) = delete;
+  // Operator Overloadings
   BGI_NetPoint& operator=(const BGI_NetPoint& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/boards/graphicsitems/bgi_plane.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_plane.h
@@ -51,6 +51,8 @@ class BI_Plane;
 class BGI_Plane final : public BGI_Base {
 public:
   // Constructors / Destructor
+  BGI_Plane() = delete;
+  BGI_Plane(const BGI_Plane& other) = delete;
   explicit BGI_Plane(BI_Plane& plane) noexcept;
   ~BGI_Plane() noexcept;
 
@@ -81,12 +83,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0);
 
-private:
-  // make some methods inaccessible...
-  BGI_Plane() = delete;
-  BGI_Plane(const BGI_Plane& other) = delete;
+  // Operator Overloadings
   BGI_Plane& operator=(const BGI_Plane& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(QString name) const noexcept;
 

--- a/libs/librepcb/project/boards/graphicsitems/bgi_via.h
+++ b/libs/librepcb/project/boards/graphicsitems/bgi_via.h
@@ -49,6 +49,8 @@ class BI_Via;
 class BGI_Via final : public BGI_Base {
 public:
   // Constructors / Destructor
+  BGI_Via() = delete;
+  BGI_Via(const BGI_Via& other) = delete;
   explicit BGI_Via(BI_Via& via) noexcept;
   ~BGI_Via() noexcept;
 
@@ -64,12 +66,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget);
 
-private:
-  // make some methods inaccessible...
-  BGI_Via() = delete;
-  BGI_Via(const BGI_Via& other) = delete;
+  // Operator Overloadings
   BGI_Via& operator=(const BGI_Via& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/erc/ercmsg.cpp
+++ b/libs/librepcb/project/erc/ercmsg.cpp
@@ -40,8 +40,7 @@ namespace project {
 ErcMsg::ErcMsg(Project& project, const IF_ErcMsgProvider& owner,
                const QString& ownerKey, const QString& msgKey,
                ErcMsgType_t msgType, const QString& msg)
-  : mProject(project),
-    mErcMsgList(project.getErcMsgList()),
+  : mErcMsgList(project.getErcMsgList()),
     mOwner(owner),
     mOwnerKey(ownerKey),
     mMsgKey(msgKey),

--- a/libs/librepcb/project/erc/ercmsg.h
+++ b/libs/librepcb/project/erc/ercmsg.h
@@ -57,6 +57,8 @@ public:
   };
 
   // Constructors / Destructor
+  ErcMsg() = delete;
+  ErcMsg(const ErcMsg& other) = delete;
   explicit ErcMsg(Project& project, const IF_ErcMsgProvider& owner,
                   const QString& ownerKey, const QString& msgKey,
                   ErcMsg::ErcMsgType_t msgType, const QString& msg = QString());
@@ -76,12 +78,10 @@ public:
   void setVisible(bool visible) noexcept;
   void setIgnored(bool ignored) noexcept;
 
-private:
-  // make some methods inaccessible...
-  ErcMsg();
-  ErcMsg(const ErcMsg& other);
-  ErcMsg& operator=(const ErcMsg& rhs);
+  // Operator Overloadings
+  ErcMsg& operator=(const ErcMsg& rhs) = delete;
 
+private:
   // General
   ErcMsgList& mErcMsgList;
 

--- a/libs/librepcb/project/erc/ercmsg.h
+++ b/libs/librepcb/project/erc/ercmsg.h
@@ -83,7 +83,6 @@ private:
   ErcMsg& operator=(const ErcMsg& rhs);
 
   // General
-  Project& mProject;
   ErcMsgList& mErcMsgList;
 
   // Attributes

--- a/libs/librepcb/project/library/projectlibrary.h
+++ b/libs/librepcb/project/library/projectlibrary.h
@@ -60,6 +60,8 @@ class ProjectLibrary final : public QObject {
 
 public:
   // Constructors / Destructor
+  ProjectLibrary() = delete;
+  ProjectLibrary(const ProjectLibrary& other) = delete;
   ProjectLibrary(std::unique_ptr<TransactionalDirectory> directory);
   ~ProjectLibrary() noexcept;
 
@@ -106,12 +108,10 @@ public:
   // General Methods
   void save();
 
-private:
-  // make some methods inaccessible...
-  ProjectLibrary();
-  ProjectLibrary(const ProjectLibrary& other);
-  ProjectLibrary& operator=(const ProjectLibrary& rhs);
+  // Operator Overloadings
+  ProjectLibrary& operator=(const ProjectLibrary& rhs) = delete;
 
+private:
   // Private Methods
   template <typename ElementType>
   void loadElements(const QString& dirname, const QString& type,

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_base.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_base.h
@@ -45,12 +45,10 @@ class SGI_Base : public QGraphicsItem {
 public:
   // Constructors / Destructor
   explicit SGI_Base() noexcept;
+  SGI_Base(const SGI_Base& other) = delete;
   virtual ~SGI_Base() noexcept;
 
-private:
-  // make some methods inaccessible...
-  // SGI_Base() = delete;
-  SGI_Base(const SGI_Base& other) = delete;
+  // Operator Overloadings
   SGI_Base& operator=(const SGI_Base& rhs) = delete;
 };
 

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netlabel.h
@@ -50,6 +50,8 @@ class SI_NetLabel;
 class SGI_NetLabel final : public SGI_Base {
 public:
   // Constructors / Destructor
+  SGI_NetLabel() = delete;
+  SGI_NetLabel(const SGI_NetLabel& other) = delete;
   explicit SGI_NetLabel(SI_NetLabel& netlabel) noexcept;
   ~SGI_NetLabel() noexcept;
 
@@ -62,12 +64,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget);
 
-private:
-  // make some methods inaccessible...
-  SGI_NetLabel() = delete;
-  SGI_NetLabel(const SGI_NetLabel& other) = delete;
+  // Operator Overloadings
   SGI_NetLabel& operator=(const SGI_NetLabel& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netline.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netline.h
@@ -49,6 +49,8 @@ class SI_NetLine;
 class SGI_NetLine final : public SGI_Base {
 public:
   // Constructors / Destructor
+  SGI_NetLine() = delete;
+  SGI_NetLine(const SGI_NetLine& other) = delete;
   explicit SGI_NetLine(SI_NetLine& netline) noexcept;
   ~SGI_NetLine() noexcept;
 
@@ -61,12 +63,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget);
 
-private:
-  // make some methods inaccessible...
-  SGI_NetLine() = delete;
-  SGI_NetLine(const SGI_NetLine& other) = delete;
+  // Operator Overloadings
   SGI_NetLine& operator=(const SGI_NetLine& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_netpoint.h
@@ -49,6 +49,8 @@ class SI_NetPoint;
 class SGI_NetPoint final : public SGI_Base {
 public:
   // Constructors / Destructor
+  SGI_NetPoint() = delete;
+  SGI_NetPoint(const SGI_NetPoint& other) = delete;
   explicit SGI_NetPoint(SI_NetPoint& netpoint) noexcept;
   ~SGI_NetPoint() noexcept;
 
@@ -60,12 +62,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget);
 
-private:
-  // make some methods inaccessible...
-  SGI_NetPoint() = delete;
-  SGI_NetPoint(const SGI_NetPoint& other) = delete;
+  // Operator Overloadings
   SGI_NetPoint& operator=(const SGI_NetPoint& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbol.h
@@ -54,6 +54,8 @@ class SI_Symbol;
 class SGI_Symbol final : public SGI_Base {
 public:
   // Constructors / Destructor
+  SGI_Symbol() = delete;
+  SGI_Symbol(const SGI_Symbol& other) = delete;
   explicit SGI_Symbol(SI_Symbol& symbol) noexcept;
   ~SGI_Symbol() noexcept;
 
@@ -66,12 +68,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0);
 
-private:
-  // make some methods inaccessible...
-  SGI_Symbol() = delete;
-  SGI_Symbol(const SGI_Symbol& other) = delete;
+  // Operator Overloadings
   SGI_Symbol& operator=(const SGI_Symbol& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.h
+++ b/libs/librepcb/project/schematics/graphicsitems/sgi_symbolpin.h
@@ -53,6 +53,8 @@ class SI_SymbolPin;
 class SGI_SymbolPin final : public SGI_Base {
 public:
   // Constructors / Destructor
+  SGI_SymbolPin() = delete;
+  SGI_SymbolPin(const SGI_SymbolPin& other) = delete;
   explicit SGI_SymbolPin(SI_SymbolPin& pin) noexcept;
   ~SGI_SymbolPin() noexcept;
 
@@ -65,12 +67,10 @@ public:
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0);
 
-private:
-  // make some methods inaccessible...
-  SGI_SymbolPin() = delete;
-  SGI_SymbolPin(const SGI_SymbolPin& other) = delete;
+  // Operator Overloadings
   SGI_SymbolPin& operator=(const SGI_SymbolPin& rhs) = delete;
 
+private:
   // Private Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 

--- a/libs/librepcb/project/settings/projectsettings.h
+++ b/libs/librepcb/project/settings/projectsettings.h
@@ -48,6 +48,8 @@ class ProjectSettings final : public QObject, public SerializableObject {
 
 public:
   // Constructors / Destructor
+  ProjectSettings() = delete;
+  ProjectSettings(const ProjectSettings& other) = delete;
   explicit ProjectSettings(Project& project, const Version& fileFormat,
                            bool create);
   ~ProjectSettings() noexcept;
@@ -70,16 +72,14 @@ public:
   void triggerSettingsChanged() noexcept;
   void save();
 
+  // Operator Overloadings
+  ProjectSettings& operator=(const ProjectSettings& rhs) = delete;
+
 signals:
 
   void settingsChanged();
 
 private:
-  // make some methods inaccessible...
-  ProjectSettings();
-  ProjectSettings(const ProjectSettings& other);
-  ProjectSettings& operator=(const ProjectSettings& rhs);
-
   // Private Methods
 
   /// @copydoc librepcb::SerializableObject::serialize()

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -71,6 +71,8 @@ class BoardEditor final : public QMainWindow,
 
 public:
   // Constructors / Destructor
+  BoardEditor() = delete;
+  BoardEditor(const BoardEditor& other) = delete;
   explicit BoardEditor(ProjectEditor& projectEditor, Project& project);
   ~BoardEditor();
 
@@ -84,6 +86,9 @@ public:
 
   // General Methods
   void abortAllCommands() noexcept;
+
+  // Operator Overloadings
+  BoardEditor& operator=(const BoardEditor& rhs) = delete;
 
 protected:
   void closeEvent(QCloseEvent* event);
@@ -120,11 +125,6 @@ private slots:
   void boardListActionGroupTriggered(QAction* action);
 
 private:
-  // make some methods inaccessible...
-  BoardEditor() = delete;
-  BoardEditor(const BoardEditor& other) = delete;
-  BoardEditor& operator=(const BoardEditor& rhs) = delete;
-
   // Private Methods
   bool graphicsViewEventHandler(QEvent* event);
   void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;

--- a/libs/librepcb/projecteditor/boardeditor/boardlayersdock.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardlayersdock.h
@@ -59,11 +59,16 @@ class BoardLayersDock final : public QDockWidget {
 
 public:
   // Constructors / Destructor
+  BoardLayersDock() = delete;
+  BoardLayersDock(const BoardLayersDock& other) = delete;
   explicit BoardLayersDock(BoardEditor& editor) noexcept;
   ~BoardLayersDock() noexcept;
 
   // Setters
   void setActiveBoard(Board* board);
+
+  // Operator Overloadings
+  BoardLayersDock& operator=(const BoardLayersDock& rhs) = delete;
 
 private slots:
 
@@ -75,11 +80,6 @@ private slots:
   void on_btnNone_clicked();
 
 private:
-  // make some methods inaccessible...
-  BoardLayersDock();
-  BoardLayersDock(const BoardLayersDock& other);
-  BoardLayersDock& operator=(const BoardLayersDock& rhs);
-
   // Private Methods
   void updateListWidget() noexcept;
   void setVisibleLayers(const QList<QString>& layers) noexcept;

--- a/libs/librepcb/projecteditor/dialogs/editnetclassesdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/editnetclassesdialog.h
@@ -57,9 +57,14 @@ class EditNetClassesDialog final : public QDialog {
 
 public:
   // Constructors / Destructor
+  EditNetClassesDialog() = delete;
+  EditNetClassesDialog(const EditNetClassesDialog& other) = delete;
   explicit EditNetClassesDialog(Circuit& circuit, UndoStack& undoStack,
                                 QWidget* parent = 0);
   ~EditNetClassesDialog() noexcept;
+
+  // Operator Overloadings
+  EditNetClassesDialog& operator=(const EditNetClassesDialog& rhs) = delete;
 
 private slots:
 
@@ -68,11 +73,6 @@ private slots:
   void on_btnRemove_clicked();
 
 private:
-  // make some methods inaccessible...
-  EditNetClassesDialog();
-  EditNetClassesDialog(const EditNetClassesDialog& other);
-  EditNetClassesDialog& operator=(const EditNetClassesDialog& rhs);
-
   // General Attributes
   Circuit& mCircuit;
   Ui::EditNetClassesDialog* mUi;

--- a/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.h
+++ b/libs/librepcb/projecteditor/dialogs/projectsettingsdialog.h
@@ -58,10 +58,15 @@ class ProjectSettingsDialog final : public QDialog {
 
 public:
   // Constructors / Destructor
+  ProjectSettingsDialog() = delete;
+  ProjectSettingsDialog(const ProjectSettingsDialog& other) = delete;
   explicit ProjectSettingsDialog(ProjectSettings& settings,
                                  UndoStack& undoStack,
                                  QWidget* parent = 0) noexcept;
   ~ProjectSettingsDialog() noexcept;
+
+  // Operator Overloadings
+  ProjectSettingsDialog& operator=(const ProjectSettingsDialog& rhs) = delete;
 
 private slots:
 
@@ -77,11 +82,6 @@ private slots:
   void on_btnNormDown_clicked();
 
 private:
-  // make some methods inaccessible...
-  ProjectSettingsDialog();
-  ProjectSettingsDialog(const ProjectSettingsDialog& other);
-  ProjectSettingsDialog& operator=(const ProjectSettingsDialog& rhs);
-
   // Private Methods
   void accept();
   void reject();

--- a/libs/librepcb/projecteditor/docks/ercmsgdock.h
+++ b/libs/librepcb/projecteditor/docks/ercmsgdock.h
@@ -54,8 +54,13 @@ class ErcMsgDock final : public QDockWidget {
 
 public:
   // Constructors / Destructor
+  ErcMsgDock() = delete;
+  ErcMsgDock(const ErcMsgDock& other) = delete;
   explicit ErcMsgDock(Project& project);
   ~ErcMsgDock();
+
+  // Operator Overloadings
+  ErcMsgDock& operator=(const ErcMsgDock& rhs) = delete;
 
 public slots:
 
@@ -72,11 +77,6 @@ private slots:
 private:
   // Private Methods
   void updateTopLevelItemTexts() noexcept;
-
-  // make some methods inaccessible...
-  ErcMsgDock();
-  ErcMsgDock(const ErcMsgDock& other);
-  ErcMsgDock& operator=(const ErcMsgDock& rhs);
 
   // General
   Project& mProject;

--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.h
@@ -67,6 +67,8 @@ class SchematicEditor final : public QMainWindow,
 
 public:
   // Constructors / Destructor
+  SchematicEditor() = delete;
+  SchematicEditor(const SchematicEditor& other) = delete;
   explicit SchematicEditor(ProjectEditor& projectEditor, Project& project);
   ~SchematicEditor();
 
@@ -81,6 +83,9 @@ public:
 
   // General Methods
   void abortAllCommands() noexcept;
+
+  // Operator Overloadings
+  SchematicEditor& operator=(const SchematicEditor& rhs) = delete;
 
 protected:
   void closeEvent(QCloseEvent* event);
@@ -108,11 +113,6 @@ signals:
   void activeSchematicChanged(int index);
 
 private:
-  // make some methods inaccessible...
-  SchematicEditor();
-  SchematicEditor(const SchematicEditor& other);
-  SchematicEditor& operator=(const SchematicEditor& rhs);
-
   // Private Methods
   bool graphicsViewEventHandler(QEvent* event);
   void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;


### PR DESCRIPTION
Replace the old style copy-inhibiting idiom of declaring the copy
constructor and copy operator as private (with no implementation)
with the new Scott Meyers recommended one of declaring them public
and deleted.

Fixes #93.