### PR TITLE
Control panel: Fix UX flaws due to blocking UI when opening project

### DIFF
--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -326,7 +326,12 @@ ProjectEditor* ControlPanel::openProject(const FilePath& filepath) noexcept {
       connect(editor, &ProjectEditor::openProjectLibraryUpdaterClicked, this,
               &ControlPanel::openProjectLibraryUpdater);
       mOpenProjectEditors.insert(filepath.toUnique().toStr(), editor);
-      mRecentProjectsModel->setLastRecentProject(filepath);
+
+      // Delay updating the last opened project to avoid an issue when
+      // double-clicking: https://github.com/LibrePCB/LibrePCB/issues/293
+      QTimer::singleShot(500, this, [this, filepath]() {
+        mRecentProjectsModel->setLastRecentProject(filepath);
+      });
     }
     editor->showAllRequiredEditors();
     return editor;

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -43,6 +43,7 @@
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/library/library.h>
 #include <librepcb/core/project/project.h>
+#include <librepcb/core/utils/scopeguard.h>
 #include <librepcb/core/workspace/workspace.h>
 #include <librepcb/core/workspace/workspacelibrarydb.h>
 #include <librepcb/core/workspace/workspacesettings.h>
@@ -311,6 +312,11 @@ ProjectEditor* ControlPanel::openProject(const FilePath& filepath) noexcept {
   try {
     ProjectEditor* editor = getOpenProject(filepath);
     if (!editor) {
+      // Opening the project can take some time, use wait cursor to provide
+      // immediate UI feedback.
+      setCursor(Qt::WaitCursor);
+      auto cursorScopeGuard = scopeGuard([this]() { unsetCursor(); });
+
       std::shared_ptr<TransactionalFileSystem> fs =
           TransactionalFileSystem::openRW(
               filepath.getParentDir(), &askForRestoringBackup,


### PR DESCRIPTION
- Fix opening 2 projects when double-clicking on a recent project (see #293). This is done by delaying the update of `QListView` by 500ms (a bit ugly, but fixes the problem and doesn't really matter since during this delayed update, the ControlPanel is in background anyway since a project was just opened).
- Set "wait cursor" while opening project - when clicking on a project, this gives immediate feedback that the application is busy with loading the project. The cursor is reset to normal once the project is fully opened.

Fixes #293.
