### PR TITLE
BOM Export: Show whether devices are in sync with schematic

### DIFF
--- a/libs/librepcb/projecteditor/dialogs/bomgeneratordialog.ui
+++ b/libs/librepcb/projecteditor/dialogs/bomgeneratordialog.ui
@@ -34,7 +34,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="lblSuccess">
      <property name="text">
       <string>Success!</string>
@@ -44,7 +44,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -124,6 +124,22 @@
      </property>
      <property name="placeholderText">
       <string extracomment="Don't translate the attributes MANUFACTURER and MPN, they must be in English.">Comma-separated list of additional attributes, e.g. &quot;MANUFACTURER, MPN&quot;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QLabel" name="lblMessage">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>3</number>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
As explained in #584, it can happen that one adds a device to the board which is different to the device pre-selected in the schematic. Currently it's very hard to detect such inconsistencies.

Maybe we should raise ERC warnings in this situation, I'm still thinking about what would be the best solution. Anyway, I think it makes sense to show a message in the BOM export dialog about the consistency of devices between board and schematic, since this information is most relevant when generating the BOM.

This is how it looks now when all devices are in sync with the schematic:

![image](https://user-images.githubusercontent.com/5374821/116826463-67ce1280-ab94-11eb-81b5-aa397a692dd5.png)

Or when there are inconsistencies:

![image](https://user-images.githubusercontent.com/5374821/116826757-e5dee900-ab95-11eb-92f1-6680bb008d93.png)

And if no board is selected at all, there is a note that no devices will be exported at all:

![image](https://user-images.githubusercontent.com/5374821/116826767-ed9e8d80-ab95-11eb-8471-0e39f2a12065.png)