### PR TITLE
CI: Update macOS job to macOS 11 Big Sur

### DIFF
--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: macOS
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   timeoutInMinutes: 180
   variables:
     OS: 'mac'


### PR DESCRIPTION
The macOS 10.15 image is not working anymore because it's deprecated.