### PR TITLE
By default, skip devices without pads in BOM/pick&place export

### DIFF
--- a/libs/librepcb/core/project/board/boardpickplacegenerator.cpp
+++ b/libs/librepcb/core/project/board/boardpickplacegenerator.cpp
@@ -62,6 +62,15 @@ std::shared_ptr<PickPlaceData> BoardPickPlaceGenerator::generate() noexcept {
       mBoard.getProject().getSettings().getLocaleOrder();
 
   foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
+    // Skip devices which are considered as no device to be mounted.
+    switch (device->determineMountType()) {
+      case BI_Device::MountType::None:
+      case BI_Device::MountType::Fiducial:
+        continue;
+      default:
+        break;
+    }
+
     QString designator = *device->getComponentInstance().getName();
     QString value = device->getComponentInstance().getValue(true).trimmed();
     QString deviceName = *device->getLibDevice().getNames().value(locale);

--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -35,6 +35,7 @@
 #include "../../projectsettings.h"
 #include "../board.h"
 #include "bi_footprint.h"
+#include "bi_footprintpad.h"
 
 #include <QtCore>
 
@@ -195,6 +196,39 @@ const Uuid& BI_Device::getComponentInstanceUuid() const noexcept {
 
 bool BI_Device::isUsed() const noexcept {
   return mFootprint->isUsed();
+}
+
+BI_Device::MountType BI_Device::determineMountType() const noexcept {
+  const QString mountType = getAttributeValue("MOUNT_TYPE").trimmed().toLower();
+  if (mountType.isEmpty()) {
+    // Auto-detection depending on footprint pads.
+    bool hasThtPads = false;
+    bool hasSmtPads = false;
+    foreach (const BI_FootprintPad* pad, mFootprint->getPads()) {
+      if (pad->getLibPad().getDrillDiameter() > 0) {
+        hasThtPads = true;
+      } else {
+        hasSmtPads = true;
+      }
+    }
+    if (hasThtPads) {
+      return MountType::Tht;
+    } else if (hasSmtPads) {
+      return MountType::Smt;
+    } else {
+      return MountType::None;
+    }
+  } else if (mountType == "tht") {
+    return MountType::Tht;
+  } else if (mountType == "smt") {
+    return MountType::Smt;
+  } else if (mountType == "fiducial") {
+    return MountType::Fiducial;
+  } else if (mountType == "none") {
+    return MountType::None;
+  } else {
+    return MountType::Other;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/items/bi_device.h
+++ b/libs/librepcb/core/project/board/items/bi_device.h
@@ -61,6 +61,9 @@ class BI_Device final : public BI_Base,
   DECLARE_ERC_MSG_CLASS_NAME(BI_Device)
 
 public:
+  // Types
+  enum class MountType { Tht, Smt, Fiducial, Other, None };
+
   // Constructors / Destructor
   BI_Device() = delete;
   BI_Device(const BI_Device& other) = delete;
@@ -85,6 +88,24 @@ public:
   bool getMirrored() const noexcept { return mMirrored; }
   bool isSelectable() const noexcept override;
   bool isUsed() const noexcept;
+
+  /**
+   * @brief Determine the mount (assembly) type of this device
+   *
+   * By default, this is automatically detected from the footprint pads (THT or
+   * SMT). If there are no pads, ::librepcb::BI_Device::MountType::None is
+   * returned since probably it is just a logo or so.
+   *
+   * However, the user can manually override this mechanism by adding a
+   * device property `MOUNT_TYPE` set to `THT`, `SMT`, `FIDUCIAL`, `OTHER` or
+   * `NONE`.
+   *
+   * Note that this mechanism should be refactored in v0.2, see
+   * https://github.com/LibrePCB/LibrePCB/issues/1001 for details.
+   *
+   * @return The determined device mount type.
+   */
+  MountType determineMountType() const noexcept;
 
   // Setters
   void setPosition(const Point& pos) noexcept;

--- a/libs/librepcb/core/project/bomgenerator.cpp
+++ b/libs/librepcb/core/project/bomgenerator.cpp
@@ -68,9 +68,16 @@ std::shared_ptr<Bom> BomGenerator::generate(const Board* board) noexcept {
     QString devName;
     QString pkgName;
     if (board) {
-      const BI_Device* device =
-          board->getDeviceInstanceByComponentUuid(cmpInst->getUuid());
-      if (device) {
+      if (const BI_Device* device =
+              board->getDeviceInstanceByComponentUuid(cmpInst->getUuid())) {
+        // Skip devices which are considered as no device to be mounted.
+        switch (device->determineMountType()) {
+          case BI_Device::MountType::None:
+          case BI_Device::MountType::Fiducial:
+            continue;
+          default:
+            break;
+        }
         devName = *device->getLibDevice().getNames().getDefaultValue();
         pkgName = *device->getLibPackage().getNames().getDefaultValue();
       }


### PR DESCRIPTION
Currently, exported pick&place and BOM files contained even devices like the "LibrePCB Logo" which makes no sense since this is not a real device you need to mount. Often such devices do not have any pads, while real devices do have pads. Thus let's skip devices without pads in the pick&place and BOM export.

However, if this auto-detection fails in some edge cases, an attribute `MOUNT_TYPE` could be added to these devices, set to `THT`, `SMT`, `FIDUCIAL` or `NONE`. This overrides the auto-detection. These values will also be used later in the Gerber X3 pick&place export since Gerber specifies these values.

Note that this is just a quick temporary solution (without file format changes) until a more explicit solution is implemented as described in #1001. I think this is good enough for now.