### PR TITLE
Implement "Find" and "Find Next/Previous" in editors

### DIFF
--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -113,6 +113,8 @@ LibraryEditor::LibraryEditor(Workspace& ws, const FilePath& libFp,
           &LibraryEditor::flipTriggered);
   connect(mUi->actionRemove, &QAction::triggered, this,
           &LibraryEditor::removeTriggered);
+  connect(mUi->actionFind, &QAction::triggered, mUi->filterToolbar,
+          &SearchToolBar::selectAllAndSetFocus);
   connect(mUi->actionAbortCommand, &QAction::triggered, this,
           &LibraryEditor::abortCommandTriggered);
   connect(mUi->actionZoomIn, &QAction::triggered, this,
@@ -160,14 +162,9 @@ LibraryEditor::LibraryEditor(Workspace& ws, const FilePath& libFp,
   setWindowIcon(mLibrary->getIconAsPixmap());
 
   // setup "filter" toolbar
-  QLineEdit* filterLineEdit = new QLineEdit();
-  filterLineEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-  filterLineEdit->setMaxLength(30);  // avoid too large widget in toolbar
-  filterLineEdit->setClearButtonEnabled(true);  // to quickly reset the filter
-  filterLineEdit->setPlaceholderText(tr("Filter elements"));
-  connect(filterLineEdit, &QLineEdit::textEdited, overviewWidget,
+  mUi->filterToolbar->setPlaceholderText(tr("Filter elements"));
+  connect(mUi->filterToolbar, &SearchToolBar::textChanged, overviewWidget,
           &LibraryOverviewWidget::setFilter);
-  mUi->filterToolbar->addWidget(filterLineEdit);
 
   // setup status bar
   mUi->statusBar->setFields(StatusBar::ProgressBar);

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -764,6 +764,19 @@ void LibraryEditor::updateTabTitles() noexcept {
   }
 }
 
+void LibraryEditor::keyPressEvent(QKeyEvent* event) noexcept {
+  // If the overview tab is opened and a filter is active, discard the filter
+  // with the escape key.
+  if ((event->key() == Qt::Key_Escape) &&
+      (!mUi->filterToolbar->getText().isEmpty())) {
+    if (dynamic_cast<LibraryOverviewWidget*>(mCurrentEditorWidget)) {
+      mUi->filterToolbar->clear();
+      return;
+    }
+  }
+  QMainWindow::keyPressEvent(event);
+}
+
 void LibraryEditor::closeEvent(QCloseEvent* event) noexcept {
   if (closeAndDestroy(true)) {
     QMainWindow::closeEvent(event);

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -170,6 +170,7 @@ private:  // Methods
   void editNewLibraryElement(NewElementWizardContext::ElementType type,
                              const FilePath& fp);
   void updateTabTitles() noexcept;
+  void keyPressEvent(QKeyEvent* event) noexcept override;
   void closeEvent(QCloseEvent* event) noexcept override;
   void addLayer(const QString& name, bool forceVisible = false) noexcept;
 

--- a/libs/librepcb/editor/library/libraryeditor.ui
+++ b/libs/librepcb/editor/library/libraryeditor.ui
@@ -137,6 +137,8 @@
     <addaction name="actionCut"/>
     <addaction name="actionPaste"/>
     <addaction name="actionRemove"/>
+    <addaction name="separator"/>
+    <addaction name="actionFind"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -236,7 +238,7 @@
    <addaction name="actionZoomAll"/>
    <addaction name="actionGridProperties"/>
   </widget>
-  <widget class="QToolBar" name="filterToolbar">
+  <widget class="librepcb::editor::SearchToolBar" name="filterToolbar">
    <property name="windowTitle">
     <string>Filter</string>
    </property>
@@ -804,6 +806,18 @@
     <string>Export as image file</string>
    </property>
   </action>
+  <action name="actionFind">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
+   </property>
+   <property name="text">
+    <string notr="true">Find...</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+F</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
@@ -811,6 +825,11 @@
    <class>librepcb::editor::StatusBar</class>
    <extends>QStatusBar</extends>
    <header location="global">librepcb/editor/widgets/statusbar.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::SearchToolBar</class>
+   <extends>QToolBar</extends>
+   <header location="global">librepcb/editor/widgets/searchtoolbar.h</header>
   </customwidget>
   <customwidget>
    <class>librepcb::editor::TabWidget</class>

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -258,6 +258,12 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
           &BoardEditorFsm::processImportDxf);
   connect(mUi->actionOrderPcb, &QAction::triggered, this,
           [this]() { mProjectEditor.execOrderPcbDialog(nullptr, this); });
+  connect(mUi->actionFind, &QAction::triggered, mUi->searchToolbar,
+          &SearchToolBar::selectAllAndSetFocus);
+  connect(mUi->actionFindNext, &QAction::triggered, mUi->searchToolbar,
+          &SearchToolBar::findNext);
+  connect(mUi->actionFindPrevious, &QAction::triggered, mUi->searchToolbar,
+          &SearchToolBar::findPrevious);
 
   // connect the undo/redo actions with the UndoStack of the project
   mUndoStackActionGroup.reset(

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -838,7 +838,7 @@ QStringList BoardEditor::getSearchToolBarCompleterList() noexcept {
   return list;
 }
 
-void BoardEditor::goToDevice(const QString& name, unsigned int index) noexcept {
+void BoardEditor::goToDevice(const QString& name, int index) noexcept {
   QList<BI_Device*> deviceCandidates = {};
   foreach (BI_Device* device, getSearchCandidates()) {
     if (device->getComponentInstance().getName()->startsWith(
@@ -848,6 +848,9 @@ void BoardEditor::goToDevice(const QString& name, unsigned int index) noexcept {
   }
 
   if (deviceCandidates.count()) {
+    while (index < 0) {
+      index += deviceCandidates.count();
+    }
     index %= deviceCandidates.count();
     BI_Device* device = deviceCandidates[index];
     Board* board = getActiveBoard();

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.h
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.h
@@ -135,7 +135,7 @@ private:
   void clearDrcMarker() noexcept;
   QList<BI_Device*> getSearchCandidates() noexcept;
   QStringList getSearchToolBarCompleterList() noexcept;
-  void goToDevice(const QString& name, unsigned int index) noexcept;
+  void goToDevice(const QString& name, int index) noexcept;
   void execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                 const QString& settingsKey) noexcept;
 

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.ui
@@ -144,6 +144,10 @@
     <addaction name="actionPaste"/>
     <addaction name="actionRemove"/>
     <addaction name="separator"/>
+    <addaction name="actionFind"/>
+    <addaction name="actionFindNext"/>
+    <addaction name="actionFindPrevious"/>
+    <addaction name="separator"/>
     <addaction name="actionEditNetClasses"/>
    </widget>
    <widget class="QMenu" name="menuView">
@@ -974,6 +978,34 @@
    </property>
    <property name="toolTip">
     <string>Export board as image file</string>
+   </property>
+  </action>
+  <action name="actionFind">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
+   </property>
+   <property name="text">
+    <string notr="true">Find...</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+F</string>
+   </property>
+  </action>
+  <action name="actionFindNext">
+   <property name="text">
+    <string notr="true">Find Next</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">F3</string>
+   </property>
+  </action>
+  <action name="actionFindPrevious">
+   <property name="text">
+    <string notr="true">Find Previous</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Shift+F3</string>
    </property>
   </action>
  </widget>

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -615,8 +615,7 @@ QStringList SchematicEditor::getSearchToolBarCompleterList() noexcept {
   return list;
 }
 
-void SchematicEditor::goToSymbol(const QString& name,
-                                 unsigned int index) noexcept {
+void SchematicEditor::goToSymbol(const QString& name, int index) noexcept {
   QList<SI_Symbol*> symbolCandidates = {};
   foreach (SI_Symbol* symbol, getSearchCandidates()) {
     if (symbol->getName().startsWith(name, Qt::CaseInsensitive)) {
@@ -625,6 +624,9 @@ void SchematicEditor::goToSymbol(const QString& name,
   }
 
   if (symbolCandidates.count()) {
+    while (index < 0) {
+      index += symbolCandidates.count();
+    }
     index %= symbolCandidates.count();
     SI_Symbol* symbol = symbolCandidates[index];
     Schematic& schematic = symbol->getSchematic();

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -163,6 +163,12 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
           [this]() { mProjectEditor.execLppzExportDialog(this); });
   connect(mUi->actionOrderPcb, &QAction::triggered, this,
           [this]() { mProjectEditor.execOrderPcbDialog(nullptr, this); });
+  connect(mUi->actionFind, &QAction::triggered, mUi->searchToolbar,
+          &SearchToolBar::selectAllAndSetFocus);
+  connect(mUi->actionFindNext, &QAction::triggered, mUi->searchToolbar,
+          &SearchToolBar::findNext);
+  connect(mUi->actionFindPrevious, &QAction::triggered, mUi->searchToolbar,
+          &SearchToolBar::findPrevious);
 
   // connect the undo/redo actions with the UndoStack of the project
   mUndoStackActionGroup.reset(

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -116,7 +116,7 @@ private:
   void renameSchematic(int index) noexcept;
   QList<SI_Symbol*> getSearchCandidates() noexcept;
   QStringList getSearchToolBarCompleterList() noexcept;
-  void goToSymbol(const QString& name, unsigned int index) noexcept;
+  void goToSymbol(const QString& name, int index) noexcept;
   void updateComponentToolbarIcons() noexcept;
   void execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                 const QString& settingsKey) noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.ui
@@ -109,6 +109,10 @@
     <addaction name="actionPaste"/>
     <addaction name="actionRemove"/>
     <addaction name="separator"/>
+    <addaction name="actionFind"/>
+    <addaction name="actionFindNext"/>
+    <addaction name="actionFindPrevious"/>
+    <addaction name="separator"/>
     <addaction name="actionEditNetclasses"/>
    </widget>
    <widget class="QMenu" name="menuView">
@@ -874,6 +878,34 @@
    </property>
    <property name="toolTip">
     <string>Export schematics as image file</string>
+   </property>
+  </action>
+  <action name="actionFind">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
+   </property>
+   <property name="text">
+    <string notr="true">Find...</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+F</string>
+   </property>
+  </action>
+  <action name="actionFindNext">
+   <property name="text">
+    <string notr="true">Find Next</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">F3</string>
+   </property>
+  </action>
+  <action name="actionFindPrevious">
+   <property name="text">
+    <string notr="true">Find Previous</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Shift+F3</string>
    </property>
   </action>
  </widget>

--- a/libs/librepcb/editor/widgets/searchtoolbar.cpp
+++ b/libs/librepcb/editor/widgets/searchtoolbar.cpp
@@ -48,9 +48,20 @@ SearchToolBar::SearchToolBar(QWidget* parent) noexcept
   connect(mLineEdit.data(), &QLineEdit::returnPressed, this,
           &SearchToolBar::enterPressed);
   addWidget(mLineEdit.data());
+  setFocusPolicy(mLineEdit->focusPolicy());
+  setFocusProxy(mLineEdit.data());
 }
 
 SearchToolBar::~SearchToolBar() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void SearchToolBar::selectAllAndSetFocus() noexcept {
+  mLineEdit->selectAll();
+  mLineEdit->setFocus();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/searchtoolbar.cpp
+++ b/libs/librepcb/editor/widgets/searchtoolbar.cpp
@@ -43,8 +43,8 @@ SearchToolBar::SearchToolBar(QWidget* parent) noexcept
   mLineEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   mLineEdit->setMaxLength(30);  // avoid too large widget in toolbar
   mLineEdit->setClearButtonEnabled(true);  // to quickly clear the search term
-  connect(mLineEdit.data(), &QLineEdit::textEdited, this,
-          &SearchToolBar::textEdited);
+  connect(mLineEdit.data(), &QLineEdit::textChanged, this,
+          &SearchToolBar::textChangedHandler);
   connect(mLineEdit.data(), &QLineEdit::returnPressed, this,
           &SearchToolBar::enterPressed);
   addWidget(mLineEdit.data());
@@ -58,6 +58,10 @@ SearchToolBar::~SearchToolBar() noexcept {
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+void SearchToolBar::clear() noexcept {
+  mLineEdit->clear();
+}
 
 void SearchToolBar::selectAllAndSetFocus() noexcept {
   mLineEdit->selectAll();
@@ -86,10 +90,11 @@ void SearchToolBar::updateCompleter() noexcept {
   mLineEdit->setCompleter(completer);
 }
 
-void SearchToolBar::textEdited(const QString& text) noexcept {
+void SearchToolBar::textChangedHandler(const QString& text) noexcept {
   Q_UNUSED(text);
   updateCompleter();
   mIndex = 0;
+  emit textChanged(text);
 }
 
 void SearchToolBar::enterPressed() noexcept {

--- a/libs/librepcb/editor/widgets/searchtoolbar.cpp
+++ b/libs/librepcb/editor/widgets/searchtoolbar.cpp
@@ -39,6 +39,7 @@ SearchToolBar::SearchToolBar(QWidget* parent) noexcept
   : QToolBar(parent),
     mCompleterListFunction(),
     mLineEdit(new QLineEdit()),
+    mForward(true),
     mIndex(0) {
   mLineEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
   mLineEdit->setMaxLength(30);  // avoid too large widget in toolbar
@@ -46,7 +47,7 @@ SearchToolBar::SearchToolBar(QWidget* parent) noexcept
   connect(mLineEdit.data(), &QLineEdit::textChanged, this,
           &SearchToolBar::textChangedHandler);
   connect(mLineEdit.data(), &QLineEdit::returnPressed, this,
-          &SearchToolBar::enterPressed);
+          &SearchToolBar::findNext);
   addWidget(mLineEdit.data());
   setFocusPolicy(mLineEdit->focusPolicy());
   setFocusProxy(mLineEdit.data());
@@ -66,6 +67,24 @@ void SearchToolBar::clear() noexcept {
 void SearchToolBar::selectAllAndSetFocus() noexcept {
   mLineEdit->selectAll();
   mLineEdit->setFocus();
+}
+
+void SearchToolBar::findNext() noexcept {
+  if (!mForward) {
+    mForward = true;
+    mIndex += 2;
+  }
+  emit goToTriggered(mLineEdit->text().trimmed(), mIndex);
+  ++mIndex;
+}
+
+void SearchToolBar::findPrevious() noexcept {
+  if (mForward) {
+    mForward = false;
+    mIndex -= 2;
+  }
+  emit goToTriggered(mLineEdit->text().trimmed(), mIndex);
+  --mIndex;
 }
 
 /*******************************************************************************
@@ -91,14 +110,10 @@ void SearchToolBar::updateCompleter() noexcept {
 }
 
 void SearchToolBar::textChangedHandler(const QString& text) noexcept {
-  Q_UNUSED(text);
   updateCompleter();
   mIndex = 0;
+  mForward = true;
   emit textChanged(text);
-}
-
-void SearchToolBar::enterPressed() noexcept {
-  emit goToTriggered(mLineEdit->text().trimmed(), mIndex++);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/searchtoolbar.h
+++ b/libs/librepcb/editor/widgets/searchtoolbar.h
@@ -66,23 +66,25 @@ public:
   // General Methods
   void clear() noexcept;
   void selectAllAndSetFocus() noexcept;
+  void findNext() noexcept;
+  void findPrevious() noexcept;
 
   // Operator Overloadings
   SearchToolBar& operator=(const SearchToolBar& rhs) = delete;
 
 signals:
   void textChanged(const QString& text);
-  void goToTriggered(const QString& name, unsigned int index = 0);
+  void goToTriggered(const QString& name, int index = 0);
 
 private:
   void updateCompleter() noexcept;
   void textChangedHandler(const QString& text) noexcept;
-  void enterPressed() noexcept;
 
 private:
   CompleterListFunction mCompleterListFunction;
   QScopedPointer<QLineEdit> mLineEdit;
-  unsigned int mIndex;  ///< Number of searches with the current search term
+  bool mForward;  ///< Current search direction (forward or backward)
+  int mIndex;  ///< Number of searches with the current search term
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/searchtoolbar.h
+++ b/libs/librepcb/editor/widgets/searchtoolbar.h
@@ -52,6 +52,9 @@ public:
   explicit SearchToolBar(QWidget* parent = nullptr) noexcept;
   ~SearchToolBar() noexcept;
 
+  // Getters
+  QString getText() const noexcept { return mLineEdit->text(); }
+
   // Setters
   void setPlaceholderText(const QString& text) noexcept {
     mLineEdit->setPlaceholderText(text);
@@ -61,17 +64,19 @@ public:
   }
 
   // General Methods
+  void clear() noexcept;
   void selectAllAndSetFocus() noexcept;
 
   // Operator Overloadings
   SearchToolBar& operator=(const SearchToolBar& rhs) = delete;
 
 signals:
+  void textChanged(const QString& text);
   void goToTriggered(const QString& name, unsigned int index = 0);
 
 private:
   void updateCompleter() noexcept;
-  void textEdited(const QString& text) noexcept;
+  void textChangedHandler(const QString& text) noexcept;
   void enterPressed() noexcept;
 
 private:

--- a/libs/librepcb/editor/widgets/searchtoolbar.h
+++ b/libs/librepcb/editor/widgets/searchtoolbar.h
@@ -60,6 +60,9 @@ public:
     mCompleterListFunction = fun;
   }
 
+  // General Methods
+  void selectAllAndSetFocus() noexcept;
+
   // Operator Overloadings
   SearchToolBar& operator=(const SearchToolBar& rhs) = delete;
 


### PR DESCRIPTION
The "search" toolbar was already added to all editors some time ago. However, so far you had to manually move the cursor into that toolbar to start searching, go to the next result (pressing Enter again) or to clear the search keyword. This PR adds several improvements to this feature:

- Add "Find" entry to the menus of all editors, with the keyboard shortcut Ctrl+F. So in any editor you can now press Ctrl+F to move the focus to the search field, then just start typing the term to search for.
- Add "Find Next" and "Find Previous" entries to the menu of the schematic- and board editor, with keyboard shortcuts F3 resp. Shift+F3. These allow to navigate to the next/previous search result even if the focus is not in the search toolbar anymore.
- Fix non-numeric order of search results (e.g. R10 appeared before R2).
- Library editor: Clear the applied filter with the Escape key. No more need to manually clear the search term in the toolbar.