### PR TITLE
Library editor: Make GUI of remote libraries completely read-only

### DIFF
--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.cpp
@@ -77,6 +77,28 @@ CirclePropertiesDialog::~CirclePropertiesDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CirclePropertiesDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->cbxLayer->setDisabled(readOnly);
+  mUi->edtLineWidth->setReadOnly(readOnly);
+  mUi->cbxFillArea->setCheckable(!readOnly);
+  mUi->cbxIsGrabArea->setCheckable(!readOnly);
+  mUi->edtDiameter->setReadOnly(readOnly);
+  mUi->edtPosX->setReadOnly(readOnly);
+  mUi->edtPosY->setReadOnly(readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Apply |
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/common/dialogs/circlepropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/circlepropertiesdialog.h
@@ -61,6 +61,9 @@ public:
                          QWidget* parent = nullptr) noexcept;
   ~CirclePropertiesDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   CirclePropertiesDialog& operator=(const CirclePropertiesDialog& rhs) = delete;
 

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.cpp
@@ -67,6 +67,24 @@ HolePropertiesDialog::~HolePropertiesDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void HolePropertiesDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->edtDiameter->setReadOnly(readOnly);
+  mUi->edtPosX->setReadOnly(readOnly);
+  mUi->edtPosY->setReadOnly(readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Apply |
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/common/dialogs/holepropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/holepropertiesdialog.h
@@ -59,6 +59,9 @@ public:
                        QWidget* parent = nullptr) noexcept;
   ~HolePropertiesDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   HolePropertiesDialog& operator=(const HolePropertiesDialog& rhs) = delete;
 

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.cpp
@@ -72,6 +72,26 @@ PolygonPropertiesDialog::~PolygonPropertiesDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void PolygonPropertiesDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->cbxLayer->setDisabled(readOnly);
+  mUi->edtLineWidth->setReadOnly(readOnly);
+  mUi->cbxFillArea->setCheckable(!readOnly);
+  mUi->cbxIsGrabArea->setCheckable(!readOnly);
+  mUi->pathEditorWidget->setReadOnly(readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Apply |
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/common/dialogs/polygonpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/polygonpropertiesdialog.h
@@ -63,6 +63,9 @@ public:
                           QWidget* parent = nullptr) noexcept;
   ~PolygonPropertiesDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   PolygonPropertiesDialog& operator=(const PolygonPropertiesDialog& rhs) =
       delete;

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.cpp
@@ -110,6 +110,35 @@ StrokeTextPropertiesDialog::~StrokeTextPropertiesDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void StrokeTextPropertiesDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->edtText->setReadOnly(readOnly);
+  mUi->cbxLayer->setDisabled(readOnly);
+  mUi->alignmentSelector->setReadOnly(readOnly);
+  mUi->edtHeight->setReadOnly(readOnly);
+  mUi->edtStrokeWidth->setReadOnly(readOnly);
+  mUi->edtLetterSpacingRatio->setReadOnly(readOnly);
+  mUi->cbxLetterSpacingAuto->setCheckable(!readOnly);
+  mUi->edtLineSpacingRatio->setReadOnly(readOnly);
+  mUi->cbxLineSpacingAuto->setCheckable(!readOnly);
+  mUi->edtPosX->setReadOnly(readOnly);
+  mUi->edtPosY->setReadOnly(readOnly);
+  mUi->edtRotation->setReadOnly(readOnly);
+  mUi->cbxMirrored->setCheckable(!readOnly);
+  mUi->cbxAutoRotate->setCheckable(!readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Apply |
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/common/dialogs/stroketextpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/stroketextpropertiesdialog.h
@@ -61,6 +61,9 @@ public:
                              QWidget* parent = nullptr) noexcept;
   ~StrokeTextPropertiesDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   StrokeTextPropertiesDialog& operator=(const StrokeTextPropertiesDialog& rhs) =
       delete;

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.cpp
@@ -79,6 +79,28 @@ TextPropertiesDialog::~TextPropertiesDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void TextPropertiesDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->cbxLayer->setDisabled(readOnly);
+  mUi->edtText->setReadOnly(readOnly);
+  mUi->alignmentSelector->setReadOnly(readOnly);
+  mUi->edtHeight->setReadOnly(readOnly);
+  mUi->edtPosX->setReadOnly(readOnly);
+  mUi->edtPosY->setReadOnly(readOnly);
+  mUi->edtRotation->setReadOnly(readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Apply |
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/common/dialogs/textpropertiesdialog.h
+++ b/libs/librepcb/common/dialogs/textpropertiesdialog.h
@@ -61,6 +61,9 @@ public:
                        QWidget* parent = nullptr) noexcept;
   ~TextPropertiesDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   TextPropertiesDialog& operator=(const TextPropertiesDialog& rhs) = delete;
 

--- a/libs/librepcb/common/widgets/alignmentselector.cpp
+++ b/libs/librepcb/common/widgets/alignmentselector.cpp
@@ -58,6 +58,18 @@ AlignmentSelector::~AlignmentSelector() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void AlignmentSelector::setReadOnly(bool readOnly) noexcept {
+  mUi->tl->setDisabled(readOnly);
+  mUi->tc->setDisabled(readOnly);
+  mUi->tr->setDisabled(readOnly);
+  mUi->cl->setDisabled(readOnly);
+  mUi->cc->setDisabled(readOnly);
+  mUi->cr->setDisabled(readOnly);
+  mUi->bl->setDisabled(readOnly);
+  mUi->bc->setDisabled(readOnly);
+  mUi->br->setDisabled(readOnly);
+}
+
 Alignment AlignmentSelector::getAlignment() const noexcept {
   foreach (QRadioButton* btn, mLookupTable.keys()) {
     if (btn->isChecked()) return mLookupTable.value(btn);

--- a/libs/librepcb/common/widgets/alignmentselector.h
+++ b/libs/librepcb/common/widgets/alignmentselector.h
@@ -54,6 +54,7 @@ public:
   ~AlignmentSelector() noexcept;
 
   // General Methods
+  void setReadOnly(bool readOnly) noexcept;
   Alignment getAlignment() const noexcept;
   void setAlignment(const Alignment& align) noexcept;
 

--- a/libs/librepcb/common/widgets/attributelisteditorwidget.cpp
+++ b/libs/librepcb/common/widgets/attributelisteditorwidget.cpp
@@ -83,6 +83,10 @@ AttributeListEditorWidget::~AttributeListEditorWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void AttributeListEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setReadOnly(readOnly);
+}
+
 void AttributeListEditorWidget::setReferences(UndoStack* undoStack,
                                               AttributeList* list) noexcept {
   mModel->setAttributeList(list);

--- a/libs/librepcb/common/widgets/attributelisteditorwidget.h
+++ b/libs/librepcb/common/widgets/attributelisteditorwidget.h
@@ -54,6 +54,7 @@ public:
   ~AttributeListEditorWidget() noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(UndoStack* undoStack, AttributeList* list) noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/common/widgets/editabletablewidget.h
+++ b/libs/librepcb/common/widgets/editabletablewidget.h
@@ -50,24 +50,29 @@ public:
   virtual ~EditableTableWidget() noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setShowCopyButton(bool show) noexcept { mShowCopyButton = show; }
   void setShowEditButton(bool show) noexcept { mShowEditButton = show; }
   void setShowMoveButtons(bool show) noexcept { mShowMoveButtons = show; }
   void setBrowseButtonColumn(int col) noexcept { mBrowseButtonColumn = col; }
 
   // Inherited
+  using QAbstractItemView::edit;  // Required to override edit() overload below.
   virtual void reset() override;
 
   // Operator Overloadings
   EditableTableWidget& operator=(const EditableTableWidget& rhs) = delete;
 
 protected:
+  virtual bool edit(const QModelIndex& index, EditTrigger trigger,
+                    QEvent* event) override;
   virtual void currentChanged(const QModelIndex& current,
                               const QModelIndex& previous) override;
   virtual void rowsInserted(const QModelIndex& parent, int start,
                             int end) override;
 
 signals:
+  void readOnlyChanged(bool readOnly);
   void currentRowChanged(int row);
   void btnAddClicked(const QVariant& data);
   void btnRemoveClicked(const QVariant& data);
@@ -82,7 +87,8 @@ private:
   QToolButton* createButton(const QString& objectName, const QIcon& icon,
                             const QString& text, const QString& toolTip,
                             int width, int height, Signal clickedSignal,
-                            const QPersistentModelIndex& index) noexcept;
+                            const QPersistentModelIndex& index,
+                            bool doesModify) noexcept;
   void buttonClickedHandler(Signal clickedSignal,
                             const QPersistentModelIndex& index) noexcept;
 
@@ -90,6 +96,7 @@ private:
   bool mShowEditButton;
   bool mShowMoveButtons;
   int mBrowseButtonColumn;
+  bool mReadOnly;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/common/widgets/lengtheditbase.cpp
+++ b/libs/librepcb/common/widgets/lengtheditbase.cpp
@@ -177,11 +177,13 @@ QSize LengthEditBase::sizeHint() const {
 
 QAbstractSpinBox::StepEnabled LengthEditBase::stepEnabled() const {
   QAbstractSpinBox::StepEnabled enabled = QAbstractSpinBox::StepNone;
-  if ((mSingleStepUp > 0) && (mValue < mMaximum)) {
-    enabled |= QAbstractSpinBox::StepUpEnabled;
-  }
-  if ((mSingleStepDown > 0) && (mValue > mMinimum)) {
-    enabled |= QAbstractSpinBox::StepDownEnabled;
+  if (!isReadOnly()) {
+    if ((mSingleStepUp > 0) && (mValue < mMaximum)) {
+      enabled |= QAbstractSpinBox::StepUpEnabled;
+    }
+    if ((mSingleStepDown > 0) && (mValue > mMinimum)) {
+      enabled |= QAbstractSpinBox::StepDownEnabled;
+    }
   }
   return enabled;
 }

--- a/libs/librepcb/common/widgets/numbereditbase.cpp
+++ b/libs/librepcb/common/widgets/numbereditbase.cpp
@@ -61,6 +61,10 @@ NumberEditBase::~NumberEditBase() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void NumberEditBase::setReadOnly(bool readOnly) noexcept {
+  mSpinBox->setReadOnly(readOnly);
+}
+
 void NumberEditBase::setSingleStep(tl::optional<double> step) noexcept {
   if (step) {
     mSpinBox->setSingleStep(*step);

--- a/libs/librepcb/common/widgets/numbereditbase.h
+++ b/libs/librepcb/common/widgets/numbereditbase.h
@@ -55,6 +55,7 @@ public:
   virtual ~NumberEditBase() noexcept;
 
   // General Methods
+  void setReadOnly(bool readOnly) noexcept;
   void setSingleStep(tl::optional<double> step) noexcept;
   void setFrame(bool frame) noexcept;
   void selectAll() noexcept;

--- a/libs/librepcb/common/widgets/patheditorwidget.cpp
+++ b/libs/librepcb/common/widgets/patheditorwidget.cpp
@@ -83,6 +83,10 @@ PathEditorWidget::~PathEditorWidget() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void PathEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setReadOnly(readOnly);
+}
+
 void PathEditorWidget::setPath(const Path& path) noexcept {
   mModel->setPath(path);
 }

--- a/libs/librepcb/common/widgets/patheditorwidget.h
+++ b/libs/librepcb/common/widgets/patheditorwidget.h
@@ -54,6 +54,7 @@ public:
   ~PathEditorWidget() noexcept;
 
   // General Methods
+  void setReadOnly(bool readOnly) noexcept;
   void setPath(const Path& path) noexcept;
   const Path& getPath() const noexcept;
   void setLengthUnit(const LengthUnit& unit) noexcept;

--- a/libs/librepcb/libraryeditor/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componenteditorwidget.cpp
@@ -54,12 +54,26 @@ ComponentEditorWidget::ComponentEditorWidget(const Context& context,
   : EditorWidgetBase(context, fp, parent), mUi(new Ui::ComponentEditorWidget) {
   mUi->setupUi(this);
   mUi->lstMessages->setHandler(this);
+  mUi->lstMessages->setProvideFixes(!mContext.readOnly);
+  mUi->edtName->setReadOnly(mContext.readOnly);
+  mUi->edtDescription->setReadOnly(mContext.readOnly);
+  mUi->edtKeywords->setReadOnly(mContext.readOnly);
+  mUi->edtAuthor->setReadOnly(mContext.readOnly);
+  mUi->edtVersion->setReadOnly(mContext.readOnly);
+  mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
+  mUi->cbxSchematicOnly->setCheckable(!mContext.readOnly);
+  mUi->edtPrefix->setReadOnly(mContext.readOnly);
+  mUi->edtDefaultValue->setReadOnly(mContext.readOnly);
+  mUi->signalEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->symbolVariantsEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->attributesEditorWidget->setReadOnly(mContext.readOnly);
   setupErrorNotificationWidget(*mUi->errorNotificationWidget);
   setWindowIcon(QIcon(":/img/library/component.png"));
 
   // Insert category list editor widget.
   mCategoriesEditorWidget.reset(
       new ComponentCategoryListEditorWidget(mContext.workspace, this));
+  mCategoriesEditorWidget->setReadOnly(mContext.readOnly);
   mCategoriesEditorWidget->setRequiresMinimumOneEntry(true);
   int row;
   QFormLayout::ItemRole role;
@@ -204,6 +218,7 @@ bool ComponentEditorWidget::openComponentSymbolVariantEditor(
     ComponentSymbolVariant& variant) noexcept {
   ComponentSymbolVariantEditDialog dialog(mContext.workspace, *mComponent,
                                           variant);
+  dialog.setReadOnly(mContext.readOnly);
   return (dialog.exec() == QDialog::Accepted);
 }
 

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.cpp
@@ -77,6 +77,10 @@ ComponentSignalListEditorWidget::~ComponentSignalListEditorWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void ComponentSignalListEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setReadOnly(readOnly);
+}
+
 void ComponentSignalListEditorWidget::setReferences(
     UndoStack* undoStack, ComponentSignalList* list) noexcept {
   mModel->setSignalList(list);

--- a/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsignallisteditorwidget.h
@@ -60,6 +60,7 @@ public:
   ~ComponentSignalListEditorWidget() noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(UndoStack* undoStack, ComponentSignalList* list) noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.cpp
@@ -90,6 +90,25 @@ ComponentSymbolVariantEditDialog::~ComponentSymbolVariantEditDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void ComponentSymbolVariantEditDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->edtName->setReadOnly(readOnly);
+  mUi->edtDescription->setReadOnly(readOnly);
+  mUi->cbxNorm->setDisabled(readOnly);
+  mUi->symbolListWidget->setReadOnly(readOnly);
+  mUi->pinSignalMapEditorWidget->setReadOnly(readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvarianteditdialog.h
@@ -76,6 +76,9 @@ public:
                                    QWidget* parent = nullptr) noexcept;
   ~ComponentSymbolVariantEditDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   ComponentSymbolVariantEditDialog& operator=(
       const ComponentSymbolVariantEditDialog& rhs) = delete;

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.cpp
@@ -103,6 +103,11 @@ ComponentSymbolVariantItemListEditorWidget::
  *  Setters
  ******************************************************************************/
 
+void ComponentSymbolVariantItemListEditorWidget::setReadOnly(
+    bool readOnly) noexcept {
+  mView->setReadOnly(readOnly);
+}
+
 void ComponentSymbolVariantItemListEditorWidget::setReferences(
     const workspace::Workspace& ws,
     const IF_GraphicsLayerProvider& layerProvider,

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantitemlisteditorwidget.h
@@ -66,6 +66,7 @@ public:
   ~ComponentSymbolVariantItemListEditorWidget() noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(
       const workspace::Workspace& ws,
       const IF_GraphicsLayerProvider& layerProvider,

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.cpp
@@ -93,6 +93,10 @@ ComponentSymbolVariantListWidget::~ComponentSymbolVariantListWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void ComponentSymbolVariantListWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setReadOnly(readOnly);
+}
+
 void ComponentSymbolVariantListWidget::setReferences(
     UndoStack* undoStack, ComponentSymbolVariantList* list,
     IF_ComponentSymbolVariantEditorProvider* editorProvider) noexcept {

--- a/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/componentsymbolvariantlistwidget.h
@@ -61,6 +61,7 @@ public:
   ~ComponentSymbolVariantListWidget() noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(
       UndoStack* undoStack, ComponentSymbolVariantList* list,
       IF_ComponentSymbolVariantEditorProvider* editorProvider) noexcept;

--- a/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.cpp
@@ -45,7 +45,9 @@ CompSymbVarPinSignalMapEditorWidget::CompSymbVarPinSignalMapEditorWidget(
   : QWidget(parent),
     mModel(new ComponentPinSignalMapModel(this)),
     mProxy(new SortFilterProxyModel(this)),
-    mView(new QTableView(this)) {
+    mView(new QTableView(this)),
+    mBtnAutoAssign(
+        new QPushButton(tr("Automatically assign all signals by name"), this)) {
   mProxy->setSourceModel(mModel.data());
   mView->setModel(mProxy.data());
   mView->setAlternatingRowColors(true);  // increase readability
@@ -77,11 +79,9 @@ CompSymbVarPinSignalMapEditorWidget::CompSymbVarPinSignalMapEditorWidget(
   layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(3);
   layout->addWidget(mView.data());
-  QPushButton* btn =
-      new QPushButton(tr("Automatically assign all signals by name"), this);
-  connect(btn, &QPushButton::clicked, mModel.data(),
+  connect(mBtnAutoAssign.data(), &QPushButton::clicked, mModel.data(),
           &ComponentPinSignalMapModel::autoAssignSignals);
-  layout->addWidget(btn);
+  layout->addWidget(mBtnAutoAssign.data());
 }
 
 CompSymbVarPinSignalMapEditorWidget::
@@ -91,6 +91,13 @@ CompSymbVarPinSignalMapEditorWidget::
 /*******************************************************************************
  *  Setters
  ******************************************************************************/
+
+void CompSymbVarPinSignalMapEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setEditTriggers(readOnly
+                             ? QAbstractItemView::EditTrigger::NoEditTriggers
+                             : QAbstractItemView::AllEditTriggers);
+  mBtnAutoAssign->setHidden(readOnly);
+}
 
 void CompSymbVarPinSignalMapEditorWidget::setReferences(
     ComponentSymbolVariant* variant,

--- a/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.h
+++ b/libs/librepcb/libraryeditor/cmp/compsymbvarpinsignalmapeditorwidget.h
@@ -64,6 +64,7 @@ public:
   ~CompSymbVarPinSignalMapEditorWidget() noexcept;
 
   // General Methods
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(
       ComponentSymbolVariant* variant,
       const std::shared_ptr<const LibraryElementCache>& symbolCache,
@@ -78,6 +79,7 @@ private:
   QScopedPointer<ComponentPinSignalMapModel> mModel;
   QScopedPointer<SortFilterProxyModel> mProxy;
   QScopedPointer<QTableView> mView;
+  QScopedPointer<QPushButton> mBtnAutoAssign;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/cmpcat/componentcategoryeditorwidget.cpp
@@ -53,6 +53,15 @@ ComponentCategoryEditorWidget::ComponentCategoryEditorWidget(
     mUi(new Ui::ComponentCategoryEditorWidget) {
   mUi->setupUi(this);
   mUi->lstMessages->setHandler(this);
+  mUi->lstMessages->setProvideFixes(!mContext.readOnly);
+  mUi->edtName->setReadOnly(mContext.readOnly);
+  mUi->edtDescription->setReadOnly(mContext.readOnly);
+  mUi->edtKeywords->setReadOnly(mContext.readOnly);
+  mUi->edtAuthor->setReadOnly(mContext.readOnly);
+  mUi->edtVersion->setReadOnly(mContext.readOnly);
+  mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
+  mUi->btnChooseParentCategory->setEnabled(!mContext.readOnly);
+  mUi->btnResetParentCategory->setEnabled(!mContext.readOnly);
   setWindowIcon(QIcon(":/img/places/folder.png"));
   connect(mUi->btnChooseParentCategory, &QToolButton::clicked, this,
           &ComponentCategoryEditorWidget::btnChooseParentCategoryClicked);

--- a/libs/librepcb/libraryeditor/common/categorylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/common/categorylisteditorwidget.cpp
@@ -63,6 +63,11 @@ CategoryListEditorWidgetBase::~CategoryListEditorWidgetBase() noexcept {
  *  Setters
  ******************************************************************************/
 
+void CategoryListEditorWidgetBase::setReadOnly(bool readOnly) noexcept {
+  mUi->btnAdd->setHidden(readOnly);
+  mUi->btnRemove->setHidden(readOnly);
+}
+
 void CategoryListEditorWidgetBase::setRequiresMinimumOneEntry(bool v) noexcept {
   mRequiresMinimumOneEntry = v;
   updateColor();

--- a/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/common/categorylisteditorwidget.h
@@ -68,6 +68,7 @@ public:
   const QSet<Uuid>& getUuids() const noexcept { return mUuids; }
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setRequiresMinimumOneEntry(bool v) noexcept;
   void setUuids(const QSet<Uuid>& uuids) noexcept;
 

--- a/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.cpp
+++ b/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.cpp
@@ -37,7 +37,10 @@ namespace editor {
 
 LibraryElementCheckListWidget::LibraryElementCheckListWidget(
     QWidget* parent) noexcept
-  : QWidget(parent), mListWidget(new QListWidget(this)), mHandler(nullptr) {
+  : QWidget(parent),
+    mListWidget(new QListWidget(this)),
+    mHandler(nullptr),
+    mProvideFixes(true) {
   QVBoxLayout* layout = new QVBoxLayout(this);
   layout->setContentsMargins(0, 0, 0, 0);
   layout->addWidget(mListWidget.data());
@@ -52,6 +55,14 @@ LibraryElementCheckListWidget::~LibraryElementCheckListWidget() noexcept {
 /*******************************************************************************
  *  Setters
  ******************************************************************************/
+
+void LibraryElementCheckListWidget::setProvideFixes(
+    bool provideFixes) noexcept {
+  if (provideFixes != mProvideFixes) {
+    mProvideFixes = provideFixes;
+    updateList();
+  }
+}
 
 void LibraryElementCheckListWidget::setHandler(
     IF_LibraryElementCheckHandler* handler) noexcept {
@@ -112,7 +123,7 @@ void LibraryElementCheckListWidget::itemDoubleClicked(
   std::shared_ptr<const LibraryElementCheckMessage> msg =
       mMessages.value(mListWidget->row(item));
   if (msg && mHandler) {
-    if (mHandler->libraryElementCheckFixAvailable(msg)) {
+    if (mProvideFixes && mHandler->libraryElementCheckFixAvailable(msg)) {
       mHandler->libraryElementCheckFixRequested(msg);
     } else {
       mHandler->libraryElementCheckDescriptionRequested(msg);
@@ -122,7 +133,7 @@ void LibraryElementCheckListWidget::itemDoubleClicked(
 
 bool LibraryElementCheckListWidget::libraryElementCheckFixAvailable(
     std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept {
-  if (mHandler) {
+  if (mProvideFixes && mHandler) {
     return mHandler->libraryElementCheckFixAvailable(msg);
   } else {
     return false;
@@ -131,7 +142,7 @@ bool LibraryElementCheckListWidget::libraryElementCheckFixAvailable(
 
 void LibraryElementCheckListWidget::libraryElementCheckFixRequested(
     std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept {
-  if (mHandler) {
+  if (mProvideFixes && mHandler) {
     mHandler->libraryElementCheckFixRequested(msg);
   }
 }

--- a/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.h
+++ b/libs/librepcb/libraryeditor/common/libraryelementchecklistwidget.h
@@ -151,6 +151,7 @@ public:
   ~LibraryElementCheckListWidget() noexcept;
 
   // Setters
+  void setProvideFixes(bool provideFixes) noexcept;
   void setHandler(IF_LibraryElementCheckHandler* handler) noexcept;
   void setMessages(LibraryElementCheckMessageList messages) noexcept;
 
@@ -172,6 +173,7 @@ private:  // Data
   QScopedPointer<QListWidget> mListWidget;
   IF_LibraryElementCheckHandler* mHandler;
   LibraryElementCheckMessageList mMessages;
+  bool mProvideFixes;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/libraryeditor/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/dev/deviceeditorwidget.cpp
@@ -63,6 +63,16 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
   : EditorWidgetBase(context, fp, parent), mUi(new Ui::DeviceEditorWidget) {
   mUi->setupUi(this);
   mUi->lstMessages->setHandler(this);
+  mUi->lstMessages->setProvideFixes(!mContext.readOnly);
+  mUi->edtName->setReadOnly(mContext.readOnly);
+  mUi->edtDescription->setReadOnly(mContext.readOnly);
+  mUi->edtKeywords->setReadOnly(mContext.readOnly);
+  mUi->edtAuthor->setReadOnly(mContext.readOnly);
+  mUi->edtVersion->setReadOnly(mContext.readOnly);
+  mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
+  mUi->btnChoosePackage->setHidden(mContext.readOnly);
+  mUi->btnChooseComponent->setHidden(mContext.readOnly);
+  mUi->padSignalMapEditorWidget->setReadOnly(mContext.readOnly);
   setupErrorNotificationWidget(*mUi->errorNotificationWidget);
   setWindowIcon(QIcon(":/img/library/device.png"));
 
@@ -77,6 +87,7 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
   // Insert category list editor widget.
   mCategoriesEditorWidget.reset(
       new ComponentCategoryListEditorWidget(mContext.workspace, this));
+  mCategoriesEditorWidget->setReadOnly(mContext.readOnly);
   mCategoriesEditorWidget->setRequiresMinimumOneEntry(true);
   int row;
   QFormLayout::ItemRole role;

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.cpp
@@ -76,6 +76,12 @@ PadSignalMapEditorWidget::~PadSignalMapEditorWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void PadSignalMapEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setEditTriggers(readOnly
+                             ? QAbstractItemView::EditTrigger::NoEditTriggers
+                             : QAbstractItemView::AllEditTriggers);
+}
+
 void PadSignalMapEditorWidget::setReferences(UndoStack* undoStack,
                                              DevicePadSignalMap* map) noexcept {
   mModel->setPadSignalMap(map);

--- a/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
+++ b/libs/librepcb/libraryeditor/dev/padsignalmapeditorwidget.h
@@ -64,6 +64,7 @@ public:
   ~PadSignalMapEditorWidget() noexcept;
 
   // General Methods
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(UndoStack* undoStack, DevicePadSignalMap* map) noexcept;
   void setPadList(const PackagePadList& list) noexcept;
   void setSignalList(const ComponentSignalList& list) noexcept;

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.cpp
@@ -111,6 +111,10 @@ QSet<Uuid> LibraryListEditorWidget::getUuids() const noexcept {
  *  Setters
  ******************************************************************************/
 
+void LibraryListEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mUi->tableView->setReadOnly(readOnly);
+}
+
 void LibraryListEditorWidget::setUuids(const QSet<Uuid>& uuids) noexcept {
   mModel->setValues(uuids.values());
 }

--- a/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/lib/librarylisteditorwidget.h
@@ -71,6 +71,7 @@ public:
   QSet<Uuid> getUuids() const noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setUuids(const QSet<Uuid>& uuids) noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -45,7 +45,7 @@
 };</string>
       </property>
       <property name="text">
-       <string>WARNING: This is a remote library, so all modifications will be lost after updating the library the next time! You should use a local library to manage your own library elements.</string>
+       <string>This is a remote library and thus opened in read-only mode. Use a local library to manage your own library elements. To override remote library elements, copy them to a local library and set a higher version number.</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.cpp
@@ -118,6 +118,34 @@ FootprintPadPropertiesDialog::~FootprintPadPropertiesDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void FootprintPadPropertiesDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->cbxPackagePad->setDisabled(readOnly);
+  mUi->rbtnBoardSideTht->setDisabled(readOnly);
+  mUi->rbtnBoardSideTop->setDisabled(readOnly);
+  mUi->rbtnBoardSideBottom->setDisabled(readOnly);
+  mUi->rbtnShapeRound->setDisabled(readOnly);
+  mUi->rbtnShapeRect->setDisabled(readOnly);
+  mUi->rbtnShapeOctagon->setDisabled(readOnly);
+  mUi->edtDrillDiameter->setReadOnly(readOnly);
+  mUi->edtWidth->setReadOnly(readOnly);
+  mUi->edtHeight->setReadOnly(readOnly);
+  mUi->edtPosX->setReadOnly(readOnly);
+  mUi->edtPosY->setReadOnly(readOnly);
+  mUi->edtRotation->setReadOnly(readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Apply |
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/libraryeditor/pkg/dialogs/footprintpadpropertiesdialog.h
@@ -68,6 +68,9 @@ public:
                                QWidget* parent = nullptr) noexcept;
   ~FootprintPadPropertiesDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   FootprintPadPropertiesDialog& operator=(
       const FootprintPadPropertiesDialog& rhs) = delete;

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.cpp
@@ -75,6 +75,10 @@ FootprintListEditorWidget::~FootprintListEditorWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void FootprintListEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setReadOnly(readOnly);
+}
+
 void FootprintListEditorWidget::setReferences(FootprintList& list,
                                               UndoStack& stack) noexcept {
   mModel->setFootprintList(&list);

--- a/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/footprintlisteditorwidget.h
@@ -58,6 +58,7 @@ public:
   ~FootprintListEditorWidget() noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(FootprintList& list, UndoStack& stack) noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/libraryeditor/pkg/fsm/packageeditorfsm.h
@@ -84,6 +84,7 @@ public:  // Types
     workspace::Workspace& workspace;
     PackageEditorWidget& editorWidget;
     UndoStack& undoStack;
+    bool readOnly;
     GraphicsScene& graphicsScene;
     GraphicsView& graphicsView;
     const IF_GraphicsLayerProvider& layerProvider;

--- a/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packageeditorwidget.cpp
@@ -64,6 +64,15 @@ PackageEditorWidget::PackageEditorWidget(const Context& context,
     mGraphicsScene(new GraphicsScene()) {
   mUi->setupUi(this);
   mUi->lstMessages->setHandler(this);
+  mUi->lstMessages->setProvideFixes(!mContext.readOnly);
+  mUi->edtName->setReadOnly(mContext.readOnly);
+  mUi->edtDescription->setReadOnly(mContext.readOnly);
+  mUi->edtKeywords->setReadOnly(mContext.readOnly);
+  mUi->edtAuthor->setReadOnly(mContext.readOnly);
+  mUi->edtVersion->setReadOnly(mContext.readOnly);
+  mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
+  mUi->footprintEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->padListEditorWidget->setReadOnly(mContext.readOnly);
   setupErrorNotificationWidget(*mUi->errorNotificationWidget);
   mUi->graphicsView->setUseOpenGl(
       mContext.workspace.getSettings().useOpenGl.get());
@@ -85,6 +94,7 @@ PackageEditorWidget::PackageEditorWidget(const Context& context,
   // Insert category list editor widget.
   mCategoriesEditorWidget.reset(
       new PackageCategoryListEditorWidget(mContext.workspace, this));
+  mCategoriesEditorWidget->setReadOnly(mContext.readOnly);
   mCategoriesEditorWidget->setRequiresMinimumOneEntry(true);
   int row;
   QFormLayout::ItemRole role;
@@ -137,6 +147,7 @@ PackageEditorWidget::PackageEditorWidget(const Context& context,
   PackageEditorFsm::Context fsmContext{mContext.workspace,
                                        *this,
                                        *mUndoStack,
+                                       mContext.readOnly,
                                        *mGraphicsScene,
                                        *mUi->graphicsView,
                                        mContext.layerProvider,
@@ -171,17 +182,18 @@ void PackageEditorWidget::setToolsActionGroup(
   EditorWidgetBase::setToolsActionGroup(group);
 
   if (mToolsActionGroup) {
+    bool enabled = !mContext.readOnly;
     mToolsActionGroup->setActionEnabled(Tool::SELECT, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_THT_PADS, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_SMT_PADS, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_NAMES, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_VALUES, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_LINE, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_RECT, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_POLYGON, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_CIRCLE, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_TEXT, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_HOLES, true);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_THT_PADS, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_SMT_PADS, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_NAMES, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_VALUES, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_LINE, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_RECT, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_POLYGON, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_CIRCLE, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_TEXT, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_HOLES, enabled);
     mToolsActionGroup->setCurrentAction(mFsm->getCurrentTool());
     connect(mFsm.data(), &PackageEditorFsm::toolChanged, mToolsActionGroup,
             &ExclusiveActionGroup::setCurrentAction);

--- a/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.cpp
@@ -70,6 +70,10 @@ PackagePadListEditorWidget::~PackagePadListEditorWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void PackagePadListEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mView->setReadOnly(readOnly);
+}
+
 void PackagePadListEditorWidget::setReferences(PackagePadList& list,
                                                UndoStack* stack) noexcept {
   mModel->setPadList(&list);

--- a/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
+++ b/libs/librepcb/libraryeditor/pkg/packagepadlisteditorwidget.h
@@ -59,6 +59,7 @@ public:
   ~PackagePadListEditorWidget() noexcept;
 
   // Setters
+  void setReadOnly(bool readOnly) noexcept;
   void setReferences(PackagePadList& list, UndoStack* stack) noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/pkgcat/packagecategoryeditorwidget.cpp
@@ -53,6 +53,15 @@ PackageCategoryEditorWidget::PackageCategoryEditorWidget(const Context& context,
     mUi(new Ui::PackageCategoryEditorWidget) {
   mUi->setupUi(this);
   mUi->lstMessages->setHandler(this);
+  mUi->lstMessages->setProvideFixes(!mContext.readOnly);
+  mUi->edtName->setReadOnly(mContext.readOnly);
+  mUi->edtDescription->setReadOnly(mContext.readOnly);
+  mUi->edtKeywords->setReadOnly(mContext.readOnly);
+  mUi->edtAuthor->setReadOnly(mContext.readOnly);
+  mUi->edtVersion->setReadOnly(mContext.readOnly);
+  mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
+  mUi->btnChooseParentCategory->setEnabled(!mContext.readOnly);
+  mUi->btnResetParentCategory->setEnabled(!mContext.readOnly);
   setWindowIcon(QIcon(":/img/places/folder_green.png"));
   connect(mUi->btnChooseParentCategory, &QToolButton::clicked, this,
           &PackageCategoryEditorWidget::btnChooseParentCategoryClicked);

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.cpp
@@ -71,6 +71,26 @@ SymbolPinPropertiesDialog::~SymbolPinPropertiesDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void SymbolPinPropertiesDialog::setReadOnly(bool readOnly) noexcept {
+  mUi->edtName->setReadOnly(readOnly);
+  mUi->edtPosX->setReadOnly(readOnly);
+  mUi->edtPosY->setReadOnly(readOnly);
+  mUi->edtRotation->setReadOnly(readOnly);
+  mUi->edtLength->setReadOnly(readOnly);
+  if (readOnly) {
+    mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
+  } else {
+    mUi->buttonBox->setStandardButtons(
+        QDialogButtonBox::StandardButton::Apply |
+        QDialogButtonBox::StandardButton::Cancel |
+        QDialogButtonBox::StandardButton::Ok);
+  }
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.h
+++ b/libs/librepcb/libraryeditor/sym/dialogs/symbolpinpropertiesdialog.h
@@ -64,6 +64,9 @@ public:
                             QWidget* parent = nullptr) noexcept;
   ~SymbolPinPropertiesDialog() noexcept;
 
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+
   // Operator Overloadings
   SymbolPinPropertiesDialog& operator=(const SymbolPinPropertiesDialog& rhs) =
       delete;

--- a/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/libraryeditor/sym/fsm/symboleditorfsm.h
@@ -80,6 +80,7 @@ public:  // Types
     workspace::Workspace& workspace;
     SymbolEditorWidget& editorWidget;
     UndoStack& undoStack;
+    bool readOnly;
     const IF_GraphicsLayerProvider& layerProvider;
     GraphicsScene& graphicsScene;
     GraphicsView& graphicsView;

--- a/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/libraryeditor/sym/symboleditorwidget.cpp
@@ -69,6 +69,13 @@ SymbolEditorWidget::SymbolEditorWidget(const Context& context,
     mGraphicsScene(new GraphicsScene()) {
   mUi->setupUi(this);
   mUi->lstMessages->setHandler(this);
+  mUi->lstMessages->setProvideFixes(!mContext.readOnly);
+  mUi->edtName->setReadOnly(mContext.readOnly);
+  mUi->edtDescription->setReadOnly(mContext.readOnly);
+  mUi->edtKeywords->setReadOnly(mContext.readOnly);
+  mUi->edtAuthor->setReadOnly(mContext.readOnly);
+  mUi->edtVersion->setReadOnly(mContext.readOnly);
+  mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
   setupErrorNotificationWidget(*mUi->errorNotificationWidget);
   mUi->graphicsView->setUseOpenGl(
       mContext.workspace.getSettings().useOpenGl.get());
@@ -87,6 +94,7 @@ SymbolEditorWidget::SymbolEditorWidget(const Context& context,
   // Insert category list editor widget.
   mCategoriesEditorWidget.reset(
       new ComponentCategoryListEditorWidget(mContext.workspace, this));
+  mCategoriesEditorWidget->setReadOnly(mContext.readOnly);
   mCategoriesEditorWidget->setRequiresMinimumOneEntry(true);
   int row;
   QFormLayout::ItemRole role;
@@ -133,6 +141,7 @@ SymbolEditorWidget::SymbolEditorWidget(const Context& context,
   SymbolEditorFsm::Context fsmContext{mContext.workspace,
                                       *this,
                                       *mUndoStack,
+                                      mContext.readOnly,
                                       mContext.layerProvider,
                                       *mGraphicsScene,
                                       *mUi->graphicsView,
@@ -162,15 +171,16 @@ void SymbolEditorWidget::setToolsActionGroup(
   EditorWidgetBase::setToolsActionGroup(group);
 
   if (mToolsActionGroup) {
+    bool enabled = !mContext.readOnly;
     mToolsActionGroup->setActionEnabled(Tool::SELECT, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_PINS, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_NAMES, true);
-    mToolsActionGroup->setActionEnabled(Tool::ADD_VALUES, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_LINE, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_RECT, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_POLYGON, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_CIRCLE, true);
-    mToolsActionGroup->setActionEnabled(Tool::DRAW_TEXT, true);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_PINS, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_NAMES, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::ADD_VALUES, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_LINE, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_RECT, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_POLYGON, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_CIRCLE, enabled);
+    mToolsActionGroup->setActionEnabled(Tool::DRAW_TEXT, enabled);
     mToolsActionGroup->setCurrentAction(mFsm->getCurrentTool());
     connect(mFsm.data(), &SymbolEditorFsm::toolChanged, mToolsActionGroup,
             &ExclusiveActionGroup::setCurrentAction);


### PR DESCRIPTION
Until now, remote libraries (i.e. libraries installed with the library manager) could be modified as usual, but it was not possible to save them (error message when clicking on "save"). This was a bit problematic:

- IMHO it's not user friendly at all if the GUI allows you to make modifications, but afterwards you're not able to save these modifications to disk.
- There are some features which bypass the "save" mechanism, and those were not protected until now. So it was even possible to actually modify remote libraries by accident (see #832).

This PR now really disables all widgets which would allow to make modifications (only for remote libraries, of course). Even things like moving graphics elements with the mouse is not possible anymore.

It's a bit cumbersome to implement and maintain (easy to forget disabling some particular widgets) and strange to add ~500 lines of code just to *disable* some of the features :sob: But in the end, it might be worth the effort because now the GUI no longer provides "illegal" functionality.

Fixes #832.

*Btw, somehow I don't like read-only GUIs - although this is safe way for beginners, power-users might even have reasons to modify remote libraries. If you know what you're doing, it's not that dangerous. Thus I wonder if it would make sense to even completely remove the read-only feature :thinking: A compromise would be to make it read-only by default, but provide a "remove read-only protection" feature - but this would make the whole thing even more complex... We can still consider that option some day later, if needed.*