### PR TITLE
Board editor: Avoid creating vias with drill>size

### DIFF
--- a/libs/librepcb/core/geometry/via.cpp
+++ b/libs/librepcb/core/geometry/via.cpp
@@ -98,10 +98,12 @@ Path Via::getSceneOutline(const Length& expansion) const noexcept {
 }
 
 QPainterPath Via::toQPainterPathPx(const Length& expansion) const noexcept {
+  // Avoid creating inverted graphics if drill>size, since it looks correct.
+  PositiveLength drill = std::min(mDrillDiameter, mSize);
+
   QPainterPath p = getOutline(expansion).toQPainterPathPx();
-  p.setFillRule(Qt::OddEvenFill);  // important to subtract the hole!
-  p.addEllipse(QPointF(0, 0), mDrillDiameter->toPx() / 2,
-               mDrillDiameter->toPx() / 2);
+  p.setFillRule(Qt::OddEvenFill);  // Important to subtract the hole!
+  p.addEllipse(QPointF(0, 0), drill->toPx() / 2, drill->toPx() / 2);
   return p;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.cpp
@@ -65,6 +65,21 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &BoardViaPropertiesDialog::buttonBoxClicked);
 
+  // Avoid creating vias with a drill diameter larger than its size!
+  // See https://github.com/LibrePCB/LibrePCB/issues/946.
+  connect(mUi->edtSize, &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value < mUi->edtDrillDiameter->getValue()) {
+              mUi->edtDrillDiameter->setValue(value);
+            }
+          });
+  connect(mUi->edtDrillDiameter, &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value > mUi->edtSize->getValue()) {
+              mUi->edtSize->setValue(value);
+            }
+          });
+
   // shape combobox
   mUi->cbxShape->addItem(tr("Round"), static_cast<int>(Via::Shape::Round));
   mUi->cbxShape->addItem(tr("Square"), static_cast<int>(Via::Shape::Square));

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -176,6 +176,21 @@ bool BoardEditorState_AddVia::entry() noexcept {
       this, &BoardEditorState_AddVia::applySelectedNetSignal,
       Qt::QueuedConnection);
 
+  // Avoid creating vias with a drill diameter larger than its size!
+  // See https://github.com/LibrePCB/LibrePCB/issues/946.
+  connect(mSizeEdit.data(), &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value < mDrillEdit->getValue()) {
+              mDrillEdit->setValue(value);
+            }
+          });
+  connect(mDrillEdit.data(), &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value > mSizeEdit->getValue()) {
+              mSizeEdit->setValue(value);
+            }
+          });
+
   return true;
 }
 


### PR DESCRIPTION
Automatically increase the via size or decrease the drill diameter to avoid creating vias with a drill diameter larger than the size:

![librepcb-via-size](https://user-images.githubusercontent.com/5374821/158078794-2668bcff-54d1-4383-9fe9-02f9460547f2.gif)

Fixes #946.