### PR TITLE
Board editor: Fix some strange trace layer change behavior

### DIFF
--- a/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
+++ b/libs/librepcb/projecteditor/boardeditor/fsm/boardeditorstate_drawtrace.h
@@ -121,11 +121,14 @@ private:
    *                          beginning a new trace.
    * @param fixedVia          The BI_Via used as the start anchor, when
    *                          beginning a new trace.
+   * @param fixedPad          The BI_FootprintPad used as the start anchor,
+   *                          when beginning a new trace.
    * @return True, when the tracing is successfully started.
    */
   bool startPositioning(Board& board, const Point& pos,
                         BI_NetPoint* fixedPoint = nullptr,
-                        BI_Via* fixedVia = nullptr) noexcept;
+                        BI_Via* fixedVia = nullptr,
+                        BI_FootprintPad* fixedPad = nullptr) noexcept;
 
   /**
    * @brief Finalize the BI_NetLines and connect them to other


### PR DESCRIPTION
### Fix unintended layer change when drawing trace

When drawing traces, the layer sometimes switched to another layer when clicking on a position where another trace was already present. This happened because the last drawn trace segment was not memorized before deciding where to start the next segment. Now it is memorized so the next segment should always start where the last segment ended.

Fixes #865 

### Fix strange layer change behavior when starting at via or pad

When starting to draw a new trace segment at a via or THT pad, sometimes it was not possible to change the layer, because the trace segment was deleted and a new one created, but its start point could have moved to another, very close anchor instead of the original starting via or pad. Now the original starting via or pad is used when switching the layer.