### PR TITLE
Project editor: Only autosave project if there were changes

### DIFF
--- a/libs/librepcb/common/undostack.cpp
+++ b/libs/librepcb/common/undostack.cpp
@@ -110,6 +110,22 @@ bool UndoStack::canRedo() const noexcept {
   return (mCurrentIndex < mCommands.count());
 }
 
+uint UndoStack::getUniqueStateId() const noexcept {
+  // Just building a hash of all executed command pointers should be good
+  // enough to detect state changes. Future (undone) commands must be ignored
+  // since they are not relevant for the current state.
+  QList<UndoCommand*> commands = mCommands.mid(0, mCurrentIndex);
+  uint id = qHashRange(commands.constBegin(), commands.constEnd());
+
+  // If there is a command group currently active, we should take it into
+  // account as well to avoid ambiguous state IDs.
+  if (mActiveCommandGroup) {
+    id ^= qHash(mActiveCommandGroup) ^ mActiveCommandGroup->getChildCount();
+  }
+
+  return id;
+}
+
 bool UndoStack::isClean() const noexcept {
   return (mCurrentIndex == mCleanIndex);
 }

--- a/libs/librepcb/common/undostack.h
+++ b/libs/librepcb/common/undostack.h
@@ -149,11 +149,22 @@ public:
   bool canRedo() const noexcept;
 
   /**
+   * @brief Get a unique identification of the current state
+   *
+   * Useful to detect if there were any changes made between to different
+   * points in time.
+   *
+   * @return The current state identification
+   */
+  uint getUniqueStateId() const noexcept;
+
+  /**
    * @brief Check if the stack is in a clean state (the state of the last
    * #setClean())
    *
-   * This is used to determine if the document/project/whatever has changed since
-   * the last time it was saved. You need to call #setClean() when you save it.
+   * This is used to determine if the document/project/whatever has changed
+   * since the last time it was saved. You need to call #setClean() when you
+   * save it.
    *
    * @return true | false
    */

--- a/libs/librepcb/projecteditor/projecteditor.h
+++ b/libs/librepcb/projecteditor/projecteditor.h
@@ -222,6 +222,11 @@ private:  // Data
   UndoStack* mUndoStack;  ///< See @ref doc_project_undostack
   SchematicEditor* mSchematicEditor;  ///< The schematic editor (GUI)
   BoardEditor* mBoardEditor;  ///< The board editor (GUI)
+
+  /**
+   * The UndoStack state ID of the last successful project (auto)save
+   */
+  uint mLastAutosaveStateId;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
Only create a new autosave backup if there are any changes compared to the last autosave backup. Saves disk space and avoids the lagging UI during autosave, if not really needed.

Fixes #895 