### PR TITLE
Fix some inconsistent behavior in editors

### DIFF
--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
@@ -62,6 +62,30 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &FootprintPadPropertiesDialog::on_buttonBox_clicked);
 
+  // Avoid creating pads with a drill diameter larger than its size!
+  // See https://github.com/LibrePCB/LibrePCB/issues/946.
+  connect(mUi->edtWidth, &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value < mUi->edtDrillDiameter->getValue()) {
+              mUi->edtDrillDiameter->setValue(positiveToUnsigned(value));
+            }
+          });
+  connect(mUi->edtHeight, &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value < mUi->edtDrillDiameter->getValue()) {
+              mUi->edtDrillDiameter->setValue(positiveToUnsigned(value));
+            }
+          });
+  connect(mUi->edtDrillDiameter, &UnsignedLengthEdit::valueChanged, this,
+          [this](const UnsignedLength& value) {
+            if (value > mUi->edtWidth->getValue()) {
+              mUi->edtWidth->setValue(PositiveLength(*value));
+            }
+            if (value > mUi->edtHeight->getValue()) {
+              mUi->edtHeight->setValue(PositiveLength(*value));
+            }
+          });
+
   // load pad attributes
   int currentPadIndex = 0;
   mUi->cbxPackagePad->addItem(tr("(not connected)"), "");

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -148,11 +148,13 @@ private:  // Methods
   bool setNextState(State state) noexcept;
   bool leaveCurrentState() noexcept;
   bool enterNextState(State state) noexcept;
+  bool switchToPreviousState() noexcept;
 
 private:  // Data
   Context mContext;
   QMap<State, PackageEditorState*> mStates;
   State mCurrentState;
+  State mPreviousState;
   QScopedPointer<PrimitiveTextGraphicsItem> mSelectFootprintGraphicsItem;
 };
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.cpp
@@ -65,7 +65,6 @@ PackageEditorState_AddHoles::~PackageEditorState_AddHoles() noexcept {
 
 bool PackageEditorState_AddHoles::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   mContext.commandToolBar.addLabel(tr("Diameter:"), 10);
@@ -81,7 +80,11 @@ bool PackageEditorState_AddHoles::entry() noexcept {
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
-  return startAddHole(pos);
+  if (!startAddHole(pos)) {
+    return false;
+  }
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
+  return true;
 }
 
 bool PackageEditorState_AddHoles::exit() noexcept {
@@ -92,7 +95,7 @@ bool PackageEditorState_AddHoles::exit() noexcept {
   // cleanup command toolbar
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
@@ -82,7 +82,6 @@ PackageEditorState_AddPads::~PackageEditorState_AddPads() noexcept {
 
 bool PackageEditorState_AddPads::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
 
@@ -156,7 +155,11 @@ bool PackageEditorState_AddPads::entry() noexcept {
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
-  return startAddPad(pos);
+  if (!startAddPad(pos)) {
+    return false;
+  }
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
+  return true;
 }
 
 bool PackageEditorState_AddPads::exit() noexcept {
@@ -168,7 +171,7 @@ bool PackageEditorState_AddPads::exit() noexcept {
   mPackagePadComboBox = nullptr;
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -69,7 +69,6 @@ PackageEditorState_DrawCircle::~PackageEditorState_DrawCircle() noexcept {
 
 bool PackageEditorState_DrawCircle::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   mContext.commandToolBar.addLabel(tr("Layer:"));
@@ -103,6 +102,7 @@ bool PackageEditorState_DrawCircle::entry() noexcept {
           &PackageEditorState_DrawCircle::grabAreaCheckBoxCheckedChanged);
   mContext.commandToolBar.addWidget(std::move(grabAreaCheckBox));
 
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
 
@@ -114,7 +114,7 @@ bool PackageEditorState_DrawCircle::exit() noexcept {
   // cleanup command toolbar
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -73,7 +73,6 @@ PackageEditorState_DrawPolygonBase::
 
 bool PackageEditorState_DrawPolygonBase::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   mContext.commandToolBar.addLabel(tr("Layer:"));
@@ -122,6 +121,7 @@ bool PackageEditorState_DrawPolygonBase::entry() noexcept {
     mContext.commandToolBar.addWidget(std::move(grabAreaCheckBox));
   }
 
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
 
@@ -133,7 +133,7 @@ bool PackageEditorState_DrawPolygonBase::exit() noexcept {
   // cleanup command toolbar
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -74,7 +74,6 @@ PackageEditorState_DrawTextBase::~PackageEditorState_DrawTextBase() noexcept {
 
 bool PackageEditorState_DrawTextBase::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   if (mMode == Mode::TEXT) {
@@ -150,7 +149,11 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
-  return startAddText(pos);
+  if (!startAddText(pos)) {
+    return false;
+  }
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
+  return true;
 }
 
 bool PackageEditorState_DrawTextBase::exit() noexcept {
@@ -161,7 +164,7 @@ bool PackageEditorState_DrawTextBase::exit() noexcept {
   // cleanup command toolbar
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
@@ -137,10 +137,12 @@ private:  // Methods
   bool setNextState(State state) noexcept;
   bool leaveCurrentState() noexcept;
   bool enterNextState(State state) noexcept;
+  bool switchToPreviousState() noexcept;
 
 private:  // Data
   QMap<State, SymbolEditorState*> mStates;
   State mCurrentState;
+  State mPreviousState;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.cpp
@@ -64,7 +64,6 @@ SymbolEditorState_AddPins::~SymbolEditorState_AddPins() noexcept {
 
 bool SymbolEditorState_AddPins::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   mContext.commandToolBar.addLabel(tr("Name:"));
@@ -88,7 +87,11 @@ bool SymbolEditorState_AddPins::entry() noexcept {
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
-  return addNextPin(pos, Angle::deg0());
+  if (!addNextPin(pos, Angle::deg0())) {
+    return false;
+  }
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
+  return true;
 }
 
 bool SymbolEditorState_AddPins::exit() noexcept {
@@ -107,7 +110,7 @@ bool SymbolEditorState_AddPins::exit() noexcept {
   mNameLineEdit = nullptr;
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -69,7 +69,6 @@ SymbolEditorState_DrawCircle::~SymbolEditorState_DrawCircle() noexcept {
 
 bool SymbolEditorState_DrawCircle::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   mContext.commandToolBar.addLabel(tr("Layer:"));
@@ -103,6 +102,7 @@ bool SymbolEditorState_DrawCircle::entry() noexcept {
           &SymbolEditorState_DrawCircle::grabAreaCheckBoxCheckedChanged);
   mContext.commandToolBar.addWidget(std::move(grabAreaCheckBox));
 
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
 
@@ -114,7 +114,7 @@ bool SymbolEditorState_DrawCircle::exit() noexcept {
   // cleanup command toolbar
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -73,7 +73,6 @@ SymbolEditorState_DrawPolygonBase::
 
 bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   mContext.commandToolBar.addLabel(tr("Layer:"));
@@ -121,6 +120,7 @@ bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
     mContext.commandToolBar.addWidget(std::move(grabAreaCheckBox));
   }
 
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
 
@@ -132,7 +132,7 @@ bool SymbolEditorState_DrawPolygonBase::exit() noexcept {
   // cleanup command toolbar
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -68,7 +68,6 @@ SymbolEditorState_DrawTextBase::~SymbolEditorState_DrawTextBase() noexcept {
 
 bool SymbolEditorState_DrawTextBase::entry() noexcept {
   mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-  mContext.graphicsView.setCursor(Qt::CrossCursor);
 
   // populate command toolbar
   if (mMode == Mode::TEXT) {
@@ -112,7 +111,11 @@ bool SymbolEditorState_DrawTextBase::entry() noexcept {
 
   Point pos =
       mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(), true, true);
-  return startAddText(pos);
+  if (!startAddText(pos)) {
+    return false;
+  }
+  mContext.graphicsView.setCursor(Qt::CrossCursor);
+  return true;
 }
 
 bool SymbolEditorState_DrawTextBase::exit() noexcept {
@@ -123,7 +126,7 @@ bool SymbolEditorState_DrawTextBase::exit() noexcept {
   // cleanup command toolbar
   mContext.commandToolBar.clear();
 
-  mContext.graphicsView.setCursor(Qt::ArrowCursor);
+  mContext.graphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorfsm.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorfsm.cpp
@@ -289,11 +289,15 @@ bool BoardEditorFsm::processGraphicsSceneRightMouseButtonReleased(
   if (BoardEditorState* state = getCurrentStateObj()) {
     if (state->processGraphicsSceneRightMouseButtonReleased(e)) {
       return true;
+    } else if (mCurrentState != State::SELECT) {
+      // If right click is not handled, abort current command.
+      return processAbortCommand();
+    } else {
+      // In select state, switch back to last state.
+      return switchToPreviousState();
     }
   }
-
-  // Switch back to last state
-  return switchToPreviousState();
+  return false;
 }
 
 bool BoardEditorFsm::processSwitchToBoard(int index) noexcept {

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.cpp
@@ -87,9 +87,7 @@ bool BoardEditorState_AddHole::entry() noexcept {
           &BoardEditorState_AddHole::diameterEditValueChanged);
   mContext.editorUi.commandToolbar->addWidget(mDiameterEdit.data());
 
-  // Change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -101,9 +99,7 @@ bool BoardEditorState_AddHole::exit() noexcept {
   mDiameterEdit.reset();
   mDiameterLabel.reset();
 
-  // Reset the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addstroketext.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addstroketext.cpp
@@ -147,9 +147,7 @@ bool BoardEditorState_AddStrokeText::entry() noexcept {
           &BoardEditorState_AddStrokeText::mirrorCheckBoxToggled);
   mContext.editorUi.commandToolbar->addWidget(mMirrorCheckBox.data());
 
-  // Change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -167,9 +165,7 @@ bool BoardEditorState_AddStrokeText::exit() noexcept {
   mLayerComboBox.reset();
   mLayerLabel.reset();
 
-  // Reset the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -191,6 +191,7 @@ bool BoardEditorState_AddVia::entry() noexcept {
             }
           });
 
+  mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
 
@@ -210,6 +211,7 @@ bool BoardEditorState_AddVia::exit() noexcept {
   qDeleteAll(mActionSeparators);
   mActionSeparators.clear();
 
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -124,7 +124,7 @@ bool BoardEditorState_AddVia::entry() noexcept {
   mSizeLabel->setIndent(10);
   mContext.editorUi.commandToolbar->addWidget(mSizeLabel.data());
 
-  // Add the size combobox to the toolbar
+  // Add the size edit to the toolbar
   mSizeEdit.reset(new PositiveLengthEdit());
   mSizeEdit->setValue(mLastViaProperties.getSize());
   mContext.editorUi.commandToolbar->addWidget(mSizeEdit.data());
@@ -136,7 +136,7 @@ bool BoardEditorState_AddVia::entry() noexcept {
   mDrillLabel->setIndent(10);
   mContext.editorUi.commandToolbar->addWidget(mDrillLabel.data());
 
-  // Add the drill combobox to the toolbar
+  // Add the drill edit to the toolbar
   mDrillEdit.reset(new PositiveLengthEdit());
   mDrillEdit->setValue(mLastViaProperties.getDrillDiameter());
   mContext.editorUi.commandToolbar->addWidget(mDrillEdit.data());

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
@@ -188,12 +188,6 @@ bool BoardEditorState_DrawPlane::
   return processGraphicsSceneLeftMouseButtonPressed(e);
 }
 
-bool BoardEditorState_DrawPlane::processGraphicsSceneRightMouseButtonReleased(
-    QGraphicsSceneMouseEvent& e) noexcept {
-  Q_UNUSED(e);
-  return processAbortCommand();
-}
-
 bool BoardEditorState_DrawPlane::processSwitchToBoard(int index) noexcept {
   // Allow switching to an existing board if no command is active.
   return (!mIsUndoCmdActive) && (index >= 0);

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
@@ -124,9 +124,7 @@ bool BoardEditorState_DrawPlane::entry() noexcept {
   connect(mLayerComboBox.data(), &GraphicsLayerComboBox::currentLayerChanged,
           this, &BoardEditorState_DrawPlane::layerComboBoxLayerChanged);
 
-  // Change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -142,9 +140,7 @@ bool BoardEditorState_DrawPlane::exit() noexcept {
   qDeleteAll(mActionSeparators);
   mActionSeparators.clear();
 
-  // Reset the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.h
@@ -73,8 +73,6 @@ public:
       QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processGraphicsSceneLeftMouseButtonDoubleClicked(
       QGraphicsSceneMouseEvent& e) noexcept override;
-  virtual bool processGraphicsSceneRightMouseButtonReleased(
-      QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processSwitchToBoard(int index) noexcept override;
 
   // Operator Overloadings

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
@@ -183,12 +183,6 @@ bool BoardEditorState_DrawPolygon::
   return processGraphicsSceneLeftMouseButtonPressed(e);
 }
 
-bool BoardEditorState_DrawPolygon::processGraphicsSceneRightMouseButtonReleased(
-    QGraphicsSceneMouseEvent& e) noexcept {
-  Q_UNUSED(e);
-  return processAbortCommand();
-}
-
 bool BoardEditorState_DrawPolygon::processSwitchToBoard(int index) noexcept {
   // Allow switching to an existing board if no command is active.
   return (!mIsUndoCmdActive) && (index >= 0);

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
@@ -117,9 +117,7 @@ bool BoardEditorState_DrawPolygon::entry() noexcept {
   connect(mFillCheckBox.data(), &QCheckBox::toggled, this,
           &BoardEditorState_DrawPolygon::filledCheckBoxCheckedChanged);
 
-  // Change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -137,9 +135,7 @@ bool BoardEditorState_DrawPolygon::exit() noexcept {
   qDeleteAll(mActionSeparators);
   mActionSeparators.clear();
 
-  // Reset the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.h
@@ -74,8 +74,6 @@ public:
       QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processGraphicsSceneLeftMouseButtonDoubleClicked(
       QGraphicsSceneMouseEvent& e) noexcept override;
-  virtual bool processGraphicsSceneRightMouseButtonReleased(
-      QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processSwitchToBoard(int index) noexcept override;
 
   // Operator Overloadings

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
@@ -200,7 +200,7 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
   mSizeLabel->setIndent(10);
   mContext.editorUi.commandToolbar->addWidget(mSizeLabel.data());
 
-  // Add the size combobox to the toolbar
+  // Add the size edit to the toolbar
   mSizeEdit.reset(new PositiveLengthEdit());
   mSizeEdit->setValue(mCurrentViaProperties.getSize());
   mContext.editorUi.commandToolbar->addWidget(mSizeEdit.data());
@@ -212,13 +212,28 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
   mDrillLabel->setIndent(10);
   mContext.editorUi.commandToolbar->addWidget(mDrillLabel.data());
 
-  // Add the drill combobox to the toolbar
+  // Add the drill edit to the toolbar
   mDrillEdit.reset(new PositiveLengthEdit());
   mDrillEdit->setValue(mCurrentViaProperties.getDrillDiameter());
   mContext.editorUi.commandToolbar->addWidget(mDrillEdit.data());
   connect(mDrillEdit.data(), &PositiveLengthEdit::valueChanged, this,
           &BoardEditorState_DrawTrace::drillDiameterEditValueChanged);
   mActionSeparators.append(mContext.editorUi.commandToolbar->addSeparator());
+
+  // Avoid creating vias with a drill diameter larger than its size!
+  // See https://github.com/LibrePCB/LibrePCB/issues/946.
+  connect(mSizeEdit.data(), &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value < mDrillEdit->getValue()) {
+              mDrillEdit->setValue(value);
+            }
+          });
+  connect(mDrillEdit.data(), &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (value > mSizeEdit->getValue()) {
+              mSizeEdit->setValue(value);
+            }
+          });
 
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
   return true;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
@@ -220,9 +220,7 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
           &BoardEditorState_DrawTrace::drillDiameterEditValueChanged);
   mActionSeparators.append(mContext.editorUi.commandToolbar->addSeparator());
 
-  // Change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -247,9 +245,7 @@ bool BoardEditorState_DrawTrace::exit() noexcept {
   qDeleteAll(mWireModeActions);
   mWireModeActions.clear();
 
-  // Reset the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
@@ -265,11 +265,15 @@ bool SchematicEditorFsm::processGraphicsSceneRightMouseButtonReleased(
   if (SchematicEditorState* state = getCurrentStateObj()) {
     if (state->processGraphicsSceneRightMouseButtonReleased(e)) {
       return true;
+    } else if (mCurrentState != State::SELECT) {
+      // If right click is not handled, abort current command.
+      return processAbortCommand();
+    } else {
+      // In select state, switch back to last state.
+      return switchToPreviousState();
     }
   }
-
-  // Switch back to last state
-  return switchToPreviousState();
+  return false;
 }
 
 bool SchematicEditorFsm::processSwitchToSchematicPage(int index) noexcept {
@@ -312,7 +316,6 @@ bool SchematicEditorFsm::leaveCurrentState() noexcept {
       // The "add component" state does not make much sense to restore with
       // rightclick, thus not memorizing it.
       break;
-
     default:
       mPreviousState = mCurrentState;
       break;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -122,6 +122,7 @@ bool SchematicEditorState_AddComponent::entry() noexcept {
   connect(mAttributeUnitComboBox, &AttributeUnitComboBox::currentItemChanged,
           this, &SchematicEditorState_AddComponent::attributeChanged);
 
+  mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
 
@@ -142,6 +143,7 @@ bool SchematicEditorState_AddComponent::exit() noexcept {
   delete mValueLabel;
   mValueLabel = nullptr;
 
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
@@ -66,9 +66,7 @@ bool SchematicEditorState_AddNetLabel::entry() noexcept {
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
-  // change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -83,9 +81,7 @@ bool SchematicEditorState_AddNetLabel::exit() noexcept {
     }
   }
 
-  // change the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.cpp
@@ -132,12 +132,10 @@ bool SchematicEditorState_AddText::entry() noexcept {
           &SchematicEditorState_AddText::heightEditValueChanged);
   mContext.editorUi.commandToolbar->addWidget(mHeightEdit.data());
 
-  // Change the cursor
-  mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   // Set focus to text combobox to allow typing the text immediately
   setFocusToTextEdit();
 
+  mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
 
@@ -153,9 +151,7 @@ bool SchematicEditorState_AddText::exit() noexcept {
   mLayerComboBox.reset();
   mLayerLabel.reset();
 
-  // Reset the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
@@ -118,9 +118,7 @@ bool SchematicEditorState_DrawPolygon::entry() noexcept {
   connect(mFillCheckBox.data(), &QCheckBox::toggled, this,
           &SchematicEditorState_DrawPolygon::filledCheckBoxCheckedChanged);
 
-  // Change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -138,9 +136,7 @@ bool SchematicEditorState_DrawPolygon::exit() noexcept {
   qDeleteAll(mActionSeparators);
   mActionSeparators.clear();
 
-  // Reset the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
@@ -185,13 +185,6 @@ bool SchematicEditorState_DrawPolygon::
   return processGraphicsSceneLeftMouseButtonPressed(e);
 }
 
-bool SchematicEditorState_DrawPolygon::
-    processGraphicsSceneRightMouseButtonReleased(
-        QGraphicsSceneMouseEvent& e) noexcept {
-  Q_UNUSED(e);
-  return processAbortCommand();
-}
-
 bool SchematicEditorState_DrawPolygon::processSwitchToSchematicPage(
     int index) noexcept {
   // Allow switching to an existing schematic if no command is active.

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.h
@@ -74,8 +74,6 @@ public:
       QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processGraphicsSceneLeftMouseButtonDoubleClicked(
       QGraphicsSceneMouseEvent& e) noexcept override;
-  virtual bool processGraphicsSceneRightMouseButtonReleased(
-      QGraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processSwitchToSchematicPage(int index) noexcept override;
 
   // Operator Overloadings

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
@@ -120,9 +120,7 @@ bool SchematicEditorState_DrawWire::entry() noexcept {
     });
   }
 
-  // change the cursor
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
-
   return true;
 }
 
@@ -138,9 +136,7 @@ bool SchematicEditorState_DrawWire::exit() noexcept {
   qDeleteAll(mActionSeparators);
   mActionSeparators.clear();
 
-  // change the cursor
-  mContext.editorGraphicsView.setCursor(Qt::ArrowCursor);
-
+  mContext.editorGraphicsView.unsetCursor();
   return true;
 }
 


### PR DESCRIPTION
- Implement consistent right-click behavior in all editors
- Fix inconsistent cursors of some tools
- Avoid creating vias and pads with drill>size everywhere (#963 didn't fix it everywhere)