### PR TITLE
AddComponentDialog: Fix placement of "Add more" checkbox

### DIFF
--- a/libs/librepcb/editor/project/addcomponentdialog.cpp
+++ b/libs/librepcb/editor/project/addcomponentdialog.cpp
@@ -61,7 +61,6 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
     mLocaleOrder(localeOrder),
     mNormOrder(normOrder),
     mUi(new Ui::AddComponentDialog),
-    mAddMoreCheckbox(new QCheckBox(tr("&Add more"), this)),
     mComponentPreviewScene(new GraphicsScene()),
     mDevicePreviewScene(new GraphicsScene()),
     mGraphicsLayerProvider(new DefaultGraphicsLayerProvider()),
@@ -104,19 +103,12 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
           &QItemSelectionModel::currentChanged, this,
           &AddComponentDialog::treeCategories_currentItemChanged);
 
-  // Add "Add more"-checkbox to button group.
-  mAddMoreCheckbox->setObjectName("cbxAddMore");  // For automated tests.
-  mAddMoreCheckbox->setToolTip(
-      tr("If checked, this dialog will automatically be opened again after "
-         "finishing placement of the current component."));
-  mUi->buttonBox->addButton(mAddMoreCheckbox, QDialogButtonBox::ActionRole);
-
   // Reset GUI to state of nothing selected.
   setSelectedComponent(nullptr);
 
   // Restore client settings.
   QSettings clientSettings;
-  mAddMoreCheckbox->setChecked(
+  mUi->cbxAddMore->setChecked(
       clientSettings
           .value("schematic_editor/add_component_dialog/add_more", true)
           .toBool());
@@ -132,7 +124,7 @@ AddComponentDialog::~AddComponentDialog() noexcept {
   // Save client settings.
   QSettings clientSettings;
   clientSettings.setValue("schematic_editor/add_component_dialog/add_more",
-                          mAddMoreCheckbox->isChecked());
+                          mUi->cbxAddMore->isChecked());
   clientSettings.setValue("schematic_editor/add_component_dialog/window_size",
                           size());
 }
@@ -173,8 +165,7 @@ tl::optional<Uuid> AddComponentDialog::getSelectedDeviceUuid() const noexcept {
 }
 
 bool AddComponentDialog::getAutoOpenAgain() const noexcept {
-  Q_ASSERT(mAddMoreCheckbox);
-  return mAddMoreCheckbox->isChecked();
+  return mUi->cbxAddMore->isChecked();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/addcomponentdialog.h
+++ b/libs/librepcb/editor/project/addcomponentdialog.h
@@ -135,7 +135,6 @@ private:
   QStringList mLocaleOrder;
   QStringList mNormOrder;
   QScopedPointer<Ui::AddComponentDialog> mUi;
-  QPointer<QCheckBox> mAddMoreCheckbox;
   QScopedPointer<GraphicsScene> mComponentPreviewScene;
   QScopedPointer<GraphicsScene> mDevicePreviewScene;
   QScopedPointer<DefaultGraphicsLayerProvider> mGraphicsLayerProvider;

--- a/libs/librepcb/editor/project/addcomponentdialog.ui
+++ b/libs/librepcb/editor/project/addcomponentdialog.ui
@@ -154,14 +154,53 @@
     </widget>
    </item>
    <item row="4" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbxAddMore">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>If checked, this dialog will automatically be opened again after finishing placement of the current component.</string>
+       </property>
+       <property name="text">
+        <string>&amp;Add more</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -175,6 +214,9 @@
  <tabstops>
   <tabstop>edtSearch</tabstop>
   <tabstop>treeCategories</tabstop>
+  <tabstop>treeComponents</tabstop>
+  <tabstop>cbxAddMore</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/tests/unittests/editor/project/addcomponentdialogtest.cpp
+++ b/tests/unittests/editor/project/addcomponentdialogtest.cpp
@@ -103,8 +103,7 @@ TEST_F(AddComponentDialogTest, testAddMore) {
     AddComponentDialog dialog(*mWsDb, {}, {});
 
     // Check the default value.
-    QCheckBox& cbx =
-        TestHelpers::getChild<QCheckBox>(dialog, "buttonBox/cbxAddMore");
+    QCheckBox& cbx = TestHelpers::getChild<QCheckBox>(dialog, "cbxAddMore");
     EXPECT_EQ(defaultValue, cbx.isChecked());
     EXPECT_EQ(defaultValue, dialog.getAutoOpenAgain());
 
@@ -116,8 +115,7 @@ TEST_F(AddComponentDialogTest, testAddMore) {
   // Check if the setting is saved and restored automatically.
   {
     AddComponentDialog dialog(*mWsDb, {}, {});
-    QCheckBox& cbx =
-        TestHelpers::getChild<QCheckBox>(dialog, "buttonBox/cbxAddMore");
+    QCheckBox& cbx = TestHelpers::getChild<QCheckBox>(dialog, "cbxAddMore");
     EXPECT_EQ(newValue, cbx.isChecked());
     EXPECT_EQ(newValue, dialog.getAutoOpenAgain());
   }


### PR DESCRIPTION
The "Add more" checkbox (introduced in #951) placement position was managed by `QDialogButtonBox` and was therefore depending on the operating system. On Windows, it was placed between the "Ok" and "Cancel" buttons, which is very strange.

Now managing the layout manually with `QLayout` to ensure the checkbox is always on the left side of both buttons.