### PR TITLE
Ask for new workspace path if workspace failed to open

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -172,18 +172,20 @@ static int runApplication() noexcept {
 
   // If creating or opening a workspace failed, allow to choose another
   // workspace path until it succeeds or the user aborts.
-  try {
-    return openWorkspace(path);  // can throw
-  } catch (const UserCanceled& e) {
-    return 0;  // User canceled -> exit application.
-  } catch (const Exception& e) {
-    QMessageBox::critical(
-        nullptr, Application::translate("Workspace", "Error"),
-        QString(Application::translate("Workspace",
-                                       "Could not open the workspace \"%1\":"))
-                .arg(path.toNative()) %
-            "\n\n" % e.getMsg());
-    return 0;  // Failure -> exit application.
+  while (true) {
+    try {
+      return openWorkspace(path);  // can throw
+    } catch (const UserCanceled& e) {
+      return 0;  // User canceled -> exit application.
+    } catch (const Exception& e) {
+      QMessageBox::critical(
+          nullptr, Application::translate("Workspace", "Error"),
+          QString(Application::translate(
+                      "Workspace", "Could not open the workspace \"%1\":"))
+                  .arg(path.toNative()) %
+              "\n\n" % e.getMsg());
+      path = FilePath();  // Make sure the workspace selector wizard is shown.
+    }
   }
 }
 

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -223,7 +223,7 @@ static bool isFileFormatStableOrAcceptUnstable() noexcept {
 
 static int openWorkspace(FilePath& path) {
   // If no valid workspace path is available, ask the user to choose it.
-  if (!Workspace::isValidWorkspacePath(path)) {
+  if (!path.isValid()) {
     FirstRunWizard wizard;
     if (wizard.exec() == QDialog::Accepted) {
       path = wizard.getWorkspaceFilePath();
@@ -234,6 +234,16 @@ static int openWorkspace(FilePath& path) {
     } else {
       throw UserCanceled(__FILE__, __LINE__);
     }
+  }
+
+  // If the selected directory is not a valid workspace, we need to abort here
+  // to avoid the InitializeWorkspaceWizard to silently/unintentielly creating
+  // new files within the specified directory.
+  if (!Workspace::isValidWorkspacePath(path)) {
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        Application::translate(
+            "Workspace", "This directory is not a valid LibrePCB workspace."));
   }
 
   // Migrate workspace to new major version, if needed. Note that this needs


### PR DESCRIPTION
### Show error message if invalid workspace path specified

If the workspace path to open (e.g. loaded from user settings) does not point to a valid workspace, an error message will be shown now. Previously, the "first run"-wizard has been shown silently in this case, so the user didn't notice that there was something wrong with the specified workspace path.

### Ask for new workspace path if workspace failed to open

If the workspace path was valid, but still failed to open for some reason (e.g. not writable), now the "first run"-wizard will be shown as well after the error message so the user is able to choose another workspace directory. Previously, the application just closed with an error message in this case, and the user had to manually reset the workspace path stored in the user settings (`$HOME/.config/LibrePCB/`) to get LibrePCB running again.

### Note

Both changes do not affect the normal behavior of LibrePCB at all, they only improve error handling in case opening a workspace failed for some reason.

Fixes #154 