### PR TITLE
issue #852 - OpenGL rendering changes Schematic Editor Background to black

### DIFF
--- a/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/projecteditor/schematiceditor/schematiceditor.cpp
@@ -109,6 +109,7 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   mGraphicsView = new GraphicsView(nullptr, this);
   mGraphicsView->setUseOpenGl(
       mProjectEditor.getWorkspace().getSettings().useOpenGl.get());
+  mGraphicsView->setBackgroundBrush(Qt::white);
   setCentralWidget(mGraphicsView);
 
   // Add actions to toggle visibility of dock widgets


### PR DESCRIPTION
backgroundBrush() would return "no brush" when switching to opengl for rendering for graphicsview. For boardeditor  setbackgroundbrush is used in the constructor for BoardEditor class but not for SchematicEditor class. Simply added white brush to SchematicEditor constructor to set background