### PR TITLE
Add "apply" button to via- and component properties dialog

### DIFF
--- a/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.cpp
@@ -62,6 +62,8 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(
                           settingsPrefix % "/pos_x");
   mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
                           settingsPrefix % "/pos_y");
+  connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
+          &BoardViaPropertiesDialog::buttonBoxClicked);
 
   // shape combobox
   mUi->cbxShape->addItem(tr("Round"), static_cast<int>(Via::Shape::Round));
@@ -92,16 +94,22 @@ BoardViaPropertiesDialog::~BoardViaPropertiesDialog() noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void BoardViaPropertiesDialog::keyPressEvent(QKeyEvent* e) {
-  switch (e->key()) {
-    case Qt::Key_Return:
-      accept();
+void BoardViaPropertiesDialog::buttonBoxClicked(
+    QAbstractButton* button) noexcept {
+  switch (mUi->buttonBox->buttonRole(button)) {
+    case QDialogButtonBox::ApplyRole:
+      applyChanges();
       break;
-    case Qt::Key_Escape:
+    case QDialogButtonBox::AcceptRole:
+      if (applyChanges()) {
+        accept();
+      }
+      break;
+    case QDialogButtonBox::RejectRole:
       reject();
       break;
     default:
-      QDialog::keyPressEvent(e);
+      Q_ASSERT(false);
       break;
   }
 }

--- a/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.h
+++ b/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.h
@@ -67,7 +67,7 @@ public:
 
 private:
   // Private Methods
-  void keyPressEvent(QKeyEvent* e);
+  void buttonBoxClicked(QAbstractButton* button) noexcept;
   void accept();
   bool applyChanges() noexcept;
 

--- a/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.ui
@@ -85,7 +85,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -113,38 +113,5 @@
   <tabstop>edtDrillDiameter</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::editor::BoardViaPropertiesDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::editor::BoardViaPropertiesDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/libs/librepcb/editor/project/cmd/cmdboardviaedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardviaedit.cpp
@@ -109,7 +109,11 @@ void CmdBoardViaEdit::setDrillDiameter(const PositiveLength& diameter,
 bool CmdBoardViaEdit::performExecute() {
   performRedo();  // can throw
 
-  return true;  // TODO: determine if the via was really modified
+  if (mNewPos != mOldPos) return true;
+  if (mNewShape != mOldShape) return true;
+  if (mNewSize != mOldSize) return true;
+  if (mNewDrillDiameter != mOldDrillDiameter) return true;
+  return false;
 }
 
 void CmdBoardViaEdit::performUndo() {

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -74,6 +74,8 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
                                   settingsPrefix % "/pos_y");
   mUi->edtSymbInstRotation->setSingleStep(90.0);  // [°]
   setWindowTitle(tr("Properties of %1").arg(mSymbol.getName()));
+  connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
+          &SymbolInstancePropertiesDialog::buttonBoxClicked);
 
   // Component Instance Attributes
   mUi->edtCompInstName->setText(*mComponentInstance.getName());
@@ -175,16 +177,22 @@ SymbolInstancePropertiesDialog::~SymbolInstancePropertiesDialog() noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void SymbolInstancePropertiesDialog::keyPressEvent(QKeyEvent* e) {
-  switch (e->key()) {
-    case Qt::Key_Return:
-      accept();
+void SymbolInstancePropertiesDialog::buttonBoxClicked(
+    QAbstractButton* button) noexcept {
+  switch (mUi->buttonBox->buttonRole(button)) {
+    case QDialogButtonBox::ApplyRole:
+      applyChanges();
       break;
-    case Qt::Key_Escape:
+    case QDialogButtonBox::AcceptRole:
+      if (applyChanges()) {
+        accept();
+      }
+      break;
+    case QDialogButtonBox::RejectRole:
       reject();
       break;
     default:
-      QDialog::keyPressEvent(e);
+      Q_ASSERT(false);
       break;
   }
 }

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.h
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.h
@@ -76,7 +76,7 @@ public:
       const SymbolInstancePropertiesDialog& rhs) = delete;
 
 private:  // Methods
-  void keyPressEvent(QKeyEvent* e);
+  void buttonBoxClicked(QAbstractButton* button) noexcept;
   void accept();
   bool applyChanges() noexcept;
 

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -283,7 +283,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -320,38 +320,5 @@
   <tabstop>cbxPreselectedDevice</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::editor::SymbolInstancePropertiesDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::editor::SymbolInstancePropertiesDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
Almost all property dialogs already have an "apply" button (which is sometimes quite useful to see the result of the change without closing the dialog), but the "Via Properties" (board editor) and "Component Properties" (schematic editor) dialogs didn't have that button. This PR adds an apply button to these dialogs as well.