### PR TITLE
Library editor: Make symbol pin text placement configurable

### DIFF
--- a/libs/librepcb/core/library/sym/symbolpainter.cpp
+++ b/libs/librepcb/core/library/sym/symbolpainter.cpp
@@ -100,9 +100,8 @@ void SymbolPainter::paint(QPainter& painter,
                     QColor());
     p.drawText(
         pin.getPosition() + pin.getNamePosition().rotated(pin.getRotation()),
-        pin.getRotation(), *SymbolPin::getNameHeight(),
-        Alignment(HAlign::left(), VAlign::center()), *pin.getName(),
-        qApp->getDefaultSansSerifFont(),
+        pin.getRotation() + pin.getNameRotation(), *pin.getNameHeight(),
+        pin.getNameAlignment(), *pin.getName(), qApp->getDefaultSansSerifFont(),
         settings.getColor(GraphicsLayer::sSymbolPinNames), false);
   }
 }

--- a/libs/librepcb/core/library/sym/symbolpin.h
+++ b/libs/librepcb/core/library/sym/symbolpin.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../serialization/serializableobjectlist.h"
+#include "../../types/alignment.h"
 #include "../../types/angle.h"
 #include "../../types/circuitidentifier.h"
 #include "../../types/length.h"
@@ -58,6 +59,10 @@ public:
     PositionChanged,
     LengthChanged,
     RotationChanged,
+    NamePositionChanged,
+    NameRotationChanged,
+    NameHeightChanged,
+    NameAlignmentChanged,
   };
   Signal<SymbolPin, Event> onEdited;
   typedef Slot<SymbolPin, Event> OnEditedSlot;
@@ -67,7 +72,9 @@ public:
   SymbolPin(const SymbolPin& other) noexcept;
   SymbolPin(const Uuid& uuid, const CircuitIdentifier& name,
             const Point& position, const UnsignedLength& length,
-            const Angle& rotation) noexcept;
+            const Angle& rotation, const Point& namePosition,
+            const Angle& nameRotation, const PositiveLength& nameHeight,
+            const Alignment& nameAlign) noexcept;
   SymbolPin(const SExpression& node, const Version& fileFormat);
   ~SymbolPin() noexcept;
 
@@ -77,15 +84,20 @@ public:
   const Point& getPosition() const noexcept { return mPosition; }
   const UnsignedLength& getLength() const noexcept { return mLength; }
   const Angle& getRotation() const noexcept { return mRotation; }
-  Point getNamePosition() const noexcept {
-    return Point(mLength + Length(800000), 0);  // Without rotation!
-  }
+  const Point& getNamePosition() const noexcept { return mNamePosition; }
+  const Angle& getNameRotation() const noexcept { return mNameRotation; }
+  const PositiveLength& getNameHeight() const noexcept { return mNameHeight; }
+  const Alignment& getNameAlignment() const noexcept { return mNameAlignment; }
 
   // Setters
   bool setPosition(const Point& pos) noexcept;
   bool setLength(const UnsignedLength& length) noexcept;
   bool setRotation(const Angle& rotation) noexcept;
   bool setName(const CircuitIdentifier& name) noexcept;
+  bool setNamePosition(const Point& position) noexcept;
+  bool setNameRotation(const Angle& rotation) noexcept;
+  bool setNameHeight(const PositiveLength& height) noexcept;
+  bool setNameAlignment(const Alignment& align) noexcept;
 
   /// @copydoc ::librepcb::SerializableObject::serialize()
   void serialize(SExpression& root) const override;
@@ -98,8 +110,14 @@ public:
   SymbolPin& operator=(const SymbolPin& rhs) noexcept;
 
   // Static Methods
-  static PositiveLength getNameHeight() noexcept {
+  static Point getDefaultNamePosition(const UnsignedLength& length) noexcept {
+    return Point(length + Length(1270000), 0);
+  }
+  static PositiveLength getDefaultNameHeight() noexcept {
     return PositiveLength(2500000);
+  }
+  static Alignment getDefaultNameAlignment() noexcept {
+    return Alignment(HAlign::left(), VAlign::center());
   }
 
 private:  // Data
@@ -108,6 +126,10 @@ private:  // Data
   Point mPosition;
   UnsignedLength mLength;
   Angle mRotation;
+  Point mNamePosition;
+  Angle mNameRotation;
+  PositiveLength mNameHeight;
+  Alignment mNameAlignment;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbolpin.cpp
@@ -24,6 +24,7 @@
 
 #include "../../../library/sym/symbolpin.h"
 #include "../../../utils/toolbox.h"
+#include "../../../utils/transform.h"
 #include "../../circuit/netsignal.h"
 #include "../../project.h"
 #include "../items/si_symbol.h"
@@ -54,7 +55,7 @@ SGI_SymbolPin::SGI_SymbolPin(SI_SymbolPin& pin) noexcept
     mTextGraphicsItem(new PrimitiveTextGraphicsItem(this)) {
   setFlag(QGraphicsItem::ItemHasNoContents, false);
   setFlag(QGraphicsItem::ItemIsSelectable, true);
-  setZValue(Schematic::ZValue_Symbols);
+  setZValue(Schematic::ZValue_SymbolPins);
   setToolTip(*mPin.getLibPin().getName());
 
   // Setup circle.
@@ -71,13 +72,11 @@ SGI_SymbolPin::SGI_SymbolPin(SI_SymbolPin& pin) noexcept
   mLineGraphicsItem->setFlag(QGraphicsItem::ItemStacksBehindParent, true);
 
   // Setup text.
-  mTextGraphicsItem->setPosition(mPin.getLibPin().getNamePosition());
   mTextGraphicsItem->setFont(PrimitiveTextGraphicsItem::Font::SansSerif);
-  mTextGraphicsItem->setHeight(SymbolPin::getNameHeight());
+  mTextGraphicsItem->setHeight(mPin.getLibPin().getNameHeight());
   mTextGraphicsItem->setLayer(getLayer(GraphicsLayer::sSymbolPinNames));
   mTextGraphicsItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
   mTextGraphicsItem->setFlag(QGraphicsItem::ItemStacksBehindParent, true);
-  updateTextRotationAndAlignment();
 
   updateData();
 }
@@ -86,21 +85,31 @@ SGI_SymbolPin::~SGI_SymbolPin() noexcept {
 }
 
 /*******************************************************************************
- *  Setters
- ******************************************************************************/
-
-void SGI_SymbolPin::setPosition(const Point& pos) noexcept {
-  QGraphicsItem::setPos(pos.toPxQPointF());
-}
-
-void SGI_SymbolPin::setRotation(const Angle& rot) noexcept {
-  QGraphicsItem::setRotation(-rot.toDeg());
-  updateTextRotationAndAlignment();  // Auto-rotation may need to be updated.
-}
-
-/*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+void SGI_SymbolPin::updateTransform() noexcept {
+  mLineGraphicsItem->setRotation(mPin.getRotation());
+
+  const Transform transform(mPin.getSymbol());
+  const Point namePosition =
+      transform.map(mPin.getLibPin().getNamePosition().rotated(
+          mPin.getLibPin().getRotation())) -
+      transform.getPosition();
+  Angle nameRotation = transform.map(mPin.getLibPin().getRotation() +
+                                     mPin.getLibPin().getNameRotation());
+  Alignment nameAlignment = mPin.getLibPin().getNameAlignment();
+  if (transform.getMirrored()) {
+    nameAlignment.mirrorV();
+  }
+  if (Toolbox::isTextUpsideDown(nameRotation, false)) {
+    nameRotation += Angle::deg180();
+    nameAlignment.mirror();
+  }
+  mTextGraphicsItem->setPosition(namePosition);
+  mTextGraphicsItem->setRotation(nameRotation);
+  mTextGraphicsItem->setAlignment(nameAlignment);
+}
 
 void SGI_SymbolPin::updateData() noexcept {
   mTextGraphicsItem->setText(mPin.getDisplayText());
@@ -155,17 +164,6 @@ void SGI_SymbolPin::paint(QPainter* painter,
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
-
-void SGI_SymbolPin::updateTextRotationAndAlignment() noexcept {
-  Angle rotation(0);
-  Alignment alignment(HAlign::left(), VAlign::center());
-  if (Toolbox::isTextUpsideDown(mPin.getRotation(), false)) {
-    rotation += Angle::deg180();
-    alignment.mirror();
-  }
-  mTextGraphicsItem->setRotation(rotation);
-  mTextGraphicsItem->setAlignment(alignment);
-}
 
 GraphicsLayer* SGI_SymbolPin::getLayer(const QString& name) const noexcept {
   return mPin.getSymbol().getProject().getLayers().getLayer(name);

--- a/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbolpin.h
+++ b/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbolpin.h
@@ -54,11 +54,8 @@ public:
   explicit SGI_SymbolPin(SI_SymbolPin& pin) noexcept;
   ~SGI_SymbolPin() noexcept;
 
-  // Setters
-  void setPosition(const Point& pos) noexcept;
-  void setRotation(const Angle& rot) noexcept;
-
   // General Methods
+  void updateTransform() noexcept;
   void updateData() noexcept;
   void updateSelection() noexcept;
 
@@ -72,7 +69,6 @@ public:
   SGI_SymbolPin& operator=(const SGI_SymbolPin& rhs) = delete;
 
 private:  // Methods
-  void updateTextRotationAndAlignment() noexcept;
   GraphicsLayer* getLayer(const QString& name) const noexcept;
 
 private:  // Data

--- a/libs/librepcb/core/project/schematic/items/si_symbol.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_symbol.cpp
@@ -155,7 +155,7 @@ void SI_Symbol::setPosition(const Point& newPos) noexcept {
   if (newPos != mPosition) {
     mPosition = newPos;
     mGraphicsItem->setPosition(newPos);
-    foreach (SI_SymbolPin* pin, mPins) { pin->updatePosition(); }
+    foreach (SI_SymbolPin* pin, mPins) { pin->updatePosition(false); }
   }
 }
 
@@ -163,7 +163,7 @@ void SI_Symbol::setRotation(const Angle& newRotation) noexcept {
   if (newRotation != mRotation) {
     mRotation = newRotation;
     mGraphicsItem->updateRotationAndMirror();
-    foreach (SI_SymbolPin* pin, mPins) { pin->updatePosition(); }
+    foreach (SI_SymbolPin* pin, mPins) { pin->updatePosition(true); }
   }
 }
 
@@ -171,7 +171,7 @@ void SI_Symbol::setMirrored(bool newMirrored) noexcept {
   if (newMirrored != mMirrored) {
     mMirrored = newMirrored;
     mGraphicsItem->updateRotationAndMirror();
-    foreach (SI_SymbolPin* pin, mPins) { pin->updatePosition(); }
+    foreach (SI_SymbolPin* pin, mPins) { pin->updatePosition(true); }
   }
 }
 

--- a/libs/librepcb/core/project/schematic/items/si_symbolpin.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_symbolpin.cpp
@@ -63,7 +63,7 @@ SI_SymbolPin::SI_SymbolPin(SI_Symbol& symbol, const Uuid& pinUuid)
   }
 
   mGraphicsItem.reset(new SGI_SymbolPin(*this));
-  updatePosition();
+  updatePosition(true);
 
   // create ERC messages
   mErcMsgUnconnectedRequiredPin.reset(new ErcMsg(
@@ -230,12 +230,14 @@ void SI_SymbolPin::unregisterNetLine(SI_NetLine& netline) {
   mGraphicsItem->updateData();
 }
 
-void SI_SymbolPin::updatePosition() noexcept {
+void SI_SymbolPin::updatePosition(bool mirroredOrRotated) noexcept {
   Transform transform(mSymbol);
   mPosition = transform.map(mSymbolPin->getPosition());
   mRotation = transform.map(mSymbolPin->getRotation());
-  mGraphicsItem->setPosition(mPosition);
-  mGraphicsItem->setRotation(mRotation);
+  mGraphicsItem->setPos(mPosition.toPxQPointF());
+  if (mirroredOrRotated) {
+    mGraphicsItem->updateTransform();
+  }
   foreach (SI_NetLine* netline, mRegisteredNetLines) { netline->updateLine(); }
 }
 

--- a/libs/librepcb/core/project/schematic/items/si_symbolpin.h
+++ b/libs/librepcb/core/project/schematic/items/si_symbolpin.h
@@ -97,7 +97,7 @@ public:
   // General Methods
   void addToSchematic() override;
   void removeFromSchematic() override;
-  void updatePosition() noexcept;
+  void updatePosition(bool mirroredOrRotated) noexcept;
 
   // Inherited from SI_Base
   Type_t getType() const noexcept override {

--- a/libs/librepcb/core/project/schematic/schematic.h
+++ b/libs/librepcb/core/project/schematic/schematic.h
@@ -98,6 +98,7 @@ public:
   enum ItemZValue {
     ZValue_Default = 0,  ///< this is the default value (behind all other items)
     ZValue_Symbols,  ///< Z value for ::librepcb::SI_Symbol items
+    ZValue_SymbolPins,  ///< Z value for ::librepcb::SI_SymbolPin items
     ZValue_Polygons,  ///< Z value for ::librepcb::SI_Polygon items
     ZValue_Texts,  ///< Z value for ::librepcb::SI_Text items
     ZValue_NetLabels,  ///< Z value for ::librepcb::SI_NetLabel items

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -62,6 +62,9 @@ SchematicPainter::SchematicPainter(const Schematic& schematic) noexcept {
           pin->getLibPin().getLength(),
           pin->getDisplayText(),
           pin->getLibPin().getNamePosition(),
+          pin->getLibPin().getNameRotation(),
+          pin->getLibPin().getNameHeight(),
+          pin->getLibPin().getNameAlignment(),
       });
       if (pin->isVisibleJunction()) {
         mJunctions.append(pin->getPosition());
@@ -158,11 +161,14 @@ void SchematicPainter::paint(QPainter& painter,
                       symbol.transform.map(pin.rotation), *pin.length,
                       settings.getColor(GraphicsLayer::sSymbolOutlines),
                       QColor());
+      Alignment nameAlignment = pin.nameAlignment;
+      if (symbol.transform.getMirrored()) {
+        nameAlignment.mirrorV();
+      }
       p.drawText(symbol.transform.map(pin.position +
                                       pin.namePosition.rotated(pin.rotation)),
-                 symbol.transform.map(pin.rotation),
-                 *SymbolPin::getNameHeight(),
-                 Alignment(HAlign::left(), VAlign::center()), pin.name,
+                 symbol.transform.map(pin.rotation + pin.nameRotation),
+                 *pin.nameHeight, nameAlignment, pin.name,
                  qApp->getDefaultSansSerifFont(),
                  settings.getColor(GraphicsLayer::sSymbolPinNames), false);
     }

--- a/libs/librepcb/core/project/schematic/schematicpainter.h
+++ b/libs/librepcb/core/project/schematic/schematicpainter.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../export/graphicsexport.h"
+#include "../../types/alignment.h"
 #include "../../types/length.h"
 #include "../../utils/transform.h"
 
@@ -57,6 +58,9 @@ class SchematicPainter final : public GraphicsPagePainter {
     UnsignedLength length;
     QString name;
     Point namePosition;
+    Angle nameRotation;
+    PositiveLength nameHeight;
+    Alignment nameAlignment;
   };
 
   struct Line {

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -360,12 +360,17 @@ std::shared_ptr<StrokeText> EagleTypeConverter::convertBoardText(
 
 std::shared_ptr<SymbolPin> EagleTypeConverter::convertSymbolPin(
     const parseagle::Pin& p) {
+  UnsignedLength length(convertLength(p.getLengthInMillimeters()));
   return std::make_shared<SymbolPin>(
       Uuid::createRandom(),  // UUID
       convertPinOrPadName(p.getName()),  // Name
       convertPoint(p.getPosition()),  // Position
-      UnsignedLength(convertLength(p.getLengthInMillimeters())),  // Length
-      convertAngle(p.getRotation().getAngle())  // Rotation
+      length,  // Length
+      convertAngle(p.getRotation().getAngle()),  // Rotation
+      SymbolPin::getDefaultNamePosition(length),  // Name position
+      Angle(0),  // Name rotation
+      SymbolPin::getDefaultNameHeight(),  // Name height
+      Alignment(HAlign::left(), VAlign::center())  // Name alignment
   );
 }
 

--- a/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
@@ -64,7 +64,7 @@ CmdDragSelectedSymbolItems::CmdDragSelectedSymbolItems(
       context.symbolGraphicsItem.getSelectedPins();
   foreach (const std::shared_ptr<SymbolPinGraphicsItem>& pin, pins) {
     Q_ASSERT(pin);
-    mPinEditCmds.append(new CmdSymbolPinEdit(*pin->getPin()));
+    mPinEditCmds.append(new CmdSymbolPinEdit(pin->getPin()));
     mCenterPos += pin->getPin()->getPosition();
     if (!pin->getPin()->getPosition().isOnGrid(grid)) {
       mHasOffTheGridElements = true;

--- a/libs/librepcb/editor/library/cmd/cmdpastesymbolitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastesymbolitems.cpp
@@ -93,9 +93,10 @@ bool CmdPasteSymbolItems::performExecute() {
       name = CircuitIdentifier(
           Toolbox::incrementNumberInString(*name));  // can throw
     }
-    std::shared_ptr<SymbolPin> copy =
-        std::make_shared<SymbolPin>(uuid, name, pin.getPosition() + mPosOffset,
-                                    pin.getLength(), pin.getRotation());
+    std::shared_ptr<SymbolPin> copy = std::make_shared<SymbolPin>(
+        uuid, name, pin.getPosition() + mPosOffset, pin.getLength(),
+        pin.getRotation(), pin.getNamePosition(), pin.getNameRotation(),
+        pin.getNameHeight(), pin.getNameAlignment());
     execNewChildCmd(new CmdSymbolPinInsert(mSymbol.getPins(), copy));
     if (auto graphicsItem = mGraphicsItem.getGraphicsItem(copy)) {
       graphicsItem->setSelected(true);

--- a/libs/librepcb/editor/library/cmd/cmdsymbolpinedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdsymbolpinedit.cpp
@@ -34,17 +34,26 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-CmdSymbolPinEdit::CmdSymbolPinEdit(SymbolPin& pin) noexcept
+CmdSymbolPinEdit::CmdSymbolPinEdit(std::shared_ptr<SymbolPin> pin) noexcept
   : UndoCommand(tr("Edit pin")),
     mPin(pin),
-    mOldName(pin.getName()),
+    mOldName(pin->getName()),
     mNewName(mOldName),
-    mOldLength(pin.getLength()),
+    mOldLength(pin->getLength()),
     mNewLength(mOldLength),
-    mOldPos(pin.getPosition()),
+    mOldPos(pin->getPosition()),
     mNewPos(mOldPos),
-    mOldRotation(pin.getRotation()),
-    mNewRotation(mOldRotation) {
+    mOldRotation(pin->getRotation()),
+    mNewRotation(mOldRotation),
+    mOldNamePosition(pin->getNamePosition()),
+    mNewNamePosition(mOldNamePosition),
+    mOldNameRotation(pin->getNameRotation()),
+    mNewNameRotation(mOldNameRotation),
+    mOldNameHeight(pin->getNameHeight()),
+    mNewNameHeight(mOldNameHeight),
+    mOldNameAlignment(pin->getNameAlignment()),
+    mNewNameAlignment(mOldNameAlignment) {
+  Q_ASSERT(mPin);
 }
 
 CmdSymbolPinEdit::~CmdSymbolPinEdit() noexcept {
@@ -65,27 +74,55 @@ void CmdSymbolPinEdit::setName(const CircuitIdentifier& name,
                                bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewName = name;
-  if (immediate) mPin.setName(mNewName);
+  if (immediate) mPin->setName(mNewName);
 }
 
 void CmdSymbolPinEdit::setLength(const UnsignedLength& length,
                                  bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewLength = length;
-  if (immediate) mPin.setLength(mNewLength);
+  if (immediate) mPin->setLength(mNewLength);
+}
+
+void CmdSymbolPinEdit::setNamePosition(const Point& position,
+                                       bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewNamePosition = position;
+  if (immediate) mPin->setNamePosition(mNewNamePosition);
+}
+
+void CmdSymbolPinEdit::setNameRotation(const Angle& rotation,
+                                       bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewNameRotation = rotation;
+  if (immediate) mPin->setNameRotation(mNewNameRotation);
+}
+
+void CmdSymbolPinEdit::setNameHeight(const PositiveLength& height,
+                                     bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewNameHeight = height;
+  if (immediate) mPin->setNameHeight(mNewNameHeight);
+}
+
+void CmdSymbolPinEdit::setNameAlignment(const Alignment& align,
+                                        bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewNameAlignment = align;
+  if (immediate) mPin->setNameAlignment(mNewNameAlignment);
 }
 
 void CmdSymbolPinEdit::setPosition(const Point& pos, bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewPos = pos;
-  if (immediate) mPin.setPosition(mNewPos);
+  if (immediate) mPin->setPosition(mNewPos);
 }
 
 void CmdSymbolPinEdit::translate(const Point& deltaPos,
                                  bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewPos += deltaPos;
-  if (immediate) mPin.setPosition(mNewPos);
+  if (immediate) mPin->setPosition(mNewPos);
 }
 
 void CmdSymbolPinEdit::snapToGrid(const PositiveLength& gridInterval,
@@ -97,7 +134,7 @@ void CmdSymbolPinEdit::setRotation(const Angle& angle,
                                    bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewRotation = angle;
-  if (immediate) mPin.setRotation(mNewRotation);
+  if (immediate) mPin->setRotation(mNewRotation);
 }
 
 void CmdSymbolPinEdit::rotate(const Angle& angle, const Point& center,
@@ -106,8 +143,8 @@ void CmdSymbolPinEdit::rotate(const Angle& angle, const Point& center,
   mNewPos.rotate(angle, center);
   mNewRotation += angle;
   if (immediate) {
-    mPin.setPosition(mNewPos);
-    mPin.setRotation(mNewRotation);
+    mPin->setPosition(mNewPos);
+    mPin->setRotation(mNewRotation);
   }
 }
 
@@ -121,8 +158,8 @@ void CmdSymbolPinEdit::mirror(Qt::Orientation orientation, const Point& center,
     mNewRotation = -mNewRotation;
   }
   if (immediate) {
-    mPin.setPosition(mNewPos);
-    mPin.setRotation(mNewRotation);
+    mPin->setPosition(mNewPos);
+    mPin->setRotation(mNewRotation);
   }
 }
 
@@ -137,21 +174,33 @@ bool CmdSymbolPinEdit::performExecute() {
   if (mNewLength != mOldLength) return true;
   if (mNewPos != mOldPos) return true;
   if (mNewRotation != mOldRotation) return true;
+  if (mNewNamePosition != mOldNamePosition) return true;
+  if (mNewNameRotation != mOldNameRotation) return true;
+  if (mNewNameHeight != mOldNameHeight) return true;
+  if (mNewNameAlignment != mOldNameAlignment) return true;
   return false;
 }
 
 void CmdSymbolPinEdit::performUndo() {
-  mPin.setName(mOldName);
-  mPin.setLength(mOldLength);
-  mPin.setPosition(mOldPos);
-  mPin.setRotation(mOldRotation);
+  mPin->setName(mOldName);
+  mPin->setLength(mOldLength);
+  mPin->setPosition(mOldPos);
+  mPin->setRotation(mOldRotation);
+  mPin->setNamePosition(mOldNamePosition);
+  mPin->setNameRotation(mOldNameRotation);
+  mPin->setNameHeight(mOldNameHeight);
+  mPin->setNameAlignment(mOldNameAlignment);
 }
 
 void CmdSymbolPinEdit::performRedo() {
-  mPin.setName(mNewName);
-  mPin.setLength(mNewLength);
-  mPin.setPosition(mNewPos);
-  mPin.setRotation(mNewRotation);
+  mPin->setName(mNewName);
+  mPin->setLength(mNewLength);
+  mPin->setPosition(mNewPos);
+  mPin->setRotation(mNewRotation);
+  mPin->setNamePosition(mNewNamePosition);
+  mPin->setNameRotation(mNewNameRotation);
+  mPin->setNameHeight(mNewNameHeight);
+  mPin->setNameAlignment(mNewNameAlignment);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdsymbolpinedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdsymbolpinedit.h
@@ -50,12 +50,16 @@ public:
   // Constructors / Destructor
   CmdSymbolPinEdit() = delete;
   CmdSymbolPinEdit(const CmdSymbolPinEdit& other) = delete;
-  explicit CmdSymbolPinEdit(SymbolPin& pin) noexcept;
+  explicit CmdSymbolPinEdit(std::shared_ptr<SymbolPin> pin) noexcept;
   ~CmdSymbolPinEdit() noexcept;
 
   // Setters
   void setName(const CircuitIdentifier& name, bool immediate) noexcept;
   void setLength(const UnsignedLength& length, bool immediate) noexcept;
+  void setNamePosition(const Point& position, bool immediate) noexcept;
+  void setNameRotation(const Angle& rotation, bool immediate) noexcept;
+  void setNameHeight(const PositiveLength& height, bool immediate) noexcept;
+  void setNameAlignment(const Alignment& align, bool immediate) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
@@ -82,7 +86,7 @@ private:
   // Private Member Variables
 
   // Attributes from the constructor
-  SymbolPin& mPin;
+  std::shared_ptr<SymbolPin> mPin;
 
   // General Attributes
   CircuitIdentifier mOldName;
@@ -93,6 +97,14 @@ private:
   Point mNewPos;
   Angle mOldRotation;
   Angle mNewRotation;
+  Point mOldNamePosition;
+  Point mNewNamePosition;
+  Angle mOldNameRotation;
+  Angle mNewNameRotation;
+  PositiveLength mOldNameHeight;
+  PositiveLength mNewNameHeight;
+  Alignment mOldNameAlignment;
+  Alignment mNewNameAlignment;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -167,7 +167,9 @@ void NewElementWizardContext::copyElement(ElementType type,
       for (const SymbolPin& pin : symbol->getPins()) {
         mSymbolPins.append(std::make_shared<SymbolPin>(
             Uuid::createRandom(), pin.getName(), pin.getPosition(),
-            pin.getLength(), pin.getRotation()));
+            pin.getLength(), pin.getRotation(), pin.getNamePosition(),
+            pin.getNameRotation(), pin.getNameHeight(),
+            pin.getNameAlignment()));
       }
       // copy polygons but generate new UUIDs
       mSymbolPolygons.clear();

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.h
@@ -89,9 +89,9 @@ private:  // Methods
   bool hasPin(const QString& name) const noexcept;
 
 private:  // Types / Data
-  QScopedPointer<CmdSymbolPinEdit> mEditCmd;
   std::shared_ptr<SymbolPin> mCurrentPin;
   std::shared_ptr<SymbolPinGraphicsItem> mCurrentGraphicsItem;
+  QScopedPointer<CmdSymbolPinEdit> mEditCmd;
   QLineEdit* mNameLineEdit;
 
   // parameter memory

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -549,7 +549,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
 
   if (auto i = std::dynamic_pointer_cast<SymbolPinGraphicsItem>(item)) {
     SymbolPinPropertiesDialog dialog(
-        *i->getPin(), mContext.undoStack, getDefaultLengthUnit(),
+        i->getPin(), mContext.undoStack, getDefaultLengthUnit(),
         "symbol_editor/pin_properties_dialog", &mContext.editorWidget);
     dialog.setReadOnly(mContext.readOnly);
     dialog.exec();

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
@@ -464,7 +464,7 @@ template <>
 void SymbolEditorWidget::fixMsg(const MsgSymbolPinNotOnGrid& msg) {
   std::shared_ptr<SymbolPin> pin = mSymbol->getPins().get(msg.getPin().get());
   Point newPos = pin->getPosition().mappedToGrid(msg.getGridInterval());
-  QScopedPointer<CmdSymbolPinEdit> cmd(new CmdSymbolPinEdit(*pin));
+  QScopedPointer<CmdSymbolPinEdit> cmd(new CmdSymbolPinEdit(pin));
   cmd->setPosition(newPos, false);
   mUndoStack->execCmd(cmd.take());
 }

--- a/libs/librepcb/editor/library/sym/symbolpingraphicsitem.h
+++ b/libs/librepcb/editor/library/sym/symbolpingraphicsitem.h
@@ -84,7 +84,10 @@ public:
 private:  // Methods
   void pinEdited(const SymbolPin& pin, SymbolPin::Event event) noexcept;
   void setLength(const UnsignedLength& length) noexcept;
-  void updateTextRotationAndAlignment() noexcept;
+  void setNamePosition(const Point& position) noexcept;
+  void setNameHeight(const PositiveLength& height) noexcept;
+  void setNameRotationAndAlignment(const Angle& rotation,
+                                   const Alignment& align) noexcept;
 
 private:  // Data
   std::shared_ptr<SymbolPin> mPin;

--- a/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.cpp
+++ b/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.cpp
@@ -38,12 +38,14 @@ namespace librepcb {
 namespace editor {
 
 SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(
-    SymbolPin& pin, UndoStack& undoStack, const LengthUnit& lengthUnit,
-    const QString& settingsPrefix, QWidget* parent) noexcept
+    std::shared_ptr<SymbolPin> pin, UndoStack& undoStack,
+    const LengthUnit& lengthUnit, const QString& settingsPrefix,
+    QWidget* parent) noexcept
   : QDialog(parent),
     mSymbolPin(pin),
     mUndoStack(undoStack),
     mUi(new Ui::SymbolPinPropertiesDialog) {
+  Q_ASSERT(mSymbolPin);
   mUi->setupUi(this);
   mUi->edtLength->configure(lengthUnit, LengthEditBase::Steps::pinLength(),
                             settingsPrefix % "/length");
@@ -52,15 +54,44 @@ SymbolPinPropertiesDialog::SymbolPinPropertiesDialog(
   mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
                           settingsPrefix % "/pos_y");
   mUi->edtRotation->setSingleStep(90.0);  // [°]
+  mUi->edtNameHeight->configure(lengthUnit, LengthEditBase::Steps::textHeight(),
+                                settingsPrefix % "/name_height");
+  mUi->edtNameHeight->setDefaultValueToolTip(
+      *SymbolPin::getDefaultNameHeight());
+  mUi->edtNamePosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                              settingsPrefix % "/name_pos_x");
+  mUi->edtNamePosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                              settingsPrefix % "/name_pos_y");
+  updateNamePositionTooltip(mSymbolPin->getLength());
+  mUi->edtNameRotation->setSingleStep(90.0);  // [°]
+  mUi->lblNameAlignment->setText(mUi->lblNameAlignment->text() % "<br/><i>" %
+                                 tr("(at 0° rotation)") % "</i>");
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &SymbolPinPropertiesDialog::on_buttonBox_clicked);
 
   // load pin attributes
-  mUi->edtName->setText(*mSymbolPin.getName());
-  mUi->edtPosX->setValue(mSymbolPin.getPosition().getX());
-  mUi->edtPosY->setValue(mSymbolPin.getPosition().getY());
-  mUi->edtRotation->setValue(mSymbolPin.getRotation());
-  mUi->edtLength->setValue(mSymbolPin.getLength());
+  mUi->edtName->setText(*mSymbolPin->getName());
+  mUi->edtPosX->setValue(mSymbolPin->getPosition().getX());
+  mUi->edtPosY->setValue(mSymbolPin->getPosition().getY());
+  mUi->edtRotation->setValue(mSymbolPin->getRotation());
+  mUi->edtLength->setValue(mSymbolPin->getLength());
+  mUi->edtNameHeight->setValue(mSymbolPin->getNameHeight());
+  mUi->edtNamePosX->setValue(mSymbolPin->getNamePosition().getX());
+  mUi->edtNamePosY->setValue(mSymbolPin->getNamePosition().getY());
+  mUi->edtNameRotation->setValue(mSymbolPin->getNameRotation());
+  mUi->edtNameAlignment->setAlignment(mSymbolPin->getNameAlignment());
+
+  // Setup auto-move text checkbox. Check it if the text is on the right side
+  // of the pin.
+  mUi->cbxAutoMoveText->setChecked(
+      (mSymbolPin->getNamePosition().getX() >= *mSymbolPin->getLength()));
+  connect(mUi->edtLength, &UnsignedLengthEdit::valueChanged, this,
+          [this](const UnsignedLength& length, const Length& diff) {
+            if (mUi->cbxAutoMoveText->isChecked()) {
+              mUi->edtNamePosX->setValue(mUi->edtNamePosX->getValue() + diff);
+            }
+            updateNamePositionTooltip(length);
+          });
 
   // preselect name
   mUi->edtName->selectAll();
@@ -79,6 +110,11 @@ void SymbolPinPropertiesDialog::setReadOnly(bool readOnly) noexcept {
   mUi->edtPosY->setReadOnly(readOnly);
   mUi->edtRotation->setReadOnly(readOnly);
   mUi->edtLength->setReadOnly(readOnly);
+  mUi->edtNameHeight->setReadOnly(readOnly);
+  mUi->edtNamePosX->setReadOnly(readOnly);
+  mUi->edtNamePosY->setReadOnly(readOnly);
+  mUi->edtNameRotation->setReadOnly(readOnly);
+  mUi->edtNameAlignment->setReadOnly(readOnly);
   if (readOnly) {
     mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
   } else {
@@ -92,6 +128,13 @@ void SymbolPinPropertiesDialog::setReadOnly(bool readOnly) noexcept {
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void SymbolPinPropertiesDialog::updateNamePositionTooltip(
+    const UnsignedLength& length) noexcept {
+  const Point pos = SymbolPin::getDefaultNamePosition(length);
+  mUi->edtNamePosX->setDefaultValueToolTip(pos.getX());
+  mUi->edtNamePosY->setDefaultValueToolTip(pos.getY());
+}
 
 void SymbolPinPropertiesDialog::on_buttonBox_clicked(QAbstractButton* button) {
   switch (mUi->buttonBox->buttonRole(button)) {
@@ -121,6 +164,12 @@ bool SymbolPinPropertiesDialog::applyChanges() noexcept {
     cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
                      false);
     cmd->setRotation(mUi->edtRotation->getValue(), false);
+    cmd->setNameHeight(mUi->edtNameHeight->getValue(), false);
+    cmd->setNamePosition(
+        Point(mUi->edtNamePosX->getValue(), mUi->edtNamePosY->getValue()),
+        false);
+    cmd->setNameRotation(mUi->edtNameRotation->getValue(), false);
+    cmd->setNameAlignment(mUi->edtNameAlignment->getAlignment(), false);
     mUndoStack.execCmd(cmd.take());
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.h
+++ b/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.h
@@ -23,8 +23,12 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/core/types/length.h>
+
 #include <QtCore>
 #include <QtWidgets>
+
+#include <memory>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -56,8 +60,8 @@ public:
   // Constructors / Destructor
   SymbolPinPropertiesDialog() = delete;
   SymbolPinPropertiesDialog(const SymbolPinPropertiesDialog& other) = delete;
-  SymbolPinPropertiesDialog(SymbolPin& pin, UndoStack& undoStack,
-                            const LengthUnit& lengthUnit,
+  SymbolPinPropertiesDialog(std::shared_ptr<SymbolPin> pin,
+                            UndoStack& undoStack, const LengthUnit& lengthUnit,
                             const QString& settingsPrefix,
                             QWidget* parent = nullptr) noexcept;
   ~SymbolPinPropertiesDialog() noexcept;
@@ -70,11 +74,12 @@ public:
       delete;
 
 private:  // Methods
+  void updateNamePositionTooltip(const UnsignedLength& length) noexcept;
   void on_buttonBox_clicked(QAbstractButton* button);
   bool applyChanges() noexcept;
 
 private:  // Data
-  SymbolPin& mSymbolPin;
+  std::shared_ptr<SymbolPin> mSymbolPin;
   UndoStack& mUndoStack;
   QScopedPointer<Ui::SymbolPinPropertiesDialog> mUi;
 };

--- a/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>313</width>
-    <height>145</height>
+    <width>391</width>
+    <height>287</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="lblName">
        <property name="text">
         <string>Name:</string>
        </property>
@@ -31,14 +31,31 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_6">
+      <widget class="QLabel" name="lblLength">
        <property name="text">
         <string>Length:</string>
        </property>
       </widget>
      </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="librepcb::editor::UnsignedLengthEdit" name="edtLength" native="true"/>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbxAutoMoveText">
+         <property name="toolTip">
+          <string>Move text automatically when changing the pin length.</string>
+         </property>
+         <property name="text">
+          <string>Move Text</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="lblPosition">
        <property name="text">
         <string>Position:</string>
        </property>
@@ -55,17 +72,71 @@
       </layout>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="lblRotation">
        <property name="text">
         <string>Rotation:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="librepcb::editor::UnsignedLengthEdit" name="edtLength" native="true"/>
-     </item>
      <item row="3" column="1">
       <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
+     </item>
+     <item row="4" column="0" colspan="2">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="lblNamePosition">
+       <property name="text">
+        <string>Text Position:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="librepcb::editor::LengthEdit" name="edtNamePosX" native="true"/>
+       </item>
+       <item>
+        <widget class="librepcb::editor::LengthEdit" name="edtNamePosY" native="true"/>
+       </item>
+      </layout>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="lblNameRotation">
+       <property name="text">
+        <string>Text Rotation:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="librepcb::editor::AngleEdit" name="edtNameRotation" native="true"/>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="lblNameHeight">
+       <property name="text">
+        <string>Text Height:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="librepcb::editor::PositiveLengthEdit" name="edtNameHeight" native="true"/>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="lblNameAlignment">
+       <property name="text">
+        <string>Text Alignment:</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::RichText</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="librepcb::editor::AlignmentSelector" name="edtNameAlignment" native="true"/>
      </item>
     </layout>
    </item>
@@ -100,13 +171,28 @@
    <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>librepcb::editor::AlignmentSelector</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/alignmentselector.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>edtName</tabstop>
-  <tabstop>edtLength</tabstop>
   <tabstop>edtPosX</tabstop>
   <tabstop>edtPosY</tabstop>
   <tabstop>edtRotation</tabstop>
+  <tabstop>edtNamePosX</tabstop>
+  <tabstop>edtNamePosY</tabstop>
+  <tabstop>edtNameRotation</tabstop>
+  <tabstop>edtNameAlignment</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/libs/librepcb/editor/widgets/lengthedit.cpp
+++ b/libs/librepcb/editor/widgets/lengthedit.cpp
@@ -61,8 +61,8 @@ void LengthEdit::setValue(const Length& value) noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void LengthEdit::valueChangedImpl() noexcept {
-  emit valueChanged(getValue());
+void LengthEdit::valueChangedImpl(const Length& diff) noexcept {
+  emit valueChanged(getValue(), diff);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/lengthedit.h
+++ b/libs/librepcb/editor/widgets/lengthedit.h
@@ -62,10 +62,11 @@ public:
 
 signals:
   // Note: Full namespace librepcb::Length is required for the MOC!
-  void valueChanged(const librepcb::Length& value);
+  void valueChanged(const librepcb::Length& value,
+                    const librepcb::Length& diff);
 
 private:
-  virtual void valueChangedImpl() noexcept override;
+  virtual void valueChangedImpl(const Length& diff) noexcept override;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/lengtheditbase.cpp
+++ b/libs/librepcb/editor/widgets/lengtheditbase.cpp
@@ -92,6 +92,10 @@ const LengthUnit& LengthEditBase::getDisplayedUnit() const noexcept {
  *  Setters
  ******************************************************************************/
 
+void LengthEditBase::setDefaultValueToolTip(const Length& value) noexcept {
+  setToolTip(tr("Default value:") % " " % value.toMmString() % " mm");
+}
+
 void LengthEditBase::setDefaultUnit(const LengthUnit& unit) noexcept {
   if (unit != mDefaultUnit) {
     mDefaultUnit = unit;

--- a/libs/librepcb/editor/widgets/lengtheditbase.cpp
+++ b/libs/librepcb/editor/widgets/lengtheditbase.cpp
@@ -201,10 +201,11 @@ void LengthEditBase::setValueImpl(Length value) noexcept {
   // To avoid unnecessary clearing the QLineEdit selection, only update the
   // value (and therefore the text) if really needed.
   if (value != mValue) {
+    const Length diff = value - mValue;
     mValue = value;
     updateSingleStep();
     updateText();
-    valueChangedImpl();
+    valueChangedImpl(diff);
     update();  // step buttons might need to be repainted
   }
 }
@@ -217,12 +218,13 @@ void LengthEditBase::updateValueFromText(QString text) noexcept {
       Length value = unit.convertFromUnit(result.value);  // can throw
       // Only accept values in the allowed range.
       if ((value >= mMinimum) && (value <= mMaximum)) {
+        const Length diff = value - mValue;
         mValue = value;
         setSelectedUnit(unit);
         updateSingleStep();
         // In contrast to setValueImpl(), do NOT call updateText() to avoid
         // disturbing the user while writing the text!
-        valueChangedImpl();
+        valueChangedImpl(diff);
         update();  // step buttons might need to be repainted
       } else {
         qWarning() << "LengthEditBase: Entered text was a valid number, but "

--- a/libs/librepcb/editor/widgets/lengtheditbase.h
+++ b/libs/librepcb/editor/widgets/lengtheditbase.h
@@ -100,6 +100,7 @@ public:
   const LengthUnit& getDisplayedUnit() const noexcept;
 
   // Setters
+  void setDefaultValueToolTip(const Length& value) noexcept;
   void setDefaultUnit(const LengthUnit& unit) noexcept;
   void setChangeUnitActionVisible(bool visible) noexcept;
   void setStepBehavior(StepBehavior behavior) noexcept;

--- a/libs/librepcb/editor/widgets/lengtheditbase.h
+++ b/libs/librepcb/editor/widgets/lengtheditbase.h
@@ -150,7 +150,7 @@ protected:  // Methods
   void setSelectedUnit(const LengthUnit& unit) noexcept;
   void saveSelectedUnit() noexcept;
   QString getValueStr(const LengthUnit& unit) const noexcept;
-  virtual void valueChangedImpl() noexcept = 0;
+  virtual void valueChangedImpl(const Length& diff) noexcept = 0;
 
 protected:  // Data
   QAction* mChangeUnitAction;

--- a/libs/librepcb/editor/widgets/positivelengthedit.cpp
+++ b/libs/librepcb/editor/widgets/positivelengthedit.cpp
@@ -65,8 +65,8 @@ void PositiveLengthEdit::setValue(const PositiveLength& value) noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void PositiveLengthEdit::valueChangedImpl() noexcept {
-  emit valueChanged(getValue());
+void PositiveLengthEdit::valueChangedImpl(const Length& diff) noexcept {
+  emit valueChanged(getValue(), diff);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/positivelengthedit.h
+++ b/libs/librepcb/editor/widgets/positivelengthedit.h
@@ -59,10 +59,11 @@ public:
 
 signals:
   // Note: Full namespace librepcb::PositiveLength is required for the MOC!
-  void valueChanged(const librepcb::PositiveLength& value);
+  void valueChanged(const librepcb::PositiveLength& value,
+                    const librepcb::Length& diff);
 
 private:
-  virtual void valueChangedImpl() noexcept override;
+  virtual void valueChangedImpl(const Length& diff) noexcept override;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/unsignedlengthedit.cpp
+++ b/libs/librepcb/editor/widgets/unsignedlengthedit.cpp
@@ -65,8 +65,8 @@ void UnsignedLengthEdit::setValue(const UnsignedLength& value) noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void UnsignedLengthEdit::valueChangedImpl() noexcept {
-  emit valueChanged(getValue());
+void UnsignedLengthEdit::valueChangedImpl(const Length& diff) noexcept {
+  emit valueChanged(getValue(), diff);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/unsignedlengthedit.h
+++ b/libs/librepcb/editor/widgets/unsignedlengthedit.h
@@ -59,10 +59,11 @@ public:
 
 signals:
   // Note: Full namespace librepcb::UnsignedLength is required for the MOC!
-  void valueChanged(const librepcb::UnsignedLength& value);
+  void valueChanged(const librepcb::UnsignedLength& value,
+                    const librepcb::Length& diff);
 
 private:
-  virtual void valueChangedImpl() noexcept override;
+  virtual void valueChangedImpl(const Length& diff) noexcept override;
 };
 
 /*******************************************************************************

--- a/tests/unittests/core/library/sym/symbolpintest.cpp
+++ b/tests/unittests/core/library/sym/symbolpintest.cpp
@@ -62,19 +62,29 @@ TEST_F(SymbolPinTest, testConstructFromSExpressionCurrentVersion) {
   SExpression sexpr = SExpression::parse(
       "(pin d48b8bd2-a46c-4495-87a5-662747034098 (name \"1\")\n"
       " (position 1.234 2.345) (rotation 45.0) (length 0.5)\n"
+      " (name_position 0.1 0.2) (name_rotation -90.0) (name_height 1.234)\n"
+      " (name_align center bottom)\n"
       ")",
       FilePath());
   SymbolPin obj(sexpr, qApp->getFileFormatVersion());
   EXPECT_EQ(Uuid::fromString("d48b8bd2-a46c-4495-87a5-662747034098"),
             obj.getUuid());
+  EXPECT_EQ("1", obj.getName()->toStdString());
   EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
   EXPECT_EQ(Angle::deg45(), obj.getRotation());
   EXPECT_EQ(UnsignedLength(500000), obj.getLength());
+  EXPECT_EQ(Point(100000, 200000), obj.getNamePosition());
+  EXPECT_EQ(-Angle::deg90(), obj.getNameRotation());
+  EXPECT_EQ(PositiveLength(1234000), obj.getNameHeight());
+  EXPECT_EQ(Alignment(HAlign::center(), VAlign::bottom()),
+            obj.getNameAlignment());
 }
 
 TEST_F(SymbolPinTest, testSerializeAndDeserialize) {
   SymbolPin obj1(Uuid::createRandom(), CircuitIdentifier("foo"),
-                 Point(123, 567), UnsignedLength(321), Angle(789));
+                 Point(123, 567), UnsignedLength(321), Angle(789),
+                 Point(100000, 200000), Angle(321), PositiveLength(123456),
+                 Alignment(HAlign::center(), VAlign::bottom()));
   SExpression sexpr1 = obj1.serializeToDomElement("pin");
 
   SymbolPin obj2(sexpr1, qApp->getFileFormatVersion());

--- a/tests/unittests/editor/library/sym/symbolclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/sym/symbolclipboarddatatest.cpp
@@ -73,11 +73,13 @@ TEST(SymbolClipboardDataTest, testToFromMimeDataPopulated) {
 
   std::shared_ptr<SymbolPin> pin1 = std::make_shared<SymbolPin>(
       Uuid::createRandom(), CircuitIdentifier("foo"), Point(12, 34),
-      UnsignedLength(0), Angle(56));
+      UnsignedLength(0), Angle(56), Point(78, 90), Angle(98),
+      PositiveLength(76), Alignment(HAlign::center(), VAlign::top()));
 
   std::shared_ptr<SymbolPin> pin2 = std::make_shared<SymbolPin>(
       Uuid::createRandom(), CircuitIdentifier("bar"), Point(120, 340),
-      UnsignedLength(123), Angle(789));
+      UnsignedLength(123), Angle(789), Point(987, 654), Angle(32),
+      PositiveLength(10), Alignment(HAlign::right(), VAlign::bottom()));
 
   std::shared_ptr<Polygon> polygon1 = std::make_shared<Polygon>(
       Uuid::createRandom(), GraphicsLayerName("foo"), UnsignedLength(1), false,


### PR DESCRIPTION
### File format change

Currently a symbol pin looks like this:

```lisp
 (pin 48dad2d5-4392-4d8f-870e-9e69d9727b83 (name "C")
  (position 2.54 0.0) (rotation 180.0) (length 2.54)
 )
```

This PR extends to file format to make the text position, rotation, height (font size) and alignment configurable:

```lisp
 (pin 48dad2d5-4392-4d8f-870e-9e69d9727b83 (name "C")
  (position 2.54 0.0) (rotation 180.0) (length 2.54)
  (name_position 3.81 0.0) (name_rotation 0.0) (name_height 2.5)
  (name_align left center)
 )
```

### Symbol editor change

The new properties can then be modified in the pin properties dialog:

![image](https://user-images.githubusercontent.com/5374821/164787170-6a919987-1c73-49fb-9661-ac999a2dd05d.png)

### Open questions

I'm not sure whether the text position should be stored in absolute coordinates (i.e. relative to the pin's origin, the circle), or relative to the right end of the pin line. Currently (without the configuration option) the text is placed relative to the right end of the line to avoid strange placement when making the line shorter or longer.

Somehow it sounds reasonable to keep this behavior for the following reasons:
- When changing the pin length (e.g. from 2.54mm to 5.08mm), the name does not need to be moved manually to the right, and the `name_position` property is not affected.
- Since `name_position` would then be independent of the pin length, we could set its default value to some nice, easy-to-memorize value like `(1.0, 0.0)`. If the position is relative to the pin's origin, this value would be e.g. `(3.54, 0.0)` for a 2.54mm pin, `(6.08, 0.0)` for a 5.08mm pin etc, i.e. ugly numbers.

But it also has some downsides:
- For non-standard pins, where you don't place the text on the right side of the pin but e.g. above the line, the text placement is kind of independent of the pin length and therefore it would be very counterintuitive if the text moves every time you change the pin length - feels like an anti-feature to me.
- The absolute placement of the text is no longer directly visible in the file, you have to calculate `(pin_length, 0.0) + (name_x, name_y)` to get the actual text coordinate. Feels like a more complicated file format compared to just storing the absolute coordinates.

At the moment I think I'd go with absolute coordinates and a checkbox "Move text" in the dialog to easily update the text position when changing the pin length. And I have chosen a default text position of `(3.81, 0.0)`, i.e. pin length plus 1.27mm (still odd when using the metric system, but at least well known numbers). But any additional opinion would be welcome :slightly_smiling_face: 

Fixes #383