### PR TITLE
Workspace setting: Extend external applications config

### DIFF
--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -50,6 +50,8 @@ WorkspaceSettings::WorkspaceSettings(QObject* parent)
     libraryNormOrder("library_norm_order", "norm", QStringList(), this),
     repositoryUrls("repositories", "repository",
                    QList<QUrl>{QUrl("https://api.librepcb.org")}, this),
+    externalWebBrowserCommands("external_web_browser", "command", QStringList(),
+                               this),
     externalPdfReaderCommands("external_pdf_reader", "command", QStringList(),
                               this),
     keyboardShortcuts(this) {

--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -52,6 +52,8 @@ WorkspaceSettings::WorkspaceSettings(QObject* parent)
                    QList<QUrl>{QUrl("https://api.librepcb.org")}, this),
     externalWebBrowserCommands("external_web_browser", "command", QStringList(),
                                this),
+    externalFileManagerCommands("external_file_manager", "command",
+                                QStringList(), this),
     externalPdfReaderCommands("external_pdf_reader", "command", QStringList(),
                               this),
     keyboardShortcuts(this) {

--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -50,9 +50,8 @@ WorkspaceSettings::WorkspaceSettings(QObject* parent)
     libraryNormOrder("library_norm_order", "norm", QStringList(), this),
     repositoryUrls("repositories", "repository",
                    QList<QUrl>{QUrl("https://api.librepcb.org")}, this),
-    useCustomPdfReader("use_custom_pdf_reader", false, this),
-    pdfReaderCommand("pdf_custom_reader_command", "", this),
-    pdfOpenBehavior("pdf_open_behavior", PdfOpenBehavior::ALWAYS, this),
+    externalPdfReaderCommands("external_pdf_reader", "command", QStringList(),
+                              this),
     keyboardShortcuts(this) {
 }
 

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -216,6 +216,20 @@ public:
       externalWebBrowserCommands;
 
   /**
+   * @brief Custom command(s) to be used for opening directories
+   *
+   * When opening a directory, the application will iterate through this list
+   * of commands until a command was successful. If none was successful, the
+   * system's default command will be used as fallback.
+   *
+   * Supported placeholders: `{{URL}}`, `{{FILEPATH}}`
+   *
+   * Default: []
+   */
+  WorkspaceSettingsItem_GenericValueList<QStringList>
+      externalFileManagerCommands;
+
+  /**
    * @brief Custom command(s) to be used for opening PDF files
    *
    * When opening a PDF file, the application will iterate through this list

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -202,6 +202,20 @@ public:
   WorkspaceSettingsItem_GenericValueList<QList<QUrl>> repositoryUrls;
 
   /**
+   * @brief Custom command(s) to be used for opening web URLs
+   *
+   * When opening an URL, the application will iterate through this list of
+   * commands until a command was successful. If none was successful, the
+   * system's default command will be used as fallback.
+   *
+   * Supported placeholders: `{{URL}}`
+   *
+   * Default: []
+   */
+  WorkspaceSettingsItem_GenericValueList<QStringList>
+      externalWebBrowserCommands;
+
+  /**
    * @brief Custom command(s) to be used for opening PDF files
    *
    * When opening a PDF file, the application will iterate through this list

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -59,17 +59,6 @@ class WorkspaceSettings final : public QObject {
   Q_OBJECT
 
 public:
-  // Enums for n-state settings
-
-  /// @see ::librepcb::WorkspaceSettings::pdfOpenBehavior
-  // The underlying type int is needed to map QButtonGroup IDs
-  // to values in this enum. See for ex. WorkspaceSettingsDialog::loadSettings()
-  enum class PdfOpenBehavior : int {
-    ALWAYS,
-    NEVER,
-    ASK,
-  };
-
   // Constructors / Destructor
   WorkspaceSettings(const WorkspaceSettings& other) = delete;
   explicit WorkspaceSettings(QObject* parent = nullptr);
@@ -213,25 +202,17 @@ public:
   WorkspaceSettingsItem_GenericValueList<QList<QUrl>> repositoryUrls;
 
   /**
-   * @brief Use a PDF Reader other than the system default
+   * @brief Custom command(s) to be used for opening PDF files
    *
-   * Default: false
-   */
-  WorkspaceSettingsItem_GenericValue<bool> useCustomPdfReader;
-
-  /**
-   * @brief Custom command to open a PDF reader
+   * When opening a PDF file, the application will iterate through this list
+   * of commands until a command was successful. If none was successful, the
+   * system's default command will be used as fallback.
    *
-   * Default: ""
-   */
-  WorkspaceSettingsItem_GenericValue<QString> pdfReaderCommand;
-
-  /**
-   * @brief Behavior after a PDF has been exported
+   * Supported placeholders: `{{URL}}`, `{{FILEPATH}}`
    *
-   * Default: PdfOpenBehavior::ALWAYS
+   * Default: []
    */
-  WorkspaceSettingsItem_GenericValue<PdfOpenBehavior> pdfOpenBehavior;
+  WorkspaceSettingsItem_GenericValueList<QStringList> externalPdfReaderCommands;
 
   /**
    * @brief Keyboard shortcuts
@@ -249,36 +230,6 @@ public:
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
-
-// Serialize settings values
-template <>
-inline SExpression serialize(const WorkspaceSettings::PdfOpenBehavior& b) {
-  switch (b) {
-    case WorkspaceSettings::PdfOpenBehavior::ALWAYS:
-      return SExpression::createToken("always");
-    case WorkspaceSettings::PdfOpenBehavior::NEVER:
-      return SExpression::createToken("never");
-    case WorkspaceSettings::PdfOpenBehavior::ASK:
-      return SExpression::createToken("ask");
-    default:
-      throw LogicError(__FILE__, __LINE__);
-  };
-}
-
-template <>
-inline WorkspaceSettings::PdfOpenBehavior deserialize(
-    const SExpression& sexpr, const Version& fileFormat) {
-  Q_UNUSED(fileFormat);
-  QString str = sexpr.getValue();
-  if (str == QLatin1String("always"))
-    return WorkspaceSettings::PdfOpenBehavior::ALWAYS;
-  else if (str == QLatin1String("never"))
-    return WorkspaceSettings::PdfOpenBehavior::NEVER;
-  else if (str == QLatin1String("ask"))
-    return WorkspaceSettings::PdfOpenBehavior::ASK;
-  else
-    throw RuntimeError(__FILE__, __LINE__, str);
-}
 
 }  // namespace librepcb
 

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -621,8 +621,8 @@ bool PackageEditorWidget::execGraphicsExportDialog(
         "package_editor/" % settingsKey, this);
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
-              DesktopServices services(mContext.workspace.getSettings(), true);
-              services.openFile(fp);
+              DesktopServices services(mContext.workspace.getSettings(), this);
+              services.openLocalPath(fp);
             });
     dialog.exec();
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
@@ -571,8 +571,8 @@ bool SymbolEditorWidget::execGraphicsExportDialog(
         "symbol_editor/" % settingsKey, this);
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
-              DesktopServices services(mContext.workspace.getSettings(), true);
-              services.openFile(fp);
+              DesktopServices services(mContext.workspace.getSettings(), this);
+              services.openLocalPath(fp);
             });
     dialog.exec();
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -392,13 +392,15 @@ void BoardEditor::createActions() noexcept {
     execGraphicsExportDialog(GraphicsExportDialog::Output::Print, "print");
   }));
   mActionGenerateBom.reset(cmd.generateBom.createAction(this, this, [this]() {
-    BomGeneratorDialog dialog(mProject, getActiveBoard(), this);
+    BomGeneratorDialog dialog(mProjectEditor.getWorkspace().getSettings(),
+                              mProject, getActiveBoard(), this);
     dialog.exec();
   }));
   mActionGenerateFabricationData.reset(
       cmd.generateFabricationData.createAction(this, this, [this]() {
         if (Board* board = getActiveBoard()) {
-          FabricationOutputDialog dialog(*board, this);
+          FabricationOutputDialog dialog(
+              mProjectEditor.getWorkspace().getSettings(), *board, this);
           dialog.exec();
         }
       }));

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -1289,8 +1289,8 @@ void BoardEditor::execGraphicsExportDialog(
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
               DesktopServices services(
-                  mProjectEditor.getWorkspace().getSettings(), true);
-              services.openFile(fp);
+                  mProjectEditor.getWorkspace().getSettings(), this);
+              services.openLocalPath(fp);
             });
     dialog.exec();
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "fabricationoutputdialog.h"
 
+#include "../../workspace/desktopservices.h"
 #include "ui_fabricationoutputdialog.h"
 
 #include <librepcb/core/graphics/graphicslayer.h>
@@ -43,8 +44,10 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-FabricationOutputDialog::FabricationOutputDialog(Board& board, QWidget* parent)
+FabricationOutputDialog::FabricationOutputDialog(
+    const WorkspaceSettings& settings, Board& board, QWidget* parent)
   : QDialog(parent),
+    mSettings(settings),
     mProject(board.getProject()),
     mBoard(board),
     mUi(new Ui::FabricationOutputDialog) {
@@ -181,7 +184,8 @@ void FabricationOutputDialog::on_btnBrowseOutputDir_clicked() {
   BoardGerberExport grbExport(mBoard, mBoard.getFabricationOutputSettings());
   FilePath dir = grbExport.getOutputDirectory();
   if (dir.isExistingDir()) {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(dir.toStr()));
+    DesktopServices ds(mSettings, this);
+    ds.openLocalPath(dir);
   } else {
     QMessageBox::warning(this, tr("Warning"), tr("Directory does not exist."));
   }

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.h
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.h
@@ -33,6 +33,7 @@ namespace librepcb {
 
 class Board;
 class Project;
+class WorkspaceSettings;
 
 namespace editor {
 
@@ -54,7 +55,8 @@ public:
   // Constructors / Destructor
   FabricationOutputDialog() = delete;
   FabricationOutputDialog(const FabricationOutputDialog& other) = delete;
-  explicit FabricationOutputDialog(Board& board, QWidget* parent = 0);
+  explicit FabricationOutputDialog(const WorkspaceSettings& settings,
+                                   Board& board, QWidget* parent = 0);
   ~FabricationOutputDialog();
 
 private slots:
@@ -67,6 +69,7 @@ private:
   QStringList getTopSilkscreenLayers() const noexcept;
   QStringList getBotSilkscreenLayers() const noexcept;
 
+  const WorkspaceSettings& mSettings;
   Project& mProject;
   Board& mBoard;
   Ui::FabricationOutputDialog* mUi;

--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -23,6 +23,7 @@
 #include "bomgeneratordialog.h"
 
 #include "../dialogs/filedialog.h"
+#include "../workspace/desktopservices.h"
 #include "ui_bomgeneratordialog.h"
 
 #include <librepcb/core/attribute/attributesubstitutor.h>
@@ -49,10 +50,12 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BomGeneratorDialog::BomGeneratorDialog(const Project& project,
+BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
+                                       const Project& project,
                                        const Board* board,
                                        QWidget* parent) noexcept
   : QDialog(parent),
+    mSettings(settings),
     mProject(project),
     mBom(new Bom(QStringList())),
     mUi(new Ui::BomGeneratorDialog) {
@@ -107,8 +110,8 @@ void BomGeneratorDialog::btnChooseOutputPathClicked() noexcept {
 }
 
 void BomGeneratorDialog::btnOpenOutputDirectoryClicked() noexcept {
-  QDesktopServices::openUrl(
-      QUrl::fromLocalFile(getOutputFilePath().getParentDir().toStr()));
+  DesktopServices ds(mSettings, this);
+  ds.openLocalPath(getOutputFilePath().getParentDir());
 }
 
 void BomGeneratorDialog::btnGenerateClicked() noexcept {

--- a/libs/librepcb/editor/project/bomgeneratordialog.h
+++ b/libs/librepcb/editor/project/bomgeneratordialog.h
@@ -39,6 +39,7 @@ namespace librepcb {
 class Board;
 class Bom;
 class Project;
+class WorkspaceSettings;
 
 namespace editor {
 
@@ -60,9 +61,9 @@ public:
   // Constructors / Destructor
   BomGeneratorDialog() = delete;
   BomGeneratorDialog(const BomGeneratorDialog& other) = delete;
-  explicit BomGeneratorDialog(const Project& project,
-                              const Board* board = nullptr,
-                              QWidget* parent = nullptr) noexcept;
+  BomGeneratorDialog(const WorkspaceSettings& settings, const Project& project,
+                     const Board* board = nullptr,
+                     QWidget* parent = nullptr) noexcept;
   ~BomGeneratorDialog() noexcept;
 
   // Operator Overloads
@@ -80,6 +81,7 @@ private:  // Methods
   FilePath getOutputFilePath() const noexcept;
 
 private:  // Data
+  const WorkspaceSettings& mSettings;
   const Project& mProject;
   std::shared_ptr<Bom> mBom;
   QScopedPointer<Ui::BomGeneratorDialog> mUi;

--- a/libs/librepcb/editor/project/orderpcbdialog.h
+++ b/libs/librepcb/editor/project/orderpcbdialog.h
@@ -34,6 +34,7 @@
 namespace librepcb {
 
 class OrderPcbApiRequest;
+class WorkspaceSettings;
 
 namespace editor {
 
@@ -55,7 +56,7 @@ public:
   // Constructors / Destructor
   OrderPcbDialog() = delete;
   OrderPcbDialog(const OrderPcbDialog& other) = delete;
-  explicit OrderPcbDialog(const QList<QUrl>& repositories,
+  explicit OrderPcbDialog(const WorkspaceSettings& settings,
                           std::function<QByteArray()> createLppzCallback,
                           const QString& boardRelativePath = QString(),
                           QWidget* parent = nullptr) noexcept;
@@ -76,6 +77,7 @@ private:  // Methods
   void setError(const QString& msg) noexcept;
 
 private:  // Data
+  const WorkspaceSettings& mSettings;
   QScopedPointer<OrderPcbApiRequest> mRequest;
   std::function<QByteArray()> mCreateLppzCallback;
   QString mBoardRelativePath;

--- a/libs/librepcb/editor/project/projecteditor.cpp
+++ b/libs/librepcb/editor/project/projecteditor.cpp
@@ -234,7 +234,7 @@ void ProjectEditor::execOrderPcbDialog(const Board* board,
         filter);  // can throw
   };
 
-  OrderPcbDialog dialog(mWorkspace.getSettings().repositoryUrls.get(), callback,
+  OrderPcbDialog dialog(mWorkspace.getSettings(), callback,
                         board ? board->getRelativePath() : QString(), parent);
   dialog.exec();
 }

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -303,7 +303,8 @@ void SchematicEditor::createActions() noexcept {
     const Board* board = mProject.getBoards().count() == 1
         ? mProject.getBoardByIndex(0)
         : nullptr;
-    BomGeneratorDialog dialog(mProject, board, this);
+    BomGeneratorDialog dialog(mProjectEditor.getWorkspace().getSettings(),
+                              mProject, board, this);
     dialog.exec();
   }));
   mActionOrderPcb.reset(cmd.orderPcb.createAction(this, this, [this]() {

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -1057,8 +1057,8 @@ void SchematicEditor::execGraphicsExportDialog(
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
               DesktopServices services(
-                  mProjectEditor.getWorkspace().getSettings(), true);
-              services.openFile(fp);
+                  mProjectEditor.getWorkspace().getSettings(), this);
+              services.openLocalPath(fp);
             });
     dialog.exec();
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/utils/editortoolbox.cpp
+++ b/libs/librepcb/editor/utils/editortoolbox.cpp
@@ -60,7 +60,7 @@ void EditorToolbox::deleteLayoutItemRecursively(QLayoutItem* item) noexcept {
   if (QWidget* widget = item->widget()) {
     delete widget;
   } else if (QLayout* layout = item->layout()) {
-    for (int i = 0; i < layout->count(); ++i) {
+    for (int i = layout->count() - 1; i >= 0; --i) {
       deleteLayoutItemRecursively(layout->takeAt(i));
     }
   } else if (QSpacerItem* spacer = item->spacerItem()) {

--- a/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
+++ b/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
@@ -69,8 +69,8 @@ void StandardEditorCommandHandler::website() const noexcept {
 
 void StandardEditorCommandHandler::fileManager(const FilePath& fp) const
     noexcept {
-  DesktopServices ds(mSettings, false);
-  ds.openFile(fp);
+  DesktopServices ds(mSettings, mParent);
+  ds.openLocalPath(fp);
 }
 
 void StandardEditorCommandHandler::shortcutsReference() const noexcept {
@@ -86,8 +86,8 @@ void StandardEditorCommandHandler::shortcutsReference() const noexcept {
     ShortcutsReferenceGenerator generator(EditorCommandSet::instance());
     generator.generatePdf(fp);
 
-    DesktopServices ds(mSettings, true, mParent);
-    ds.openPdf(fp);
+    DesktopServices ds(mSettings, mParent);
+    ds.openLocalPath(fp);
   } catch (const Exception& e) {
     QMessageBox::critical(mParent, tr("Error"), e.getMsg());
   }

--- a/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
+++ b/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
@@ -60,11 +60,13 @@ void StandardEditorCommandHandler::aboutLibrePcb() const noexcept {
 }
 
 void StandardEditorCommandHandler::onlineDocumentation() const noexcept {
-  QDesktopServices::openUrl(QUrl("https://docs.librepcb.org"));
+  DesktopServices ds(mSettings, mParent);
+  ds.openWebUrl(QUrl("https://docs.librepcb.org"));
 }
 
 void StandardEditorCommandHandler::website() const noexcept {
-  QDesktopServices::openUrl(QUrl("https://librepcb.org"));
+  DesktopServices ds(mSettings, mParent);
+  ds.openWebUrl(QUrl("https://librepcb.org"));
 }
 
 void StandardEditorCommandHandler::fileManager(const FilePath& fp) const

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -32,6 +32,7 @@
 #include "../../utils/standardeditorcommandhandler.h"
 #include "../../workspace/desktopservices.h"
 #include "../../workspace/librarymanager/librarymanager.h"
+#include "../desktopservices.h"
 #include "../initializeworkspacewizard/initializeworkspacewizard.h"
 #include "../projectlibraryupdater/projectlibraryupdater.h"
 #include "../workspacesettingsdialog.h"

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -614,7 +614,8 @@ void ControlPanel::on_projectTreeView_doubleClicked(const QModelIndex& index) {
   } else if (fp.getSuffix() == "lpp") {
     openProject(fp);
   } else {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(fp.toStr()));
+    DesktopServices ds(mWorkspace.getSettings(), this);
+    ds.openLocalPath(fp);
   }
 }
 
@@ -659,14 +660,14 @@ void ControlPanel::on_projectTreeView_customContextMenuRequested(
         &menu, this, [this, fp]() { openProjectLibraryUpdater(fp); },
         EditorCommand::ActionFlag::NoShortcuts));
   } else {
-    mb.addAction(
-        cmd.itemOpen.createAction(&menu, this,
-                                  [fp]() {
-                                    QDesktopServices::openUrl(
-                                        QUrl::fromLocalFile(fp.toStr()));
-                                  },
-                                  EditorCommand::ActionFlag::NoShortcuts),
-        MenuBuilder::Flag::DefaultAction);
+    mb.addAction(cmd.itemOpen.createAction(
+                     &menu, this,
+                     [this, fp]() {
+                       DesktopServices ds(mWorkspace.getSettings(), this);
+                       ds.openLocalPath(fp);
+                     },
+                     EditorCommand::ActionFlag::NoShortcuts),
+                 MenuBuilder::Flag::DefaultAction);
   }
   mb.addSeparator();
   if (fp.isExistingDir() && (!isProjectDir) && (!isInProjectDir)) {

--- a/libs/librepcb/editor/workspace/desktopservices.cpp
+++ b/libs/librepcb/editor/workspace/desktopservices.cpp
@@ -65,7 +65,9 @@ bool DesktopServices::openWebUrl(const QUrl& url) const noexcept {
 
 bool DesktopServices::openLocalPath(const FilePath& filePath) const noexcept {
   const QString ext = filePath.getSuffix().toLower();
-  if (ext == "pdf") {
+  if (filePath.isExistingDir()) {
+    return openDirectory(filePath);
+  } else if (ext == "pdf") {
     return openLocalPathWithCommand(filePath,
                                     mSettings.externalPdfReaderCommands.get());
   } else {
@@ -76,6 +78,11 @@ bool DesktopServices::openLocalPath(const FilePath& filePath) const noexcept {
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+bool DesktopServices::openDirectory(const FilePath& filePath) const noexcept {
+  return openLocalPathWithCommand(filePath,
+                                  mSettings.externalFileManagerCommands.get());
+}
 
 bool DesktopServices::openLocalPathWithCommand(
     const FilePath& filePath, const QStringList& commands) const noexcept {

--- a/libs/librepcb/editor/workspace/desktopservices.cpp
+++ b/libs/librepcb/editor/workspace/desktopservices.cpp
@@ -50,6 +50,19 @@ DesktopServices::~DesktopServices() noexcept {
  *  General Methods
  ******************************************************************************/
 
+bool DesktopServices::openWebUrl(const QUrl& url) const noexcept {
+  foreach (QString cmd, mSettings.externalWebBrowserCommands.get()) {
+    cmd.replace("{{URL}}", url.toString());
+    if (QProcess::startDetached(cmd)) {
+      qDebug() << "Successfully opened URL with command:" << cmd;
+      return true;
+    } else {
+      qWarning() << "Failed to open URL with command:" << cmd;
+    }
+  }
+  return openUrl(url);
+}
+
 bool DesktopServices::openLocalPath(const FilePath& filePath) const noexcept {
   const QString ext = filePath.getSuffix().toLower();
   if (ext == "pdf") {

--- a/libs/librepcb/editor/workspace/desktopservices.cpp
+++ b/libs/librepcb/editor/workspace/desktopservices.cpp
@@ -39,8 +39,8 @@ namespace editor {
  ******************************************************************************/
 
 DesktopServices::DesktopServices(const WorkspaceSettings& settings,
-                                 bool forceOpen, QWidget* parent) noexcept
-  : mSettings(settings), mForceOpen(forceOpen), mParent(parent) {
+                                 QWidget* parent) noexcept
+  : mSettings(settings), mParent(parent) {
 }
 
 DesktopServices::~DesktopServices() noexcept {
@@ -50,60 +50,39 @@ DesktopServices::~DesktopServices() noexcept {
  *  General Methods
  ******************************************************************************/
 
-bool DesktopServices::openFile(const FilePath& filePath) const noexcept {
+bool DesktopServices::openLocalPath(const FilePath& filePath) const noexcept {
   const QString ext = filePath.getSuffix().toLower();
   if (ext == "pdf") {
-    return openPdf(filePath);
+    return openLocalPathWithCommand(filePath,
+                                    mSettings.externalPdfReaderCommands.get());
   } else {
     return openUrl(QUrl::fromLocalFile(filePath.toNative()));
   }
-}
-
-bool DesktopServices::openPdf(const FilePath& filePath) const noexcept {
-  if (!mForceOpen) {
-    switch (mSettings.pdfOpenBehavior.get()) {
-      case WorkspaceSettings::PdfOpenBehavior::NEVER: {
-        return false;  // Do not open file -> abort.
-      }
-      case WorkspaceSettings::PdfOpenBehavior::ALWAYS: {
-        break;  // Open file -> just continue.
-      }
-      case WorkspaceSettings::PdfOpenBehavior::ASK: {
-        int result = QMessageBox::information(
-            mParent, tr("PDF Export"), tr("PDF exported successfully."),
-            QMessageBox::Ok | QMessageBox::Open);
-        if (result != QMessageBox::Open) {
-          return false;  // Do not open file -> abort.
-        }
-        break;
-      }
-      default: {
-        qCritical() << "DesktopServices: Unhandled switch-case!";
-        return false;
-      }
-    }
-  }
-
-  // Open file now.
-  if (mSettings.useCustomPdfReader.get()) {
-    QString cmd = mSettings.pdfReaderCommand.get();
-    cmd.replace("{{FILEPATH}}", filePath.toNative());
-    if (!QProcess::startDetached(cmd)) {
-      qCritical() << "Failed to open PDF with custom command:" << cmd;
-      return false;
-    }
-  } else {
-    return openUrl(QUrl::fromLocalFile(filePath.toNative()));
-  }
-  return true;
 }
 
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 
+bool DesktopServices::openLocalPathWithCommand(
+    const FilePath& filePath, const QStringList& commands) const noexcept {
+  const QUrl url = QUrl::fromLocalFile(filePath.toNative());
+  foreach (QString cmd, commands) {
+    cmd.replace("{{FILEPATH}}", filePath.toNative());
+    cmd.replace("{{URL}}", url.toString());
+    if (QProcess::startDetached(cmd)) {
+      qDebug() << "Successfully opened file or directory with command:" << cmd;
+      return true;
+    } else {
+      qWarning() << "Failed to open file or directory with command:" << cmd;
+    }
+  }
+  return openUrl(url);
+}
+
 bool DesktopServices::openUrl(const QUrl& url) const noexcept {
   if (QDesktopServices::openUrl(url)) {
+    qDebug() << "Successfully opened URL with QDesktopServices:" << url;
     return true;
   } else {
     qCritical() << "Failed to open URL with QDesktopServices:" << url;

--- a/libs/librepcb/editor/workspace/desktopservices.h
+++ b/libs/librepcb/editor/workspace/desktopservices.h
@@ -66,6 +66,7 @@ public:
   DesktopServices& operator=(const DesktopServices& rhs) = delete;
 
 private:  // Methods
+  bool openDirectory(const FilePath& filePath) const noexcept;
   bool openLocalPathWithCommand(const FilePath& filePath,
                                 const QStringList& commands) const noexcept;
   bool openUrl(const QUrl& url) const noexcept;

--- a/libs/librepcb/editor/workspace/desktopservices.h
+++ b/libs/librepcb/editor/workspace/desktopservices.h
@@ -54,23 +54,23 @@ public:
   // Constructors / Destructor
   DesktopServices() = delete;
   DesktopServices(const DesktopServices& other) = delete;
-  explicit DesktopServices(const WorkspaceSettings& settings, bool forceOpen,
-                           QWidget* parent = nullptr) noexcept;
+  explicit DesktopServices(const WorkspaceSettings& settings,
+                           QWidget* parent) noexcept;
   ~DesktopServices() noexcept;
 
   // General Methods
-  bool openFile(const FilePath& filePath) const noexcept;
-  bool openPdf(const FilePath& filePath) const noexcept;
+  bool openLocalPath(const FilePath& filePath) const noexcept;
 
   // Operator Overloadings
   DesktopServices& operator=(const DesktopServices& rhs) = delete;
 
 private:  // Methods
+  bool openLocalPathWithCommand(const FilePath& filePath,
+                                const QStringList& commands) const noexcept;
   bool openUrl(const QUrl& url) const noexcept;
 
 private:  // Data
   const WorkspaceSettings& mSettings;
-  const bool mForceOpen;
   QPointer<QWidget> mParent;
 };
 

--- a/libs/librepcb/editor/workspace/desktopservices.h
+++ b/libs/librepcb/editor/workspace/desktopservices.h
@@ -59,6 +59,7 @@ public:
   ~DesktopServices() noexcept;
 
   // General Methods
+  bool openWebUrl(const QUrl& url) const noexcept;
   bool openLocalPath(const FilePath& filePath) const noexcept;
 
   // Operator Overloadings

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -164,6 +164,18 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
     connect(mUi->lstExternalApplications, &QListWidget::currentRowChanged, this,
             &WorkspaceSettingsDialog::externalApplicationListIndexChanged);
 
+    mUi->lstExternalApplications->addItem(new QListWidgetItem(
+        QIcon(":/img/actions/open_browser.png"), tr("Web Browser")));
+    mExternalApplications.append(ExternalApplication{
+        &mSettings.externalWebBrowserCommands,
+        "firefox",
+        "\"{{URL}}\"",
+        {std::make_pair(
+            QString("{{URL}}"),
+            tr("Website URL to open", "Decription for '{{URL}}' placeholder"))},
+        {},
+    });
+
     mUi->lstExternalApplications->addItem(
         new QListWidgetItem(QIcon(":/img/actions/pdf.png"), tr("PDF Reader")));
     mExternalApplications.append(ExternalApplication{

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -22,11 +22,13 @@
  ******************************************************************************/
 #include "workspacesettingsdialog.h"
 
+#include "../dialogs/filedialog.h"
 #include "../editorcommandset.h"
 #include "../modelview/comboboxdelegate.h"
 #include "../modelview/editablelistmodel.h"
 #include "../modelview/keyboardshortcutsmodel.h"
 #include "../modelview/keysequencedelegate.h"
+#include "../utils/editortoolbox.h"
 #include "ui_workspacesettingsdialog.h"
 
 #include <librepcb/core/application.h>
@@ -150,39 +152,31 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
 
   // Initialize external applications widgets
   {
-    connect(mUi->pdfCustomRadioBtn, &QRadioButton::toggled,
-            mUi->pdfCustomCmdEdit, &QTextEdit::setEnabled);
-    connect(mUi->pdfCustomRadioBtn, &QRadioButton::toggled,
-            mUi->pdfCustomCmdPickBtn, &QToolButton::setEnabled);
+    auto placeholderFilePath =
+        std::make_pair(QString("{{FILEPATH}}"),
+                       tr("Absolute path to the file to open",
+                          "Decription for '{{FILEPATH}}' placeholder"));
+    auto placeholderUrl =
+        std::make_pair(QString("{{URL}}"),
+                       tr("URL to the file to open (file://)",
+                          "Decription for '{{URL}}' placeholder"));
 
-    // PDF Reader
-    // match IDs with enum values
-    mUi->pdfOpenGroup->setId(
-        mUi->pdfOpenAlwaysRadio,
-        static_cast<int>(WorkspaceSettings::PdfOpenBehavior::ALWAYS));
+    connect(mUi->lstExternalApplications, &QListWidget::currentRowChanged, this,
+            &WorkspaceSettingsDialog::externalApplicationListIndexChanged);
 
-    mUi->pdfOpenGroup->setId(
-        mUi->pdfOpenNeverRadio,
-        static_cast<int>(WorkspaceSettings::PdfOpenBehavior::NEVER));
-
-    mUi->pdfOpenGroup->setId(
-        mUi->pdfOpenAskRadio,
-        static_cast<int>(WorkspaceSettings::PdfOpenBehavior::ASK));
-
-    // File picker
-    connect(mUi->pdfCustomCmdPickBtn, &QToolButton::clicked, [&]() {
-      QFileDialog fileDialog(this);
-
-      fileDialog.setWindowTitle(tr("Select an executable file"));
-      fileDialog.setFileMode(QFileDialog::ExistingFile);
-      fileDialog.setFilter(QDir::Executable);
-      fileDialog.setDirectory(QDir::home());
-
-      if (fileDialog.exec()) {
-        mUi->pdfCustomCmdEdit->setText(fileDialog.selectedFiles().first() +
-                                       " \"{{FILEPATH}}\"");
-      }
+    mUi->lstExternalApplications->addItem(
+        new QListWidgetItem(QIcon(":/img/actions/pdf.png"), tr("PDF Reader")));
+    mExternalApplications.append(ExternalApplication{
+        &mSettings.externalPdfReaderCommands,
+        "evince",
+        "\"{{FILEPATH}}\"",
+        {placeholderFilePath, placeholderUrl},
+        {},
     });
+
+    mUi->lstExternalApplications->setMinimumWidth(
+        mUi->lstExternalApplications->sizeHintForColumn(0) + 20);
+    mUi->lstExternalApplications->setCurrentRow(0);
   }
 
   // Initialize keyboard shortcuts widgets
@@ -301,6 +295,85 @@ void WorkspaceSettingsDialog::keyPressEvent(QKeyEvent* event) noexcept {
   QDialog::keyPressEvent(event);
 }
 
+void WorkspaceSettingsDialog::externalApplicationListIndexChanged(
+    int index) noexcept {
+  if ((index < 0) || (index >= mExternalApplications.count())) {
+    return;
+  }
+
+  while (mUi->layoutExternalApplicationCommands->count() > 0) {
+    QLayoutItem* item = mUi->layoutExternalApplicationCommands->takeAt(0);
+    Q_ASSERT(item);
+    EditorToolbox::deleteLayoutItemRecursively(item);
+  }
+
+  QStringList commands = mExternalApplications[index].currentValue;
+  for (int i = 0; i <= commands.count(); ++i) {
+    QHBoxLayout* hLayout = new QHBoxLayout();
+    hLayout->setContentsMargins(0, 0, 0, 0);
+    hLayout->setSpacing(0);
+
+    QLineEdit* edit = new QLineEdit(commands.value(i), this);
+    edit->setPlaceholderText(
+        tr("Example:") % " " % mExternalApplications[index].exampleExecutable %
+        " " % mExternalApplications[index].defaultArgument);
+    if (i < commands.count()) {
+      connect(edit, &QLineEdit::textChanged, edit, [this, index, edit, i]() {
+        mExternalApplications[index].currentValue.replace(i, edit->text());
+      });
+    } else {
+      connect(edit, &QLineEdit::editingFinished, edit, [this, index, edit]() {
+        if (!edit->text().isEmpty()) {
+          mExternalApplications[index].currentValue.append(edit->text());
+        }
+      });
+      connect(edit, &QLineEdit::editingFinished, edit,
+              [this]() {
+                externalApplicationListIndexChanged(
+                    mUi->lstExternalApplications->currentRow());
+              },
+              Qt::QueuedConnection);
+    }
+    hLayout->addWidget(edit);
+
+    QToolButton* btnBrowse = new QToolButton(this);
+    btnBrowse->setToolTip(tr("Select executable..."));
+    btnBrowse->setIcon(QIcon(":/img/actions/open.png"));
+    connect(btnBrowse, &QToolButton::clicked, this, [this, edit, index]() {
+      QString fp = FileDialog::getOpenFileName(this, tr("Select executable"),
+                                               QDir::rootPath());
+      if (!fp.isEmpty()) {
+        edit->setText(fp % " " % mExternalApplications[index].defaultArgument);
+        emit edit->editingFinished();
+      }
+    });
+    hLayout->addWidget(btnBrowse);
+
+    if (i < commands.count()) {
+      QToolButton* btnRemove = new QToolButton(this);
+      btnRemove->setToolTip(tr("Remove this command"));
+      btnRemove->setIcon(QIcon(":/img/actions/delete.png"));
+      connect(btnRemove, &QToolButton::clicked, this,
+              [this, index, i]() {
+                mExternalApplications[index].currentValue.removeAt(i);
+                externalApplicationListIndexChanged(index);
+              },
+              Qt::QueuedConnection);
+      hLayout->addWidget(btnRemove);
+    }
+
+    mUi->layoutExternalApplicationCommands->addLayout(hLayout);
+  }
+
+  QString placeholdersText =
+      "<p>" % tr("Available placeholders:") % "</p><p><ul>";
+  foreach (const auto& p, mExternalApplications[index].placeholders) {
+    placeholdersText += "<li><tt>" % p.first % "</tt>: " % p.second % "</li>";
+  }
+  placeholdersText += "</ul></p>";
+  mUi->lblExternalApplicationsPlaceholders->setText(placeholdersText);
+}
+
 void WorkspaceSettingsDialog::loadSettings() noexcept {
   // User Name
   mUi->edtUserName->setText(mSettings.userName.get());
@@ -333,16 +406,12 @@ void WorkspaceSettingsDialog::loadSettings() noexcept {
   // Repository URLs
   mRepositoryUrlsModel->setValues(mSettings.repositoryUrls.get());
 
-  // External PDF Reader
-  mUi->pdfCustomCmdEdit->setEnabled(mSettings.useCustomPdfReader.get());
-  mUi->pdfCustomCmdPickBtn->setEnabled(mSettings.useCustomPdfReader.get());
-
-  mUi->pdfCustomCmdEdit->setText(mSettings.pdfReaderCommand.get());
-  mUi->pdfCustomRadioBtn->setChecked(mSettings.useCustomPdfReader.get());
-
-  // External PDF reader behaviour
-  mUi->pdfOpenGroup->button(static_cast<int>(mSettings.pdfOpenBehavior.get()))
-      ->setChecked(true);
+  // External Applications
+  for (auto& app : mExternalApplications) {
+    app.currentValue = app.setting->get();
+  }
+  externalApplicationListIndexChanged(
+      mUi->lstExternalApplications->currentRow());
 
   // Keyboard Shortcuts
   mKeyboardShortcutsModel->setOverrides(mSettings.keyboardShortcuts.get());
@@ -382,14 +451,16 @@ void WorkspaceSettingsDialog::saveSettings() noexcept {
     // Repository URLs
     mSettings.repositoryUrls.set(mRepositoryUrlsModel->getValues());
 
-    // External PDF Reader
-    mSettings.useCustomPdfReader.set(mUi->pdfCustomRadioBtn->isChecked());
-    mSettings.pdfReaderCommand.set(mUi->pdfCustomCmdEdit->text().trimmed());
-
-    // External PDF reader behaviour
-    mSettings.pdfOpenBehavior.set(
-        static_cast<WorkspaceSettings::PdfOpenBehavior>(
-            mUi->pdfOpenGroup->checkedId()));
+    // External Applications
+    for (auto& app : mExternalApplications) {
+      QStringList commands;
+      foreach (const QString& cmd, app.currentValue) {
+        if (!cmd.trimmed().isEmpty()) {
+          commands.append(cmd.trimmed());
+        }
+      }
+      app.setting->set(commands);
+    }
 
     // Keyboard shortcuts
     mSettings.keyboardShortcuts.set(mKeyboardShortcutsModel->getOverrides());

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -176,6 +176,16 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
         {},
     });
 
+    mUi->lstExternalApplications->addItem(new QListWidgetItem(
+        QIcon(":/img/actions/open.png"), tr("File Manager")));
+    mExternalApplications.append(ExternalApplication{
+        &mSettings.externalFileManagerCommands,
+        "explorer",
+        "\"{{FILEPATH}}\"",
+        {placeholderFilePath, placeholderUrl},
+        {},
+    });
+
     mUi->lstExternalApplications->addItem(
         new QListWidgetItem(QIcon(":/img/actions/pdf.png"), tr("PDF Reader")));
     mExternalApplications.append(ExternalApplication{

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.h
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.h
@@ -25,6 +25,8 @@
  ******************************************************************************/
 #include "../modelview/editablelistmodel.h"
 
+#include <librepcb/core/workspace/workspacesettingsitem_genericvaluelist.h>
+
 #include <QtCore>
 #include <QtWidgets>
 
@@ -59,6 +61,14 @@ class WorkspaceSettingsDialog final : public QDialog {
   using LibraryNormOrderModel = EditableListModel<QStringList>;
   using RepositoryUrlModel = EditableListModel<QList<QUrl>>;
 
+  struct ExternalApplication {
+    QPointer<WorkspaceSettingsItem_GenericValueList<QStringList>> setting;
+    QString exampleExecutable;
+    QString defaultArgument;
+    QVector<std::pair<QString, QString>> placeholders;
+    QStringList currentValue;
+  };
+
 public:
   // Constructors / Destructor
   WorkspaceSettingsDialog() = delete;
@@ -74,6 +84,7 @@ public:
 private:
   void buttonBoxClicked(QAbstractButton* button) noexcept;
   void keyPressEvent(QKeyEvent* event) noexcept override;
+  void externalApplicationListIndexChanged(int index) noexcept;
   void loadSettings() noexcept;
   void saveSettings() noexcept;
 
@@ -86,6 +97,9 @@ private:
   QScopedPointer<KeyboardShortcutsModel> mKeyboardShortcutsModel;
   QScopedPointer<QSortFilterProxyModel> mKeyboardShortcutsFilterModel;
   QScopedPointer<Ui::WorkspaceSettingsDialog> mUi;
+
+  // Cached settings
+  QVector<ExternalApplication> mExternalApplications;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>528</width>
-    <height>367</height>
+    <width>530</width>
+    <height>365</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
@@ -284,169 +284,100 @@
       <attribute name="title">
        <string>External Applications</string>
       </attribute>
-      <layout class="QFormLayout" name="formLayout_5">
-       <item row="0" column="1">
-        <widget class="QGroupBox" name="pdfBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QListWidget" name="lstExternalApplications">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
          </property>
-         <property name="title">
-          <string>PDF Reader</string>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
          </property>
-         <layout class="QFormLayout" name="formLayout_4">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_13">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Reader to use:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <layout class="QHBoxLayout" name="pdfReaderHLayout">
-            <item>
-             <widget class="QRadioButton" name="pdfDefaultRadioBtn">
-              <property name="text">
-               <string>System default</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-              <attribute name="buttonGroup">
-               <string notr="true">pdfReaderGroup</string>
-              </attribute>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="pdfCustomRadioBtn">
-              <property name="text">
-               <string>Run custom command</string>
-              </property>
-              <attribute name="buttonGroup">
-               <string notr="true">pdfReaderGroup</string>
-              </attribute>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_14">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Custom command:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_15">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Open PDF after export:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <layout class="QHBoxLayout" name="pdfOpenHLayout">
-            <item>
-             <widget class="QRadioButton" name="pdfOpenAlwaysRadio">
-              <property name="text">
-               <string>Always</string>
-              </property>
-              <attribute name="buttonGroup">
-               <string notr="true">pdfOpenGroup</string>
-              </attribute>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="pdfOpenNeverRadio">
-              <property name="text">
-               <string>Never</string>
-              </property>
-              <attribute name="buttonGroup">
-               <string notr="true">pdfOpenGroup</string>
-              </attribute>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="pdfOpenAskRadio">
-              <property name="text">
-               <string>Ask every time</string>
-              </property>
-              <attribute name="buttonGroup">
-               <string notr="true">pdfOpenGroup</string>
-              </attribute>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QLineEdit" name="pdfCustomCmdEdit">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <family>Monospace</family>
-               </font>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use &lt;span style=&quot; font-family:'monospace';&quot;&gt;{{FILEPATH}}}&lt;/span&gt; as placeholder for the filename.&lt;/p&gt;&lt;p&gt;Notice: If your path contains space you may need to add quotes like this: &lt;span style=&quot; font-family:'monospace';&quot;&gt;&amp;quot;{{FILEPATH}}&amp;quot;&lt;/span&gt; .&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="maxLength">
-               <number>500</number>
-              </property>
-              <property name="placeholderText">
-               <string>example: evince &quot;{{FILEPATH}}&quot;</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QToolButton" name="pdfCustomCmdPickBtn">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pick an executable file&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Pick</string>
-              </property>
-              <property name="icon">
-               <iconset>
-                <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="tabKeyNavigation">
+          <bool>true</bool>
+         </property>
         </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,0,0,1">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <property name="topMargin">
+          <number>3</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_14">
+           <property name="font">
+            <font>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Custom command(s):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="layoutExternalApplicationCommands">
+           <property name="spacing">
+            <number>1</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+          </layout>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblExternalApplicationsPlaceholders">
+           <property name="text">
+            <string notr="true">Available placeholders:</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_13">
+           <property name="font">
+            <font>
+             <italic>true</italic>
+            </font>
+           </property>
+           <property name="text">
+            <string>You can add multiple commands to make the same settings working on multiple computers. LibrePCB will iterate through the list of commands until one of them succeeds. If none succeeds, the system's default application will be used.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -549,8 +480,4 @@
  </customwidgets>
  <resources/>
  <connections/>
- <buttongroups>
-  <buttongroup name="pdfOpenGroup"/>
-  <buttongroup name="pdfReaderGroup"/>
- </buttongroups>
 </ui>

--- a/tests/unittests/core/workspace/workspacesettingstest.cpp
+++ b/tests/unittests/core/workspace/workspacesettingstest.cpp
@@ -77,6 +77,7 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionV01) {
   EXPECT_EQ(QStringList{"IEC 60617"}, obj.libraryNormOrder.get());
   EXPECT_EQ(QList<QUrl>{QUrl("https://api.librepcb.org")},
             obj.repositoryUrls.get());
+  EXPECT_EQ(QStringList{}, obj.externalWebBrowserCommands.get());
 }
 
 TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
@@ -96,6 +97,9 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
       " (repositories\n"
       "  (repository \"https://api.librepcb.org\")\n"
       " )\n"
+      " (external_web_browser\n"
+      "  (command \"firefox \\\"{{URL}}\\\"\")\n"
+      " )\n"
       " (external_pdf_reader\n"
       "  (command \"evince \\\"{{FILEPATH}}\\\"\")\n"
       " )\n"
@@ -113,6 +117,8 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
   EXPECT_EQ(QStringList{"IEC 60617"}, obj.libraryNormOrder.get());
   EXPECT_EQ(QList<QUrl>{QUrl("https://api.librepcb.org")},
             obj.repositoryUrls.get());
+  EXPECT_EQ(QStringList{"firefox \"{{URL}}\""},
+            obj.externalWebBrowserCommands.get());
   EXPECT_EQ(QStringList{"evince \"{{FILEPATH}}\""},
             obj.externalPdfReaderCommands.get());
 }
@@ -128,6 +134,7 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   obj1.libraryLocaleOrder.set({"de_CH", "en_US"});
   obj1.libraryNormOrder.set({"foo", "bar"});
   obj1.repositoryUrls.set({QUrl("https://foo"), QUrl("https://bar")});
+  obj1.externalWebBrowserCommands.set({"foo", "bar"});
   obj1.externalPdfReaderCommands.set({"pdf", "reader"});
   const SExpression root1 = obj1.serialize();
 
@@ -145,6 +152,8 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   EXPECT_EQ(obj1.libraryLocaleOrder.get(), obj2.libraryLocaleOrder.get());
   EXPECT_EQ(obj1.libraryNormOrder.get(), obj2.libraryNormOrder.get());
   EXPECT_EQ(obj1.repositoryUrls.get(), obj2.repositoryUrls.get());
+  EXPECT_EQ(obj1.externalWebBrowserCommands.get(),
+            obj2.externalWebBrowserCommands.get());
   EXPECT_EQ(obj1.externalPdfReaderCommands.get(),
             obj2.externalPdfReaderCommands.get());
   const SExpression root2 = obj2.serialize();

--- a/tests/unittests/core/workspace/workspacesettingstest.cpp
+++ b/tests/unittests/core/workspace/workspacesettingstest.cpp
@@ -78,6 +78,7 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionV01) {
   EXPECT_EQ(QList<QUrl>{QUrl("https://api.librepcb.org")},
             obj.repositoryUrls.get());
   EXPECT_EQ(QStringList{}, obj.externalWebBrowserCommands.get());
+  EXPECT_EQ(QStringList{}, obj.externalFileManagerCommands.get());
 }
 
 TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
@@ -100,6 +101,9 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
       " (external_web_browser\n"
       "  (command \"firefox \\\"{{URL}}\\\"\")\n"
       " )\n"
+      " (external_file_manager\n"
+      "  (command \"nautilus \\\"{{FILEPATH}}\\\"\")\n"
+      " )\n"
       " (external_pdf_reader\n"
       "  (command \"evince \\\"{{FILEPATH}}\\\"\")\n"
       " )\n"
@@ -119,6 +123,8 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
             obj.repositoryUrls.get());
   EXPECT_EQ(QStringList{"firefox \"{{URL}}\""},
             obj.externalWebBrowserCommands.get());
+  EXPECT_EQ(QStringList{"nautilus \"{{FILEPATH}}\""},
+            obj.externalFileManagerCommands.get());
   EXPECT_EQ(QStringList{"evince \"{{FILEPATH}}\""},
             obj.externalPdfReaderCommands.get());
 }
@@ -135,6 +141,7 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   obj1.libraryNormOrder.set({"foo", "bar"});
   obj1.repositoryUrls.set({QUrl("https://foo"), QUrl("https://bar")});
   obj1.externalWebBrowserCommands.set({"foo", "bar"});
+  obj1.externalFileManagerCommands.set({"file", "manager"});
   obj1.externalPdfReaderCommands.set({"pdf", "reader"});
   const SExpression root1 = obj1.serialize();
 
@@ -154,6 +161,8 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   EXPECT_EQ(obj1.repositoryUrls.get(), obj2.repositoryUrls.get());
   EXPECT_EQ(obj1.externalWebBrowserCommands.get(),
             obj2.externalWebBrowserCommands.get());
+  EXPECT_EQ(obj1.externalFileManagerCommands.get(),
+            obj2.externalFileManagerCommands.get());
   EXPECT_EQ(obj1.externalPdfReaderCommands.get(),
             obj2.externalPdfReaderCommands.get());
   const SExpression root2 = obj2.serialize();

--- a/tests/unittests/core/workspace/workspacesettingstest.cpp
+++ b/tests/unittests/core/workspace/workspacesettingstest.cpp
@@ -96,6 +96,9 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
       " (repositories\n"
       "  (repository \"https://api.librepcb.org\")\n"
       " )\n"
+      " (external_pdf_reader\n"
+      "  (command \"evince \\\"{{FILEPATH}}\\\"\")\n"
+      " )\n"
       ")",
       FilePath());
 
@@ -110,6 +113,8 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
   EXPECT_EQ(QStringList{"IEC 60617"}, obj.libraryNormOrder.get());
   EXPECT_EQ(QList<QUrl>{QUrl("https://api.librepcb.org")},
             obj.repositoryUrls.get());
+  EXPECT_EQ(QStringList{"evince \"{{FILEPATH}}\""},
+            obj.externalPdfReaderCommands.get());
 }
 
 TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
@@ -123,9 +128,7 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   obj1.libraryLocaleOrder.set({"de_CH", "en_US"});
   obj1.libraryNormOrder.set({"foo", "bar"});
   obj1.repositoryUrls.set({QUrl("https://foo"), QUrl("https://bar")});
-  obj1.useCustomPdfReader.set(obj1.useCustomPdfReader.get());
-  obj1.pdfReaderCommand.set("my reader");
-  obj1.pdfOpenBehavior.set(WorkspaceSettings::PdfOpenBehavior::NEVER);
+  obj1.externalPdfReaderCommands.set({"pdf", "reader"});
   const SExpression root1 = obj1.serialize();
 
   // Load
@@ -142,9 +145,8 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   EXPECT_EQ(obj1.libraryLocaleOrder.get(), obj2.libraryLocaleOrder.get());
   EXPECT_EQ(obj1.libraryNormOrder.get(), obj2.libraryNormOrder.get());
   EXPECT_EQ(obj1.repositoryUrls.get(), obj2.repositoryUrls.get());
-  EXPECT_EQ(obj1.useCustomPdfReader.get(), obj2.useCustomPdfReader.get());
-  EXPECT_EQ(obj1.pdfReaderCommand.get(), obj2.pdfReaderCommand.get());
-  EXPECT_EQ(obj1.pdfOpenBehavior.get(), obj2.pdfOpenBehavior.get());
+  EXPECT_EQ(obj1.externalPdfReaderCommands.get(),
+            obj2.externalPdfReaderCommands.get());
   const SExpression root2 = obj2.serialize();
 
   // Check if serialization of loaded settings leads to same file content

--- a/tests/unittests/editor/project/orderpcbdialogtest.cpp
+++ b/tests/unittests/editor/project/orderpcbdialogtest.cpp
@@ -24,6 +24,7 @@
 #include "../../testhelpers.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/workspace/workspacesettings.h>
 #include <librepcb/editor/project/orderpcbdialog.h>
 
 #include <QtTest>
@@ -51,11 +52,13 @@ protected:
  ******************************************************************************/
 
 TEST_F(OrderPcbDialogTest, testAutoOpenBrowser) {
+  WorkspaceSettings settings;
+  settings.repositoryUrls.set(QList<QUrl>());  // Avoid API calls during test!
   const bool defaultValue = true;
   const bool newValue = false;
 
   {
-    OrderPcbDialog dialog(QList<QUrl>(), nullptr);
+    OrderPcbDialog dialog(settings, nullptr);
 
     // Check the default value.
     QCheckBox& cbx = TestHelpers::getChild<QCheckBox>(dialog, "cbxOpenBrowser");
@@ -67,14 +70,16 @@ TEST_F(OrderPcbDialogTest, testAutoOpenBrowser) {
 
   // Check if the setting is saved and restored automatically.
   {
-    OrderPcbDialog dialog(QList<QUrl>(), nullptr);
+    OrderPcbDialog dialog(settings, nullptr);
     QCheckBox& cbx = TestHelpers::getChild<QCheckBox>(dialog, "cbxOpenBrowser");
     EXPECT_EQ(newValue, cbx.isChecked());
   }
 }
 
 TEST_F(OrderPcbDialogTest, testTabOrder) {
-  OrderPcbDialog dialog(QList<QUrl>(), nullptr);
+  WorkspaceSettings settings;
+  settings.repositoryUrls.set(QList<QUrl>());  // Avoid API calls during test!
+  OrderPcbDialog dialog(settings, nullptr);
   TestHelpers::testTabOrder(dialog);
 }
 


### PR DESCRIPTION
### Description

- Rework external PDF reader config:
  - Allow configuring *multiple* custom commands instead of only one. LibrePCB will iterate through the list of custom commands until one of them succeeds. This is important because the workspace is intended to be platform independent, but configuring only one PDF reader command is not portable. Now you can add the PDF reader of *each* of your computers, which makes it much more portable.
  - Remove setting "use custom PDF reader" - I'm not sure if this is really needed. If you don't want a custom PDF reader, just don't configure custom commands...
  - Remove setting "PDF open behavior [always/never/ask]" since it was not used anymore. Export dialogs contain a checkbox to choose whether to open the PDF or not.
- Make the web browser and file manager commands configurable as well, just like the PDF reader.
- Extend the workspace settings GUI to allow configuring these external application commands.

### Preview

![image](https://user-images.githubusercontent.com/5374821/188308693-bb86dcd6-49a3-4089-b723-26577f71aaca.png)
