### PR TITLE
Display TLS library version in about dialog

### DIFF
--- a/libs/librepcb/common/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/common/dialogs/aboutdialog.cpp
@@ -26,6 +26,8 @@
 
 #include <librepcb/common/application.h>
 
+#include <QtNetwork>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -99,6 +101,7 @@ AboutDialog::AboutDialog(QWidget* parent) noexcept
   details << "CPU Architecture: " + QSysInfo::currentCpuArchitecture();
   details << "Operating System: " + QSysInfo::prettyProductName();
   details << "Platform Plugin:  " + qApp->platformName();
+  details << "TLS Library:      " + QSslSocket::sslLibraryVersionString();
   mUi->txtDetails->setPlainText(details.join("\n"));
 }
 


### PR DESCRIPTION
Properly bundling the OpenSSL library with our binary releases can be tricky. Its version needs to be compatible with the used Qt version, it must be recent enough to avoid issues like #919, it needs to be bundled (either by `linuxdeployqt` or manually) although it is not a required link time library but an optional runtime library. Several things can go wrong, but it's not easy to verify if the correct library is bundled. This PR adds the TLS library version, which was detected by Qt, to the about dialog so it can be checked very easy.

Now the "details" tab looks like this:

```
LibrePCB Version: 0.2.0-unstable
Git Revision:     7f511d7da
Build Date:       2021-10-12T22:16:14
Qt Version:       5.15.2 (built against 5.15.2)
CPU Architecture: x86_64
Operating System: Manjaro Linux
Platform Plugin:  xcb
TLS Library:      OpenSSL 1.1.1k  25 Mar 2021
```

I thought twice about this change because actually I don't want to clutter up the about dialog with too much information. However, probably the TLS library is really worth to add because it is quite special compared to most other libraries.