### PR TITLE
Board editor: Fix broken "go to device" zoom

### DIFF
--- a/libs/librepcb/core/project/board/graphicsitems/bgi_footprint.cpp
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_footprint.cpp
@@ -96,6 +96,8 @@ BGI_Footprint::BGI_Footprint(BI_Footprint& footprint) noexcept
   }
 
   updateBoardSide();
+
+  mBoundingRect = childrenBoundingRect();
 }
 
 BGI_Footprint::~BGI_Footprint() noexcept {

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_footprint.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_footprint.h
@@ -63,7 +63,7 @@ public:
   void updateBoardSide() noexcept;
 
   // Inherited from QGraphicsItem
-  QRectF boundingRect() const noexcept { return QRectF(); }
+  QRectF boundingRect() const noexcept { return mBoundingRect; }
   QPainterPath shape() const noexcept;
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0);
@@ -83,6 +83,7 @@ private:  // Data
   QVector<std::shared_ptr<PrimitiveCircleGraphicsItem>> mCircleGraphicsItems;
   QVector<std::shared_ptr<PrimitivePathGraphicsItem>> mPolygonGraphicsItems;
   QVector<std::shared_ptr<PrimitiveCircleGraphicsItem>> mHoleGraphicsItems;
+  QRectF mBoundingRect;
   QPainterPath mShape;
 
   // Slots

--- a/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/core/project/schematic/graphicsitems/sgi_symbol.cpp
@@ -101,9 +101,10 @@ SGI_Symbol::SGI_Symbol(SI_Symbol& symbol) noexcept
     mTextGraphicsItems.append(i);
   }
 
-  mBoundingRect = mShape.boundingRect();
   updateRotationAndMirror();
   updateAllTexts();
+
+  mBoundingRect = childrenBoundingRect();
 }
 
 SGI_Symbol::~SGI_Symbol() noexcept {


### PR DESCRIPTION
Zooming to a footprint was broken in #975 due to empty graphics items bounding rect...