### PR TITLE
Refactor database classes, fixing some minor issues 

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -472,6 +472,8 @@ add_library(
   workspace/workspace.h
   workspace/workspacelibrarydb.cpp
   workspace/workspacelibrarydb.h
+  workspace/workspacelibrarydbwriter.cpp
+  workspace/workspacelibrarydbwriter.h
   workspace/workspacelibraryscanner.cpp
   workspace/workspacelibraryscanner.h
   workspace/workspacesettings.cpp

--- a/libs/librepcb/core/sqlitedatabase.cpp
+++ b/libs/librepcb/core/sqlitedatabase.cpp
@@ -135,7 +135,12 @@ void SQLiteDatabase::clearTable(const QString& table) {
  *  General Methods
  ******************************************************************************/
 
-QSqlQuery SQLiteDatabase::prepareQuery(const QString& query) const {
+QSqlQuery SQLiteDatabase::prepareQuery(QString query,
+                                       const Replacements& replacements) const {
+  for (auto it = replacements.begin(); it != replacements.end(); it++) {
+    query.replace(it->first, it->second);
+  }
+
   QSqlQuery q(mDb);
   if (!q.prepare(query)) {
     qCritical() << "SQLiteDatabase query:" << query;

--- a/libs/librepcb/core/sqlitedatabase.h
+++ b/libs/librepcb/core/sqlitedatabase.h
@@ -45,6 +45,7 @@ class SQLiteDatabase final : public QObject {
 
 public:
   // Types
+  typedef QVector<std::pair<QString, QString>> Replacements;
   class TransactionScopeGuard final {
   public:
     TransactionScopeGuard() = delete;
@@ -72,7 +73,8 @@ public:
   void clearTable(const QString& table);
 
   // General Methods
-  QSqlQuery prepareQuery(const QString& query) const;
+  QSqlQuery prepareQuery(QString query,
+                         const Replacements& replacements = {}) const;
   int count(QSqlQuery& query);
   int insert(QSqlQuery& query);
   void exec(QSqlQuery& query);

--- a/libs/librepcb/core/sqlitedatabase.h
+++ b/libs/librepcb/core/sqlitedatabase.h
@@ -62,7 +62,7 @@ public:
   // Constructors / Destructor
   SQLiteDatabase() = delete;
   SQLiteDatabase(const SQLiteDatabase& other) = delete;
-  SQLiteDatabase(const FilePath& filepath);
+  SQLiteDatabase(const FilePath& filepath, QObject* parent = nullptr);
   ~SQLiteDatabase() noexcept;
 
   // SQL Commands
@@ -85,9 +85,9 @@ private:  // Methods
   /**
    * @brief Enable the "Write-Ahead Logging" (WAL) feature of SQLite
    *
-   * @note LibrePCB requires to enable WAL to avoid blocking readers by writers.
-   * If not enabled, the library scanner would also block all read-only accesses
-   *       to the library database.
+   * @note  LibrePCB requires to enable WAL to avoid blocking readers by
+   *        writers. If not enabled, the library scanner would also block
+   *        all read-only accesses to the library database.
    *
    * @see http://www.sqlite.org/wal.html
    */
@@ -104,7 +104,6 @@ private:  // Methods
 
 private:  // Data
   QSqlDatabase mDb;
-  // int mNestedTransactionCount;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/workspace/workspace.cpp
+++ b/libs/librepcb/core/workspace/workspace.cpp
@@ -86,7 +86,7 @@ Workspace::Workspace(const FilePath& wsPath,
                             qApp->getFileFormatVersion(), this));
 
   // load library database
-  mLibraryDb.reset(new WorkspaceLibraryDb(*this));  // can throw
+  mLibraryDb.reset(new WorkspaceLibraryDb(getLibrariesPath()));  // can throw
 }
 
 Workspace::~Workspace() noexcept {

--- a/libs/librepcb/core/workspace/workspacelibrarydb.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.cpp
@@ -33,7 +33,6 @@
 #include "../library/sym/symbol.h"
 #include "../serialization/sexpression.h"
 #include "../sqlitedatabase.h"
-#include "workspace.h"
 #include "workspacelibrarydbwriter.h"
 #include "workspacelibraryscanner.h"
 
@@ -49,13 +48,14 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-WorkspaceLibraryDb::WorkspaceLibraryDb(Workspace& ws)
-  : QObject(nullptr), mWorkspace(ws) {
+WorkspaceLibraryDb::WorkspaceLibraryDb(const FilePath& librariesPath)
+  : QObject(nullptr),
+    mLibrariesPath(librariesPath),
+    mFilePath(mLibrariesPath.getPathTo(
+        QString("cache_v%1.sqlite").arg(sCurrentDbVersion))) {
   qDebug("Load workspace library database...");
 
   // open SQLite database
-  mFilePath = ws.getLibrariesPath().getPathTo(
-      QString("cache_v%1.sqlite").arg(sCurrentDbVersion));
   mDb.reset(new SQLiteDatabase(mFilePath));  // can throw
 
   // Check database version - actually it must match the version in the
@@ -63,17 +63,18 @@ WorkspaceLibraryDb::WorkspaceLibraryDb(Workspace& ws)
   // database and create a new one.
   int dbVersion = getDbVersion();
   if (dbVersion != sCurrentDbVersion) {
-    qCritical() << "Library database version" << dbVersion << "is wrong!";
+    qWarning() << "Library database version" << dbVersion
+               << "not supported, will be reinitialized.";
     mDb.reset();
     QFile(mFilePath.toStr()).remove();
     mDb.reset(new SQLiteDatabase(mFilePath));  // can throw
-    WorkspaceLibraryDbWriter writer(ws.getLibrariesPath(), *mDb);
+    WorkspaceLibraryDbWriter writer(mLibrariesPath, *mDb);
     writer.createAllTables();  // can throw
     writer.addInternalData("version", sCurrentDbVersion);  // can throw
   }
 
   // create library scanner object
-  mLibraryScanner.reset(new WorkspaceLibraryScanner(mWorkspace, mFilePath));
+  mLibraryScanner.reset(new WorkspaceLibraryScanner(mLibrariesPath, mFilePath));
   connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::scanStarted, this,
           &WorkspaceLibraryDb::scanStarted, Qt::QueuedConnection);
   connect(mLibraryScanner.data(),
@@ -95,417 +96,65 @@ WorkspaceLibraryDb::~WorkspaceLibraryDb() noexcept {
 }
 
 /*******************************************************************************
- *  Getters: Libraries
+ *  Getters
  ******************************************************************************/
 
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getLibraries() const {
-  QSqlQuery query =
-      mDb->prepareQuery("SELECT version, filepath FROM libraries");
-  mDb->exec(query);
-
-  QMultiMap<Version, FilePath> libraries;
-  while (query.next()) {
-    Version version =
-        Version::fromString(query.value(0).toString());  // can throw
-    FilePath filepath(FilePath::fromRelative(mWorkspace.getLibrariesPath(),
-                                             query.value(1).toString()));
-    if (filepath.isValid()) {
-      libraries.insert(version, filepath);
-    } else {
-      throw LogicError(__FILE__, __LINE__);
-    }
-  }
-  return libraries;
-}
-
-/*******************************************************************************
- *  Getters: Library Elements by their UUID
- ******************************************************************************/
-
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getLibraries(
-    const Uuid& uuid) const {
-  return getElementFilePathsFromDb("libraries", uuid);
-}
-
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getComponentCategories(
-    const Uuid& uuid) const {
-  return getElementFilePathsFromDb("component_categories", uuid);
-}
-
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getPackageCategories(
-    const Uuid& uuid) const {
-  return getElementFilePathsFromDb("package_categories", uuid);
-}
-
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getSymbols(
-    const Uuid& uuid) const {
-  return getElementFilePathsFromDb("symbols", uuid);
-}
-
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getPackages(
-    const Uuid& uuid) const {
-  return getElementFilePathsFromDb("packages", uuid);
-}
-
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getComponents(
-    const Uuid& uuid) const {
-  return getElementFilePathsFromDb("components", uuid);
-}
-
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getDevices(
-    const Uuid& uuid) const {
-  return getElementFilePathsFromDb("devices", uuid);
-}
-
-/*******************************************************************************
- *  Getters: Best Match Library Elements by their UUID
- ******************************************************************************/
-
-FilePath WorkspaceLibraryDb::getLatestLibrary(const Uuid& uuid) const {
-  return getLatestVersionFilePath(getLibraries(uuid));
-}
-
-FilePath WorkspaceLibraryDb::getLatestComponentCategory(
-    const Uuid& uuid) const {
-  return getLatestVersionFilePath(getComponentCategories(uuid));
-}
-
-FilePath WorkspaceLibraryDb::getLatestPackageCategory(const Uuid& uuid) const {
-  return getLatestVersionFilePath(getPackageCategories(uuid));
-}
-
-FilePath WorkspaceLibraryDb::getLatestSymbol(const Uuid& uuid) const {
-  return getLatestVersionFilePath(getSymbols(uuid));
-}
-
-FilePath WorkspaceLibraryDb::getLatestPackage(const Uuid& uuid) const {
-  return getLatestVersionFilePath(getPackages(uuid));
-}
-
-FilePath WorkspaceLibraryDb::getLatestComponent(const Uuid& uuid) const {
-  return getLatestVersionFilePath(getComponents(uuid));
-}
-
-FilePath WorkspaceLibraryDb::getLatestDevice(const Uuid& uuid) const {
-  return getLatestVersionFilePath(getDevices(uuid));
-}
-
-/*******************************************************************************
- *  Getters: Library elements by search keyword
- ******************************************************************************/
-
-template <>
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<Library>(
-    const QString& keyword) const {
-  return getElementsBySearchKeyword("libraries", "lib_id", keyword);
-}
-
-template <>
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<ComponentCategory>(
-    const QString& keyword) const {
-  return getElementsBySearchKeyword("component_categories", "cat_id", keyword);
-}
-
-template <>
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<PackageCategory>(
-    const QString& keyword) const {
-  return getElementsBySearchKeyword("package_categories", "cat_id", keyword);
-}
-
-template <>
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<Symbol>(
-    const QString& keyword) const {
-  return getElementsBySearchKeyword("symbols", "symbol_id", keyword);
-}
-
-template <>
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<Package>(
-    const QString& keyword) const {
-  return getElementsBySearchKeyword("packages", "package_id", keyword);
-}
-
-template <>
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<Component>(
-    const QString& keyword) const {
-  return getElementsBySearchKeyword("components", "component_id", keyword);
-}
-
-template <>
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword<Device>(
-    const QString& keyword) const {
-  return getElementsBySearchKeyword("devices", "device_id", keyword);
-}
-
-/*******************************************************************************
- *  Getters: Library elements of a specified library
- ******************************************************************************/
-
-template <>
-QList<FilePath> WorkspaceLibraryDb::getLibraryElements<ComponentCategory>(
-    const FilePath& lib) const {
-  return getLibraryElements(lib, "component_categories");  // can throw
-}
-
-template <>
-QList<FilePath> WorkspaceLibraryDb::getLibraryElements<PackageCategory>(
-    const FilePath& lib) const {
-  return getLibraryElements(lib, "package_categories");  // can throw
-}
-
-template <>
-QList<FilePath> WorkspaceLibraryDb::getLibraryElements<Symbol>(
-    const FilePath& lib) const {
-  return getLibraryElements(lib, "symbols");  // can throw
-}
-
-template <>
-QList<FilePath> WorkspaceLibraryDb::getLibraryElements<Package>(
-    const FilePath& lib) const {
-  return getLibraryElements(lib, "packages");  // can throw
-}
-
-template <>
-QList<FilePath> WorkspaceLibraryDb::getLibraryElements<Component>(
-    const FilePath& lib) const {
-  return getLibraryElements(lib, "components");  // can throw
-}
-
-template <>
-QList<FilePath> WorkspaceLibraryDb::getLibraryElements<Device>(
-    const FilePath& lib) const {
-  return getLibraryElements(lib, "devices");  // can throw
-}
-
-/*******************************************************************************
- *  Getters: Element Metadata
- ******************************************************************************/
-
-template <>
-void WorkspaceLibraryDb::getElementTranslations<Library>(
-    const FilePath& elemDir, const QStringList& localeOrder, QString* name,
-    QString* desc, QString* keywords) const {
-  getElementTranslations("libraries", "lib_id", elemDir, localeOrder, name,
-                         desc, keywords);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementTranslations<ComponentCategory>(
-    const FilePath& elemDir, const QStringList& localeOrder, QString* name,
-    QString* desc, QString* keywords) const {
-  getElementTranslations("component_categories", "cat_id", elemDir, localeOrder,
-                         name, desc, keywords);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementTranslations<PackageCategory>(
-    const FilePath& elemDir, const QStringList& localeOrder, QString* name,
-    QString* desc, QString* keywords) const {
-  getElementTranslations("package_categories", "cat_id", elemDir, localeOrder,
-                         name, desc, keywords);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementTranslations<Symbol>(
-    const FilePath& elemDir, const QStringList& localeOrder, QString* name,
-    QString* desc, QString* keywords) const {
-  getElementTranslations("symbols", "symbol_id", elemDir, localeOrder, name,
-                         desc, keywords);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementTranslations<Package>(
-    const FilePath& elemDir, const QStringList& localeOrder, QString* name,
-    QString* desc, QString* keywords) const {
-  getElementTranslations("packages", "package_id", elemDir, localeOrder, name,
-                         desc, keywords);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementTranslations<Component>(
-    const FilePath& elemDir, const QStringList& localeOrder, QString* name,
-    QString* desc, QString* keywords) const {
-  getElementTranslations("components", "component_id", elemDir, localeOrder,
-                         name, desc, keywords);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementTranslations<Device>(
-    const FilePath& elemDir, const QStringList& localeOrder, QString* name,
-    QString* desc, QString* keywords) const {
-  getElementTranslations("devices", "device_id", elemDir, localeOrder, name,
-                         desc, keywords);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementMetadata<Library>(const FilePath elemDir,
-                                                     Uuid* uuid,
-                                                     Version* version) const {
-  return getElementMetadata("libraries", elemDir, uuid, version);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementMetadata<ComponentCategory>(
-    const FilePath elemDir, Uuid* uuid, Version* version) const {
-  return getElementMetadata("component_categories", elemDir, uuid, version);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementMetadata<PackageCategory>(
-    const FilePath elemDir, Uuid* uuid, Version* version) const {
-  return getElementMetadata("package_categories", elemDir, uuid, version);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementMetadata<Symbol>(const FilePath elemDir,
-                                                    Uuid* uuid,
-                                                    Version* version) const {
-  return getElementMetadata("symbols", elemDir, uuid, version);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementMetadata<Package>(const FilePath elemDir,
-                                                     Uuid* uuid,
-                                                     Version* version) const {
-  return getElementMetadata("packages", elemDir, uuid, version);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementMetadata<Component>(const FilePath elemDir,
-                                                       Uuid* uuid,
-                                                       Version* version) const {
-  return getElementMetadata("components", elemDir, uuid, version);
-}
-
-template <>
-void WorkspaceLibraryDb::getElementMetadata<Device>(const FilePath elemDir,
-                                                    Uuid* uuid,
-                                                    Version* version) const {
-  return getElementMetadata("devices", elemDir, uuid, version);
-}
-
-void WorkspaceLibraryDb::getLibraryMetadata(const FilePath libDir,
+bool WorkspaceLibraryDb::getLibraryMetadata(const FilePath libDir,
                                             QPixmap* icon) const {
   QSqlQuery query = mDb->prepareQuery(
-      "SELECT icon_png FROM libraries WHERE filepath = :filepath");
-  query.bindValue(":filepath",
-                  libDir.toRelative(mWorkspace.getLibrariesPath()));
+      "SELECT icon_png FROM libraries "
+      "WHERE filepath = :filepath "
+      "LIMIT 1");
+  query.bindValue(":filepath", libDir.toRelative(mLibrariesPath));
   mDb->exec(query);
 
-  if (query.first()) {
-    QByteArray blob = query.value(0).toByteArray();
-    if (icon) icon->loadFromData(blob, "png");
-  } else {
-    throw RuntimeError(__FILE__, __LINE__,
-                       tr("Library not found in workspace library: \"%1\"")
-                           .arg(libDir.toNative()));
+  if (!query.next()) {
+    qWarning() << "Library not found in database:" << libDir.toStr();
+    return false;
   }
+
+  if (icon) {
+    icon->loadFromData(query.value(0).toByteArray(), "png");
+  }
+  return true;
 }
 
-void WorkspaceLibraryDb::getDeviceMetadata(const FilePath& devDir,
-                                           Uuid* pkgUuid, Uuid* cmpUuid) const {
+bool WorkspaceLibraryDb::getDeviceMetadata(const FilePath& devDir,
+                                           Uuid* cmpUuid, Uuid* pkgUuid) const {
   QSqlQuery query = mDb->prepareQuery(
-      "SELECT package_uuid, component_uuid "
-      "FROM devices WHERE filepath = :filepath");
-  query.bindValue(":filepath",
-                  devDir.toRelative(mWorkspace.getLibrariesPath()));
+      "SELECT component_uuid, package_uuid FROM devices "
+      "WHERE filepath = :filepath "
+      "LIMIT 1");
+  query.bindValue(":filepath", devDir.toRelative(mLibrariesPath));
   mDb->exec(query);
 
-  if (query.first()) {
-    Uuid uuid = Uuid::fromString(query.value(0).toString());  // can throw
-    if (pkgUuid) *pkgUuid = uuid;
-    uuid = Uuid::fromString(query.value(1).toString());  // can throw
-    if (cmpUuid) *cmpUuid = uuid;
-  } else {
-    throw RuntimeError(__FILE__, __LINE__,
-                       tr("Device not found in workspace library: \"%1\"")
-                           .arg(devDir.toNative()));
+  if (!query.next()) {
+    qWarning() << "Device not found in database:" << devDir.toStr();
+    return false;
   }
+
+  if (cmpUuid) {
+    *cmpUuid = Uuid::fromString(query.value(0).toString());  // can throw
+  }
+  if (pkgUuid) {
+    *pkgUuid = Uuid::fromString(query.value(1).toString());  // can throw
+  }
+  return true;
 }
 
 /*******************************************************************************
  *  Getters: Special
  ******************************************************************************/
 
-QSet<Uuid> WorkspaceLibraryDb::getComponentCategoryChilds(
-    const tl::optional<Uuid>& parent) const {
-  return getCategoryChilds("component_categories", parent);
-}
-
-QSet<Uuid> WorkspaceLibraryDb::getPackageCategoryChilds(
-    const tl::optional<Uuid>& parent) const {
-  return getCategoryChilds("package_categories", parent);
-}
-
-QList<Uuid> WorkspaceLibraryDb::getComponentCategoryParents(
-    const Uuid& category) const {
-  return getCategoryParents("component_categories", category);
-}
-
-QList<Uuid> WorkspaceLibraryDb::getPackageCategoryParents(
-    const Uuid& category) const {
-  return getCategoryParents("package_categories", category);
-}
-
-void WorkspaceLibraryDb::getComponentCategoryElementCount(
-    const tl::optional<Uuid>& category, int* categories, int* symbols,
-    int* components, int* devices) const {
-  if (categories) {
-    *categories = getCategoryChildCount("component_categories", category);
-  }
-  if (symbols) {
-    *symbols = getCategoryElementCount("symbols", "symbol_id", category);
-  }
-  if (components) {
-    *components =
-        getCategoryElementCount("components", "component_id", category);
-  }
-  if (devices) {
-    *devices = getCategoryElementCount("devices", "device_id", category);
-  }
-}
-
-void WorkspaceLibraryDb::getPackageCategoryElementCount(
-    const tl::optional<Uuid>& category, int* categories, int* packages) const {
-  if (categories) {
-    *categories = getCategoryChildCount("package_categories", category);
-  }
-  if (packages) {
-    *packages = getCategoryElementCount("packages", "package_id", category);
-  }
-}
-
-QSet<Uuid> WorkspaceLibraryDb::getSymbolsByCategory(
-    const tl::optional<Uuid>& category) const {
-  return getElementsByCategory("symbols", "symbol_id", category);
-}
-
-QSet<Uuid> WorkspaceLibraryDb::getPackagesByCategory(
-    const tl::optional<Uuid>& category) const {
-  return getElementsByCategory("packages", "package_id", category);
-}
-
-QSet<Uuid> WorkspaceLibraryDb::getComponentsByCategory(
-    const tl::optional<Uuid>& category) const {
-  return getElementsByCategory("components", "component_id", category);
-}
-
-QSet<Uuid> WorkspaceLibraryDb::getDevicesByCategory(
-    const tl::optional<Uuid>& category) const {
-  return getElementsByCategory("devices", "device_id", category);
-}
-
-QSet<Uuid> WorkspaceLibraryDb::getDevicesOfComponent(
+QSet<Uuid> WorkspaceLibraryDb::getComponentDevices(
     const Uuid& component) const {
   QSqlQuery query = mDb->prepareQuery(
-      "SELECT uuid FROM devices WHERE component_uuid = :uuid");
+      "SELECT uuid FROM devices "
+      "WHERE component_uuid = :uuid "
+      "GROUP BY uuid");
   query.bindValue(":uuid", component.toStr());
   mDb->exec(query);
-
-  QSet<Uuid> elements;
-  while (query.next()) {
-    elements.insert(Uuid::fromString(query.value(0).toString()));  // can throw
-  }
-  return elements;
+  return getUuidSet(query);
 }
 
 /*******************************************************************************
@@ -520,72 +169,46 @@ void WorkspaceLibraryDb::startLibraryRescan() noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void WorkspaceLibraryDb::getElementTranslations(const QString& table,
-                                                const QString& idRow,
-                                                const FilePath& elemDir,
-                                                const QStringList& localeOrder,
-                                                QString* name, QString* desc,
-                                                QString* keywords) const {
-  QSqlQuery query = mDb->prepareQuery(
-      "SELECT locale, name, description, keywords FROM " % table %
-      "_tr "
-      "INNER JOIN " %
-      table % " ON " % table % ".id=" % table % "_tr." % idRow %
-      " "
-      "WHERE " %
-      table % ".filepath = :filepath");
-  query.bindValue(":filepath",
-                  elemDir.toRelative(mWorkspace.getLibrariesPath()));
-  mDb->exec(query);
-
-  LocalizedNameMap nameMap(ElementName("unknown"));
-  LocalizedDescriptionMap descriptionMap("unknown");
-  LocalizedKeywordsMap keywordsMap("unknown");
-  while (query.next()) {
-    QString locale = query.value(0).toString();
-    QString name = query.value(1).toString();
-    QString description = query.value(2).toString();
-    QString keywords = query.value(3).toString();
-    if (!name.isNull()) nameMap.insert(locale, ElementName(name));  // can throw
-    if (!description.isNull()) descriptionMap.insert(locale, description);
-    if (!keywords.isNull()) keywordsMap.insert(locale, keywords);
+QMultiMap<Version, FilePath> WorkspaceLibraryDb::getAll(
+    const QString& elementsTable, const tl::optional<Uuid>& uuid,
+    const FilePath& lib) const {
+  if (lib.isValid() && (elementsTable == "libraries")) {
+    throw LogicError(__FILE__, __LINE__,
+                     "Filtering for libraries makes no sense and doesn't work "
+                     "for libraries!");
   }
 
-  if (name) *name = *nameMap.value(localeOrder);
-  if (desc) *desc = descriptionMap.value(localeOrder);
-  if (keywords) *keywords = keywordsMap.value(localeOrder);
-}
-
-void WorkspaceLibraryDb::getElementMetadata(const QString& table,
-                                            const FilePath elemDir, Uuid* uuid,
-                                            Version* version) const {
-  QSqlQuery query = mDb->prepareQuery("SELECT uuid, version FROM " % table %
-                                      " WHERE filepath = :filepath");
-  query.bindValue(":filepath",
-                  elemDir.toRelative(mWorkspace.getLibrariesPath()));
-  mDb->exec(query);
-
-  while (query.next()) {
-    QString uuidStr = query.value(0).toString();
-    QString versionStr = query.value(1).toString();
-    if (uuid) *uuid = Uuid::fromString(uuidStr);  // can throw
-    if (version) *version = Version::fromString(versionStr);  // can throw
+  QStringList conditions;
+  if (uuid) {
+    conditions.append("%elements.uuid = :uuid");
   }
-}
+  if (lib.isValid()) {
+    conditions.append("libraries.filepath = :filepath");
+  }
 
-QMultiMap<Version, FilePath> WorkspaceLibraryDb::getElementFilePathsFromDb(
-    const QString& tablename, const Uuid& uuid) const {
-  QSqlQuery query = mDb->prepareQuery("SELECT version, filepath FROM " %
-                                      tablename % " WHERE uuid = :uuid");
-  query.bindValue(":uuid", uuid.toStr());
+  QString sql = "SELECT %elements.version, %elements.filepath FROM %elements ";
+  if (lib.isValid()) {
+    sql += "LEFT JOIN libraries ON %elements.library_id = libraries.id ";
+  }
+  if (!conditions.isEmpty()) {
+    sql += "WHERE " % conditions.join(" AND ") % " ";
+  }
+
+  QSqlQuery query = mDb->prepareQuery(sql, {{"%elements", elementsTable}});
+  if (uuid) {
+    query.bindValue(":uuid", uuid->toStr());
+  }
+  if (lib.isValid()) {
+    query.bindValue(":filepath", lib.toRelative(mLibrariesPath));
+  }
   mDb->exec(query);
 
   QMultiMap<Version, FilePath> elements;
   while (query.next()) {
     Version version =
         Version::fromString(query.value(0).toString());  // can throw
-    FilePath filepath(FilePath::fromRelative(mWorkspace.getLibrariesPath(),
-                                             query.value(1).toString()));
+    FilePath filepath(
+        FilePath::fromRelative(mLibrariesPath, query.value(1).toString()));
     if (filepath.isValid()) {
       elements.insert(version, filepath);
     } else {
@@ -603,167 +226,200 @@ FilePath WorkspaceLibraryDb::getLatestVersionFilePath(
     return list.last();  // highest version number
 }
 
-QSet<Uuid> WorkspaceLibraryDb::getCategoryChilds(
-    const QString& tablename, const tl::optional<Uuid>& categoryUuid) const {
+QList<Uuid> WorkspaceLibraryDb::find(const QString& elementsTable,
+                                     const QString& keyword) const {
   QSqlQuery query = mDb->prepareQuery(
-      "SELECT uuid FROM " % tablename % " WHERE parent_uuid " %
-      (categoryUuid ? "= '" % categoryUuid->toStr() % "'"
-                    : QString("IS NULL")));
-  mDb->exec(query);
-
-  QSet<Uuid> elements;
-  while (query.next()) {
-    elements.insert(Uuid::fromString(query.value(0).toString()));  // can throw
-  }
-  return elements;
-}
-
-QList<Uuid> WorkspaceLibraryDb::getCategoryParents(const QString& tablename,
-                                                   const Uuid& category) const {
-  tl::optional<Uuid> optCategory = category;
-  QList<Uuid> parentUuids;
-  while ((optCategory = getCategoryParent(tablename, *optCategory))) {
-    if (parentUuids.contains(*optCategory)) {
-      throw RuntimeError(__FILE__, __LINE__,
-                         tr("Endless loop "
-                            "in category parentship detected (%1).")
-                             .arg(optCategory->toStr()));
-    } else {
-      parentUuids.append(*optCategory);
-    }
-  }
-  return parentUuids;
-}
-
-tl::optional<Uuid> WorkspaceLibraryDb::getCategoryParent(
-    const QString& tablename, const Uuid& category) const {
-  QSqlQuery query = mDb->prepareQuery(
-      "SELECT parent_uuid FROM " % tablename % " WHERE uuid = '" %
-      category.toStr() % "'" % " ORDER BY version DESC" % " LIMIT 1");
-  mDb->exec(query);
-
-  if (query.next()) {
-    QVariant value = query.value(0);
-    if (!value.isNull()) {
-      return Uuid::fromString(value.toString());  // can throw
-    } else {
-      return tl::nullopt;
-    }
-  } else {
-    throw RuntimeError(__FILE__, __LINE__,
-                       tr("The category "
-                          "\"%1\" does not exist in the library database.")
-                           .arg(category.toStr()));
-  }
-}
-
-int WorkspaceLibraryDb::getCategoryChildCount(
-    const QString& tablename, const tl::optional<Uuid>& category) const {
-  QSqlQuery query = mDb->prepareQuery(
-      "SELECT COUNT(*) FROM " % tablename % " WHERE parent_uuid " %
-      (category ? "= '" % category->toStr() % "'" : QString("IS NULL")));
-  return mDb->count(query);
-}
-
-int WorkspaceLibraryDb::getCategoryElementCount(
-    const QString& tablename, const QString& idrowname,
-    const tl::optional<Uuid>& category) const {
-  QSqlQuery query = mDb->prepareQuery(
-      "SELECT COUNT(*) FROM " % tablename % " LEFT JOIN " % tablename % "_cat" %
-      " ON " % tablename % ".id=" % tablename % "_cat." % idrowname %
-      " WHERE category_uuid " %
-      (category ? "= '" % category->toStr() % "'" : QString("IS NULL")));
-  return mDb->count(query);
-}
-
-QSet<Uuid> WorkspaceLibraryDb::getElementsByCategory(
-    const QString& tablename, const QString& idrowname,
-    const tl::optional<Uuid>& categoryUuid) const {
-  QSqlQuery query = mDb->prepareQuery(
-      "SELECT uuid FROM " % tablename % " LEFT JOIN " % tablename %
-      "_cat "
-      "ON " %
-      tablename % ".id=" % tablename % "_cat." % idrowname %
-      " "
-      "WHERE category_uuid " %
-      (categoryUuid ? "= '" % categoryUuid->toStr() % "'"
-                    : QString("IS NULL")));
-  mDb->exec(query);
-
-  QSet<Uuid> elements;
-  while (query.next()) {
-    elements.insert(Uuid::fromString(query.value(0).toString()));  // can throw
-  }
-  return elements;
-}
-
-QList<Uuid> WorkspaceLibraryDb::getElementsBySearchKeyword(
-    const QString& tablename, const QString& idrowname,
-    const QString& keyword) const {
-  QSqlQuery query = mDb->prepareQuery(QString("SELECT %1.uuid FROM %1, %1_tr "
-                                              "ON %1.id=%1_tr.%2 "
-                                              "WHERE %1_tr.name LIKE :keyword "
-                                              "OR %1_tr.keywords LIKE :keyword "
-                                              "ORDER BY %1_tr.name ASC ")
-                                          .arg(tablename, idrowname));
+      "SELECT %elements.uuid FROM %elements "
+      "LEFT JOIN %elements_tr "
+      "ON %elements.id = %elements_tr.element_id "
+      "WHERE %elements_tr.name LIKE :keyword "
+      "OR %elements_tr.keywords LIKE :keyword "
+      "GROUP BY %elements.uuid "
+      "ORDER BY %elements_tr.name ASC",
+      {
+          {"%elements", elementsTable},
+      });
   query.bindValue(":keyword", "%" + keyword + "%");
   mDb->exec(query);
 
-  QList<Uuid> elements;
-  elements.reserve(query.size());
+  QList<Uuid> uuids;
   while (query.next()) {
-    elements.append(Uuid::fromString(query.value(0).toString()));  // can throw
+    uuids.append(Uuid::fromString(query.value(0).toString()));  // can throw
   }
-  return elements;
+  return uuids;
 }
 
-int WorkspaceLibraryDb::getLibraryId(const FilePath& lib) const {
-  QString relativeLibraryPath = lib.toRelative(mWorkspace.getLibrariesPath());
+bool WorkspaceLibraryDb::getTranslations(const QString& elementsTable,
+                                         const FilePath& elemDir,
+                                         const QStringList& localeOrder,
+                                         QString* name, QString* description,
+                                         QString* keywords) const {
   QSqlQuery query = mDb->prepareQuery(
-      "SELECT id FROM libraries "
-      "WHERE filepath = '" %
-      relativeLibraryPath %
-      "'"
-      "LIMIT 1");
+      "SELECT locale, name, description, keywords FROM %elements_tr "
+      "INNER JOIN %elements "
+      "ON %elements.id = %elements_tr.element_id "
+      "WHERE %elements.filepath = :filepath",
+      {
+          {"%elements", elementsTable},
+      });
+  query.bindValue(":filepath", elemDir.toRelative(mLibrariesPath));
   mDb->exec(query);
 
-  if (query.next()) {
-    bool ok = false;
-    int id = query.value(0).toInt(&ok);
-    if (!ok) throw LogicError(__FILE__, __LINE__);
-    return id;
-  } else {
-    throw RuntimeError(__FILE__, __LINE__,
-                       tr("The library "
-                          "\"%1\" does not exist in the library database.")
-                           .arg(relativeLibraryPath));
+  // Using LocalizedDescriptionMap for all values since it allows empty strings
+  // (in contrast to LocalizedNameMap, which is more restrictive).
+  LocalizedDescriptionMap nameMap(QString{});
+  LocalizedDescriptionMap descriptionMap(QString{});
+  LocalizedDescriptionMap keywordsMap(QString{});
+  bool elementFound = false;
+  while (query.next()) {
+    elementFound = true;
+    QString locale = query.value(0).toString();
+    QString name = query.value(1).toString();
+    QString description = query.value(2).toString();
+    QString keywords = query.value(3).toString();
+    if (!name.isNull()) nameMap.insert(locale, name);
+    if (!description.isNull()) descriptionMap.insert(locale, description);
+    if (!keywords.isNull()) keywordsMap.insert(locale, keywords);
   }
+
+  if (name) *name = nameMap.value(localeOrder);
+  if (description) *description = descriptionMap.value(localeOrder);
+  if (keywords) *keywords = keywordsMap.value(localeOrder);
+  return elementFound;
 }
 
-QList<FilePath> WorkspaceLibraryDb::getLibraryElements(
-    const FilePath& lib, const QString& tablename) const {
-  QSqlQuery query = mDb->prepareQuery("SELECT filepath FROM " % tablename %
-                                      " WHERE lib_id = :lib_id");
-  query.bindValue(":lib_id", getLibraryId(lib));
+bool WorkspaceLibraryDb::getMetadata(const QString& elementsTable,
+                                     const FilePath elemDir, Uuid* uuid,
+                                     Version* version, bool* deprecated) const {
+  QSqlQuery query = mDb->prepareQuery(
+      "SELECT uuid, version, deprecated FROM %elements "
+      "WHERE filepath = :filepath "
+      "LIMIT 1",
+      {
+          {"%elements", elementsTable},
+      });
+  query.bindValue(":filepath", elemDir.toRelative(mLibrariesPath));
   mDb->exec(query);
 
-  QList<FilePath> elements;
-  while (query.next()) {
-    FilePath filepath(FilePath::fromRelative(mWorkspace.getLibrariesPath(),
-                                             query.value(0).toString()));
-    if (filepath.isValid()) {
-      elements.append(filepath);
-    } else {
-      throw LogicError(__FILE__, __LINE__);
-    }
+  if (!query.next()) {
+    qWarning() << "Element not found in database:" << elemDir.toStr();
+    return false;
   }
-  return elements;
+
+  if (uuid) {
+    *uuid = Uuid::fromString(query.value(0).toString());  // can throw
+  }
+  if (version) {
+    *version = Version::fromString(query.value(1).toString());  // can throw
+  }
+  if (deprecated) {
+    *deprecated = query.value(2).toBool();
+  }
+  return true;
+}
+
+bool WorkspaceLibraryDb::getCategoryMetadata(const QString& categoriesTable,
+                                             const FilePath catDir,
+                                             tl::optional<Uuid>* parent) const {
+  QSqlQuery query = mDb->prepareQuery(
+      "SELECT parent_uuid FROM %categories "
+      "WHERE filepath = :filepath "
+      "LIMIT 1",
+      {
+          {"%categories", categoriesTable},
+      });
+  query.bindValue(":filepath", catDir.toRelative(mLibrariesPath));
+  mDb->exec(query);
+
+  if (!query.next()) {
+    qWarning() << "Category not found in database:" << catDir.toStr();
+    return false;
+  }
+
+  if (parent) {
+    *parent = Uuid::tryFromString(query.value(0).toString());
+  }
+  return true;
+}
+
+QSet<Uuid> WorkspaceLibraryDb::getChilds(
+    const QString& categoriesTable,
+    const tl::optional<Uuid>& categoryUuid) const {
+  QSqlQuery query;
+  SQLiteDatabase::Replacements replacements = {
+      {"%categories", categoriesTable},
+  };
+  if (categoryUuid) {
+    query = mDb->prepareQuery(
+        "SELECT uuid FROM %categories "
+        "WHERE parent_uuid = :category_uuid "
+        "GROUP BY uuid",
+        replacements);
+    query.bindValue(":category_uuid", categoryUuid->toStr());
+  } else {
+    query = mDb->prepareQuery(
+        "SELECT children.uuid FROM %categories AS children "
+        "LEFT JOIN %categories AS parents "
+        "ON children.parent_uuid = parents.uuid "
+        "WHERE parents.uuid IS NULL "
+        "GROUP BY children.uuid",
+        replacements);
+  }
+  mDb->exec(query);
+  return getUuidSet(query);
+}
+
+QSet<Uuid> WorkspaceLibraryDb::getByCategory(const QString& elementsTable,
+                                             const QString& categoryTable,
+                                             const tl::optional<Uuid>& category,
+                                             int limit) const {
+  QSqlQuery query;
+  SQLiteDatabase::Replacements replacements = {
+      {"%elements", elementsTable},
+      {"%categories", categoryTable},
+  };
+  if (category) {
+    // Find all elements assigned to the specified category.
+    query = mDb->prepareQuery(
+        "SELECT %elements.uuid FROM %elements "
+        "INNER JOIN %elements_cat "
+        "ON %elements.id = %elements_cat.element_id "
+        "WHERE category_uuid = :uuid "
+        "GROUP BY uuid "
+        "LIMIT :limit",
+        replacements);
+    query.bindValue(":uuid", category->toStr());
+  } else {
+    // Find all elements with no (existent) category.
+    query = mDb->prepareQuery(
+        "SELECT %elements.uuid FROM %elements "
+        "LEFT JOIN %elements_cat "
+        "ON %elements.id = %elements_cat.element_id "
+        "LEFT JOIN %categories "
+        "ON %elements_cat.category_uuid = %categories.uuid "
+        "GROUP BY %elements.uuid "
+        "HAVING COUNT(%categories.uuid) = 0 "
+        "LIMIT :limit",
+        replacements);
+  }
+  query.bindValue(":limit", limit);
+  mDb->exec(query);
+  return getUuidSet(query);
+}
+
+QSet<Uuid> WorkspaceLibraryDb::getUuidSet(QSqlQuery& query) {
+  QSet<Uuid> uuids;
+  while (query.next()) {
+    uuids.insert(Uuid::fromString(query.value(0).toString()));  // can throw
+  }
+  return uuids;
 }
 
 int WorkspaceLibraryDb::getDbVersion() const noexcept {
   try {
     QSqlQuery query = mDb->prepareQuery(
-        "SELECT value_int FROM internal WHERE key = 'version'");
+        "SELECT value_int FROM internal "
+        "WHERE key = 'version'");
     mDb->exec(query);
     if (query.next()) {
       bool ok = false;
@@ -777,6 +433,31 @@ int WorkspaceLibraryDb::getDbVersion() const noexcept {
     return -1;
   }
 }
+
+template <typename ElementType>
+QString WorkspaceLibraryDb::getTable() noexcept {
+  return WorkspaceLibraryDbWriter::getElementTable<ElementType>();
+}
+
+// explicit template instantiations
+template QString WorkspaceLibraryDb::getTable<Library>() noexcept;
+template QString WorkspaceLibraryDb::getTable<ComponentCategory>() noexcept;
+template QString WorkspaceLibraryDb::getTable<PackageCategory>() noexcept;
+template QString WorkspaceLibraryDb::getTable<Symbol>() noexcept;
+template QString WorkspaceLibraryDb::getTable<Package>() noexcept;
+template QString WorkspaceLibraryDb::getTable<Component>() noexcept;
+template QString WorkspaceLibraryDb::getTable<Device>() noexcept;
+
+template <typename ElementType>
+QString WorkspaceLibraryDb::getCategoryTable() noexcept {
+  return WorkspaceLibraryDbWriter::getCategoryTable<ElementType>();
+}
+
+// explicit template instantiations
+template QString WorkspaceLibraryDb::getCategoryTable<Symbol>() noexcept;
+template QString WorkspaceLibraryDb::getCategoryTable<Package>() noexcept;
+template QString WorkspaceLibraryDb::getCategoryTable<Component>() noexcept;
+template QString WorkspaceLibraryDb::getCategoryTable<Device>() noexcept;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/core/workspace/workspacelibrarydb.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.h
@@ -176,8 +176,6 @@ private:
   int getLibraryId(const FilePath& lib) const;
   QList<FilePath> getLibraryElements(const FilePath& lib,
                                      const QString& tablename) const;
-  void createAllTables();
-  void setDbVersion(int version);
   int getDbVersion() const noexcept;
 
   // Attributes

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
@@ -78,180 +78,187 @@ void WorkspaceLibraryDbWriter::createAllTables() {
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
       "`version` TEXT NOT NULL, "
+      "`deprecated` BOOLEAN NOT NULL, "
       "`icon_png` BLOB "
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS libraries_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES libraries(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
       "`keywords` TEXT, "
-      "UNIQUE(lib_id, locale)"
+      "UNIQUE(element_id, locale)"
       ")");
 
   // component categories
   queries << QString(
       "CREATE TABLE IF NOT EXISTS component_categories ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER NOT NULL, "
+      "`library_id` INTEGER NOT NULL, "
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
       "`version` TEXT NOT NULL, "
+      "`deprecated` BOOLEAN NOT NULL, "
       "`parent_uuid` TEXT"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS component_categories_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`cat_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES component_categories(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
       "`keywords` TEXT, "
-      "UNIQUE(cat_id, locale)"
+      "UNIQUE(element_id, locale)"
       ")");
 
   // package categories
   queries << QString(
       "CREATE TABLE IF NOT EXISTS package_categories ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER NOT NULL, "
+      "`library_id` INTEGER NOT NULL, "
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
       "`version` TEXT NOT NULL, "
+      "`deprecated` BOOLEAN NOT NULL, "
       "`parent_uuid` TEXT"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS package_categories_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`cat_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES package_categories(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
       "`keywords` TEXT, "
-      "UNIQUE(cat_id, locale)"
+      "UNIQUE(element_id, locale)"
       ")");
 
   // symbols
   queries << QString(
       "CREATE TABLE IF NOT EXISTS symbols ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER NOT NULL, "
+      "`library_id` INTEGER NOT NULL, "
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
-      "`version` TEXT NOT NULL"
+      "`version` TEXT NOT NULL, "
+      "`deprecated` BOOLEAN NOT NULL"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS symbols_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`symbol_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES symbols(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
       "`keywords` TEXT, "
-      "UNIQUE(symbol_id, locale)"
+      "UNIQUE(element_id, locale)"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS symbols_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`symbol_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES symbols(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
-      "UNIQUE(symbol_id, category_uuid)"
+      "UNIQUE(element_id, category_uuid)"
       ")");
 
   // packages
   queries << QString(
       "CREATE TABLE IF NOT EXISTS packages ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER NOT NULL, "
+      "`library_id` INTEGER NOT NULL, "
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
-      "`version` TEXT NOT NULL "
+      "`version` TEXT NOT NULL, "
+      "`deprecated` BOOLEAN NOT NULL"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS packages_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`package_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES packages(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
       "`keywords` TEXT, "
-      "UNIQUE(package_id, locale)"
+      "UNIQUE(element_id, locale)"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS packages_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`package_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES packages(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
-      "UNIQUE(package_id, category_uuid)"
+      "UNIQUE(element_id, category_uuid)"
       ")");
 
   // components
   queries << QString(
       "CREATE TABLE IF NOT EXISTS components ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER NOT NULL, "
+      "`library_id` INTEGER NOT NULL, "
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
-      "`version` TEXT NOT NULL"
+      "`version` TEXT NOT NULL, "
+      "`deprecated` BOOLEAN NOT NULL"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS components_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`component_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES components(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
       "`keywords` TEXT, "
-      "UNIQUE(component_id, locale)"
+      "UNIQUE(element_id, locale)"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS components_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`component_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES components(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
-      "UNIQUE(component_id, category_uuid)"
+      "UNIQUE(element_id, category_uuid)"
       ")");
 
   // devices
   queries << QString(
       "CREATE TABLE IF NOT EXISTS devices ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`lib_id` INTEGER NOT NULL, "
+      "`library_id` INTEGER NOT NULL, "
       "`filepath` TEXT UNIQUE NOT NULL, "
       "`uuid` TEXT NOT NULL, "
       "`version` TEXT NOT NULL, "
+      "`deprecated` BOOLEAN NOT NULL, "
       "`component_uuid` TEXT NOT NULL, "
       "`package_uuid` TEXT NOT NULL"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS devices_tr ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`device_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
       "`locale` TEXT NOT NULL, "
       "`name` TEXT, "
       "`description` TEXT, "
       "`keywords` TEXT, "
-      "UNIQUE(device_id, locale)"
+      "UNIQUE(element_id, locale)"
       ")");
   queries << QString(
       "CREATE TABLE IF NOT EXISTS devices_cat ("
       "`id` INTEGER PRIMARY KEY NOT NULL, "
-      "`device_id` INTEGER "
+      "`element_id` INTEGER "
       "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
-      "UNIQUE(device_id, category_uuid)"
+      "UNIQUE(element_id, category_uuid)"
       ")");
 
   // execute queries
@@ -272,14 +279,16 @@ void WorkspaceLibraryDbWriter::addInternalData(const QString& key, int value) {
 
 int WorkspaceLibraryDbWriter::addLibrary(const FilePath& fp, const Uuid& uuid,
                                          const Version& version,
+                                         bool deprecated,
                                          const QByteArray& iconPng) {
   QSqlQuery query = mDb.prepareQuery(
       "INSERT INTO libraries "
-      "(filepath, uuid, version, icon_png) VALUES "
-      "(:filepath, :uuid, :version, :icon_png)");
+      "(filepath, uuid, version, deprecated, icon_png) VALUES "
+      "(:filepath, :uuid, :version, :deprecated, :icon_png)");
   query.bindValue(":filepath", filePathToString(fp));
   query.bindValue(":uuid", uuid.toStr());
   query.bindValue(":version", version.toStr());
+  query.bindValue(":deprecated", deprecated);
   query.bindValue(":icon_png", iconPng);
   return mDb.insert(query);
 }
@@ -287,31 +296,37 @@ int WorkspaceLibraryDbWriter::addLibrary(const FilePath& fp, const Uuid& uuid,
 void WorkspaceLibraryDbWriter::updateLibrary(const FilePath& fp,
                                              const Uuid& uuid,
                                              const Version& version,
+                                             bool deprecated,
                                              const QByteArray& iconPng) {
   QSqlQuery query = mDb.prepareQuery(
       "UPDATE libraries "
-      "SET uuid = :uuid, version = :version, icon_png = :icon_png "
+      "SET uuid = :uuid, version = :version, deprecated = :deprecated, "
+      "icon_png = :icon_png "
       "WHERE filepath = :filepath");
   query.bindValue(":filepath", filePathToString(fp));
   query.bindValue(":uuid", uuid.toStr());
   query.bindValue(":version", version.toStr());
+  query.bindValue(":deprecated", deprecated);
   query.bindValue(":icon_png", iconPng);
   mDb.exec(query);
 }
 
 int WorkspaceLibraryDbWriter::addDevice(int libId, const FilePath& fp,
                                         const Uuid& uuid,
-                                        const Version& version,
+                                        const Version& version, bool deprecated,
                                         const Uuid& component,
                                         const Uuid& package) {
   QSqlQuery query = mDb.prepareQuery(
       "INSERT INTO devices "
-      "(lib_id, filepath, uuid, version, component_uuid, package_uuid) VALUES "
-      "(:lib_id, :filepath, :uuid, :version, :component_uuid, :package_uuid)");
-  query.bindValue(":lib_id", libId);
+      "(library_id, filepath, uuid, version, deprecated, component_uuid, "
+      "package_uuid) VALUES "
+      "(:library_id, :filepath, :uuid, :version, :deprecated, :component_uuid, "
+      ":package_uuid)");
+  query.bindValue(":library_id", libId);
   query.bindValue(":filepath", filePathToString(fp));
   query.bindValue(":uuid", uuid.toStr());
   query.bindValue(":version", version.toStr());
+  query.bindValue(":deprecated", deprecated);
   query.bindValue(":component_uuid", component.toStr());
   query.bindValue(":package_uuid", package.toStr());
   return mDb.insert(query);
@@ -358,43 +373,6 @@ QString WorkspaceLibraryDbWriter::getElementTable<Device>() noexcept {
 }
 
 template <>
-QString WorkspaceLibraryDbWriter::getElementIdColumn<Library>() noexcept {
-  return "lib_id";
-}
-
-template <>
-QString
-    WorkspaceLibraryDbWriter::getElementIdColumn<ComponentCategory>() noexcept {
-  return "cat_id";
-}
-
-template <>
-QString
-    WorkspaceLibraryDbWriter::getElementIdColumn<PackageCategory>() noexcept {
-  return "cat_id";
-}
-
-template <>
-QString WorkspaceLibraryDbWriter::getElementIdColumn<Symbol>() noexcept {
-  return "symbol_id";
-}
-
-template <>
-QString WorkspaceLibraryDbWriter::getElementIdColumn<Package>() noexcept {
-  return "package_id";
-}
-
-template <>
-QString WorkspaceLibraryDbWriter::getElementIdColumn<Component>() noexcept {
-  return "component_id";
-}
-
-template <>
-QString WorkspaceLibraryDbWriter::getElementIdColumn<Device>() noexcept {
-  return "device_id";
-}
-
-template <>
 QString WorkspaceLibraryDbWriter::getCategoryTable<Symbol>() noexcept {
   return getElementTable<ComponentCategory>();
 }
@@ -421,18 +399,20 @@ QString WorkspaceLibraryDbWriter::getCategoryTable<Device>() noexcept {
 int WorkspaceLibraryDbWriter::addElement(const QString& elementsTable,
                                          int libId, const FilePath& fp,
                                          const Uuid& uuid,
-                                         const Version& version) {
+                                         const Version& version,
+                                         bool deprecated) {
   QSqlQuery query = mDb.prepareQuery(
       "INSERT INTO %elements "
-      "(lib_id, filepath, uuid, version) VALUES "
-      "(:lib_id, :filepath, :uuid, :version)",
+      "(library_id, filepath, uuid, version, deprecated) VALUES "
+      "(:library_id, :filepath, :uuid, :version, :deprecated)",
       {
           {"%elements", elementsTable},
       });
-  query.bindValue(":lib_id", libId);
+  query.bindValue(":library_id", libId);
   query.bindValue(":filepath", filePathToString(fp));
   query.bindValue(":uuid", uuid.toStr());
   query.bindValue(":version", version.toStr());
+  query.bindValue(":deprecated", deprecated);
   return mDb.insert(query);
 }
 
@@ -440,18 +420,20 @@ int WorkspaceLibraryDbWriter::addCategory(const QString& categoriesTable,
                                           int libId, const FilePath& fp,
                                           const Uuid& uuid,
                                           const Version& version,
+                                          bool deprecated,
                                           const tl::optional<Uuid>& parent) {
   QSqlQuery query = mDb.prepareQuery(
       "INSERT INTO %categories "
-      "(lib_id, filepath, uuid, version, parent_uuid) VALUES "
-      "(:lib_id, :filepath, :uuid, :version, :parent_uuid)",
+      "(library_id, filepath, uuid, version, deprecated, parent_uuid) VALUES "
+      "(:library_id, :filepath, :uuid, :version, :deprecated, :parent_uuid)",
       {
           {"%categories", categoriesTable},
       });
-  query.bindValue(":lib_id", libId);
+  query.bindValue(":library_id", libId);
   query.bindValue(":filepath", filePathToString(fp));
   query.bindValue(":uuid", uuid.toStr());
   query.bindValue(":version", version.toStr());
+  query.bindValue(":deprecated", deprecated);
   query.bindValue(":parent_uuid",
                   parent ? parent->toStr() : QVariant(QVariant::String));
   return mDb.insert(query);
@@ -474,17 +456,16 @@ void WorkspaceLibraryDbWriter::removeAllElements(const QString& elementsTable) {
 }
 
 int WorkspaceLibraryDbWriter::addTranslation(
-    const QString& elementsTable, const QString& idColumn, int elementId,
-    const QString& locale, const tl::optional<ElementName>& name,
+    const QString& elementsTable, int elementId, const QString& locale,
+    const tl::optional<ElementName>& name,
     const tl::optional<QString>& description,
     const tl::optional<QString>& keywords) {
   QSqlQuery query = mDb.prepareQuery(
       "INSERT INTO %elements_tr "
-      "(%id, locale, name, description, keywords) VALUES "
+      "(element_id, locale, name, description, keywords) VALUES "
       "(:element_id, :locale, :name, :description, :keywords)",
       {
           {"%elements", elementsTable},
-          {"%id", idColumn},
       });
   query.bindValue(":element_id", elementId);
   query.bindValue(":locale", locale);
@@ -502,16 +483,14 @@ void WorkspaceLibraryDbWriter::removeAllTranslations(
 }
 
 int WorkspaceLibraryDbWriter::addToCategory(const QString& elementsTable,
-                                            const QString& idColumn,
                                             int elementId,
                                             const Uuid& category) {
   QSqlQuery query = mDb.prepareQuery(
       "INSERT INTO %elements_cat "
-      "(%id, category_uuid) VALUES "
+      "(element_id, category_uuid) VALUES "
       "(:element_id, :category_uuid)",
       {
           {"%elements", elementsTable},
-          {"%id", idColumn},
       });
   query.bindValue(":element_id", elementId);
   query.bindValue(":category_uuid", category.toStr());

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
@@ -1,0 +1,530 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "workspacelibrarydbwriter.h"
+
+#include "../library/cat/componentcategory.h"
+#include "../library/cat/packagecategory.h"
+#include "../library/cmp/component.h"
+#include "../library/dev/device.h"
+#include "../library/library.h"
+#include "../library/pkg/package.h"
+#include "../library/sym/symbol.h"
+#include "../sqlitedatabase.h"
+#include "../types/uuid.h"
+#include "../types/version.h"
+
+#include <QtCore>
+#include <QtSql>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+WorkspaceLibraryDbWriter::WorkspaceLibraryDbWriter(
+    const FilePath& librariesRoot, SQLiteDatabase& db)
+  : mLibrariesRoot(librariesRoot), mDb(db) {
+}
+
+WorkspaceLibraryDbWriter::~WorkspaceLibraryDbWriter() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void WorkspaceLibraryDbWriter::createAllTables() {
+  QStringList queries;
+
+  // internal
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS internal ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`key` TEXT UNIQUE NOT NULL, "
+      "`value_text` TEXT, "
+      "`value_int` INTEGER, "
+      "`value_real` REAL, "
+      "`value_blob` BLOB "
+      ")");
+
+  // libraries
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS libraries ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`filepath` TEXT UNIQUE NOT NULL, "
+      "`uuid` TEXT NOT NULL, "
+      "`version` TEXT NOT NULL, "
+      "`icon_png` BLOB "
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS libraries_tr ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`lib_id` INTEGER "
+      "REFERENCES libraries(id) ON DELETE CASCADE NOT NULL, "
+      "`locale` TEXT NOT NULL, "
+      "`name` TEXT, "
+      "`description` TEXT, "
+      "`keywords` TEXT, "
+      "UNIQUE(lib_id, locale)"
+      ")");
+
+  // component categories
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS component_categories ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`lib_id` INTEGER NOT NULL, "
+      "`filepath` TEXT UNIQUE NOT NULL, "
+      "`uuid` TEXT NOT NULL, "
+      "`version` TEXT NOT NULL, "
+      "`parent_uuid` TEXT"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS component_categories_tr ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`cat_id` INTEGER "
+      "REFERENCES component_categories(id) ON DELETE CASCADE NOT NULL, "
+      "`locale` TEXT NOT NULL, "
+      "`name` TEXT, "
+      "`description` TEXT, "
+      "`keywords` TEXT, "
+      "UNIQUE(cat_id, locale)"
+      ")");
+
+  // package categories
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS package_categories ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`lib_id` INTEGER NOT NULL, "
+      "`filepath` TEXT UNIQUE NOT NULL, "
+      "`uuid` TEXT NOT NULL, "
+      "`version` TEXT NOT NULL, "
+      "`parent_uuid` TEXT"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS package_categories_tr ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`cat_id` INTEGER "
+      "REFERENCES package_categories(id) ON DELETE CASCADE NOT NULL, "
+      "`locale` TEXT NOT NULL, "
+      "`name` TEXT, "
+      "`description` TEXT, "
+      "`keywords` TEXT, "
+      "UNIQUE(cat_id, locale)"
+      ")");
+
+  // symbols
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS symbols ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`lib_id` INTEGER NOT NULL, "
+      "`filepath` TEXT UNIQUE NOT NULL, "
+      "`uuid` TEXT NOT NULL, "
+      "`version` TEXT NOT NULL"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS symbols_tr ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`symbol_id` INTEGER "
+      "REFERENCES symbols(id) ON DELETE CASCADE NOT NULL, "
+      "`locale` TEXT NOT NULL, "
+      "`name` TEXT, "
+      "`description` TEXT, "
+      "`keywords` TEXT, "
+      "UNIQUE(symbol_id, locale)"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS symbols_cat ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`symbol_id` INTEGER "
+      "REFERENCES symbols(id) ON DELETE CASCADE NOT NULL, "
+      "`category_uuid` TEXT NOT NULL, "
+      "UNIQUE(symbol_id, category_uuid)"
+      ")");
+
+  // packages
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS packages ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`lib_id` INTEGER NOT NULL, "
+      "`filepath` TEXT UNIQUE NOT NULL, "
+      "`uuid` TEXT NOT NULL, "
+      "`version` TEXT NOT NULL "
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS packages_tr ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`package_id` INTEGER "
+      "REFERENCES packages(id) ON DELETE CASCADE NOT NULL, "
+      "`locale` TEXT NOT NULL, "
+      "`name` TEXT, "
+      "`description` TEXT, "
+      "`keywords` TEXT, "
+      "UNIQUE(package_id, locale)"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS packages_cat ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`package_id` INTEGER "
+      "REFERENCES packages(id) ON DELETE CASCADE NOT NULL, "
+      "`category_uuid` TEXT NOT NULL, "
+      "UNIQUE(package_id, category_uuid)"
+      ")");
+
+  // components
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS components ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`lib_id` INTEGER NOT NULL, "
+      "`filepath` TEXT UNIQUE NOT NULL, "
+      "`uuid` TEXT NOT NULL, "
+      "`version` TEXT NOT NULL"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS components_tr ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`component_id` INTEGER "
+      "REFERENCES components(id) ON DELETE CASCADE NOT NULL, "
+      "`locale` TEXT NOT NULL, "
+      "`name` TEXT, "
+      "`description` TEXT, "
+      "`keywords` TEXT, "
+      "UNIQUE(component_id, locale)"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS components_cat ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`component_id` INTEGER "
+      "REFERENCES components(id) ON DELETE CASCADE NOT NULL, "
+      "`category_uuid` TEXT NOT NULL, "
+      "UNIQUE(component_id, category_uuid)"
+      ")");
+
+  // devices
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS devices ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`lib_id` INTEGER NOT NULL, "
+      "`filepath` TEXT UNIQUE NOT NULL, "
+      "`uuid` TEXT NOT NULL, "
+      "`version` TEXT NOT NULL, "
+      "`component_uuid` TEXT NOT NULL, "
+      "`package_uuid` TEXT NOT NULL"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS devices_tr ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`device_id` INTEGER "
+      "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
+      "`locale` TEXT NOT NULL, "
+      "`name` TEXT, "
+      "`description` TEXT, "
+      "`keywords` TEXT, "
+      "UNIQUE(device_id, locale)"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS devices_cat ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`device_id` INTEGER "
+      "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
+      "`category_uuid` TEXT NOT NULL, "
+      "UNIQUE(device_id, category_uuid)"
+      ")");
+
+  // execute queries
+  foreach (const QString& string, queries) {
+    QSqlQuery query = mDb.prepareQuery(string);
+    mDb.exec(query);
+  }
+}
+
+void WorkspaceLibraryDbWriter::addInternalData(const QString& key, int value) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO internal (key, value_int) "
+      "VALUES (:key, :version)");
+  query.bindValue(":key", key);
+  query.bindValue(":version", value);
+  mDb.insert(query);
+}
+
+int WorkspaceLibraryDbWriter::addLibrary(const FilePath& fp, const Uuid& uuid,
+                                         const Version& version,
+                                         const QByteArray& iconPng) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO libraries "
+      "(filepath, uuid, version, icon_png) VALUES "
+      "(:filepath, :uuid, :version, :icon_png)");
+  query.bindValue(":filepath", filePathToString(fp));
+  query.bindValue(":uuid", uuid.toStr());
+  query.bindValue(":version", version.toStr());
+  query.bindValue(":icon_png", iconPng);
+  return mDb.insert(query);
+}
+
+void WorkspaceLibraryDbWriter::updateLibrary(const FilePath& fp,
+                                             const Uuid& uuid,
+                                             const Version& version,
+                                             const QByteArray& iconPng) {
+  QSqlQuery query = mDb.prepareQuery(
+      "UPDATE libraries "
+      "SET uuid = :uuid, version = :version, icon_png = :icon_png "
+      "WHERE filepath = :filepath");
+  query.bindValue(":filepath", filePathToString(fp));
+  query.bindValue(":uuid", uuid.toStr());
+  query.bindValue(":version", version.toStr());
+  query.bindValue(":icon_png", iconPng);
+  mDb.exec(query);
+}
+
+int WorkspaceLibraryDbWriter::addDevice(int libId, const FilePath& fp,
+                                        const Uuid& uuid,
+                                        const Version& version,
+                                        const Uuid& component,
+                                        const Uuid& package) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO devices "
+      "(lib_id, filepath, uuid, version, component_uuid, package_uuid) VALUES "
+      "(:lib_id, :filepath, :uuid, :version, :component_uuid, :package_uuid)");
+  query.bindValue(":lib_id", libId);
+  query.bindValue(":filepath", filePathToString(fp));
+  query.bindValue(":uuid", uuid.toStr());
+  query.bindValue(":version", version.toStr());
+  query.bindValue(":component_uuid", component.toStr());
+  query.bindValue(":package_uuid", package.toStr());
+  return mDb.insert(query);
+}
+
+/*******************************************************************************
+ *  Helper Functions
+ ******************************************************************************/
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementTable<Library>() noexcept {
+  return "libraries";
+}
+
+template <>
+QString
+    WorkspaceLibraryDbWriter::getElementTable<ComponentCategory>() noexcept {
+  return "component_categories";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementTable<PackageCategory>() noexcept {
+  return "package_categories";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementTable<Symbol>() noexcept {
+  return "symbols";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementTable<Package>() noexcept {
+  return "packages";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementTable<Component>() noexcept {
+  return "components";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementTable<Device>() noexcept {
+  return "devices";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementIdColumn<Library>() noexcept {
+  return "lib_id";
+}
+
+template <>
+QString
+    WorkspaceLibraryDbWriter::getElementIdColumn<ComponentCategory>() noexcept {
+  return "cat_id";
+}
+
+template <>
+QString
+    WorkspaceLibraryDbWriter::getElementIdColumn<PackageCategory>() noexcept {
+  return "cat_id";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementIdColumn<Symbol>() noexcept {
+  return "symbol_id";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementIdColumn<Package>() noexcept {
+  return "package_id";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementIdColumn<Component>() noexcept {
+  return "component_id";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getElementIdColumn<Device>() noexcept {
+  return "device_id";
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getCategoryTable<Symbol>() noexcept {
+  return getElementTable<ComponentCategory>();
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getCategoryTable<Package>() noexcept {
+  return getElementTable<PackageCategory>();
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getCategoryTable<Component>() noexcept {
+  return getElementTable<ComponentCategory>();
+}
+
+template <>
+QString WorkspaceLibraryDbWriter::getCategoryTable<Device>() noexcept {
+  return getElementTable<ComponentCategory>();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+int WorkspaceLibraryDbWriter::addElement(const QString& elementsTable,
+                                         int libId, const FilePath& fp,
+                                         const Uuid& uuid,
+                                         const Version& version) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO %elements "
+      "(lib_id, filepath, uuid, version) VALUES "
+      "(:lib_id, :filepath, :uuid, :version)",
+      {
+          {"%elements", elementsTable},
+      });
+  query.bindValue(":lib_id", libId);
+  query.bindValue(":filepath", filePathToString(fp));
+  query.bindValue(":uuid", uuid.toStr());
+  query.bindValue(":version", version.toStr());
+  return mDb.insert(query);
+}
+
+int WorkspaceLibraryDbWriter::addCategory(const QString& categoriesTable,
+                                          int libId, const FilePath& fp,
+                                          const Uuid& uuid,
+                                          const Version& version,
+                                          const tl::optional<Uuid>& parent) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO %categories "
+      "(lib_id, filepath, uuid, version, parent_uuid) VALUES "
+      "(:lib_id, :filepath, :uuid, :version, :parent_uuid)",
+      {
+          {"%categories", categoriesTable},
+      });
+  query.bindValue(":lib_id", libId);
+  query.bindValue(":filepath", filePathToString(fp));
+  query.bindValue(":uuid", uuid.toStr());
+  query.bindValue(":version", version.toStr());
+  query.bindValue(":parent_uuid",
+                  parent ? parent->toStr() : QVariant(QVariant::String));
+  return mDb.insert(query);
+}
+
+void WorkspaceLibraryDbWriter::removeElement(const QString& elementsTable,
+                                             const FilePath& fp) {
+  QSqlQuery query = mDb.prepareQuery(
+      "DELETE FROM %elements "
+      "WHERE filepath = :filepath",
+      {
+          {"%elements", elementsTable},
+      });
+  query.bindValue(":filepath", filePathToString(fp));
+  mDb.exec(query);
+}
+
+void WorkspaceLibraryDbWriter::removeAllElements(const QString& elementsTable) {
+  mDb.clearTable(elementsTable);
+}
+
+int WorkspaceLibraryDbWriter::addTranslation(
+    const QString& elementsTable, const QString& idColumn, int elementId,
+    const QString& locale, const tl::optional<ElementName>& name,
+    const tl::optional<QString>& description,
+    const tl::optional<QString>& keywords) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO %elements_tr "
+      "(%id, locale, name, description, keywords) VALUES "
+      "(:element_id, :locale, :name, :description, :keywords)",
+      {
+          {"%elements", elementsTable},
+          {"%id", idColumn},
+      });
+  query.bindValue(":element_id", elementId);
+  query.bindValue(":locale", locale);
+  query.bindValue(":name", name ? **name : QVariant(QVariant::String));
+  query.bindValue(":description",
+                  description ? *description : QVariant(QVariant::String));
+  query.bindValue(":keywords",
+                  keywords ? *keywords : QVariant(QVariant::String));
+  return mDb.insert(query);
+}
+
+void WorkspaceLibraryDbWriter::removeAllTranslations(
+    const QString& elementsTable) {
+  mDb.clearTable(elementsTable % "_tr");
+}
+
+int WorkspaceLibraryDbWriter::addToCategory(const QString& elementsTable,
+                                            const QString& idColumn,
+                                            int elementId,
+                                            const Uuid& category) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO %elements_cat "
+      "(%id, category_uuid) VALUES "
+      "(:element_id, :category_uuid)",
+      {
+          {"%elements", elementsTable},
+          {"%id", idColumn},
+      });
+  query.bindValue(":element_id", elementId);
+  query.bindValue(":category_uuid", category.toStr());
+  return mDb.insert(query);
+}
+
+QString WorkspaceLibraryDbWriter::filePathToString(const FilePath& fp) const
+    noexcept {
+  return fp.toRelative(mLibrariesRoot);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
@@ -1,0 +1,300 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_WORKSPACELIBRARYDBWRITER_H
+#define LIBREPCB_CORE_WORKSPACELIBRARYDBWRITER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../fileio/filepath.h"
+#include "../types/elementname.h"
+
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class Component;
+class ComponentCategory;
+class Device;
+class Package;
+class PackageCategory;
+class SQLiteDatabase;
+class Symbol;
+class Uuid;
+class Version;
+
+/*******************************************************************************
+ *  Class WorkspaceLibraryDbWriter
+ ******************************************************************************/
+
+/**
+ * @brief Database write functions for ::librepcb::WorkspaceLibraryDb
+ */
+class WorkspaceLibraryDbWriter final {
+public:
+  // Constructors / Destructor
+  WorkspaceLibraryDbWriter() = delete;
+  WorkspaceLibraryDbWriter(const WorkspaceLibraryDbWriter& other) = delete;
+  WorkspaceLibraryDbWriter(const FilePath& librariesRoot, SQLiteDatabase& db);
+  ~WorkspaceLibraryDbWriter() noexcept;
+
+  // General Methods
+
+  /**
+   * @brief Create all tables to initialize the database
+   *
+   * This has to be done only once, after creating a new database.
+   */
+  void createAllTables();
+
+  /**
+   * @brief Add an integer value to the "internal" table
+   *
+   * @param key     The key to add.
+   * @param value   The value to add.
+   */
+  void addInternalData(const QString& key, int value);
+
+  /**
+   * @brief Add a library
+   *
+   * @param fp            Filepath of the library.
+   * @param uuid          UUID of the library.
+   * @param version       Version of the library.
+   * @param iconPng       Icon as a PNG.
+   * @return ID of the added library.
+   */
+  int addLibrary(const FilePath& fp, const Uuid& uuid, const Version& version,
+                 const QByteArray& iconPng);
+
+  /**
+   * @brief Update library metadata
+   *
+   * @param fp            Filepath of the library to update.
+   * @param uuid          New UUID of the library.
+   * @param version       New version of the library.
+   * @param iconPng       New icon as a PNG.
+   */
+  void updateLibrary(const FilePath& fp, const Uuid& uuid,
+                     const Version& version, const QByteArray& iconPng);
+
+  /**
+   * @brief Add a library element
+   *
+   * @tparam ElementType  Type of element to add.
+   * @param libId         ID of the library containing this element.
+   * @param fp            Filepath of the element.
+   * @param uuid          UUID of the element.
+   * @param version       Version of the element.
+   * @return ID of the added element.
+   */
+  template <typename ElementType>
+  int addElement(int libId, const FilePath& fp, const Uuid& uuid,
+                 const Version& version) {
+    static_assert(std::is_same<ElementType, Symbol>::value ||
+                      std::is_same<ElementType, Package>::value ||
+                      std::is_same<ElementType, Component>::value,
+                  "Unsupported ElementType");
+    return addElement(getElementTable<ElementType>(), libId, fp, uuid, version);
+  }
+
+  /**
+   * @brief #addElement() specialized for categories
+   *
+   * @tparam ElementType  Type of category to add.
+   * @param libId         ID of the library containing this category.
+   * @param fp            Filepath of the category.
+   * @param uuid          UUID of the category.
+   * @param version       Version of the category.
+   * @param parent        Parent of the category.
+   * @return ID of the added category.
+   */
+  template <typename ElementType>
+  int addCategory(int libId, const FilePath& fp, const Uuid& uuid,
+                  const Version& version, const tl::optional<Uuid>& parent) {
+    static_assert(std::is_same<ElementType, ComponentCategory>::value ||
+                      std::is_same<ElementType, PackageCategory>::value,
+                  "Unsupported ElementType");
+    return addCategory(getElementTable<ElementType>(), libId, fp, uuid, version,
+                       parent);
+  }
+
+  /**
+   * @brief #addElement() specialized for devices
+   *
+   * @param libId         ID of the library containing this device.
+   * @param fp            Filepath of the device.
+   * @param uuid          UUID of the device.
+   * @param version       Version of the device.
+   * @param component     Component UUID of the device.
+   * @param package       Package UUID of the device.
+   * @return ID of the added device.
+   */
+  int addDevice(int libId, const FilePath& fp, const Uuid& uuid,
+                const Version& version, const Uuid& component,
+                const Uuid& package);
+
+  /**
+   * @brief Remove a library element
+   *
+   * @note  This will automatically remove its translations and categories
+   *        as well.
+   *
+   * @tparam ElementType  Type of element to remove.
+   * @param fp            Filepath of the element to remove.
+   */
+  template <typename ElementType>
+  void removeElement(const FilePath& fp) {
+    removeElement(getElementTable<ElementType>(), fp);
+  }
+
+  /**
+   * @brief Remove all library elements of a specific type
+   *
+   * @note  This will automatically remove their translations and categories
+   *        as well.
+   *
+   * @tparam ElementType  Type of elements to remove.
+   */
+  template <typename ElementType>
+  void removeAllElements() {
+    removeAllElements(getElementTable<ElementType>());
+  }
+
+  /**
+   * @brief Add a translation for a library element
+   *
+   * @tparam ElementType  Type of element to add translations.
+   * @param elementId     ID of the element to add translations.
+   * @param locale        Locale of the translations.
+   * @param name          Element name.
+   * @param description   Eleemnt description.
+   * @param keywords      Element keywords.
+   * @return ID of the added translation.
+   */
+  template <typename ElementType>
+  int addTranslation(int elementId, const QString& locale,
+                     const tl::optional<ElementName>& name,
+                     const tl::optional<QString>& description,
+                     const tl::optional<QString>& keywords) {
+    return addTranslation(getElementTable<ElementType>(),
+                          getElementIdColumn<ElementType>(), elementId, locale,
+                          name, description, keywords);
+  }
+
+  /**
+   * @brief Remove all translations for a library element type
+   *
+   * @tparam ElementType  Type of element to remove translationss.
+   */
+  template <typename ElementType>
+  void removeAllTranslations() {
+    removeAllTranslations(getElementTable<ElementType>());
+  }
+
+  /**
+   * @brief Add a library element to a category
+   *
+   * @tparam ElementType  Type of element to add to the category.
+   * @param elementId     ID of the element to add to the category.
+   * @param category      Category UUID.
+   * @return ID of the added category.
+   */
+  template <typename ElementType>
+  int addToCategory(int elementId, const Uuid& category) {
+    static_assert(std::is_same<ElementType, Symbol>::value ||
+                      std::is_same<ElementType, Package>::value ||
+                      std::is_same<ElementType, Component>::value ||
+                      std::is_same<ElementType, Device>::value,
+                  "Unsupported ElementType");
+    return addToCategory(getElementTable<ElementType>(),
+                         getElementIdColumn<ElementType>(), elementId,
+                         category);
+  }
+
+  // Helper Functions
+
+  /**
+   * @brief Get the table name of an element type
+   *
+   * @tparam ElementType  Type of element to get the table name of.
+   * @return Table name (e.g. "symbols" for ::librepcb::Symbol).
+   */
+  template <typename ElementType>
+  static QString getElementTable() noexcept;
+
+  /**
+   * @brief Get the ID column name of an element type
+   *
+   * @tparam ElementType  Type of element to get the column name of.
+   * @return Column name (e.g. "symbol_id" for ::librepcb::Symbol).
+   */
+  template <typename ElementType>
+  static QString getElementIdColumn() noexcept;
+
+  /**
+   * @brief Get the category table name of an element type
+   *
+   * @tparam ElementType  Type of element to get the category table name of.
+   * @return  Category table name (e.g. "component_categories" for
+   *          ::librepcb::Symbol).
+   */
+  template <typename ElementType>
+  static QString getCategoryTable() noexcept;
+
+  // Operator Overloadings
+  WorkspaceLibraryDbWriter& operator=(const WorkspaceLibraryDbWriter& rhs) =
+      delete;
+
+private:  // Methods
+  int addElement(const QString& elementsTable, int libId, const FilePath& fp,
+                 const Uuid& uuid, const Version& version);
+  int addCategory(const QString& categoriesTable, int libId, const FilePath& fp,
+                  const Uuid& uuid, const Version& version,
+                  const tl::optional<Uuid>& parent);
+  void removeElement(const QString& elementsTable, const FilePath& fp);
+  void removeAllElements(const QString& elementsTable);
+  int addTranslation(const QString& elementsTable, const QString& idColumn,
+                     int elementId, const QString& locale,
+                     const tl::optional<ElementName>& name,
+                     const tl::optional<QString>& description,
+                     const tl::optional<QString>& keywords);
+  void removeAllTranslations(const QString& elementsTable);
+  int addToCategory(const QString& elementsTable, const QString& idColumn,
+                    int elementId, const Uuid& category);
+  QString filePathToString(const FilePath& fp) const noexcept;
+
+private:  // Data
+  FilePath mLibrariesRoot;
+  SQLiteDatabase& mDb;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
@@ -83,11 +83,12 @@ public:
    * @param fp            Filepath of the library.
    * @param uuid          UUID of the library.
    * @param version       Version of the library.
+   * @param deprecated    Whether the library is deprecated or not.
    * @param iconPng       Icon as a PNG.
    * @return ID of the added library.
    */
   int addLibrary(const FilePath& fp, const Uuid& uuid, const Version& version,
-                 const QByteArray& iconPng);
+                 bool deprecated, const QByteArray& iconPng);
 
   /**
    * @brief Update library metadata
@@ -95,10 +96,12 @@ public:
    * @param fp            Filepath of the library to update.
    * @param uuid          New UUID of the library.
    * @param version       New version of the library.
+   * @param deprecated    Whether the library is deprecated or not.
    * @param iconPng       New icon as a PNG.
    */
   void updateLibrary(const FilePath& fp, const Uuid& uuid,
-                     const Version& version, const QByteArray& iconPng);
+                     const Version& version, bool deprecated,
+                     const QByteArray& iconPng);
 
   /**
    * @brief Add a library element
@@ -108,16 +111,18 @@ public:
    * @param fp            Filepath of the element.
    * @param uuid          UUID of the element.
    * @param version       Version of the element.
+   * @param deprecated    Whether the element is deprecated or not.
    * @return ID of the added element.
    */
   template <typename ElementType>
   int addElement(int libId, const FilePath& fp, const Uuid& uuid,
-                 const Version& version) {
+                 const Version& version, bool deprecated) {
     static_assert(std::is_same<ElementType, Symbol>::value ||
                       std::is_same<ElementType, Package>::value ||
                       std::is_same<ElementType, Component>::value,
                   "Unsupported ElementType");
-    return addElement(getElementTable<ElementType>(), libId, fp, uuid, version);
+    return addElement(getElementTable<ElementType>(), libId, fp, uuid, version,
+                      deprecated);
   }
 
   /**
@@ -128,17 +133,19 @@ public:
    * @param fp            Filepath of the category.
    * @param uuid          UUID of the category.
    * @param version       Version of the category.
+   * @param deprecated    Whether the category is deprecated or not.
    * @param parent        Parent of the category.
    * @return ID of the added category.
    */
   template <typename ElementType>
   int addCategory(int libId, const FilePath& fp, const Uuid& uuid,
-                  const Version& version, const tl::optional<Uuid>& parent) {
+                  const Version& version, bool deprecated,
+                  const tl::optional<Uuid>& parent) {
     static_assert(std::is_same<ElementType, ComponentCategory>::value ||
                       std::is_same<ElementType, PackageCategory>::value,
                   "Unsupported ElementType");
     return addCategory(getElementTable<ElementType>(), libId, fp, uuid, version,
-                       parent);
+                       deprecated, parent);
   }
 
   /**
@@ -148,12 +155,13 @@ public:
    * @param fp            Filepath of the device.
    * @param uuid          UUID of the device.
    * @param version       Version of the device.
+   * @param deprecated    Whether the device is deprecated or not.
    * @param component     Component UUID of the device.
    * @param package       Package UUID of the device.
    * @return ID of the added device.
    */
   int addDevice(int libId, const FilePath& fp, const Uuid& uuid,
-                const Version& version, const Uuid& component,
+                const Version& version, bool deprecated, const Uuid& component,
                 const Uuid& package);
 
   /**
@@ -199,8 +207,7 @@ public:
                      const tl::optional<ElementName>& name,
                      const tl::optional<QString>& description,
                      const tl::optional<QString>& keywords) {
-    return addTranslation(getElementTable<ElementType>(),
-                          getElementIdColumn<ElementType>(), elementId, locale,
+    return addTranslation(getElementTable<ElementType>(), elementId, locale,
                           name, description, keywords);
   }
 
@@ -229,9 +236,7 @@ public:
                       std::is_same<ElementType, Component>::value ||
                       std::is_same<ElementType, Device>::value,
                   "Unsupported ElementType");
-    return addToCategory(getElementTable<ElementType>(),
-                         getElementIdColumn<ElementType>(), elementId,
-                         category);
+    return addToCategory(getElementTable<ElementType>(), elementId, category);
   }
 
   // Helper Functions
@@ -244,15 +249,6 @@ public:
    */
   template <typename ElementType>
   static QString getElementTable() noexcept;
-
-  /**
-   * @brief Get the ID column name of an element type
-   *
-   * @tparam ElementType  Type of element to get the column name of.
-   * @return Column name (e.g. "symbol_id" for ::librepcb::Symbol).
-   */
-  template <typename ElementType>
-  static QString getElementIdColumn() noexcept;
 
   /**
    * @brief Get the category table name of an element type
@@ -270,20 +266,20 @@ public:
 
 private:  // Methods
   int addElement(const QString& elementsTable, int libId, const FilePath& fp,
-                 const Uuid& uuid, const Version& version);
+                 const Uuid& uuid, const Version& version, bool deprecated);
   int addCategory(const QString& categoriesTable, int libId, const FilePath& fp,
-                  const Uuid& uuid, const Version& version,
+                  const Uuid& uuid, const Version& version, bool deprecated,
                   const tl::optional<Uuid>& parent);
   void removeElement(const QString& elementsTable, const FilePath& fp);
   void removeAllElements(const QString& elementsTable);
-  int addTranslation(const QString& elementsTable, const QString& idColumn,
-                     int elementId, const QString& locale,
+  int addTranslation(const QString& elementsTable, int elementId,
+                     const QString& locale,
                      const tl::optional<ElementName>& name,
                      const tl::optional<QString>& description,
                      const tl::optional<QString>& keywords);
   void removeAllTranslations(const QString& elementsTable);
-  int addToCategory(const QString& elementsTable, const QString& idColumn,
-                    int elementId, const Uuid& category);
+  int addToCategory(const QString& elementsTable, int elementId,
+                    const Uuid& category);
   QString filePathToString(const FilePath& fp) const noexcept;
 
 private:  // Data

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -33,6 +33,7 @@
 #include "../sqlitedatabase.h"
 #include "../utils/toolbox.h"
 #include "workspace.h"
+#include "workspacelibrarydbwriter.h"
 
 #include <QtCore>
 
@@ -79,18 +80,6 @@ void WorkspaceLibraryScanner::startScan() noexcept {
  *  Private Methods
  ******************************************************************************/
 
-template <>
-QVariant WorkspaceLibraryScanner::optionalToVariant(
-    const tl::optional<QString>& opt) noexcept {
-  return opt ? *opt : QVariant();
-}
-
-template <>
-QVariant WorkspaceLibraryScanner::optionalToVariant(
-    const tl::optional<ElementName>& opt) noexcept {
-  return opt ? **opt : QVariant();
-}
-
 void WorkspaceLibraryScanner::run() noexcept {
   qDebug() << "Workspace library scanner thread started.";
 
@@ -116,14 +105,16 @@ void WorkspaceLibraryScanner::scan() noexcept {
 
     // open SQLite database
     SQLiteDatabase db(mDbFilePath);  // can throw
+    WorkspaceLibraryDbWriter writer(mWorkspace.getLibrariesPath(), db);
 
     // update list of libraries
     std::shared_ptr<TransactionalFileSystem> fs =
         TransactionalFileSystem::openRO(mWorkspace.getLibrariesPath());
-    QHash<QString, std::shared_ptr<Library>> libraries;
+    QList<std::shared_ptr<Library>> libraries;
     getLibrariesOfDirectory(fs, "local", libraries);
     getLibrariesOfDirectory(fs, "remote", libraries);
-    QHash<QString, int> libIds = updateLibraries(db, libraries);  // can throw
+    QHash<FilePath, int> libIds =
+        updateLibraries(db, writer, libraries);  // can throw
     emit scanLibraryListUpdated(libIds.count());
     emit scanProgressUpdate(1);
     qDebug() << "Workspace libraries indexed:" << libIds.count()
@@ -133,45 +124,43 @@ void WorkspaceLibraryScanner::scan() noexcept {
     SQLiteDatabase::TransactionScopeGuard transactionGuard(db);  // can throw
 
     // clear all tables
-    clearAllTables(db);
+    writer.removeAllElements<ComponentCategory>();
+    writer.removeAllElements<PackageCategory>();
+    writer.removeAllElements<Symbol>();
+    writer.removeAllElements<Package>();
+    writer.removeAllElements<Component>();
+    writer.removeAllElements<Device>();
 
     // scan all libraries
     int count = 0;
     qreal percent = 1;
-    foreach (const QString& fp, libraries.keys()) {
+    foreach (const std::shared_ptr<Library>& lib, libraries) {
+      FilePath fp = lib->getDirectory().getAbsPath();
       Q_ASSERT(libIds.contains(fp));
       int libId = libIds[fp];
-      const std::shared_ptr<Library>& lib = libraries[fp];
-      Q_ASSERT(lib);
       if (mAbort || (mSemaphore.available() > 0)) break;
-      count += addCategoriesToDb<ComponentCategory>(
-          db, fs, fp, lib->searchForElements<ComponentCategory>(),
-          "component_categories", "cat_id", libId);
+      count += addElementsToDb<ComponentCategory>(
+          writer, fs, fp, lib->searchForElements<ComponentCategory>(), libId);
       emit scanProgressUpdate(percent += qreal(98) / (libraries.count() * 6));
       if (mAbort || (mSemaphore.available() > 0)) break;
-      count += addCategoriesToDb<PackageCategory>(
-          db, fs, fp, lib->searchForElements<PackageCategory>(),
-          "package_categories", "cat_id", libId);
+      count += addElementsToDb<PackageCategory>(
+          writer, fs, fp, lib->searchForElements<PackageCategory>(), libId);
       emit scanProgressUpdate(percent += qreal(98) / (libraries.count() * 6));
       if (mAbort || (mSemaphore.available() > 0)) break;
-      count +=
-          addElementsToDb<Symbol>(db, fs, fp, lib->searchForElements<Symbol>(),
-                                  "symbols", "symbol_id", libId);
+      count += addElementsToDb<Symbol>(writer, fs, fp,
+                                       lib->searchForElements<Symbol>(), libId);
       emit scanProgressUpdate(percent += qreal(98) / (libraries.count() * 6));
       if (mAbort || (mSemaphore.available() > 0)) break;
-      count += addElementsToDb<Package>(db, fs, fp,
-                                        lib->searchForElements<Package>(),
-                                        "packages", "package_id", libId);
+      count += addElementsToDb<Package>(
+          writer, fs, fp, lib->searchForElements<Package>(), libId);
       emit scanProgressUpdate(percent += qreal(98) / (libraries.count() * 6));
       if (mAbort || (mSemaphore.available() > 0)) break;
-      count += addElementsToDb<Component>(db, fs, fp,
-                                          lib->searchForElements<Component>(),
-                                          "components", "component_id", libId);
+      count += addElementsToDb<Component>(
+          writer, fs, fp, lib->searchForElements<Component>(), libId);
       emit scanProgressUpdate(percent += qreal(98) / (libraries.count() * 6));
       if (mAbort || (mSemaphore.available() > 0)) break;
-      count +=
-          addElementsToDb<Device>(db, fs, fp, lib->searchForElements<Device>(),
-                                  "devices", "device_id", libId);
+      count += addElementsToDb<Device>(writer, fs, fp,
+                                       lib->searchForElements<Device>(), libId);
       emit scanProgressUpdate(percent += qreal(98) / (libraries.count() * 6));
     }
 
@@ -195,14 +184,14 @@ void WorkspaceLibraryScanner::scan() noexcept {
 
 void WorkspaceLibraryScanner::getLibrariesOfDirectory(
     std::shared_ptr<TransactionalFileSystem> fs, const QString& root,
-    QHash<QString, std::shared_ptr<Library>>& libs) noexcept {
+    QList<std::shared_ptr<Library>>& libs) noexcept {
   foreach (const QString& name, fs->getDirs(root)) {
     QString dirpath = root % "/" % name;
     std::unique_ptr<TransactionalDirectory> dir(
         new TransactionalDirectory(fs, dirpath));
     if (Library::isValidElementDirectory<Library>(*dir, "")) {
       try {
-        libs.insert(dirpath, std::make_shared<Library>(std::move(dir)));
+        libs.append(std::make_shared<Library>(std::move(dir)));
       } catch (Exception& e) {
         qCritical() << "Could not open workspace library!";
         qCritical() << "Library:" << fs->getAbsPath(dirpath).toNative();
@@ -215,275 +204,144 @@ void WorkspaceLibraryScanner::getLibrariesOfDirectory(
   }
 }
 
-QHash<QString, int> WorkspaceLibraryScanner::updateLibraries(
-    SQLiteDatabase& db, const QHash<QString, std::shared_ptr<Library>>& libs) {
+QHash<FilePath, int> WorkspaceLibraryScanner::updateLibraries(
+    SQLiteDatabase& db, WorkspaceLibraryDbWriter& writer,
+    const QList<std::shared_ptr<Library>>& libs) {
   SQLiteDatabase::TransactionScopeGuard transactionGuard(db);  // can throw
 
-  // get IDs of libraries in DB
-  QHash<QString, int> dbLibIds;
+  // get filepaths of all libraries
+  QSet<FilePath> libFilePaths;
+  foreach (const std::shared_ptr<Library>& lib, libs) {
+    FilePath fp = lib->getDirectory().getAbsPath();
+    libFilePaths.insert(fp);
+  }
+
+  // get IDs of existing libraries in DB
+  QHash<FilePath, int> dbLibIds;
   QSqlQuery query = db.prepareQuery("SELECT id, filepath FROM libraries");
   db.exec(query);
   while (query.next()) {
     int id = query.value(0).toInt();
-    QString fp = query.value(1).toString();
-    if (fp.isEmpty()) throw LogicError(__FILE__, __LINE__);
-    dbLibIds[fp] = id;
+    FilePath fp =
+        mWorkspace.getLibrariesPath().getPathTo(query.value(1).toString());
+    if (!fp.isValid()) throw LogicError(__FILE__, __LINE__);
+    dbLibIds.insert(fp, id);
   }
 
-  // update existing libraries in DB
-  foreach (const QString& fp,
-           Toolbox::toSet(libs.keys()) & Toolbox::toSet(dbLibIds.keys())) {
-    Q_ASSERT(dbLibIds.contains(fp));
-    std::shared_ptr<Library> lib = libs[fp];
-    Q_ASSERT(lib);
-    query = db.prepareQuery(
-        "UPDATE libraries SET "
-        "filepath = :filepath, "
-        "uuid = :uuid, "
-        "version = :version, "
-        "icon_png = :icon_png "
-        "WHERE id = :id");
-    query.bindValue(":filepath", fp);
-    query.bindValue(":uuid", lib->getUuid().toStr());
-    query.bindValue(":version", lib->getVersion().toStr());
-    query.bindValue(":icon_png", lib->getIcon());
-    query.bindValue(":id", dbLibIds[fp]);
-    db.exec(query);
-  }
-
-  // add new libraries to DB
-  foreach (const QString& fp,
-           Toolbox::toSet(libs.keys()) - Toolbox::toSet(dbLibIds.keys())) {
-    Q_ASSERT(!dbLibIds.contains(fp));
-    std::shared_ptr<Library> lib = libs[fp];
-    Q_ASSERT(lib);
-    query = db.prepareQuery(
-        "INSERT INTO libraries "
-        "(filepath, uuid, version, icon_png) VALUES "
-        "(:filepath, :uuid, :version, :icon_png)");
-    query.bindValue(":filepath", fp);
-    query.bindValue(":uuid", lib->getUuid().toStr());
-    query.bindValue(":version", lib->getVersion().toStr());
-    query.bindValue(":icon_png", lib->getIcon());
-    dbLibIds[fp] = db.insert(query);
+  // update existing and add new libraries to DB
+  foreach (const std::shared_ptr<Library>& lib, libs) {
+    FilePath fp = lib->getDirectory().getAbsPath();
+    if (dbLibIds.contains(fp)) {
+      writer.updateLibrary(fp, lib->getUuid(), lib->getVersion(),
+                           lib->getIcon());
+    } else {
+      int id = writer.addLibrary(fp, lib->getUuid(), lib->getVersion(),
+                                 lib->getIcon());
+      dbLibIds.insert(fp, id);
+    }
   }
 
   // remove no longer existing libraries from DB
-  foreach (const QString& fp,
-           Toolbox::toSet(dbLibIds.keys()) - Toolbox::toSet(libs.keys())) {
-    Q_ASSERT(dbLibIds.contains(fp));
-    query = db.prepareQuery("DELETE FROM libraries WHERE id = :id");
-    query.bindValue(":id", dbLibIds[fp]);
-    db.exec(query);
+  foreach (const FilePath& fp, Toolbox::toSet(dbLibIds.keys()) - libFilePaths) {
+    Q_ASSERT(dbLibIds.contains(fp) && (!libFilePaths.contains(fp)));
+    writer.removeElement<Library>(fp);
     dbLibIds.remove(fp);
   }
 
   // update all library translations
-  db.clearTable("libraries_tr");
-  foreach (const QString& fp, libs.keys()) {
-    Q_ASSERT(dbLibIds.contains(fp));
-    std::shared_ptr<Library> lib = libs[fp];
-    Q_ASSERT(lib);
-    foreach (const QString& locale, lib->getAllAvailableLocales()) {
-      query = db.prepareQuery(
-          "INSERT INTO libraries_tr "
-          "(lib_id, locale, name, description, keywords) VALUES "
-          "(:lib_id, :locale, :name, :description, :keywords)");
-      query.bindValue(":lib_id", dbLibIds[fp]);
-      query.bindValue(":locale", locale);
-      query.bindValue(":name",
-                      optionalToVariant(lib->getNames().tryGet(locale)));
-      query.bindValue(":description",
-                      optionalToVariant(lib->getDescriptions().tryGet(locale)));
-      query.bindValue(":keywords",
-                      optionalToVariant(lib->getKeywords().tryGet(locale)));
-      db.insert(query);
-    }
+  writer.removeAllTranslations<Library>();
+  foreach (const std::shared_ptr<Library>& lib, libs) {
+    int id = dbLibIds.value(lib->getDirectory().getAbsPath());
+    Q_ASSERT(id >= 0);
+    addTranslationsToDb(writer, id, *lib);
   }
 
   transactionGuard.commit();  // can throw
   return dbLibIds;
 }
 
-void WorkspaceLibraryScanner::clearAllTables(SQLiteDatabase& db) {
-  // component categories
-  db.clearTable("component_categories_tr");
-  db.clearTable("component_categories");
-
-  // package categories
-  db.clearTable("package_categories_tr");
-  db.clearTable("package_categories");
-
-  // symbols
-  db.clearTable("symbols_tr");
-  db.clearTable("symbols_cat");
-  db.clearTable("symbols");
-
-  // packages
-  db.clearTable("packages_tr");
-  db.clearTable("packages_cat");
-  db.clearTable("packages");
-
-  // components
-  db.clearTable("components_tr");
-  db.clearTable("components_cat");
-  db.clearTable("components");
-
-  // devices
-  db.clearTable("devices_tr");
-  db.clearTable("devices_cat");
-  db.clearTable("devices");
-}
-
-template <typename ElementType>
-int WorkspaceLibraryScanner::addCategoriesToDb(
-    SQLiteDatabase& db, std::shared_ptr<TransactionalFileSystem> fs,
-    const QString& libPath, const QStringList& dirs, const QString& table,
-    const QString& idColumn, int libId) {
-  int count = 0;
-  foreach (const QString& dirpath, dirs) {
-    if (mAbort || (mSemaphore.available() > 0)) break;
-    QString fullPath = libPath % "/" % dirpath;
-    try {
-      std::unique_ptr<TransactionalDirectory> dir(
-          new TransactionalDirectory(fs, fullPath));  // can throw
-      ElementType element(std::move(dir));  // can throw
-      QSqlQuery query = db.prepareQuery(
-          "INSERT INTO " % table %
-          " "
-          "(lib_id, filepath, uuid, version, parent_uuid) VALUES "
-          "(:lib_id, :filepath, :uuid, :version, :parent_uuid)");
-      query.bindValue(":lib_id", libId);
-      query.bindValue(":filepath", fullPath);
-      query.bindValue(":uuid", element.getUuid().toStr());
-      query.bindValue(":version", element.getVersion().toStr());
-      query.bindValue(":parent_uuid",
-                      element.getParentUuid() ? element.getParentUuid()->toStr()
-                                              : QVariant(QVariant::String));
-      int id = db.insert(query);
-      foreach (const QString& locale, element.getAllAvailableLocales()) {
-        QSqlQuery query = db.prepareQuery(
-            "INSERT INTO " % table %
-            "_tr "
-            "(" %
-            idColumn %
-            ", locale, name, description, keywords) VALUES "
-            "(:element_id, :locale, :name, :description, :keywords)");
-        query.bindValue(":element_id", id);
-        query.bindValue(":locale", locale);
-        query.bindValue(":name",
-                        optionalToVariant(element.getNames().tryGet(locale)));
-        query.bindValue(
-            ":description",
-            optionalToVariant(element.getDescriptions().tryGet(locale)));
-        query.bindValue(
-            ":keywords",
-            optionalToVariant(element.getKeywords().tryGet(locale)));
-        db.insert(query);
-      }
-      count++;
-    } catch (const Exception& e) {
-      qWarning() << "Failed to open library element:" << fullPath;
-    }
-  }
-  return count;
-}
-
 template <typename ElementType>
 int WorkspaceLibraryScanner::addElementsToDb(
-    SQLiteDatabase& db, std::shared_ptr<TransactionalFileSystem> fs,
-    const QString& libPath, const QStringList& dirs, const QString& table,
-    const QString& idColumn, int libId) {
+    WorkspaceLibraryDbWriter& writer,
+    std::shared_ptr<TransactionalFileSystem> fs, const FilePath& libPath,
+    const QStringList& dirs, int libId) {
   int count = 0;
   foreach (const QString& dirpath, dirs) {
     if (mAbort || (mSemaphore.available() > 0)) break;
-    QString fullPath = libPath % "/" % dirpath;
+    FilePath absPath = libPath.getPathTo(dirpath);
+    QString relPath = absPath.toRelative(fs->getAbsPath());
     try {
       std::unique_ptr<TransactionalDirectory> dir(
-          new TransactionalDirectory(fs, fullPath));  // can throw
+          new TransactionalDirectory(fs, relPath));  // can throw
       ElementType element(std::move(dir));  // can throw
-      addElementToDb(db, table, idColumn, libId, fullPath, element);
+      int id = addElementToDb(writer, libId, element);
+      addTranslationsToDb(writer, id, element);
       count++;
     } catch (const Exception& e) {
-      qWarning() << "Failed to open library element:" << fullPath;
+      qWarning() << "Failed to open library element:" << absPath.toStr();
     }
   }
   return count;
 }
 
 template <typename ElementType>
-void WorkspaceLibraryScanner::addElementToDb(SQLiteDatabase& db,
-                                             const QString& table,
-                                             const QString& idColumn, int libId,
-                                             const QString& path,
-                                             const ElementType& element) {
-  QSqlQuery query = db.prepareQuery("INSERT INTO " % table %
-                                    " (lib_id, filepath, uuid, version) VALUES "
-                                    "(:lib_id, :filepath, :uuid, :version)");
-  query.bindValue(":lib_id", libId);
-  query.bindValue(":filepath", path);
-  query.bindValue(":uuid", element.getUuid().toStr());
-  query.bindValue(":version", element.getVersion().toStr());
-  int id = db.insert(query);
-  addElementTranslationsToDb(db, table % "_tr", idColumn, id, element);
-  addElementCategoriesToDb(db, table % "_cat", idColumn, id,
-                           element.getCategories());
+int WorkspaceLibraryScanner::addElementToDb(WorkspaceLibraryDbWriter& writer,
+                                            int libId,
+                                            const ElementType& element) {
+  const int id =
+      writer.addElement<ElementType>(libId, element.getDirectory().getAbsPath(),
+                                     element.getUuid(), element.getVersion());
+  addToCategories(writer, id, element);
+  return id;
 }
 
 template <>
-void WorkspaceLibraryScanner::addElementToDb<Device>(
-    SQLiteDatabase& db, const QString& table, const QString& idColumn,
-    int libId, const QString& path, const Device& element) {
-  QSqlQuery query = db.prepareQuery("INSERT INTO " % table %
-                                    " "
-                                    "(lib_id, filepath, uuid, version, "
-                                    "component_uuid, package_uuid) VALUES "
-                                    "(:lib_id, :filepath, :uuid, :version, "
-                                    ":component_uuid, :package_uuid)");
-  query.bindValue(":lib_id", libId);
-  query.bindValue(":filepath", path);
-  query.bindValue(":uuid", element.getUuid().toStr());
-  query.bindValue(":version", element.getVersion().toStr());
-  query.bindValue(":component_uuid", element.getComponentUuid().toStr());
-  query.bindValue(":package_uuid", element.getPackageUuid().toStr());
-  int id = db.insert(query);
-  addElementTranslationsToDb(db, table % "_tr", idColumn, id, element);
-  addElementCategoriesToDb(db, table % "_cat", idColumn, id,
-                           element.getCategories());
+int WorkspaceLibraryScanner::addElementToDb<ComponentCategory>(
+    WorkspaceLibraryDbWriter& writer, int libId,
+    const ComponentCategory& element) {
+  return writer.addCategory<ComponentCategory>(
+      libId, element.getDirectory().getAbsPath(), element.getUuid(),
+      element.getVersion(), element.getParentUuid());
+}
+
+template <>
+int WorkspaceLibraryScanner::addElementToDb<PackageCategory>(
+    WorkspaceLibraryDbWriter& writer, int libId,
+    const PackageCategory& element) {
+  return writer.addCategory<PackageCategory>(
+      libId, element.getDirectory().getAbsPath(), element.getUuid(),
+      element.getVersion(), element.getParentUuid());
+}
+
+template <>
+int WorkspaceLibraryScanner::addElementToDb<Device>(
+    WorkspaceLibraryDbWriter& writer, int libId, const Device& element) {
+  const int id =
+      writer.addDevice(libId, element.getDirectory().getAbsPath(),
+                       element.getUuid(), element.getVersion(),
+                       element.getComponentUuid(), element.getPackageUuid());
+  addToCategories(writer, id, element);
+  return id;
 }
 
 template <typename ElementType>
-void WorkspaceLibraryScanner::addElementTranslationsToDb(
-    SQLiteDatabase& db, const QString& table, const QString& idColumn, int id,
+void WorkspaceLibraryScanner::addTranslationsToDb(
+    WorkspaceLibraryDbWriter& writer, int elementId,
     const ElementType& element) {
   foreach (const QString& locale, element.getAllAvailableLocales()) {
-    QSqlQuery query = db.prepareQuery(
-        "INSERT INTO " % table % " (" % idColumn %
-        ", locale, name, description, keywords) VALUES "
-        "(:element_id, :locale, :name, :description, :keywords)");
-    query.bindValue(":element_id", id);
-    query.bindValue(":locale", locale);
-    query.bindValue(":name",
-                    optionalToVariant(element.getNames().tryGet(locale)));
-    query.bindValue(
-        ":description",
-        optionalToVariant(element.getDescriptions().tryGet(locale)));
-    query.bindValue(":keywords",
-                    optionalToVariant(element.getKeywords().tryGet(locale)));
-    db.insert(query);
+    writer.addTranslation<ElementType>(elementId, locale,
+                                       element.getNames().tryGet(locale),
+                                       element.getDescriptions().tryGet(locale),
+                                       element.getKeywords().tryGet(locale));
   }
 }
 
-void WorkspaceLibraryScanner::addElementCategoriesToDb(
-    SQLiteDatabase& db, const QString& table, const QString& idColumn, int id,
-    const QSet<Uuid>& categories) {
-  foreach (const Uuid& categoryUuid, categories) {
-    QSqlQuery query = db.prepareQuery("INSERT INTO " % table % " (" % idColumn %
-                                      ", category_uuid) VALUES "
-                                      "(:element_id, :category_uuid)");
-    query.bindValue(":element_id", id);
-    query.bindValue(":category_uuid", categoryUuid.toStr());
-    db.insert(query);
+template <typename ElementType>
+void WorkspaceLibraryScanner::addToCategories(WorkspaceLibraryDbWriter& writer,
+                                              int elementId,
+                                              const ElementType& element) {
+  foreach (const Uuid& category, element.getCategories()) {
+    writer.addToCategory<ElementType>(elementId, category);
   }
 }
 

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.h
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.h
@@ -37,8 +37,8 @@ namespace librepcb {
 class Library;
 class SQLiteDatabase;
 class TransactionalFileSystem;
-class Uuid;
 class Workspace;
+class WorkspaceLibraryDbWriter;
 
 /*******************************************************************************
  *  Class WorkspaceLibraryScanner
@@ -78,36 +78,26 @@ signals:
 private:  // Methods
   void run() noexcept override;
   void scan() noexcept;
-  QHash<QString, int> updateLibraries(
-      SQLiteDatabase& db, const QHash<QString, std::shared_ptr<Library>>& libs);
-  void clearAllTables(SQLiteDatabase& db);
-  void getLibrariesOfDirectory(
-      std::shared_ptr<TransactionalFileSystem> fs, const QString& root,
-      QHash<QString, std::shared_ptr<Library>>& libs) noexcept;
+  void getLibrariesOfDirectory(std::shared_ptr<TransactionalFileSystem> fs,
+                               const QString& root,
+                               QList<std::shared_ptr<Library>>& libs) noexcept;
+  QHash<FilePath, int> updateLibraries(
+      SQLiteDatabase& db, WorkspaceLibraryDbWriter& writer,
+      const QList<std::shared_ptr<Library>>& libs);
   template <typename ElementType>
-  int addCategoriesToDb(SQLiteDatabase& db,
-                        std::shared_ptr<TransactionalFileSystem> fs,
-                        const QString& libPath, const QStringList& dirs,
-                        const QString& table, const QString& idColumn,
-                        int libId);
-  template <typename ElementType>
-  int addElementsToDb(SQLiteDatabase& db,
+  int addElementsToDb(WorkspaceLibraryDbWriter& writer,
                       std::shared_ptr<TransactionalFileSystem> fs,
-                      const QString& libPath, const QStringList& dirs,
-                      const QString& table, const QString& idColumn, int libId);
+                      const FilePath& libPath, const QStringList& dirs,
+                      int libId);
   template <typename ElementType>
-  void addElementToDb(SQLiteDatabase& db, const QString& table,
-                      const QString& idColumn, int libId, const QString& path,
-                      const ElementType& element);
+  int addElementToDb(WorkspaceLibraryDbWriter& writer, int libId,
+                     const ElementType& element);
   template <typename ElementType>
-  void addElementTranslationsToDb(SQLiteDatabase& db, const QString& table,
-                                  const QString& idColumn, int id,
-                                  const ElementType& element);
-  void addElementCategoriesToDb(SQLiteDatabase& db, const QString& table,
-                                const QString& idColumn, int id,
-                                const QSet<Uuid>& categories);
-  template <typename T>
-  static QVariant optionalToVariant(const T& opt) noexcept;
+  void addTranslationsToDb(WorkspaceLibraryDbWriter& writer, int elementId,
+                           const ElementType& element);
+  template <typename ElementType>
+  void addToCategories(WorkspaceLibraryDbWriter& writer, int elementId,
+                       const ElementType& element);
 
 private:  // Data
   Workspace& mWorkspace;

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.h
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.h
@@ -37,7 +37,6 @@ namespace librepcb {
 class Library;
 class SQLiteDatabase;
 class TransactionalFileSystem;
-class Workspace;
 class WorkspaceLibraryDbWriter;
 
 /*******************************************************************************
@@ -56,7 +55,8 @@ class WorkspaceLibraryScanner final : public QThread {
 
 public:
   // Constructors / Destructor
-  WorkspaceLibraryScanner(Workspace& ws, const FilePath& dbFilePath) noexcept;
+  WorkspaceLibraryScanner(const FilePath& librariesPath,
+                          const FilePath& dbFilePath) noexcept;
   WorkspaceLibraryScanner(const WorkspaceLibraryScanner& other) = delete;
   ~WorkspaceLibraryScanner() noexcept;
 
@@ -100,8 +100,8 @@ private:  // Methods
                        const ElementType& element);
 
 private:  // Data
-  Workspace& mWorkspace;
-  FilePath mDbFilePath;
+  const FilePath mLibrariesPath;  ///< Path to workspace libraries directory.
+  const FilePath mDbFilePath;  ///< Path to the SQLite database file.
   QSemaphore mSemaphore;
   volatile bool mAbort;
 };

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -56,6 +56,8 @@ add_library(
   library/cat/categorylisteditorwidget.cpp
   library/cat/categorylisteditorwidget.h
   library/cat/categorylisteditorwidget.ui
+  library/cat/categorytreebuilder.cpp
+  library/cat/categorytreebuilder.h
   library/cat/categorytreelabeltextbuilder.cpp
   library/cat/categorytreelabeltextbuilder.h
   library/cat/componentcategoryeditorwidget.cpp

--- a/libs/librepcb/editor/library/cat/categorylisteditorwidget.h
+++ b/libs/librepcb/editor/library/cat/categorylisteditorwidget.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "categorytreebuilder.h"
+
 #include <librepcb/core/library/cat/componentcategory.h>
 #include <librepcb/core/library/cat/packagecategory.h>
 
@@ -55,8 +57,7 @@ class CategoryListEditorWidgetBase : public QWidget {
 public:
   // Constructors / Destructor
   CategoryListEditorWidgetBase() = delete;
-  explicit CategoryListEditorWidgetBase(const Workspace& ws,
-                                        QWidget* parent = nullptr) noexcept;
+  explicit CategoryListEditorWidgetBase(QWidget* parent = nullptr) noexcept;
   CategoryListEditorWidgetBase(const CategoryListEditorWidgetBase& other) =
       delete;
   virtual ~CategoryListEditorWidgetBase() noexcept;
@@ -78,9 +79,7 @@ public:
 
 protected:
   virtual tl::optional<Uuid> chooseCategoryWithDialog() noexcept = 0;
-  virtual FilePath getLatestCategory(const Uuid& category) const = 0;
-  virtual QList<Uuid> getCategoryParents(const Uuid& category) const = 0;
-  virtual QString getCategoryName(const FilePath& fp) const = 0;
+  virtual QStringList buildTree(const tl::optional<Uuid>& category) const = 0;
 
 private:
   void btnAddClicked() noexcept;
@@ -98,7 +97,6 @@ signals:
   void categoryRemoved(const Uuid& category);
 
 protected:  // Data
-  const Workspace& mWorkspace;
   QScopedPointer<Ui::CategoryListEditorWidget> mUi;
   bool mRequiresMinimumOneEntry;
   QSet<Uuid> mUuids;
@@ -125,11 +123,13 @@ public:
   CategoryListEditorWidget& operator=(const CategoryListEditorWidget& rhs) =
       delete;
 
-private:
+private:  // Methods
   tl::optional<Uuid> chooseCategoryWithDialog() noexcept override;
-  FilePath getLatestCategory(const Uuid& category) const override;
-  QList<Uuid> getCategoryParents(const Uuid& category) const override;
-  QString getCategoryName(const FilePath& fp) const override;
+  QStringList buildTree(const tl::optional<Uuid>& category) const override;
+
+private:  // Data
+  const Workspace& mWorkspace;
+  CategoryTreeBuilder<ElementType> mBuilder;
 };
 
 typedef CategoryListEditorWidget<ComponentCategory>

--- a/libs/librepcb/editor/library/cat/categorytreebuilder.h
+++ b/libs/librepcb/editor/library/cat/categorytreebuilder.h
@@ -66,20 +66,24 @@ public:
    *
    * @param category  The category to get the tree from. If tl::nullopt,
    *                  it is assumed to represent the root category.
+   * @param success   If not sullptr, this is set to whether the tree was
+   *                  successfully built or not.
    * @return All category names. The top level category comes first (root
    *         category if `nulloptIsRootCategory=true` passed to the
    *         constructor), then down the tree, with the passed category as
-   *         the last element.
+   *         the last element. In case of invalid categories, the returned list
+   *         is either empty or contains error messages.
    * @throw In case of database errors.
    */
-  QStringList buildTree(const tl::optional<Uuid>& category) const;
+  QStringList buildTree(const tl::optional<Uuid>& category,
+                        bool* success = nullptr) const;
 
   // Operator Overloadings
   CategoryTreeBuilder& operator=(const CategoryTreeBuilder& rhs) = delete;
 
 private:  // Methods
-  FilePath getLatestCategory(const Uuid& category) const;
-  QList<Uuid> getCategoryParents(const Uuid& category) const;
+  bool getParentNames(const tl::optional<Uuid>& category, QStringList& names,
+                      QSet<FilePath>& filePaths) const;
 
 private:  // Data
   const WorkspaceLibraryDb& mDb;

--- a/libs/librepcb/editor/library/cat/categorytreebuilder.h
+++ b/libs/librepcb/editor/library/cat/categorytreebuilder.h
@@ -17,78 +17,75 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_CATEGORYTREELABELTEXTBUILDER_H
-#define LIBREPCB_EDITOR_CATEGORYTREELABELTEXTBUILDER_H
+#ifndef LIBREPCB_EDITOR_CATEGORYTREEBUILDER_H
+#define LIBREPCB_EDITOR_CATEGORYTREEBUILDER_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "categorytreebuilder.h"
-
-#include <librepcb/core/library/cat/componentcategory.h>
-#include <librepcb/core/library/cat/packagecategory.h>
+#include <optional/tl/optional.hpp>
 
 #include <QtCore>
-#include <QtWidgets>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 
+class FilePath;
+class Uuid;
 class WorkspaceLibraryDb;
 
 namespace editor {
 
 /*******************************************************************************
- *  Class CategoryTreeLabelTextBuilder
+ *  Class CategoryTreeBuilder
  ******************************************************************************/
 
 /**
- * @brief The CategoryTreeLabelTextBuilder class
+ * @brief Helper class to extract a category tree from
+ *        ::librepcb::WorkspaceLibraryDb
  */
 template <typename ElementType>
-class CategoryTreeLabelTextBuilder final {
-  Q_DECLARE_TR_FUNCTIONS(CategoryTreeLabelTextBuilder)
+class CategoryTreeBuilder final {
+  Q_DECLARE_TR_FUNCTIONS(CategoryTreeBuilder)
 
 public:
   // Constructors / Destructor
-  CategoryTreeLabelTextBuilder() = delete;
-  CategoryTreeLabelTextBuilder(const CategoryTreeLabelTextBuilder& other) =
-      delete;
-  CategoryTreeLabelTextBuilder(const WorkspaceLibraryDb& db,
-                               const QStringList& localeOrder,
-                               bool nulloptIsRootCategory,
-                               QLabel& label) noexcept;
-  ~CategoryTreeLabelTextBuilder() noexcept;
-
-  // Setters
-  void setOneLine(bool oneLine) noexcept { mOneLine = oneLine; }
-  void setPleaseChooseIfEmpty(bool choose) noexcept { mChooseIfEmpty = choose; }
-  void setText(const QString& text) noexcept;
-  void setErrorText(const QString& error) noexcept;
+  CategoryTreeBuilder() = delete;
+  CategoryTreeBuilder(const CategoryTreeBuilder& other) = delete;
+  CategoryTreeBuilder(const WorkspaceLibraryDb& db,
+                      const QStringList& localeOrder,
+                      bool nulloptIsRootCategory) noexcept;
+  ~CategoryTreeBuilder() noexcept;
 
   // General Methods
-  bool updateText(const tl::optional<Uuid>& category) noexcept;
+
+  /**
+   * @brief Build the parents tree for a specific category
+   *
+   * @param category  The category to get the tree from. If tl::nullopt,
+   *                  it is assumed to represent the root category.
+   * @return All category names. The top level category comes first (root
+   *         category if `nulloptIsRootCategory=true` passed to the
+   *         constructor), then down the tree, with the passed category as
+   *         the last element.
+   * @throw In case of database errors.
+   */
+  QStringList buildTree(const tl::optional<Uuid>& category) const;
 
   // Operator Overloadings
-  CategoryTreeLabelTextBuilder& operator=(
-      const CategoryTreeLabelTextBuilder& rhs) = delete;
+  CategoryTreeBuilder& operator=(const CategoryTreeBuilder& rhs) = delete;
 
 private:  // Methods
-  void setText(const QStringList& lines) noexcept;
+  FilePath getLatestCategory(const Uuid& category) const;
+  QList<Uuid> getCategoryParents(const Uuid& category) const;
 
 private:  // Data
-  CategoryTreeBuilder<ElementType> mBuilder;
-  QLabel& mLabel;
-  bool mOneLine;
-  bool mChooseIfEmpty;
+  const WorkspaceLibraryDb& mDb;
+  const QStringList& mLocaleOrder;
+  const bool mNulloptIsRootCategory;
 };
-
-typedef CategoryTreeLabelTextBuilder<ComponentCategory>
-    ComponentCategoryTreeLabelTextBuilder;
-typedef CategoryTreeLabelTextBuilder<PackageCategory>
-    PackageCategoryTreeLabelTextBuilder;
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.cpp
+++ b/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.cpp
@@ -219,11 +219,9 @@ void ComponentCategoryEditorWidget::btnResetParentCategoryClicked() noexcept {
 
 void ComponentCategoryEditorWidget::updateCategoryLabel() noexcept {
   const WorkspaceLibraryDb& db = mContext.workspace.getLibraryDb();
-  ComponentCategoryTreeLabelTextBuilder textBuilder(db, getLibLocaleOrder(),
-                                                    *mUi->lblParentCategories);
-  textBuilder.setEndlessRecursionUuid(mCategory->getUuid());
-  textBuilder.setHighlightLastLine(true);
-  textBuilder.updateText(mParentUuid, mUi->edtName->text());
+  ComponentCategoryTreeLabelTextBuilder textBuilder(
+      db, getLibLocaleOrder(), true, *mUi->lblParentCategories);
+  textBuilder.updateText(mParentUuid);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.cpp
+++ b/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.cpp
@@ -219,11 +219,9 @@ void PackageCategoryEditorWidget::btnResetParentCategoryClicked() noexcept {
 
 void PackageCategoryEditorWidget::updateCategoryLabel() noexcept {
   const WorkspaceLibraryDb& db = mContext.workspace.getLibraryDb();
-  PackageCategoryTreeLabelTextBuilder textBuilder(db, getLibLocaleOrder(),
+  PackageCategoryTreeLabelTextBuilder textBuilder(db, getLibLocaleOrder(), true,
                                                   *mUi->lblParentCategories);
-  textBuilder.setEndlessRecursionUuid(mCategory->getUuid());
-  textBuilder.setHighlightLastLine(true);
-  textBuilder.updateText(mParentUuid, mUi->edtName->text());
+  textBuilder.updateText(mParentUuid);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
+++ b/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
@@ -130,15 +130,13 @@ void ComponentChooserDialog::searchComponents(const QString& input) {
 
   // min. 2 chars to avoid freeze on entering first character due to huge result
   if (input.length() > 1) {
-    QList<Uuid> components =
-        mWorkspace.getLibraryDb().getElementsBySearchKeyword<Component>(input);
+    QList<Uuid> components = mWorkspace.getLibraryDb().find<Component>(input);
     foreach (const Uuid& uuid, components) {
       FilePath fp =
-          mWorkspace.getLibraryDb().getLatestComponent(uuid);  // can throw
+          mWorkspace.getLibraryDb().getLatest<Component>(uuid);  // can throw
       QString name;
-      mWorkspace.getLibraryDb().getElementTranslations<Component>(
-          fp, localeOrder(),
-          &name);  // can throw
+      mWorkspace.getLibraryDb().getTranslations<Component>(fp, localeOrder(),
+                                                           &name);  // can throw
       QListWidgetItem* item = new QListWidgetItem(name);
       item->setData(Qt::UserRole, uuid.toStr());
       mUi->listComponents->addItem(item);
@@ -156,13 +154,13 @@ void ComponentChooserDialog::setSelectedCategory(
   mSelectedCategoryUuid = uuid;
   try {
     QSet<Uuid> components =
-        mWorkspace.getLibraryDb().getComponentsByCategory(uuid);  // can throw
+        mWorkspace.getLibraryDb().getByCategory<Component>(uuid);  // can throw
     foreach (const Uuid& uuid, components) {
       try {
         FilePath fp =
-            mWorkspace.getLibraryDb().getLatestComponent(uuid);  // can throw
+            mWorkspace.getLibraryDb().getLatest<Component>(uuid);  // can throw
         QString name;
-        mWorkspace.getLibraryDb().getElementTranslations<Component>(
+        mWorkspace.getLibraryDb().getTranslations<Component>(
             fp, localeOrder(),
             &name);  // can throw
         QListWidgetItem* item = new QListWidgetItem(name);
@@ -186,8 +184,8 @@ void ComponentChooserDialog::setSelectedComponent(
 
   if (uuid) {
     try {
-      fp = mWorkspace.getLibraryDb().getLatestComponent(*uuid);  // can throw
-      mWorkspace.getLibraryDb().getElementTranslations<Component>(
+      fp = mWorkspace.getLibraryDb().getLatest<Component>(*uuid);  // can throw
+      mWorkspace.getLibraryDb().getTranslations<Component>(
           fp, localeOrder(), &name, &desc);  // can throw
     } catch (const Exception& e) {
       QMessageBox::critical(this, tr("Could not load component metadata"),
@@ -216,7 +214,7 @@ void ComponentChooserDialog::updatePreview(const FilePath& fp) noexcept {
         for (const ComponentSymbolVariantItem& item :
              symbVar.getSymbolItems()) {
           try {
-            FilePath fp = mWorkspace.getLibraryDb().getLatestSymbol(
+            FilePath fp = mWorkspace.getLibraryDb().getLatest<Symbol>(
                 item.getSymbolUuid());  // can throw
             std::shared_ptr<Symbol> sym = std::make_shared<Symbol>(
                 std::unique_ptr<TransactionalDirectory>(

--- a/libs/librepcb/editor/library/cmp/componentsymbolvarianteditdialog.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvarianteditdialog.cpp
@@ -131,7 +131,7 @@ void ComponentSymbolVariantEditDialog::updateGraphicsItems() noexcept {
   mSymbols.clear();
   for (const ComponentSymbolVariantItem& item : mSymbVar.getSymbolItems()) {
     try {
-      FilePath fp = mWorkspace.getLibraryDb().getLatestSymbol(
+      FilePath fp = mWorkspace.getLibraryDb().getLatest<Symbol>(
           item.getSymbolUuid());  // can throw
       std::shared_ptr<Symbol> sym = std::make_shared<Symbol>(
           std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
@@ -240,7 +240,7 @@ void DeviceEditorWidget::btnChooseComponentClicked() noexcept {
     if (cmpUuid && (*cmpUuid != mDevice->getComponentUuid())) {
       try {
         // load component
-        FilePath fp = mContext.workspace.getLibraryDb().getLatestComponent(
+        FilePath fp = mContext.workspace.getLibraryDb().getLatest<Component>(
             *cmpUuid);  // can throw
         if (!fp.isValid()) {
           throw RuntimeError(__FILE__, __LINE__, tr("Component not found!"));
@@ -280,7 +280,7 @@ void DeviceEditorWidget::btnChoosePackageClicked() noexcept {
     if (pkgUuid && (*pkgUuid != mDevice->getPackageUuid())) {
       try {
         // load package
-        FilePath fp = mContext.workspace.getLibraryDb().getLatestPackage(
+        FilePath fp = mContext.workspace.getLibraryDb().getLatest<Package>(
             *pkgUuid);  // can throw
         if (!fp.isValid()) {
           throw RuntimeError(__FILE__, __LINE__, tr("Package not found!"));
@@ -321,7 +321,7 @@ void DeviceEditorWidget::updateDeviceComponentUuid(const Uuid& uuid) noexcept {
   mSymbolGraphicsItems.clear();
   mSymbols.clear();
   try {
-    FilePath fp = mContext.workspace.getLibraryDb().getLatestComponent(
+    FilePath fp = mContext.workspace.getLibraryDb().getLatest<Component>(
         uuid);  // can throw
     if (!fp.isValid()) {
       throw RuntimeError(__FILE__, __LINE__, tr("Component not found!"));
@@ -350,7 +350,7 @@ void DeviceEditorWidget::updateComponentPreview() noexcept {
         *mComponent->getSymbolVariants().first();
     for (const ComponentSymbolVariantItem& item : symbVar.getSymbolItems()) {
       try {
-        FilePath fp = mContext.workspace.getLibraryDb().getLatestSymbol(
+        FilePath fp = mContext.workspace.getLibraryDb().getLatest<Symbol>(
             item.getSymbolUuid());  // can throw
         std::shared_ptr<Symbol> sym = std::make_shared<Symbol>(
             std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
@@ -375,8 +375,8 @@ void DeviceEditorWidget::updateComponentPreview() noexcept {
 void DeviceEditorWidget::updateDevicePackageUuid(const Uuid& uuid) noexcept {
   mFootprintGraphicsItem.reset();
   try {
-    FilePath fp =
-        mContext.workspace.getLibraryDb().getLatestPackage(uuid);  // can throw
+    FilePath fp = mContext.workspace.getLibraryDb().getLatest<Package>(
+        uuid);  // can throw
     if (!fp.isValid()) {
       throw RuntimeError(__FILE__, __LINE__, tr("Package not found!"));
     }

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_setoptions.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_setoptions.cpp
@@ -113,9 +113,8 @@ void EagleLibraryImportWizardPage_SetOptions::
     updateComponentCategoryTreeLabel() noexcept {
   ComponentCategoryTreeLabelTextBuilder builder(
       mContext->getWorkspace().getLibraryDb(),
-      mContext->getWorkspace().getSettings().libraryLocaleOrder.get(),
+      mContext->getWorkspace().getSettings().libraryLocaleOrder.get(), false,
       *mUi->lblComponentCategoryTree);
-  builder.setHighlightLastLine(true);
   builder.setOneLine(true);
   builder.updateText(mContext->getComponentCategory());
 }
@@ -124,9 +123,8 @@ void EagleLibraryImportWizardPage_SetOptions::
     updatePackageCategoryTreeLabel() noexcept {
   PackageCategoryTreeLabelTextBuilder builder(
       mContext->getWorkspace().getLibraryDb(),
-      mContext->getWorkspace().getSettings().libraryLocaleOrder.get(),
+      mContext->getWorkspace().getSettings().libraryLocaleOrder.get(), false,
       *mUi->lblPackageCategoryTree);
-  builder.setHighlightLastLine(true);
   builder.setOneLine(true);
   builder.updateText(mContext->getPackageCategory());
 }

--- a/libs/librepcb/editor/library/lib/librarylisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/lib/librarylisteditorwidget.cpp
@@ -75,12 +75,12 @@ LibraryListEditorWidget::LibraryListEditorWidget(const Workspace& ws,
   try {
     QList<Uuid> uuids;
     QMultiMap<Version, FilePath> libs =
-        ws.getLibraryDb().getLibraries();  // can throw
+        ws.getLibraryDb().getAll<Library>();  // can throw
     foreach (const FilePath& fp, libs) {
       Uuid uuid = Uuid::createRandom();
-      ws.getLibraryDb().getElementMetadata<Library>(fp, &uuid);  // can throw
+      ws.getLibraryDb().getMetadata<Library>(fp, &uuid);  // can throw
       QString name;
-      ws.getLibraryDb().getElementTranslations<Library>(
+      ws.getLibraryDb().getTranslations<Library>(
           fp, ws.getSettings().libraryLocaleOrder.get(),
           &name);  // can throw
       mModel->setDisplayText(uuid, name);

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
@@ -318,12 +318,13 @@ void LibraryOverviewWidget::updateElementList(QListWidget& listWidget,
 
   try {
     // get all library element names
-    QList<FilePath> elements =
-        mContext.workspace.getLibraryDb().getLibraryElements<ElementType>(
+    QMultiMap<Version, FilePath> elements =
+        mContext.workspace.getLibraryDb().getAll<ElementType>(
+            tl::nullopt,
             mLibrary->getDirectory().getAbsPath());  // can throw
     foreach (const FilePath& filepath, elements) {
       QString name;
-      mContext.workspace.getLibraryDb().getElementTranslations<ElementType>(
+      mContext.workspace.getLibraryDb().getTranslations<ElementType>(
           filepath, getLibLocaleOrder(), &name);  // can throw
       elementNames.insert(filepath, name);
     }
@@ -620,12 +621,12 @@ QList<LibraryOverviewWidget::LibraryMenuItem>
   QList<LibraryMenuItem> libs;
   try {
     QMultiMap<Version, FilePath> libraries =
-        mContext.workspace.getLibraryDb().getLibraries();  // can throw
+        mContext.workspace.getLibraryDb().getAll<Library>();  // can throw
     foreach (const FilePath& libDir, libraries) {
       // Don't list remote libraries since they are read-only!
       if (libDir.isLocatedInDir(mContext.workspace.getLocalLibrariesPath())) {
         QString name;
-        mContext.workspace.getLibraryDb().getElementTranslations<Library>(
+        mContext.workspace.getLibraryDb().getTranslations<Library>(
             libDir, getLibLocaleOrder(), &name);  // can throw
         QPixmap icon;
         mContext.workspace.getLibraryDb().getLibraryMetadata(

--- a/libs/librepcb/editor/library/libraryelementcache.cpp
+++ b/libs/librepcb/editor/library/libraryelementcache.cpp
@@ -57,34 +57,32 @@ LibraryElementCache::~LibraryElementCache() noexcept {
 
 std::shared_ptr<const ComponentCategory>
     LibraryElementCache::getComponentCategory(const Uuid& uuid) const noexcept {
-  return getElement(&WorkspaceLibraryDb::getLatestComponentCategory, mCmpCat,
-                    uuid);
+  return getElement(mCmpCat, uuid);
 }
 
 std::shared_ptr<const PackageCategory> LibraryElementCache::getPackageCategory(
     const Uuid& uuid) const noexcept {
-  return getElement(&WorkspaceLibraryDb::getLatestPackageCategory, mPkgCat,
-                    uuid);
+  return getElement(mPkgCat, uuid);
 }
 
 std::shared_ptr<const Symbol> LibraryElementCache::getSymbol(
     const Uuid& uuid) const noexcept {
-  return getElement(&WorkspaceLibraryDb::getLatestSymbol, mSym, uuid);
+  return getElement(mSym, uuid);
 }
 
 std::shared_ptr<const Package> LibraryElementCache::getPackage(
     const Uuid& uuid) const noexcept {
-  return getElement(&WorkspaceLibraryDb::getLatestPackage, mPkg, uuid);
+  return getElement(mPkg, uuid);
 }
 
 std::shared_ptr<const Component> LibraryElementCache::getComponent(
     const Uuid& uuid) const noexcept {
-  return getElement(&WorkspaceLibraryDb::getLatestComponent, mCmp, uuid);
+  return getElement(mCmp, uuid);
 }
 
 std::shared_ptr<const Device> LibraryElementCache::getDevice(
     const Uuid& uuid) const noexcept {
-  return getElement(&WorkspaceLibraryDb::getLatestDevice, mDev, uuid);
+  return getElement(mDev, uuid);
 }
 
 /*******************************************************************************
@@ -93,13 +91,12 @@ std::shared_ptr<const Device> LibraryElementCache::getDevice(
 
 template <typename T>
 std::shared_ptr<const T> LibraryElementCache::getElement(
-    FilePath (WorkspaceLibraryDb::*getter)(const Uuid&) const,
     QHash<Uuid, std::shared_ptr<const T>>& container, const Uuid& uuid) const
     noexcept {
   std::shared_ptr<const T> element = container.value(uuid);
   if ((!element) && mDb) {
     try {
-      FilePath fp = (mDb->*getter)(uuid);
+      FilePath fp = mDb->getLatest<T>(uuid);
       element = std::make_shared<T>(std::unique_ptr<TransactionalDirectory>(
           new TransactionalDirectory(TransactionalFileSystem::openRO(fp))));
       container.insert(uuid, element);

--- a/libs/librepcb/editor/library/libraryelementcache.h
+++ b/libs/librepcb/editor/library/libraryelementcache.h
@@ -79,7 +79,6 @@ public:
 private:  // Methods
   template <typename T>
   std::shared_ptr<const T> getElement(
-      FilePath (WorkspaceLibraryDb::*getter)(const Uuid&) const,
       QHash<Uuid, std::shared_ptr<const T>>& container, const Uuid& uuid) const
       noexcept;
 

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentsignals.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentsignals.cpp
@@ -77,7 +77,7 @@ QHash<Uuid, CircuitIdentifier>
         const Uuid& symbol, const QString& suffix) const noexcept {
   QHash<Uuid, CircuitIdentifier> names;
   try {
-    FilePath fp = mContext.getWorkspace().getLibraryDb().getLatestSymbol(
+    FilePath fp = mContext.getWorkspace().getLibraryDb().getLatest<Symbol>(
         symbol);  // can throw
     Symbol sym(
         std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_copyfrom.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_copyfrom.cpp
@@ -26,6 +26,8 @@
 #include "ui_newelementwizardpage_copyfrom.h"
 
 #include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/library/cat/componentcategory.h>
+#include <librepcb/core/library/cat/packagecategory.h>
 #include <librepcb/core/workspace/workspace.h>
 #include <librepcb/core/workspace/workspacelibrarydb.h>
 
@@ -175,10 +177,11 @@ FilePath NewElementWizardPage_CopyFrom::getCategoryFilePath(
       case NewElementWizardContext::ElementType::ComponentCategory:
         return mContext.getWorkspace()
             .getLibraryDb()
-            .getLatestComponentCategory(*category);
+            .getLatest<ComponentCategory>(*category);
       case NewElementWizardContext::ElementType::PackageCategory:
-        return mContext.getWorkspace().getLibraryDb().getLatestPackageCategory(
-            *category);
+        return mContext.getWorkspace()
+            .getLibraryDb()
+            .getLatest<PackageCategory>(*category);
       default:
         throw LogicError(__FILE__, __LINE__);
     }
@@ -191,16 +194,16 @@ QSet<Uuid> NewElementWizardPage_CopyFrom::getElementsByCategory(
     const tl::optional<Uuid>& category) const {
   switch (mContext.mElementType) {
     case NewElementWizardContext::ElementType::Symbol:
-      return mContext.getWorkspace().getLibraryDb().getSymbolsByCategory(
+      return mContext.getWorkspace().getLibraryDb().getByCategory<Symbol>(
           category);
     case NewElementWizardContext::ElementType::Component:
-      return mContext.getWorkspace().getLibraryDb().getComponentsByCategory(
+      return mContext.getWorkspace().getLibraryDb().getByCategory<Component>(
           category);
     case NewElementWizardContext::ElementType::Device:
-      return mContext.getWorkspace().getLibraryDb().getDevicesByCategory(
+      return mContext.getWorkspace().getLibraryDb().getByCategory<Device>(
           category);
     case NewElementWizardContext::ElementType::Package:
-      return mContext.getWorkspace().getLibraryDb().getPackagesByCategory(
+      return mContext.getWorkspace().getLibraryDb().getByCategory<Package>(
           category);
     default:
       throw LogicError(__FILE__, __LINE__);
@@ -212,27 +215,27 @@ void NewElementWizardPage_CopyFrom::getElementMetadata(const Uuid& uuid,
                                                        QString& name) const {
   switch (mContext.mElementType) {
     case NewElementWizardContext::ElementType::Symbol:
-      fp = mContext.getWorkspace().getLibraryDb().getLatestSymbol(
+      fp = mContext.getWorkspace().getLibraryDb().getLatest<Symbol>(
           uuid);  // can throw
-      mContext.getWorkspace().getLibraryDb().getElementTranslations<Symbol>(
+      mContext.getWorkspace().getLibraryDb().getTranslations<Symbol>(
           fp, mContext.getLibLocaleOrder(), &name);  // can throw
       return;
     case NewElementWizardContext::ElementType::Component:
-      fp = mContext.getWorkspace().getLibraryDb().getLatestComponent(
+      fp = mContext.getWorkspace().getLibraryDb().getLatest<Component>(
           uuid);  // can throw
-      mContext.getWorkspace().getLibraryDb().getElementTranslations<Component>(
+      mContext.getWorkspace().getLibraryDb().getTranslations<Component>(
           fp, mContext.getLibLocaleOrder(), &name);  // can throw
       return;
     case NewElementWizardContext::ElementType::Device:
-      fp = mContext.getWorkspace().getLibraryDb().getLatestDevice(
+      fp = mContext.getWorkspace().getLibraryDb().getLatest<Device>(
           uuid);  // can throw
-      mContext.getWorkspace().getLibraryDb().getElementTranslations<Device>(
+      mContext.getWorkspace().getLibraryDb().getTranslations<Device>(
           fp, mContext.getLibLocaleOrder(), &name);  // can throw
       return;
     case NewElementWizardContext::ElementType::Package:
-      fp = mContext.getWorkspace().getLibraryDb().getLatestPackage(
+      fp = mContext.getWorkspace().getLibraryDb().getLatest<Package>(
           uuid);  // can throw
-      mContext.getWorkspace().getLibraryDb().getElementTranslations<Package>(
+      mContext.getWorkspace().getLibraryDb().getTranslations<Package>(
           fp, mContext.getLibLocaleOrder(), &name);  // can throw
       return;
     default:

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_deviceproperties.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_deviceproperties.cpp
@@ -99,10 +99,10 @@ void NewElementWizardPage_DeviceProperties::setComponent(
   mContext.mDeviceComponentUuid = uuid;
   if (uuid) {
     try {
-      FilePath fp = mContext.getWorkspace().getLibraryDb().getLatestComponent(
+      FilePath fp = mContext.getWorkspace().getLibraryDb().getLatest<Component>(
           *uuid);  // can throw
       QString name, desc;
-      mContext.getWorkspace().getLibraryDb().getElementTranslations<Component>(
+      mContext.getWorkspace().getLibraryDb().getTranslations<Component>(
           fp, mContext.getLibLocaleOrder(), &name, &desc);  // can throw
       mUi->lblComponentName->setText(name);
       mUi->lblComponentDescription->setText(desc);
@@ -122,7 +122,7 @@ void NewElementWizardPage_DeviceProperties::setPackage(
   mContext.mDevicePackageUuid = uuid;
   if (uuid) {
     try {
-      FilePath fp = mContext.getWorkspace().getLibraryDb().getLatestPackage(
+      FilePath fp = mContext.getWorkspace().getLibraryDb().getLatest<Package>(
           *uuid);  // can throw
       Package package(
           std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_entermetadata.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_entermetadata.cpp
@@ -169,33 +169,40 @@ void NewElementWizardPage_EnterMetadata::updateCategoryTreeLabel() noexcept {
     rootCategoryUuid = mContext.mElementCategoryUuids.values().first();
   }
 
+  bool nulloptIsRootCategory = false;
   switch (mContext.mElementType) {
     case NewElementWizardContext::ElementType::ComponentCategory:
+      nulloptIsRootCategory = true;
+      // fallthrough
     case NewElementWizardContext::ElementType::Symbol:
     case NewElementWizardContext::ElementType::Component:
     case NewElementWizardContext::ElementType::Device: {
       ComponentCategoryTreeLabelTextBuilder builder(
           mContext.getWorkspace().getLibraryDb(),
           mContext.getWorkspace().getSettings().libraryLocaleOrder.get(),
-          *mUi->lblCategoryTree);
-      builder.setHighlightLastLine(true);
+          nulloptIsRootCategory, *mUi->lblCategoryTree);
       builder.setOneLine(true);
+      builder.setPleaseChooseIfEmpty(true);
       builder.updateText(rootCategoryUuid);
       break;
     }
     case NewElementWizardContext::ElementType::PackageCategory:
+      nulloptIsRootCategory = true;
+      // fallthrough
     case NewElementWizardContext::ElementType::Package: {
       PackageCategoryTreeLabelTextBuilder builder(
           mContext.getWorkspace().getLibraryDb(),
           mContext.getWorkspace().getSettings().libraryLocaleOrder.get(),
-          *mUi->lblCategoryTree);
-      builder.setHighlightLastLine(true);
+          nulloptIsRootCategory, *mUi->lblCategoryTree);
       builder.setOneLine(true);
+      builder.setPleaseChooseIfEmpty(true);
       builder.updateText(rootCategoryUuid);
       break;
     }
     default: {
-      mUi->lblCategoryTree->setText(tr("Root category"));
+      qCritical()
+          << "NewElementWizardPage_EnterMetadata: Unhandled switch-case value:"
+          << static_cast<int>(mContext.mElementType);
       break;
     }
   }

--- a/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
@@ -129,15 +129,13 @@ void PackageChooserDialog::searchPackages(const QString& input) {
 
   // min. 2 chars to avoid freeze on entering first character due to huge result
   if (input.length() > 1) {
-    QList<Uuid> packages =
-        mWorkspace.getLibraryDb().getElementsBySearchKeyword<Package>(input);
+    QList<Uuid> packages = mWorkspace.getLibraryDb().find<Package>(input);
     foreach (const Uuid& uuid, packages) {
       FilePath fp =
-          mWorkspace.getLibraryDb().getLatestPackage(uuid);  // can throw
+          mWorkspace.getLibraryDb().getLatest<Package>(uuid);  // can throw
       QString name;
-      mWorkspace.getLibraryDb().getElementTranslations<Package>(
-          fp, localeOrder(),
-          &name);  // can throw
+      mWorkspace.getLibraryDb().getTranslations<Package>(fp, localeOrder(),
+                                                         &name);  // can throw
       QListWidgetItem* item = new QListWidgetItem(name);
       item->setData(Qt::UserRole, uuid.toStr());
       mUi->listPackages->addItem(item);
@@ -156,15 +154,14 @@ void PackageChooserDialog::setSelectedCategory(
 
   try {
     QSet<Uuid> packages =
-        mWorkspace.getLibraryDb().getPackagesByCategory(uuid);  // can throw
+        mWorkspace.getLibraryDb().getByCategory<Package>(uuid);  // can throw
     foreach (const Uuid& pkgUuid, packages) {
       try {
         FilePath fp =
-            mWorkspace.getLibraryDb().getLatestPackage(pkgUuid);  // can throw
+            mWorkspace.getLibraryDb().getLatest<Package>(pkgUuid);  // can throw
         QString name;
-        mWorkspace.getLibraryDb().getElementTranslations<Package>(
-            fp, localeOrder(),
-            &name);  // can throw
+        mWorkspace.getLibraryDb().getTranslations<Package>(fp, localeOrder(),
+                                                           &name);  // can throw
         QListWidgetItem* item = new QListWidgetItem(name);
         item->setData(Qt::UserRole, pkgUuid.toStr());
         mUi->listPackages->addItem(item);
@@ -186,8 +183,8 @@ void PackageChooserDialog::setSelectedPackage(
 
   if (uuid) {
     try {
-      fp = mWorkspace.getLibraryDb().getLatestPackage(*uuid);  // can throw
-      mWorkspace.getLibraryDb().getElementTranslations<Package>(
+      fp = mWorkspace.getLibraryDb().getLatest<Package>(*uuid);  // can throw
+      mWorkspace.getLibraryDb().getTranslations<Package>(
           fp, localeOrder(), &name, &desc);  // can throw
     } catch (const Exception& e) {
       QMessageBox::critical(this, tr("Could not load package metadata"),

--- a/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
+++ b/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
@@ -146,15 +146,13 @@ void SymbolChooserDialog::searchSymbols(const QString& input) {
 
   // min. 2 chars to avoid freeze on entering first character due to huge result
   if (input.length() > 1) {
-    QList<Uuid> symbols =
-        mWorkspace.getLibraryDb().getElementsBySearchKeyword<Symbol>(input);
+    QList<Uuid> symbols = mWorkspace.getLibraryDb().find<Symbol>(input);
     foreach (const Uuid& uuid, symbols) {
       FilePath fp =
-          mWorkspace.getLibraryDb().getLatestSymbol(uuid);  // can throw
+          mWorkspace.getLibraryDb().getLatest<Symbol>(uuid);  // can throw
       QString name;
-      mWorkspace.getLibraryDb().getElementTranslations<Symbol>(
-          fp, localeOrder(),
-          &name);  // can throw
+      mWorkspace.getLibraryDb().getTranslations<Symbol>(fp, localeOrder(),
+                                                        &name);  // can throw
       QListWidgetItem* item = new QListWidgetItem(name);
       item->setData(Qt::UserRole, fp.toStr());
       mUi->listSymbols->addItem(item);
@@ -173,13 +171,13 @@ void SymbolChooserDialog::setSelectedCategory(
 
   try {
     QSet<Uuid> symbols =
-        mWorkspace.getLibraryDb().getSymbolsByCategory(uuid);  // can throw
+        mWorkspace.getLibraryDb().getByCategory<Symbol>(uuid);  // can throw
     foreach (const Uuid& symbolUuid, symbols) {
       try {
         QString symName;
-        FilePath symFp =
-            mWorkspace.getLibraryDb().getLatestSymbol(symbolUuid);  // can throw
-        mWorkspace.getLibraryDb().getElementTranslations<Symbol>(
+        FilePath symFp = mWorkspace.getLibraryDb().getLatest<Symbol>(
+            symbolUuid);  // can throw
+        mWorkspace.getLibraryDb().getTranslations<Symbol>(
             symFp, localeOrder(), &symName);  // can throw
         QListWidgetItem* item = new QListWidgetItem(symName);
         item->setData(Qt::UserRole, symFp.toStr());

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -1339,20 +1339,20 @@ QList<BoardEditorState_Select::DeviceMenuItem>
   QList<BoardEditorState_Select::DeviceMenuItem> items;
   try {
     QIcon icon(":/img/library/device.png");
-    QSet<Uuid> devices =
-        mContext.workspace.getLibraryDb().getDevicesOfComponent(
-            cmpInst.getLibComponent().getUuid());  // can throw
+    QSet<Uuid> devices = mContext.workspace.getLibraryDb().getComponentDevices(
+        cmpInst.getLibComponent().getUuid());  // can throw
     foreach (const Uuid& deviceUuid, devices) {
       QString devName, pkgName;
       FilePath devFp =
-          mContext.workspace.getLibraryDb().getLatestDevice(deviceUuid);
-      mContext.workspace.getLibraryDb().getElementTranslations<Device>(
+          mContext.workspace.getLibraryDb().getLatest<Device>(deviceUuid);
+      mContext.workspace.getLibraryDb().getTranslations<Device>(
           devFp, mContext.project.getSettings().getLocaleOrder(), &devName);
       Uuid pkgUuid = Uuid::createRandom();  // only for initialization...
-      mContext.workspace.getLibraryDb().getDeviceMetadata(devFp, &pkgUuid);
+      mContext.workspace.getLibraryDb().getDeviceMetadata(devFp, nullptr,
+                                                          &pkgUuid);
       FilePath pkgFp =
-          mContext.workspace.getLibraryDb().getLatestPackage(pkgUuid);
-      mContext.workspace.getLibraryDb().getElementTranslations<Package>(
+          mContext.workspace.getLibraryDb().getLatest<Package>(pkgUuid);
+      mContext.workspace.getLibraryDb().getTranslations<Package>(
           pkgFp, mContext.project.getSettings().getLocaleOrder(), &pkgName);
       items.append(DeviceMenuItem{QString("%1 [%2]").arg(devName, pkgName),
                                   icon, deviceUuid});

--- a/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
@@ -283,7 +283,7 @@ void UnplacedComponentsDock::currentDeviceIndexChanged(int index) noexcept {
     if (!package) {
       // If package does not exist in project library, use workspace library.
       FilePath pkgFp =
-          mProjectEditor.getWorkspace().getLibraryDb().getLatestPackage(
+          mProjectEditor.getWorkspace().getLibraryDb().getLatest<Package>(
               device.packageUuid);
       if (pkgFp.isValid()) {
         package = new Package(
@@ -547,23 +547,22 @@ std::pair<QList<UnplacedComponentsDock::DeviceMetadata>, int>
   // Get matching devices in workspace library.
   try {
     QSet<Uuid> wsLibDev =
-        mProjectEditor.getWorkspace().getLibraryDb().getDevicesOfComponent(
+        mProjectEditor.getWorkspace().getLibraryDb().getComponentDevices(
             cmpUuid);  // can throw
     wsLibDev -= Toolbox::toSet(prjLibDev.keys());
     foreach (const Uuid& deviceUuid, wsLibDev) {
       // Get device metadata.
       FilePath devFp =
-          mProjectEditor.getWorkspace().getLibraryDb().getLatestDevice(
+          mProjectEditor.getWorkspace().getLibraryDb().getLatest<Device>(
               deviceUuid);  // can throw
       if (!devFp.isValid()) continue;
       QString devName;
-      mProjectEditor.getWorkspace()
-          .getLibraryDb()
-          .getElementTranslations<Device>(devFp, localeOrder,
-                                          &devName);  // can throw
+      mProjectEditor.getWorkspace().getLibraryDb().getTranslations<Device>(
+          devFp, localeOrder,
+          &devName);  // can throw
       Uuid pkgUuid = Uuid::createRandom();  // Temporary.
       mProjectEditor.getWorkspace().getLibraryDb().getDeviceMetadata(
-          devFp,
+          devFp, nullptr,
           &pkgUuid);  // can throw
 
       devices.append(
@@ -583,13 +582,12 @@ std::pair<QList<UnplacedComponentsDock::DeviceMetadata>, int>
     } else {
       try {
         FilePath pkgFp =
-            mProjectEditor.getWorkspace().getLibraryDb().getLatestPackage(
+            mProjectEditor.getWorkspace().getLibraryDb().getLatest<Package>(
                 device.packageUuid);  // can throw
         if (!pkgFp.isValid()) continue;
-        mProjectEditor.getWorkspace()
-            .getLibraryDb()
-            .getElementTranslations<Package>(pkgFp, localeOrder,
-                                             &device.packageName);  // can throw
+        mProjectEditor.getWorkspace().getLibraryDb().getTranslations<Package>(
+            pkgFp, localeOrder,
+            &device.packageName);  // can throw
       } catch (const Exception& e) {
         qCritical()
             << "Error while querying packages in unplaced components dock:"

--- a/libs/librepcb/editor/project/cmd/cmdaddcomponenttocircuit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdaddcomponenttocircuit.cpp
@@ -78,7 +78,7 @@ bool CmdAddComponentToCircuit::performExecute() {
   // workspace library to the project's library
   if (!mProject.getLibrary().getComponent(mComponentUuid)) {
     FilePath cmpFp =
-        mWorkspace.getLibraryDb().getLatestComponent(mComponentUuid);
+        mWorkspace.getLibraryDb().getLatest<Component>(mComponentUuid);
     if (!cmpFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,

--- a/libs/librepcb/editor/project/cmd/cmdadddevicetoboard.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdadddevicetoboard.cpp
@@ -81,7 +81,7 @@ bool CmdAddDeviceToBoard::performExecute() {
   // workspace library to the project's library
   Device* dev = mBoard.getProject().getLibrary().getDevice(mDeviceUuid);
   if (!dev) {
-    FilePath devFp = mWorkspace.getLibraryDb().getLatestDevice(mDeviceUuid);
+    FilePath devFp = mWorkspace.getLibraryDb().getLatest<Device>(mDeviceUuid);
     if (!devFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,
@@ -103,7 +103,7 @@ bool CmdAddDeviceToBoard::performExecute() {
   Uuid pkgUuid = dev->getPackageUuid();
   Package* pkg = mBoard.getProject().getLibrary().getPackage(pkgUuid);
   if (!pkg) {
-    FilePath pkgFp = mWorkspace.getLibraryDb().getLatestPackage(pkgUuid);
+    FilePath pkgFp = mWorkspace.getLibraryDb().getLatest<Package>(pkgUuid);
     if (!pkgFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,

--- a/libs/librepcb/editor/project/cmd/cmdaddsymboltoschematic.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdaddsymboltoschematic.cpp
@@ -82,7 +82,7 @@ bool CmdAddSymbolToSchematic::performExecute() {
   // if there is no such symbol in the project's library, copy it from the
   // workspace library to the project's library
   if (!mSchematic.getProject().getLibrary().getSymbol(symbolUuid)) {
-    FilePath symFp = mWorkspace.getLibraryDb().getLatestSymbol(symbolUuid);
+    FilePath symFp = mWorkspace.getLibraryDb().getLatest<Symbol>(symbolUuid);
     if (!symFp.isValid()) {
       throw RuntimeError(
           __FILE__, __LINE__,

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -134,16 +134,16 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
       mUi->cbxPreselectedDevice->addItem(name, device->getUuid().toStr());
     }
     // Then add remaining devices from workspace library (lower priority)
-    QSet<Uuid> wsLibDevices = mWorkspace.getLibraryDb().getDevicesOfComponent(
+    QSet<Uuid> wsLibDevices = mWorkspace.getLibraryDb().getComponentDevices(
         mComponentInstance.getLibComponent().getUuid());  // can throw
     wsLibDevices -= Toolbox::toSet(prjLibDevices.keys());  // avoid duplicates
     foreach (const Uuid& deviceUuid, wsLibDevices) {
       FilePath devFp =
-          mWorkspace.getLibraryDb().getLatestDevice(deviceUuid);  // can throw
+          mWorkspace.getLibraryDb().getLatest<Device>(deviceUuid);  // can throw
       if (devFp.isValid()) {
         QString name;
-        mWorkspace.getLibraryDb().getElementTranslations<Device>(
-            devFp, localeOrder, &name);  // can throw
+        mWorkspace.getLibraryDb().getTranslations<Device>(devFp, localeOrder,
+                                                          &name);  // can throw
         mUi->cbxPreselectedDevice->addItem(name, deviceUuid.toStr());
       }
     }

--- a/libs/librepcb/editor/workspace/categorytreeitem.h
+++ b/libs/librepcb/editor/workspace/categorytreeitem.h
@@ -93,8 +93,6 @@ private:
   using ChildType = QSharedPointer<CategoryTreeItem<ElementType>>;
 
   // Methods
-  FilePath getLatestCategory(const WorkspaceLibraryDb& lib) const;
-  QSet<Uuid> getCategoryChilds(const WorkspaceLibraryDb& lib) const;
   bool matchesFilter(const WorkspaceLibraryDb& lib,
                      CategoryTreeFilter::Flags filter) const;
 

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -244,7 +244,7 @@ void ControlPanel::loadSettings() {
 void ControlPanel::updateNoLibrariesWarningVisibility() noexcept {
   bool showWarning = false;
   try {
-    showWarning = mWorkspace.getLibraryDb().getLibraries().isEmpty();
+    showWarning = mWorkspace.getLibraryDb().getAll<Library>().isEmpty();
   } catch (const Exception& e) {
     qCritical() << "Could not get library list:" << e.getMsg();
   }

--- a/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.cpp
@@ -89,11 +89,11 @@ LibraryInfoWidget::LibraryInfoWidget(Workspace& ws, const FilePath& libDir)
   QString dependencies;
   foreach (const Uuid& uuid, lib.getDependencies()) {
     QString line = dependencies.isEmpty() ? "" : "<br>";
-    FilePath fp = ws.getLibraryDb().getLatestLibrary(uuid);  // can throw
+    FilePath fp = ws.getLibraryDb().getLatest<Library>(uuid);  // can throw
     if (fp.isValid()) {
       QString name;
-      ws.getLibraryDb().getElementTranslations<Library>(fp, localeOrder,
-                                                        &name);  // can throw
+      ws.getLibraryDb().getTranslations<Library>(fp, localeOrder,
+                                                 &name);  // can throw
       line += QString(" <font color=\"green\">%1 ✔</font>").arg(name);
     } else {
       line += QString(" <font color=\"red\">%1 ✖</font>").arg(uuid.toStr());

--- a/libs/librepcb/editor/workspace/librarymanager/librarymanager.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/librarymanager.cpp
@@ -127,11 +127,11 @@ void LibraryManager::updateLibraryList() noexcept {
   // add all existing libraries
   try {
     QMultiMap<Version, FilePath> libraries =
-        mWorkspace.getLibraryDb().getLibraries();  // can throw
+        mWorkspace.getLibraryDb().getAll<Library>();  // can throw
 
     foreach (const FilePath& libDir, libraries) {
       QString name, description, keywords;
-      mWorkspace.getLibraryDb().getElementTranslations<Library>(
+      mWorkspace.getLibraryDb().getTranslations<Library>(
           libDir, mWorkspace.getSettings().libraryLocaleOrder.get(), &name,
           &description, &keywords);  // can throw
       QPixmap icon;

--- a/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -193,11 +193,11 @@ void RepositoryLibraryListWidgetItem::updateInstalledStatus() noexcept {
     tl::optional<Version> installedVersion;
     try {
       FilePath fp =
-          mWorkspace.getLibraryDb().getLatestLibrary(*mUuid);  // can throw
+          mWorkspace.getLibraryDb().getLatest<Library>(*mUuid);  // can throw
       if (fp.isValid()) {
         Version v = Version::fromString("0.1");  // only for initialization
-        mWorkspace.getLibraryDb().getElementMetadata<Library>(fp, nullptr,
-                                                              &v);  // can throw
+        mWorkspace.getLibraryDb().getMetadata<Library>(fp, nullptr,
+                                                       &v);  // can throw
         installedVersion = v;
       }
     } catch (const Exception& e) {

--- a/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.h
+++ b/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.h
@@ -73,10 +73,9 @@ private slots:
 private:
   void log(const QString& msg) noexcept;
   QString prettyPath(const FilePath& fp) const noexcept;
+  template <typename T>
   void updateElements(std::shared_ptr<TransactionalFileSystem> fs,
-                      const QString& type,
-                      FilePath (WorkspaceLibraryDb::*getter)(const Uuid&)
-                          const);
+                      const QString& type);
 
 private:
   Workspace& mWorkspace;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(
   eagleimport/eaglelibraryimporttest.cpp
   eagleimport/eagletypeconvertertest.cpp
   editor/dialogs/dxfimportdialogtest.cpp
+  editor/library/cat/categorytreebuildertest.cpp
   editor/library/pkg/footprintclipboarddatatest.cpp
   editor/library/sym/symbolclipboarddatatest.cpp
   editor/modelview/pathmodeltest.cpp

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(
   core/utils/signalslottest.cpp
   core/utils/tangentpathjoinertest.cpp
   core/utils/toolboxtest.cpp
+  core/workspace/workspacelibrarydbtest.cpp
   core/workspace/workspacesettingstest.cpp
   core/workspace/workspacetest.cpp
   eagleimport/eaglelibraryimporttest.cpp

--- a/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
+++ b/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
@@ -1,0 +1,1008 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/fileio/fileutils.h>
+#include <librepcb/core/library/cat/componentcategory.h>
+#include <librepcb/core/library/cat/packagecategory.h>
+#include <librepcb/core/library/cmp/component.h>
+#include <librepcb/core/library/dev/device.h>
+#include <librepcb/core/library/library.h>
+#include <librepcb/core/library/pkg/package.h>
+#include <librepcb/core/library/sym/symbol.h>
+#include <librepcb/core/sqlitedatabase.h>
+#include <librepcb/core/utils/toolbox.h>
+#include <librepcb/core/workspace/workspacelibrarydb.h>
+#include <librepcb/core/workspace/workspacelibrarydbwriter.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class WorkspaceLibraryDbTest : public ::testing::Test {
+protected:
+  FilePath mWsDir;
+  std::unique_ptr<WorkspaceLibraryDb> mWsDb;
+  std::unique_ptr<SQLiteDatabase> mDb;
+  std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
+
+  WorkspaceLibraryDbTest() : mWsDir(FilePath::getRandomTempPath()) {
+    FileUtils::makePath(mWsDir);
+    mWsDb.reset(new WorkspaceLibraryDb(mWsDir));
+    mDb.reset(new SQLiteDatabase(mWsDb->getFilePath()));
+    mWriter.reset(new WorkspaceLibraryDbWriter(mWsDir, *mDb));
+  }
+
+  virtual ~WorkspaceLibraryDbTest() {
+    QDir(mWsDir.toStr()).removeRecursively();
+  }
+
+  std::string str(const FilePath& fp) { return fp.toStr().toStdString(); }
+
+  std::string str(const Uuid& uuid) { return uuid.toStr().toStdString(); }
+
+  std::string str(const Version& version) {
+    return version.toStr().toStdString();
+  }
+
+  std::string str(const QList<Uuid>& set) {
+    QStringList s;
+    foreach (const Uuid& uuid, set) { s.append(uuid.toStr()); }
+    return s.join(", ").toStdString();
+  }
+
+  std::string str(const QSet<Uuid>& set) {
+    return str(Toolbox::sortedQSet(set));
+  }
+
+  std::string str(const QMultiMap<Version, FilePath>& map) {
+    QStringList s;
+    for (auto it = map.constBegin(); it != map.constEnd(); it++) {
+      s.append(it.key().toStr() % " -> " % it.value().toStr());
+    }
+    return s.join(", ").toStdString();
+  }
+
+  FilePath toAbs(const QString& fp) { return mWsDir.getPathTo(fp); }
+
+  Uuid uuid(int index = -1) {
+    static QHash<int, Uuid> cache;
+    if (index >= 0) {
+      auto it = cache.find(index);
+      if (it == cache.end()) {
+        it = cache.insert(index, uuid());
+      }
+      return *it;
+    } else {
+      return Uuid::createRandom();
+    }
+  }
+
+  Version version(const QString& version) {
+    return Version::fromString(version);
+  }
+};
+
+/*******************************************************************************
+ *  Tests for getAll()
+ ******************************************************************************/
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllEmptyDb) {
+  EXPECT_EQ(0, mWsDb->getAll<Library>().count());
+  EXPECT_EQ(0, mWsDb->getAll<ComponentCategory>().count());
+  EXPECT_EQ(0, mWsDb->getAll<PackageCategory>().count());
+  EXPECT_EQ(0, mWsDb->getAll<Symbol>().count());
+  EXPECT_EQ(0, mWsDb->getAll<Package>().count());
+  EXPECT_EQ(0, mWsDb->getAll<Component>().count());
+  EXPECT_EQ(0, mWsDb->getAll<Device>().count());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllEmptyDbWithUuid) {
+  EXPECT_EQ(0, mWsDb->getAll<Library>(uuid()).count());
+  EXPECT_EQ(0, mWsDb->getAll<ComponentCategory>(uuid()).count());
+  EXPECT_EQ(0, mWsDb->getAll<PackageCategory>(uuid()).count());
+  EXPECT_EQ(0, mWsDb->getAll<Symbol>(uuid()).count());
+  EXPECT_EQ(0, mWsDb->getAll<Package>(uuid()).count());
+  EXPECT_EQ(0, mWsDb->getAll<Component>(uuid()).count());
+  EXPECT_EQ(0, mWsDb->getAll<Device>(uuid()).count());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllEmptyDbWithLibrary) {
+  FilePath lib = toAbs("lib");
+  // Note: Library filter with getAll<Library> is not possible, thus not tested.
+  EXPECT_EQ(0, mWsDb->getAll<ComponentCategory>(tl::nullopt, lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<PackageCategory>(tl::nullopt, lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Symbol>(tl::nullopt, lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Package>(tl::nullopt, lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Component>(tl::nullopt, lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Device>(tl::nullopt, lib).count());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllEmptyDbWithUuidAndLibrary) {
+  FilePath lib = toAbs("lib");
+  // Note: Library filter with getAll<Library> is not possible, thus not tested.
+  EXPECT_EQ(0, mWsDb->getAll<ComponentCategory>(uuid(), lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<PackageCategory>(uuid(), lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Symbol>(uuid(), lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Package>(uuid(), lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Component>(uuid(), lib).count());
+  EXPECT_EQ(0, mWsDb->getAll<Device>(uuid(), lib).count());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetAll) {
+  for (int i = 0; i < 2; ++i) {
+    QString number = QString::number(i + 1);
+    mWriter->addLibrary(toAbs("lib" % number), uuid(), version("0.1." % number),
+                        false, QByteArray());
+    mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat" % number), uuid(),
+                                            version("0.2." % number), false,
+                                            tl::nullopt);
+    mWriter->addCategory<PackageCategory>(0, toAbs("pkgcat" % number), uuid(),
+                                          version("0.3." % number), false,
+                                          tl::nullopt);
+    mWriter->addElement<Symbol>(0, toAbs("sym" % number), uuid(),
+                                version("0.4." % number), false);
+    mWriter->addElement<Package>(0, toAbs("pkg" % number), uuid(),
+                                 version("0.5." % number), false);
+    mWriter->addElement<Component>(0, toAbs("cmp" % number), uuid(),
+                                   version("0.6." % number), false);
+    mWriter->addDevice(0, toAbs("dev" % number), uuid(),
+                       version("0.7." % number), false, uuid(), uuid());
+  }
+
+  EXPECT_EQ(str({{version("0.1.1"), toAbs("lib1")},
+                 {version("0.1.2"), toAbs("lib2")}}),
+            str(mWsDb->getAll<Library>()));
+  EXPECT_EQ(str({{version("0.2.1"), toAbs("cmpcat1")},
+                 {version("0.2.2"), toAbs("cmpcat2")}}),
+            str(mWsDb->getAll<ComponentCategory>()));
+  EXPECT_EQ(str({{version("0.3.1"), toAbs("pkgcat1")},
+                 {version("0.3.2"), toAbs("pkgcat2")}}),
+            str(mWsDb->getAll<PackageCategory>()));
+  EXPECT_EQ(str({{version("0.4.1"), toAbs("sym1")},
+                 {version("0.4.2"), toAbs("sym2")}}),
+            str(mWsDb->getAll<Symbol>()));
+  EXPECT_EQ(str({{version("0.5.1"), toAbs("pkg1")},
+                 {version("0.5.2"), toAbs("pkg2")}}),
+            str(mWsDb->getAll<Package>()));
+  EXPECT_EQ(str({{version("0.6.1"), toAbs("cmp1")},
+                 {version("0.6.2"), toAbs("cmp2")}}),
+            str(mWsDb->getAll<Component>()));
+  EXPECT_EQ(str({{version("0.7.1"), toAbs("dev1")},
+                 {version("0.7.2"), toAbs("dev2")}}),
+            str(mWsDb->getAll<Device>()));
+}
+
+// Further tests only check with Symbol, since the implementation is the same
+// for all library element types and the tests above have proven that each
+// element type is generally working.
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllWithDuplicates) {
+  int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
+                                 QByteArray());
+  int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
+                                 QByteArray());
+  mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
+                              false);
+  mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym3"), uuid(1), version("0.3"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym4"), uuid(2), version("0.2"),
+                              false);
+
+  EXPECT_EQ(str({{version("0.1"), toAbs("sym1")},
+                 {version("0.2"), toAbs("sym2")},
+                 {version("0.3"), toAbs("sym3")},
+                 {version("0.2"), toAbs("sym4")}}),
+            str(mWsDb->getAll<Symbol>()));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllWithUuid) {
+  int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
+                                 QByteArray());
+  int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
+                                 QByteArray());
+  mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
+                              false);
+  mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym3"), uuid(1), version("0.3"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym4"), uuid(2), version("0.2"),
+                              false);
+
+  EXPECT_EQ(
+      str({{version("0.1"), toAbs("sym1")}, {version("0.3"), toAbs("sym3")}}),
+      str(mWsDb->getAll<Symbol>(uuid(1))));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllWithLibrary) {
+  int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
+                                 QByteArray());
+  int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
+                                 QByteArray());
+  mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
+                              false);
+  mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym3"), uuid(1), version("0.3"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym4"), uuid(2), version("0.2"),
+                              false);
+
+  EXPECT_EQ(
+      str({{version("0.3"), toAbs("sym3")}, {version("0.2"), toAbs("sym4")}}),
+      str(mWsDb->getAll<Symbol>(tl::nullopt, toAbs("lib2"))));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetAllWithUuidAndLibrary) {
+  int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
+                                 QByteArray());
+  int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
+                                 QByteArray());
+  mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
+                              false);
+  mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym3"), uuid(1), version("0.3"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym4"), uuid(2), version("0.2"),
+                              false);
+
+  EXPECT_EQ(str({{version("0.3"), toAbs("sym3")}}),
+            str(mWsDb->getAll<Symbol>(uuid(1), toAbs("lib2"))));
+}
+
+/*******************************************************************************
+ *  Tests for getLatest()
+ ******************************************************************************/
+
+// Only very few, simple tests since the implementation is only a small,
+// generic wrapper around getAll().
+
+TEST_F(WorkspaceLibraryDbTest, testGetLatestEmptyDb) {
+  EXPECT_FALSE(mWsDb->getLatest<Symbol>(uuid()).isValid());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetLatest) {
+  int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
+                                 QByteArray());
+  int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
+                                 QByteArray());
+  mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(0), version("0.1"),
+                              false);
+  mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(0), version("0.2"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym3"), uuid(0), version("0.3"),
+                              false);
+  mWriter->addElement<Symbol>(lib2, toAbs("sym4"), uuid(0), version("0.2"),
+                              false);
+
+  EXPECT_EQ(str(toAbs("sym3")), str(mWsDb->getLatest<Symbol>(uuid(0))));
+}
+
+/*******************************************************************************
+ *  Tests for find()
+ ******************************************************************************/
+
+// Only tested with Symbol, since the implementation is shared across all
+// element types.
+
+TEST_F(WorkspaceLibraryDbTest, testFindEmptyDb) {
+  EXPECT_EQ(str(QList<Uuid>{}), str(mWsDb->find<Symbol>("foo")));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testFindEmptyKeyword) {
+  int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
+                                QByteArray());
+  int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(),
+                                        version("0.1"), false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("some name"),
+                                  "some desc", "some keywords");
+
+  EXPECT_EQ(str(QList<Uuid>{}), str(mWsDb->find<Symbol>("foo")));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testFind) {
+  int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
+                                QByteArray());
+  int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(1),
+                                        version("0.1"), false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym1 name"),
+                                  "the sym1 desc", "the sym1 keywords");
+  sym = mWriter->addElement<Symbol>(lib, toAbs("sym2"), uuid(2), version("0.2"),
+                                    false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym2 name"),
+                                  "the sym2 desc", "the sym2 keywords");
+  sym = mWriter->addElement<Symbol>(lib, toAbs("sym3"), uuid(3), version("0.3"),
+                                    false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym3 name"),
+                                  "the sym3 desc", "the sym3 keywords");
+
+  EXPECT_EQ(str(QList<Uuid>{uuid(1), uuid(2), uuid(3)}),
+            str(mWsDb->find<Symbol>("name")));
+  EXPECT_EQ(str(QList<Uuid>{uuid(1)}), str(mWsDb->find<Symbol>("sym1 name")));
+  EXPECT_EQ(str(QList<Uuid>{uuid(3)}),
+            str(mWsDb->find<Symbol>("sym3 keywords")));
+
+  // Descriptions are not taken into account to avoit way too verbose results!
+  EXPECT_EQ(str(QList<Uuid>{}), str(mWsDb->find<Symbol>("sym2 desc")));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testFindWithDuplicates) {
+  int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
+                                QByteArray());
+  int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(1),
+                                        version("0.1"), false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym1 name"),
+                                  "the sym1 desc", "the sym1 keywords");
+  sym = mWriter->addElement<Symbol>(lib, toAbs("sym2"), uuid(1), version("0.2"),
+                                    false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym2 name"),
+                                  "the sym2 desc", "the sym2 keywords");
+  sym = mWriter->addElement<Symbol>(lib, toAbs("sym3"), uuid(2), version("0.3"),
+                                    false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym3 name"),
+                                  "the sym3 desc", "the sym3 keywords");
+
+  EXPECT_EQ(str(QList<Uuid>{uuid(1), uuid(2)}),
+            str(mWsDb->find<Symbol>("name")));
+  EXPECT_EQ(str(QList<Uuid>{uuid(1)}), str(mWsDb->find<Symbol>("sym1 name")));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testFindWithMultipleTranslations) {
+  int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
+                                QByteArray());
+  int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(1),
+                                        version("0.1"), false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym1 name"),
+                                  "the sym1 desc", "the sym1 keywords");
+  mWriter->addTranslation<Symbol>(
+      sym, "en_US", ElementName("the sym1 en_US name"), "the sym1 en_US desc",
+      "the sym1 en_US keywords");
+  mWriter->addTranslation<Symbol>(
+      sym, "de_DE", ElementName("the sym1 de_DE name"), "the sym1 de_DE desc",
+      "the sym1 de_DE keywords");
+  sym = mWriter->addElement<Symbol>(lib, toAbs("sym2"), uuid(2), version("0.2"),
+                                    false);
+  mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym2 name"),
+                                  "the sym2 desc", "the sym2 keywords");
+
+  EXPECT_EQ(str(QList<Uuid>{uuid(1), uuid(2)}),
+            str(mWsDb->find<Symbol>("name")));
+  EXPECT_EQ(str(QList<Uuid>{uuid(1)}), str(mWsDb->find<Symbol>("sym1 name")));
+  EXPECT_EQ(str(QList<Uuid>{uuid(1)}),
+            str(mWsDb->find<Symbol>("sym1 en_US name")));
+}
+
+/*******************************************************************************
+ *  Tests for getTranslations()
+ ******************************************************************************/
+
+template <typename ElementType>
+static void testGetTr(WorkspaceLibraryDb& db, const FilePath& fp,
+                      const QStringList& localeOrder, bool expectedReturnValue,
+                      const QString& expectedName,
+                      const QString& expectedDescription,
+                      const QString& expectedKeywords) {
+  QString name = "_default", description = "_default", keywords = "_default";
+  const bool returnValue = db.getTranslations<ElementType>(
+      fp, localeOrder, &name, &description, &keywords);
+  EXPECT_EQ(expectedReturnValue, returnValue);
+  EXPECT_EQ(expectedName.toStdString(), name.toStdString());
+  EXPECT_EQ(expectedDescription.toStdString(), description.toStdString());
+  EXPECT_EQ(expectedKeywords.toStdString(), keywords.toStdString());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetTranslationsInexistent) {
+  testGetTr<Library>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<ComponentCategory>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<PackageCategory>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Symbol>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Package>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Component>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Device>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetTranslationsEmpty) {
+  int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("0.1"), false,
+                                  QByteArray());
+  mWriter->addCategory<ComponentCategory>(libId, toAbs("fp"), uuid(),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<PackageCategory>(libId, toAbs("fp"), uuid(),
+                                        version("0.1"), false, tl::nullopt);
+  mWriter->addElement<Symbol>(libId, toAbs("fp"), uuid(), version("0.1"),
+                              false);
+  mWriter->addElement<Package>(libId, toAbs("fp"), uuid(), version("0.1"),
+                               false);
+  mWriter->addElement<Component>(libId, toAbs("fp"), uuid(), version("0.1"),
+                                 false);
+  mWriter->addDevice(libId, toAbs("fp"), uuid(), version("0.1"), false, uuid(),
+                     uuid());
+
+  testGetTr<Library>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<ComponentCategory>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<PackageCategory>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Symbol>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Package>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Component>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+  testGetTr<Device>(*mWsDb, toAbs("fp"), {}, false, "", "", "");
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetTranslationsDefaultLocale) {
+  int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("0.1"), false,
+                                  QByteArray());
+  mWriter->addTranslation<Library>(libId, "", ElementName("lib_n"), "lib_d",
+                                   "lib_k");
+  int id = mWriter->addCategory<ComponentCategory>(
+      libId, toAbs("fp"), uuid(), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(id, "", ElementName("cmpcat_n"),
+                                             "cmpcat_d", "cmpcat_k");
+  id = mWriter->addCategory<PackageCategory>(
+      libId, toAbs("fp"), uuid(), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<PackageCategory>(id, "", ElementName("pkgcat_n"),
+                                           "pkgcat_d", "pkgcat_k");
+  id = mWriter->addElement<Symbol>(libId, toAbs("fp"), uuid(), version("0.1"),
+                                   false);
+  mWriter->addTranslation<Symbol>(id, "", ElementName("sym_n"), "sym_d",
+                                  "sym_k");
+  id = mWriter->addElement<Package>(libId, toAbs("fp"), uuid(), version("0.1"),
+                                    false);
+  mWriter->addTranslation<Package>(id, "", ElementName("pkg_n"), "pkg_d",
+                                   "pkg_k");
+  id = mWriter->addElement<Component>(libId, toAbs("fp"), uuid(),
+                                      version("0.1"), false);
+  mWriter->addTranslation<Component>(id, "", ElementName("cmp_n"), "cmp_d",
+                                     "cmp_k");
+  id = mWriter->addDevice(libId, toAbs("fp"), uuid(), version("0.1"), false,
+                          uuid(), uuid());
+  mWriter->addTranslation<Device>(id, "", ElementName("dev_n"), "dev_d",
+                                  "dev_k");
+
+  testGetTr<Library>(*mWsDb, toAbs("fp"), {}, true, "lib_n", "lib_d", "lib_k");
+  testGetTr<ComponentCategory>(*mWsDb, toAbs("fp"), {}, true, "cmpcat_n",
+                               "cmpcat_d", "cmpcat_k");
+  testGetTr<PackageCategory>(*mWsDb, toAbs("fp"), {}, true, "pkgcat_n",
+                             "pkgcat_d", "pkgcat_k");
+  testGetTr<Symbol>(*mWsDb, toAbs("fp"), {}, true, "sym_n", "sym_d", "sym_k");
+  testGetTr<Package>(*mWsDb, toAbs("fp"), {}, true, "pkg_n", "pkg_d", "pkg_k");
+  testGetTr<Component>(*mWsDb, toAbs("fp"), {}, true, "cmp_n", "cmp_d",
+                       "cmp_k");
+  testGetTr<Device>(*mWsDb, toAbs("fp"), {}, true, "dev_n", "dev_d", "dev_k");
+}
+
+// Further tests only check with Symbol, since the implementation is the same
+// for all library element types and the tests above have proven that each
+// element type is generally working.
+
+TEST_F(WorkspaceLibraryDbTest, testGetTranslationsDefaultWithOrder) {
+  int id = mWriter->addElement<Symbol>(0, toAbs("fp"), uuid(), version("0.1"),
+                                       false);
+  mWriter->addTranslation<Symbol>(id, "", ElementName("_n"), "_d", "_k");
+
+  testGetTr<Symbol>(*mWsDb, toAbs("fp"), QStringList{"en_US", "zh_CN", "de_DE"},
+                    true, "_n", "_d", "_k");
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetTranslationsMultipleWithoutOrder) {
+  int id = mWriter->addElement<Symbol>(0, toAbs("fp"), uuid(), version("0.1"),
+                                       false);
+  mWriter->addTranslation<Symbol>(id, "de_DE", tl::nullopt, "de_d",
+                                  tl::nullopt);
+  mWriter->addTranslation<Symbol>(id, "", ElementName("_n"), "_d", "_k");
+  mWriter->addTranslation<Symbol>(id, "en_US", ElementName("en_n"), tl::nullopt,
+                                  tl::nullopt);
+  mWriter->addTranslation<Symbol>(id, "it_IT", ElementName("it_n"), "it_d",
+                                  "it_k");
+
+  testGetTr<Symbol>(*mWsDb, toAbs("fp"), {}, true, "_n", "_d", "_k");
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetTranslationsMultipleWithOrder) {
+  int id = mWriter->addElement<Symbol>(0, toAbs("fp"), uuid(), version("0.1"),
+                                       false);
+  mWriter->addTranslation<Symbol>(id, "de_DE", tl::nullopt, "de_d",
+                                  tl::nullopt);
+  mWriter->addTranslation<Symbol>(id, "", tl::nullopt, "_d", "_k");
+  mWriter->addTranslation<Symbol>(id, "en_US", ElementName("en_n"), tl::nullopt,
+                                  tl::nullopt);
+  mWriter->addTranslation<Symbol>(id, "it_IT", ElementName("it_n"), "it_d",
+                                  "it_k");
+
+  testGetTr<Symbol>(*mWsDb, toAbs("fp"), QStringList{"en_US", "zh_CN", "de_DE"},
+                    true, "en_n", "de_d", "_k");
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetTranslationsNullptr) {
+  int id = mWriter->addElement<Symbol>(0, toAbs("fp"), uuid(), version("0.1"),
+                                       false);
+  mWriter->addTranslation<Symbol>(id, "", ElementName("_n"), "_d", "_k");
+
+  QStringList localeOrder{"en_US", "zh_CN", "de_DE"};
+  QString name = "_default", description = "_default", keywords = "_default";
+  mWsDb->getTranslations<Symbol>(toAbs("fp"), localeOrder);
+  mWsDb->getTranslations<Symbol>(toAbs("fp"), localeOrder, &name, nullptr,
+                                 nullptr);
+  mWsDb->getTranslations<Symbol>(toAbs("fp"), localeOrder, nullptr,
+                                 &description, nullptr);
+  mWsDb->getTranslations<Symbol>(toAbs("fp"), localeOrder, nullptr, nullptr,
+                                 &keywords);
+  EXPECT_EQ("_n", name.toStdString());
+  EXPECT_EQ("_d", description.toStdString());
+  EXPECT_EQ("_k", keywords.toStdString());
+}
+
+/*******************************************************************************
+ *  Tests for getMetadata()
+ ******************************************************************************/
+
+template <typename ElementType>
+static void testGetMetadata(WorkspaceLibraryDb& db, const FilePath& fp,
+                            bool expRetVal, const tl::optional<Uuid>& expUuid,
+                            const tl::optional<Version>& expVersion,
+                            const tl::optional<bool>& expDeprecated) {
+  Uuid retUuid = Uuid::createRandom();
+  Version retVersion = Version::fromString("1");
+  bool retDeprecated = false;
+  const bool retVal =
+      db.getMetadata<ElementType>(fp, &retUuid, &retVersion, &retDeprecated);
+  EXPECT_EQ(expRetVal, retVal);
+  if (expUuid) {
+    EXPECT_EQ(expUuid->toStr().toStdString(), retUuid.toStr().toStdString());
+  }
+  if (expVersion) {
+    EXPECT_EQ(expVersion->toStr().toStdString(),
+              retVersion.toStr().toStdString());
+  }
+  if (expDeprecated) {
+    EXPECT_EQ(*expDeprecated, retDeprecated);
+  }
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetMetadataInexistent) {
+  FilePath fp = toAbs("fp");
+  testGetMetadata<Library>(*mWsDb, fp, false, tl::nullopt, tl::nullopt,
+                           tl::nullopt);
+  testGetMetadata<ComponentCategory>(*mWsDb, fp, false, tl::nullopt,
+                                     tl::nullopt, tl::nullopt);
+  testGetMetadata<PackageCategory>(*mWsDb, fp, false, tl::nullopt, tl::nullopt,
+                                   tl::nullopt);
+  testGetMetadata<Symbol>(*mWsDb, fp, false, tl::nullopt, tl::nullopt,
+                          tl::nullopt);
+  testGetMetadata<Package>(*mWsDb, fp, false, tl::nullopt, tl::nullopt,
+                           tl::nullopt);
+  testGetMetadata<Component>(*mWsDb, fp, false, tl::nullopt, tl::nullopt,
+                             tl::nullopt);
+  testGetMetadata<Device>(*mWsDb, fp, false, tl::nullopt, tl::nullopt,
+                          tl::nullopt);
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetMetadata) {
+  FilePath fp = toAbs("fp");
+  int libId =
+      mWriter->addLibrary(fp, uuid(1), version("1.1"), false, QByteArray());
+  mWriter->addCategory<ComponentCategory>(libId, fp, uuid(2), version("2.2"),
+                                          true, tl::nullopt);
+  mWriter->addCategory<PackageCategory>(libId, fp, uuid(3), version("3.3"),
+                                        false, tl::nullopt);
+  mWriter->addElement<Symbol>(libId, fp, uuid(4), version("4.4"), true);
+  mWriter->addElement<Package>(libId, fp, uuid(5), version("5.5"), false);
+  mWriter->addElement<Component>(libId, fp, uuid(6), version("6.6"), true);
+  mWriter->addDevice(libId, fp, uuid(7), version("7.7"), false, uuid(), uuid());
+
+  testGetMetadata<Library>(*mWsDb, fp, true, uuid(1), version("1.1"), false);
+  testGetMetadata<ComponentCategory>(*mWsDb, fp, true, uuid(2), version("2.2"),
+                                     true);
+  testGetMetadata<PackageCategory>(*mWsDb, fp, true, uuid(3), version("3.3"),
+                                   false);
+  testGetMetadata<Symbol>(*mWsDb, fp, true, uuid(4), version("4.4"), true);
+  testGetMetadata<Package>(*mWsDb, fp, true, uuid(5), version("5.5"), false);
+  testGetMetadata<Component>(*mWsDb, fp, true, uuid(6), version("6.6"), true);
+  testGetMetadata<Device>(*mWsDb, fp, true, uuid(7), version("7.7"), false);
+}
+
+// Further tests only check with Symbol, since the implementation is the same
+// for all library element types and the tests above have proven that each
+// element type is generally working.
+
+TEST_F(WorkspaceLibraryDbTest, testGetMetadataNullptr) {
+  FilePath fp = toAbs("fp");
+  mWriter->addElement<Symbol>(0, fp, uuid(1), version("1.1"), true);
+
+  Uuid retUuid = Uuid::createRandom();
+  Version retVersion = version("1");
+  bool retDeprecated = false;
+  mWsDb->getMetadata<Symbol>(fp);
+  mWsDb->getMetadata<Symbol>(fp, &retUuid);
+  mWsDb->getMetadata<Symbol>(fp, nullptr, &retVersion);
+  mWsDb->getMetadata<Symbol>(fp, nullptr, nullptr, &retDeprecated);
+  EXPECT_EQ(str(uuid(1)), str(retUuid));
+  EXPECT_EQ("1.1", str(retVersion));
+  EXPECT_TRUE(retDeprecated);
+}
+
+/*******************************************************************************
+ *  Tests for getLibraryMetadata()
+ ******************************************************************************/
+
+TEST_F(WorkspaceLibraryDbTest, testGetLibraryMetadataInexistent) {
+  QPixmap icon;
+  EXPECT_FALSE(mWsDb->getLibraryMetadata(toAbs("fp"), &icon));
+  EXPECT_TRUE(icon.isNull());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetLibraryMetadataNoIcon) {
+  FilePath fp = toAbs("fp");
+  mWriter->addLibrary(fp, uuid(), version("1.1"), false, QByteArray());
+
+  QPixmap icon;
+  EXPECT_TRUE(mWsDb->getLibraryMetadata(fp, &icon));
+  EXPECT_TRUE(icon.isNull());
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetLibraryMetadataNullptr) {
+  FilePath fp = toAbs("fp");
+  mWriter->addLibrary(fp, uuid(), version("1.1"), false, QByteArray());
+
+  EXPECT_TRUE(mWsDb->getLibraryMetadata(fp));
+}
+
+/*******************************************************************************
+ *  Tests for getCategoryMetadata()
+ ******************************************************************************/
+
+TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadataEmptyDb) {
+  tl::optional<Uuid> parent;
+  EXPECT_FALSE(
+      mWsDb->getCategoryMetadata<ComponentCategory>(toAbs("fp"), &parent));
+  EXPECT_FALSE(
+      mWsDb->getCategoryMetadata<PackageCategory>(toAbs("fp"), &parent));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadataInexistent) {
+  int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("1.1"), false,
+                                  QByteArray());
+  mWriter->addCategory<ComponentCategory>(libId, toAbs("fp"), uuid(),
+                                          version("2.2"), false, tl::nullopt);
+  mWriter->addCategory<PackageCategory>(libId, toAbs("fp"), uuid(),
+                                        version("3.3"), false, tl::nullopt);
+
+  tl::optional<Uuid> parent;
+  EXPECT_FALSE(
+      mWsDb->getCategoryMetadata<ComponentCategory>(toAbs("foo"), &parent));
+  EXPECT_FALSE(
+      mWsDb->getCategoryMetadata<PackageCategory>(toAbs("foo"), &parent));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadata) {
+  int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("1.1"), false,
+                                  QByteArray());
+  mWriter->addCategory<ComponentCategory>(libId, toAbs("fp1"), uuid(1),
+                                          version("2.2"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(libId, toAbs("fp2"), uuid(2),
+                                          version("3.3"), false, uuid(1));
+  mWriter->addCategory<PackageCategory>(libId, toAbs("fp3"), uuid(2),
+                                        version("4.4"), false, tl::nullopt);
+  mWriter->addCategory<PackageCategory>(libId, toAbs("fp4"), uuid(1),
+                                        version("5.5"), false, uuid(2));
+
+  tl::optional<Uuid> parent;
+
+  EXPECT_TRUE(
+      mWsDb->getCategoryMetadata<ComponentCategory>(toAbs("fp1"), &parent));
+  EXPECT_FALSE(parent.has_value());
+
+  EXPECT_TRUE(
+      mWsDb->getCategoryMetadata<ComponentCategory>(toAbs("fp2"), &parent));
+  EXPECT_EQ(uuid(1), parent);
+
+  EXPECT_TRUE(
+      mWsDb->getCategoryMetadata<PackageCategory>(toAbs("fp3"), &parent));
+  EXPECT_FALSE(parent.has_value());
+
+  EXPECT_TRUE(
+      mWsDb->getCategoryMetadata<PackageCategory>(toAbs("fp4"), &parent));
+  EXPECT_EQ(uuid(2), parent);
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadataNullptr) {
+  int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("1.1"), false,
+                                  QByteArray());
+  mWriter->addCategory<ComponentCategory>(libId, toAbs("fp1"), uuid(1),
+                                          version("2.2"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(libId, toAbs("fp2"), uuid(2),
+                                          version("3.3"), false, uuid(1));
+
+  tl::optional<Uuid> parent;
+
+  EXPECT_TRUE(mWsDb->getCategoryMetadata<ComponentCategory>(toAbs("fp2")));
+  EXPECT_TRUE(
+      mWsDb->getCategoryMetadata<ComponentCategory>(toAbs("fp2"), &parent));
+  EXPECT_EQ(uuid(1), parent);
+}
+
+/*******************************************************************************
+ *  Tests for getDeviceMetadata()
+ ******************************************************************************/
+
+TEST_F(WorkspaceLibraryDbTest, testGetDeviceMetadataInexistent) {
+  Uuid cmpUuid = Uuid::createRandom();
+  Uuid pkgUuid = Uuid::createRandom();
+  EXPECT_FALSE(mWsDb->getDeviceMetadata(toAbs("fp"), &cmpUuid, &pkgUuid));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetDeviceMetadata) {
+  FilePath fp = toAbs("fp");
+  mWriter->addDevice(0, fp, uuid(), version("1.1"), false, uuid(1), uuid(2));
+
+  Uuid cmpUuid = Uuid::createRandom();
+  Uuid pkgUuid = Uuid::createRandom();
+  EXPECT_TRUE(mWsDb->getDeviceMetadata(fp, &cmpUuid, &pkgUuid));
+  EXPECT_EQ(str(uuid(1)), str(cmpUuid));
+  EXPECT_EQ(str(uuid(2)), str(pkgUuid));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetDeviceMetadataNullptr) {
+  FilePath fp = toAbs("fp");
+  mWriter->addDevice(0, fp, uuid(), version("1.1"), false, uuid(1), uuid(2));
+
+  Uuid cmpUuid = Uuid::createRandom();
+  Uuid pkgUuid = Uuid::createRandom();
+  EXPECT_TRUE(mWsDb->getDeviceMetadata(fp));
+  EXPECT_TRUE(mWsDb->getDeviceMetadata(fp, &cmpUuid, nullptr));
+  EXPECT_TRUE(mWsDb->getDeviceMetadata(fp, nullptr, &pkgUuid));
+  EXPECT_EQ(str(uuid(1)), str(cmpUuid));
+  EXPECT_EQ(str(uuid(2)), str(pkgUuid));
+}
+
+/*******************************************************************************
+ *  Tests for getChilds()
+ ******************************************************************************/
+
+TEST_F(WorkspaceLibraryDbTest, testGetChildsEmptyDb) {
+  EXPECT_EQ(str(QSet<Uuid>{}),
+            str(mWsDb->getChilds<ComponentCategory>(tl::nullopt)));
+  EXPECT_EQ(str(QSet<Uuid>{}),
+            str(mWsDb->getChilds<PackageCategory>(tl::nullopt)));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetChildsInexistent) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat"), uuid(1),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<PackageCategory>(0, toAbs("pkgcat"), uuid(2),
+                                        version("0.1"), false, tl::nullopt);
+
+  EXPECT_EQ(str(QSet<Uuid>{}),
+            str(mWsDb->getChilds<ComponentCategory>(uuid(2))));
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getChilds<PackageCategory>(uuid(1))));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetChildsInvalidWithUuid) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat"), uuid(1),
+                                          version("0.1"), false, uuid(2));
+  mWriter->addCategory<PackageCategory>(0, toAbs("pkgcat"), uuid(3),
+                                        version("0.1"), false, uuid(4));
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(1)}),
+            str(mWsDb->getChilds<ComponentCategory>(uuid(2))));
+  EXPECT_EQ(str(QSet<Uuid>{uuid(3)}),
+            str(mWsDb->getChilds<PackageCategory>(uuid(4))));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetChildsInvalidWithoutUuid) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat"), uuid(1),
+                                          version("0.1"), false, uuid(2));
+  mWriter->addCategory<PackageCategory>(0, toAbs("pkgcat"), uuid(3),
+                                        version("0.1"), false, uuid(4));
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(1)}),
+            str(mWsDb->getChilds<ComponentCategory>(tl::nullopt)));
+  EXPECT_EQ(str(QSet<Uuid>{uuid(3)}),
+            str(mWsDb->getChilds<PackageCategory>(tl::nullopt)));
+}
+
+// Further tests only check with ComponentCategory, since the implementation
+// is the same for PackageCategory and the tests above have proven that each
+// element type is generally working.
+
+TEST_F(WorkspaceLibraryDbTest, testGetChildsDuplicatesWithUuid) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat1"), uuid(1),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat2"), uuid(2),
+                                          version("0.1"), false, uuid(1));
+  mWriter->addCategory<ComponentCategory>(1, toAbs("cmpcat3"), uuid(1),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(1, toAbs("cmpcat4"), uuid(2),
+                                          version("0.1"), false, uuid(1));
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(2)}),
+            str(mWsDb->getChilds<ComponentCategory>(uuid(1))));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetChildsDuplicatesWithoutUuid) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat1"), uuid(1),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat2"), uuid(2),
+                                          version("0.1"), false, uuid(1));
+  mWriter->addCategory<ComponentCategory>(1, toAbs("cmpcat3"), uuid(1),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(1, toAbs("cmpcat4"), uuid(2),
+                                          version("0.1"), false, uuid(1));
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(1)}),
+            str(mWsDb->getChilds<ComponentCategory>(tl::nullopt)));
+}
+
+/*******************************************************************************
+ *  Tests for getByCategory()
+ ******************************************************************************/
+
+TEST_F(WorkspaceLibraryDbTest, testGetByCategoryEmptyDb) {
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getByCategory<Symbol>(tl::nullopt)));
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getByCategory<Package>(tl::nullopt)));
+  EXPECT_EQ(str(QSet<Uuid>{}),
+            str(mWsDb->getByCategory<Component>(tl::nullopt)));
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getByCategory<Device>(tl::nullopt)));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetByCategoryInexistent) {
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getByCategory<Symbol>(uuid())));
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getByCategory<Package>(uuid())));
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getByCategory<Component>(uuid())));
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getByCategory<Device>(uuid())));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetByCategory) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat"), uuid(1),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<PackageCategory>(0, toAbs("pkgcat"), uuid(2),
+                                        version("0.1"), false, tl::nullopt);
+  int sym = mWriter->addElement<Symbol>(0, toAbs("sym"), uuid(3),
+                                        version("0.1"), false);
+  mWriter->addToCategory<Symbol>(sym, uuid(1));
+  int pkg = mWriter->addElement<Package>(0, toAbs("pkg"), uuid(4),
+                                         version("0.1"), false);
+  mWriter->addToCategory<Package>(pkg, uuid(2));
+  int cmp = mWriter->addElement<Component>(0, toAbs("cmp"), uuid(5),
+                                           version("0.1"), false);
+  mWriter->addToCategory<Component>(cmp, uuid(1));
+  int dev = mWriter->addDevice(0, toAbs("dev"), uuid(6), version("0.1"), false,
+                               uuid(), uuid());
+  mWriter->addToCategory<Device>(dev, uuid(1));
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(3)}),
+            str(mWsDb->getByCategory<Symbol>(uuid(1))));
+  EXPECT_EQ(str(QSet<Uuid>{uuid(4)}),
+            str(mWsDb->getByCategory<Package>(uuid(2))));
+  EXPECT_EQ(str(QSet<Uuid>{uuid(5)}),
+            str(mWsDb->getByCategory<Component>(uuid(1))));
+  EXPECT_EQ(str(QSet<Uuid>{uuid(6)}),
+            str(mWsDb->getByCategory<Device>(uuid(1))));
+}
+
+// Further tests only check with Component, since the implementation is the
+// same for all library element types and the tests above have proven that
+// each element type is generally working.
+
+TEST_F(WorkspaceLibraryDbTest, testGetByCategoryInvalidParent) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat"), uuid(1),
+                                          version("0.1"), false, uuid(2));
+  int cmp = mWriter->addElement<Component>(0, toAbs("fp"), uuid(3),
+                                           version("0.1"), false);
+  mWriter->addToCategory<Component>(cmp, uuid(1));
+
+  // The category "uuid(1)" does not have a valid parent, but it will still
+  // be listed in category trees as a root category. So its contained elements
+  // shall be listed as usual, not in the "without category" node.
+  EXPECT_EQ(str(QSet<Uuid>{uuid(3)}),
+            str(mWsDb->getByCategory<Component>(uuid(1))));
+  EXPECT_EQ(str(QSet<Uuid>{}),
+            str(mWsDb->getByCategory<Component>(tl::nullopt)));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetByCategoryEndlessRecursion) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat1"), uuid(1),
+                                          version("0.1"), false, uuid(2));
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat2"), uuid(2),
+                                          version("0.1"), false, uuid(1));
+  int cmp = mWriter->addElement<Component>(0, toAbs("fp"), uuid(3),
+                                           version("0.1"), false);
+  mWriter->addToCategory<Component>(cmp, uuid(1));
+
+  // None of the categories will be shown in the category tree, which is not
+  // ideal but also not a big problem since endless recursion is not really
+  // a real situation. However, the test should verify that nothing strange
+  // happens here.
+  EXPECT_EQ(str(QSet<Uuid>{uuid(3)}),
+            str(mWsDb->getByCategory<Component>(uuid(1))));
+  EXPECT_EQ(str(QSet<Uuid>{}),
+            str(mWsDb->getByCategory<Component>(tl::nullopt)));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetByCategoryDuplicates) {
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat1"), uuid(2),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat2"), uuid(1),
+                                          version("0.1"), false, uuid(2));
+  mWriter->addCategory<ComponentCategory>(1, toAbs("cmpcat3"), uuid(2),
+                                          version("0.1"), false, tl::nullopt);
+  mWriter->addCategory<ComponentCategory>(1, toAbs("cmpcat4"), uuid(1),
+                                          version("0.1"), false, uuid(2));
+  int cmp1 = mWriter->addElement<Component>(0, toAbs("cmp1"), uuid(3),
+                                            version("0.1"), false);
+  mWriter->addToCategory<Component>(cmp1, uuid(1));
+  int cmp2 = mWriter->addElement<Component>(0, toAbs("cmp2"), uuid(3),
+                                            version("0.1"), false);
+  mWriter->addToCategory<Component>(cmp2, uuid(1));
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(3)}),
+            str(mWsDb->getByCategory<Component>(uuid(1))));
+  EXPECT_EQ(str(QSet<Uuid>{}),
+            str(mWsDb->getByCategory<Component>(tl::nullopt)));
+}
+
+/*******************************************************************************
+ *  Tests for getComponentDevices()
+ ******************************************************************************/
+
+TEST_F(WorkspaceLibraryDbTest, testGetComponentDevicesEmptyDb) {
+  EXPECT_EQ(str(QSet<Uuid>{}), str(mWsDb->getComponentDevices(uuid())));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetComponentDevices) {
+  mWriter->addDevice(0, toAbs("dev1"), uuid(1), version("0.1"), false, uuid(0),
+                     uuid());
+  mWriter->addDevice(0, toAbs("dev2"), uuid(2), version("0.1"), false, uuid(0),
+                     uuid());
+  mWriter->addDevice(0, toAbs("dev3"), uuid(3), version("0.1"), false, uuid(),
+                     uuid());
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(1), uuid(2)}),
+            str(mWsDb->getComponentDevices(uuid(0))));
+}
+
+TEST_F(WorkspaceLibraryDbTest, testGetComponentDevicesDuplicates) {
+  mWriter->addDevice(0, toAbs("dev1"), uuid(1), version("0.1"), false, uuid(0),
+                     uuid());
+  mWriter->addDevice(1, toAbs("dev2"), uuid(1), version("0.1"), false, uuid(0),
+                     uuid());
+  mWriter->addDevice(1, toAbs("dev3"), uuid(2), version("0.1"), false, uuid(),
+                     uuid());
+
+  EXPECT_EQ(str(QSet<Uuid>{uuid(1)}), str(mWsDb->getComponentDevices(uuid(0))));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/editor/library/cat/categorytreebuildertest.cpp
+++ b/tests/unittests/editor/library/cat/categorytreebuildertest.cpp
@@ -1,0 +1,264 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/fileio/fileutils.h>
+#include <librepcb/core/library/cat/componentcategory.h>
+#include <librepcb/core/library/cat/packagecategory.h>
+#include <librepcb/core/sqlitedatabase.h>
+#include <librepcb/core/workspace/workspacelibrarydb.h>
+#include <librepcb/core/workspace/workspacelibrarydbwriter.h>
+#include <librepcb/editor/library/cat/categorytreebuilder.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class CategoryTreeBuilderTest : public ::testing::Test {
+protected:
+  FilePath mWsDir;
+  std::unique_ptr<WorkspaceLibraryDb> mWsDb;
+  std::unique_ptr<SQLiteDatabase> mDb;
+  std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
+
+  CategoryTreeBuilderTest() : mWsDir(FilePath::getRandomTempPath()) {
+    FileUtils::makePath(mWsDir);
+    mWsDb.reset(new WorkspaceLibraryDb(mWsDir));
+    mDb.reset(new SQLiteDatabase(mWsDb->getFilePath()));
+    mWriter.reset(new WorkspaceLibraryDbWriter(mWsDir, *mDb));
+  }
+
+  virtual ~CategoryTreeBuilderTest() {
+    QDir(mWsDir.toStr()).removeRecursively();
+  }
+
+  std::string str(const QStringList& list) {
+    return list.join(", ").toStdString();
+  }
+
+  FilePath toAbs(const QString& fp) { return mWsDir.getPathTo(fp); }
+
+  Uuid uuid(int index = -1) {
+    static QHash<int, Uuid> cache;
+    if (index >= 0) {
+      auto it = cache.find(index);
+      if (it == cache.end()) {
+        it = cache.insert(index, uuid());
+      }
+      return *it;
+    } else {
+      return Uuid::createRandom();
+    }
+  }
+
+  Version version(const QString& version) {
+    return Version::fromString(version);
+  }
+
+  template <typename ElementType>
+  void test(const QStringList& localeOrder, bool nulloptIsRootCategory,
+            const tl::optional<Uuid>& category, bool expSuccess,
+            const QStringList& expOutput) {
+    CategoryTreeBuilder<ElementType> builder(*mWsDb, localeOrder,
+                                             nulloptIsRootCategory);
+    bool retSuccess = !expSuccess;
+    QStringList output = builder.buildTree(category, &retSuccess);
+    EXPECT_EQ(str(expOutput), str(output));
+    EXPECT_EQ(expSuccess, retSuccess);
+  }
+};
+
+/*******************************************************************************
+ *  Tests
+ ******************************************************************************/
+
+TEST_F(CategoryTreeBuilderTest, testDatabaseError) {
+  mDb->exec("DROP TABLE component_categories");
+  mDb->exec("DROP TABLE package_categories");
+
+  EXPECT_THROW(test<ComponentCategory>({}, false, uuid(), false, {}),
+               RuntimeError);
+  EXPECT_THROW(test<PackageCategory>({}, false, uuid(), false, {}),
+               RuntimeError);
+}
+
+TEST_F(CategoryTreeBuilderTest, testEmptyDbNull) {
+  test<ComponentCategory>({}, false, tl::nullopt, true, {});
+  test<PackageCategory>({}, false, tl::nullopt, true, {});
+}
+
+TEST_F(CategoryTreeBuilderTest, testEmptyRootDbNull) {
+  test<ComponentCategory>({}, true, tl::nullopt, true, {"Root category"});
+  test<PackageCategory>({}, true, tl::nullopt, true, {"Root category"});
+}
+
+TEST_F(CategoryTreeBuilderTest, testInexistent) {
+  Uuid uuid = Uuid::fromString("a39c1053-cbd3-478b-8455-57dff69c6375");
+  test<ComponentCategory>({}, false, uuid, false,
+                          {"ERROR: a39c1053 not found"});
+  test<PackageCategory>({}, false, uuid, false, {"ERROR: a39c1053 not found"});
+  test<ComponentCategory>({}, true, uuid, false, {"ERROR: a39c1053 not found"});
+  test<PackageCategory>({}, true, uuid, false, {"ERROR: a39c1053 not found"});
+}
+
+TEST_F(CategoryTreeBuilderTest, testInexistentParent) {
+  Uuid parentUuid = Uuid::fromString("a39c1053-cbd3-478b-8455-57dff69c6375");
+  int cmpCat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cmpcat"), uuid(1), version("0.1"), false, parentUuid);
+  mWriter->addTranslation<ComponentCategory>(cmpCat, "", ElementName("cmp cat"),
+                                             tl::nullopt, tl::nullopt);
+  int pkgCat = mWriter->addCategory<PackageCategory>(
+      0, toAbs("pkgcat"), uuid(2), version("0.1"), false, parentUuid);
+  mWriter->addTranslation<PackageCategory>(pkgCat, "", ElementName("pkg cat"),
+                                           tl::nullopt, tl::nullopt);
+
+  test<ComponentCategory>({}, false, uuid(1), false,
+                          {"ERROR: a39c1053 not found", "cmp cat"});
+  test<PackageCategory>({}, false, uuid(2), false,
+                        {"ERROR: a39c1053 not found", "pkg cat"});
+  test<ComponentCategory>({}, true, uuid(1), false,
+                          {"ERROR: a39c1053 not found", "cmp cat"});
+  test<PackageCategory>({}, true, uuid(2), false,
+                        {"ERROR: a39c1053 not found", "pkg cat"});
+}
+
+// Note: Tests above have shown that the class works for both, ComponentCategory
+// and PackageCategory. Thus the detailed tests below now only test with
+// ComponentCategory (for simplicity).
+
+TEST_F(CategoryTreeBuilderTest, testNullptr) {
+  CategoryTreeBuilder<ComponentCategory> builder(*mWsDb, {}, false);
+  QStringList output = builder.buildTree(tl::nullopt);
+  EXPECT_EQ(str({}), str(output));
+}
+
+TEST_F(CategoryTreeBuilderTest, testLocaleOrder) {
+  int cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat1"), uuid(1), version("0.1"), false, uuid(2));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 1"),
+                                             tl::nullopt, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(
+      cat, "de_DE", ElementName("cat 1 de"), tl::nullopt, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(
+      cat, "it_IT", ElementName("cat 1 it"), tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(0, toAbs("cat2"), uuid(2),
+                                                version("0.1"), false, uuid(3));
+  mWriter->addTranslation<ComponentCategory>(
+      cat, "it_IT", ElementName("cat 2 it"), tl::nullopt, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 2"),
+                                             tl::nullopt, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(
+      cat, "de_CH", ElementName("cat 2 ch"), tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat3"), uuid(3), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 3"),
+                                             tl::nullopt, tl::nullopt);
+
+  test<ComponentCategory>({"fr_FR", "de_CH", "de_DE"}, false, uuid(1), true,
+                          {"cat 3", "cat 2 ch", "cat 1 de"});
+  test<ComponentCategory>({"fr_FR", "de_CH", "de_DE"}, true, uuid(1), true,
+                          {"Root category", "cat 3", "cat 2 ch", "cat 1 de"});
+}
+
+TEST_F(CategoryTreeBuilderTest, testMultipleParents) {
+  int cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat1"), uuid(1), version("0.1"), false, uuid(2));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 1"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(0, toAbs("cat2"), uuid(2),
+                                                version("0.1"), false, uuid(3));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 2"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(0, toAbs("cat3"), uuid(3),
+                                                version("0.1"), false, uuid(4));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 3"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat4"), uuid(4), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 4"),
+                                             tl::nullopt, tl::nullopt);
+
+  test<ComponentCategory>({}, false, uuid(1), true,
+                          {"cat 4", "cat 3", "cat 2", "cat 1"});
+  test<ComponentCategory>(
+      {}, true, uuid(1), true,
+      {"Root category", "cat 4", "cat 3", "cat 2", "cat 1"});
+}
+
+TEST_F(CategoryTreeBuilderTest, testEndlessRecursionDirect) {
+  int cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat1"), uuid(1), version("0.1"), false, uuid(2));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 1"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(0, toAbs("cat2"), uuid(2),
+                                                version("0.1"), false, uuid(1));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 2"),
+                                             tl::nullopt, tl::nullopt);
+
+  test<ComponentCategory>({}, false, uuid(1), false,
+                          {"ERROR: Endless recursion", "cat 2", "cat 1"});
+  test<ComponentCategory>({}, true, uuid(1), false,
+                          {"ERROR: Endless recursion", "cat 2", "cat 1"});
+}
+
+TEST_F(CategoryTreeBuilderTest, testEndlessRecursionMultipleParents) {
+  int cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat1"), uuid(1), version("0.1"), false, uuid(2));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 1"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(0, toAbs("cat2"), uuid(2),
+                                                version("0.1"), false, uuid(3));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 2"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(0, toAbs("cat3"), uuid(3),
+                                                version("0.1"), false, uuid(4));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 3"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(0, toAbs("cat4"), uuid(4),
+                                                version("0.1"), false, uuid(2));
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 4"),
+                                             tl::nullopt, tl::nullopt);
+
+  test<ComponentCategory>(
+      {}, false, uuid(1), false,
+      {"ERROR: Endless recursion", "cat 4", "cat 3", "cat 2", "cat 1"});
+  test<ComponentCategory>(
+      {}, true, uuid(1), false,
+      {"ERROR: Endless recursion", "cat 4", "cat 3", "cat 2", "cat 1"});
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace editor
+}  // namespace librepcb


### PR DESCRIPTION
Some code refactoring of the SQLite database classes, required for an upcoming PR. Was time for a cleanup anyway, since all that code is pretty old and ugly :see_no_evil: 

## Library editor: Factor out code into `CategoryTreeBuilder`

Factor out common functionality of `CategoryListEditorWidget` and `CategoryTreeLabelTextBuilder` into new class `CategoryTreeBuilder` to share code between these classes.

Also slightly changed the behavior of the classes, leading to some small visual improvements in the library editor.

## `SQLiteDatabase`: Cleanup code and error messages

- Remove commented out code
- More verbose exception messages and console output in case of database errors
- Remove `tr()` from low level error messages which basically never occur, to avoid unnecessary translation effort

## `SQLiteDatabase`: Support placeholders in SQL queries

Support using placeholders like "%table" in SQL query strings to allow writing much more readable SQL queries (e.g. "SELECT * from %table ..." instead of "SELECT * from " + table + " ...").

## `WorkspaceLibraryScanner`: Factor out code into writer class

Having the database writer functionality separated in a simple, independent class allows to use it in unit tests to fill test databases with data required by the tests.

## `WorkspaceLibraryDb`: Refactor and simplify code and database

- Replace dependency to the `Workspace` object by a simple `FilePath` to the workspace library directory, to make it much easier to write unit tests (no workspace needed anymore)
- Generally refactor the class API for higher flexibility and testability
- Rewrite all SQL queries using placeholders instead of string concatenation (much more readable)
- Rename some database column names to simplify the SQL queries (e.g. name them always "element_id" instead of "symbol_id", "device_id", ...)
- Fix returning the string "unknown" for inexistent library element metadata, caused "unknown" shown as tooltips in the category tree
- Add deprecation information of elements to the database
- Add class API documentation
- Add lots of unit tests (there were none yet)

Note: This introduces a new database format version. LibrePCB will automatically create a new file "cache_v3.sqlite" in the workspace.