### PR TITLE
CMake: Add alias for muparser target

### DIFF
--- a/cmake/FindMuParser.cmake
+++ b/cmake/FindMuParser.cmake
@@ -37,6 +37,11 @@ find_package(muparser 2.0 QUIET)
 if(muparser_FOUND)
   message(STATUS "Using system MuParser")
 
+  # Add uppercase alias if only the lowercase target is defined
+  if(NOT TARGET MuParser::MuParser)
+    add_library(MuParser::MuParser ALIAS muparser::muparser)
+  endif()
+
   # Stop here, we're done
   return()
 endif()


### PR DESCRIPTION
Building LibrePCB with unbundled MuParser on Arch Linux currently fails,
because the target `MuParser::MuParser` is not defined. Because this
used to work before, I assume the target was renamed from
`MuParser::MuParser` to `muparser::muparser` some time ago.

To fix this, add an alias if the CMake package was found, but the pascal
case alias isn't defined yet.