### PR TITLE
DXF Import: Support joining tangent polylines

### DIFF
--- a/libs/librepcb/editor/dialogs/dxfimportdialog.cpp
+++ b/libs/librepcb/editor/dialogs/dxfimportdialog.cpp
@@ -70,9 +70,6 @@ DxfImportDialog::DxfImportDialog(QList<GraphicsLayer*> layers,
     mUi->cbxLayer->setCurrentLayer(GraphicsLayerName(
         clientSettings.value(settingsPrefix % "/layer", *defaultLayer)
             .toString()));
-    mUi->cbxCirclesAsDrills->setChecked(
-        clientSettings.value(settingsPrefix % "/circles_as_drills", false)
-            .toBool());
     mUi->edtLineWidth->setValue(UnsignedLength(Length::fromMm(
         clientSettings.value(settingsPrefix % "/line_width", "0").toString())));
     mUi->spbxScaleFactor->setValue(
@@ -84,6 +81,12 @@ DxfImportDialog::DxfImportDialog(QList<GraphicsLayer*> layers,
         clientSettings.value(settingsPrefix % "/pos_x", "0").toString()));
     mUi->edtPosY->setValue(Length::fromMm(
         clientSettings.value(settingsPrefix % "/pos_y", "0").toString()));
+    mUi->cbxJoinTangentPolylines->setChecked(
+        clientSettings.value(settingsPrefix % "/join_tangent_polylines", true)
+            .toBool());
+    mUi->cbxCirclesAsDrills->setChecked(
+        clientSettings.value(settingsPrefix % "/circles_as_drills", false)
+            .toBool());
     restoreGeometry(clientSettings.value(settingsPrefix % "/window_geometry")
                         .toByteArray());
   } catch (const Exception& e) {
@@ -97,8 +100,6 @@ DxfImportDialog::~DxfImportDialog() noexcept {
   if (auto layerName = mUi->cbxLayer->getCurrentLayerName()) {
     clientSettings.setValue(mSettingsPrefix % "/layer", **layerName);
   }
-  clientSettings.setValue(mSettingsPrefix % "/circles_as_drills",
-                          mUi->cbxCirclesAsDrills->isChecked());
   clientSettings.setValue(mSettingsPrefix % "/line_width",
                           mUi->edtLineWidth->getValue()->toMmString());
   clientSettings.setValue(mSettingsPrefix % "/scale_factor",
@@ -109,6 +110,10 @@ DxfImportDialog::~DxfImportDialog() noexcept {
                           mUi->edtPosX->getValue().toMmString());
   clientSettings.setValue(mSettingsPrefix % "/pos_y",
                           mUi->edtPosY->getValue().toMmString());
+  clientSettings.setValue(mSettingsPrefix % "/join_tangent_polylines",
+                          mUi->cbxJoinTangentPolylines->isChecked());
+  clientSettings.setValue(mSettingsPrefix % "/circles_as_drills",
+                          mUi->cbxCirclesAsDrills->isChecked());
   clientSettings.setValue(mSettingsPrefix % "/window_geometry", saveGeometry());
 }
 
@@ -122,10 +127,6 @@ GraphicsLayerName DxfImportDialog::getLayerName() const noexcept {
   } else {
     return mDefaultLayer;
   }
-}
-
-bool DxfImportDialog::getImportCirclesAsDrills() const noexcept {
-  return mUi->cbxCirclesAsDrills->isChecked();
 }
 
 UnsignedLength DxfImportDialog::getLineWidth() const noexcept {
@@ -142,6 +143,14 @@ tl::optional<Point> DxfImportDialog::getPlacementPosition() const noexcept {
   } else {
     return Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue());
   }
+}
+
+bool DxfImportDialog::getJoinTangentPolylines() const noexcept {
+  return mUi->cbxJoinTangentPolylines->isChecked();
+}
+
+bool DxfImportDialog::getImportCirclesAsDrills() const noexcept {
+  return mUi->cbxCirclesAsDrills->isChecked();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/dialogs/dxfimportdialog.h
+++ b/libs/librepcb/editor/dialogs/dxfimportdialog.h
@@ -70,10 +70,11 @@ public:
 
   // Getters
   GraphicsLayerName getLayerName() const noexcept;
-  bool getImportCirclesAsDrills() const noexcept;
   UnsignedLength getLineWidth() const noexcept;
   qreal getScaleFactor() const noexcept;
   tl::optional<Point> getPlacementPosition() const noexcept;
+  bool getJoinTangentPolylines() const noexcept;
+  bool getImportCirclesAsDrills() const noexcept;
 
   // General Methods
   FilePath chooseFile() const noexcept;

--- a/libs/librepcb/editor/dialogs/dxfimportdialog.ui
+++ b/libs/librepcb/editor/dialogs/dxfimportdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>339</width>
-    <height>212</height>
+    <height>250</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,46 +30,55 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="cbxCirclesAsDrills">
-       <property name="toolTip">
-        <string>If checked, circles will be imported as drills.
-If unchecked (the default), circles will be imported as polygons.</string>
-       </property>
-       <property name="text">
-        <string>Import circles as drills</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Line width:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <widget class="librepcb::editor::UnsignedLengthEdit" name="edtLineWidth" native="true">
        <property name="toolTip">
         <string>The line width to set on the imported objects.</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Scale factor:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="2" column="1">
+      <widget class="librepcb::editor::DoubleSpinBox" name="spbxScaleFactor">
+       <property name="toolTip">
+        <string>Additional scale factor, in case the DXF is not scaled properly.
+Note: If you have issues with scaling, make sure to configure the measuring unit of the DXF in your MCAD.</string>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>10000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Position:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="cbxInteractivePlacement">
        <property name="toolTip">
         <string>If checked (the default), you can interactively place the imported objects by cursor.
@@ -80,7 +89,7 @@ If unchecked, you need to specify exact coordinates where the point (0,0) of the
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true">
@@ -98,23 +107,32 @@ If unchecked, you need to specify exact coordinates where the point (0,0) of the
        </item>
       </layout>
      </item>
-     <item row="3" column="1">
-      <widget class="librepcb::editor::DoubleSpinBox" name="spbxScaleFactor">
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Options:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="cbxJoinTangentPolylines">
        <property name="toolTip">
-        <string>Additional scale factor, in case the DXF is not scaled properly.
-Note: If you have issues with scaling, make sure to configure the measuring unit of the DXF in your MCAD.</string>
+        <string>If checked, tangent polylines of the DXF will be joined together.
+Helps for example to avoid invalid board outline polygons.</string>
        </property>
-       <property name="buttonSymbols">
-        <enum>QAbstractSpinBox::NoButtons</enum>
+       <property name="text">
+        <string>Join tangent polylines</string>
        </property>
-       <property name="decimals">
-        <number>6</number>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="cbxCirclesAsDrills">
+       <property name="toolTip">
+        <string>If checked, circles will be imported as drills.
+If unchecked (the default), circles will be imported as polygons.</string>
        </property>
-       <property name="maximum">
-        <double>10000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
+       <property name="text">
+        <string>Import circles as drills</string>
        </property>
       </widget>
      </item>
@@ -172,13 +190,14 @@ Note: If you have issues with scaling, make sure to configure the measuring unit
  </customwidgets>
  <tabstops>
   <tabstop>cbxLayer</tabstop>
-  <tabstop>cbxCirclesAsDrills</tabstop>
   <tabstop>spbxScaleFactor</tabstop>
   <tabstop>edtLineWidth</tabstop>
   <tabstop>spbxScaleFactor</tabstop>
   <tabstop>cbxInteractivePlacement</tabstop>
   <tabstop>edtPosX</tabstop>
   <tabstop>edtPosY</tabstop>
+  <tabstop>cbxJoinTangentPolylines</tabstop>
+  <tabstop>cbxCirclesAsDrills</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/tests/unittests/editor/dialogs/dxfimportdialogtest.cpp
+++ b/tests/unittests/editor/dialogs/dxfimportdialogtest.cpp
@@ -141,6 +141,36 @@ TEST_F(DxfImportDialogTest, testCirclesAsDrills) {
   }
 }
 
+TEST_F(DxfImportDialogTest, testJoinTangentPolylines) {
+  const bool defaultValue = true;
+  const bool newValue = false;
+
+  {
+    DxfImportDialog dialog(mLayers, GraphicsLayerName(mLayers[0]->getName()),
+                           true, LengthUnit::millimeters(), "test");
+
+    // Check the default value.
+    QCheckBox& cbx =
+        TestHelpers::getChild<QCheckBox>(dialog, "cbxJoinTangentPolylines");
+    EXPECT_EQ(defaultValue, cbx.isChecked());
+    EXPECT_EQ(defaultValue, dialog.getJoinTangentPolylines());
+
+    // Check if the value can be changed.
+    cbx.setChecked(newValue);
+    EXPECT_EQ(newValue, dialog.getImportCirclesAsDrills());
+  }
+
+  // Check if the setting is saved and restored automatically.
+  {
+    DxfImportDialog dialog(mLayers, GraphicsLayerName(mLayers[0]->getName()),
+                           true, LengthUnit::millimeters(), "test");
+    QCheckBox& cbx =
+        TestHelpers::getChild<QCheckBox>(dialog, "cbxJoinTangentPolylines");
+    EXPECT_EQ(newValue, cbx.isChecked());
+    EXPECT_EQ(newValue, dialog.getJoinTangentPolylines());
+  }
+}
+
 TEST_F(DxfImportDialogTest, testLineWidth) {
   const UnsignedLength defaultValue(0);
   const UnsignedLength newValue(1230000);


### PR DESCRIPTION
Often DXF files contain multiple straight lines which are tangent instead of a single polyline consisting of multiple segments. When importing such DXF files, it sometimes causes problems. Especially board outlines will not work properly if it's not a single, closed polygon.

Now the DXF import dialog provides an option "Join tangent polylines". If checked (the default), tangent lines will automatically be joined and converted to polygons. This reduces the risk to import invalid board outlines.

![image](https://user-images.githubusercontent.com/5374821/157989005-723ca329-1643-4d40-8f5c-f5ac2d149524.png)
