### PR TITLE
DRC: Support partial checks & quick re-run from dock widget

### DIFF
--- a/libs/librepcb/project/boards/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/project/boards/drc/boarddesignrulecheck.cpp
@@ -82,15 +82,33 @@ void BoardDesignRuleCheck::execute() {
   mProgressStatus.clear();
   mMessages.clear();
 
-  rebuildPlanes(5, 15);
-  checkCopperBoardClearances(15, 40);
-  checkCopperCopperClearances(40, 70);
-  checkMinimumCopperWidth(70, 72);
-  checkMinimumPthRestring(72, 74);
-  checkMinimumPthDrillDiameter(74, 76);
-  checkMinimumNpthDrillDiameter(76, 78);
-  checkCourtyardClearances(78, 88);
-  checkForMissingConnections(88, 90);
+  if (mOptions.rebuildPlanes) {
+    rebuildPlanes(5, 15);
+  }
+  if (mOptions.checkCopperBoardClearance || mOptions.checkCopperNpthClearance) {
+    checkCopperBoardClearances(15, 40);
+  }
+  if (mOptions.checkCopperCopperClearance) {
+    checkCopperCopperClearances(40, 70);
+  }
+  if (mOptions.checkCopperWidth) {
+    checkMinimumCopperWidth(70, 72);
+  }
+  if (mOptions.checkPthRestring) {
+    checkMinimumPthRestring(72, 74);
+  }
+  if (mOptions.checkPthDrillDiameter) {
+    checkMinimumPthDrillDiameter(74, 76);
+  }
+  if (mOptions.checkNpthDrillDiameter) {
+    checkMinimumNpthDrillDiameter(76, 78);
+  }
+  if (mOptions.checkCourtyardClearance) {
+    checkCourtyardClearances(78, 88);
+  }
+  if (mOptions.checkMissingConnections) {
+    checkForMissingConnections(88, 90);
+  }
 
   emitStatus(
       tr("Finished with %1 message(s)!", "Count of messages", mMessages.count())
@@ -140,7 +158,7 @@ void BoardDesignRuleCheck::checkCopperBoardClearances(int progressStart,
 
   // Board outline
   ClipperLib::Paths outlineRestrictedArea;
-  {
+  if (mOptions.checkCopperBoardClearance) {
     BoardClipperPathGenerator gen(mBoard, maxArcTolerance());
     gen.addBoardOutline();
     outlineRestrictedArea = gen.getPaths();
@@ -153,7 +171,7 @@ void BoardDesignRuleCheck::checkCopperBoardClearances(int progressStart,
   }
 
   // Holes
-  {
+  if (mOptions.checkCopperNpthClearance) {
     BoardClipperPathGenerator gen(mBoard, maxArcTolerance());
     gen.addHoles(*mOptions.minCopperNpthClearance - *maxArcTolerance());
     ClipperHelpers::unite(outlineRestrictedArea, gen.getPaths());

--- a/libs/librepcb/project/boards/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/project/boards/drc/boarddesignrulecheck.h
@@ -55,25 +55,53 @@ class BoardDesignRuleCheck final : public QObject {
 
 public:
   struct Options {
+    bool rebuildPlanes;
+
+    bool checkCopperWidth;
     UnsignedLength minCopperWidth;
+
+    bool checkCopperCopperClearance;
     UnsignedLength minCopperCopperClearance;
+
+    bool checkCopperBoardClearance;
     UnsignedLength minCopperBoardClearance;
+
+    bool checkCopperNpthClearance;
     UnsignedLength minCopperNpthClearance;
+
+    bool checkPthRestring;
     UnsignedLength minPthRestring;
+
+    bool checkNpthDrillDiameter;
     UnsignedLength minNpthDrillDiameter;
+
+    bool checkPthDrillDiameter;
     UnsignedLength minPthDrillDiameter;
+
+    bool checkCourtyardClearance;
     Length courtyardOffset;
 
+    bool checkMissingConnections;
+
     Options()
-      : minCopperWidth(200000),  // 200um
+      : rebuildPlanes(true),
+        checkCopperWidth(true),
+        minCopperWidth(200000),  // 200um
+        checkCopperCopperClearance(true),
         minCopperCopperClearance(200000),  // 200um
+        checkCopperBoardClearance(true),
         minCopperBoardClearance(300000),  // 300um
+        checkCopperNpthClearance(true),
         minCopperNpthClearance(200000),  // 200um
+        checkPthRestring(true),
         minPthRestring(150000),  // 150um
+        checkNpthDrillDiameter(true),
         minNpthDrillDiameter(250000),  // 250um
+        checkPthDrillDiameter(true),
         minPthDrillDiameter(250000),  // 250um
-        courtyardOffset(0)  // 0um
-    {}
+        checkCourtyardClearance(true),
+        courtyardOffset(0),  // 0um
+        checkMissingConnections(true) {}
   };
 
   // Constructors / Destructor

--- a/libs/librepcb/project/boards/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/project/boards/drc/boarddesignrulecheck.h
@@ -82,6 +82,9 @@ public:
   ~BoardDesignRuleCheck() noexcept;
 
   // Getters
+  const QStringList& getProgressStatus() const noexcept {
+    return mProgressStatus;
+  }
   const QList<BoardDesignRuleCheckMessage>& getMessages() const noexcept {
     return mMessages;
   }
@@ -110,7 +113,8 @@ private:  // Methods
                                           const NetSignal* netsignal);
   ClipperLib::Paths getDeviceCourtyardPaths(const BI_Device& device,
                                             const GraphicsLayer* layer);
-  void addMessage(const BoardDesignRuleCheckMessage& msg) noexcept;
+  void emitStatus(const QString& status) noexcept;
+  void emitMessage(const BoardDesignRuleCheckMessage& msg) noexcept;
   QString formatLength(const Length& length) const noexcept;
 
   /**
@@ -123,6 +127,7 @@ private:  // Methods
 private:  // Data
   Board& mBoard;
   Options mOptions;
+  QStringList mProgressStatus;
   QList<BoardDesignRuleCheckMessage> mMessages;
   QHash<const GraphicsLayer*, QHash<const NetSignal*, ClipperLib::Paths>>
       mCachedPaths;

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
@@ -116,9 +116,17 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
   mUi->cbxCourtyardOffset->setChecked(options.checkCourtyardClearance);
   mUi->edtCourtyardOffset->setValue(options.courtyardOffset);
   mUi->cbxMissingConnections->setChecked(options.checkMissingConnections);
+
+  // Load the window geometry.
+  QSettings clientSettings;
+  restoreGeometry(
+      clientSettings.value("drc_dialog/window_geometry").toByteArray());
 }
 
 BoardDesignRuleCheckDialog::~BoardDesignRuleCheckDialog() {
+  // Save the window geometry.
+  QSettings clientSettings;
+  clientSettings.setValue("drc_dialog/window_geometry", saveGeometry());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.cpp
@@ -76,16 +76,46 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
   btnRun->setDefault(true);  // Allow just pressing the return key to run DRC.
   connect(btnRun, &QPushButton::clicked, this,
           &BoardDesignRuleCheckDialog::btnRunDrcClicked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxRebuildPlanes,
+          &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked,
+          mUi->cbxClearanceCopperCopper, &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked,
+          mUi->cbxClearanceCopperBoard, &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxClearanceCopperNpth,
+          &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxMinCopperWidth,
+          &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxMinPthRestring,
+          &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxMinPthDrillDiameter,
+          &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked,
+          mUi->cbxMinNpthDrillDiameter, &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxCourtyardOffset,
+          &QCheckBox::setChecked);
+  connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxMissingConnections,
+          &QCheckBox::setChecked);
 
   // set options
+  mUi->cbxRebuildPlanes->setChecked(options.rebuildPlanes);
+  mUi->cbxClearanceCopperCopper->setChecked(options.checkCopperCopperClearance);
   mUi->edtClearanceCopperCopper->setValue(options.minCopperCopperClearance);
+  mUi->cbxClearanceCopperBoard->setChecked(options.checkCopperBoardClearance);
   mUi->edtClearanceCopperBoard->setValue(options.minCopperBoardClearance);
+  mUi->cbxClearanceCopperNpth->setChecked(options.checkCopperNpthClearance);
   mUi->edtClearanceCopperNpth->setValue(options.minCopperNpthClearance);
+  mUi->cbxMinCopperWidth->setChecked(options.checkCopperWidth);
   mUi->edtMinCopperWidth->setValue(options.minCopperWidth);
+  mUi->cbxMinPthRestring->setChecked(options.checkPthRestring);
   mUi->edtMinPthRestring->setValue(options.minPthRestring);
+  mUi->cbxMinPthDrillDiameter->setChecked(options.checkPthDrillDiameter);
   mUi->edtMinPthDrillDiameter->setValue(options.minPthDrillDiameter);
+  mUi->cbxMinNpthDrillDiameter->setChecked(options.checkNpthDrillDiameter);
   mUi->edtMinNpthDrillDiameter->setValue(options.minNpthDrillDiameter);
+  mUi->cbxCourtyardOffset->setChecked(options.checkCourtyardClearance);
   mUi->edtCourtyardOffset->setValue(options.courtyardOffset);
+  mUi->cbxMissingConnections->setChecked(options.checkMissingConnections);
 }
 
 BoardDesignRuleCheckDialog::~BoardDesignRuleCheckDialog() {
@@ -98,14 +128,25 @@ BoardDesignRuleCheckDialog::~BoardDesignRuleCheckDialog() {
 BoardDesignRuleCheck::Options BoardDesignRuleCheckDialog::getOptions() const
     noexcept {
   BoardDesignRuleCheck::Options options;
+  options.rebuildPlanes = mUi->cbxRebuildPlanes->isChecked();
+  options.checkCopperCopperClearance =
+      mUi->cbxClearanceCopperCopper->isChecked();
   options.minCopperCopperClearance = mUi->edtClearanceCopperCopper->getValue();
+  options.checkCopperBoardClearance = mUi->cbxClearanceCopperBoard->isChecked();
   options.minCopperBoardClearance = mUi->edtClearanceCopperBoard->getValue();
+  options.checkCopperNpthClearance = mUi->cbxClearanceCopperNpth->isChecked();
   options.minCopperNpthClearance = mUi->edtClearanceCopperNpth->getValue();
+  options.checkCopperWidth = mUi->cbxMinCopperWidth->isChecked();
   options.minCopperWidth = mUi->edtMinCopperWidth->getValue();
+  options.checkPthRestring = mUi->cbxMinPthRestring->isChecked();
   options.minPthRestring = mUi->edtMinPthRestring->getValue();
+  options.checkPthDrillDiameter = mUi->cbxMinPthDrillDiameter->isChecked();
   options.minPthDrillDiameter = mUi->edtMinPthDrillDiameter->getValue();
+  options.checkNpthDrillDiameter = mUi->cbxMinNpthDrillDiameter->isChecked();
   options.minNpthDrillDiameter = mUi->edtMinNpthDrillDiameter->getValue();
+  options.checkCourtyardClearance = mUi->cbxCourtyardOffset->isChecked();
   options.courtyardOffset = mUi->edtCourtyardOffset->getValue();
+  options.checkMissingConnections = mUi->cbxMissingConnections->isChecked();
   return options;
 }
 

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.ui
@@ -7,148 +7,144 @@
     <x>0</x>
     <y>0</y>
     <width>780</width>
-    <height>677</height>
+    <height>520</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Design Rule Check</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1">
-       <item>
-        <widget class="QGroupBox" name="grpOptions">
-         <property name="title">
-          <string>Options</string>
-         </property>
-         <layout class="QFormLayout" name="formLayout">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Clearance Copper to Copper:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Clearance Copper to Board Edge:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Minimum Copper Width:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Minimum PTH Drill Diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Minimum NPTH Drill Diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Minimum PTH Restring:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperCopper" native="true"/>
-          </item>
-          <item row="2" column="1">
-           <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperBoard" native="true"/>
-          </item>
-          <item row="4" column="1">
-           <widget class="librepcb::UnsignedLengthEdit" name="edtMinCopperWidth" native="true"/>
-          </item>
-          <item row="5" column="1">
-           <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthRestring" native="true"/>
-          </item>
-          <item row="6" column="1">
-           <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthDrillDiameter" native="true"/>
-          </item>
-          <item row="7" column="1">
-           <widget class="librepcb::UnsignedLengthEdit" name="edtMinNpthDrillDiameter" native="true"/>
-          </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="label_7">
-            <property name="styleSheet">
-             <string notr="true">QLabel {
-	background-color: rgb(255, 255, 127);
-	color: rgb(170, 0, 0);
-};</string>
-            </property>
-            <property name="text">
-             <string>Note: These values are not (yet) stored permanently in the project files, so they will be reset when closing the project.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="margin">
-             <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Clearance Copper to NPTH Drills:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperNpth" native="true"/>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Additional Courtyard Offset:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
-           <widget class="librepcb::LengthEdit" name="edtCourtyardOffset" native="true"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="title">
-          <string>Execution</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QPushButton" name="btnRun">
-            <property name="text">
-             <string>Run DRC</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QListWidget" name="lstProgress"/>
-          </item>
-          <item>
-           <widget class="QProgressBar" name="prgProgress"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QGroupBox" name="grpOptions">
+       <property name="title">
+        <string>Options</string>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0" colspan="2">
+         <widget class="QLabel" name="label_7">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Note: These values are not (yet) stored permanently in the project files, so they will be reset when closing the project.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="margin">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Clearance Copper to Copper:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperCopper" native="true"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Clearance Copper to Board Edge:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperBoard" native="true"/>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Clearance Copper to NPTH Drills:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperNpth" native="true"/>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Minimum Copper Width:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinCopperWidth" native="true"/>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Minimum PTH Restring:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthRestring" native="true"/>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Minimum PTH Drill Diameter:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthDrillDiameter" native="true"/>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Minimum NPTH Drill Diameter:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinNpthDrillDiameter" native="true"/>
+        </item>
+        <item row="8" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Additional Courtyard Offset:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="librepcb::LengthEdit" name="edtCourtyardOffset" native="true"/>
+        </item>
+        <item row="9" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="10" column="0" colspan="2">
+         <widget class="QProgressBar" name="prgProgress">
+          <property name="value">
+           <number>0</number>
+          </property>
+          <property name="format">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </item>
      <item>
       <widget class="QGroupBox" name="groupBox_2">
@@ -191,7 +187,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>btnRun</tabstop>
   <tabstop>edtClearanceCopperCopper</tabstop>
   <tabstop>edtClearanceCopperBoard</tabstop>
   <tabstop>edtClearanceCopperNpth</tabstop>

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckdialog.ui
@@ -40,87 +40,121 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label">
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="cbxClearanceCopperCopper">
           <property name="text">
            <string>Clearance Copper to Copper:</string>
           </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperCopper" native="true"/>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Clearance Copper to Board Edge:</string>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperBoard" native="true"/>
+         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperCopper" native="true"/>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="label_8">
+         <widget class="QCheckBox" name="cbxClearanceCopperBoard">
           <property name="text">
-           <string>Clearance Copper to NPTH Drills:</string>
+           <string>Clearance Copper to Board Edge:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperNpth" native="true"/>
+         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperBoard" native="true"/>
         </item>
         <item row="4" column="0">
-         <widget class="QLabel" name="label_3">
+         <widget class="QCheckBox" name="cbxClearanceCopperNpth">
           <property name="text">
-           <string>Minimum Copper Width:</string>
+           <string>Clearance Copper to NPTH Drills:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="4" column="1">
-         <widget class="librepcb::UnsignedLengthEdit" name="edtMinCopperWidth" native="true"/>
+         <widget class="librepcb::UnsignedLengthEdit" name="edtClearanceCopperNpth" native="true"/>
         </item>
         <item row="5" column="0">
-         <widget class="QLabel" name="label_6">
+         <widget class="QCheckBox" name="cbxMinCopperWidth">
           <property name="text">
-           <string>Minimum PTH Restring:</string>
+           <string>Minimum Copper Width:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="5" column="1">
-         <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthRestring" native="true"/>
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinCopperWidth" native="true"/>
         </item>
         <item row="6" column="0">
-         <widget class="QLabel" name="label_4">
+         <widget class="QCheckBox" name="cbxMinPthRestring">
           <property name="text">
-           <string>Minimum PTH Drill Diameter:</string>
+           <string>Minimum PTH Restring:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="6" column="1">
-         <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthDrillDiameter" native="true"/>
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthRestring" native="true"/>
         </item>
         <item row="7" column="0">
-         <widget class="QLabel" name="label_5">
+         <widget class="QCheckBox" name="cbxMinPthDrillDiameter">
           <property name="text">
-           <string>Minimum NPTH Drill Diameter:</string>
+           <string>Minimum PTH Drill Diameter:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="7" column="1">
-         <widget class="librepcb::UnsignedLengthEdit" name="edtMinNpthDrillDiameter" native="true"/>
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinPthDrillDiameter" native="true"/>
         </item>
         <item row="8" column="0">
-         <widget class="QLabel" name="label_9">
+         <widget class="QCheckBox" name="cbxMinNpthDrillDiameter">
           <property name="text">
-           <string>Additional Courtyard Offset:</string>
+           <string>Minimum NPTH Drill Diameter:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="8" column="1">
-         <widget class="librepcb::LengthEdit" name="edtCourtyardOffset" native="true"/>
+         <widget class="librepcb::UnsignedLengthEdit" name="edtMinNpthDrillDiameter" native="true"/>
         </item>
         <item row="9" column="0">
+         <widget class="QCheckBox" name="cbxCourtyardOffset">
+          <property name="text">
+           <string>Additional Courtyard Offset:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <widget class="librepcb::LengthEdit" name="edtCourtyardOffset" native="true"/>
+        </item>
+        <item row="10" column="0">
+         <widget class="QCheckBox" name="cbxMissingConnections">
+          <property name="text">
+           <string>Check for missing connections</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="0">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -133,13 +167,36 @@
           </property>
          </spacer>
         </item>
-        <item row="10" column="0" colspan="2">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cbxRebuildPlanes">
+          <property name="text">
+           <string>Rebuild planes before running checks</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="13" column="0" colspan="2">
          <widget class="QProgressBar" name="prgProgress">
           <property name="value">
            <number>0</number>
           </property>
           <property name="format">
            <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="0">
+         <widget class="QPushButton" name="btnSelectAll">
+          <property name="text">
+           <string>Select All/None</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckmessagesdock.h
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckmessagesdock.h
@@ -57,6 +57,17 @@ public:
   ~BoardDesignRuleCheckMessagesDock() noexcept;
 
   // Setters
+  /**
+   * @brief Set whether the dock widget should be interactive or not
+   *
+   * @param interactive   True if enabled, false if disabled.
+   *
+   * @return  Whether the widget was interactive *before* calling this method.
+   *          Useful to temporarily disable widget & restore previous state.
+   */
+  bool setInteractive(bool interactive) noexcept;
+  void setProgressPercent(int percent) noexcept;
+  void setProgressStatus(const QString& status) noexcept;
   void setMessages(const QList<BoardDesignRuleCheckMessage>& messages) noexcept;
 
   // Operator Overloadings
@@ -64,6 +75,8 @@ public:
       const BoardDesignRuleCheckMessagesDock& rhs) = delete;
 
 signals:
+  void settingsDialogRequested();
+  void runDrcRequested();
   void messageSelected(const BoardDesignRuleCheckMessage& msg, bool zoomTo);
 
 private:  // Methods

--- a/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckmessagesdock.ui
+++ b/libs/librepcb/projecteditor/boardeditor/boarddesignrulecheckmessagesdock.ui
@@ -34,17 +34,59 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QListWidget" name="listWidget"/>
+     <widget class="QListWidget" name="lstMessages"/>
     </item>
     <item>
-     <widget class="QCheckBox" name="cbxCenterInView">
-      <property name="text">
-       <string>Center highlighted message in view</string>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>0</number>
       </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
+      <item>
+       <widget class="QCheckBox" name="cbxCenterInView">
+        <property name="text">
+         <string>Zoom to location</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="prgProgress">
+        <property name="format">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnSettings">
+        <property name="toolTip">
+         <string>Open DRC Settings</string>
+        </property>
+        <property name="text">
+         <string notr="true"/>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/img/actions/settings.png</normaloff>:/img/actions/settings.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnRun">
+        <property name="toolTip">
+         <string>Run DRC</string>
+        </property>
+        <property name="text">
+         <string notr="true"/>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -185,6 +185,12 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   tabifyDockWidget(mBoardLayersDock, mErcMsgDock);
   mDrcMessagesDock.reset(new BoardDesignRuleCheckMessagesDock(this));
   connect(mDrcMessagesDock.data(),
+          &BoardDesignRuleCheckMessagesDock::settingsDialogRequested, this,
+          &BoardEditor::on_actionDesignRuleCheck_triggered);
+  connect(mDrcMessagesDock.data(),
+          &BoardDesignRuleCheckMessagesDock::runDrcRequested, this,
+          &BoardEditor::runDrcNonInteractive);
+  connect(mDrcMessagesDock.data(),
           &BoardDesignRuleCheckMessagesDock::messageSelected, this,
           &BoardEditor::highlightDrcMessage);
   addDockWidget(Qt::RightDockWidgetArea, mDrcMessagesDock.data());
@@ -338,6 +344,7 @@ bool BoardEditor::setActiveBoardIndex(int index) noexcept {
     // update dock widgets
     mUnplacedComponentsDock->setBoard(mActiveBoard);
     mBoardLayersDock->setActiveBoard(mActiveBoard);
+    mDrcMessagesDock->setInteractive(mActiveBoard != nullptr);
     mDrcMessagesDock->setMessages(mActiveBoard
                                       ? mDrcMessages[mActiveBoard->getUuid()]
                                       : QList<BoardDesignRuleCheckMessage>());
@@ -722,11 +729,9 @@ void BoardEditor::on_actionDesignRuleCheck_triggered() {
                                     "board_editor/drc_dialog", this);
   dialog.exec();
   mDrcOptions = dialog.getOptions();
-  if (dialog.getMessages()) {
-    clearDrcMarker();
-    mDrcMessages.insert(board->getUuid(), *dialog.getMessages());
-    mDrcMessagesDock->setMessages(*dialog.getMessages());
-    if (dialog.getMessages()->count() > 0) {
+  if (auto messages = dialog.getMessages()) {
+    updateBoardDrcMessages(*board, *messages);
+    if (messages->count() > 0) {
       mDrcMessagesDock->show();
       mDrcMessagesDock->raise();
     }
@@ -886,6 +891,39 @@ void BoardEditor::toolActionGroupChangeTriggered(
 
 void BoardEditor::unplacedComponentsCountChanged(int count) noexcept {
   mUi->lblUnplacedComponentsNote->setVisible(count > 0);
+}
+
+void BoardEditor::runDrcNonInteractive() noexcept {
+  Board* board = getActiveBoard();
+  if (!board) return;
+
+  bool wasInteractive = mDrcMessagesDock->setInteractive(false);
+
+  try {
+    BoardDesignRuleCheck drc(*board, mDrcOptions);
+    connect(&drc, &BoardDesignRuleCheck::progressPercent,
+            mDrcMessagesDock.data(),
+            &BoardDesignRuleCheckMessagesDock::setProgressPercent);
+    connect(&drc, &BoardDesignRuleCheck::progressStatus,
+            mDrcMessagesDock.data(),
+            &BoardDesignRuleCheckMessagesDock::setProgressStatus);
+    drc.execute();  // can throw
+    updateBoardDrcMessages(*board, drc.getMessages());
+  } catch (const Exception& e) {
+    QMessageBox::critical(this, tr("Error"), e.getMsg());
+  }
+
+  mDrcMessagesDock->setInteractive(wasInteractive);
+}
+
+void BoardEditor::updateBoardDrcMessages(
+    const Board& board,
+    const QList<BoardDesignRuleCheckMessage>& messages) noexcept {
+  clearDrcMarker();
+  mDrcMessages.insert(board.getUuid(), messages);
+  if (&board == getActiveBoard()) {
+    mDrcMessagesDock->setMessages(messages);
+  }
 }
 
 void BoardEditor::highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.h
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.h
@@ -129,6 +129,10 @@ private:
   bool graphicsViewEventHandler(QEvent* event);
   void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
   void unplacedComponentsCountChanged(int count) noexcept;
+  void runDrcNonInteractive() noexcept;
+  void updateBoardDrcMessages(
+      const Board& board,
+      const QList<BoardDesignRuleCheckMessage>& messages) noexcept;
   void highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,
                            bool zoomTo) noexcept;
   void clearDrcMarker() noexcept;


### PR DESCRIPTION
# DRC Dialog

### Save/restore window position/size

Restore the last dialog window position and size instead of using defaults every time opening the dialog.

### Simplify/cleanup user interface

- Remove status list widget on the left side of the dialog
- Display status messages as tooltip of progress bar (mouse hover)
- Display last status message as text of progress bar
- Hide progress bar until the DRC is started
- Move run button into button box (next to the close button)
- Remove yellow background of hint text, use italic font instead

### Add checkboxes to select checks to execute

By default, all checks are enabled. But now the user can disable specific checks to focus on specific things. For example, it might be useful to disable the check for missing connections if the layout is not finished yet. Or the rebuild of planes can be disabled since this can consume quite some time, even though the user might know they are already up to date.

|   |   |
| --- | --- |
| **Old:** | ![librepcb-drc-dialog-old](https://user-images.githubusercontent.com/5374821/131215291-9596075f-bd73-4491-a438-79a49ce104cf.gif) |
| **New:** | ![librepcb-drc-dialog-new](https://user-images.githubusercontent.com/5374821/131215298-62175594-3c2a-4e90-a611-b4989f5038d4.gif) |

# DRC Dock Widget

### Add buttons to DRC dock widget to open settings or quickly re-run DRC

When fixing DRC messages, currently one had to open the DRC dialog, run the DRC, and close the dialog every time one wanted to know if the messages are fixed. Now this is much easier: Just one click on the new button in the dock widget is needed to run the DRC again (with the same settings as used in the previous run). In addition, there's also a button to open the DRC dialog (e.g. if settings need to be changed).

![librepcb-drc-dock](https://user-images.githubusercontent.com/5374821/131215303-bf178662-ff35-4360-bd92-9306e9131285.gif)

Fixes #869