### PR TITLE
Schematic editor: Keep state of "Add Component"-dialog and make auto-open optional

### DIFF
--- a/libs/librepcb/editor/project/addcomponentdialog.cpp
+++ b/libs/librepcb/editor/project/addcomponentdialog.cpp
@@ -61,6 +61,7 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
     mLocaleOrder(localeOrder),
     mNormOrder(normOrder),
     mUi(new Ui::AddComponentDialog),
+    mAddMoreCheckbox(new QCheckBox(tr("&Add more"), this)),
     mComponentPreviewScene(new GraphicsScene()),
     mDevicePreviewScene(new GraphicsScene()),
     mGraphicsLayerProvider(new DefaultGraphicsLayerProvider()),
@@ -103,11 +104,22 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
           &QItemSelectionModel::currentChanged, this,
           &AddComponentDialog::treeCategories_currentItemChanged);
 
-  // Reset GUI to state of nothing selected
+  // Add "Add more"-checkbox to button group.
+  mAddMoreCheckbox->setObjectName("cbxAddMore");  // For automated tests.
+  mAddMoreCheckbox->setToolTip(
+      tr("If checked, this dialog will automatically be opened again after "
+         "finishing placement of the current component."));
+  mUi->buttonBox->addButton(mAddMoreCheckbox, QDialogButtonBox::ActionRole);
+
+  // Reset GUI to state of nothing selected.
   setSelectedComponent(nullptr);
 
   // Restore client settings.
   QSettings clientSettings;
+  mAddMoreCheckbox->setChecked(
+      clientSettings
+          .value("schematic_editor/add_component_dialog/add_more", true)
+          .toBool());
   QSize windowSize =
       clientSettings.value("schematic_editor/add_component_dialog/window_size")
           .toSize();
@@ -119,6 +131,8 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
 AddComponentDialog::~AddComponentDialog() noexcept {
   // Save client settings.
   QSettings clientSettings;
+  clientSettings.setValue("schematic_editor/add_component_dialog/add_more",
+                          mAddMoreCheckbox->isChecked());
   clientSettings.setValue("schematic_editor/add_component_dialog/window_size",
                           size());
 }
@@ -156,6 +170,11 @@ tl::optional<Uuid> AddComponentDialog::getSelectedDeviceUuid() const noexcept {
     return mSelectedDevice->getUuid();
   else
     return tl::nullopt;
+}
+
+bool AddComponentDialog::getAutoOpenAgain() const noexcept {
+  Q_ASSERT(mAddMoreCheckbox);
+  return mAddMoreCheckbox->isChecked();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/addcomponentdialog.cpp
+++ b/libs/librepcb/editor/project/addcomponentdialog.cpp
@@ -105,9 +105,22 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
 
   // Reset GUI to state of nothing selected
   setSelectedComponent(nullptr);
+
+  // Restore client settings.
+  QSettings clientSettings;
+  QSize windowSize =
+      clientSettings.value("schematic_editor/add_component_dialog/window_size")
+          .toSize();
+  if (!windowSize.isEmpty()) {
+    resize(windowSize);
+  }
 }
 
 AddComponentDialog::~AddComponentDialog() noexcept {
+  // Save client settings.
+  QSettings clientSettings;
+  clientSettings.setValue("schematic_editor/add_component_dialog/window_size",
+                          size());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/addcomponentdialog.h
+++ b/libs/librepcb/editor/project/addcomponentdialog.h
@@ -94,6 +94,18 @@ public:
   tl::optional<Uuid> getSelectedSymbVarUuid() const noexcept;
   tl::optional<Uuid> getSelectedDeviceUuid() const noexcept;
 
+  /**
+   * @brief Check if dialog shall be opened again after the current component
+   *
+   * Returns the checked state of the "Add More" checkbox, i.e. whether the
+   * caller should open this dialog again after finishing placement of the
+   * component.
+   *
+   * @retval true   Must open this dialog again after placing the component.
+   * @retval false  Shall not open this dialog again, exit placement tool.
+   */
+  bool getAutoOpenAgain() const noexcept;
+
   // Setters
   void setLocaleOrder(const QStringList& order) noexcept;
   void setNormOrder(const QStringList& order) noexcept { mNormOrder = order; }
@@ -123,6 +135,7 @@ private:
   QStringList mLocaleOrder;
   QStringList mNormOrder;
   QScopedPointer<Ui::AddComponentDialog> mUi;
+  QPointer<QCheckBox> mAddMoreCheckbox;
   QScopedPointer<GraphicsScene> mComponentPreviewScene;
   QScopedPointer<GraphicsScene> mDevicePreviewScene;
   QScopedPointer<DefaultGraphicsLayerProvider> mGraphicsLayerProvider;

--- a/libs/librepcb/editor/project/addcomponentdialog.h
+++ b/libs/librepcb/editor/project/addcomponentdialog.h
@@ -31,21 +31,20 @@
 #include <QtCore>
 #include <QtWidgets>
 
+#include <memory>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 
 class Component;
-class ComponentCategory;
 class ComponentSymbolVariant;
 class DefaultGraphicsLayerProvider;
 class Device;
 class GraphicsScene;
 class Package;
-class Project;
-class Symbol;
-class Workspace;
+class WorkspaceLibraryDb;
 
 namespace editor {
 
@@ -84,7 +83,9 @@ class AddComponentDialog final : public QDialog {
 
 public:
   // Constructors / Destructor
-  explicit AddComponentDialog(Workspace& workspace, Project& project,
+  explicit AddComponentDialog(const WorkspaceLibraryDb& db,
+                              const QStringList& localeOrder,
+                              const QStringList& normOrder,
                               QWidget* parent = nullptr);
   ~AddComponentDialog() noexcept;
 
@@ -92,6 +93,10 @@ public:
   tl::optional<Uuid> getSelectedComponentUuid() const noexcept;
   tl::optional<Uuid> getSelectedSymbVarUuid() const noexcept;
   tl::optional<Uuid> getSelectedDeviceUuid() const noexcept;
+
+  // Setters
+  void setLocaleOrder(const QStringList& order) noexcept;
+  void setNormOrder(const QStringList& order) noexcept { mNormOrder = order; }
 
 private slots:
   void searchEditTextChanged(const QString& text) noexcept;
@@ -101,7 +106,7 @@ private slots:
                                          QTreeWidgetItem* previous) noexcept;
   void treeComponents_itemDoubleClicked(QTreeWidgetItem* item,
                                         int column) noexcept;
-  void on_cbxSymbVar_currentIndexChanged(int index) noexcept;
+  void cbxSymbVar_currentIndexChanged(int index) noexcept;
 
 private:
   // Private Methods
@@ -114,22 +119,23 @@ private:
   void accept() noexcept;
 
   // General
-  Workspace& mWorkspace;
-  Project& mProject;
-  Ui::AddComponentDialog* mUi;
-  GraphicsScene* mComponentPreviewScene;
-  GraphicsScene* mDevicePreviewScene;
+  const WorkspaceLibraryDb& mDb;
+  QStringList mLocaleOrder;
+  QStringList mNormOrder;
+  QScopedPointer<Ui::AddComponentDialog> mUi;
+  QScopedPointer<GraphicsScene> mComponentPreviewScene;
+  QScopedPointer<GraphicsScene> mDevicePreviewScene;
   QScopedPointer<DefaultGraphicsLayerProvider> mGraphicsLayerProvider;
-  CategoryTreeModel* mCategoryTreeModel;
+  QScopedPointer<CategoryTreeModel> mCategoryTreeModel;
 
   // Attributes
   tl::optional<Uuid> mSelectedCategoryUuid;
-  const Component* mSelectedComponent;
+  QScopedPointer<const Component> mSelectedComponent;
   const ComponentSymbolVariant* mSelectedSymbVar;
-  const Device* mSelectedDevice;
-  const Package* mSelectedPackage;
-  QList<SymbolPreviewGraphicsItem*> mPreviewSymbolGraphicsItems;
-  FootprintPreviewGraphicsItem* mPreviewFootprintGraphicsItem;
+  QScopedPointer<const Device> mSelectedDevice;
+  QScopedPointer<const Package> mSelectedPackage;
+  QList<std::shared_ptr<SymbolPreviewGraphicsItem>> mPreviewSymbolGraphicsItems;
+  QScopedPointer<FootprintPreviewGraphicsItem> mPreviewFootprintGraphicsItem;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -35,7 +35,10 @@
 #include <librepcb/core/attribute/attributeunit.h>
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/project/circuit/componentinstance.h>
+#include <librepcb/core/project/project.h>
+#include <librepcb/core/project/projectsettings.h>
 #include <librepcb/core/project/schematic/items/si_symbol.h>
+#include <librepcb/core/workspace/workspace.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -333,9 +336,17 @@ void SchematicEditorState_AddComponent::startAddingComponent(
       mCurrentComponent = cmd->getComponentInstance();
     } else {
       // show component chooser dialog
-      if (!mAddComponentDialog)
+      if (mAddComponentDialog) {
+        mAddComponentDialog->setLocaleOrder(
+            mContext.project.getSettings().getLocaleOrder());
+        mAddComponentDialog->setNormOrder(
+            mContext.project.getSettings().getNormOrder());
+      } else {
         mAddComponentDialog.reset(new AddComponentDialog(
-            mContext.workspace, mContext.project, parentWidget()));
+            mContext.workspace.getLibraryDb(),
+            mContext.project.getSettings().getLocaleOrder(),
+            mContext.project.getSettings().getNormOrder(), parentWidget()));
+      }
       if (mAddComponentDialog->exec() != QDialog::Accepted)
         throw UserCanceled(__FILE__, __LINE__);  // abort
       if (!mAddComponentDialog->getSelectedComponentUuid())

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -130,9 +130,6 @@ bool SchematicEditorState_AddComponent::exit() noexcept {
   if (!abortCommand(true)) return false;
   Q_ASSERT(mIsUndoCmdActive == false);
 
-  // Delete the "Add Component" dialog
-  mAddComponentDialog.reset();
-
   // Remove actions / widgets from the "command" toolbar
   mAttributeUnitComboBoxAction = nullptr;
   mAttributeValueEditAction = nullptr;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -196,19 +196,21 @@ bool SchematicEditorState_AddComponent::processRotateCcw() noexcept {
 }
 
 bool SchematicEditorState_AddComponent::processAbortCommand() noexcept {
-  if (mAddComponentDialog) {
-    try {
-      if (!abortCommand(true)) return false;
+  try {
+    if (!abortCommand(true)) {
+      return false;
+    }
+    if (mAddComponentDialog && mAddComponentDialog->getAutoOpenAgain()) {
       mLastAngle.setAngleMicroDeg(0);  // reset the angle
       startAddingComponent();
       return true;
-    } catch (UserCanceled& exc) {
-    } catch (Exception& exc) {
-      QMessageBox::critical(parentWidget(), tr("Error"), exc.getMsg());
     }
+  } catch (UserCanceled& exc) {
+  } catch (Exception& exc) {
+    QMessageBox::critical(parentWidget(), tr("Error"), exc.getMsg());
   }
 
-  return false;
+  return false;  // FSM will handle the event and exit this state.
 }
 
 bool SchematicEditorState_AddComponent::processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/workspace/categorytreemodel.h
+++ b/libs/librepcb/editor/workspace/categorytreemodel.h
@@ -80,6 +80,9 @@ public:
                              Filters filters) noexcept;
   ~CategoryTreeModel() noexcept;
 
+  // Setters
+  void setLocaleOrder(const QStringList& order) noexcept;
+
   // Inherited Methods
   int columnCount(const QModelIndex& parent = QModelIndex()) const
       noexcept override;
@@ -112,7 +115,7 @@ private:  // Methods
 
 private:  // Data
   const WorkspaceLibraryDb& mLibrary;
-  const QStringList mLocaleOrder;
+  QStringList mLocaleOrder;
   const Filters mFilters;
   std::shared_ptr<Item> mRootItem;
 };

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -86,6 +86,7 @@ add_executable(
   editor/library/pkg/footprintclipboarddatatest.cpp
   editor/library/sym/symbolclipboarddatatest.cpp
   editor/modelview/pathmodeltest.cpp
+  editor/project/addcomponentdialogtest.cpp
   editor/project/boardeditor/boardclipboarddatatest.cpp
   editor/project/orderpcbdialogtest.cpp
   editor/project/schematiceditor/schematicclipboarddatatest.cpp

--- a/tests/unittests/editor/project/addcomponentdialogtest.cpp
+++ b/tests/unittests/editor/project/addcomponentdialogtest.cpp
@@ -1,0 +1,324 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include "../../testhelpers.h"
+
+#include <gtest/gtest.h>
+#include <librepcb/core/fileio/fileutils.h>
+#include <librepcb/core/fileio/transactionaldirectory.h>
+#include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/library/cmp/component.h>
+#include <librepcb/core/library/dev/device.h>
+#include <librepcb/core/library/pkg/package.h>
+#include <librepcb/core/sqlitedatabase.h>
+#include <librepcb/core/workspace/workspacelibrarydb.h>
+#include <librepcb/core/workspace/workspacelibrarydbwriter.h>
+#include <librepcb/editor/project/addcomponentdialog.h>
+
+#include <QtTest>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+namespace tests {
+
+using ::librepcb::tests::TestHelpers;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class AddComponentDialogTest : public ::testing::Test {
+protected:
+  FilePath mWsDir;
+  std::unique_ptr<WorkspaceLibraryDb> mWsDb;
+  std::unique_ptr<SQLiteDatabase> mDb;
+  std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
+  std::shared_ptr<TransactionalFileSystem> mFs;
+
+  AddComponentDialogTest() : mWsDir(FilePath::getRandomTempPath()) {
+    QSettings().clear();
+    FileUtils::makePath(mWsDir);
+    mWsDb.reset(new WorkspaceLibraryDb(mWsDir));
+    mDb.reset(new SQLiteDatabase(mWsDb->getFilePath()));
+    mWriter.reset(new WorkspaceLibraryDbWriter(mWsDir, *mDb));
+    mFs.reset(new TransactionalFileSystem(mWsDir, true));
+  }
+
+  std::string str(const tl::optional<Uuid>& uuid) {
+    return uuid ? uuid->toStr().toStdString() : "";
+  }
+
+  FilePath toAbs(const QString& fp) { return mWsDir.getPathTo(fp); }
+
+  Uuid uuid(int index = -1) {
+    static QHash<int, Uuid> cache;
+    if (index >= 0) {
+      auto it = cache.find(index);
+      if (it == cache.end()) {
+        it = cache.insert(index, uuid());
+      }
+      return *it;
+    } else {
+      return Uuid::createRandom();
+    }
+  }
+
+  Version version(const QString& version) {
+    return Version::fromString(version);
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(AddComponentDialogTest, testAddMore) {
+  const bool defaultValue = true;
+  const bool newValue = false;
+
+  {
+    AddComponentDialog dialog(*mWsDb, {}, {});
+
+    // Check the default value.
+    QCheckBox& cbx =
+        TestHelpers::getChild<QCheckBox>(dialog, "buttonBox/cbxAddMore");
+    EXPECT_EQ(defaultValue, cbx.isChecked());
+    EXPECT_EQ(defaultValue, dialog.getAutoOpenAgain());
+
+    // Check if the value can be changed.
+    cbx.setChecked(newValue);
+    EXPECT_EQ(newValue, dialog.getAutoOpenAgain());
+  }
+
+  // Check if the setting is saved and restored automatically.
+  {
+    AddComponentDialog dialog(*mWsDb, {}, {});
+    QCheckBox& cbx =
+        TestHelpers::getChild<QCheckBox>(dialog, "buttonBox/cbxAddMore");
+    EXPECT_EQ(newValue, cbx.isChecked());
+    EXPECT_EQ(newValue, dialog.getAutoOpenAgain());
+  }
+}
+
+TEST_F(AddComponentDialogTest, testChooseComponentDevice) {
+  // - cat 1
+  //   - cat 2
+  //     - cmp 1
+  //     - cmp 2
+  //       - dev 1
+  int catId = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat1"), uuid(1), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(catId, "", ElementName("cat 1"),
+                                             tl::nullopt, tl::nullopt);
+  catId = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat2"), uuid(2), version("0.1"), false, uuid(1));
+  mWriter->addTranslation<ComponentCategory>(catId, "", ElementName("cat 2"),
+                                             tl::nullopt, tl::nullopt);
+  int cmpId = mWriter->addElement<Component>(0, toAbs("cmp1"), uuid(3),
+                                             version("0.1"), false);
+  mWriter->addTranslation<Component>(cmpId, "", ElementName("cmp 1"),
+                                     tl::nullopt, tl::nullopt);
+  mWriter->addToCategory<Component>(cmpId, uuid(2));
+  cmpId = mWriter->addElement<Component>(0, toAbs(uuid(4).toStr()), uuid(4),
+                                         version("0.1"), false);
+  mWriter->addTranslation<Component>(cmpId, "", ElementName("cmp 2"),
+                                     tl::nullopt, tl::nullopt);
+  mWriter->addToCategory<Component>(cmpId, uuid(2));
+  int pkgId = mWriter->addElement<Package>(0, toAbs(uuid(5).toStr()), uuid(5),
+                                           version("0.1"), false);
+  mWriter->addTranslation<Package>(pkgId, "", ElementName("pkg 1"), tl::nullopt,
+                                   tl::nullopt);
+  int devId = mWriter->addDevice(0, toAbs(uuid(6).toStr()), uuid(6),
+                                 version("0.1"), false, uuid(4), uuid(5));
+  mWriter->addTranslation<Device>(devId, "", ElementName("dev 1"), tl::nullopt,
+                                  tl::nullopt);
+
+  // Create component
+  TransactionalDirectory cmp2Dir(mFs, uuid(4).toStr());
+  Component cmp2(uuid(4), version("0.1"), "", ElementName("cmp 2"), "", "");
+  auto cmp2SymbVar1 = std::make_shared<ComponentSymbolVariant>(
+      uuid(7), "", ElementName("var 1"), "");
+  cmp2.getSymbolVariants().append(cmp2SymbVar1);
+  auto cmp2SymbVar2 = std::make_shared<ComponentSymbolVariant>(
+      uuid(8), "", ElementName("var 2"), "");
+  cmp2.getSymbolVariants().append(cmp2SymbVar2);
+  cmp2.saveTo(cmp2Dir);
+
+  // Create package
+  TransactionalDirectory pkg1Dir(mFs, uuid(5).toStr());
+  Package pkg1(uuid(5), version("0.1"), "", ElementName("pkg 1"), "", "");
+  pkg1.saveTo(pkg1Dir);
+
+  // Create device
+  TransactionalDirectory dev1Dir(mFs, uuid(6).toStr());
+  Device dev1(uuid(6), version("0.1"), "", ElementName("dev 1"), "", "",
+              uuid(4), uuid(5));
+  dev1.saveTo(dev1Dir);
+
+  // Save everything to disk
+  mFs->save();
+
+  // Create dialog
+  AddComponentDialog dialog(*mWsDb, {}, {});
+  QTreeView& catView =
+      TestHelpers::getChild<QTreeView>(dialog, "treeCategories");
+  QTreeWidget& cmpView =
+      TestHelpers::getChild<QTreeWidget>(dialog, "treeComponents");
+  QLabel& lblCmpName = TestHelpers::getChild<QLabel>(dialog, "lblCompName");
+  QComboBox& cbxSymbVar =
+      TestHelpers::getChild<QComboBox>(dialog, "cbxSymbVar");
+  QLabel& lblDevName = TestHelpers::getChild<QLabel>(dialog, "lblDeviceName");
+
+  // Select cat 2
+  QModelIndex cat1Index = catView.model()->index(0, 0);
+  EXPECT_EQ("cat 1", cat1Index.data().toString().toStdString());
+  QModelIndex cat2Index = catView.model()->index(0, 0, cat1Index);
+  EXPECT_EQ("cat 2", cat2Index.data().toString().toStdString());
+  catView.setCurrentIndex(cat2Index);
+  EXPECT_EQ(2, cmpView.model()->rowCount());
+
+  // Select cmp 2
+  QModelIndex cmp2Index = cmpView.model()->index(1, 0);
+  EXPECT_EQ("cmp 2", cmp2Index.data().toString().toStdString());
+  cmpView.setCurrentIndex(cmp2Index);
+  EXPECT_EQ("cmp 2", lblCmpName.text().toStdString());
+  EXPECT_EQ(2, cbxSymbVar.count());
+  EXPECT_EQ("var 1", cbxSymbVar.currentText().toStdString());
+
+  // Select symbvar 2
+  cbxSymbVar.setCurrentIndex(1);
+  EXPECT_EQ("var 2", cbxSymbVar.currentText().toStdString());
+
+  // Check getters
+  EXPECT_EQ(str(uuid(4)), str(dialog.getSelectedComponentUuid()));
+  EXPECT_EQ(str(uuid(8)), str(dialog.getSelectedSymbVarUuid()));
+  EXPECT_EQ(str(tl::nullopt), str(dialog.getSelectedDeviceUuid()));
+
+  // Now select dev 1
+  QModelIndex dev1Index = cmpView.model()->index(0, 0, cmp2Index);
+  EXPECT_EQ("dev 1", dev1Index.data().toString().toStdString());
+  cmpView.setCurrentIndex(dev1Index);
+  EXPECT_EQ("dev 1 [pkg 1]", lblDevName.text().toStdString());
+
+  // Check getters again
+  EXPECT_EQ(str(uuid(4)), str(dialog.getSelectedComponentUuid()));
+  EXPECT_EQ(str(uuid(8)), str(dialog.getSelectedSymbVarUuid()));
+  EXPECT_EQ(str(uuid(6)), str(dialog.getSelectedDeviceUuid()));
+}
+
+TEST_F(AddComponentDialogTest, testSetNormOrder) {
+  // - cat 1
+  //   - cmp 1
+  int catId = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat1"), uuid(1), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(catId, "", ElementName("cat 1"),
+                                             tl::nullopt, tl::nullopt);
+  int cmpId = mWriter->addElement<Component>(0, toAbs(uuid(3).toStr()), uuid(3),
+                                             version("0.1"), false);
+  mWriter->addTranslation<Component>(cmpId, "", ElementName("cmp 1"),
+                                     tl::nullopt, tl::nullopt);
+  mWriter->addToCategory<Component>(cmpId, uuid(1));
+
+  // Create component
+  TransactionalDirectory cmp2Dir(mFs, uuid(3).toStr());
+  Component cmp2(uuid(3), version("0.1"), "", ElementName("cmp 2"), "", "");
+  auto cmp2SymbVar1 = std::make_shared<ComponentSymbolVariant>(
+      uuid(4), "", ElementName("var 1"), "");
+  cmp2.getSymbolVariants().append(cmp2SymbVar1);
+  auto cmp2SymbVar2 = std::make_shared<ComponentSymbolVariant>(
+      uuid(5), "NORM", ElementName("var 2"), "");
+  cmp2.getSymbolVariants().append(cmp2SymbVar2);
+  cmp2.saveTo(cmp2Dir);
+
+  // Save everything to disk
+  mFs->save();
+
+  // Create dialog
+  AddComponentDialog dialog(*mWsDb, {}, {"NORM"});
+  QTreeView& catView =
+      TestHelpers::getChild<QTreeView>(dialog, "treeCategories");
+  QTreeWidget& cmpView =
+      TestHelpers::getChild<QTreeWidget>(dialog, "treeComponents");
+  QComboBox& cbxSymbVar =
+      TestHelpers::getChild<QComboBox>(dialog, "cbxSymbVar");
+
+  // Select cmp 1 and check selected symbol variant
+  catView.setCurrentIndex(catView.model()->index(0, 0));
+  cmpView.setCurrentIndex(cmpView.model()->index(0, 0));
+  EXPECT_EQ("var 2 [NORM]", cbxSymbVar.currentText().toStdString());
+
+  // Change norm order
+  dialog.setNormOrder({});
+
+  // Update selection and check selected symbol variant again
+  catView.setCurrentIndex(QModelIndex());
+  catView.setCurrentIndex(catView.model()->index(0, 0));
+  cmpView.setCurrentIndex(cmpView.model()->index(0, 0));
+  EXPECT_EQ("var 1", cbxSymbVar.currentText().toStdString());
+}
+
+TEST_F(AddComponentDialogTest, testSearch) {
+  int cmpId = mWriter->addElement<Component>(0, toAbs("cmp1"), uuid(1),
+                                             version("0.1"), false);
+  mWriter->addTranslation<Component>(cmpId, "", ElementName("cmp 1"),
+                                     tl::nullopt, "key 1");
+  cmpId = mWriter->addElement<Component>(0, toAbs("cmp2"), uuid(2),
+                                         version("0.1"), false);
+  mWriter->addTranslation<Component>(cmpId, "", ElementName("cmp 2"),
+                                     tl::nullopt, tl::nullopt);
+
+  // Create dialog
+  AddComponentDialog dialog(*mWsDb, {}, {});
+  QLineEdit& edtSearch = TestHelpers::getChild<QLineEdit>(dialog, "edtSearch");
+  QTreeWidget& cmpView =
+      TestHelpers::getChild<QTreeWidget>(dialog, "treeComponents");
+
+  // Search "cmp" -> 2 results
+  edtSearch.setText("cmp");
+  EXPECT_EQ(2, cmpView.model()->rowCount());
+  EXPECT_EQ("cmp 1",
+            cmpView.model()->index(0, 0).data().toString().toStdString());
+  EXPECT_EQ("cmp 2",
+            cmpView.model()->index(1, 0).data().toString().toStdString());
+
+  // Search "foo" -> 0 results
+  edtSearch.setText("foo");
+  EXPECT_EQ(0, cmpView.model()->rowCount());
+
+  // Search "key" -> 1 results
+  edtSearch.setText("key");
+  EXPECT_EQ(1, cmpView.model()->rowCount());
+  EXPECT_EQ("cmp 1",
+            cmpView.model()->index(0, 0).data().toString().toStdString());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace editor
+}  // namespace librepcb

--- a/tests/unittests/editor/workspace/categorytreemodeltest.cpp
+++ b/tests/unittests/editor/workspace/categorytreemodeltest.cpp
@@ -569,7 +569,7 @@ TEST_F(CategoryTreeModelTest, testLiveUpdateVariousModifications) {
   };
   EXPECT_EQ(str(expected), str(getItems(model)));
 
-  // Show a the model in a QTreeView and select an item which gets removed,
+  // Show the model in a QTreeView and select an item which gets removed,
   // just to ensure the model update also works while a view is connected.
   QTreeView view;
   view.setModel(&model);
@@ -614,9 +614,38 @@ TEST_F(CategoryTreeModelTest, testLiveUpdateVariousModifications) {
   };
   EXPECT_EQ(str(expected), str(getItems(model)));
 
-  // Verify that "cat 1 renamed" (the parent of the removed item) is now
-  // selected.
-  EXPECT_EQ(model.index(0, 0), view.currentIndex());
+  // Verify that the selection was updated in a reasonable way.
+  EXPECT_EQ("cat 5", str(view.currentIndex().data()));
+}
+
+TEST_F(CategoryTreeModelTest, testSetLocaleOrder) {
+  // - cat 1
+  // - cat 2, cat 0 (de_CH)
+  int cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat1"), uuid(1), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 1"),
+                                             tl::nullopt, tl::nullopt);
+  cat = mWriter->addCategory<ComponentCategory>(
+      0, toAbs("cat2"), uuid(2), version("0.1"), false, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(cat, "", ElementName("cat 2"),
+                                             tl::nullopt, tl::nullopt);
+  mWriter->addTranslation<ComponentCategory>(cat, "de_CH", ElementName("cat 0"),
+                                             tl::nullopt, tl::nullopt);
+
+  CategoryTreeModel model(*mWsDb, {}, CategoryTreeModel::Filter::CmpCat);
+  QVector<Item> expected = {
+      {"cat 1", {}},
+      {"cat 2", {}},
+  };
+  EXPECT_EQ(str(expected), str(getItems(model)));
+
+  model.setLocaleOrder({"de_CH"});
+
+  expected = {
+      {"cat 0", {}},
+      {"cat 1", {}},
+  };
+  EXPECT_EQ(str(expected), str(getItems(model)));
 }
 
 /*******************************************************************************


### PR DESCRIPTION
I got the feedback that it is counterintuitive that the "Add Component"-dialog automatically appears again when aborting placement (e.g. with the escape key), in particular when you only want to add one component to the schematic. Generally I agree, but still think that in most cases this is handy since it avoids to manually open the dialog many times.

Thus I made this behavior configurable with a checkbox:

![image](https://user-images.githubusercontent.com/5374821/153773635-62f8c051-9244-449a-9b4f-d39ebaf28ac6.png)

The checkbox is checked by default (i.e. current behavior is kept) but its state is memorized in the user settings and automatically restored the next time. So if you don't like the auto-open feature, just disable it once and it will never open again automatically.

Additional improvements:
- The window size is now saved and restored automatically as well.
- The dialog selection is no longer reset when leaving the placement tool in the schematic editor. So even after leaving and re-entering the placement tool, the "Add Component"-dialog will show up with the previously selected device when opening the next time.
- Added some unit tests.