### PR TITLE
CMake: Allow in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,6 @@ set(BUILD_SHARED_LIBS
 # Auto-include current directory
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Require out-of-source builds
-file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
-if(EXISTS "${LOC_PATH}")
-  message(
-    FATAL_ERROR
-      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles."
-  )
-endif()
-
 # Use C++11
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Although for development we usually work with out-of-source builds to not cluttering up the whole source directory with output files, there are situations where in-source builds are totally fine, or even much easier to use than out-of-source builds.

For example, Snapcraft uses in-source builds and it would be a nightmare to manually override the build commands to use out-of-source builds. Maybe there are also other packaging systems which have some kind of pre-defined CMake build workflow where out-of-source builds are not supported. You can also imagine building LibrePCB in a Docker container where it is just irrelevant if the output files are created in-source (but it's simpler, since no mkdir && cd is needed).

I think the risk of annoying developers by accidentally doing an in-source build is not as high as the annoyance of package maintainers and users who only want to compile it (no development). Especially since the number of developers is quite small :wink: In addition, our official build instructions only show commands for out-of-source builds, so for those following the instructions, it shouldn't matter if in-source builds are possible or not.

/cc @dbrgn 