### PR TITLE
Library/board editors: Set tab bars to document mode

### DIFF
--- a/libs/librepcb/libraryeditor/libraryeditor.ui
+++ b/libs/librepcb/libraryeditor/libraryeditor.ui
@@ -60,6 +60,9 @@
       <property name="currentIndex">
        <number>-1</number>
       </property>
+      <property name="documentMode">
+       <bool>true</bool>
+      </property>
       <property name="tabsClosable">
        <bool>true</bool>
       </property>

--- a/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/projecteditor/boardeditor/boardeditor.cpp
@@ -95,6 +95,7 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
     mDrcMessagesDock(),
     mFsm(nullptr) {
   mUi->setupUi(this);
+  mUi->tabBar->setDocumentMode(true);  // For MacOS
   mUi->lblUnplacedComponentsNote->hide();
   mUi->actionProjectSave->setEnabled(mProject.getDirectory().isWritable());
 


### PR DESCRIPTION
On MacOS, so far the tab bars in the library- and board editors had the look of a settings dialog or so:

![Selection_020](https://user-images.githubusercontent.com/5374821/139601801-1509bae1-deec-43ee-b31b-81fb9165b7cf.png)

But actually the tab items represent the currently opened "documents". With the "document mode" enabled, now it looks like this:

![Selection_021](https://user-images.githubusercontent.com/5374821/139601804-6db57897-2bfa-4794-aec3-3823bd9a2cc2.png)

Unfortunately the tab titles are still cropped too much, they are almost not readable but I don't know why this happens :sob:

I guess other operating systems are not affected by this change since most systems don't distinguish between these two styles.