### PR TITLE
Schematic editor: Fix copy&paste of multi-symbol components

### DIFF
--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.h
@@ -98,6 +98,9 @@ public:
         attributes(node, fileFormat),
         onEdited(*this) {}
 
+    /// Required for ::librepcb::SerializableObjectList::contains()
+    const Uuid& getUuid() const noexcept { return uuid; }
+
     /// @copydoc ::librepcb::SerializableObject::serialize()
     void serialize(SExpression& root) const override {
       root.appendChild(uuid);

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.cpp
@@ -84,6 +84,11 @@ std::unique_ptr<SchematicClipboardData> SchematicClipboardDataBuilder::generate(
 
   // Add components
   foreach (SI_Symbol* symbol, query->getSymbols()) {
+    // Components with multiple symbols (gates) shall be added only once.
+    if (data->getComponentInstances().contains(
+            symbol->getComponentInstance().getUuid())) {
+      continue;
+    }
     std::unique_ptr<TransactionalDirectory> dir = data->getDirectory(
         "cmp/" %
         symbol->getComponentInstance().getLibComponent().getUuid().toStr());


### PR DESCRIPTION
Components with multiple symbols (gates) were added multiple times
to the circuit after copy&paste, leading in stale components which
could not be removed anymore since they had no symbol in the schematic.

See
https://librepcb.discourse.group/t/removed-components-devices-still-in-project/472