### PR TITLE
Implement distance measure tool in all editors

### DIFF
--- a/libs/librepcb/core/graphics/graphicspainter.cpp
+++ b/libs/librepcb/core/graphics/graphicspainter.cpp
@@ -109,19 +109,24 @@ void GraphicsPainter::drawCircle(const Point& center, const Length& diameter,
 void GraphicsPainter::drawText(const Point& position, const Angle& rotation,
                                const Length& height, const Alignment& alignment,
                                const QString& text, QFont font,
-                               const QColor& color,
-                               bool mirrorInPlace) noexcept {
+                               const QColor& color, bool autoRotate,
+                               bool mirrorInPlace, int fontPixelSize) noexcept {
   if (text.trimmed().isEmpty() || (!color.isValid())) {
     return;  // Nothing to draw.
   }
 
-  const bool rotate180 = Toolbox::isTextUpsideDown(rotation, false);
+  const bool rotate180 =
+      autoRotate && Toolbox::isTextUpsideDown(rotation, false);
   Alignment align = rotate180 ? alignment.mirrored() : alignment;
   if (mirrorInPlace) {
     align.mirrorH();
   }
   const int flags = align.toQtAlign();
-  font.setPixelSize(qCeil(height.toPx()));
+  if (fontPixelSize > 0) {
+    font.setPixelSize(fontPixelSize);
+  } else {
+    font.setPixelSize(qCeil(height.toPx()));
+  }
   const QFontMetricsF metrics(font);
   const qreal scale = height.toPx() / metrics.height();
   const QRectF rect =

--- a/libs/librepcb/core/graphics/graphicspainter.h
+++ b/libs/librepcb/core/graphics/graphicspainter.h
@@ -71,7 +71,8 @@ public:
   void drawText(const Point& position, const Angle& rotation,
                 const Length& height, const Alignment& alignment,
                 const QString& text, QFont font, const QColor& color,
-                bool mirrorInPlace) noexcept;
+                bool autoRotate, bool mirrorInPlace,
+                int fontPixelSize = 0) noexcept;
   void drawSymbolPin(const Point& position, const Angle& rotation,
                      const Length& length, const QColor& lineColor,
                      const QColor& circleColor) noexcept;

--- a/libs/librepcb/core/library/pkg/footprintpainter.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpainter.cpp
@@ -125,7 +125,7 @@ void FootprintPainter::paint(QPainter& painter,
     foreach (const Text& text, content.texts) {
       p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
                  text.getAlign(), text.getText(),
-                 qApp->getDefaultMonospaceFont(), Qt::transparent,
+                 qApp->getDefaultMonospaceFont(), Qt::transparent, true,
                  settings.getMirror());
     }
   }

--- a/libs/librepcb/core/library/sym/symbolpainter.cpp
+++ b/libs/librepcb/core/library/sym/symbolpainter.cpp
@@ -90,7 +90,7 @@ void SymbolPainter::paint(QPainter& painter,
   foreach (const Text& text, mTexts) {
     p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
                text.getAlign(), text.getText(), qApp->getDefaultSansSerifFont(),
-               settings.getColor(*text.getLayerName()), false);
+               settings.getColor(*text.getLayerName()), true, false);
   }
 
   // Draw Pins.
@@ -102,7 +102,7 @@ void SymbolPainter::paint(QPainter& painter,
         pin.getPosition() + pin.getNamePosition().rotated(pin.getRotation()),
         pin.getRotation() + pin.getNameRotation(), *pin.getNameHeight(),
         pin.getNameAlignment(), *pin.getName(), qApp->getDefaultSansSerifFont(),
-        settings.getColor(GraphicsLayer::sSymbolPinNames), false);
+        settings.getColor(GraphicsLayer::sSymbolPinNames), true, false);
   }
 }
 

--- a/libs/librepcb/core/project/board/boardpainter.cpp
+++ b/libs/librepcb/core/project/board/boardpainter.cpp
@@ -179,7 +179,7 @@ void BoardPainter::paint(QPainter& painter,
     foreach (const Text& text, content.texts) {
       p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
                  text.getAlign(), text.getText(),
-                 qApp->getDefaultMonospaceFont(), Qt::transparent,
+                 qApp->getDefaultMonospaceFont(), Qt::transparent, true,
                  settings.getMirror());
     }
   }

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -152,7 +152,7 @@ void SchematicPainter::paint(QPainter& painter,
       p.drawText(symbol.transform.map(text.getPosition()),
                  symbol.transform.map(text.getRotation()), *text.getHeight(),
                  alignment, text.getText(), qApp->getDefaultSansSerifFont(),
-                 settings.getColor(*text.getLayerName()), false);
+                 settings.getColor(*text.getLayerName()), true, false);
     }
 
     // Draw Symbol Pins.
@@ -170,7 +170,8 @@ void SchematicPainter::paint(QPainter& painter,
                  symbol.transform.map(pin.rotation + pin.nameRotation),
                  *pin.nameHeight, nameAlignment, pin.name,
                  qApp->getDefaultSansSerifFont(),
-                 settings.getColor(GraphicsLayer::sSymbolPinNames), false);
+                 settings.getColor(GraphicsLayer::sSymbolPinNames), true,
+                 false);
     }
   }
 
@@ -187,7 +188,7 @@ void SchematicPainter::paint(QPainter& painter,
   foreach (const Text& text, mTexts) {
     p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
                text.getAlign(), text.getText(), qApp->getDefaultSansSerifFont(),
-               settings.getColor(*text.getLayerName()), false);
+               settings.getColor(*text.getLayerName()), true, false);
   }
 
   // Draw Net Lines.

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -258,6 +258,8 @@ add_library(
   library/pkg/fsm/packageeditorstate_drawtext.h
   library/pkg/fsm/packageeditorstate_drawtextbase.cpp
   library/pkg/fsm/packageeditorstate_drawtextbase.h
+  library/pkg/fsm/packageeditorstate_measure.cpp
+  library/pkg/fsm/packageeditorstate_measure.h
   library/pkg/fsm/packageeditorstate_select.cpp
   library/pkg/fsm/packageeditorstate_select.h
   library/pkg/packagechooserdialog.cpp
@@ -296,6 +298,8 @@ add_library(
   library/sym/fsm/symboleditorstate_drawtext.h
   library/sym/fsm/symboleditorstate_drawtextbase.cpp
   library/sym/fsm/symboleditorstate_drawtextbase.h
+  library/sym/fsm/symboleditorstate_measure.cpp
+  library/sym/fsm/symboleditorstate_measure.h
   library/sym/fsm/symboleditorstate_select.cpp
   library/sym/fsm/symboleditorstate_select.h
   library/sym/symbolchooserdialog.cpp
@@ -390,6 +394,8 @@ add_library(
   project/boardeditor/fsm/boardeditorstate_drawpolygon.h
   project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
   project/boardeditor/fsm/boardeditorstate_drawtrace.h
+  project/boardeditor/fsm/boardeditorstate_measure.cpp
+  project/boardeditor/fsm/boardeditorstate_measure.h
   project/boardeditor/fsm/boardeditorstate_select.cpp
   project/boardeditor/fsm/boardeditorstate_select.h
   project/boardeditor/unplacedcomponentsdock.cpp
@@ -603,6 +609,8 @@ add_library(
   project/schematiceditor/fsm/schematiceditorstate_drawpolygon.h
   project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
   project/schematiceditor/fsm/schematiceditorstate_drawwire.h
+  project/schematiceditor/fsm/schematiceditorstate_measure.cpp
+  project/schematiceditor/fsm/schematiceditorstate_measure.h
   project/schematiceditor/fsm/schematiceditorstate_select.cpp
   project/schematiceditor/fsm/schematiceditorstate_select.h
   project/schematiceditor/renamenetsegmentdialog.cpp
@@ -635,6 +643,8 @@ add_library(
   utils/exclusiveactiongroup.h
   utils/halignactiongroup.cpp
   utils/halignactiongroup.h
+  utils/measuretool.cpp
+  utils/measuretool.h
   utils/menubuilder.cpp
   utils/menubuilder.h
   utils/shortcutsreferencegenerator.cpp

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -908,6 +908,15 @@ public:
       {QKeySequence(Qt::Key_N)},
       &categoryTools,
   };
+  EditorCommand toolMeasure{
+      "tool_measure",  // clang-format break
+      QT_TR_NOOP("Measure Distance"),
+      QT_TR_NOOP("Measure the distance between two points"),
+      QIcon(":/img/actions/ruler.png"),
+      EditorCommand::Flags(),
+      {QKeySequence(Qt::CTRL + Qt::Key_M)},
+      &categoryTools,
+  };
 
   EditorCommandCategory categoryCommands{
       "categoryCommands", QT_TR_NOOP("Commands"), true, &categoryRoot};

--- a/libs/librepcb/editor/library/editorwidgetbase.cpp
+++ b/libs/librepcb/editor/library/editorwidgetbase.cpp
@@ -57,7 +57,8 @@ EditorWidgetBase::EditorWidgetBase(const Context& context, const FilePath& fp,
     mUndoStackActionGroup(nullptr),
     mToolsActionGroup(nullptr),
     mStatusBar(nullptr),
-    mIsInterfaceBroken(false) {
+    mIsInterfaceBroken(false),
+    mStatusBarMessage() {
   mUndoStack.reset(new UndoStack());
   connect(mUndoStack.data(), &UndoStack::cleanChanged, this,
           &EditorWidgetBase::undoStackCleanChanged);
@@ -92,6 +93,7 @@ void EditorWidgetBase::connectEditor(UndoStackActionGroup& undoStackActionGroup,
   mCommandToolBarProxy->setToolBar(&commandToolBar);
 
   mStatusBar = &statusBar;
+  mStatusBar->setPermanentMessage(mStatusBarMessage);
 }
 
 void EditorWidgetBase::disconnectEditor() noexcept {
@@ -103,6 +105,10 @@ void EditorWidgetBase::disconnectEditor() noexcept {
   mToolsActionGroup->reset();
 
   mCommandToolBarProxy->setToolBar(nullptr);
+
+  mStatusBar->clearMessage();
+  mStatusBar->clearPermanentMessage();
+  mStatusBar = nullptr;
 }
 
 /*******************************************************************************
@@ -185,6 +191,20 @@ void EditorWidgetBase::undoStackStateModified() noexcept {
     }
   }
   scheduleLibraryElementChecks();
+}
+
+void EditorWidgetBase::setStatusBarMessage(const QString& message,
+                                           int timeoutMs) noexcept {
+  if (mStatusBar) {
+    if (timeoutMs < 0) {
+      mStatusBar->setPermanentMessage(message);
+    } else {
+      mStatusBar->showMessage(message, timeoutMs);
+    }
+  }
+  if (timeoutMs < 0) {
+    mStatusBarMessage = message;
+  }
 }
 
 const QStringList& EditorWidgetBase::getLibLocaleOrder() const noexcept {

--- a/libs/librepcb/editor/library/editorwidgetbase.h
+++ b/libs/librepcb/editor/library/editorwidgetbase.h
@@ -86,6 +86,7 @@ public:
     ADD_THT_PADS,
     ADD_SMT_PADS,
     ADD_HOLES,
+    MEASURE,
   };
 
   enum class Feature {
@@ -186,6 +187,7 @@ protected:  // Methods
     return false;
   }
   void undoStackStateModified() noexcept;
+  void setStatusBarMessage(const QString& message, int timeoutMs = -1) noexcept;
   const QStringList& getLibLocaleOrder() const noexcept;
   QString getWorkspaceSettingsUserName() noexcept;
 
@@ -234,6 +236,7 @@ protected:  // Data
   StatusBar* mStatusBar;
   QScopedPointer<ToolBarProxy> mCommandToolBarProxy;
   bool mIsInterfaceBroken;
+  QString mStatusBarMessage;
 };
 
 inline uint qHash(const EditorWidgetBase::Feature& feature,

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -644,6 +644,7 @@ void LibraryEditor::createActions() noexcept {
   mActionToolSmtPad.reset(cmd.toolPadSmt.createAction(this));
   mActionToolThtPad.reset(cmd.toolPadTht.createAction(this));
   mActionToolHole.reset(cmd.toolHole.createAction(this));
+  mActionToolMeasure.reset(cmd.toolMeasure.createAction(this));
 
   // Undo stack action group.
   mUndoStackActionGroup.reset(new UndoStackActionGroup(
@@ -675,6 +676,8 @@ void LibraryEditor::createActions() noexcept {
                                mActionToolSmtPad.data());
   mToolsActionGroup->addAction(EditorWidgetBase::Tool::ADD_HOLES,
                                mActionToolHole.data());
+  mToolsActionGroup->addAction(EditorWidgetBase::Tool::MEASURE,
+                               mActionToolMeasure.data());
   mToolsActionGroup->setEnabled(false);
 }
 
@@ -755,6 +758,8 @@ void LibraryEditor::createToolBars() noexcept {
   mToolBarTools->addAction(mActionToolThtPad.data());
   mToolBarTools->addAction(mActionToolSmtPad.data());
   mToolBarTools->addAction(mActionToolHole.data());
+  mToolBarTools->addSeparator();
+  mToolBarTools->addAction(mActionToolMeasure.data());
   addToolBar(Qt::LeftToolBarArea, mToolBarTools.data());
 }
 
@@ -838,6 +843,8 @@ void LibraryEditor::createMenus() noexcept {
   mb.addAction(mActionToolThtPad);
   mb.addAction(mActionToolSmtPad);
   mb.addAction(mActionToolHole);
+  mb.addSeparator();
+  mb.addAction(mActionToolMeasure);
 
   // Help.
   mb.newMenu(&MenuBuilder::createHelpMenu);

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -237,6 +237,7 @@ private:  // Data
   QScopedPointer<QAction> mActionToolSmtPad;
   QScopedPointer<QAction> mActionToolThtPad;
   QScopedPointer<QAction> mActionToolHole;
+  QScopedPointer<QAction> mActionToolMeasure;
 
   // Action groups
   QScopedPointer<UndoStackActionGroup> mUndoStackActionGroup;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -74,6 +74,7 @@ private:  // Types
     DRAW_CIRCLE,
     DRAW_TEXT,
     ADD_HOLES,
+    MEASURE,
   };
 
 public:  // Types
@@ -109,6 +110,8 @@ public:
   // Event Handlers
   bool processChangeCurrentFootprint(
       const std::shared_ptr<Footprint>& fpt) noexcept;
+  bool processKeyPressed(const QKeyEvent& e) noexcept;
+  bool processKeyReleased(const QKeyEvent& e) noexcept;
   bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept;
   bool processGraphicsSceneLeftMouseButtonPressed(
       QGraphicsSceneMouseEvent& e) noexcept;
@@ -142,6 +145,7 @@ public:
   bool processStartDrawTexts() noexcept;
   bool processStartAddingHoles() noexcept;
   bool processStartDxfImport() noexcept;
+  bool processStartMeasure() noexcept;
 
   // Operator Overloadings
   PackageEditorFsm& operator=(const PackageEditorFsm& rhs) = delete;
@@ -149,6 +153,7 @@ public:
 signals:
   void toolChanged(EditorWidgetBase::Tool newTool);
   void availableFeaturesChanged();
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 
 private:  // Methods
   PackageEditorState* getCurrentState() const noexcept;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
@@ -68,6 +68,14 @@ public:
       noexcept = 0;
 
   // Event Handlers
+  virtual bool processKeyPressed(const QKeyEvent& e) noexcept {
+    Q_UNUSED(e);
+    return false;
+  }
+  virtual bool processKeyReleased(const QKeyEvent& e) noexcept {
+    Q_UNUSED(e);
+    return false;
+  }
   virtual bool processGraphicsSceneMouseMoved(
       QGraphicsSceneMouseEvent& e) noexcept {
     Q_UNUSED(e);
@@ -124,6 +132,7 @@ public:
 
 signals:
   void availableFeaturesChanged();
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 
 protected:  // Methods
   const PositiveLength& getGridInterval() const noexcept;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_measure.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_measure.cpp
@@ -1,0 +1,114 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "packageeditorstate_measure.h"
+
+#include "../../../utils/measuretool.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PackageEditorState_Measure::PackageEditorState_Measure(
+    Context& context) noexcept
+  : PackageEditorState(context), mTool(new MeasureTool(mContext.graphicsView)) {
+  connect(mTool.data(), &MeasureTool::statusBarMessageChanged, this,
+          &PackageEditorState_Measure::statusBarMessageChanged);
+}
+
+PackageEditorState_Measure::~PackageEditorState_Measure() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+bool PackageEditorState_Measure::entry() noexcept {
+  mTool->setFootprint(mContext.currentFootprint.get());
+  mTool->enter();
+  return true;
+}
+
+bool PackageEditorState_Measure::exit() noexcept {
+  mTool->leave();
+  return true;
+}
+
+QSet<EditorWidgetBase::Feature>
+    PackageEditorState_Measure::getAvailableFeatures() const noexcept {
+  return {
+      EditorWidgetBase::Feature::Abort,
+      EditorWidgetBase::Feature::Copy,
+      EditorWidgetBase::Feature::Remove,
+  };
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool PackageEditorState_Measure::processKeyPressed(
+    const QKeyEvent& e) noexcept {
+  return mTool->processKeyPressed(e);
+}
+
+bool PackageEditorState_Measure::processKeyReleased(
+    const QKeyEvent& e) noexcept {
+  return mTool->processKeyReleased(e);
+}
+
+bool PackageEditorState_Measure::processGraphicsSceneMouseMoved(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneMouseMoved(e);
+}
+
+bool PackageEditorState_Measure::processGraphicsSceneLeftMouseButtonPressed(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneLeftMouseButtonPressed(e);
+}
+
+bool PackageEditorState_Measure::processCopy() noexcept {
+  return mTool->processCopy();
+}
+
+bool PackageEditorState_Measure::processRemove() noexcept {
+  return mTool->processRemove();
+}
+
+bool PackageEditorState_Measure::processAbortCommand() noexcept {
+  return mTool->processAbortCommand();
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_measure.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_measure.h
@@ -1,0 +1,88 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_PACKAGEEDITORSTATE_MEASURE_H
+#define LIBREPCB_EDITOR_PACKAGEEDITORSTATE_MEASURE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "packageeditorstate.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+class MeasureTool;
+
+/*******************************************************************************
+ *  Class PackageEditorState_Measure
+ ******************************************************************************/
+
+/**
+ * @brief The PackageEditorState_Measure class
+ */
+class PackageEditorState_Measure final : public PackageEditorState {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  PackageEditorState_Measure() = delete;
+  PackageEditorState_Measure(const PackageEditorState_Measure& other) = delete;
+  explicit PackageEditorState_Measure(Context& context) noexcept;
+  ~PackageEditorState_Measure() noexcept;
+
+  // General Methods
+  bool entry() noexcept override;
+  bool exit() noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
+      noexcept override;
+
+  // Event Handlers
+  bool processKeyPressed(const QKeyEvent& e) noexcept override;
+  bool processKeyReleased(const QKeyEvent& e) noexcept override;
+  bool processGraphicsSceneMouseMoved(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  bool processCopy() noexcept override;
+  bool processRemove() noexcept override;
+  bool processAbortCommand() noexcept override;
+
+  // Operator Overloadings
+  PackageEditorState_Measure& operator=(const PackageEditorState_Measure& rhs) =
+      delete;
+
+private:  // Data
+  QScopedPointer<MeasureTool> mTool;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
@@ -69,7 +69,8 @@ private:  // Types
     DRAW_RECT,
     DRAW_POLYGON,
     DRAW_CIRCLE,
-    DRAW_TEXT
+    DRAW_TEXT,
+    MEASURE,
   };
 
 public:  // Types
@@ -101,6 +102,8 @@ public:
   void updateAvailableFeatures() noexcept;
 
   // Event Handlers
+  bool processKeyPressed(const QKeyEvent& e) noexcept;
+  bool processKeyReleased(const QKeyEvent& e) noexcept;
   bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept;
   bool processGraphicsSceneLeftMouseButtonPressed(
       QGraphicsSceneMouseEvent& e) noexcept;
@@ -131,6 +134,7 @@ public:
   bool processStartDrawCircles() noexcept;
   bool processStartDrawTexts() noexcept;
   bool processStartDxfImport() noexcept;
+  bool processStartMeasure() noexcept;
 
   // Operator Overloadings
   SymbolEditorState& operator=(const SymbolEditorState& rhs) = delete;
@@ -138,6 +142,7 @@ public:
 signals:
   void toolChanged(EditorWidgetBase::Tool newTool);
   void availableFeaturesChanged();
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 
 private:  // Methods
   SymbolEditorState* getCurrentState() const noexcept;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
@@ -68,6 +68,14 @@ public:
       noexcept = 0;
 
   // Event Handlers
+  virtual bool processKeyPressed(const QKeyEvent& e) noexcept {
+    Q_UNUSED(e);
+    return false;
+  }
+  virtual bool processKeyReleased(const QKeyEvent& e) noexcept {
+    Q_UNUSED(e);
+    return false;
+  }
   virtual bool processGraphicsSceneMouseMoved(
       QGraphicsSceneMouseEvent& e) noexcept {
     Q_UNUSED(e);
@@ -120,6 +128,7 @@ public:
 
 signals:
   void availableFeaturesChanged();
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 
 protected:  // Methods
   const PositiveLength& getGridInterval() const noexcept;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_measure.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_measure.cpp
@@ -1,0 +1,113 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "symboleditorstate_measure.h"
+
+#include "../../../utils/measuretool.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+SymbolEditorState_Measure::SymbolEditorState_Measure(
+    const Context& context) noexcept
+  : SymbolEditorState(context), mTool(new MeasureTool(mContext.graphicsView)) {
+  connect(mTool.data(), &MeasureTool::statusBarMessageChanged, this,
+          &SymbolEditorState_Measure::statusBarMessageChanged);
+}
+
+SymbolEditorState_Measure::~SymbolEditorState_Measure() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+bool SymbolEditorState_Measure::entry() noexcept {
+  mTool->setSymbol(&mContext.symbol);
+  mTool->enter();
+  return true;
+}
+
+bool SymbolEditorState_Measure::exit() noexcept {
+  mTool->leave();
+  return true;
+}
+
+QSet<EditorWidgetBase::Feature>
+    SymbolEditorState_Measure::getAvailableFeatures() const noexcept {
+  return {
+      EditorWidgetBase::Feature::Abort,
+      EditorWidgetBase::Feature::Copy,
+      EditorWidgetBase::Feature::Remove,
+  };
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool SymbolEditorState_Measure::processKeyPressed(const QKeyEvent& e) noexcept {
+  return mTool->processKeyPressed(e);
+}
+
+bool SymbolEditorState_Measure::processKeyReleased(
+    const QKeyEvent& e) noexcept {
+  return mTool->processKeyReleased(e);
+}
+
+bool SymbolEditorState_Measure::processGraphicsSceneMouseMoved(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneMouseMoved(e);
+}
+
+bool SymbolEditorState_Measure::processGraphicsSceneLeftMouseButtonPressed(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneLeftMouseButtonPressed(e);
+}
+
+bool SymbolEditorState_Measure::processCopy() noexcept {
+  return mTool->processCopy();
+}
+
+bool SymbolEditorState_Measure::processRemove() noexcept {
+  return mTool->processRemove();
+}
+
+bool SymbolEditorState_Measure::processAbortCommand() noexcept {
+  return mTool->processAbortCommand();
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_measure.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_measure.h
@@ -1,0 +1,88 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_SYMBOLEDITORSTATE_MEASURE_H
+#define LIBREPCB_EDITOR_SYMBOLEDITORSTATE_MEASURE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "symboleditorstate.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+class MeasureTool;
+
+/*******************************************************************************
+ *  Class SymbolEditorState_Measure
+ ******************************************************************************/
+
+/**
+ * @brief The SymbolEditorState_Measure class
+ */
+class SymbolEditorState_Measure final : public SymbolEditorState {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  SymbolEditorState_Measure() = delete;
+  SymbolEditorState_Measure(const SymbolEditorState_Measure& other) = delete;
+  explicit SymbolEditorState_Measure(const Context& context) noexcept;
+  ~SymbolEditorState_Measure() noexcept;
+
+  // General Methods
+  bool entry() noexcept override;
+  bool exit() noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
+      noexcept override;
+
+  // Event Handlers
+  bool processKeyPressed(const QKeyEvent& e) noexcept override;
+  bool processKeyReleased(const QKeyEvent& e) noexcept override;
+  bool processGraphicsSceneMouseMoved(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  bool processCopy() noexcept override;
+  bool processRemove() noexcept override;
+  bool processAbortCommand() noexcept override;
+
+  // Operator Overloadings
+  SymbolEditorState_Measure& operator=(const SymbolEditorState_Measure& rhs) =
+      delete;
+
+private:  // Data
+  QScopedPointer<MeasureTool> mTool;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.h
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.h
@@ -227,6 +227,7 @@ private:
   QScopedPointer<QAction> mActionToolText;
   QScopedPointer<QAction> mActionToolPlane;
   QScopedPointer<QAction> mActionToolHole;
+  QScopedPointer<QAction> mActionToolMeasure;
   QScopedPointer<QAction> mActionDockErc;
   QScopedPointer<QAction> mActionDockDrc;
   QScopedPointer<QAction> mActionDockLayers;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorfsm.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorfsm.cpp
@@ -29,6 +29,7 @@
 #include "boardeditorstate_drawplane.h"
 #include "boardeditorstate_drawpolygon.h"
 #include "boardeditorstate_drawtrace.h"
+#include "boardeditorstate_measure.h"
 #include "boardeditorstate_select.h"
 
 #include <QtCore>
@@ -59,6 +60,13 @@ BoardEditorFsm::BoardEditorFsm(const Context& context, QObject* parent) noexcept
                  new BoardEditorState_DrawPolygon(context));
   mStates.insert(State::DRAW_PLANE, new BoardEditorState_DrawPlane(context));
   mStates.insert(State::DRAW_TRACE, new BoardEditorState_DrawTrace(context));
+  mStates.insert(State::MEASURE, new BoardEditorState_Measure(context));
+
+  foreach (BoardEditorState* state, mStates) {
+    connect(state, &BoardEditorState::statusBarMessageChanged, this,
+            &BoardEditorFsm::statusBarMessageChanged);
+  }
+
   enterNextState(State::SELECT);
 
   // Connect the requestLeavingState() signal of all states to the
@@ -132,6 +140,10 @@ bool BoardEditorFsm::processImportDxf() noexcept {
     }
   }
   return false;
+}
+
+bool BoardEditorFsm::processMeasure() noexcept {
+  return setNextState(State::MEASURE);
 }
 
 bool BoardEditorFsm::processAbortCommand() noexcept {

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorfsm.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorfsm.h
@@ -77,6 +77,8 @@ public:
     DRAW_PLANE,
     /// ::librepcb::editor::BoardEditorState_DrawTrace
     DRAW_TRACE,
+    /// ::librepcb::editor::BoardEditorState_Measure
+    MEASURE,
   };
 
   /// FSM Context
@@ -110,6 +112,7 @@ public:
   bool processDrawPlane() noexcept;
   bool processDrawTrace() noexcept;
   bool processImportDxf() noexcept;
+  bool processMeasure() noexcept;
   bool processAbortCommand() noexcept;
   bool processSelectAll() noexcept;
   bool processCut() noexcept;
@@ -156,6 +159,7 @@ public:
 
 signals:
   void stateChanged(State newState);
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 
 private:
   BoardEditorState* getCurrentStateObj() const noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.h
@@ -148,6 +148,7 @@ signals:
    * the current state and entering the select tool.
    */
   void requestLeavingState();
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 
 protected:  // Methods
   Board* getActiveBoard() noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_measure.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_measure.cpp
@@ -1,0 +1,112 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "boardeditorstate_measure.h"
+
+#include "../../../utils/measuretool.h"
+
+#include <librepcb/core/project/project.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BoardEditorState_Measure::BoardEditorState_Measure(
+    const Context& context) noexcept
+  : BoardEditorState(context),
+    mTool(new MeasureTool(mContext.editorGraphicsView)) {
+  connect(mTool.data(), &MeasureTool::statusBarMessageChanged, this,
+          &BoardEditorState_Measure::statusBarMessageChanged);
+}
+
+BoardEditorState_Measure::~BoardEditorState_Measure() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+bool BoardEditorState_Measure::entry() noexcept {
+  mTool->setBoard(getActiveBoard());
+  mTool->enter();
+  return true;
+}
+
+bool BoardEditorState_Measure::exit() noexcept {
+  mTool->leave();
+  return true;
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool BoardEditorState_Measure::processCopy() noexcept {
+  return mTool->processCopy();
+}
+
+bool BoardEditorState_Measure::processRemove() noexcept {
+  return mTool->processRemove();
+}
+
+bool BoardEditorState_Measure::processAbortCommand() noexcept {
+  return mTool->processAbortCommand();
+}
+
+bool BoardEditorState_Measure::processKeyPressed(const QKeyEvent& e) noexcept {
+  return mTool->processKeyPressed(e);
+}
+
+bool BoardEditorState_Measure::processKeyReleased(const QKeyEvent& e) noexcept {
+  return mTool->processKeyReleased(e);
+}
+
+bool BoardEditorState_Measure::processGraphicsSceneMouseMoved(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneMouseMoved(e);
+}
+
+bool BoardEditorState_Measure::processGraphicsSceneLeftMouseButtonPressed(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneLeftMouseButtonPressed(e);
+}
+
+bool BoardEditorState_Measure::processSwitchToBoard(int index) noexcept {
+  mTool->setBoard(mContext.project.getBoardByIndex(index));
+  return true;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_measure.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_measure.h
@@ -1,0 +1,87 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_BOARDEDITORSTATE_MEASURE_H
+#define LIBREPCB_EDITOR_BOARDEDITORSTATE_MEASURE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "boardeditorstate.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+class MeasureTool;
+
+/*******************************************************************************
+ *  Class BoardEditorState_Measure
+ ******************************************************************************/
+
+/**
+ * @brief The "measure" state/tool of the board editor
+ */
+class BoardEditorState_Measure final : public BoardEditorState {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  BoardEditorState_Measure() = delete;
+  BoardEditorState_Measure(const BoardEditorState_Measure& other) = delete;
+  explicit BoardEditorState_Measure(const Context& context) noexcept;
+  virtual ~BoardEditorState_Measure() noexcept;
+
+  // General Methods
+  virtual bool entry() noexcept override;
+  virtual bool exit() noexcept override;
+
+  // Event Handlers
+  virtual bool processCopy() noexcept override;
+  virtual bool processRemove() noexcept override;
+  virtual bool processAbortCommand() noexcept override;
+  virtual bool processKeyPressed(const QKeyEvent& e) noexcept override;
+  virtual bool processKeyReleased(const QKeyEvent& e) noexcept override;
+  virtual bool processGraphicsSceneMouseMoved(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processSwitchToBoard(int index) noexcept override;
+
+  // Operator Overloadings
+  BoardEditorState_Measure& operator=(const BoardEditorState_Measure& rhs) =
+      delete;
+
+private:  // Data
+  QScopedPointer<MeasureTool> mTool;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
@@ -27,6 +27,7 @@
 #include "schematiceditorstate_addtext.h"
 #include "schematiceditorstate_drawpolygon.h"
 #include "schematiceditorstate_drawwire.h"
+#include "schematiceditorstate_measure.h"
 #include "schematiceditorstate_select.h"
 
 #include <QtCore>
@@ -57,6 +58,13 @@ SchematicEditorFsm::SchematicEditorFsm(const Context& context,
   mStates.insert(State::DRAW_POLYGON,
                  new SchematicEditorState_DrawPolygon(context));
   mStates.insert(State::ADD_TEXT, new SchematicEditorState_AddText(context));
+  mStates.insert(State::MEASURE, new SchematicEditorState_Measure(context));
+
+  foreach (SchematicEditorState* state, mStates) {
+    connect(state, &SchematicEditorState::statusBarMessageChanged, this,
+            &SchematicEditorFsm::statusBarMessageChanged);
+  }
+
   enterNextState(State::SELECT);
 }
 
@@ -117,6 +125,10 @@ bool SchematicEditorFsm::processAddText() noexcept {
 
 bool SchematicEditorFsm::processDrawWire() noexcept {
   return setNextState(State::DRAW_WIRE);
+}
+
+bool SchematicEditorFsm::processMeasure() noexcept {
+  return setNextState(State::MEASURE);
 }
 
 bool SchematicEditorFsm::processAbortCommand() noexcept {

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
@@ -72,6 +72,8 @@ public:
     DRAW_POLYGON,
     /// ::librepcb::editor::SchematicEditorState_AddText
     ADD_TEXT,
+    /// ::librepcb::editor::SchematicEditorState_Measure
+    MEASURE,
   };
 
   /// FSM Context
@@ -102,6 +104,7 @@ public:
   bool processDrawPolygon() noexcept;
   bool processAddText() noexcept;
   bool processDrawWire() noexcept;
+  bool processMeasure() noexcept;
   bool processAbortCommand() noexcept;
   bool processSelectAll() noexcept;
   bool processCut() noexcept;
@@ -147,6 +150,7 @@ public:
 
 signals:
   void stateChanged(State newState);
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 
 private:
   SchematicEditorState* getCurrentStateObj() const noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
@@ -136,6 +136,9 @@ public:
   // Operator Overloadings
   SchematicEditorState& operator=(const SchematicEditorState& rhs) = delete;
 
+signals:
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
+
 protected:  // Methods
   Schematic* getActiveSchematic() noexcept;
   PositiveLength getGridInterval() const noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_measure.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_measure.cpp
@@ -1,0 +1,115 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "schematiceditorstate_measure.h"
+
+#include "../../../utils/measuretool.h"
+
+#include <librepcb/core/project/project.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+SchematicEditorState_Measure::SchematicEditorState_Measure(
+    const Context& context) noexcept
+  : SchematicEditorState(context),
+    mTool(new MeasureTool(mContext.editorGraphicsView)) {
+  connect(mTool.data(), &MeasureTool::statusBarMessageChanged, this,
+          &SchematicEditorState_Measure::statusBarMessageChanged);
+}
+
+SchematicEditorState_Measure::~SchematicEditorState_Measure() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+bool SchematicEditorState_Measure::entry() noexcept {
+  mTool->setSchematic(getActiveSchematic());
+  mTool->enter();
+  return true;
+}
+
+bool SchematicEditorState_Measure::exit() noexcept {
+  mTool->leave();
+  return true;
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool SchematicEditorState_Measure::processCopy() noexcept {
+  return mTool->processCopy();
+}
+
+bool SchematicEditorState_Measure::processRemove() noexcept {
+  return mTool->processRemove();
+}
+
+bool SchematicEditorState_Measure::processAbortCommand() noexcept {
+  return mTool->processAbortCommand();
+}
+
+bool SchematicEditorState_Measure::processKeyPressed(
+    const QKeyEvent& e) noexcept {
+  return mTool->processKeyPressed(e);
+}
+
+bool SchematicEditorState_Measure::processKeyReleased(
+    const QKeyEvent& e) noexcept {
+  return mTool->processKeyReleased(e);
+}
+
+bool SchematicEditorState_Measure::processGraphicsSceneMouseMoved(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneMouseMoved(e);
+}
+
+bool SchematicEditorState_Measure::processGraphicsSceneLeftMouseButtonPressed(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  return mTool->processGraphicsSceneLeftMouseButtonPressed(e);
+}
+
+bool SchematicEditorState_Measure::processSwitchToSchematicPage(
+    int index) noexcept {
+  mTool->setSchematic(mContext.project.getSchematicByIndex(index));
+  return true;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_measure.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_measure.h
@@ -1,0 +1,88 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_SCHEMATICEDITORSTATE_MEASURE_H
+#define LIBREPCB_EDITOR_SCHEMATICEDITORSTATE_MEASURE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "schematiceditorstate.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+class MeasureTool;
+
+/*******************************************************************************
+ *  Class SchematicEditorState_Measure
+ ******************************************************************************/
+
+/**
+ * @brief The "measure" state/tool of the schematic editor
+ */
+class SchematicEditorState_Measure final : public SchematicEditorState {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  SchematicEditorState_Measure() = delete;
+  SchematicEditorState_Measure(const SchematicEditorState_Measure& other) =
+      delete;
+  explicit SchematicEditorState_Measure(const Context& context) noexcept;
+  virtual ~SchematicEditorState_Measure() noexcept;
+
+  // General Methods
+  virtual bool entry() noexcept override;
+  virtual bool exit() noexcept override;
+
+  // Event Handlers
+  virtual bool processCopy() noexcept override;
+  virtual bool processRemove() noexcept override;
+  virtual bool processAbortCommand() noexcept override;
+  virtual bool processKeyPressed(const QKeyEvent& e) noexcept override;
+  virtual bool processKeyReleased(const QKeyEvent& e) noexcept override;
+  virtual bool processGraphicsSceneMouseMoved(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processSwitchToSchematicPage(int index) noexcept override;
+
+  // Operator Overloadings
+  SchematicEditorState_Measure& operator=(
+      const SchematicEditorState_Measure& rhs) = delete;
+
+private:  // Data
+  QScopedPointer<MeasureTool> mTool;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -186,6 +186,7 @@ private:
   QScopedPointer<QAction> mActionToolPolygon;
   QScopedPointer<QAction> mActionToolText;
   QScopedPointer<QAction> mActionToolComponent;
+  QScopedPointer<QAction> mActionToolMeasure;
   QScopedPointer<QAction> mActionComponentResistor;
   QScopedPointer<QAction> mActionComponentInductor;
   QScopedPointer<QAction> mActionComponentCapacitorBipolar;

--- a/libs/librepcb/editor/utils/measuretool.cpp
+++ b/libs/librepcb/editor/utils/measuretool.cpp
@@ -1,0 +1,480 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "measuretool.h"
+
+#include "../editorcommandset.h"
+#include "../widgets/graphicsview.h"
+
+#include <librepcb/core/graphics/graphicsscene.h>
+#include <librepcb/core/library/pkg/footprint.h>
+#include <librepcb/core/library/sym/symbol.h>
+#include <librepcb/core/project/board/board.h>
+#include <librepcb/core/project/board/items/bi_device.h>
+#include <librepcb/core/project/board/items/bi_footprint.h>
+#include <librepcb/core/project/board/items/bi_hole.h>
+#include <librepcb/core/project/board/items/bi_netpoint.h>
+#include <librepcb/core/project/board/items/bi_netsegment.h>
+#include <librepcb/core/project/board/items/bi_plane.h>
+#include <librepcb/core/project/board/items/bi_polygon.h>
+#include <librepcb/core/project/board/items/bi_stroketext.h>
+#include <librepcb/core/project/board/items/bi_via.h>
+#include <librepcb/core/project/schematic/items/si_netlabel.h>
+#include <librepcb/core/project/schematic/items/si_netpoint.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
+#include <librepcb/core/project/schematic/items/si_polygon.h>
+#include <librepcb/core/project/schematic/items/si_symbol.h>
+#include <librepcb/core/project/schematic/items/si_text.h>
+#include <librepcb/core/project/schematic/schematic.h>
+#include <librepcb/core/types/angle.h>
+#include <librepcb/core/types/gridproperties.h>
+#include <librepcb/core/utils/transform.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+MeasureTool::MeasureTool(GraphicsView& view, QObject* parent) noexcept
+  : QObject(parent),
+    mView(&view),
+    mSnapCandidates(),
+    mLastScenePos(),
+    mCursorPos(),
+    mCursorSnapped(false),
+    mStartPos(),
+    mEndPos() {
+}
+
+MeasureTool::~MeasureTool() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void MeasureTool::setFootprint(const Footprint* footprint) noexcept {
+  mSnapCandidates.clear();
+  if (footprint) {
+    mSnapCandidates |= snapCandidatesFromFootprint(*footprint, Transform());
+  }
+}
+
+void MeasureTool::setSymbol(const Symbol* symbol) noexcept {
+  mSnapCandidates.clear();
+  if (symbol) {
+    mSnapCandidates |= snapCandidatesFromSymbol(*symbol, Transform());
+  }
+}
+
+void MeasureTool::setSchematic(const Schematic* schematic) noexcept {
+  mSnapCandidates.clear();
+  if (schematic) {
+    foreach (const SI_Symbol* symbol, schematic->getSymbols()) {
+      mSnapCandidates.insert(symbol->getPosition());
+      mSnapCandidates |=
+          snapCandidatesFromSymbol(symbol->getLibSymbol(), Transform(*symbol));
+    }
+    foreach (const SI_NetSegment* segment, schematic->getNetSegments()) {
+      foreach (const SI_NetPoint* netpoint, segment->getNetPoints()) {
+        mSnapCandidates.insert(netpoint->getPosition());
+      }
+      foreach (const SI_NetLabel* netlabel, segment->getNetLabels()) {
+        mSnapCandidates.insert(netlabel->getPosition());
+      }
+    }
+    foreach (const SI_Polygon* polygon, schematic->getPolygons()) {
+      mSnapCandidates |=
+          snapCandidatesFromPath(polygon->getPolygon().getPath());
+    }
+    foreach (const SI_Text* text, schematic->getTexts()) {
+      mSnapCandidates.insert(text->getPosition());
+    }
+  }
+}
+
+void MeasureTool::setBoard(const Board* board) noexcept {
+  mSnapCandidates.clear();
+  if (board) {
+    foreach (const BI_Device* device, board->getDeviceInstances()) {
+      mSnapCandidates.insert(device->getPosition());
+      mSnapCandidates |= snapCandidatesFromFootprint(device->getLibFootprint(),
+                                                     Transform(*device));
+    }
+    foreach (const BI_NetSegment* segment, board->getNetSegments()) {
+      foreach (const BI_NetPoint* netpoint, segment->getNetPoints()) {
+        mSnapCandidates.insert(netpoint->getPosition());
+      }
+      foreach (const BI_Via* via, segment->getVias()) {
+        mSnapCandidates.insert(via->getPosition());
+        Path path = via->getVia().getOutline();
+        path.addVertex(Point(via->getSize() / 2, 0));
+        path.addVertex(Point(-via->getSize() / 2, 0));
+        path.addVertex(Point(0, via->getSize() / 2));
+        path.addVertex(Point(0, -via->getSize() / 2));
+        mSnapCandidates |=
+            snapCandidatesFromPath(path.translated(via->getPosition()));
+        mSnapCandidates |= snapCandidatesFromCircle(via->getPosition(),
+                                                    *via->getDrillDiameter());
+      }
+    }
+    foreach (const BI_Plane* plane, board->getPlanes()) {
+      mSnapCandidates |= snapCandidatesFromPath(plane->getOutline());
+      foreach (const Path& fragment, plane->getFragments()) {
+        mSnapCandidates |= snapCandidatesFromPath(fragment);
+      }
+    }
+    foreach (const BI_Polygon* polygon, board->getPolygons()) {
+      mSnapCandidates |=
+          snapCandidatesFromPath(polygon->getPolygon().getPath());
+    }
+    foreach (const BI_StrokeText* text, board->getStrokeTexts()) {
+      mSnapCandidates.insert(text->getPosition());
+    }
+    foreach (const BI_Hole* hole, board->getHoles()) {
+      mSnapCandidates |= snapCandidatesFromCircle(
+          hole->getPosition(), *hole->getHole().getDiameter());
+    }
+  }
+}
+
+void MeasureTool::enter() noexcept {
+  if (mView) {
+    if (GraphicsScene* scene = mView->getScene()) {
+      scene->setSelectionArea(QPainterPath());  // clear selection
+    }
+    mView->setGrayOut(true);
+    mView->setCursor(Qt::CrossCursor);
+    mLastScenePos = mView->mapGlobalPosToScenePos(QCursor::pos(), true, true);
+  }
+  updateCursorPosition(0);
+  updateStatusBarMessage();
+}
+
+void MeasureTool::leave() noexcept {
+  // Note: Do not clear the current start/end points to make the ruler
+  // re-appear on the same coordinates when re-entering this tool some time
+  // later. This might be useful in some cases to avoid needing to measure the
+  // same distance again.
+
+  if (mView) {
+    mView->unsetCursor();
+    mView->setOverlayText(QString());
+    mView->setSceneCursor(tl::nullopt);
+    mView->setRulerPositions(tl::nullopt);
+    mView->setGrayOut(false);
+  }
+
+  emit statusBarMessageChanged(QString());
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool MeasureTool::processKeyPressed(const QKeyEvent& e) noexcept {
+  if (e.key() == Qt::Key_Shift) {
+    updateCursorPosition(e.modifiers());
+    return true;
+  }
+
+  return false;
+}
+
+bool MeasureTool::processKeyReleased(const QKeyEvent& e) noexcept {
+  if (e.key() == Qt::Key_Shift) {
+    updateCursorPosition(e.modifiers());
+    return true;
+  }
+
+  return false;
+}
+
+bool MeasureTool::processGraphicsSceneMouseMoved(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  mLastScenePos = Point::fromPx(e.scenePos());
+  updateCursorPosition(e.modifiers());
+  return true;
+}
+
+bool MeasureTool::processGraphicsSceneLeftMouseButtonPressed(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  Q_UNUSED(e);
+
+  if ((!mStartPos) || mEndPos) {
+    // Set first point.
+    mStartPos = mCursorPos;
+    mEndPos = tl::nullopt;
+  } else {
+    // Set second point.
+    mEndPos = mCursorPos;
+  }
+
+  updateRulerPositions();
+  updateStatusBarMessage();
+
+  return true;
+}
+
+bool MeasureTool::processCopy() noexcept {
+  if (mView && mStartPos && mEndPos) {
+    const LengthUnit& unit = mView->getGridProperties().getUnit();
+    const Point diff = (*mEndPos) - (*mStartPos);
+    const qreal value = unit.convertToUnit(*diff.getLength());
+    const QString str = Toolbox::floatToString(value, 12, QLocale());
+    qApp->clipboard()->setText(str);
+    emit statusBarMessageChanged(tr("Copied to clipboard: %1").arg(str), 3000);
+    return true;
+  }
+
+  return false;
+}
+
+bool MeasureTool::processRemove() noexcept {
+  if (mStartPos && mEndPos) {
+    mStartPos = tl::nullopt;
+    mEndPos = tl::nullopt;
+    updateRulerPositions();
+    updateStatusBarMessage();
+    return true;
+  }
+
+  return false;
+}
+
+bool MeasureTool::processAbortCommand() noexcept {
+  if (mStartPos && (!mEndPos)) {
+    mStartPos = tl::nullopt;
+    updateRulerPositions();
+    updateStatusBarMessage();
+    return true;
+  }
+
+  return false;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+QSet<Point> MeasureTool::snapCandidatesFromSymbol(
+    const Symbol& symbol, const Transform& transform) noexcept {
+  QSet<Point> candidates;
+  for (const SymbolPin& p : symbol.getPins()) {
+    candidates.insert(transform.map(p.getPosition()));
+    candidates.insert(transform.map(
+        p.getPosition() + Point(*p.getLength(), 0).rotated(p.getRotation())));
+  }
+  for (const Polygon& p : symbol.getPolygons()) {
+    candidates |= snapCandidatesFromPath(transform.map(p.getPath()));
+  }
+  for (const Circle& c : symbol.getCircles()) {
+    candidates |= snapCandidatesFromCircle(transform.map(c.getCenter()),
+                                           *c.getDiameter());
+  }
+  for (const Text& s : symbol.getTexts()) {
+    candidates.insert(transform.map(s.getPosition()));
+  }
+  return candidates;
+}
+
+QSet<Point> MeasureTool::snapCandidatesFromFootprint(
+    const Footprint& footprint, const Transform& transform) noexcept {
+  QSet<Point> candidates;
+  for (const FootprintPad& p : footprint.getPads()) {
+    candidates.insert(transform.map(p.getPosition()));
+    Path path = p.getOutline();
+    path.addVertex(Point(p.getWidth() / 2, 0));
+    path.addVertex(Point(-p.getWidth() / 2, 0));
+    path.addVertex(Point(0, p.getHeight() / 2));
+    path.addVertex(Point(0, -p.getHeight() / 2));
+    candidates |= snapCandidatesFromPath(transform.map(
+        path.rotated(p.getRotation()).translated(p.getPosition())));
+    if (p.getDrillDiameter() > 0) {
+      candidates |= snapCandidatesFromCircle(transform.map(p.getPosition()),
+                                             *p.getDrillDiameter());
+    }
+  }
+  for (const Polygon& p : footprint.getPolygons()) {
+    candidates |= snapCandidatesFromPath(transform.map(p.getPath()));
+  }
+  for (const Circle& c : footprint.getCircles()) {
+    candidates |= snapCandidatesFromCircle(transform.map(c.getCenter()),
+                                           *c.getDiameter());
+  }
+  for (const StrokeText& s : footprint.getStrokeTexts()) {
+    candidates.insert(transform.map(s.getPosition()));
+  }
+  for (const Hole& h : footprint.getHoles()) {
+    candidates |= snapCandidatesFromCircle(transform.map(h.getPosition()),
+                                           *h.getDiameter());
+  }
+  return candidates;
+}
+
+QSet<Point> MeasureTool::snapCandidatesFromPath(const Path& path) noexcept {
+  QSet<Point> candidates;
+  foreach (const Vertex& v, path.getVertices()) {
+    candidates.insert(v.getPos());
+  }
+  return candidates;
+}
+
+QSet<Point> MeasureTool::snapCandidatesFromCircle(
+    const Point& center, const Length& diameter) noexcept {
+  QSet<Point> candidates;
+  candidates.insert(center);
+  candidates.insert(center + Point(0, diameter / 2));
+  candidates.insert(center + Point(0, -diameter / 2));
+  candidates.insert(center + Point(diameter / 2, 0));
+  candidates.insert(center + Point(-diameter / 2, 0));
+  return candidates;
+}
+
+void MeasureTool::updateCursorPosition(
+    Qt::KeyboardModifiers modifiers) noexcept {
+  if (!mView) {
+    return;
+  }
+
+  mCursorPos = mLastScenePos;
+  mCursorSnapped = false;
+  if (!modifiers.testFlag(Qt::ShiftModifier)) {
+    Point nearestCandidate;
+    Length nearestDistance(-1);
+    foreach (const Point& candidate, mSnapCandidates) {
+      const UnsignedLength distance = (mCursorPos - candidate).getLength();
+      if ((nearestDistance < 0) || (distance < nearestDistance)) {
+        nearestCandidate = candidate;
+        nearestDistance = *distance;
+      }
+    }
+
+    const Point posOnGrid =
+        mCursorPos.mappedToGrid(mView->getGridProperties().getInterval());
+    const Length gridDistance = *(mCursorPos - posOnGrid).getLength();
+    if ((nearestDistance >= 0) && (nearestDistance <= gridDistance)) {
+      mCursorPos = nearestCandidate;
+      mCursorSnapped = true;
+    } else {
+      mCursorPos = posOnGrid;
+    }
+  }
+  updateRulerPositions();
+}
+
+void MeasureTool::updateRulerPositions() noexcept {
+  if (!mView) {
+    return;
+  }
+
+  GraphicsView::CursorOptions cursorOptions = 0;
+  if ((!mStartPos) || mEndPos) {
+    cursorOptions |= GraphicsView::CursorOption::Cross;
+  }
+  if (mCursorSnapped) {
+    cursorOptions |= GraphicsView::CursorOption::Circle;
+  }
+  mView->setSceneCursor(std::make_pair(mCursorPos, cursorOptions));
+
+  const Point startPos = mStartPos ? *mStartPos : mCursorPos;
+  const Point endPos = mEndPos ? *mEndPos : mCursorPos;
+  if (mStartPos) {
+    mView->setRulerPositions(std::make_pair(startPos, endPos));
+  } else {
+    mView->setRulerPositions(tl::nullopt);
+  }
+
+  const Point diff = endPos - startPos;
+  const UnsignedLength length = diff.getLength();
+  const Angle angle =
+      Angle::fromRad(qAtan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
+  const LengthUnit& unit = mView->getGridProperties().getUnit();
+  int decimals = unit.getReasonableNumberOfDecimals() + 1;
+
+  QString text;
+  text += QString("X0: %1 %2<br>")
+              .arg(unit.convertToUnit(startPos.getX()), 10, 'f', decimals)
+              .arg(unit.toShortStringTr());
+  text += QString("Y0: %1 %2<br>")
+              .arg(unit.convertToUnit(startPos.getY()), 10, 'f', decimals)
+              .arg(unit.toShortStringTr());
+  text += QString("X1: %1 %2<br>")
+              .arg(unit.convertToUnit(endPos.getX()), 10, 'f', decimals)
+              .arg(unit.toShortStringTr());
+  text += QString("Y1: %1 %2<br>")
+              .arg(unit.convertToUnit(endPos.getY()), 10, 'f', decimals)
+              .arg(unit.toShortStringTr());
+  text += QString("<br>");
+  text += QString("ΔX: %1 %2<br>")
+              .arg(unit.convertToUnit(diff.getX()), 10, 'f', decimals)
+              .arg(unit.toShortStringTr());
+  text += QString("ΔY: %1 %2<br>")
+              .arg(unit.convertToUnit(diff.getY()), 10, 'f', decimals)
+              .arg(unit.toShortStringTr());
+  text += QString("<br>");
+  text += QString("<b>Δ: %1 %2</b><br>")
+              .arg(unit.convertToUnit(*length), 11, 'f', decimals)
+              .arg(unit.toShortStringTr());
+  text += QString("<b>∠: %1°</b>").arg(angle.toDeg(), 14 - decimals, 'f', 3);
+  text.replace(" ", "&nbsp;");
+  mView->setOverlayText(text);
+}
+
+void MeasureTool::updateStatusBarMessage() noexcept {
+  const QList<QKeySequence> copyKeys =
+      EditorCommandSet::instance().clipboardCopy.getKeySequences();
+  const QList<QKeySequence> deleteKeys =
+      EditorCommandSet::instance().remove.getKeySequences();
+  const QString disableSnapNote = " " %
+      tr("(press %1 to disable snap)")
+          .arg(QCoreApplication::translate("QShortcut", "Shift"));
+
+  if (mEndPos && (!copyKeys.isEmpty()) && (!deleteKeys.isEmpty())) {
+    emit statusBarMessageChanged(
+        tr("Press %1 to copy the value to clipboard or %2 to clear the "
+           "measurement")
+            .arg(copyKeys.first().toString(QKeySequence::NativeText))
+            .arg(deleteKeys.first().toString(QKeySequence::NativeText)));
+  } else if (mStartPos && (!mEndPos)) {
+    emit statusBarMessageChanged(tr("Click to specify the end point") %
+                                 disableSnapNote);
+  } else {
+    emit statusBarMessageChanged(tr("Click to specify the start point") %
+                                 disableSnapNote);
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/utils/measuretool.h
+++ b/libs/librepcb/editor/utils/measuretool.h
@@ -1,0 +1,118 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_MEASURETOOL_H
+#define LIBREPCB_EDITOR_MEASURETOOL_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/types/point.h>
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class Board;
+class Footprint;
+class Path;
+class Schematic;
+class Symbol;
+class Transform;
+
+namespace editor {
+
+class GraphicsView;
+
+/*******************************************************************************
+ *  Class MeasureTool
+ ******************************************************************************/
+
+/**
+ * @brief Measure tool providing the measure functionality for the editor states
+ */
+class MeasureTool final : public QObject {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  MeasureTool() = delete;
+  MeasureTool(const MeasureTool& other) = delete;
+  explicit MeasureTool(GraphicsView& view, QObject* parent = nullptr) noexcept;
+  ~MeasureTool() noexcept;
+
+  // General Methods
+  void setSymbol(const Symbol* symbol) noexcept;
+  void setFootprint(const Footprint* footprint) noexcept;
+  void setSchematic(const Schematic* schematic) noexcept;
+  void setBoard(const Board* board) noexcept;
+  void enter() noexcept;
+  void leave() noexcept;
+
+  // Event Handlers
+  bool processKeyPressed(const QKeyEvent& e) noexcept;
+  bool processKeyReleased(const QKeyEvent& e) noexcept;
+  bool processGraphicsSceneMouseMoved(QGraphicsSceneMouseEvent& e) noexcept;
+  bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept;
+  bool processCopy() noexcept;
+  bool processRemove() noexcept;
+  bool processAbortCommand() noexcept;
+
+  // Operator Overloadings
+  MeasureTool& operator=(const MeasureTool& rhs) = delete;
+
+signals:
+  void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
+
+private:  // Methods
+  static QSet<Point> snapCandidatesFromSymbol(
+      const Symbol& symbol, const Transform& transform) noexcept;
+  static QSet<Point> snapCandidatesFromFootprint(
+      const Footprint& footprint, const Transform& transform) noexcept;
+  static QSet<Point> snapCandidatesFromPath(const Path& path) noexcept;
+  static QSet<Point> snapCandidatesFromCircle(const Point& center,
+                                              const Length& diameter) noexcept;
+  void updateCursorPosition(Qt::KeyboardModifiers modifiers) noexcept;
+  void updateRulerPositions() noexcept;
+  void updateStatusBarMessage() noexcept;
+
+private:  // Data
+  QPointer<GraphicsView> mView;
+  QSet<Point> mSnapCandidates;
+  Point mLastScenePos;
+  Point mCursorPos;
+  bool mCursorSnapped;
+  tl::optional<Point> mStartPos;
+  tl::optional<Point> mEndPos;
+};
+
+}  // namespace editor
+}  // namespace librepcb
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+#endif

--- a/libs/librepcb/editor/widgets/graphicsview.h
+++ b/libs/librepcb/editor/widgets/graphicsview.h
@@ -23,7 +23,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/core/types/lengthunit.h>
 #include <librepcb/core/types/point.h>
+#include <optional/tl/optional.hpp>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -51,6 +53,13 @@ class GraphicsView final : public QGraphicsView {
   Q_OBJECT
 
 public:
+  // Types
+  enum class CursorOption {
+    Cross = (1 << 0),
+    Circle = (1 << 1),
+  };
+  Q_DECLARE_FLAGS(CursorOptions, CursorOption)
+
   // Constructors / Destructor
   GraphicsView(const GraphicsView& other) = delete;
   explicit GraphicsView(
@@ -68,6 +77,7 @@ public:
 
   // Setters
   void setUseOpenGl(bool useOpenGl) noexcept;
+  void setGrayOut(bool grayOut) noexcept;
   void setGridProperties(const GridProperties& properties) noexcept;
   void setScene(GraphicsScene* scene) noexcept;
   void setVisibleSceneRect(const QRectF& rect) noexcept;
@@ -82,6 +92,13 @@ public:
    * @param rect    The rect to mark. Pass an empty rect to clear the marker.
    */
   void setSceneRectMarker(const QRectF& rect) noexcept;
+  void setSceneCursor(
+      const tl::optional<std::pair<Point, CursorOptions>>& cursor) noexcept;
+  void setRulerColor(const QColor& color) noexcept;
+  void setRulerPositions(
+      const tl::optional<std::pair<Point, Point>>& pos) noexcept;
+  void setOverlayColor(const QColor& color) noexcept;
+  void setOverlayText(const QString& text) noexcept;
   void setOriginCrossVisible(bool visible) noexcept;
   void setEventHandlerObject(
       IF_GraphicsViewEventHandler* eventHandler) noexcept;
@@ -123,6 +140,7 @@ private:
   void drawForeground(QPainter* painter, const QRectF& rect);
 
   // General Attributes
+  QScopedPointer<QLabel> mOverlayLabel;
   IF_GraphicsViewEventHandler* mEventHandlerObject;
   GraphicsScene* mScene;
   QVariantAnimation* mZoomAnimation;
@@ -130,6 +148,24 @@ private:
   QRectF mSceneRectMarker;
   bool mOriginCrossVisible;
   bool mUseOpenGl;
+  bool mGrayOut;
+
+  /// If not nullopt, a cursor will be shown at the given position
+  tl::optional<std::pair<Point, CursorOptions>> mSceneCursor;
+
+  // Configuration for the ruler overlay
+  struct RulerGauge {
+    int xScale;
+    LengthUnit unit;
+    QString unitSeparator;
+    Length minTickInterval;
+    Length currentTickInterval;
+  };
+  QVector<RulerGauge> mRulerGauges;
+  QColor mRulerColor;
+  tl::optional<std::pair<Point, Point>> mRulerPositions;
+
+  // State
   volatile bool mPanningActive;
   QCursor mCursorBeforePanning;
 

--- a/libs/librepcb/editor/widgets/statusbar.cpp
+++ b/libs/librepcb/editor/widgets/statusbar.cpp
@@ -36,7 +36,16 @@ namespace editor {
  ******************************************************************************/
 
 StatusBar::StatusBar(QWidget* parent) noexcept
-  : QStatusBar(parent), mFields(0), mLengthUnit(), mAbsoluteCursorPosition() {
+  : QStatusBar(parent),
+    mFields(0),
+    mPermanentMessage(),
+    mLengthUnit(),
+    mAbsoluteCursorPosition() {
+  // permanent message
+  mMessageLabel.reset(new QLabel());
+  mMessageLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+  addWidget(mMessageLabel.data(), 1);
+
   // absolute position x
   mAbsPosXLabel.reset(new QLabel());
   mAbsPosXLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
@@ -74,6 +83,15 @@ StatusBar::~StatusBar() noexcept {
 /*******************************************************************************
  *  Setters
  ******************************************************************************/
+
+void StatusBar::setPermanentMessage(const QString& message) noexcept {
+  mPermanentMessage = message;
+  updatePermanentMessage();
+}
+
+void StatusBar::clearPermanentMessage() noexcept {
+  mMessageLabel->clear();
+}
 
 void StatusBar::setFields(Fields fields) noexcept {
   mAbsPosXLabel->setVisible(fields & AbsolutePosition);
@@ -115,8 +133,26 @@ void StatusBar::setProgressBarPercent(int percent) noexcept {
 }
 
 /*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+void StatusBar::resizeEvent(QResizeEvent* e) noexcept {
+  Q_UNUSED(e);
+  updatePermanentMessage();
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void StatusBar::updatePermanentMessage() noexcept {
+  const QFontMetrics metrics(mMessageLabel->font());
+  const QString elidedText = metrics.elidedText(
+      mPermanentMessage, Qt::ElideRight, mMessageLabel->width());
+  mMessageLabel->setText(elidedText);
+  mMessageLabel->setToolTip(
+      (elidedText == mPermanentMessage) ? QString() : mPermanentMessage);
+}
 
 void StatusBar::updateAbsoluteCursorPosition() noexcept {
   mAbsPosXLabel->setText(

--- a/libs/librepcb/editor/widgets/statusbar.h
+++ b/libs/librepcb/editor/widgets/statusbar.h
@@ -64,6 +64,8 @@ public:
   // Setters
   void setFields(Fields fields) noexcept;
   void setField(Field field, bool enable) noexcept;
+  void setPermanentMessage(const QString& message) noexcept;
+  void clearPermanentMessage() noexcept;
   void setLengthUnit(const LengthUnit& unit) noexcept;
   void setAbsoluteCursorPosition(const Point& pos) noexcept;
   void setProgressBarTextFormat(const QString& format) noexcept;
@@ -72,13 +74,19 @@ public:
   // Operator Overloadings
   StatusBar& operator=(const StatusBar& rhs) = delete;
 
+protected:
+  void resizeEvent(QResizeEvent* e) noexcept override;
+
 private:  // Methods
+  void updatePermanentMessage() noexcept;
   void updateAbsoluteCursorPosition() noexcept;
 
 private:  // Data
   Fields mFields;
+  QString mPermanentMessage;
   LengthUnit mLengthUnit;
   Point mAbsoluteCursorPosition;
+  QScopedPointer<QLabel> mMessageLabel;
   QScopedPointer<QLabel> mAbsPosXLabel;
   QScopedPointer<QLabel> mAbsPosYLabel;
   QScopedPointer<QProgressBar> mProgressBar;

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -73,13 +73,10 @@ ControlPanel::ControlPanel(Workspace& workspace, bool fileFormatIsOutdated)
   setWindowTitle(
       tr("Control Panel - LibrePCB %1").arg(qApp->applicationVersion()));
 
-  // show workspace path in status bar
-  QString wsPath = mWorkspace.getPath().toNative();
-  QLabel* statusBarLabel = new QLabel(tr("Workspace: %1").arg(wsPath));
-  mUi->statusBar->addWidget(statusBarLabel, 1);
-
   // initialize status bar
   mUi->statusBar->setFields(StatusBar::ProgressBar);
+  mUi->statusBar->setPermanentMessage(
+      tr("Workspace: %1").arg(mWorkspace.getPath().toNative()));
   mUi->statusBar->setProgressBarTextFormat(tr("Scanning libraries (%p%)"));
   connect(&mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanProgressUpdate,
           mUi->statusBar, &StatusBar::setProgressBarPercent,


### PR DESCRIPTION
### Description

This adds a measure tool to the symbol-, package-, schematic- and board editors:

- The tool can be started by its toolbutton, or with Ctrl+M as default shortcut.
- When the tool is active, the whole background is grayed out and a ruler & measurement results are drawn as an overlay.
- The ruler contains ticks & labels for both metric and imperial units, and the tick interval dynamically scales with the zoom level.
- The ruler contains a circle at half the measured distance to allow verifying that something is symmetric.
- The results overlay shows various information in the unit configured in the grid settings (start/end coordinates, dX, dY, distance, angle).
- The first click specifies the start point, the second click the end point of the measurement.
- The ruler snaps on the grid and on many objects (e.g. pad edges, polygon vertices, hole circles, ...).
- Snapping on objects can temporarily be disabled by pressing SHIFT.
- The measured distance can directly be copied into the clipboard by pressing Ctrl+C (useful for further calculations outside of LibrePCB).
- The status bar shows hints about how to use the tool.

### Limitations

To keep the implementation complexity low, currently the tool doesn't respect the layer visibility to determine the snap coordinates, thus the ruler snaps even on hidden objects. During my testing this was not a problem at all. If it is indeed a problem (maybe with much more complex boards) it could be fixed some time later.

### Preview

![librepcb-measure-2-small](https://user-images.githubusercontent.com/5374821/188273459-093dfa41-2bbf-4db2-a8b6-73ca82c1182c.gif)

Closes #861