### PR TITLE
Library Editor: fix typo

### DIFF
--- a/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.ui
+++ b/libs/librepcb/libraryeditor/newelementwizard/newelementwizardpage_deviceproperties.ui
@@ -14,7 +14,7 @@
    <string>Device Properties</string>
   </property>
   <property name="title">
-   <string>De&amp;vice Properties</string>
+   <string>Device Properties</string>
   </property>
   <property name="subTitle">
    <string>Set the component and the package of the new device.</string>


### PR DESCRIPTION
Remove spurious ampersand.

Fixes #844