### PR TITLE
CMake: Add WIN32 flag to GUI applications to hide cmd.exe

### DIFF
--- a/apps/EagleImport/CMakeLists.txt
+++ b/apps/EagleImport/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_AUTOUIC ON)
 # Executable
 add_executable(
   eagle_import
+  # When building on Windows, mark this as a GUI application to hide cmd.exe
+  WIN32
   main.cpp mainwindow.cpp mainwindow.h mainwindow.ui polygonsimplifier.cpp
   polygonsimplifier.h
 )

--- a/apps/UuidGenerator/CMakeLists.txt
+++ b/apps/UuidGenerator/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_AUTOUIC ON)
 # Executable
 add_executable(
   uuid_generator
+  # When building on Windows, mark this as a GUI application to hide cmd.exe
+  WIN32
   main.cpp mainwindow.cpp mainwindow.h mainwindow.ui
 )
 target_include_directories(

--- a/apps/librepcb/CMakeLists.txt
+++ b/apps/librepcb/CMakeLists.txt
@@ -5,7 +5,11 @@ set(CMAKE_AUTORCC ON)
 
 # Executable
 add_executable(
-  librepcb MACOSX_BUNDLE # When building on macOS, create a bundle
+  librepcb
+  # When building on Windows, mark this as a GUI application to hide cmd.exe
+  WIN32
+  # When building on macOS, create a bundle
+  MACOSX_BUNDLE
   ../../img/images.qrc
   controlpanel/controlpanel.cpp
   controlpanel/controlpanel.h


### PR DESCRIPTION
When building on Windows, our executables need to be marked as GUI applications, otherwise the cmd.exe window will be visible beside the LibrePCB windows. With qmake this was the default (opt-out with "CONFIG += console") but now with CMake we have to explicitly configure this (opt-in with WIN32 flag).

See https://cmake.org/cmake/help/latest/command/add_executable.html

TODO: Test the CI artifacts on Windows to see if this really fixes the issue.

/cc @dbrgn 