### PR TITLE
Board editor: Refactor and improve "Place Devices" dock

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.ui
+++ b/libs/librepcb/projecteditor/boardeditor/unplacedcomponentsdock.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>319</width>
+    <width>392</width>
     <height>416</height>
    </rect>
   </property>
@@ -26,11 +26,7 @@
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>
-      <widget class="QListWidget" name="lstUnplacedComponents">
-       <property name="sortingEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
+      <widget class="QListWidget" name="lstUnplacedComponents"/>
       <widget class="QWidget" name="layoutWidget">
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
@@ -45,52 +41,65 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <layout class="QVBoxLayout" name="verticalLayout_3">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QComboBox" name="cbxSelectedDevice"/>
-            </item>
-            <item>
-             <widget class="QLabel" name="lblNoDeviceFound">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">color: rgb(255, 0, 0);</string>
-              </property>
-              <property name="text">
-               <string>No device for the selected component found in the library! Please add a suitable device to your workspace library.</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
              <string>Footprint:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QComboBox" name="cbxSelectedFootprint"/>
           </item>
+          <item row="0" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QComboBox" name="cbxSelectedDevice"/>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="cbxIsDefaultDevice">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Set/unset as default device for the component in schematic.</string>
+              </property>
+              <property name="tristate">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="lblNoDeviceFound">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: rgb(255, 0, 0);</string>
+          </property>
+          <property name="text">
+           <string>No device or package for the selected component found in the library! Please add a suitable device and package to your workspace library.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="GraphicsView" name="graphicsView">
@@ -112,20 +121,42 @@
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <widget class="QPushButton" name="btnAdd">
+            <property name="toolTip">
+             <string>Add the selected device to the board.</string>
+            </property>
             <property name="text">
              <string>Add</string>
+            </property>
+            <property name="default">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="pushButton">
+           <widget class="QPushButton" name="btnAddSimilar">
+            <property name="toolTip">
+             <string>Use the selected device for all identical components and add them to the board.</string>
+            </property>
             <property name="text">
              <string>Add Similar</string>
             </property>
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="btnAddPreSelected">
+            <property name="toolTip">
+             <string>Add all components with pre-selected device to the board.</string>
+            </property>
+            <property name="text">
+             <string>Add Pre-Selected</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="btnAddAll">
+            <property name="toolTip">
+             <string>Add all components to the board, using automatically determined devices.</string>
+            </property>
             <property name="text">
              <string>Auto-Add All</string>
             </property>


### PR DESCRIPTION
Heavily refactoring and improving the `UnplacedComponentsDock` widget of the board editor:

- Sort component list and device dropdown items numerically (e.g. "R2" before "R10") for a more intuitive order
- Mark components with a pre-selected device (in the schematic) by ✔ in the list to see which components don't need to manually choose a device
- Support adding components to board by double-click on a list item
- Support adding devices/packages even if they do not exist in the workspace library, but are already contained in the project library.
- Add checkbox to view and even edit the device which is pre-selected in the schematic to avoid needing to switch to the schematic editor to change the pre-selected devices
- Support adding all components with pre-selected device (in the schematic) at once. If there are such devices. there will be a button "Add Pre-Selected". If there are no such devices, the button will be named "Auto-Add All". So the first click will add all components with pre-selected device and change the button to "Auto-Add All", the second click will then add all the remaining components.
- Improve logic to determine which device will be chosen by default:
  - Priority 1: The device chosen in the schematic
  - Priority 2: The device already used for the same component before
  - Priority 3: The most used device in the current board
  - Priority 4: The first device found in the project library
  - Priority 5: The first device found in the workspace library
- Improve logic to determine which footprint will be chosen by default:
  - Priority 1: The footprint already used for the same device before
  - Priority 2: The most used footprint in the current board
  - Priority 3: The first footprint of the package
- Set dropdown lists with <=1 items to read-only (i.e. disabled) to visually indicate that there is no choice
- Load footprint preview from project library instead of workspace library to make sure the preview corresponds to the actually added footprint.
- Add tooltips to various widgets
- General code cleanup (even fixing memory leaks)

![image](https://user-images.githubusercontent.com/5374821/120937543-51285780-c70e-11eb-8659-46f0886e1dfc.png)

Fixes #575 