### PR TITLE
Fix half-filled plane if outline is not a closed path

### DIFF
--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -84,8 +84,8 @@ QVector<Path> BoardPlaneFragmentsBuilder::buildFragments() noexcept {
  ******************************************************************************/
 
 void BoardPlaneFragmentsBuilder::addPlaneOutline() {
-  mResult.push_back(
-      ClipperHelpers::convert(mPlane.getOutline(), maxArcTolerance()));
+  mResult.push_back(ClipperHelpers::convert(mPlane.getOutline().toClosedPath(),
+                                            maxArcTolerance()));
 }
 
 void BoardPlaneFragmentsBuilder::clipToBoardOutline() {


### PR DESCRIPTION
Non-closed plane outlines (i.e. last vertex position != first vertex position) make no sense so lat's implicitly consider them as closed paths. This way they are filled properly even if the outline is not a closed path.

Fixes #948.