### PR TITLE
Fix missing rounding in Point::rotate()

### DIFF
--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -26,6 +26,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -238,6 +240,16 @@ Path& Path::operator=(const Path& rhs) noexcept {
   mVertices = rhs.mVertices;
   mPainterPathPx = rhs.mPainterPathPx;
   return *this;
+}
+
+bool Path::operator<(const Path& rhs) const noexcept {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+  return mVertices < rhs.mVertices;
+#else
+  return std::lexicographical_compare(mVertices.begin(), mVertices.end(),
+                                      rhs.mVertices.begin(),
+                                      rhs.mVertices.end());
+#endif
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -99,11 +99,23 @@ public:
   void serialize(SExpression& root) const override;
 
   // Operator Overloadings
+  Path& operator=(const Path& rhs) noexcept;
   bool operator==(const Path& rhs) const noexcept {
     return mVertices == rhs.mVertices;
   }
   bool operator!=(const Path& rhs) const noexcept { return !(*this == rhs); }
-  Path& operator=(const Path& rhs) noexcept;
+
+  /**
+   * @brief The "<" operator to compare two ::librepcb::Path objects
+   *
+   * Useful for sorting path lists/sets (e.g. to for canonical order in
+   * files), or to store them in a QMap.
+   *
+   * @param rhs The right hand side object.
+   *
+   * @return true if this path is smaller, else false
+   */
+  bool operator<(const Path& rhs) const noexcept;
 
   // Static Methods
   static Path line(const Point& p1, const Point& p2,

--- a/libs/librepcb/core/geometry/vertex.cpp
+++ b/libs/librepcb/core/geometry/vertex.cpp
@@ -56,14 +56,22 @@ void Vertex::serialize(SExpression& root) const {
  *  Operator Overloadings
  ******************************************************************************/
 
-bool Vertex::operator==(const Vertex& rhs) const noexcept {
-  return mPos == rhs.mPos && mAngle == rhs.mAngle;
-}
-
 Vertex& Vertex::operator=(const Vertex& rhs) noexcept {
   mPos = rhs.mPos;
   mAngle = rhs.mAngle;
   return *this;
+}
+
+bool Vertex::operator==(const Vertex& rhs) const noexcept {
+  return mPos == rhs.mPos && mAngle == rhs.mAngle;
+}
+
+bool Vertex::operator<(const Vertex& rhs) const noexcept {
+  if (mPos != rhs.mPos) {
+    return mPos < rhs.mPos;
+  } else {
+    return mAngle < rhs.mAngle;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/vertex.h
+++ b/libs/librepcb/core/geometry/vertex.h
@@ -65,9 +65,21 @@ public:
   void serialize(SExpression& root) const override;
 
   // Operator Overloadings
+  Vertex& operator=(const Vertex& rhs) noexcept;
   bool operator==(const Vertex& rhs) const noexcept;
   bool operator!=(const Vertex& rhs) const noexcept { return !(*this == rhs); }
-  Vertex& operator=(const Vertex& rhs) noexcept;
+
+  /**
+   * @brief The "<" operator to compare two ::librepcb::Vertex objects
+   *
+   * Useful for sorting vertex lists/sets (e.g. to for canonical order in
+   * files), or to store them in a QMap.
+   *
+   * @param rhs The right hand side object.
+   *
+   * @return true if this vertex is smaller, else false
+   */
+  bool operator<(const Vertex& rhs) const noexcept;
 
 private:  // Data
   Point mPos;

--- a/libs/librepcb/core/types/point.cpp
+++ b/libs/librepcb/core/types/point.cpp
@@ -102,8 +102,10 @@ Point& Point::rotate(const Angle& angle, const Point& center) noexcept {
     // arithmetic
     qreal sin = qSin(angle.toRad());
     qreal cos = qCos(angle.toRad());
-    setX(Length(center.getX().toNm() + cos * dx.toNm() - sin * dy.toNm()));
-    setY(Length(center.getY().toNm() + sin * dx.toNm() + cos * dy.toNm()));
+    setX(Length::fromMm(center.getX().toMm() + cos * dx.toMm() -
+                        sin * dy.toMm()));
+    setY(Length::fromMm(center.getY().toMm() + sin * dx.toMm() +
+                        cos * dy.toMm()));
   }  // else: angle == 0°, nothing to do...
 
   return *this;

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -115,6 +115,20 @@ TEST_F(PathTest, testReversed) {
   EXPECT_EQ(str(expected), str(actual));
 }
 
+TEST_F(PathTest, testOperatorCompareLess) {
+  EXPECT_FALSE(Path() < Path());
+  EXPECT_FALSE(Path({Vertex(Point(1, 2))}) < Path());
+  EXPECT_FALSE(Path({Vertex(Point(1, 2))}) < Path({Vertex(Point(1, 2))}));
+  EXPECT_FALSE(Path({Vertex(Point(2, 2))}) < Path({Vertex(Point(1, 2))}));
+  EXPECT_FALSE(Path({Vertex(Point(0, 0), Angle::deg90())}) <
+               Path({Vertex(Point(0, 0), Angle::deg0())}));
+
+  EXPECT_TRUE(Path() < Path({Vertex(Point(1, 2))}));
+  EXPECT_TRUE(Path({Vertex(Point(1, 2))}) < Path({Vertex(Point(2, 2))}));
+  EXPECT_TRUE(Path({Vertex(Point(0, 0), Angle::deg0())}) <
+              Path({Vertex(Point(0, 0), Angle::deg90())}));
+}
+
 TEST_F(PathTest, testLine) {
   Point p1(Length(12), Length(34));
   Point p2(Length(56), Length(78));

--- a/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
+++ b/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
@@ -85,30 +85,19 @@ TEST(BoardPlaneFragmentsBuilderTest, testFragments) {
   foreach (const Uuid& uuid, actualPlaneFragments.keys()) {
     SExpression child = SExpression::createList("plane");
     child.appendChild(uuid);
-    foreach (const Path& fragment, actualPlaneFragments[uuid]) {
+    foreach (const Path& fragment,
+             Toolbox::sortedQSet(actualPlaneFragments[uuid])) {
       child.appendChild(fragment.serializeToDomElement("fragment"), true);
     }
     actualSexpr.appendChild(child, true);
   }
-  FileUtils::writeFile(testDataDir.getPathTo("actual.lp"),
-                       actualSexpr.toByteArray());
+  QByteArray actual = actualSexpr.toByteArray();
+  FileUtils::writeFile(testDataDir.getPathTo("actual.lp"), actual);
 
-  // load expected plane fragments from file
+  // compare with expected plane fragments loaded from file
   FilePath expectedFp = testDataDir.getPathTo("expected.lp");
-  SExpression expectedSexpr =
-      SExpression::parse(FileUtils::readFile(expectedFp), expectedFp);
-  QMap<Uuid, QSet<Path>> expectedPlaneFragments;
-  foreach (const SExpression& child, expectedSexpr.getChildren("plane")) {
-    Uuid uuid =
-        deserialize<Uuid>(child.getChild("@0"), qApp->getFileFormatVersion());
-    foreach (const SExpression& fragmentChild, child.getChildren("fragment")) {
-      expectedPlaneFragments[uuid].insert(
-          Path(fragmentChild, qApp->getFileFormatVersion()));
-    }
-  }
-
-  // compare
-  EXPECT_EQ(expectedPlaneFragments, actualPlaneFragments);
+  QByteArray expected = FileUtils::readFile(expectedFp);
+  EXPECT_EQ(expected.toStdString(), actual.toStdString());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/types/pointtest.cpp
+++ b/tests/unittests/core/types/pointtest.cpp
@@ -34,42 +34,23 @@ namespace librepcb {
 namespace tests {
 
 /*******************************************************************************
- *  Test Data Type
- ******************************************************************************/
-
-typedef struct {
-  Point pA;
-  Point pB;
-  Point pCenter;
-  Angle aRot;
-} PointTestData_t;
-
-/*******************************************************************************
  *  Test Class
  ******************************************************************************/
 
-class PointTest : public ::testing::TestWithParam<PointTestData_t> {};
+class PointTest : public ::testing::Test {};
 
 /*******************************************************************************
  *  Test Methods
  ******************************************************************************/
 
-TEST_P(PointTest, testDefaultConstructor) {
+TEST(PointTest, testDefaultConstructor) {
   Point p;
   EXPECT_EQ(0, p.getX().toNm());
   EXPECT_EQ(0, p.getY().toNm());
   EXPECT_TRUE(p.isOrigin());
 }
 
-TEST_P(PointTest, testRotate) {
-  const PointTestData_t& data = GetParam();
-
-  Point p(data.pA);
-  p.rotate(data.aRot, data.pCenter);
-  EXPECT_EQ(data.pB, p);
-}
-
-TEST_P(PointTest, testOperatorLessThan) {
+TEST(PointTest, testOperatorLessThan) {
   EXPECT_FALSE(Point(Length(0), Length(0)) < Point(Length(0), Length(0)));
   EXPECT_FALSE(Point(Length(10), Length(20)) < Point(Length(9), Length(19)));
   EXPECT_FALSE(Point(Length(10), Length(20)) < Point(Length(9), Length(21)));
@@ -83,7 +64,7 @@ TEST_P(PointTest, testOperatorLessThan) {
   EXPECT_TRUE(Point(Length(-1), Length(-2)) < Point(Length(-1), Length(-1)));
 }
 
-TEST_P(PointTest, testOperatorLessEqual) {
+TEST(PointTest, testOperatorLessEqual) {
   EXPECT_FALSE(Point(Length(10), Length(20)) <= Point(Length(9), Length(19)));
   EXPECT_FALSE(Point(Length(10), Length(20)) <= Point(Length(9), Length(21)));
   EXPECT_FALSE(Point(Length(10), Length(20)) <= Point(Length(10), Length(19)));
@@ -97,7 +78,7 @@ TEST_P(PointTest, testOperatorLessEqual) {
   EXPECT_TRUE(Point(Length(-1), Length(-2)) <= Point(Length(-1), Length(-1)));
 }
 
-TEST_P(PointTest, testOperatorGreaterThan) {
+TEST(PointTest, testOperatorGreaterThan) {
   EXPECT_FALSE(Point(Length(0), Length(0)) > Point(Length(0), Length(0)));
   EXPECT_FALSE(Point(Length(0), Length(0)) > Point(Length(0), Length(1)));
   EXPECT_FALSE(Point(Length(0), Length(0)) > Point(Length(1), Length(0)));
@@ -111,7 +92,7 @@ TEST_P(PointTest, testOperatorGreaterThan) {
   EXPECT_TRUE(Point(Length(-10), Length(20)) > Point(Length(-11), Length(0)));
 }
 
-TEST_P(PointTest, testOperatorGreaterEqual) {
+TEST(PointTest, testOperatorGreaterEqual) {
   EXPECT_FALSE(Point(Length(0), Length(0)) >= Point(Length(0), Length(1)));
   EXPECT_FALSE(Point(Length(0), Length(0)) >= Point(Length(1), Length(0)));
   EXPECT_FALSE(Point(Length(10), Length(20)) >= Point(Length(11), Length(19)));
@@ -126,23 +107,52 @@ TEST_P(PointTest, testOperatorGreaterEqual) {
 }
 
 /*******************************************************************************
- *  Test Data
+ *  Tests for rotate()
  ******************************************************************************/
 
-// clang-format off
-INSTANTIATE_TEST_SUITE_P(PointTest, PointTest, ::testing::Values(
-    //              {pA,                     pB,                     pCenter,                aRot}
-    PointTestData_t({Point::fromMm(0, 0),    Point::fromMm(0, 0),    Point::fromMm(0, 0),    Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(10, 0),   Point::fromMm(0, 10),   Point::fromMm(0, 0),    Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(0, 10),   Point::fromMm(-10, 0),  Point::fromMm(0, 0),    Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(-10, 0),  Point::fromMm(0, -10),  Point::fromMm(0, 0),    Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(0, -10),  Point::fromMm(10, 0),   Point::fromMm(0, 0),    Angle::fromDeg(90)}),
+struct PointRotateTestData {
+  Point input;
+  Angle angle;
+  Point center;
+  Point output;
+};
 
-    PointTestData_t({Point::fromMm(100, 50), Point::fromMm(100, 50), Point::fromMm(100, 50), Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(110, 50), Point::fromMm(100, 60), Point::fromMm(100, 50), Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(100, 60), Point::fromMm(90, 50),  Point::fromMm(100, 50), Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(90, 50),  Point::fromMm(100, 40), Point::fromMm(100, 50), Angle::fromDeg(90)}),
-    PointTestData_t({Point::fromMm(100, 40), Point::fromMm(110, 50), Point::fromMm(100, 50), Angle::fromDeg(90)})
+class PointRotateTest : public ::testing::TestWithParam<PointRotateTestData> {};
+
+TEST_P(PointRotateTest, test) {
+  const PointRotateTestData& data = GetParam();
+
+  Point p(data.input);
+  p.rotate(data.angle, data.center);
+  EXPECT_EQ(data.output, p);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(PointRotateTest, PointRotateTest, ::testing::Values(
+    //                  {input,                  angle,               center,                 output}
+    PointRotateTestData({Point::fromMm(10, 0),   Angle::fromDeg(0),   Point::fromMm(0, 0),    Point::fromMm(10, 0)  }),
+    PointRotateTestData({Point::fromMm(10, 0),   Angle::fromDeg(180), Point::fromMm(0, 0),    Point::fromMm(-10, 0) }),
+    PointRotateTestData({Point::fromMm(10, 0),   Angle::fromDeg(270), Point::fromMm(0, 0),    Point::fromMm(0, -10) }),
+    PointRotateTestData({Point::fromMm(10, 0),   Angle::fromDeg(0),   Point::fromMm(0, 0),    Point::fromMm(10, 0)  }),
+
+    PointRotateTestData({Point::fromMm(0, 0),    Angle::fromDeg(90),  Point::fromMm(0, 0),    Point::fromMm(0, 0)   }),
+    PointRotateTestData({Point::fromMm(10, 0),   Angle::fromDeg(90),  Point::fromMm(0, 0),    Point::fromMm(0, 10)  }),
+    PointRotateTestData({Point::fromMm(0, 10),   Angle::fromDeg(90),  Point::fromMm(0, 0),    Point::fromMm(-10, 0) }),
+    PointRotateTestData({Point::fromMm(-10, 0),  Angle::fromDeg(90),  Point::fromMm(0, 0),    Point::fromMm(0, -10) }),
+    PointRotateTestData({Point::fromMm(0, -10),  Angle::fromDeg(90),  Point::fromMm(0, 0),    Point::fromMm(10, 0)  }),
+
+    PointRotateTestData({Point::fromMm(100, 50), Angle::fromDeg(90),  Point::fromMm(100, 50), Point::fromMm(100, 50)}),
+    PointRotateTestData({Point::fromMm(110, 50), Angle::fromDeg(90),  Point::fromMm(100, 50), Point::fromMm(100, 60)}),
+    PointRotateTestData({Point::fromMm(100, 60), Angle::fromDeg(90),  Point::fromMm(100, 50), Point::fromMm(90, 50) }),
+    PointRotateTestData({Point::fromMm(90, 50),  Angle::fromDeg(90),  Point::fromMm(100, 50), Point::fromMm(100, 40)}),
+    PointRotateTestData({Point::fromMm(100, 40), Angle::fromDeg(90),  Point::fromMm(100, 50), Point::fromMm(110, 50)}),
+
+    PointRotateTestData({Point(10, 0),           Angle::fromDeg(1),   Point(0, 0),            Point(10, 0)  }),
+    PointRotateTestData({Point(10, 0),           Angle::fromDeg(2),   Point(0, 0),            Point(10, 0)  }),
+    PointRotateTestData({Point(10, 0),           Angle::fromDeg(3),   Point(0, 0),            Point(10, 1)  }),
+    PointRotateTestData({Point(10, 0),           Angle::fromDeg(4),   Point(0, 0),            Point(10, 1)  }),
+    PointRotateTestData({Point(10, 0),           Angle::fromDeg(18),  Point(0, 0),            Point(10, 3)  }),
+    PointRotateTestData({Point(10, 0),           Angle::fromDeg(19),  Point(0, 0),            Point(9, 3)   })
 ));
 // clang-format on
 


### PR DESCRIPTION
When rotating points around another point with an angle other than a multiple of 90°, currently the result was not rounded to the nearest integer. This lead to small deviations in plane calculations and therefore also affected the Gerber output.

The issue is not critical at all since most PCBs only place devices with 90° angles and the deviations were very small, but still this issue should be fixed ;) Also added a unit test to check the rounding behavior.