### PR TITLE
Board editor: Fix tooltips for invisible items

### DIFF
--- a/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../../graphics/graphicslayer.h"
 #include "bgi_base.h"
 
 #include <QtCore>
@@ -35,7 +36,6 @@ namespace librepcb {
 
 class BI_FootprintPad;
 class FootprintPad;
-class GraphicsLayer;
 class PackagePad;
 
 /*******************************************************************************
@@ -68,10 +68,15 @@ public:
   // Operator Overloadings
   BGI_FootprintPad& operator=(const BGI_FootprintPad& rhs) = delete;
 
-private:
-  // Private Methods
+private:  // Methods
   GraphicsLayer* getLayer(QString name) const noexcept;
+  void connectLayerEditedSlots() noexcept;
+  void disconnectLayerEditedSlots() noexcept;
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
+  void updateVisibility() noexcept;
 
+private:  // Data
   // General Attributes
   BI_FootprintPad& mPad;
   const FootprintPad& mLibPad;
@@ -88,6 +93,9 @@ private:
   QPainterPath mCreamMask;
   QRectF mBoundingRect;
   QFont mFont;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_netline.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_netline.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../../graphics/graphicslayer.h"
 #include "bgi_base.h"
 
 #include <QtCore>
@@ -34,7 +35,6 @@
 namespace librepcb {
 
 class BI_NetLine;
-class GraphicsLayer;
 
 /*******************************************************************************
  *  Class BGI_NetLine
@@ -66,10 +66,13 @@ public:
   // Operator Overloadings
   BGI_NetLine& operator=(const BGI_NetLine& rhs) = delete;
 
-private:
-  // Private Methods
+private:  // Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
+  void updateVisibility() noexcept;
 
+private:  // Data
   // Attributes
   BI_NetLine& mNetLine;
   GraphicsLayer* mLayer;
@@ -78,6 +81,9 @@ private:
   QLineF mLineF;
   QRectF mBoundingRect;
   QPainterPath mShape;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_netpoint.cpp
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_netpoint.cpp
@@ -43,7 +43,10 @@ namespace librepcb {
  ******************************************************************************/
 
 BGI_NetPoint::BGI_NetPoint(BI_NetPoint& netpoint) noexcept
-  : BGI_Base(), mNetPoint(netpoint) {
+  : BGI_Base(),
+    mNetPoint(netpoint),
+    mLayer(nullptr),
+    mOnLayerEditedSlot(*this, &BGI_NetPoint::layerEdited) {
   updateCacheAndRepaint();
 }
 
@@ -55,8 +58,7 @@ BGI_NetPoint::~BGI_NetPoint() noexcept {
  ******************************************************************************/
 
 bool BGI_NetPoint::isSelectable() const noexcept {
-  GraphicsLayer* layer = mNetPoint.getLayerOfLines();
-  return layer ? layer->isVisible() : false;
+  return mLayer && mLayer->isVisible();
 }
 
 /*******************************************************************************
@@ -71,6 +73,16 @@ void BGI_NetPoint::updateCacheAndRepaint() noexcept {
   // set Z value
   GraphicsLayer* layer = mNetPoint.getLayerOfLines();
   setZValue(layer ? getZValueOfCopperLayer(layer->getName()) : 0);
+
+  // set layer
+  if (mLayer) {
+    mLayer->onEdited.detach(mOnLayerEditedSlot);
+  }
+  mLayer = mNetPoint.getLayerOfLines();
+  if (mLayer) {
+    mLayer->onEdited.attach(mOnLayerEditedSlot);
+  }
+  updateVisibility();
 
   qreal radius = mNetPoint.getMaxLineWidth()->toPx() / 2;
   mBoundingRect = QRectF(-radius, -radius, 2 * radius, 2 * radius);
@@ -114,6 +126,30 @@ void BGI_NetPoint::paint(QPainter* painter,
 
 GraphicsLayer* BGI_NetPoint::getLayer(const QString& name) const noexcept {
   return mNetPoint.getBoard().getLayerStack().getLayer(name);
+}
+
+void BGI_NetPoint::layerEdited(const GraphicsLayer& layer,
+                               GraphicsLayer::Event event) noexcept {
+  Q_UNUSED(layer);
+
+  switch (event) {
+    case GraphicsLayer::Event::ColorChanged:
+      update();
+      break;
+    case GraphicsLayer::Event::HighlightColorChanged:
+      update();
+      break;
+    case GraphicsLayer::Event::VisibleChanged:
+    case GraphicsLayer::Event::EnabledChanged:
+      updateVisibility();
+      break;
+    default:
+      break;
+  }
+}
+
+void BGI_NetPoint::updateVisibility() noexcept {
+  setVisible(mLayer && mLayer->isVisible());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_netpoint.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_netpoint.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../../graphics/graphicslayer.h"
 #include "bgi_base.h"
 
 #include <QtCore>
@@ -34,7 +35,6 @@
 namespace librepcb {
 
 class BI_NetPoint;
-class GraphicsLayer;
 
 /*******************************************************************************
  *  Class BGI_NetPoint
@@ -65,15 +65,22 @@ public:
   // Operator Overloadings
   BGI_NetPoint& operator=(const BGI_NetPoint& rhs) = delete;
 
-private:
-  // Private Methods
+private:  // Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
+  void updateVisibility() noexcept;
 
+private:  // Data
   // General Attributes
   BI_NetPoint& mNetPoint;
+  GraphicsLayer* mLayer;
 
   // Cached Attributes
   QRectF mBoundingRect;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_plane.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_plane.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../../graphics/graphicslayer.h"
 #include "bgi_base.h"
 
 #include <QtCore>
@@ -34,7 +35,6 @@
 namespace librepcb {
 
 class BI_Plane;
-class GraphicsLayer;
 class Path;
 class Polygon;
 
@@ -83,10 +83,13 @@ public:
   // Operator Overloadings
   BGI_Plane& operator=(const BGI_Plane& rhs) = delete;
 
-private:
-  // Private Methods
-  GraphicsLayer* getLayer(QString name) const noexcept;
+private:  // Methods
+  GraphicsLayer* getLayer(const QString& name) const noexcept;
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
+  void updateVisibility() noexcept;
 
+private:  // Data
   // General Attributes
   BI_Plane& mPlane;
 
@@ -98,6 +101,9 @@ private:
   QVector<QPainterPath> mAreas;
   qreal mLineWidthPx;
   qreal mVertexRadiusPx;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_via.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_via.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../../graphics/graphicslayer.h"
 #include "bgi_base.h"
 
 #include <QtCore>
@@ -34,7 +35,6 @@
 namespace librepcb {
 
 class BI_Via;
-class GraphicsLayer;
 
 /*******************************************************************************
  *  Class BGI_Via
@@ -66,10 +66,15 @@ public:
   // Operator Overloadings
   BGI_Via& operator=(const BGI_Via& rhs) = delete;
 
-private:
-  // Private Methods
+private:  // Methods
   GraphicsLayer* getLayer(const QString& name) const noexcept;
+  void connectLayerEditedSlots() noexcept;
+  void disconnectLayerEditedSlots() noexcept;
+  void layerEdited(const GraphicsLayer& layer,
+                   GraphicsLayer::Event event) noexcept;
+  void updateVisibility() noexcept;
 
+private:  // Data
   // General Attributes
   BI_Via& mVia;
   GraphicsLayer* mViaLayer;
@@ -84,6 +89,9 @@ private:
   QPainterPath mCreamMask;
   QRectF mBoundingRect;
   QFont mFont;
+
+  // Slots
+  GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
The tooltip of footprint pads, vias and traces were shown on hover even if the item was actually not visible (layer disabled), which is strange. Now `QGraphicsItem::setVisible()` is called to ensure the tooltips are only enabled if the item is visible.

Fixes #938