### PR TITLE
Fix potential numeric issues with "-march=haswell"

### DIFF
--- a/libs/librepcb/core/utils/toolbox.cpp
+++ b/libs/librepcb/core/utils/toolbox.cpp
@@ -96,7 +96,8 @@ Point Toolbox::arcCenter(const Point& p1, const Point& p2,
     qreal angleSgn = (angle >= 0) ? 1 : -1;
     qreal d = qSqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
     qreal r = d / (2 * qSin(angle / 2));
-    qreal h = qSqrt(r * r - d * d / 4);
+    // Note: std::max() fixes https://github.com/LibrePCB/LibrePCB/issues/974
+    qreal h = qSqrt(std::max(r * r - d * d / 4.0, qreal(0)));
     qreal u = (x1 - x0) / d;
     qreal v = (y1 - y0) / d;
     qreal a = ((x0 + x1) / 2) - h * v * angleSgn;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(
   core/types/signalroletest.cpp
   core/types/uuidtest.cpp
   core/types/versiontest.cpp
+  core/utils/clipperhelperstest.cpp
   core/utils/mathparsertest.cpp
   core/utils/scopeguardtest.cpp
   core/utils/signalslottest.cpp

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -157,6 +157,20 @@ TEST_F(PathTest, testCircle) {
   EXPECT_TRUE(path.isClosed());
 }
 
+// Test to reproduce https://github.com/LibrePCB/LibrePCB/issues/974
+TEST_F(PathTest, testFlatArc) {
+  Path expected = Path({
+      Vertex(Point(30875000, 32385000)),
+      Vertex(Point(29725000, 30393142)),
+      Vertex(Point(27425000, 30393142)),
+      Vertex(Point(26275000, 32385000)),
+  });
+  Path actual =
+      Path::flatArc(Point(30875000, 32385000), Point(26275000, 32385000),
+                    -Angle::deg180(), PositiveLength(1000000));
+  EXPECT_EQ(str(expected), str(actual));
+}
+
 /*******************************************************************************
  *  Parametrized obround(width, height) Tests
  ******************************************************************************/

--- a/tests/unittests/core/utils/clipperhelperstest.cpp
+++ b/tests/unittests/core/utils/clipperhelperstest.cpp
@@ -1,0 +1,67 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/core/utils/clipperhelpers.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class ClipperHelpersTest : public ::testing::Test {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+// Test to reproduce https://github.com/LibrePCB/LibrePCB/issues/974
+TEST_F(ClipperHelpersTest, testConvertPathWithApproximate) {
+  Path input({Vertex(Point(30875000, 32385000), -Angle::deg180()),
+              Vertex(Point(26275000, 32385000), -Angle::deg180()),
+              Vertex(Point(30875000, 32385000), Angle::deg0())});
+  PositiveLength maxArcTolerance(1000000);
+  ClipperLib::Path output = ClipperHelpers::convert(input, maxArcTolerance);
+
+  QString outputStr;
+  for (const auto& p : output) {
+    outputStr += QString("(%1, %2) ").arg(p.X).arg(p.Y);
+  }
+  EXPECT_EQ(
+      "(30875000, 32385000) (29725000, 34376858) (27425000, 34376858) "
+      "(26275000, 32385000) (27425000, 30393142) (29725000, 30393142) "
+      "(30875000, 32385000) ",
+      outputStr.toStdString());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/core/utils/toolboxtest.cpp
+++ b/tests/unittests/core/utils/toolboxtest.cpp
@@ -132,7 +132,9 @@ TEST_P(ToolboxArcCenterTest, test) {
 // clang-format off
 static ToolboxArcCenterTestData sToolboxArcCenterTestData[] = {
 // p1,                         p2,                         angle,              center
-  {Point(47744137, 37820591),  Point(55364137, 24622364),  -Angle::deg90(),    Point(44955023, 27411478)}
+  {Point(47744137, 37820591),  Point(55364137, 24622364),  -Angle::deg90(),    Point(44955023, 27411478)},
+  // Test to reproduce https://github.com/LibrePCB/LibrePCB/issues/974
+  {Point(30875000, 32385000),  Point(26275000, 32385000),  -Angle::deg180(),   Point(28575000, 32385000)}
 };
 // clang-format on
 


### PR DESCRIPTION
Due to potential numeric inaccuracy which was observed with "-march=haswell" (see #974), the argument passed to `qSqrt()` could be a tiny negative number instead of zero, which leads to NaN return value and thus various problems, for example broken plane fragment calculations. Probably it is caused by floating-point optimizations. Fixed it by clipping negative numbers to zero.

Fixes #974 