### PR TITLE
Board editor: Fix modifying rotation of mirrored devices

### DIFF
--- a/libs/librepcb/editor/project/cmd/cmddeviceinstanceeditall.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddeviceinstanceeditall.cpp
@@ -78,7 +78,13 @@ void CmdDeviceInstanceEditAll::translate(const Point& deltaPos,
 void CmdDeviceInstanceEditAll::setRotation(const Angle& angle,
                                            bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  rotate(angle - mDevEditCmd->mNewRotation, mDevEditCmd->mNewPos, immediate);
+  const Angle delta = mDevEditCmd->mNewMirrored
+      ? (mDevEditCmd->mNewRotation - angle)  // Mirrored -> inverted rotation!
+      : (angle - mDevEditCmd->mNewRotation);
+  mDevEditCmd->setRotation(angle, immediate);
+  foreach (CmdStrokeTextEdit* cmd, mTextEditCmds) {
+    cmd->rotate(delta, mDevEditCmd->mNewPos, immediate);
+  }
 }
 
 void CmdDeviceInstanceEditAll::rotate(const Angle& angle, const Point& center,


### PR DESCRIPTION
When manually entering a new rotation value for a device in the device properties dialog, the a wrong rotation was applied for mirrored (bottom side) devices. Only for non-mirrored (top side) devices the rotation worked properly.

Fixed by considering the inverted rotation behavior for mirrored devices in the corresponding undo command.