### PR TITLE
Save only modified workspace settings to file, keeping unknown settings

### DIFF
--- a/libs/librepcb/core/attribute/attribute.cpp
+++ b/libs/librepcb/core/attribute/attribute.cpp
@@ -113,13 +113,13 @@ bool Attribute::setTypeValueUnit(const AttributeType& type,
 void Attribute::serialize(SExpression& root) const {
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
   root.appendChild(mKey);
-  root.appendChild("type", *mType, false);
+  root.appendChild("type", *mType);
   if (mUnit) {
-    root.appendChild("unit", *mUnit, false);
+    root.appendChild("unit", *mUnit);
   } else {
-    root.appendChild("unit", SExpression::createToken("none"), false);
+    root.appendChild("unit", SExpression::createToken("none"));
   }
-  root.appendChild("value", mValue, false);
+  root.appendChild("value", mValue);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/core/fileio/transactionalfilesystem.cpp
@@ -446,19 +446,25 @@ void TransactionalFileSystem::saveDiff(const QString& type) const {
   }
 
   SExpression root = SExpression::createList("librepcb_" % type);
-  root.appendChild("created", dt, true);
-  root.appendChild("modified_files_directory", filesDir.getFilename(), true);
+  root.ensureLineBreak();
+  root.appendChild("created", dt);
+  root.ensureLineBreak();
+  root.appendChild("modified_files_directory", filesDir.getFilename());
   foreach (const QString& filepath, Toolbox::sorted(mModifiedFiles.keys())) {
-    root.appendChild("modified_file", filepath, true);
+    root.ensureLineBreak();
+    root.appendChild("modified_file", filepath);
     FileUtils::writeFile(filesDir.getPathTo(filepath),
                          mModifiedFiles.value(filepath));  // can throw
   }
   foreach (const QString& filepath, Toolbox::sorted(mRemovedFiles.values())) {
-    root.appendChild("removed_file", filepath, true);
+    root.ensureLineBreak();
+    root.appendChild("removed_file", filepath);
   }
   foreach (const QString& filepath, Toolbox::sorted(mRemovedDirs.values())) {
-    root.appendChild("removed_directory", filepath, true);
+    root.ensureLineBreak();
+    root.appendChild("removed_directory", filepath);
   }
+  root.ensureLineBreak();
 
   // Writing the main file must be the last operation to "mark" this diff as
   // complete!

--- a/libs/librepcb/core/geometry/circle.cpp
+++ b/libs/librepcb/core/geometry/circle.cpp
@@ -148,12 +148,14 @@ bool Circle::setDiameter(const PositiveLength& dia) noexcept {
 
 void Circle::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("layer", mLayerName, false);
-  root.appendChild("width", mLineWidth, true);
-  root.appendChild("fill", mIsFilled, false);
-  root.appendChild("grab_area", mIsGrabArea, false);
-  root.appendChild("diameter", mDiameter, false);
-  root.appendChild(mCenter.serializeToDomElement("position"), false);
+  root.appendChild("layer", mLayerName);
+  root.ensureLineBreak();
+  root.appendChild("width", mLineWidth);
+  root.appendChild("fill", mIsFilled);
+  root.appendChild("grab_area", mIsGrabArea);
+  root.appendChild("diameter", mDiameter);
+  root.appendChild(mCenter.serializeToDomElement("position"));
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/hole.cpp
+++ b/libs/librepcb/core/geometry/hole.cpp
@@ -90,8 +90,8 @@ bool Hole::setDiameter(const PositiveLength& diameter) noexcept {
 
 void Hole::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("diameter", mDiameter, false);
-  root.appendChild(mPosition.serializeToDomElement("position"), false);
+  root.appendChild("diameter", mDiameter);
+  root.appendChild(mPosition.serializeToDomElement("position"));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/junction.cpp
+++ b/libs/librepcb/core/geometry/junction.cpp
@@ -85,7 +85,7 @@ bool Junction::setPosition(const Point& position) noexcept {
 
 void Junction::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild(mPosition.serializeToDomElement("position"), false);
+  root.appendChild(mPosition.serializeToDomElement("position"));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/netlabel.cpp
+++ b/libs/librepcb/core/geometry/netlabel.cpp
@@ -121,9 +121,11 @@ bool NetLabel::setMirrored(const bool mirrored) noexcept {
 
 void NetLabel::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild(mPosition.serializeToDomElement("position"), true);
-  root.appendChild("rotation", mRotation, false);
-  root.appendChild("mirror", mMirrored, false);
+  root.ensureLineBreak();
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("rotation", mRotation);
+  root.appendChild("mirror", mMirrored);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/netline.cpp
+++ b/libs/librepcb/core/geometry/netline.cpp
@@ -58,10 +58,10 @@ NetLineAnchor::~NetLineAnchor() noexcept {
 
 void NetLineAnchor::serialize(SExpression& root) const {
   if (mJunction) {
-    root.appendChild("junction", *mJunction, false);
+    root.appendChild("junction", *mJunction);
   } else if (mPin) {
-    root.appendChild("symbol", mPin->symbol, false);
-    root.appendChild("pin", mPin->pin, false);
+    root.appendChild("symbol", mPin->symbol);
+    root.appendChild("pin", mPin->pin);
   } else {
     throw LogicError(__FILE__, __LINE__);
   }
@@ -168,9 +168,12 @@ bool NetLine::setEndPoint(const NetLineAnchor& end) noexcept {
 
 void NetLine::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("width", mWidth, false);
-  root.appendChild(mStart.serializeToDomElement("from"), true);
-  root.appendChild(mEnd.serializeToDomElement("to"), true);
+  root.appendChild("width", mWidth);
+  root.ensureLineBreak();
+  root.appendChild(mStart.serializeToDomElement("from"));
+  root.ensureLineBreak();
+  root.appendChild(mEnd.serializeToDomElement("to"));
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/polygon.cpp
+++ b/libs/librepcb/core/geometry/polygon.cpp
@@ -137,11 +137,14 @@ bool Polygon::setPath(const Path& path) noexcept {
 
 void Polygon::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("layer", mLayerName, false);
-  root.appendChild("width", mLineWidth, true);
-  root.appendChild("fill", mIsFilled, false);
-  root.appendChild("grab_area", mIsGrabArea, false);
+  root.appendChild("layer", mLayerName);
+  root.ensureLineBreak();
+  root.appendChild("width", mLineWidth);
+  root.appendChild("fill", mIsFilled);
+  root.appendChild("grab_area", mIsGrabArea);
+  root.ensureLineBreak();
   mPath.serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/stroketext.cpp
+++ b/libs/librepcb/core/geometry/stroketext.cpp
@@ -329,17 +329,21 @@ void StrokeText::updatePaths() noexcept {
 
 void StrokeText::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("layer", mLayerName, false);
-  root.appendChild("height", mHeight, true);
-  root.appendChild("stroke_width", mStrokeWidth, false);
-  root.appendChild("letter_spacing", mLetterSpacing, false);
-  root.appendChild("line_spacing", mLineSpacing, false);
-  root.appendChild(mAlign.serializeToDomElement("align"), true);
-  root.appendChild(mPosition.serializeToDomElement("position"), false);
-  root.appendChild("rotation", mRotation, false);
-  root.appendChild("auto_rotate", mAutoRotate, true);
-  root.appendChild("mirror", mMirrored, false);
-  root.appendChild("value", mText, false);
+  root.appendChild("layer", mLayerName);
+  root.ensureLineBreak();
+  root.appendChild("height", mHeight);
+  root.appendChild("stroke_width", mStrokeWidth);
+  root.appendChild("letter_spacing", mLetterSpacing);
+  root.appendChild("line_spacing", mLineSpacing);
+  root.ensureLineBreak();
+  root.appendChild(mAlign.serializeToDomElement("align"));
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("rotation", mRotation);
+  root.ensureLineBreak();
+  root.appendChild("auto_rotate", mAutoRotate);
+  root.appendChild("mirror", mMirrored);
+  root.appendChild("value", mText);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/text.cpp
+++ b/libs/librepcb/core/geometry/text.cpp
@@ -147,12 +147,14 @@ bool Text::setAlign(const Alignment& align) noexcept {
 
 void Text::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("layer", mLayerName, false);
-  root.appendChild("value", mText, false);
-  root.appendChild(mAlign.serializeToDomElement("align"), true);
-  root.appendChild("height", mHeight, false);
-  root.appendChild(mPosition.serializeToDomElement("position"), false);
-  root.appendChild("rotation", mRotation, false);
+  root.appendChild("layer", mLayerName);
+  root.appendChild("value", mText);
+  root.ensureLineBreak();
+  root.appendChild(mAlign.serializeToDomElement("align"));
+  root.appendChild("height", mHeight);
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("rotation", mRotation);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/trace.cpp
+++ b/libs/librepcb/core/geometry/trace.cpp
@@ -62,12 +62,12 @@ TraceAnchor::~TraceAnchor() noexcept {
 
 void TraceAnchor::serialize(SExpression& root) const {
   if (mJunction) {
-    root.appendChild("junction", *mJunction, false);
+    root.appendChild("junction", *mJunction);
   } else if (mVia) {
-    root.appendChild("via", *mVia, false);
+    root.appendChild("via", *mVia);
   } else if (mPad) {
-    root.appendChild("device", mPad->device, false);
-    root.appendChild("pad", mPad->pad, false);
+    root.appendChild("device", mPad->device);
+    root.appendChild("pad", mPad->pad);
   } else {
     throw LogicError(__FILE__, __LINE__);
   }
@@ -198,10 +198,13 @@ bool Trace::setEndPoint(const TraceAnchor& end) noexcept {
 
 void Trace::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("layer", SExpression::createToken(*mLayer), false);
-  root.appendChild("width", mWidth, false);
-  root.appendChild(mStart.serializeToDomElement("from"), true);
-  root.appendChild(mEnd.serializeToDomElement("to"), true);
+  root.appendChild("layer", SExpression::createToken(*mLayer));
+  root.appendChild("width", mWidth);
+  root.ensureLineBreak();
+  root.appendChild(mStart.serializeToDomElement("from"));
+  root.ensureLineBreak();
+  root.appendChild(mEnd.serializeToDomElement("to"));
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/vertex.cpp
+++ b/libs/librepcb/core/geometry/vertex.cpp
@@ -48,8 +48,8 @@ Vertex::Vertex(const SExpression& node, const Version& fileFormat) {
  ******************************************************************************/
 
 void Vertex::serialize(SExpression& root) const {
-  root.appendChild(mPos.serializeToDomElement("position"), false);
-  root.appendChild("angle", mAngle, false);
+  root.appendChild(mPos.serializeToDomElement("position"));
+  root.appendChild("angle", mAngle);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/via.cpp
+++ b/libs/librepcb/core/geometry/via.cpp
@@ -167,10 +167,12 @@ bool Via::setDrillDiameter(const PositiveLength& diameter) noexcept {
 
 void Via::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild(mPosition.serializeToDomElement("position"), true);
-  root.appendChild("size", mSize, false);
-  root.appendChild("drill", mDrillDiameter, false);
-  root.appendChild("shape", mShape, false);
+  root.ensureLineBreak();
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("size", mSize);
+  root.appendChild("drill", mDrillDiameter);
+  root.appendChild("shape", mShape);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/graphics/graphicslayerstackappearancesettings.cpp
+++ b/libs/librepcb/core/graphics/graphicslayerstackappearancesettings.cpp
@@ -75,12 +75,14 @@ GraphicsLayerStackAppearanceSettings::
 void GraphicsLayerStackAppearanceSettings::serialize(SExpression& root) const {
   for (const GraphicsLayer* layer : mLayers.getAllLayers()) {
     Q_ASSERT(layer);
-    SExpression& child = root.appendList("layer", true);
+    root.ensureLineBreak();
+    SExpression& child = root.appendList("layer");
     child.appendChild(SExpression::createToken(layer->getName()));
-    child.appendChild("color", layer->getColor(false), false);
-    child.appendChild("color_hl", layer->getColor(true), false);
-    child.appendChild("visible", layer->getVisible(), false);
+    child.appendChild("color", layer->getColor(false));
+    child.appendChild("color_hl", layer->getColor(true));
+    child.appendChild("visible", layer->getVisible());
   }
+  root.ensureLineBreakIfMultiLine();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -138,12 +138,19 @@ LibraryElementCheckMessageList Component::runChecks() const {
 
 void Component::serialize(SExpression& root) const {
   LibraryElement::serialize(root);
-  root.appendChild("schematic_only", mSchematicOnly, true);
-  root.appendChild("default_value", mDefaultValue, true);
+  root.ensureLineBreak();
+  root.appendChild("schematic_only", mSchematicOnly);
+  root.ensureLineBreak();
+  root.appendChild("default_value", mDefaultValue);
+  root.ensureLineBreak();
   mPrefixes.serialize(root);
+  root.ensureLineBreak();
   mAttributes.serialize(root);
+  root.ensureLineBreak();
   mSignals.serialize(root);
+  root.ensureLineBreak();
   mSymbolVariants.serialize(root);
+  root.ensureLineBreak();
 }
 
 QString Component::cleanNorm(QString norm) noexcept {

--- a/libs/librepcb/core/library/cmp/componentpinsignalmap.cpp
+++ b/libs/librepcb/core/library/cmp/componentpinsignalmap.cpp
@@ -94,8 +94,8 @@ bool ComponentPinSignalMapItem::setDisplayType(
 
 void ComponentPinSignalMapItem::serialize(SExpression& root) const {
   root.appendChild(mPinUuid);
-  root.appendChild("signal", mSignalUuid, false);
-  root.appendChild("text", mDisplayType, false);
+  root.appendChild("signal", mSignalUuid);
+  root.appendChild("text", mDisplayType);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/cmp/componentsignal.cpp
+++ b/libs/librepcb/core/library/cmp/componentsignal.cpp
@@ -144,12 +144,14 @@ bool ComponentSignal::setIsClock(bool clock) noexcept {
 
 void ComponentSignal::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("name", mName, false);
-  root.appendChild("role", mRole, false);
-  root.appendChild("required", mIsRequired, true);
-  root.appendChild("negated", mIsNegated, false);
-  root.appendChild("clock", mIsClock, false);
-  root.appendChild("forced_net", mForcedNetName, false);
+  root.appendChild("name", mName);
+  root.appendChild("role", mRole);
+  root.ensureLineBreak();
+  root.appendChild("required", mIsRequired);
+  root.appendChild("negated", mIsNegated);
+  root.appendChild("clock", mIsClock);
+  root.appendChild("forced_net", mForcedNetName);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/cmp/componentsymbolvariant.cpp
+++ b/libs/librepcb/core/library/cmp/componentsymbolvariant.cpp
@@ -138,10 +138,14 @@ bool ComponentSymbolVariant::setDescriptions(
 
 void ComponentSymbolVariant::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("norm", mNorm, false);
+  root.appendChild("norm", mNorm);
+  root.ensureLineBreak();
   mNames.serialize(root);
+  root.ensureLineBreak();
   mDescriptions.serialize(root);
+  root.ensureLineBreak();
   mSymbolItems.serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/cmp/componentsymbolvariantitem.cpp
+++ b/libs/librepcb/core/library/cmp/componentsymbolvariantitem.cpp
@@ -148,12 +148,16 @@ bool ComponentSymbolVariantItem::setSuffix(
 
 void ComponentSymbolVariantItem::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("symbol", mSymbolUuid, true);
-  root.appendChild(mSymbolPos.serializeToDomElement("position"), true);
-  root.appendChild("rotation", mSymbolRot, false);
-  root.appendChild("required", mIsRequired, false);
-  root.appendChild("suffix", mSuffix, false);
+  root.ensureLineBreak();
+  root.appendChild("symbol", mSymbolUuid);
+  root.ensureLineBreak();
+  root.appendChild(mSymbolPos.serializeToDomElement("position"));
+  root.appendChild("rotation", mSymbolRot);
+  root.appendChild("required", mIsRequired);
+  root.appendChild("suffix", mSuffix);
+  root.ensureLineBreak();
   mPinSignalMap.sortedByUuid().serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -94,10 +94,15 @@ LibraryElementCheckMessageList Device::runChecks() const {
 
 void Device::serialize(SExpression& root) const {
   LibraryElement::serialize(root);
-  root.appendChild("component", mComponentUuid, true);
-  root.appendChild("package", mPackageUuid, true);
+  root.ensureLineBreak();
+  root.appendChild("component", mComponentUuid);
+  root.ensureLineBreak();
+  root.appendChild("package", mPackageUuid);
+  root.ensureLineBreak();
   mAttributes.serialize(root);
+  root.ensureLineBreak();
   mPadSignalMap.sortedByUuid().serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/dev/devicepadsignalmap.cpp
+++ b/libs/librepcb/core/library/dev/devicepadsignalmap.cpp
@@ -75,7 +75,7 @@ bool DevicePadSignalMapItem::setSignalUuid(
 
 void DevicePadSignalMapItem::serialize(SExpression& root) const {
   root.appendChild(mPadUuid);
-  root.appendChild("signal", mSignalUuid, false);
+  root.appendChild("signal", mSignalUuid);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -172,10 +172,13 @@ template QStringList Library::searchForElements<Device>() const noexcept;
 
 void Library::serialize(SExpression& root) const {
   LibraryBaseElement::serialize(root);
-  root.appendChild("url", mUrl, true);
+  root.ensureLineBreak();
+  root.appendChild("url", mUrl);
   foreach (const Uuid& uuid, Toolbox::sortedQSet(mDependencies)) {
-    root.appendChild("dependency", uuid, true);
+    root.ensureLineBreak();
+    root.appendChild("dependency", uuid);
   }
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/librarybaseelement.cpp
+++ b/libs/librepcb/core/library/librarybaseelement.cpp
@@ -212,13 +212,21 @@ void LibraryBaseElement::cleanupAfterLoadingElementFromFile() noexcept {
 
 void LibraryBaseElement::serialize(SExpression& root) const {
   root.appendChild(mUuid);
+  root.ensureLineBreak();
   mNames.serialize(root);
+  root.ensureLineBreak();
   mDescriptions.serialize(root);
+  root.ensureLineBreak();
   mKeywords.serialize(root);
-  root.appendChild("author", mAuthor, true);
-  root.appendChild("version", mVersion, true);
-  root.appendChild("created", mCreated, true);
-  root.appendChild("deprecated", mIsDeprecated, true);
+  root.ensureLineBreak();
+  root.appendChild("author", mAuthor);
+  root.ensureLineBreak();
+  root.appendChild("version", mVersion);
+  root.ensureLineBreak();
+  root.appendChild("created", mCreated);
+  root.ensureLineBreak();
+  root.appendChild("deprecated", mIsDeprecated);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/libraryelement.cpp
+++ b/libs/librepcb/core/library/libraryelement.cpp
@@ -79,8 +79,10 @@ LibraryElementCheckMessageList LibraryElement::runChecks() const {
 void LibraryElement::serialize(SExpression& root) const {
   LibraryBaseElement::serialize(root);
   foreach (const Uuid& uuid, Toolbox::sortedQSet(mCategories)) {
-    root.appendChild("category", uuid, true);
+    root.ensureLineBreak();
+    root.appendChild("category", uuid);
   }
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/footprint.cpp
+++ b/libs/librepcb/core/library/pkg/footprint.cpp
@@ -148,13 +148,21 @@ void Footprint::unregisterGraphicsItem(FootprintGraphicsItem& item) noexcept {
 
 void Footprint::serialize(SExpression& root) const {
   root.appendChild(mUuid);
+  root.ensureLineBreak();
   mNames.serialize(root);
+  root.ensureLineBreak();
   mDescriptions.serialize(root);
+  root.ensureLineBreak();
   mPads.serialize(root);
+  root.ensureLineBreak();
   mPolygons.serialize(root);
+  root.ensureLineBreak();
   mCircles.serialize(root);
+  root.ensureLineBreak();
   mStrokeTexts.serialize(root);
+  root.ensureLineBreak();
   mHoles.serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpad.cpp
@@ -282,14 +282,16 @@ void FootprintPad::unregisterGraphicsItem(
 
 void FootprintPad::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("side", mBoardSide, false);
-  root.appendChild("shape", mShape, false);
-  root.appendChild(mPosition.serializeToDomElement("position"), true);
-  root.appendChild("rotation", mRotation, false);
-  root.appendChild(Point(*mWidth, *mHeight).serializeToDomElement("size"),
-                   false);
-  root.appendChild("drill", mDrillDiameter, false);
-  root.appendChild("package_pad", mPackagePadUuid, true);
+  root.appendChild("side", mBoardSide);
+  root.appendChild("shape", mShape);
+  root.ensureLineBreak();
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("rotation", mRotation);
+  root.appendChild(Point(*mWidth, *mHeight).serializeToDomElement("size"));
+  root.appendChild("drill", mDrillDiameter);
+  root.ensureLineBreak();
+  root.appendChild("package_pad", mPackagePadUuid);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -71,8 +71,11 @@ LibraryElementCheckMessageList Package::runChecks() const {
 
 void Package::serialize(SExpression& root) const {
   LibraryElement::serialize(root);
+  root.ensureLineBreak();
   mPads.serialize(root);
+  root.ensureLineBreak();
   mFootprints.serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/packagepad.cpp
+++ b/libs/librepcb/core/library/pkg/packagepad.cpp
@@ -71,7 +71,7 @@ bool PackagePad::setName(const CircuitIdentifier& name) noexcept {
 
 void PackagePad::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("name", mName, false);
+  root.appendChild("name", mName);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -195,10 +195,15 @@ void Symbol::textsEdited(const TextList& list, int index,
 
 void Symbol::serialize(SExpression& root) const {
   LibraryElement::serialize(root);
+  root.ensureLineBreak();
   mPins.serialize(root);
+  root.ensureLineBreak();
   mPolygons.serialize(root);
+  root.ensureLineBreak();
   mCircles.serialize(root);
+  root.ensureLineBreak();
   mTexts.serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/sym/symbolpin.cpp
+++ b/libs/librepcb/core/library/sym/symbolpin.cpp
@@ -136,10 +136,12 @@ void SymbolPin::unregisterGraphicsItem(SymbolPinGraphicsItem& item) noexcept {
 
 void SymbolPin::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("name", mName, false);
-  root.appendChild(mPosition.serializeToDomElement("position"), true);
-  root.appendChild("rotation", mRotation, false);
-  root.appendChild("length", mLength, false);
+  root.appendChild("name", mName);
+  root.ensureLineBreak();
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("rotation", mRotation);
+  root.appendChild("length", mLength);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -1007,27 +1007,32 @@ void Board::updateIcon() noexcept {
 
 void Board::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("name", mName, true);
-  root.appendChild("default_font", mDefaultFontFileName, true);
-  root.appendChild(mGridProperties->serializeToDomElement("grid"), true);
-  root.appendChild(mLayerStack->serializeToDomElement("layers"), true);
-  root.appendChild(mDesignRules->serializeToDomElement("design_rules"), true);
+  root.ensureLineBreak();
+  root.appendChild("name", mName);
+  root.ensureLineBreak();
+  root.appendChild("default_font", mDefaultFontFileName);
+  root.ensureLineBreak();
+  root.appendChild(mGridProperties->serializeToDomElement("grid"));
+  root.ensureLineBreak();
+  root.appendChild(mLayerStack->serializeToDomElement("layers"));
+  root.ensureLineBreak();
+  root.appendChild(mDesignRules->serializeToDomElement("design_rules"));
+  root.ensureLineBreak();
   root.appendChild(mFabricationOutputSettings->serializeToDomElement(
-                       "fabrication_output_settings"),
-                   true);
-  root.appendLineBreak();
+      "fabrication_output_settings"));
+  root.ensureEmptyLine();
   serializePointerContainer(root, mDeviceInstances, "device");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mNetSegments, "netsegment");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mPlanes, "plane");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mPolygons, "polygon");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mStrokeTexts, "stroke_text");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mHoles, "hole");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
 }
 
 void Board::updateErcMessages() noexcept {

--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -198,25 +198,41 @@ void BoardDesignRules::restoreDefaults() noexcept {
 
 void BoardDesignRules::serialize(SExpression& root) const {
   // general attributes
-  root.appendChild("name", mName, true);
-  root.appendChild("description", mDescription, true);
+  root.ensureLineBreak();
+  root.appendChild("name", mName);
+  root.ensureLineBreak();
+  root.appendChild("description", mDescription);
+  root.ensureLineBreak();
   // stop mask
-  root.appendChild("stopmask_clearance_ratio", mStopMaskClearanceRatio, true);
-  root.appendChild("stopmask_clearance_min", mStopMaskClearanceMin, true);
-  root.appendChild("stopmask_clearance_max", mStopMaskClearanceMax, true);
+  root.appendChild("stopmask_clearance_ratio", mStopMaskClearanceRatio);
+  root.ensureLineBreak();
+  root.appendChild("stopmask_clearance_min", mStopMaskClearanceMin);
+  root.ensureLineBreak();
+  root.appendChild("stopmask_clearance_max", mStopMaskClearanceMax);
+  root.ensureLineBreak();
   root.appendChild("stopmask_max_via_drill_diameter",
-                   mStopMaskMaxViaDrillDiameter, true);
+                   mStopMaskMaxViaDrillDiameter);
+  root.ensureLineBreak();
   // cream mask
-  root.appendChild("creammask_clearance_ratio", mCreamMaskClearanceRatio, true);
-  root.appendChild("creammask_clearance_min", mCreamMaskClearanceMin, true);
-  root.appendChild("creammask_clearance_max", mCreamMaskClearanceMax, true);
+  root.appendChild("creammask_clearance_ratio", mCreamMaskClearanceRatio);
+  root.ensureLineBreak();
+  root.appendChild("creammask_clearance_min", mCreamMaskClearanceMin);
+  root.ensureLineBreak();
+  root.appendChild("creammask_clearance_max", mCreamMaskClearanceMax);
+  root.ensureLineBreak();
   // restring
-  root.appendChild("restring_pad_ratio", mRestringPadRatio, true);
-  root.appendChild("restring_pad_min", mRestringPadMin, true);
-  root.appendChild("restring_pad_max", mRestringPadMax, true);
-  root.appendChild("restring_via_ratio", mRestringViaRatio, true);
-  root.appendChild("restring_via_min", mRestringViaMin, true);
-  root.appendChild("restring_via_max", mRestringViaMax, true);
+  root.appendChild("restring_pad_ratio", mRestringPadRatio);
+  root.ensureLineBreak();
+  root.appendChild("restring_pad_min", mRestringPadMin);
+  root.ensureLineBreak();
+  root.appendChild("restring_pad_max", mRestringPadMax);
+  root.ensureLineBreak();
+  root.appendChild("restring_via_ratio", mRestringViaRatio);
+  root.ensureLineBreak();
+  root.appendChild("restring_via_min", mRestringViaMin);
+  root.ensureLineBreak();
+  root.appendChild("restring_via_max", mRestringViaMax);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
+++ b/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
@@ -93,13 +93,15 @@ BoardFabricationOutputSettings::BoardFabricationOutputSettings(
 
   mSilkscreenLayersTop.clear();
   foreach (const SExpression& child,
-           node.getChild("silkscreen_top/layers").getChildren()) {
+           node.getChild("silkscreen_top/layers")
+               .getChildren(SExpression::Type::Token)) {
     mSilkscreenLayersTop.append(child.getValue());
   }
 
   mSilkscreenLayersBot.clear();
   foreach (const SExpression& child,
-           node.getChild("silkscreen_bot/layers").getChildren()) {
+           node.getChild("silkscreen_bot/layers")
+               .getChildren(SExpression::Type::Token)) {
     mSilkscreenLayersBot.append(child.getValue());
   }
 }
@@ -112,47 +114,62 @@ BoardFabricationOutputSettings::~BoardFabricationOutputSettings() noexcept {
  ******************************************************************************/
 
 void BoardFabricationOutputSettings::serialize(SExpression& root) const {
-  root.appendChild("base_path", mOutputBasePath, true);
-  root.appendList("outlines", true)
-      .appendChild("suffix", mSuffixOutlines, false);
-  root.appendList("copper_top", true)
-      .appendChild("suffix", mSuffixCopperTop, false);
-  root.appendList("copper_inner", true)
-      .appendChild("suffix", mSuffixCopperInner, false);
-  root.appendList("copper_bot", true)
-      .appendChild("suffix", mSuffixCopperBot, false);
-  root.appendList("soldermask_top", true)
-      .appendChild("suffix", mSuffixSolderMaskTop, false);
-  root.appendList("soldermask_bot", true)
-      .appendChild("suffix", mSuffixSolderMaskBot, false);
+  root.ensureLineBreak();
+  root.appendChild("base_path", mOutputBasePath);
+  root.ensureLineBreak();
+  root.appendList("outlines").appendChild("suffix", mSuffixOutlines);
+  root.ensureLineBreak();
+  root.appendList("copper_top").appendChild("suffix", mSuffixCopperTop);
+  root.ensureLineBreak();
+  root.appendList("copper_inner").appendChild("suffix", mSuffixCopperInner);
+  root.ensureLineBreak();
+  root.appendList("copper_bot").appendChild("suffix", mSuffixCopperBot);
+  root.ensureLineBreak();
+  root.appendList("soldermask_top").appendChild("suffix", mSuffixSolderMaskTop);
+  root.ensureLineBreak();
+  root.appendList("soldermask_bot").appendChild("suffix", mSuffixSolderMaskBot);
+  root.ensureLineBreak();
 
-  SExpression& silkscreenTop = root.appendList("silkscreen_top", true);
-  silkscreenTop.appendChild("suffix", mSuffixSilkscreenTop, false);
-  SExpression& silkscreenTopLayers = silkscreenTop.appendList("layers", true);
+  SExpression& silkscreenTop = root.appendList("silkscreen_top");
+  silkscreenTop.appendChild("suffix", mSuffixSilkscreenTop);
+  silkscreenTop.ensureLineBreak();
+  SExpression& silkscreenTopLayers = silkscreenTop.appendList("layers");
   foreach (const QString& layer, mSilkscreenLayersTop) {
     silkscreenTopLayers.appendChild(SExpression::createToken(layer));
   }
+  silkscreenTop.ensureLineBreak();
+  root.ensureLineBreak();
 
-  SExpression& silkscreenBot = root.appendList("silkscreen_bot", true);
-  silkscreenBot.appendChild("suffix", mSuffixSilkscreenBot, false);
-  SExpression& silkscreenBotLayers = silkscreenBot.appendList("layers", true);
+  SExpression& silkscreenBot = root.appendList("silkscreen_bot");
+  silkscreenBot.appendChild("suffix", mSuffixSilkscreenBot);
+  silkscreenBot.ensureLineBreak();
+  SExpression& silkscreenBotLayers = silkscreenBot.appendList("layers");
   foreach (const QString& layer, mSilkscreenLayersBot) {
     silkscreenBotLayers.appendChild(SExpression::createToken(layer));
   }
+  silkscreenBot.ensureLineBreak();
+  root.ensureLineBreak();
 
-  SExpression& drills = root.appendList("drills", true);
-  drills.appendChild("merge", mMergeDrillFiles, false);
-  drills.appendChild("suffix_pth", mSuffixDrillsPth, true);
-  drills.appendChild("suffix_npth", mSuffixDrillsNpth, true);
-  drills.appendChild("suffix_merged", mSuffixDrills, true);
+  SExpression& drills = root.appendList("drills");
+  drills.appendChild("merge", mMergeDrillFiles);
+  drills.ensureLineBreak();
+  drills.appendChild("suffix_pth", mSuffixDrillsPth);
+  drills.ensureLineBreak();
+  drills.appendChild("suffix_npth", mSuffixDrillsNpth);
+  drills.ensureLineBreak();
+  drills.appendChild("suffix_merged", mSuffixDrills);
+  drills.ensureLineBreak();
+  root.ensureLineBreak();
 
-  SExpression& solderPasteTop = root.appendList("solderpaste_top", true);
-  solderPasteTop.appendChild("create", mEnableSolderPasteTop, false);
-  solderPasteTop.appendChild("suffix", mSuffixSolderPasteTop, false);
+  SExpression& solderPasteTop = root.appendList("solderpaste_top");
+  solderPasteTop.appendChild("create", mEnableSolderPasteTop);
+  solderPasteTop.appendChild("suffix", mSuffixSolderPasteTop);
+  root.ensureLineBreak();
 
-  SExpression& solderPasteBot = root.appendList("solderpaste_bot", true);
-  solderPasteBot.appendChild("create", mEnableSolderPasteBot, false);
-  solderPasteBot.appendChild("suffix", mSuffixSolderPasteBot, false);
+  SExpression& solderPasteBot = root.appendList("solderpaste_bot");
+  solderPasteBot.appendChild("create", mEnableSolderPasteBot);
+  solderPasteBot.appendChild("suffix", mSuffixSolderPasteBot);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/boardlayerstack.cpp
+++ b/libs/librepcb/core/project/board/boardlayerstack.cpp
@@ -100,7 +100,7 @@ void BoardLayerStack::setInnerLayerCount(int count) noexcept {
  ******************************************************************************/
 
 void BoardLayerStack::serialize(SExpression& root) const {
-  root.appendChild("inner", mInnerLayerCount, false);
+  root.appendChild("inner", mInnerLayerCount);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/boardusersettings.cpp
+++ b/libs/librepcb/core/project/board/boardusersettings.cpp
@@ -84,11 +84,14 @@ void BoardUserSettings::serialize(SExpression& root) const {
 
   for (auto i = mPlanesVisibility.constBegin();
        i != mPlanesVisibility.constEnd(); i++) {
+    root.ensureLineBreak();
     SExpression node = SExpression::createList("plane");
     node.appendChild(i.key());
-    node.appendChild("visible", i.value(), false);
-    root.appendChild(node, true);
+    node.appendChild("visible", i.value());
+    root.appendChild(node);
   }
+
+  root.ensureLineBreakIfMultiLine();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -253,13 +253,19 @@ void BI_Device::serialize(SExpression& root) const {
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
   root.appendChild(mCompInstance->getUuid());
-  root.appendChild("lib_device", mLibDevice->getUuid(), true);
-  root.appendChild("lib_footprint", mLibFootprint->getUuid(), true);
-  root.appendChild(mPosition.serializeToDomElement("position"), true);
-  root.appendChild("rotation", mRotation, false);
-  root.appendChild("mirror", mMirrored, false);
+  root.ensureLineBreak();
+  root.appendChild("lib_device", mLibDevice->getUuid());
+  root.ensureLineBreak();
+  root.appendChild("lib_footprint", mLibFootprint->getUuid());
+  root.ensureLineBreak();
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("rotation", mRotation);
+  root.appendChild("mirror", mMirrored);
+  root.ensureLineBreak();
   mAttributes.serialize(root);
+  root.ensureLineBreak();
   mFootprint->serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/items/bi_netsegment.cpp
+++ b/libs/librepcb/core/project/board/items/bi_netsegment.cpp
@@ -554,11 +554,16 @@ void BI_NetSegment::serialize(SExpression& root) const {
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
   root.appendChild(mUuid);
-  root.appendChild(
-      "net", mNetSignal ? mNetSignal->getUuid() : tl::optional<Uuid>(), true);
+  root.ensureLineBreak();
+  root.appendChild("net",
+                   mNetSignal ? mNetSignal->getUuid() : tl::optional<Uuid>());
+  root.ensureLineBreak();
   serializePointerContainerUuidSorted(root, mVias, "via");
+  root.ensureLineBreak();
   serializePointerContainerUuidSorted(root, mNetPoints, "junction");
+  root.ensureLineBreak();
   serializePointerContainerUuidSorted(root, mNetLines, "trace");
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/items/bi_plane.cpp
+++ b/libs/librepcb/core/project/board/items/bi_plane.cpp
@@ -232,16 +232,21 @@ void BI_Plane::rebuild() noexcept {
 
 void BI_Plane::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("layer", mLayerName, false);
-  root.appendChild("net", mNetSignal->getUuid(), true);
-  root.appendChild("priority", mPriority, false);
-  root.appendChild("min_width", mMinWidth, true);
-  root.appendChild("min_clearance", mMinClearance, false);
-  root.appendChild("keep_orphans", mKeepOrphans, false);
-  root.appendChild("connect_style", mConnectStyle, true);
+  root.appendChild("layer", mLayerName);
+  root.ensureLineBreak();
+  root.appendChild("net", mNetSignal->getUuid());
+  root.appendChild("priority", mPriority);
+  root.ensureLineBreak();
+  root.appendChild("min_width", mMinWidth);
+  root.appendChild("min_clearance", mMinClearance);
+  root.appendChild("keep_orphans", mKeepOrphans);
+  root.ensureLineBreak();
+  root.appendChild("connect_style", mConnectStyle);
   // root.appendChild("thermal_gap_width", mThermalGapWidth, false);
   // root.appendChild("thermal_spoke_width", mThermalSpokeWidth, false);
+  root.ensureLineBreak();
   mOutline.serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/circuit/circuit.cpp
+++ b/libs/librepcb/core/project/circuit/circuit.cpp
@@ -383,13 +383,13 @@ void Circuit::save() {
  ******************************************************************************/
 
 void Circuit::serialize(SExpression& root) const {
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainer(root, mNetClasses, "netclass");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainer(root, mNetSignals, "net");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainer(root, mComponentInstances, "component");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/core/project/circuit/componentinstance.cpp
@@ -357,13 +357,20 @@ void ComponentInstance::serialize(SExpression& root) const {
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
   root.appendChild(mUuid);
-  root.appendChild("lib_component", mLibComponent->getUuid(), true);
-  root.appendChild("lib_variant", mCompSymbVar->getUuid(), true);
-  root.appendChild("lib_device", mDefaultDeviceUuid, true);
-  root.appendChild("name", mName, true);
-  root.appendChild("value", mValue, false);
+  root.ensureLineBreak();
+  root.appendChild("lib_component", mLibComponent->getUuid());
+  root.ensureLineBreak();
+  root.appendChild("lib_variant", mCompSymbVar->getUuid());
+  root.ensureLineBreak();
+  root.appendChild("lib_device", mDefaultDeviceUuid);
+  root.ensureLineBreak();
+  root.appendChild("name", mName);
+  root.appendChild("value", mValue);
+  root.ensureLineBreak();
   mAttributes->serialize(root);
+  root.ensureLineBreak();
   serializePointerContainer(root, mSignals, "signal");
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/circuit/componentsignalinstance.cpp
+++ b/libs/librepcb/core/project/circuit/componentsignalinstance.cpp
@@ -273,8 +273,7 @@ void ComponentSignalInstance::serialize(SExpression& root) const {
   root.appendChild(mComponentSignal->getUuid());
   root.appendChild(
       "net",
-      mNetSignal ? tl::make_optional(mNetSignal->getUuid()) : tl::nullopt,
-      false);
+      mNetSignal ? tl::make_optional(mNetSignal->getUuid()) : tl::nullopt);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/circuit/netclass.cpp
+++ b/libs/librepcb/core/project/circuit/netclass.cpp
@@ -119,7 +119,7 @@ void NetClass::unregisterNetSignal(NetSignal& signal) {
 
 void NetClass::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("name", mName, false);
+  root.appendChild("name", mName);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/circuit/netsignal.cpp
+++ b/libs/librepcb/core/project/circuit/netsignal.cpp
@@ -241,9 +241,11 @@ void NetSignal::serialize(SExpression& root) const {
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
   root.appendChild(mUuid);
-  root.appendChild("auto", mHasAutoName, false);
-  root.appendChild("name", mName, false);
-  root.appendChild("netclass", mNetClass->getUuid(), true);
+  root.appendChild("auto", mHasAutoName);
+  root.appendChild("name", mName);
+  root.ensureLineBreak();
+  root.appendChild("netclass", mNetClass->getUuid());
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/erc/ercmsglist.cpp
+++ b/libs/librepcb/core/project/erc/ercmsglist.cpp
@@ -112,13 +112,19 @@ void ErcMsgList::save() {
 void ErcMsgList::serialize(SExpression& root) const {
   foreach (ErcMsg* ercMsg, mItems) {
     if (ercMsg->isIgnored()) {
-      SExpression& itemNode = root.appendList("approved", true);
+      root.ensureLineBreak();
+      SExpression& itemNode = root.appendList("approved");
+      itemNode.ensureLineBreak();
       itemNode.appendChild<QString>(
-          "class", ercMsg->getOwner().getErcMsgOwnerClassName(), true);
-      itemNode.appendChild("instance", ercMsg->getOwnerKey(), true);
-      itemNode.appendChild("message", ercMsg->getMsgKey(), true);
+          "class", ercMsg->getOwner().getErcMsgOwnerClassName());
+      itemNode.ensureLineBreak();
+      itemNode.appendChild("instance", ercMsg->getOwnerKey());
+      itemNode.ensureLineBreak();
+      itemNode.appendChild("message", ercMsg->getMsgKey());
+      itemNode.ensureLineBreak();
     }
   }
+  root.ensureLineBreakIfMultiLine();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/project.cpp
+++ b/libs/librepcb/core/project/project.cpp
@@ -479,18 +479,21 @@ void Project::save() {
   // Save schematics/schematics.lp
   SExpression schRoot = SExpression::createList("librepcb_schematics");
   foreach (Schematic* schematic, mSchematics) {
+    schRoot.ensureLineBreak();
     schRoot.appendChild("schematic",
-                        schematic->getFilePath().toRelative(getPath()), true);
+                        schematic->getFilePath().toRelative(getPath()));
   }
+  schRoot.ensureLineBreakIfMultiLine();
   mDirectory->write("schematics/schematics.lp",
                     schRoot.toByteArray());  // can throw
 
   // Save boards/boards.lp
   SExpression brdRoot = SExpression::createList("librepcb_boards");
   foreach (Board* board, mBoards) {
-    brdRoot.appendChild("board", board->getFilePath().toRelative(getPath()),
-                        true);
+    brdRoot.ensureLineBreak();
+    brdRoot.appendChild("board", board->getFilePath().toRelative(getPath()));
   }
+  brdRoot.ensureLineBreakIfMultiLine();
   mDirectory->write("boards/boards.lp", brdRoot.toByteArray());  // can throw
 
   // Save all removed schematics (*.lp files)

--- a/libs/librepcb/core/project/projectmetadata.cpp
+++ b/libs/librepcb/core/project/projectmetadata.cpp
@@ -112,11 +112,17 @@ void ProjectMetadata::updateLastModified() noexcept {
 
 void ProjectMetadata::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("name", mName, true);
-  root.appendChild("author", mAuthor, true);
-  root.appendChild("version", mVersion, true);
-  root.appendChild("created", mCreated, true);
+  root.ensureLineBreak();
+  root.appendChild("name", mName);
+  root.ensureLineBreak();
+  root.appendChild("author", mAuthor);
+  root.ensureLineBreak();
+  root.appendChild("version", mVersion);
+  root.ensureLineBreak();
+  root.appendChild("created", mCreated);
+  root.ensureLineBreak();
   mAttributes.serialize(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/projectsettings.cpp
+++ b/libs/librepcb/core/project/projectsettings.cpp
@@ -57,13 +57,13 @@ ProjectSettings::ProjectSettings(Project& project, const Version& fileFormat,
 
     // locale order
     foreach (const SExpression& node,
-             root.getChild("library_locale_order").getChildren()) {
+             root.getChild("library_locale_order").getChildren("locale")) {
       mLocaleOrder.append(node.getChild("@0").getValue());
     }
 
     // norm order
     foreach (const SExpression& node,
-             root.getChild("library_norm_order").getChildren()) {
+             root.getChild("library_norm_order").getChildren("norm")) {
       mNormOrder.append(node.getChild("@0").getValue());
     }
   }
@@ -101,12 +101,21 @@ void ProjectSettings::save() {
  ******************************************************************************/
 
 void ProjectSettings::serialize(SExpression& root) const {
-  SExpression& locale_order = root.appendList("library_locale_order", true);
-  foreach (const QString& locale, mLocaleOrder)
-    locale_order.appendChild("locale", locale, true);
-  SExpression& norm_order = root.appendList("library_norm_order", true);
-  foreach (const QString& norm, mNormOrder)
-    norm_order.appendChild("norm", norm, true);
+  root.ensureLineBreak();
+  SExpression& locale_order = root.appendList("library_locale_order");
+  foreach (const QString& locale, mLocaleOrder) {
+    locale_order.ensureLineBreak();
+    locale_order.appendChild("locale", locale);
+  }
+  locale_order.ensureLineBreakIfMultiLine();
+  root.ensureLineBreak();
+  SExpression& norm_order = root.appendList("library_norm_order");
+  foreach (const QString& norm, mNormOrder) {
+    norm_order.ensureLineBreak();
+    norm_order.appendChild("norm", norm);
+  }
+  norm_order.ensureLineBreakIfMultiLine();
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
@@ -520,10 +520,15 @@ void SI_NetSegment::serialize(SExpression& root) const {
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
   root.appendChild(mUuid);
-  root.appendChild("net", mNetSignal->getUuid(), true);
+  root.ensureLineBreak();
+  root.appendChild("net", mNetSignal->getUuid());
+  root.ensureLineBreak();
   serializePointerContainerUuidSorted(root, mNetPoints, "junction");
+  root.ensureLineBreak();
   serializePointerContainerUuidSorted(root, mNetLines, "line");
+  root.ensureLineBreak();
   serializePointerContainerUuidSorted(root, mNetLabels, "label");
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/items/si_symbol.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_symbol.cpp
@@ -217,11 +217,15 @@ void SI_Symbol::serialize(SExpression& root) const {
   if (!checkAttributesValidity()) throw LogicError(__FILE__, __LINE__);
 
   root.appendChild(mUuid);
-  root.appendChild("component", mComponentInstance->getUuid(), true);
-  root.appendChild("lib_gate", mSymbVarItem->getUuid(), true);
-  root.appendChild(mPosition.serializeToDomElement("position"), true);
-  root.appendChild("rotation", mRotation, false);
-  root.appendChild("mirror", mMirrored, false);
+  root.ensureLineBreak();
+  root.appendChild("component", mComponentInstance->getUuid());
+  root.ensureLineBreak();
+  root.appendChild("lib_gate", mSymbVarItem->getUuid());
+  root.ensureLineBreak();
+  root.appendChild(mPosition.serializeToDomElement("position"));
+  root.appendChild("rotation", mRotation);
+  root.appendChild("mirror", mMirrored);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/schematic.cpp
+++ b/libs/librepcb/core/project/schematic/schematic.cpp
@@ -598,16 +598,19 @@ void Schematic::updateIcon() noexcept {
 
 void Schematic::serialize(SExpression& root) const {
   root.appendChild(mUuid);
-  root.appendChild("name", mName, true);
-  root.appendChild(mGridProperties->serializeToDomElement("grid"), true);
-  root.appendLineBreak();
+  root.ensureLineBreak();
+  root.appendChild("name", mName);
+  root.ensureLineBreak();
+  root.appendChild(mGridProperties->serializeToDomElement("grid"));
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mSymbols, "symbol");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mNetSegments, "netsegment");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mPolygons, "polygon");
-  root.appendLineBreak();
+  root.ensureEmptyLine();
   serializePointerContainerUuidSorted(root, mTexts, "text");
+  root.ensureEmptyLine();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/serializablekeyvaluemap.h
+++ b/libs/librepcb/core/serialization/serializablekeyvaluemap.h
@@ -80,7 +80,7 @@ public:
     foreach (const SExpression& child, node.getChildren(T::tagname)) {
       QString key;
       SExpression value;
-      if (child.getChildren().count() > 1) {
+      if (child.getChild("@0").isList()) {
         key = child.getChild(QString(T::keyname) % "/@0").getValue();
         value = child.getChild("@1");
       } else {
@@ -158,12 +158,14 @@ public:
   /// @copydoc ::librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override {
     for (auto i = mValues.constBegin(); i != mValues.constEnd(); ++i) {
-      SExpression& child = root.appendList(T::tagname, true);
+      root.ensureLineBreak();
+      SExpression& child = root.appendList(T::tagname);
       if (!i.key().isEmpty()) {
-        child.appendChild(T::keyname, i.key(), false);
+        child.appendChild(T::keyname, i.key());
       }
       child.appendChild(i.value());
     }
+    root.ensureLineBreakIfMultiLine();
   }
 
   // Operator Overloadings

--- a/libs/librepcb/core/serialization/serializableobject.h
+++ b/libs/librepcb/core/serialization/serializableobject.h
@@ -87,18 +87,20 @@ public:
   static void serializeObjectContainer(SExpression& root, const T& container,
                                        const QString& itemName) {
     for (const auto& object : container) {
-      root.appendChild(object.serializeToDomElement(itemName),
-                       true);  // can throw
+      root.ensureLineBreak();
+      root.appendChild(object.serializeToDomElement(itemName));  // can throw
     }
+    root.ensureLineBreakIfMultiLine();
   }
 
   template <typename T>
   static void serializePointerContainer(SExpression& root, const T& container,
                                         const QString& itemName) {
     for (const auto& pointer : container) {
-      root.appendChild(pointer->serializeToDomElement(itemName),
-                       true);  // can throw
+      root.ensureLineBreak();
+      root.appendChild(pointer->serializeToDomElement(itemName));  // can throw
     }
+    root.ensureLineBreakIfMultiLine();
   }
 
   template <typename T>

--- a/libs/librepcb/core/types/gridproperties.cpp
+++ b/libs/librepcb/core/types/gridproperties.cpp
@@ -62,9 +62,9 @@ GridProperties::~GridProperties() noexcept {
  ******************************************************************************/
 
 void GridProperties::serialize(SExpression& root) const {
-  root.appendChild("type", mType, false);
-  root.appendChild("interval", mInterval, false);
-  root.appendChild("unit", mUnit, false);
+  root.appendChild("type", mType);
+  root.appendChild("interval", mInterval);
+  root.appendChild("unit", mUnit);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -40,6 +40,7 @@ WorkspaceSettings::WorkspaceSettings(const FilePath& fp,
                                      const Version& fileFormat, QObject* parent)
   : QObject(parent),
     mFilePath(fp),
+    mFileContent(),
     // Initialize settings items. Their constructor will register them as
     // child objects of this object, this way we will access them later.
     userName("user", "", this),
@@ -59,9 +60,15 @@ WorkspaceSettings::WorkspaceSettings(const FilePath& fp,
     qDebug("Load workspace settings...");
     SExpression root =
         SExpression::parse(FileUtils::readFile(mFilePath), mFilePath);
+    foreach (const SExpression& child,
+             root.getChildren(SExpression::Type::List)) {
+      mFileContent.insert(child.getName(), child);
+    }
     foreach (WorkspaceSettingsItem* item, getAllItems()) {
       try {
-        item->load(root, fileFormat);  // can throw
+        if (mFileContent.contains(item->getKey())) {
+          item->load(mFileContent[item->getKey()], fileFormat);  // can throw
+        }
       } catch (const Exception& e) {
         qCritical() << "Could not load workspace settings item:" << e.getMsg();
       }
@@ -83,11 +90,33 @@ void WorkspaceSettings::restoreDefaults() noexcept {
   foreach (WorkspaceSettingsItem* item, getAllItems()) {
     item->restoreDefault();
   }
+  mFileContent.clear();  // Remove even unknown settings!
 }
 
-void WorkspaceSettings::saveToFile() const {
-  SExpression doc(serializeToDomElement("librepcb_workspace_settings"));
-  FileUtils::writeFile(mFilePath, doc.toByteArray());  // can throw
+QByteArray WorkspaceSettings::saveToByteArray() {
+  foreach (const WorkspaceSettingsItem* item, getAllItems()) {
+    if (item->isEdited()) {
+      if (item->isDefaultValue()) {
+        mFileContent.remove(item->getKey());
+      } else {
+        SExpression node = SExpression::createList(item->getKey());
+        item->serialize(node);  // can throw
+        mFileContent.insert(item->getKey(), node);
+      }
+    }
+  }
+
+  SExpression root = SExpression::createList("librepcb_workspace_settings");
+  foreach (const SExpression& child, mFileContent) {
+    root.ensureLineBreak();
+    root.appendChild(child);
+  }
+  root.ensureLineBreakIfMultiLine();
+  return root.toByteArray();
+}
+
+void WorkspaceSettings::saveToFile() {
+  FileUtils::writeFile(mFilePath, saveToByteArray());  // can throw
 }
 
 /*******************************************************************************
@@ -96,12 +125,6 @@ void WorkspaceSettings::saveToFile() const {
 
 QList<WorkspaceSettingsItem*> WorkspaceSettings::getAllItems() const noexcept {
   return findChildren<WorkspaceSettingsItem*>();
-}
-
-void WorkspaceSettings::serialize(SExpression& root) const {
-  foreach (const WorkspaceSettingsItem* item, getAllItems()) {
-    item->serialize(root);  // can throw
-  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -25,7 +25,6 @@
  ******************************************************************************/
 #include "../exceptions.h"
 #include "../fileio/filepath.h"
-#include "../serialization/serializableobject.h"
 #include "../types/lengthunit.h"
 #include "workspacesettingsitem_genericvalue.h"
 #include "workspacesettingsitem_genericvaluelist.h"
@@ -36,6 +35,8 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class SExpression;
 
 /*******************************************************************************
  *  Class WorkspaceSettings
@@ -54,7 +55,7 @@ namespace librepcb {
  *
  * @see ::librepcb::WorkspaceSettingsItem
  */
-class WorkspaceSettings final : public QObject, public SerializableObject {
+class WorkspaceSettings final : public QObject {
   Q_OBJECT
 
 public:
@@ -82,9 +83,14 @@ public:
   void restoreDefaults() noexcept;
 
   /**
+   * @brief Save all settings to a QByteArray
+   */
+  QByteArray saveToByteArray();
+
+  /**
    * @brief Save all settings to the file
    */
-  void saveToFile() const;
+  void saveToFile();
 
   // Operator Overloadings
   WorkspaceSettings& operator=(const WorkspaceSettings& rhs) = delete;
@@ -97,15 +103,40 @@ private:  // Methods
    */
   QList<WorkspaceSettingsItem*> getAllItems() const noexcept;
 
-  /// @copydoc ::librepcb::SerializableObject::serialize()
-  void serialize(SExpression& root) const override;
-
 private:  // Data
-  FilePath mFilePath;  ///< path to the "settings.lp" file
+  /**
+   * @brief Path to the "settings.lp" file
+   */
+  FilePath mFilePath;
+
+  /**
+   * @brief Settings nodes contained in the file #mFilePath
+   *
+   * This map is filled with all settings S-Expression nodes when loading the
+   * settings from file. When modifying settings with the workspace settings
+   * dialog, the nodes in this map are updated accordingly. When saving the
+   * settings to file, these S-Expression nodes will be written to the file.
+   *
+   * - Key: Settings key, e.g. "use_opengl"
+   * - Value: The corresponding serialization, e.g. "(use_opengl true)"
+   *
+   * Important:
+   *
+   *   - Keeping unknown settings is important to not loose them when opening
+   *     a workspace after an application downgrade.
+   *   - When restoring default settings, the corresponding (or all) entries
+   *     are removed from this map (i.e. not written to file at all). This
+   *     ensures that users will automatically profit from improved default
+   *     values after an application upgrade unless they have manually changed
+   *     them.
+   *   - QMap is sorted by key, which will lead to sorted entries in the
+   *     S-Expression file for a clean file format.
+   */
+  QMap<QString, SExpression> mFileContent;
 
 public:
-  // All settings item objects below, in the same order as they are safed in
-  // the settings file.
+  // All settings item objects below. The order is not relevant for saving,
+  // it should be ordered logically.
   //
   // Note: Generally we don't make member variables public, but in this case
   //       it would create a lot of boilerplate to wrap all objects with

--- a/libs/librepcb/core/workspace/workspacesettingsitem.cpp
+++ b/libs/librepcb/core/workspace/workspacesettingsitem.cpp
@@ -33,11 +33,40 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-WorkspaceSettingsItem::WorkspaceSettingsItem(QObject* parent) noexcept
-  : QObject(parent) {
+WorkspaceSettingsItem::WorkspaceSettingsItem(const QString& key,
+                                             QObject* parent) noexcept
+  : QObject(parent), mKey(key), mIsDefault(true), mEdited(false) {
 }
 
 WorkspaceSettingsItem::~WorkspaceSettingsItem() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void WorkspaceSettingsItem::valueModified() noexcept {
+  mIsDefault = false;
+  mEdited = true;
+  emit edited();
+}
+
+void WorkspaceSettingsItem::restoreDefault() noexcept {
+  restoreDefaultImpl();
+  mIsDefault = true;
+  mEdited = true;
+}
+
+void WorkspaceSettingsItem::load(const SExpression& root,
+                                 const Version& fileFormat) {
+  loadImpl(root, fileFormat);  // can throw
+  mIsDefault = false;
+  mEdited = false;
+}
+
+void WorkspaceSettingsItem::serialize(SExpression& root) const {
+  serializeImpl(root);  // can throw
+  mEdited = false;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/workspace/workspacesettingsitem_genericvalue.h
+++ b/libs/librepcb/core/workspace/workspacesettingsitem_genericvalue.h
@@ -96,7 +96,9 @@ public:
    * @copydoc ::librepcb::WorkspaceSettingsItem::serialize()
    */
   void serialize(SExpression& root) const override {
-    root.appendChild(mKey, mCurrentValue, true);
+    root.ensureLineBreak();
+    root.appendChild(mKey, mCurrentValue);
+    root.ensureLineBreak();
   }
 
   // Operator Overloadings

--- a/libs/librepcb/core/workspace/workspacesettingsitem_genericvaluelist.h
+++ b/libs/librepcb/core/workspace/workspacesettingsitem_genericvaluelist.h
@@ -104,10 +104,14 @@ public:
    * @copydoc ::librepcb::WorkspaceSettingsItem::serialize()
    */
   void serialize(SExpression& root) const override {
-    SExpression& child = root.appendList(mListKey, true);
+    root.ensureLineBreak();
+    SExpression& child = root.appendList(mListKey);
     foreach (const auto& item, mCurrentValue) {
-      child.appendChild(mItemKey, item, true);
+      child.ensureLineBreak();
+      child.appendChild(mItemKey, item);
     }
+    child.ensureLineBreakIfMultiLine();
+    root.ensureLineBreak();
   }
 
   // Operator Overloadings

--- a/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
@@ -99,15 +99,24 @@ std::unique_ptr<FootprintClipboardData> FootprintClipboardData::fromMimeData(
  ******************************************************************************/
 
 void FootprintClipboardData::serialize(SExpression& root) const {
-  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"), true);
-  root.appendChild("footprint", mFootprintUuid, true);
-  SExpression& packageRoot = root.appendList("package", true);
+  root.ensureLineBreak();
+  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"));
+  root.ensureLineBreak();
+  root.appendChild("footprint", mFootprintUuid);
+  root.ensureLineBreak();
+  SExpression& packageRoot = root.appendList("package");
   mPackagePads.serialize(packageRoot);
+  root.ensureLineBreak();
   mFootprintPads.serialize(root);
+  root.ensureLineBreak();
   mPolygons.serialize(root);
+  root.ensureLineBreak();
   mCircles.serialize(root);
+  root.ensureLineBreak();
   mStrokeTexts.serialize(root);
+  root.ensureLineBreak();
   mHoles.serialize(root);
+  root.ensureLineBreak();
 }
 
 QPixmap FootprintClipboardData::generatePixmap(

--- a/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
+++ b/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
@@ -92,12 +92,19 @@ std::unique_ptr<SymbolClipboardData> SymbolClipboardData::fromMimeData(
  ******************************************************************************/
 
 void SymbolClipboardData::serialize(SExpression& root) const {
-  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"), true);
-  root.appendChild("symbol", mSymbolUuid, true);
+  root.ensureLineBreak();
+  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"));
+  root.ensureLineBreak();
+  root.appendChild("symbol", mSymbolUuid);
+  root.ensureLineBreak();
   mPins.serialize(root);
+  root.ensureLineBreak();
   mPolygons.serialize(root);
+  root.ensureLineBreak();
   mCircles.serialize(root);
+  root.ensureLineBreak();
   mTexts.serialize(root);
+  root.ensureLineBreak();
 }
 
 QPixmap SymbolClipboardData::generatePixmap(

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddata.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddata.cpp
@@ -136,23 +136,34 @@ std::unique_ptr<BoardClipboardData> BoardClipboardData::fromMimeData(
  ******************************************************************************/
 
 void BoardClipboardData::serialize(SExpression& root) const {
-  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"), true);
-  root.appendChild("board", mBoardUuid, true);
+  root.ensureLineBreak();
+  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"));
+  root.ensureLineBreak();
+  root.appendChild("board", mBoardUuid);
+  root.ensureLineBreak();
   mDevices.serialize(root);
+  root.ensureLineBreak();
   mNetSegments.serialize(root);
+  root.ensureLineBreak();
   mPlanes.serialize(root);
+  root.ensureLineBreak();
   mPolygons.serialize(root);
+  root.ensureLineBreak();
   mStrokeTexts.serialize(root);
+  root.ensureLineBreak();
   mHoles.serialize(root);
 
   for (auto it = mPadPositions.constBegin(); it != mPadPositions.constEnd();
        ++it) {
     SExpression child = SExpression::createList("pad_position");
-    child.appendChild("device", it.key().first, false);
-    child.appendChild("pad", it.key().second, false);
-    child.appendChild(it.value().serializeToDomElement("position"), false);
-    root.appendChild(child, true);
+    child.appendChild("device", it.key().first);
+    child.appendChild("pad", it.key().second);
+    child.appendChild(it.value().serializeToDomElement("position"));
+    root.ensureLineBreak();
+    root.appendChild(child);
   }
+
+  root.ensureLineBreak();
 }
 
 QString BoardClipboardData::getMimeType() noexcept {

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
@@ -103,12 +103,17 @@ public:
     /// @copydoc ::librepcb::SerializableObject::serialize()
     void serialize(SExpression& root) const override {
       root.appendChild(componentUuid);
-      root.appendChild("lib_device", libDeviceUuid, true);
-      root.appendChild("lib_footprint", libFootprintUuid, true);
-      root.appendChild(position.serializeToDomElement("position"), true);
-      root.appendChild("rotation", rotation, false);
-      root.appendChild("mirror", mirrored, false);
+      root.ensureLineBreak();
+      root.appendChild("lib_device", libDeviceUuid);
+      root.ensureLineBreak();
+      root.appendChild("lib_footprint", libFootprintUuid);
+      root.ensureLineBreak();
+      root.appendChild(position.serializeToDomElement("position"));
+      root.appendChild("rotation", rotation);
+      root.appendChild("mirror", mirrored);
+      root.ensureLineBreak();
       strokeTexts.serialize(root);
+      root.ensureLineBreak();
     }
 
     bool operator!=(const Device& rhs) noexcept {
@@ -142,10 +147,15 @@ public:
 
     /// @copydoc ::librepcb::SerializableObject::serialize()
     void serialize(SExpression& root) const override {
-      root.appendChild("net", netName, true);
+      root.ensureLineBreak();
+      root.appendChild("net", netName);
+      root.ensureLineBreak();
       vias.serialize(root);
+      root.ensureLineBreak();
       junctions.serialize(root);
+      root.ensureLineBreak();
       traces.serialize(root);
+      root.ensureLineBreak();
     }
 
     bool operator!=(const NetSegment& rhs) noexcept {
@@ -204,14 +214,19 @@ public:
     /// @copydoc ::librepcb::SerializableObject::serialize()
     void serialize(SExpression& root) const override {
       root.appendChild(uuid);
-      root.appendChild("layer", layer, false);
-      root.appendChild("net", netSignalName, true);
-      root.appendChild("priority", priority, false);
-      root.appendChild("min_width", minWidth, true);
-      root.appendChild("min_clearance", minClearance, false);
-      root.appendChild("keep_orphans", keepOrphans, false);
-      root.appendChild("connect_style", connectStyle, true);
+      root.appendChild("layer", layer);
+      root.ensureLineBreak();
+      root.appendChild("net", netSignalName);
+      root.appendChild("priority", priority);
+      root.ensureLineBreak();
+      root.appendChild("min_width", minWidth);
+      root.appendChild("min_clearance", minClearance);
+      root.appendChild("keep_orphans", keepOrphans);
+      root.ensureLineBreak();
+      root.appendChild("connect_style", connectStyle);
+      root.ensureLineBreak();
       outline.serialize(root);
+      root.ensureLineBreak();
     }
 
     bool operator!=(const Plane& rhs) noexcept {

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.cpp
@@ -119,13 +119,21 @@ std::unique_ptr<SchematicClipboardData> SchematicClipboardData::fromMimeData(
  ******************************************************************************/
 
 void SchematicClipboardData::serialize(SExpression& root) const {
-  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"), true);
-  root.appendChild("schematic", mSchematicUuid, true);
+  root.ensureLineBreak();
+  root.appendChild(mCursorPos.serializeToDomElement("cursor_position"));
+  root.ensureLineBreak();
+  root.appendChild("schematic", mSchematicUuid);
+  root.ensureLineBreak();
   mComponentInstances.serialize(root);
+  root.ensureLineBreak();
   mSymbolInstances.serialize(root);
+  root.ensureLineBreak();
   mNetSegments.serialize(root);
+  root.ensureLineBreak();
   mPolygons.serialize(root);
+  root.ensureLineBreak();
   mTexts.serialize(root);
+  root.ensureLineBreak();
 }
 
 QString SchematicClipboardData::getMimeType() noexcept {

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.h
@@ -101,12 +101,18 @@ public:
     /// @copydoc ::librepcb::SerializableObject::serialize()
     void serialize(SExpression& root) const override {
       root.appendChild(uuid);
-      root.appendChild("lib_component", libComponentUuid, true);
-      root.appendChild("lib_variant", libVariantUuid, true);
-      root.appendChild("lib_device", libDeviceUuid, true);
-      root.appendChild("name", name, true);
-      root.appendChild("value", value, false);
+      root.ensureLineBreak();
+      root.appendChild("lib_component", libComponentUuid);
+      root.ensureLineBreak();
+      root.appendChild("lib_variant", libVariantUuid);
+      root.ensureLineBreak();
+      root.appendChild("lib_device", libDeviceUuid);
+      root.ensureLineBreak();
+      root.appendChild("name", name);
+      root.appendChild("value", value);
+      root.ensureLineBreak();
       attributes.serialize(root);
+      root.ensureLineBreak();
     }
 
     bool operator!=(const ComponentInstance& rhs) noexcept {
@@ -154,11 +160,15 @@ public:
     /// @copydoc ::librepcb::SerializableObject::serialize()
     void serialize(SExpression& root) const override {
       root.appendChild(uuid);
-      root.appendChild("component", componentInstanceUuid, true);
-      root.appendChild("lib_gate", symbolVariantItemUuid, true);
-      root.appendChild(position.serializeToDomElement("position"), true);
-      root.appendChild("rotation", rotation, false);
-      root.appendChild("mirror", mirrored, false);
+      root.ensureLineBreak();
+      root.appendChild("component", componentInstanceUuid);
+      root.ensureLineBreak();
+      root.appendChild("lib_gate", symbolVariantItemUuid);
+      root.ensureLineBreak();
+      root.appendChild(position.serializeToDomElement("position"));
+      root.appendChild("rotation", rotation);
+      root.appendChild("mirror", mirrored);
+      root.ensureLineBreak();
     }
 
     bool operator!=(const SymbolInstance& rhs) noexcept {
@@ -192,10 +202,15 @@ public:
 
     /// @copydoc ::librepcb::SerializableObject::serialize()
     void serialize(SExpression& root) const override {
-      root.appendChild("net", netName, true);
+      root.ensureLineBreak();
+      root.appendChild("net", netName);
+      root.ensureLineBreak();
       junctions.serialize(root);
+      root.ensureLineBreak();
       lines.serialize(root);
+      root.ensureLineBreak();
       labels.serialize(root);
+      root.ensureLineBreak();
     }
 
     bool operator!=(const NetSegment& rhs) noexcept {

--- a/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
@@ -109,9 +109,10 @@ void FavoriteProjectsModel::save() noexcept {
     // save the new list in the workspace
     SExpression root = SExpression::createList("librepcb_favorite_projects");
     foreach (const FilePath& filepath, mAllProjects) {
-      root.appendChild("project", filepath.toRelative(mWorkspace.getPath()),
-                       true);
+      root.ensureLineBreak();
+      root.appendChild("project", filepath.toRelative(mWorkspace.getPath()));
     }
+    root.ensureLineBreakIfMultiLine();
     FileUtils::writeFile(mFilePath, root.toByteArray());  // can throw
   } catch (Exception& e) {
     qWarning() << "Could not save favorite projects file:" << e.getMsg();

--- a/libs/librepcb/editor/workspace/controlpanel/recentprojectsmodel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/recentprojectsmodel.cpp
@@ -101,9 +101,10 @@ void RecentProjectsModel::save() noexcept {
     // save the new list in the workspace
     SExpression root = SExpression::createList("librepcb_recent_projects");
     foreach (const FilePath& filepath, mAllProjects) {
-      root.appendChild("project", filepath.toRelative(mWorkspace.getPath()),
-                       true);
+      root.ensureLineBreak();
+      root.appendChild("project", filepath.toRelative(mWorkspace.getPath()));
     }
+    root.ensureLineBreakIfMultiLine();
     FileUtils::writeFile(mFilePath, root.toByteArray());  // can throw
   } catch (Exception& e) {
     qWarning() << "Could not save recent projects file:" << e.getMsg();

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(
   core/project/projecttest.cpp
   core/serialization/serializableobjectlisttest.cpp
   core/serialization/serializableobjectmock.h
+  core/serialization/sexpressionlegacymode.h
   core/serialization/sexpressiontest.cpp
   core/sqlitedatabasetest.cpp
   core/systeminfotest.cpp

--- a/tests/unittests/core/import/dxfreadertest.cpp
+++ b/tests/unittests/core/import/dxfreadertest.cpp
@@ -61,8 +61,8 @@ protected:
    */
   static std::string str(const DxfReader::Circle& circle) {
     SExpression s = SExpression::createList("object");
-    s.appendChild(circle.position.serializeToDomElement("position"), false);
-    s.appendChild("diameter", circle.diameter, false);
+    s.appendChild(circle.position.serializeToDomElement("position"));
+    s.appendChild("diameter", circle.diameter);
     return s.toByteArray().toStdString();
   }
 };

--- a/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
+++ b/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
@@ -87,10 +87,14 @@ TEST(BoardPlaneFragmentsBuilderTest, testFragments) {
     child.appendChild(uuid);
     foreach (const Path& fragment,
              Toolbox::sortedQSet(actualPlaneFragments[uuid])) {
-      child.appendChild(fragment.serializeToDomElement("fragment"), true);
+      child.ensureLineBreak();
+      child.appendChild(fragment.serializeToDomElement("fragment"));
     }
-    actualSexpr.appendChild(child, true);
+    child.ensureLineBreakIfMultiLine();
+    actualSexpr.ensureLineBreak();
+    actualSexpr.appendChild(child);
   }
+  actualSexpr.ensureLineBreakIfMultiLine();
   QByteArray actual = actualSexpr.toByteArray();
   FileUtils::writeFile(testDataDir.getPathTo("actual.lp"), actual);
 

--- a/tests/unittests/core/serialization/serializableobjectmock.h
+++ b/tests/unittests/core/serialization/serializableobjectmock.h
@@ -59,7 +59,9 @@ public:
   ~MinimalSerializableObjectMock() {}
 
   void serialize(SExpression& root) const override {
-    root.appendChild("value", mValue, true);
+    root.ensureLineBreak();
+    root.appendChild("value", mValue);
+    root.ensureLineBreak();
   }
 
   bool operator==(const MinimalSerializableObjectMock& rhs) = delete;
@@ -97,7 +99,9 @@ public:
 
   void serialize(SExpression& root) const override {
     root.appendChild(mUuid);
-    root.appendChild("name", mName, true);
+    root.ensureLineBreak();
+    root.appendChild("name", mName);
+    root.ensureLineBreak();
   }
 
   bool operator==(const SerializableObjectMock& rhs) const noexcept {

--- a/tests/unittests/core/serialization/sexpressionlegacymode.h
+++ b/tests/unittests/core/serialization/sexpressionlegacymode.h
@@ -17,12 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef UNITTESTS_CORE_SEXPRESSIONLEGACYMODE_H
+#define UNITTESTS_CORE_SEXPRESSIONLEGACYMODE_H
+
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "librarycategory.h"
 
-#include "../../serialization/sexpression.h"
+#include <librepcb/core/serialization/sexpression.h>
 
 #include <QtCore>
 
@@ -30,47 +32,29 @@
  *  Namespace
  ******************************************************************************/
 namespace librepcb {
+namespace tests {
 
 /*******************************************************************************
- *  Constructors / Destructor
+ *  Class SExpressionLegacyMode
  ******************************************************************************/
 
-LibraryCategory::LibraryCategory(const QString& shortElementName,
-                                 const QString& longElementName,
-                                 const Uuid& uuid, const Version& version,
-                                 const QString& author,
-                                 const ElementName& name_en_US,
-                                 const QString& description_en_US,
-                                 const QString& keywords_en_US)
-  : LibraryBaseElement(true, shortElementName, longElementName, uuid, version,
-                       author, name_en_US, description_en_US, keywords_en_US) {
-}
+class SExpressionLegacyMode final {
+  bool mOldValue;
 
-LibraryCategory::LibraryCategory(
-    std::unique_ptr<TransactionalDirectory> directory,
-    const QString& shortElementName, const QString& longElementName)
-  : LibraryBaseElement(std::move(directory), true, shortElementName,
-                       longElementName),
-    mParentUuid(deserialize<tl::optional<Uuid>>(
-        mLoadingFileDocument.getChild("parent/@0"), mLoadingFileFormat)) {
-}
-
-LibraryCategory::~LibraryCategory() noexcept {
-}
-
-/*******************************************************************************
- *  Protected Methods
- ******************************************************************************/
-
-void LibraryCategory::serialize(SExpression& root) const {
-  LibraryBaseElement::serialize(root);
-  root.ensureLineBreak();
-  root.appendChild("parent", mParentUuid);
-  root.ensureLineBreak();
-}
+public:
+  SExpressionLegacyMode() = delete;
+  SExpressionLegacyMode(bool newValue) : mOldValue(SExpression::legacyMode()) {
+    SExpression::legacyMode() = newValue;
+  }
+  SExpressionLegacyMode(const SExpressionLegacyMode& other) = delete;
+  ~SExpressionLegacyMode() { SExpression::legacyMode() = mOldValue; }
+};
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace tests
 }  // namespace librepcb
+
+#endif

--- a/tests/unittests/core/utils/tangentpathjoinertest.cpp
+++ b/tests/unittests/core/utils/tangentpathjoinertest.cpp
@@ -41,8 +41,10 @@ protected:
   std::string str(QVector<Path> paths, const QString& name = "paths") const {
     SExpression root = SExpression::createList(name);
     foreach (const Path& p, paths) {
-      root.appendChild(p.serializeToDomElement("path"), true);
+      root.ensureLineBreak();
+      root.appendChild(p.serializeToDomElement("path"));
     }
+    root.ensureLineBreakIfMultiLine();
     return root.toByteArray().toStdString();
   }
 

--- a/tests/unittests/core/workspace/workspacesettingstest.cpp
+++ b/tests/unittests/core/workspace/workspacesettingstest.cpp
@@ -20,6 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../serialization/sexpressionlegacymode.h"
+
 #include <gtest/gtest.h>
 #include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
@@ -149,9 +151,129 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   EXPECT_EQ(obj1.pdfOpenBehavior.get(), obj2.pdfOpenBehavior.get());
 
   // Check if serialization of loaded settings leads to same file content
-  SExpression sexpr1 = obj1.serializeToDomElement("settings");
-  SExpression sexpr2 = obj2.serializeToDomElement("settings");
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(obj1.saveToByteArray().toStdString(),
+            obj2.saveToByteArray().toStdString());
+}
+
+// Verify that saving to file does only overwrite modified settings, but keeps
+// unknown file entries and does not add new entries for default settings.
+// This allows to switch between different application versions without
+// creating unnecessary modifications after an upgrade, or - even worse -
+// loosing settings after a downgrade. This allows us to improve/extend the
+// workspace settings even between minor versions (i.e. without introducing
+// a new file format) without any pain for users.
+//
+// In addition, it ensures that the built-in default values are used unless
+// the user explicitly changed the settings. This way, most users will profit
+// from improved default settings automatically. If we saved all settings every
+// time, users would keep the settings at the time writing the settings file
+// the first time forever.
+TEST_F(WorkspaceSettingsTest, testSaveOnlyModifiedSettings) {
+  SExpression sexpr = SExpression::parse(
+      "(librepcb_workspace_settings\n"
+      " (project_autosave_interval 1234)\n"
+      " (unknown_item \"Foo Bar\")\n"
+      " (unknown_list\n"
+      "  (unknown_list_item 42)\n"
+      " )\n"
+      ")\n",
+      FilePath());
+  FilePath fp = FilePath::getRandomTempPath().getPathTo("test.lp");
+  FileUtils::writeFile(fp, sexpr.toByteArray());
+
+  WorkspaceSettings obj(fp, qApp->getFileFormatVersion());
+  EXPECT_EQ(1234U, obj.projectAutosaveIntervalSeconds.get());
+  obj.projectAutosaveIntervalSeconds.set(42);
+  obj.saveToFile();
+
+  QString actualContent = FileUtils::readFile(fp);
+  QString expectedContent =
+      "(librepcb_workspace_settings\n"
+      " (project_autosave_interval 42)\n"
+      " (unknown_item \"Foo Bar\")\n"
+      " (unknown_list\n"
+      "  (unknown_list_item 42)\n"
+      " )\n"
+      ")\n";
+  EXPECT_EQ(expectedContent.toStdString(), actualContent.toStdString());
+}
+
+// Addition for the previous test: Saving a default-constructed object to file
+// shall create a file without any entries.
+TEST_F(WorkspaceSettingsTest, testDefaultIsEmptyFile) {
+  SExpressionLegacyMode legacyMode(false);  // File format v0.2+
+  FilePath fp = FilePath::getRandomTempPath().getPathTo("test.lp");
+
+  WorkspaceSettings obj(fp, qApp->getFileFormatVersion());
+  obj.saveToFile();
+
+  QString actualContent = FileUtils::readFile(fp);
+  QString expectedContent =
+      "(librepcb_workspace_settings\n"
+      ")\n";
+  EXPECT_EQ(expectedContent.toStdString(), actualContent.toStdString());
+}
+
+TEST_F(WorkspaceSettingsTest, testDefaultIsEmptyFileLegacy) {
+  SExpressionLegacyMode legacyMode(true);  // File format v0.1
+  FilePath fp = FilePath::getRandomTempPath().getPathTo("test.lp");
+
+  WorkspaceSettings obj(fp, qApp->getFileFormatVersion());
+  obj.saveToFile();
+
+  QString actualContent = FileUtils::readFile(fp);
+  QString expectedContent = "(librepcb_workspace_settings)\n";
+  EXPECT_EQ(expectedContent.toStdString(), actualContent.toStdString());
+}
+
+// Test that restoring all default values also removes unknown entries from the
+// settings file, since an empty file is the real default.
+TEST_F(WorkspaceSettingsTest, testRestoreDefaultsClearsFile) {
+  SExpressionLegacyMode legacyMode(false);  // File format v0.2+
+  SExpression sexpr = SExpression::parse(
+      "(librepcb_workspace_settings\n"
+      " (project_autosave_interval 1234)\n"
+      " (unknown_value \"Foo Bar\")\n"
+      " (unknown_list\n"
+      "  (unknown_list_item 42)\n"
+      " )\n"
+      ")\n",
+      FilePath());
+  FilePath fp = FilePath::getRandomTempPath().getPathTo("test.lp");
+  FileUtils::writeFile(fp, sexpr.toByteArray());
+
+  WorkspaceSettings obj(fp, qApp->getFileFormatVersion());
+  obj.restoreDefaults();
+  obj.saveToFile();
+
+  QString actualContent = FileUtils::readFile(fp);
+  QString expectedContent =
+      "(librepcb_workspace_settings\n"
+      ")\n";
+  EXPECT_EQ(expectedContent.toStdString(), actualContent.toStdString());
+}
+
+TEST_F(WorkspaceSettingsTest, testRestoreDefaultsClearsFileLegacy) {
+  SExpressionLegacyMode legacyMode(true);  // File format v0.1
+  SExpression sexpr = SExpression::parse(
+      "(librepcb_workspace_settings\n"
+      " (project_autosave_interval 1234)\n"
+      " (unknown_value \"Foo Bar\")\n"
+      " (unknown_list\n"
+      "  (unknown_list_item 42)\n"
+      " )\n"
+      ")\n",
+      FilePath());
+  FilePath fp = FilePath::getRandomTempPath().getPathTo("test.lp");
+  FileUtils::writeFile(fp, sexpr.toByteArray());
+
+  WorkspaceSettings obj(fp, qApp->getFileFormatVersion());
+  obj.restoreDefaults();
+  obj.saveToFile();
+
+  QString actualContent = FileUtils::readFile(fp);
+  QString expectedContent = "(librepcb_workspace_settings)\n";
+  EXPECT_EQ(expectedContent.toStdString(), actualContent.toStdString());
 }
 
 /*******************************************************************************


### PR DESCRIPTION
### Problem

Until now, the workspace settings file (`v0.1/settings.lp`) has been considered as stable, i.e. identical for all v0.1.x application versions - just like we keep the file format stable for library- and project files. But unfortunately this doesn't allow us to implement any additional application settings without introducing a new file format version - although probably most users don't put this file under version control (in contrast to libraries and projects).

### Idea

So my idea was to allow file format changes for that `settings.lp` file, as long as it is compatible between all applications of the same major version. However, currently we always build the whole file content from scratch every time it is saved - this means that unknown file entries will be lost (e.g. after downgrading to an older application version, which has less settings). Probably it's not a big deal, but somehow I still don't like the fact that settings could be lost in this case.

### Workspace Settings Modifications

Thus I refactored the workspace settings load/save mechanism to overwrite only *modified* settings. This way, unknown settings file entries are not lost when saving the settings to disk. In addition, this means that the application will always work with the latest default values unless the user explicitly modified the settings - or in other words, most users will now automatically profit from improved default values with new LibrePCB releases. Currently this is not the case, default values are loaded only when opening the application the first time, and then all these values are saved and then restored the next time, so even when we change default values, users will continue using the *old* default values which were valid at the time they started LibrePCB the first time.

One drawback is that with keeping unknown entries, it's not so clear anymore which order the file entries shall have (the order is not relevant for function, just for having a well defined, stable file format). Thus I decided to make the file simply sorted alphabetically, which will lead to a reformatting of the settings file when upgrading from LibrePCB 0.1.6 to 0.1.7. Hopefully nobody cares about this :wink:

### S-Expression File Format Changes

To support keeping unknown file entries, I had to adjust the S-Expression parser to preserve linebreaks. Until now they were skipped (i.e. the formatting was lost) because we didn't need the formatting information.

During this adjustment, I realized that currently linebreaks are sometimes not optimal for version control. Consider this file content, which represents a list of items:

```scheme
 (library_norm_order
  (norm "IEC 60617")
 )
```

If the list is empty, currently the linebreak is omitted:

```scheme
 (library_norm_order)
```

It looks nice, but it leads to less clean diffs when adding/removing entries. In addition, some logic is needed to conditionally add the trailing linebreak or not. IMHO it would be cleaner to always add a linebreak for such elements, i.e.:

```scheme
 (library_norm_order
 )
```

So for file format v0.2 I implemented it this way now (no change for v0.1.x to keep the file format stable).

Another ugly thing is that some files currently contain even empty lines. For example `circuit.lp` looks like that:

```scheme
(librepcb_circuit

 (netclass ada6400e-cb5c-41b6-9a4e-e2f39ffa3383 (name "default"))

 (net 0654411b-a090-4025-a026-4c61e686662e (auto false) (name "LED_TX")
  (netclass ada6400e-cb5c-41b6-9a4e-e2f39ffa3383)
 )

 (component 04187e1b-d8f2-490f-8731-96198fa4fa7e
  (lib_component b91cf23a-4f07-4b99-8f52-0b42304aef20)
  (lib_variant 0eebde17-6d45-4f73-95fe-3078a0f68ab6)
  (lib_device none)
  (name "LOGO1") (value "Made With\nLibrePCB")
 )

)
```

Especially the last empty line is ugly IMHO. Thus for file format v0.2 I also completely removed the possibility to create empty lines. I think that's much cleaner and simpler:

```scheme
(librepcb_circuit
 (netclass ada6400e-cb5c-41b6-9a4e-e2f39ffa3383 (name "default"))
 (net 0654411b-a090-4025-a026-4c61e686662e (auto false) (name "LED_TX")
  (netclass ada6400e-cb5c-41b6-9a4e-e2f39ffa3383)
 )
 (component 04187e1b-d8f2-490f-8731-96198fa4fa7e
  (lib_component b91cf23a-4f07-4b99-8f52-0b42304aef20)
  (lib_variant 0eebde17-6d45-4f73-95fe-3078a0f68ab6)
  (lib_device none)
  (name "LOGO1") (value "Made With\nLibrePCB")
 )
)
```

Any thoughts welcome :slightly_smiling_face: 