### PR TITLE
Fix rotation & height of some symbol / pin texts

### DIFF
--- a/libs/librepcb/core/geometry/stroketext.cpp
+++ b/libs/librepcb/core/geometry/stroketext.cpp
@@ -24,6 +24,7 @@
 
 #include "../attribute/attributesubstitutor.h"
 #include "../font/strokefont.h"
+#include "../utils/toolbox.h"
 
 #include <QtCore>
 
@@ -122,9 +123,7 @@ const QVector<Path>& StrokeText::getPaths() const noexcept {
 }
 
 bool StrokeText::needsAutoRotation() const noexcept {
-  Angle rot360 = (mMirrored ? -mRotation : mRotation).mappedTo0_360deg();
-  return mAutoRotate && (rot360 > Angle::deg90()) &&
-      (rot360 <= Angle::deg270());
+  return mAutoRotate && Toolbox::isTextUpsideDown(mRotation, mMirrored);
 }
 
 Length StrokeText::calcLetterSpacing() const noexcept {

--- a/libs/librepcb/core/graphics/graphicspainter.cpp
+++ b/libs/librepcb/core/graphics/graphicspainter.cpp
@@ -27,6 +27,7 @@
 #include "../types/angle.h"
 #include "../types/length.h"
 #include "../types/point.h"
+#include "../utils/toolbox.h"
 
 #include <QtCore>
 #include <QtGui>
@@ -114,7 +115,7 @@ void GraphicsPainter::drawText(const Point& position, const Angle& rotation,
     return;  // Nothing to draw.
   }
 
-  const bool rotate180 = textIsUpsideDown(rotation);
+  const bool rotate180 = Toolbox::isTextUpsideDown(rotation, false);
   Alignment align = rotate180 ? alignment.mirrored() : alignment;
   if (mirrorInPlace) {
     align.mirrorH();
@@ -170,7 +171,7 @@ void GraphicsPainter::drawSymbolPin(const Point& position,
 
   // Draw Text.
   if (textColor.isValid()) {
-    const bool rotate180 = textIsUpsideDown(rotation);
+    const bool rotate180 = Toolbox::isTextUpsideDown(rotation, false);
     const int flags =
         Qt::AlignVCenter | (rotate180 ? Qt::AlignRight : Qt::AlignLeft);
     const Point anchor =
@@ -214,7 +215,7 @@ void GraphicsPainter::drawNetLabel(const Point& position, const Angle& rotation,
 
   const Alignment align(mirror ? HAlign::right() : HAlign::left(),
                         VAlign::bottom());
-  const bool rotate180 = textIsUpsideDown(rotation);
+  const bool rotate180 = Toolbox::isTextUpsideDown(rotation, false);
   const int flags =
       rotate180 ? align.mirrored().toQtAlign() : align.toQtAlign();
   const QFontMetricsF metrics(font);
@@ -239,11 +240,6 @@ void GraphicsPainter::drawNetLabel(const Point& position, const Angle& rotation,
 
 qreal GraphicsPainter::getPenWidthPx(const Length& width) const noexcept {
   return std::max(width, *mMinLineWidth).toPx();
-}
-
-bool GraphicsPainter::textIsUpsideDown(const Angle& rotation) noexcept {
-  const Angle rotation180 = rotation.mappedTo180deg();
-  return ((rotation180 <= -Angle::deg90()) || (rotation180 > Angle::deg90()));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/graphics/graphicspainter.cpp
+++ b/libs/librepcb/core/graphics/graphicspainter.cpp
@@ -108,7 +108,7 @@ void GraphicsPainter::drawCircle(const Point& center, const Length& diameter,
 
 void GraphicsPainter::drawText(const Point& position, const Angle& rotation,
                                const Length& height, const Alignment& alignment,
-                               const QString& text, const QFont& font,
+                               const QString& text, QFont font,
                                const QColor& color,
                                bool mirrorInPlace) noexcept {
   if (text.trimmed().isEmpty() || (!color.isValid())) {
@@ -121,6 +121,7 @@ void GraphicsPainter::drawText(const Point& position, const Angle& rotation,
     align.mirrorH();
   }
   const int flags = align.toQtAlign();
+  font.setPixelSize(qCeil(height.toPx()));
   const QFontMetricsF metrics(font);
   const qreal scale = height.toPx() / metrics.height();
   const QRectF rect =
@@ -148,10 +149,8 @@ void GraphicsPainter::drawText(const Point& position, const Angle& rotation,
 
 void GraphicsPainter::drawSymbolPin(const Point& position,
                                     const Angle& rotation, const Length& length,
-                                    const QString& text, const QFont& font,
                                     const QColor& lineColor,
-                                    const QColor& circleColor,
-                                    const QColor& textColor) noexcept {
+                                    const QColor& circleColor) noexcept {
   // Draw Line.
   if (lineColor.isValid()) {
     const Point endPosition = position + Point(length, 0).rotated(rotation);
@@ -167,29 +166,6 @@ void GraphicsPainter::drawSymbolPin(const Point& position,
     mPainter.setPen(QPen(circleColor, mMinLineWidth->toPx()));
     mPainter.setBrush(Qt::NoBrush);
     mPainter.drawEllipse(position.toPxQPointF(), radius, radius);
-  }
-
-  // Draw Text.
-  if (textColor.isValid()) {
-    const bool rotate180 = Toolbox::isTextUpsideDown(rotation, false);
-    const int flags =
-        Qt::AlignVCenter | (rotate180 ? Qt::AlignRight : Qt::AlignLeft);
-    const Point anchor =
-        position + Point::fromPx(length.toPx() + 4, 0).rotated(rotation);
-    const QFontMetricsF metrics(font);
-    const QRectF rect =
-        metrics.boundingRect(QRectF(), flags | Qt::TextDontClip, text);
-
-    mPainter.save();
-    mPainter.setPen(QPen(textColor, 0));
-    mPainter.setBrush(Qt::NoBrush);
-    mPainter.setFont(font);
-    mPainter.translate(anchor.toPxQPointF().x(), anchor.toPxQPointF().y());
-    mPainter.rotate(-rotation.mappedTo180deg().toDeg() + (rotate180 ? 180 : 0));
-    mPainter.drawText(rect, flags, text);
-    mPainter.setPen(Qt::transparent);
-    mPainter.drawRect(rect);  // Required for correct bounding rect calculation!
-    mPainter.restore();
   }
 }
 

--- a/libs/librepcb/core/graphics/graphicspainter.h
+++ b/libs/librepcb/core/graphics/graphicspainter.h
@@ -70,13 +70,11 @@ public:
                   const QColor& fillColor) noexcept;
   void drawText(const Point& position, const Angle& rotation,
                 const Length& height, const Alignment& alignment,
-                const QString& text, const QFont& font, const QColor& color,
+                const QString& text, QFont font, const QColor& color,
                 bool mirrorInPlace) noexcept;
   void drawSymbolPin(const Point& position, const Angle& rotation,
-                     const Length& length, const QString& text,
-                     const QFont& font, const QColor& lineColor,
-                     const QColor& circleColor,
-                     const QColor& textColor) noexcept;
+                     const Length& length, const QColor& lineColor,
+                     const QColor& circleColor) noexcept;
   void drawNetJunction(const Point& position, const QColor& color) noexcept;
   void drawNetLabel(const Point& position, const Angle& rotation, bool mirror,
                     const QString& text, const QFont& font,

--- a/libs/librepcb/core/graphics/graphicspainter.h
+++ b/libs/librepcb/core/graphics/graphicspainter.h
@@ -87,7 +87,6 @@ public:
 
 private:  // Methods
   qreal getPenWidthPx(const Length& width) const noexcept;
-  static bool textIsUpsideDown(const Angle& rotation) noexcept;
 
 private:  // Data
   QPainter& mPainter;

--- a/libs/librepcb/core/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/primitivetextgraphicsitem.cpp
@@ -42,12 +42,12 @@ PrimitiveTextGraphicsItem::PrimitiveTextGraphicsItem(
     QGraphicsItem* parent) noexcept
   : QGraphicsItem(parent),
     mLayer(nullptr),
+    mText(),
+    mHeight(1),
     mAlignment(HAlign::left(), VAlign::bottom()),
     mTextFlags(0),
     mOnLayerEditedSlot(*this, &PrimitiveTextGraphicsItem::layerEdited) {
   mFont = qApp->getDefaultSansSerifFont();
-  mFont.setPixelSize(1);
-
   updateBoundingRectAndShape();
   setVisible(false);
 }
@@ -76,7 +76,7 @@ void PrimitiveTextGraphicsItem::setText(const QString& text) noexcept {
 
 void PrimitiveTextGraphicsItem::setHeight(
     const PositiveLength& height) noexcept {
-  mFont.setPixelSize(height->toPx());
+  mHeight = height;
   updateBoundingRectAndShape();
 }
 
@@ -86,7 +86,6 @@ void PrimitiveTextGraphicsItem::setAlignment(const Alignment& align) noexcept {
 }
 
 void PrimitiveTextGraphicsItem::setFont(Font font) noexcept {
-  int size = mFont.pixelSize();  // memorize size
   switch (font) {
     case Font::SansSerif:
       mFont = qApp->getDefaultSansSerifFont();
@@ -100,7 +99,6 @@ void PrimitiveTextGraphicsItem::setFont(Font font) noexcept {
       break;
     }
   }
-  mFont.setPixelSize(size);
   updateBoundingRectAndShape();
 }
 
@@ -169,10 +167,12 @@ void PrimitiveTextGraphicsItem::layerEdited(
 void PrimitiveTextGraphicsItem::updateBoundingRectAndShape() noexcept {
   prepareGeometryChange();
   mTextFlags = Qt::TextDontClip | mAlignment.toQtAlign();
+  mFont.setPixelSize(qCeil(mHeight->toPx()));
   QFontMetricsF fm(mFont);
   mBoundingRect = fm.boundingRect(QRectF(), mTextFlags, mText);
   mShape = QPainterPath();
   mShape.addRect(mBoundingRect);
+  setScale(mHeight->toPx() / fm.height());
   update();
 }
 

--- a/libs/librepcb/core/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/primitivetextgraphicsitem.cpp
@@ -134,19 +134,7 @@ void PrimitiveTextGraphicsItem::paint(QPainter* painter,
   } else {
     painter->setPen(mPen);
   }
-
-  if (mapToScene(0, 1).y() < mapToScene(0, 0).y()) {
-    // The text needs to be rotated 180°!
-    // TODO: Is there a better solution to determine the overall rotation of the
-    // item?
-    // painter->save();
-    painter->rotate(180);
-    painter->translate(-mBoundingRect.topLeft() - mBoundingRect.bottomRight());
-    painter->drawText(QRectF(), mTextFlags, mText);
-    // painter->restore();
-  } else {
-    painter->drawText(QRectF(), mTextFlags, mText);
-  }
+  painter->drawText(QRectF(), mTextFlags, mText);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/graphics/primitivetextgraphicsitem.h
+++ b/libs/librepcb/core/graphics/primitivetextgraphicsitem.h
@@ -84,6 +84,7 @@ private:  // Methods
 private:  // Data
   const GraphicsLayer* mLayer;
   QString mText;
+  PositiveLength mHeight;
   Alignment mAlignment;
   QFont mFont;
   QPen mPen;

--- a/libs/librepcb/core/graphics/primitivetextgraphicsitem.h
+++ b/libs/librepcb/core/graphics/primitivetextgraphicsitem.h
@@ -59,10 +59,10 @@ public:
 
   // Setters
   void setPosition(const Point& pos) noexcept;
-  void setRotation(const Angle& rot) noexcept;
+  virtual void setRotation(const Angle& rot) noexcept;
   void setText(const QString& text) noexcept;
   void setHeight(const PositiveLength& height) noexcept;
-  void setAlignment(const Alignment& align) noexcept;
+  virtual void setAlignment(const Alignment& align) noexcept;
   void setFont(Font font) noexcept;
   void setLayer(const GraphicsLayer* layer) noexcept;
 

--- a/libs/librepcb/core/graphics/textgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/textgraphicsitem.cpp
@@ -24,6 +24,7 @@
 
 #include "../attribute/attributesubstitutor.h"
 #include "../graphics/graphicslayer.h"
+#include "../utils/toolbox.h"
 #include "origincrossgraphicsitem.h"
 
 #include <QtCore>
@@ -48,10 +49,9 @@ TextGraphicsItem::TextGraphicsItem(Text& text,
     mOnEditedSlot(*this, &TextGraphicsItem::textEdited) {
   setFont(TextGraphicsItem::Font::SansSerif);
   setPosition(mText.getPosition());
-  setRotation(mText.getRotation());
   setHeight(mText.getHeight());
-  setAlignment(mText.getAlign());
   setLayer(mLayerProvider.getLayer(*mText.getLayerName()));
+  setRotationAndAlignment(mText.getRotation(), mText.getAlign());
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   setZValue(5);
   updateText();
@@ -67,6 +67,18 @@ TextGraphicsItem::TextGraphicsItem(Text& text,
 }
 
 TextGraphicsItem::~TextGraphicsItem() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void TextGraphicsItem::setRotation(const Angle& rot) noexcept {
+  setRotationAndAlignment(rot, mText.getAlign());
+}
+
+void TextGraphicsItem::setAlignment(const Alignment& align) noexcept {
+  setRotationAndAlignment(mText.getRotation(), align);
 }
 
 /*******************************************************************************
@@ -106,18 +118,28 @@ void TextGraphicsItem::textEdited(const Text& text,
       setPosition(text.getPosition());
       break;
     case Text::Event::RotationChanged:
-      setRotation(text.getRotation());
+      setRotationAndAlignment(text.getRotation(), text.getAlign());
       break;
     case Text::Event::HeightChanged:
       setHeight(text.getHeight());
       break;
     case Text::Event::AlignChanged:
-      setAlignment(text.getAlign());
+      setRotationAndAlignment(text.getRotation(), text.getAlign());
       break;
     default:
       qWarning() << "Unhandled switch-case in TextGraphicsItem::textEdited()";
       break;
   }
+}
+
+void TextGraphicsItem::setRotationAndAlignment(Angle rotation,
+                                               Alignment align) noexcept {
+  if (Toolbox::isTextUpsideDown(rotation, false)) {
+    rotation += Angle::deg180();
+    align.mirror();
+  }
+  PrimitiveTextGraphicsItem::setRotation(rotation);
+  PrimitiveTextGraphicsItem::setAlignment(align);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/graphics/textgraphicsitem.h
+++ b/libs/librepcb/core/graphics/textgraphicsitem.h
@@ -58,6 +58,10 @@ public:
   // Getters
   Text& getText() noexcept { return mText; }
 
+  // Setters
+  void setRotation(const Angle& rot) noexcept override;
+  void setAlignment(const Alignment& align) noexcept override;
+
   // General Methods
   void setAttributeProvider(const AttributeProvider* provider) noexcept;
   void updateText() noexcept;
@@ -67,6 +71,7 @@ public:
 
 private:  // Methods
   void textEdited(const Text& text, Text::Event event) noexcept;
+  void setRotationAndAlignment(Angle rotation, Alignment align) noexcept;
 
 private:  // Data
   Text& mText;

--- a/libs/librepcb/core/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpadgraphicsitem.cpp
@@ -94,6 +94,9 @@ void FootprintPadGraphicsItem::setPosition(const Point& pos) noexcept {
 
 void FootprintPadGraphicsItem::setRotation(const Angle& rot) noexcept {
   QGraphicsItem::setRotation(-rot.toDeg());
+
+  // Keep the text always at 0° for readability.
+  mTextGraphicsItem->setRotation(-rot);
 }
 
 void FootprintPadGraphicsItem::setShape(const QPainterPath& shape) noexcept {

--- a/libs/librepcb/core/library/pkg/footprintpainter.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpainter.cpp
@@ -123,10 +123,9 @@ void FootprintPainter::paint(QPainter& painter,
     // Draw invisible texts to make them selectable and searchable in PDF and
     // SVG output.
     foreach (const Text& text, content.texts) {
-      QFont font = qApp->getDefaultMonospaceFont();
-      font.setPixelSize(qCeil(text.getHeight()->toPx()));
       p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
-                 text.getAlign(), text.getText(), font, Qt::transparent,
+                 text.getAlign(), text.getText(),
+                 qApp->getDefaultMonospaceFont(), Qt::transparent,
                  settings.getMirror());
     }
   }

--- a/libs/librepcb/core/library/sym/symbolpainter.cpp
+++ b/libs/librepcb/core/library/sym/symbolpainter.cpp
@@ -88,21 +88,22 @@ void SymbolPainter::paint(QPainter& painter,
 
   // Draw Texts.
   foreach (const Text& text, mTexts) {
-    QFont font = qApp->getDefaultSansSerifFont();
-    font.setPixelSize(qCeil(text.getHeight()->toPx()));
     p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
-               text.getAlign(), text.getText(), font,
+               text.getAlign(), text.getText(), qApp->getDefaultSansSerifFont(),
                settings.getColor(*text.getLayerName()), false);
   }
 
   // Draw Pins.
   foreach (const SymbolPin& pin, mPins) {
-    QFont font = qApp->getDefaultSansSerifFont();
-    font.setPixelSize(5);
     p.drawSymbolPin(pin.getPosition(), pin.getRotation(), *pin.getLength(),
-                    *pin.getName(), font,
-                    settings.getColor(GraphicsLayer::sSymbolOutlines), QColor(),
-                    settings.getColor(GraphicsLayer::sSymbolPinNames));
+                    settings.getColor(GraphicsLayer::sSymbolOutlines),
+                    QColor());
+    p.drawText(
+        pin.getPosition() + pin.getNamePosition().rotated(pin.getRotation()),
+        pin.getRotation(), *SymbolPin::getNameHeight(),
+        Alignment(HAlign::left(), VAlign::center()), *pin.getName(),
+        qApp->getDefaultSansSerifFont(),
+        settings.getColor(GraphicsLayer::sSymbolPinNames), false);
   }
 }
 

--- a/libs/librepcb/core/library/sym/symbolpin.h
+++ b/libs/librepcb/core/library/sym/symbolpin.h
@@ -79,6 +79,9 @@ public:
   const Point& getPosition() const noexcept { return mPosition; }
   const UnsignedLength& getLength() const noexcept { return mLength; }
   const Angle& getRotation() const noexcept { return mRotation; }
+  Point getNamePosition() const noexcept {
+    return Point(mLength + Length(800000), 0);  // Without rotation!
+  }
 
   // Setters
   bool setPosition(const Point& pos) noexcept;
@@ -99,6 +102,11 @@ public:
     return !(*this == rhs);
   }
   SymbolPin& operator=(const SymbolPin& rhs) noexcept;
+
+  // Static Methods
+  static PositiveLength getNameHeight() noexcept {
+    return PositiveLength(2500000);
+  }
 
 private:  // Data
   Uuid mUuid;

--- a/libs/librepcb/core/library/sym/symbolpingraphicsitem.cpp
+++ b/libs/librepcb/core/library/sym/symbolpingraphicsitem.cpp
@@ -28,6 +28,7 @@
 #include "../../graphics/primitivetextgraphicsitem.h"
 #include "../../types/angle.h"
 #include "../../types/point.h"
+#include "../../utils/toolbox.h"
 #include "symbolpin.h"
 
 #include <QtCore>
@@ -67,9 +68,9 @@ SymbolPinGraphicsItem::SymbolPinGraphicsItem(SymbolPin& pin,
 
   // text
   mTextGraphicsItem->setHeight(PositiveLength(Length::fromMm(qreal(2))));
-  mTextGraphicsItem->setAlignment(Alignment(HAlign::left(), VAlign::center()));
   mTextGraphicsItem->setLayer(lp.getLayer(GraphicsLayer::sSymbolPinNames));
   mTextGraphicsItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+  updateTextRotationAndAlignment();
 
   // pin properties
   setPosition(mPin.getPosition());
@@ -95,6 +96,7 @@ void SymbolPinGraphicsItem::setPosition(const Point& pos) noexcept {
 
 void SymbolPinGraphicsItem::setRotation(const Angle& rot) noexcept {
   QGraphicsItem::setRotation(-rot.toDeg());
+  updateTextRotationAndAlignment();  // Auto-rotation may need to be updated.
 }
 
 void SymbolPinGraphicsItem::setLength(const UnsignedLength& length) noexcept {
@@ -130,6 +132,21 @@ void SymbolPinGraphicsItem::paint(QPainter* painter,
   Q_UNUSED(painter);
   Q_UNUSED(option);
   Q_UNUSED(widget);
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void SymbolPinGraphicsItem::updateTextRotationAndAlignment() noexcept {
+  Angle rotation(0);
+  Alignment alignment(HAlign::left(), VAlign::center());
+  if (Toolbox::isTextUpsideDown(mPin.getRotation(), false)) {
+    rotation += Angle::deg180();
+    alignment.mirror();
+  }
+  mTextGraphicsItem->setRotation(rotation);
+  mTextGraphicsItem->setAlignment(alignment);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/sym/symbolpingraphicsitem.cpp
+++ b/libs/librepcb/core/library/sym/symbolpingraphicsitem.cpp
@@ -67,7 +67,7 @@ SymbolPinGraphicsItem::SymbolPinGraphicsItem(SymbolPin& pin,
   mLineGraphicsItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
 
   // text
-  mTextGraphicsItem->setHeight(PositiveLength(Length::fromMm(qreal(2))));
+  mTextGraphicsItem->setHeight(SymbolPin::getNameHeight());
   mTextGraphicsItem->setLayer(lp.getLayer(GraphicsLayer::sSymbolPinNames));
   mTextGraphicsItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
   updateTextRotationAndAlignment();
@@ -101,7 +101,7 @@ void SymbolPinGraphicsItem::setRotation(const Angle& rot) noexcept {
 
 void SymbolPinGraphicsItem::setLength(const UnsignedLength& length) noexcept {
   mLineGraphicsItem->setLine(Point(0, 0), Point(*length, 0));
-  mTextGraphicsItem->setPosition(Point(length + Length(800000), Length(0)));
+  mTextGraphicsItem->setPosition(mPin.getNamePosition());
 }
 
 void SymbolPinGraphicsItem::setName(const CircuitIdentifier& name) noexcept {

--- a/libs/librepcb/core/library/sym/symbolpingraphicsitem.h
+++ b/libs/librepcb/core/library/sym/symbolpingraphicsitem.h
@@ -78,7 +78,7 @@ public:
   SymbolPinGraphicsItem& operator=(const SymbolPinGraphicsItem& rhs) = delete;
 
 private:  // Methods
-  void updateShape() noexcept;
+  void updateTextRotationAndAlignment() noexcept;
 
 private:  // Data
   SymbolPin& mPin;

--- a/libs/librepcb/core/project/board/boardpainter.cpp
+++ b/libs/librepcb/core/project/board/boardpainter.cpp
@@ -177,10 +177,9 @@ void BoardPainter::paint(QPainter& painter,
     // Draw invisible texts to make them selectable and searchable in PDF and
     // SVG output.
     foreach (const Text& text, content.texts) {
-      QFont font = qApp->getDefaultMonospaceFont();
-      font.setPixelSize(qCeil(text.getHeight()->toPx()));
       p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
-                 text.getAlign(), text.getText(), font, Qt::transparent,
+                 text.getAlign(), text.getText(),
+                 qApp->getDefaultMonospaceFont(), Qt::transparent,
                  settings.getMirror());
     }
   }

--- a/libs/librepcb/core/project/schematic/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/core/project/schematic/graphicsitems/sgi_netlabel.cpp
@@ -80,8 +80,7 @@ SGI_NetLabel::~SGI_NetLabel() noexcept {
 void SGI_NetLabel::updateCacheAndRepaint() noexcept {
   prepareGeometryChange();
 
-  mRotate180 = (mNetLabel.getRotation().mappedTo180deg() <= -Angle::deg90() ||
-                mNetLabel.getRotation().mappedTo180deg() > Angle::deg90());
+  mRotate180 = Toolbox::isTextUpsideDown(mNetLabel.getRotation(), false);
 
   mStaticText.setText(*mNetLabel.getNetSignalOfNetSegment().getName());
   mStaticText.prepare(QTransform(), mFont);

--- a/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbol.cpp
@@ -26,6 +26,7 @@
 #include "../../../attribute/attributesubstitutor.h"
 #include "../../../library/cmp/component.h"
 #include "../../../library/sym/symbol.h"
+#include "../../../utils/toolbox.h"
 #include "../../circuit/componentinstance.h"
 #include "../../project.h"
 #include "../items/si_symbol.h"
@@ -141,12 +142,7 @@ void SGI_Symbol::updateCacheAndRepaint() noexcept {
     Angle absAngle = text.getRotation() + mSymbol.getRotation();
     absAngle.mapTo180deg();
     props.mirrored = mSymbol.getMirrored();
-    if (!props.mirrored)
-      props.rotate180 =
-          (absAngle <= -Angle::deg90() || absAngle > Angle::deg90());
-    else
-      props.rotate180 =
-          (absAngle < -Angle::deg90() || absAngle >= Angle::deg90());
+    props.rotate180 = Toolbox::isTextUpsideDown(absAngle, props.mirrored);
 
     // calculate text position
     scaledTextRect.translate(text.getPosition().toPxQPointF());

--- a/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbolpin.cpp
@@ -25,6 +25,7 @@
 #include "../../../application.h"
 #include "../../../library/cmp/component.h"
 #include "../../../library/sym/symbolpin.h"
+#include "../../../utils/toolbox.h"
 #include "../../circuit/componentinstance.h"
 #include "../../circuit/componentsignalinstance.h"
 #include "../../circuit/netsignal.h"
@@ -80,8 +81,7 @@ void SGI_SymbolPin::updateCacheAndRepaint() noexcept {
   mBoundingRect = QRectF();
 
   // rotation
-  const Angle absAngle = mPin.getRotation().mappedTo180deg();
-  mRotate180 = (absAngle <= -Angle::deg90() || absAngle > Angle::deg90());
+  mRotate180 = Toolbox::isTextUpsideDown(mPin.getRotation(), false);
 
   // circle
   mShape.addEllipse(-mRadiusPx, -mRadiusPx, 2 * mRadiusPx, 2 * mRadiusPx);

--- a/libs/librepcb/core/project/schematic/schematicpainter.h
+++ b/libs/librepcb/core/project/schematic/schematicpainter.h
@@ -55,7 +55,8 @@ class SchematicPainter final : public GraphicsPagePainter {
     Point position;
     Angle rotation;
     UnsignedLength length;
-    QString text;
+    QString name;
+    Point namePosition;
   };
 
   struct Line {

--- a/libs/librepcb/core/utils/toolbox.cpp
+++ b/libs/librepcb/core/utils/toolbox.cpp
@@ -33,6 +33,15 @@ namespace librepcb {
  *  Static Methods
  ******************************************************************************/
 
+bool Toolbox::isTextUpsideDown(const Angle& rotation, bool mirrored) noexcept {
+  const Angle mapped180 = rotation.mappedTo180deg();
+  if (mirrored) {
+    return ((mapped180 < -Angle::deg90()) || (mapped180 >= Angle::deg90()));
+  } else {
+    return ((mapped180 <= -Angle::deg90()) || (mapped180 > Angle::deg90()));
+  }
+}
+
 QPainterPath Toolbox::shapeFromPath(const QPainterPath& path, const QPen& pen,
                                     const QBrush& brush,
                                     const UnsignedLength& minWidth) noexcept {

--- a/libs/librepcb/core/utils/toolbox.h
+++ b/libs/librepcb/core/utils/toolbox.h
@@ -96,6 +96,21 @@ public:
     return copy;
   }
 
+  /**
+   * @brief Check if a text with a given rotation is considered as upside down
+   *
+   * A text is considered as upside down if it is rotated counterclockwise by
+   * [-90..90°[, i.e. -90° is considered as upside down, but 90° is *not*
+   * considered as upside down. For mirrored texts (rotated clockwise), it
+   * is the other way around. Used to determine whether a text needs to be
+   * auto-rotated or not.
+   *
+   * @param rotation  The global (scene coordinates) rotation of the text.
+   * @param mirrored  If the text is mirrored (inverted rotation!).
+   * @return Whether the text is upside down or not.
+   */
+  static bool isTextUpsideDown(const Angle& rotation, bool mirrored) noexcept;
+
   static QRectF boundingRectFromRadius(qreal radius) noexcept {
     return QRectF(-radius, -radius, 2 * radius, 2 * radius);
   }

--- a/libs/librepcb/editor/library/sym/symbolpinpreviewgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolpinpreviewgraphicsitem.cpp
@@ -26,6 +26,7 @@
 #include <librepcb/core/graphics/graphicslayer.h>
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/library/sym/symbolpin.h>
+#include <librepcb/core/utils/toolbox.h>
 
 #include <QPrinter>
 #include <QtCore>
@@ -89,8 +90,7 @@ void SymbolPinPreviewGraphicsItem::updateCacheAndRepaint() noexcept {
   // rotation
   Angle absAngle = mPin.getRotation() +
       Angle::fromDeg(parentItem() ? -parentItem()->rotation() : 0);
-  absAngle.mapTo180deg();
-  mRotate180 = (absAngle <= -Angle::deg90() || absAngle > Angle::deg90());
+  mRotate180 = Toolbox::isTextUpsideDown(absAngle, false);
 
   // circle
   mShape.addEllipse(-mRadiusPx, -mRadiusPx, 2 * mRadiusPx, 2 * mRadiusPx);

--- a/libs/librepcb/editor/library/sym/symbolpreviewgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolpreviewgraphicsitem.cpp
@@ -30,6 +30,7 @@
 #include <librepcb/core/graphics/graphicslayer.h>
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/library/sym/symbol.h>
+#include <librepcb/core/utils/toolbox.h>
 
 #include <QPrinter>
 #include <QtCore>
@@ -156,9 +157,7 @@ void SymbolPreviewGraphicsItem::updateCacheAndRepaint() noexcept {
 
     // check rotation
     Angle absAngle = text.getRotation() + Angle::fromDeg(rotation());
-    absAngle.mapTo180deg();
-    props.rotate180 =
-        (absAngle <= -Angle::deg90() || absAngle > Angle::deg90());
+    props.rotate180 = Toolbox::isTextUpsideDown(absAngle, false);
 
     // calculate text position
     qreal dx, dy;

--- a/tests/unittests/core/utils/toolboxtest.cpp
+++ b/tests/unittests/core/utils/toolboxtest.cpp
@@ -38,6 +38,50 @@ namespace tests {
 class ToolboxTest : public ::testing::Test {};
 
 /*******************************************************************************
+ *  isTextUpsideDown() Tests
+ ******************************************************************************/
+
+TEST_F(ToolboxTest, testIsTextUpsideDown) {
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-360000000), false));  // 0°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-315000000), false));  // 45°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-270000000), false));  // 90°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-225000000), false));  // 135°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-180000000), false));  // 180°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-135000000), false));  // 225°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-90000000), false));  // 270°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-45000000), false));  // 315°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(0), false));  // 0°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(45000000), false));  // 45°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(90000000), false));  // 90°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(135000000), false));  // 135°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(180000000), false));  // 180°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(225000000), false));  // 225°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(270000000), false));  // 270°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(315000000), false));  // 315°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(360000000), false));  // 0°
+}
+
+TEST_F(ToolboxTest, testIsTextUpsideDownMirrored) {
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-360000000), true));  // 0°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-315000000), true));  // 45°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-270000000), true));  // 90°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-225000000), true));  // 135°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-180000000), true));  // 180°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-135000000), true));  // 225°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-90000000), true));  // 270°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-45000000), true));  // 315°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(0), true));  // 0°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(45000000), true));  // 45°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(90000000), true));  // 90°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(135000000), true));  // 135°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(180000000), true));  // 180°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(225000000), true));  // 225°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(270000000), true));  // 270°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(315000000), true));  // 315°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(360000000), true));  // 0°
+}
+
+/*******************************************************************************
  *  shapeFromPath() Tests
  ******************************************************************************/
 


### PR DESCRIPTION
- Fix possibly wrong symbol/pin text auto-rotations in some cases
- Fix inconsistent height of symbol texts between symbol editor and schematic editor

Fixes #534

Replaces #556