### PR TITLE
Implement Gerber X3 pick&place export

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -505,11 +505,11 @@ bool CommandLineInterface::openProject(
       }
       foreach (const Board* board, boardList) {
         print("  " % tr("Board '%1':").arg(*board->getName()));
-        BoardGerberExport grbExport(
-            *board,
-            customSettings ? *customSettings
-                           : board->getFabricationOutputSettings());
-        grbExport.exportAllLayers();  // can throw
+        BoardGerberExport grbExport(*board);
+        grbExport.exportPcbLayers(
+            customSettings
+                ? *customSettings
+                : board->getFabricationOutputSettings());  // can throw
         foreach (const FilePath& fp, grbExport.getWrittenFiles()) {
           print(QString("    => '%1'").arg(prettyPath(fp, projectFile)));
           writtenFilesCounter[fp]++;

--- a/libs/librepcb/core/export/gerberaperturelist.cpp
+++ b/libs/librepcb/core/export/gerberaperturelist.cpp
@@ -188,6 +188,25 @@ int GerberApertureList::addOctagon(const PositiveLength& w,
   }
 }
 
+int GerberApertureList::addComponentMain() noexcept {
+  // Note: The aperture shape, size and function is defined in the Gerber
+  // specs, do not change them!
+  return addCircle(UnsignedLength(300000),
+                   GerberAttribute::ApertureFunction::ComponentMain);
+}
+
+int GerberApertureList::addComponentPin(bool isPin1) noexcept {
+  // Note: The aperture shape, size and function is defined in the Gerber
+  // specs, do not change them!
+  if (isPin1) {
+    return addAperture("%ADD{}P,0.36X4X0.0*%\n",
+                       GerberAttribute::ApertureFunction::ComponentPin);
+  } else {
+    return addAperture("%ADD{}C,0*%\n",
+                       GerberAttribute::ApertureFunction::ComponentPin);
+  }
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/

--- a/libs/librepcb/core/export/gerberaperturelist.h
+++ b/libs/librepcb/core/export/gerberaperturelist.h
@@ -140,6 +140,22 @@ public:
   int addOctagon(const PositiveLength& w, const PositiveLength& h,
                  const Angle& rot, Function function) noexcept;
 
+  /**
+   * @brief Add a component main aperture (for component layers only)
+   *
+   * @return Aperture number.
+   */
+  int addComponentMain() noexcept;
+
+  /**
+   * @brief Add a component pin aperture (for component layers only)
+   *
+   * @param isPin1    Whether the aperture is for pin 1 or another pin.
+   *
+   * @return Aperture number.
+   */
+  int addComponentPin(bool isPin1) noexcept;
+
   // Operator Overloadings
   GerberApertureList& operator=(const GerberApertureList& rhs) = delete;
 

--- a/libs/librepcb/core/export/gerberattribute.cpp
+++ b/libs/librepcb/core/export/gerberattribute.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "gerberattribute.h"
 
+#include "../types/angle.h"
 #include "../types/uuid.h"
 
 #include <QtCore>
@@ -267,6 +268,25 @@ GerberAttribute GerberAttribute::fileFunctionMixedPlating(
       {"MixedPlating", QString::number(fromLayer), QString::number(toLayer)});
 }
 
+GerberAttribute GerberAttribute::fileFunctionComponent(
+    int layer, BoardSide side) noexcept {
+  QString layerStr = "L" % QString::number(layer);
+  switch (side) {
+    case BoardSide::Top: {
+      return GerberAttribute(Type::File, ".FileFunction",
+                             {"Component", layerStr, "Top"});
+    }
+    case BoardSide::Bottom: {
+      return GerberAttribute(Type::File, ".FileFunction",
+                             {"Component", layerStr, "Bot"});
+    }
+    default: {
+      qCritical() << "Unknown Gerber board side:" << static_cast<int>(side);
+      return GerberAttribute();
+    }
+  }
+}
+
 GerberAttribute GerberAttribute::filePolarity(Polarity polarity) noexcept {
   switch (polarity) {
     case Polarity::Positive: {
@@ -324,6 +344,21 @@ GerberAttribute GerberAttribute::apertureFunction(
     case ApertureFunction::ViaPad: {
       return GerberAttribute(Type::Aperture, ".AperFunction", {"ViaPad"});
     }
+    case ApertureFunction::ComponentMain: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"ComponentMain"});
+    }
+    case ApertureFunction::ComponentPin: {
+      return GerberAttribute(Type::Aperture, ".AperFunction", {"ComponentPin"});
+    }
+    case ApertureFunction::ComponentOutlineBody: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"ComponentOutline", "Body"});
+    }
+    case ApertureFunction::ComponentOutlineCourtyard: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"ComponentOutline", "Courtyard"});
+    }
     default: {
       qCritical() << "Unknown Gerber aperture function attribute:"
                   << static_cast<int>(function);
@@ -364,6 +399,51 @@ GerberAttribute GerberAttribute::objectPin(const QString& component,
     values.append(signal);
   }
   return GerberAttribute(Type::Object, ".P", values);
+}
+
+GerberAttribute GerberAttribute::componentRotation(
+    const Angle& rotation) noexcept {
+  return GerberAttribute(Type::Object, ".CRot", {rotation.toDegString()});
+}
+
+GerberAttribute GerberAttribute::componentManufacturer(
+    const QString& manufacturer) noexcept {
+  return GerberAttribute(Type::Object, ".CMfr", {manufacturer});
+}
+
+GerberAttribute GerberAttribute::componentMpn(const QString& mpn) noexcept {
+  return GerberAttribute(Type::Object, ".CMPN", {mpn});
+}
+
+GerberAttribute GerberAttribute::componentValue(const QString& value) noexcept {
+  return GerberAttribute(Type::Object, ".CVal", {value});
+}
+
+GerberAttribute GerberAttribute::componentMountType(MountType type) noexcept {
+  switch (type) {
+    case MountType::Tht: {
+      return GerberAttribute(Type::Object, ".CMnt", {"TH"});
+    }
+    case MountType::Smt: {
+      return GerberAttribute(Type::Object, ".CMnt", {"SMD"});
+    }
+    case MountType::Fiducial: {
+      return GerberAttribute(Type::Object, ".CMnt", {"Fiducial"});
+    }
+    case MountType::Other: {
+      return GerberAttribute(Type::Object, ".CMnt", {"Other"});
+    }
+    default: {
+      qCritical() << "Unknown Gerber component mount type attribute:"
+                  << static_cast<int>(type);
+      return GerberAttribute();
+    }
+  }
+}
+
+GerberAttribute GerberAttribute::componentFootprint(
+    const QString& footprint) noexcept {
+  return GerberAttribute(Type::Object, ".CFtp", {footprint});
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/export/gerberattribute.h
+++ b/libs/librepcb/core/export/gerberattribute.h
@@ -30,6 +30,7 @@
  ******************************************************************************/
 namespace librepcb {
 
+class Angle;
 class Uuid;
 
 /*******************************************************************************
@@ -48,6 +49,7 @@ public:
   enum class Polarity { Positive, Negative };
   enum class BoardSide { Top, Bottom };
   enum class CopperSide { Top, Inner, Bottom };
+  enum class MountType { Tht, Smt, Fiducial, Other };
   enum class ApertureFunction {
     // Available on all layers:
     Profile,  ///< Board outline
@@ -64,6 +66,12 @@ public:
     SmdPadCopperDefined,  ///< SMT pad, copper-defined
     SmdPadSolderMaskDefined,  ///< SMT pad, stopmask-defined
     ViaPad,  ///< Via
+
+    // Available only on component layers:
+    ComponentMain,  ///< Center of component
+    ComponentPin,  ///< Component pin
+    ComponentOutlineBody,  ///< Component body outline
+    ComponentOutlineCourtyard,  ///< Component courtyard outline
   };
 
   // Constructors / Destructor
@@ -107,6 +115,8 @@ public:
                                                           int toLayer) noexcept;
   static GerberAttribute fileFunctionMixedPlating(int fromLayer,
                                                   int toLayer) noexcept;
+  static GerberAttribute fileFunctionComponent(int layer,
+                                               BoardSide side) noexcept;
   static GerberAttribute filePolarity(Polarity polarity) noexcept;
   static GerberAttribute fileMd5(const QString& md5) noexcept;
   static GerberAttribute apertureFunction(ApertureFunction function) noexcept;
@@ -116,6 +126,13 @@ public:
   static GerberAttribute objectComponent(const QString& component) noexcept;
   static GerberAttribute objectPin(const QString& component, const QString& pin,
                                    const QString& signal) noexcept;
+  static GerberAttribute componentRotation(const Angle& rotation) noexcept;
+  static GerberAttribute componentManufacturer(
+      const QString& manufacturer) noexcept;
+  static GerberAttribute componentMpn(const QString& mpn) noexcept;
+  static GerberAttribute componentValue(const QString& value) noexcept;
+  static GerberAttribute componentMountType(MountType type) noexcept;
+  static GerberAttribute componentFootprint(const QString& footprint) noexcept;
 
 private:  // Methods
   GerberAttribute(Type type, const QString& key,

--- a/libs/librepcb/core/export/gerberattribute.h
+++ b/libs/librepcb/core/export/gerberattribute.h
@@ -121,7 +121,7 @@ private:  // Methods
   GerberAttribute(Type type, const QString& key,
                   const QStringList& values) noexcept;
   QString toString() const noexcept;
-  static QString escapeValue(const QString& value) noexcept;
+  static QString escapeValue(const QString& value, bool strictAscii) noexcept;
 
 private:  // Data
   Type mType;

--- a/libs/librepcb/core/export/gerbergenerator.cpp
+++ b/libs/librepcb/core/export/gerbergenerator.cpp
@@ -253,7 +253,10 @@ void GerberGenerator::generate() {
 }
 
 void GerberGenerator::saveToFile(const FilePath& filepath) const {
-  FileUtils::writeFile(filepath, mOutput.toLatin1());  // can throw
+  // Note: Although we save it as UTF-8, usually it will still contain only
+  // ASCII characters for maximum compatibility with legacy crappy readers.
+  // Unicode is only required when exporting Gerber X3 assembly attributes.
+  FileUtils::writeFile(filepath, mOutput.toUtf8());  // can throw
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/export/gerbergenerator.cpp
+++ b/libs/librepcb/core/export/gerbergenerator.cpp
@@ -93,6 +93,11 @@ void GerberGenerator::setFileFunctionPaste(BoardSide side,
   mFileAttributes.append(GerberAttribute::filePolarity(polarity));
 }
 
+void GerberGenerator::setFileFunctionComponent(int layer,
+                                               BoardSide side) noexcept {
+  mFileAttributes.append(GerberAttribute::fileFunctionComponent(layer, side));
+}
+
 void GerberGenerator::setLayerPolarity(Polarity p) noexcept {
   switch (p) {
     case Polarity::Positive:
@@ -116,7 +121,13 @@ void GerberGenerator::drawLine(const Point& start, const Point& end,
                        net,  // Object: Net name
                        component,  // Object: Component designator
                        QString(),  // Object: Pin number/name
-                       QString()  // Object: Pin signal
+                       QString(),  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
   );
   moveToPosition(start);
   linearInterpolateToPosition(end);
@@ -136,7 +147,13 @@ void GerberGenerator::drawPathOutline(const Path& path,
                        net,  // Object: Net name
                        component,  // Object: Component designator
                        QString(),  // Object: Pin number/name
-                       QString()  // Object: Pin signal
+                       QString(),  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
   );
   moveToPosition(path.getVertices().first().getPos());
   for (int i = 1; i < path.getVertices().count(); ++i) {
@@ -164,7 +181,13 @@ void GerberGenerator::drawPathArea(const Path& path, Function function,
                        net,  // Object: Net name
                        component,  // Object: Component designator
                        QString(),  // Object: Pin number/name
-                       QString()  // Object: Pin signal
+                       QString(),  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
   );
   setRegionModeOn();
   moveToPosition(path.getVertices().first().getPos());
@@ -174,6 +197,37 @@ void GerberGenerator::drawPathArea(const Path& path, Function function,
     interpolateBetween(v0, v);
   }
   setRegionModeOff();
+}
+
+void GerberGenerator::drawComponentOutline(
+    const Path& path, const Angle& rot, const QString& designator,
+    const QString& value, MountType mountType, const QString& manufacturer,
+    const QString& mpn, const QString& footprintName,
+    Function function) noexcept {
+  if (path.getVertices().count() < 2) {
+    qWarning() << "Invalid path was ignored in gerber output!";
+    return;
+  }
+  setCurrentAperture(
+      mApertureList->addCircle(UnsignedLength(100000), function));
+  setCurrentAttributes(tl::nullopt,  // Aperture: Function
+                       tl::nullopt,  // Object: Net name
+                       designator,  // Object: Component designator
+                       QString(),  // Object: Pin number/name
+                       QString(),  // Object: Pin signal
+                       value,  // Object: Component value
+                       mountType,  // Object: Component mount type
+                       manufacturer,  // Object: Component manufacturer
+                       mpn,  // Object: Component MPN
+                       footprintName,  // Object: Component footprint name
+                       rot  // Object: Component rotation
+  );
+  moveToPosition(path.getVertices().first().getPos());
+  for (int i = 1; i < path.getVertices().count(); ++i) {
+    const Vertex& v = path.getVertices().at(i);
+    const Vertex& v0 = path.getVertices().at(i - 1);
+    interpolateBetween(v0, v);
+  }
 }
 
 void GerberGenerator::flashCircle(const Point& pos, const PositiveLength& dia,
@@ -187,7 +241,13 @@ void GerberGenerator::flashCircle(const Point& pos, const PositiveLength& dia,
                        net,  // Object: Net name
                        component,  // Object: Component designator
                        pin,  // Object: Pin number/name
-                       signal  // Object: Pin signal
+                       signal,  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
   );
   flashAtPosition(pos);
 }
@@ -203,7 +263,13 @@ void GerberGenerator::flashRect(const Point& pos, const PositiveLength& w,
                        net,  // Object: Net name
                        component,  // Object: Component designator
                        pin,  // Object: Pin number/name
-                       signal  // Object: Pin signal
+                       signal,  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
   );
   flashAtPosition(pos);
 }
@@ -219,7 +285,13 @@ void GerberGenerator::flashObround(const Point& pos, const PositiveLength& w,
                        net,  // Object: Net name
                        component,  // Object: Component designator
                        pin,  // Object: Pin number/name
-                       signal  // Object: Pin signal
+                       signal,  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
   );
   flashAtPosition(pos);
 }
@@ -235,7 +307,56 @@ void GerberGenerator::flashOctagon(const Point& pos, const PositiveLength& w,
                        net,  // Object: Net name
                        component,  // Object: Component designator
                        pin,  // Object: Pin number/name
-                       signal  // Object: Pin signal
+                       signal,  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
+  );
+  flashAtPosition(pos);
+}
+
+void GerberGenerator::flashComponent(const Point& pos, const Angle& rot,
+                                     const QString& designator,
+                                     const QString& value, MountType mountType,
+                                     const QString& manufacturer,
+                                     const QString& mpn,
+                                     const QString& footprintName) noexcept {
+  setCurrentAperture(mApertureList->addComponentMain());
+  setCurrentAttributes(tl::nullopt,  // Aperture: Function
+                       tl::nullopt,  // Object: Net name
+                       designator,  // Object: Component designator
+                       QString(),  // Object: Pin number/name
+                       QString(),  // Object: Pin signal
+                       value,  // Object: Component value
+                       mountType,  // Object: Component mount type
+                       manufacturer,  // Object: Component manufacturer
+                       mpn,  // Object: Component MPN
+                       footprintName,  // Object: Component footprint name
+                       rot  // Object: Component rotation
+  );
+  flashAtPosition(pos);
+}
+
+void GerberGenerator::flashComponentPin(
+    const Point& pos, const Angle& rot, const QString& designator,
+    const QString& value, MountType mountType, const QString& manufacturer,
+    const QString& mpn, const QString& footprintName, const QString& pin,
+    const QString& signal, bool isPin1) noexcept {
+  setCurrentAperture(mApertureList->addComponentPin(isPin1));
+  setCurrentAttributes(tl::nullopt,  // Aperture: Function
+                       tl::nullopt,  // Object: Net name
+                       designator,  // Object: Component designator
+                       pin,  // Object: Pin number/name
+                       signal,  // Object: Pin signal
+                       value,  // Object: Component value
+                       mountType,  // Object: Component mount type
+                       manufacturer,  // Object: Component manufacturer
+                       mpn,  // Object: Component MPN
+                       footprintName,  // Object: Component footprint name
+                       rot  // Object: Component rotation
   );
   flashAtPosition(pos);
 }
@@ -263,11 +384,14 @@ void GerberGenerator::saveToFile(const FilePath& filepath) const {
  *  Private Methods
  ******************************************************************************/
 
-void GerberGenerator::setCurrentAttributes(Function apertureFunction,
-                                           const tl::optional<QString>& netName,
-                                           const QString& componentDesignator,
-                                           const QString& pinName,
-                                           const QString& pinSignal) noexcept {
+void GerberGenerator::setCurrentAttributes(
+    Function apertureFunction, const tl::optional<QString>& netName,
+    const QString& componentDesignator, const QString& pinName,
+    const QString& pinSignal, const QString& componentValue,
+    const tl::optional<MountType>& componentMountType,
+    const QString& componentManufacturer, const QString& componentMpn,
+    const QString& componentFootprint,
+    const tl::optional<Angle>& componentRotation) noexcept {
   QList<GerberAttribute> attributes;
   if (apertureFunction) {
     attributes.append(GerberAttribute::apertureFunction(*apertureFunction));
@@ -281,6 +405,25 @@ void GerberGenerator::setCurrentAttributes(Function apertureFunction,
   if (!componentDesignator.isEmpty() && !pinName.isEmpty()) {
     attributes.append(
         GerberAttribute::objectPin(componentDesignator, pinName, pinSignal));
+  }
+  if (!componentValue.isEmpty()) {
+    attributes.append(GerberAttribute::componentValue(componentValue));
+  }
+  if (componentMountType) {
+    attributes.append(GerberAttribute::componentMountType(*componentMountType));
+  }
+  if (!componentManufacturer.isEmpty()) {
+    attributes.append(
+        GerberAttribute::componentManufacturer(componentManufacturer));
+  }
+  if (!componentMpn.isEmpty()) {
+    attributes.append(GerberAttribute::componentMpn(componentMpn));
+  }
+  if (!componentFootprint.isEmpty()) {
+    attributes.append(GerberAttribute::componentFootprint(componentFootprint));
+  }
+  if (componentRotation) {
+    attributes.append(GerberAttribute::componentRotation(*componentRotation));
   }
   mContent.append(mAttributeWriter->setAttributes(attributes));
 }

--- a/libs/librepcb/core/export/gerbergenerator.h
+++ b/libs/librepcb/core/export/gerbergenerator.h
@@ -57,6 +57,7 @@ public:
   using BoardSide = GerberAttribute::BoardSide;
   using CopperSide = GerberAttribute::CopperSide;
   using Function = GerberApertureList::Function;
+  using MountType = GerberAttribute::MountType;
 
   // Constructors / Destructor
   GerberGenerator() = delete;
@@ -75,6 +76,7 @@ public:
   void setFileFunctionSolderMask(BoardSide side, Polarity polarity) noexcept;
   void setFileFunctionLegend(BoardSide side, Polarity polarity) noexcept;
   void setFileFunctionPaste(BoardSide side, Polarity polarity) noexcept;
+  void setFileFunctionComponent(int layer, BoardSide side) noexcept;
   void setLayerPolarity(Polarity p) noexcept;
   void drawLine(const Point& start, const Point& end,
                 const UnsignedLength& width, Function function,
@@ -86,6 +88,11 @@ public:
   void drawPathArea(const Path& path, Function function,
                     const tl::optional<QString>& net,
                     const QString& component) noexcept;
+  void drawComponentOutline(const Path& path, const Angle& rot,
+                            const QString& designator, const QString& value,
+                            MountType mountType, const QString& manufacturer,
+                            const QString& mpn, const QString& footprintName,
+                            Function function) noexcept;
   void flashCircle(const Point& pos, const PositiveLength& dia,
                    Function function, const tl::optional<QString>& net,
                    const QString& component, const QString& pin,
@@ -104,6 +111,17 @@ public:
                     Function function, const tl::optional<QString>& net,
                     const QString& component, const QString& pin,
                     const QString& signal) noexcept;
+  void flashComponent(const Point& pos, const Angle& rot,
+                      const QString& designator, const QString& value,
+                      MountType mountType, const QString& manufacturer,
+                      const QString& mpn,
+                      const QString& footprintName) noexcept;
+  void flashComponentPin(const Point& pos, const Angle& rot,
+                         const QString& designator, const QString& value,
+                         MountType mountType, const QString& manufacturer,
+                         const QString& mpn, const QString& footprintName,
+                         const QString& pin, const QString& signal,
+                         bool isPin1) noexcept;
 
   // General Methods
   void generate();
@@ -114,11 +132,14 @@ public:
 
 private:
   // Private Methods
-  void setCurrentAttributes(Function apertureFunction,
-                            const tl::optional<QString>& netName,
-                            const QString& componentDesignator,
-                            const QString& pinName,
-                            const QString& pinSignal) noexcept;
+  void setCurrentAttributes(
+      Function apertureFunction, const tl::optional<QString>& netName,
+      const QString& componentDesignator, const QString& pinName,
+      const QString& pinSignal, const QString& componentValue,
+      const tl::optional<MountType>& componentMountType,
+      const QString& componentManufacturer, const QString& componentMpn,
+      const QString& componentFootprint,
+      const tl::optional<Angle>& componentRotation) noexcept;
   void setCurrentAperture(int number) noexcept;
   void setRegionModeOn() noexcept;
   void setRegionModeOff() noexcept;

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -64,11 +64,9 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BoardGerberExport::BoardGerberExport(
-    const Board& board, const BoardFabricationOutputSettings& settings) noexcept
+BoardGerberExport::BoardGerberExport(const Board& board) noexcept
   : mProject(board.getProject()),
     mBoard(board),
-    mSettings(new BoardFabricationOutputSettings(settings)),
     mCreationDateTime(QDateTime::currentDateTime()),
     mProjectName(*mProject.getMetadata().getName()),
     mCurrentInnerCopperLayer(0) {
@@ -86,36 +84,39 @@ BoardGerberExport::~BoardGerberExport() noexcept {
  *  Getters
  ******************************************************************************/
 
-FilePath BoardGerberExport::getOutputDirectory() const noexcept {
-  return getOutputFilePath("dummy").getParentDir();  // use dummy suffix
+FilePath BoardGerberExport::getOutputDirectory(
+    const BoardFabricationOutputSettings& settings) const noexcept {
+  return getOutputFilePath(settings.getOutputBasePath() + "dummy")
+      .getParentDir();  // use dummy suffix
 }
 
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
 
-void BoardGerberExport::exportAllLayers() const {
+void BoardGerberExport::exportPcbLayers(
+    const BoardFabricationOutputSettings& settings) const {
   mWrittenFiles.clear();
 
-  if (mSettings->getMergeDrillFiles()) {
-    exportDrills();
+  if (settings.getMergeDrillFiles()) {
+    exportDrills(settings);
   } else {
-    exportDrillsNpth();
-    exportDrillsPth();
+    exportDrillsNpth(settings);
+    exportDrillsPth(settings);
   }
-  exportLayerBoardOutlines();
-  exportLayerTopCopper();
-  exportLayerInnerCopper();
-  exportLayerBottomCopper();
-  exportLayerTopSolderMask();
-  exportLayerBottomSolderMask();
-  exportLayerTopSilkscreen();
-  exportLayerBottomSilkscreen();
-  if (mSettings->getEnableSolderPasteTop()) {
-    exportLayerTopSolderPaste();
+  exportLayerBoardOutlines(settings);
+  exportLayerTopCopper(settings);
+  exportLayerInnerCopper(settings);
+  exportLayerBottomCopper(settings);
+  exportLayerTopSolderMask(settings);
+  exportLayerBottomSolderMask(settings);
+  exportLayerTopSilkscreen(settings);
+  exportLayerBottomSilkscreen(settings);
+  if (settings.getEnableSolderPasteTop()) {
+    exportLayerTopSolderPaste(settings);
   }
-  if (mSettings->getEnableSolderPasteBot()) {
-    exportLayerBottomSolderPaste();
+  if (settings.getEnableSolderPasteBot()) {
+    exportLayerBottomSolderPaste(settings);
   }
 }
 
@@ -141,8 +142,10 @@ QVector<const AttributeProvider*>
  *  Private Methods
  ******************************************************************************/
 
-void BoardGerberExport::exportDrills() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixDrills());
+void BoardGerberExport::exportDrills(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixDrills());
   ExcellonGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                         mProject.getMetadata().getVersion(),
                         ExcellonGenerator::Plating::Mixed, 1,
@@ -154,8 +157,10 @@ void BoardGerberExport::exportDrills() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportDrillsNpth() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixDrillsNpth());
+void BoardGerberExport::exportDrillsNpth(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixDrillsNpth());
   ExcellonGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                         mProject.getMetadata().getVersion(),
                         ExcellonGenerator::Plating::No, 1,
@@ -172,8 +177,10 @@ void BoardGerberExport::exportDrillsNpth() const {
   }
 }
 
-void BoardGerberExport::exportDrillsPth() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixDrillsPth());
+void BoardGerberExport::exportDrillsPth(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixDrillsPth());
   ExcellonGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                         mProject.getMetadata().getVersion(),
                         ExcellonGenerator::Plating::Yes, 1,
@@ -184,8 +191,10 @@ void BoardGerberExport::exportDrillsPth() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportLayerBoardOutlines() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixOutlines());
+void BoardGerberExport::exportLayerBoardOutlines(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixOutlines());
   GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                       mProject.getMetadata().getVersion());
   gen.setFileFunctionOutlines(false);
@@ -195,8 +204,10 @@ void BoardGerberExport::exportLayerBoardOutlines() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportLayerTopCopper() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixCopperTop());
+void BoardGerberExport::exportLayerTopCopper(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixCopperTop());
   GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                       mProject.getMetadata().getVersion());
   gen.setFileFunctionCopper(1, GerberGenerator::CopperSide::Top,
@@ -207,8 +218,10 @@ void BoardGerberExport::exportLayerTopCopper() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportLayerBottomCopper() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixCopperBot());
+void BoardGerberExport::exportLayerBottomCopper(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixCopperBot());
   GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                       mProject.getMetadata().getVersion());
   gen.setFileFunctionCopper(mBoard.getLayerStack().getInnerLayerCount() + 2,
@@ -220,10 +233,12 @@ void BoardGerberExport::exportLayerBottomCopper() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportLayerInnerCopper() const {
+void BoardGerberExport::exportLayerInnerCopper(
+    const BoardFabricationOutputSettings& settings) const {
   for (int i = 1; i <= mBoard.getLayerStack().getInnerLayerCount(); ++i) {
     mCurrentInnerCopperLayer = i;  // used for attribute provider
-    FilePath fp = getOutputFilePath(mSettings->getSuffixCopperInner());
+    FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                    settings.getSuffixCopperInner());
     GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                         mProject.getMetadata().getVersion());
     gen.setFileFunctionCopper(i + 1, GerberGenerator::CopperSide::Inner,
@@ -236,8 +251,10 @@ void BoardGerberExport::exportLayerInnerCopper() const {
   mCurrentInnerCopperLayer = 0;
 }
 
-void BoardGerberExport::exportLayerTopSolderMask() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixSolderMaskTop());
+void BoardGerberExport::exportLayerTopSolderMask(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixSolderMaskTop());
   GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                       mProject.getMetadata().getVersion());
   gen.setFileFunctionSolderMask(GerberGenerator::BoardSide::Top,
@@ -248,8 +265,10 @@ void BoardGerberExport::exportLayerTopSolderMask() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportLayerBottomSolderMask() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixSolderMaskBot());
+void BoardGerberExport::exportLayerBottomSolderMask(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixSolderMaskBot());
   GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                       mProject.getMetadata().getVersion());
   gen.setFileFunctionSolderMask(GerberGenerator::BoardSide::Bottom,
@@ -260,11 +279,13 @@ void BoardGerberExport::exportLayerBottomSolderMask() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportLayerTopSilkscreen() const {
-  QStringList layers = mSettings->getSilkscreenLayersTop();
+void BoardGerberExport::exportLayerTopSilkscreen(
+    const BoardFabricationOutputSettings& settings) const {
+  QStringList layers = settings.getSilkscreenLayersTop();
   if (layers.count() >
       0) {  // don't create silkscreen file if no layers selected
-    FilePath fp = getOutputFilePath(mSettings->getSuffixSilkscreenTop());
+    FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                    settings.getSuffixSilkscreenTop());
     GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                         mProject.getMetadata().getVersion());
     gen.setFileFunctionLegend(GerberGenerator::BoardSide::Top,
@@ -278,11 +299,13 @@ void BoardGerberExport::exportLayerTopSilkscreen() const {
   }
 }
 
-void BoardGerberExport::exportLayerBottomSilkscreen() const {
-  QStringList layers = mSettings->getSilkscreenLayersBot();
+void BoardGerberExport::exportLayerBottomSilkscreen(
+    const BoardFabricationOutputSettings& settings) const {
+  QStringList layers = settings.getSilkscreenLayersBot();
   if (layers.count() >
       0) {  // don't create silkscreen file if no layers selected
-    FilePath fp = getOutputFilePath(mSettings->getSuffixSilkscreenBot());
+    FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                    settings.getSuffixSilkscreenBot());
     GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                         mProject.getMetadata().getVersion());
     gen.setFileFunctionLegend(GerberGenerator::BoardSide::Bottom,
@@ -296,8 +319,10 @@ void BoardGerberExport::exportLayerBottomSilkscreen() const {
   }
 }
 
-void BoardGerberExport::exportLayerTopSolderPaste() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixSolderPasteTop());
+void BoardGerberExport::exportLayerTopSolderPaste(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixSolderPasteTop());
   GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                       mProject.getMetadata().getVersion());
   gen.setFileFunctionPaste(GerberGenerator::BoardSide::Top,
@@ -308,8 +333,10 @@ void BoardGerberExport::exportLayerTopSolderPaste() const {
   mWrittenFiles.append(fp);
 }
 
-void BoardGerberExport::exportLayerBottomSolderPaste() const {
-  FilePath fp = getOutputFilePath(mSettings->getSuffixSolderPasteBot());
+void BoardGerberExport::exportLayerBottomSolderPaste(
+    const BoardFabricationOutputSettings& settings) const {
+  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                  settings.getSuffixSolderPasteBot());
   GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
                       mProject.getMetadata().getVersion());
   gen.setFileFunctionPaste(GerberGenerator::BoardSide::Bottom,
@@ -669,9 +696,7 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator& gen,
   }
 }
 
-FilePath BoardGerberExport::getOutputFilePath(const QString& suffix) const
-    noexcept {
-  QString path = mSettings->getOutputBasePath() + suffix;
+FilePath BoardGerberExport::getOutputFilePath(QString path) const noexcept {
   path = AttributeSubstitutor::substitute(path, this, [&](const QString& str) {
     return FilePath::cleanFileName(
         str, FilePath::ReplaceSpaces | FilePath::KeepCase);

--- a/libs/librepcb/core/project/board/boardgerberexport.h
+++ b/libs/librepcb/core/project/board/boardgerberexport.h
@@ -61,18 +61,18 @@ public:
   // Constructors / Destructor
   BoardGerberExport() = delete;
   BoardGerberExport(const BoardGerberExport& other) = delete;
-  BoardGerberExport(const Board& board,
-                    const BoardFabricationOutputSettings& settings) noexcept;
+  explicit BoardGerberExport(const Board& board) noexcept;
   ~BoardGerberExport() noexcept;
 
   // Getters
-  FilePath getOutputDirectory() const noexcept;
+  FilePath getOutputDirectory(
+      const BoardFabricationOutputSettings& settings) const noexcept;
   const QVector<FilePath>& getWrittenFiles() const noexcept {
     return mWrittenFiles;
   }
 
   // General Methods
-  void exportAllLayers() const;
+  void exportPcbLayers(const BoardFabricationOutputSettings& settings) const;
 
   // Inherited from AttributeProvider
   /// @copydoc ::librepcb::AttributeProvider::getBuiltInAttributeValue()
@@ -89,19 +89,29 @@ signals:
 
 private:
   // Private Methods
-  void exportDrills() const;
-  void exportDrillsNpth() const;
-  void exportDrillsPth() const;
-  void exportLayerBoardOutlines() const;
-  void exportLayerTopCopper() const;
-  void exportLayerInnerCopper() const;
-  void exportLayerBottomCopper() const;
-  void exportLayerTopSolderMask() const;
-  void exportLayerBottomSolderMask() const;
-  void exportLayerTopSilkscreen() const;
-  void exportLayerBottomSilkscreen() const;
-  void exportLayerTopSolderPaste() const;
-  void exportLayerBottomSolderPaste() const;
+  void exportDrills(const BoardFabricationOutputSettings& settings) const;
+  void exportDrillsNpth(const BoardFabricationOutputSettings& settings) const;
+  void exportDrillsPth(const BoardFabricationOutputSettings& settings) const;
+  void exportLayerBoardOutlines(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerTopCopper(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerInnerCopper(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerBottomCopper(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerTopSolderMask(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerBottomSolderMask(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerTopSilkscreen(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerBottomSilkscreen(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerTopSolderPaste(
+      const BoardFabricationOutputSettings& settings) const;
+  void exportLayerBottomSolderPaste(
+      const BoardFabricationOutputSettings& settings) const;
 
   int drawNpthDrills(ExcellonGenerator& gen) const;
   int drawPthDrills(ExcellonGenerator& gen) const;
@@ -113,7 +123,7 @@ private:
   void drawFootprintPad(GerberGenerator& gen, const BI_FootprintPad& pad,
                         const QString& layerName) const;
 
-  FilePath getOutputFilePath(const QString& suffix) const noexcept;
+  FilePath getOutputFilePath(QString path) const noexcept;
 
   // Static Methods
   static UnsignedLength calcWidthOfLayer(const UnsignedLength& width,
@@ -131,7 +141,6 @@ private:
   // Private Member Variables
   const Project& mProject;
   const Board& mBoard;
-  QScopedPointer<const BoardFabricationOutputSettings> mSettings;
   QDateTime mCreationDateTime;
   QString mProjectName;
   mutable int mCurrentInnerCopperLayer;

--- a/libs/librepcb/core/project/board/boardgerberexport.h
+++ b/libs/librepcb/core/project/board/boardgerberexport.h
@@ -58,6 +58,8 @@ class BoardGerberExport final : public QObject, public AttributeProvider {
   Q_OBJECT
 
 public:
+  enum class BoardSide { Top, Bottom };
+
   // Constructors / Destructor
   BoardGerberExport() = delete;
   BoardGerberExport(const BoardGerberExport& other) = delete;
@@ -73,6 +75,7 @@ public:
 
   // General Methods
   void exportPcbLayers(const BoardFabricationOutputSettings& settings) const;
+  void exportComponentLayer(BoardSide side, const FilePath& filePath) const;
 
   // Inherited from AttributeProvider
   /// @copydoc ::librepcb::AttributeProvider::getBuiltInAttributeValue()

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -407,7 +407,8 @@ void BoardEditor::createActions() noexcept {
   mActionGeneratePickPlace.reset(
       cmd.generatePickPlace.createAction(this, this, [this]() {
         if (Board* board = getActiveBoard()) {
-          BoardPickPlaceGeneratorDialog dialog(*board);
+          BoardPickPlaceGeneratorDialog dialog(
+              mProjectEditor.getWorkspace().getSettings(), *board);
           dialog.exec();
         }
       }));

--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.h
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.h
@@ -37,6 +37,7 @@ namespace librepcb {
 
 class Board;
 class PickPlaceData;
+class WorkspaceSettings;
 
 namespace editor {
 
@@ -59,11 +60,13 @@ public:
   BoardPickPlaceGeneratorDialog() = delete;
   BoardPickPlaceGeneratorDialog(const BoardPickPlaceGeneratorDialog& other) =
       delete;
-  explicit BoardPickPlaceGeneratorDialog(Board& board,
+  explicit BoardPickPlaceGeneratorDialog(const WorkspaceSettings& settings,
+                                         Board& board,
                                          QWidget* parent = nullptr);
   ~BoardPickPlaceGeneratorDialog();
 
 private:  // Methods
+  void setFileExtension(const QString& extension) noexcept;
   void btnGenerateClicked() noexcept;
   void updateTable() noexcept;
   FilePath getOutputFilePath(const QString& text) const noexcept;
@@ -72,6 +75,7 @@ private:  // Data
   Board& mBoard;
   std::shared_ptr<PickPlaceData> mData;
   QScopedPointer<Ui::BoardPickPlaceGeneratorDialog> mUi;
+  QPointer<QPushButton> mBtnGenerate;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.ui
@@ -29,6 +29,66 @@
     </widget>
    </item>
    <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Format:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QRadioButton" name="rbtnFormatCsvWithMetadata">
+       <property name="text">
+        <string>CSV with metadata*</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbtnFormatCsvWithoutMetadata">
+       <property name="text">
+        <string>CSV without metadata</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbtnFormatGerberX3">
+       <property name="text">
+        <string>Gerber X3</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="label_3">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>*) Adds additional information to the files, but might cause issues with some CSV readers.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QCheckBox" name="cbxTopDevices">
      <property name="text">
       <string>Top Devices:</string>
@@ -38,7 +98,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="edtTopFilePath"/>
+   </item>
+   <item row="4" column="0">
     <widget class="QCheckBox" name="cbxBottomDevices">
      <property name="text">
       <string>Bottom Devices:</string>
@@ -48,10 +111,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="4" column="1">
     <widget class="QLineEdit" name="edtBottomFilePath"/>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QTableWidget" name="tableWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -61,38 +124,26 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="edtTopFilePath"/>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QCheckBox" name="cbxIncludeComment">
-     <property name="text">
-      <string>Include comment with some metadata (provides additional information, but might cause issues with some CSV readers)</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lblSuccess">
-     <property name="text">
-      <string>Success!</string>
-     </property>
-     <property name="indent">
-      <number>6</number>
-     </property>
-    </widget>
+   <item row="8" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="btnBrowseOutputDir">
+       <property name="text">
+        <string>Browse Output Directory</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -173,16 +173,17 @@ void FabricationOutputDialog::on_btnGenerate_clicked() {
     }
 
     // generate files
-    BoardGerberExport grbExport(mBoard, mBoard.getFabricationOutputSettings());
-    grbExport.exportAllLayers();
+    BoardGerberExport grbExport(mBoard);
+    grbExport.exportPcbLayers(mBoard.getFabricationOutputSettings());
   } catch (Exception& e) {
     QMessageBox::warning(this, tr("Error"), e.getMsg());
   }
 }
 
 void FabricationOutputDialog::on_btnBrowseOutputDir_clicked() {
-  BoardGerberExport grbExport(mBoard, mBoard.getFabricationOutputSettings());
-  FilePath dir = grbExport.getOutputDirectory();
+  BoardGerberExport grbExport(mBoard);
+  FilePath dir =
+      grbExport.getOutputDirectory(mBoard.getFabricationOutputSettings());
   if (dir.isExistingDir()) {
     DesktopServices ds(mSettings, this);
     ds.openLocalPath(dir);

--- a/tests/unittests/core/export/gerberaperturelisttest.cpp
+++ b/tests/unittests/core/export/gerberaperturelisttest.cpp
@@ -863,6 +863,34 @@ TEST_F(GerberApertureListTest, testWideOctagon100deg) {
   }
 }
 
+TEST_F(GerberApertureListTest, testComponentMain) {
+  GerberApertureList l;
+
+  // Note: The Gerber specs require exactly this aperture shape!!!
+  const char* expected =
+      "G04 #@! TA.AperFunction,ComponentMain*\n"
+      "%ADD10C,0.3*%\n"
+      "G04 #@! TD*\n";
+
+  EXPECT_EQ(10, l.addComponentMain());
+  EXPECT_EQ(expected, l.generateString().toStdString());
+}
+
+TEST_F(GerberApertureListTest, testComponentPin) {
+  GerberApertureList l;
+
+  // Note: The Gerber specs require exactly this aperture shape!!!
+  const char* expected =
+      "G04 #@! TA.AperFunction,ComponentPin*\n"
+      "%ADD10C,0*%\n"
+      "%ADD11P,0.36X4X0.0*%\n"
+      "G04 #@! TD*\n";
+
+  EXPECT_EQ(10, l.addComponentPin(false));
+  EXPECT_EQ(11, l.addComponentPin(true));
+  EXPECT_EQ(expected, l.generateString().toStdString());
+}
+
 /*******************************************************************************
  *  End of File
  ******************************************************************************/

--- a/tests/unittests/core/export/gerberattributetest.cpp
+++ b/tests/unittests/core/export/gerberattributetest.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include <librepcb/core/export/gerberattribute.h>
+#include <librepcb/core/types/angle.h>
 #include <librepcb/core/types/uuid.h>
 
 #include <QtCore>
@@ -309,6 +310,66 @@ TEST_F(GerberAttributeTest, testObjectPin) {
                 .toStdString());
   EXPECT_EQ("G04 #@! TO.P,C7,42,VCC*\n",
             GerberAttribute::objectPin("C7", "42", "VCC")
+                .toGerberString()
+                .toStdString());
+}
+
+TEST_F(GerberAttributeTest, testComponentRotation) {
+  EXPECT_EQ("G04 #@! TO.CRot,-90.0*\n",
+            GerberAttribute::componentRotation(-Angle::deg90())
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TO.CRot,0.123456*\n",
+            GerberAttribute::componentRotation(Angle(123456))
+                .toGerberString()
+                .toStdString());
+}
+
+TEST_F(GerberAttributeTest, testComponentManufacturer) {
+  EXPECT_EQ("G04 #@! TO.CMfr,Foo \u00E4 \\u005C \\u0025 \\u002A \\u002C*\n",
+            GerberAttribute::componentManufacturer("Foo\n\u00E4\r\n\\ % * ,")
+                .toGerberString()
+                .toStdString());
+}
+
+TEST_F(GerberAttributeTest, testComponentMpn) {
+  EXPECT_EQ("G04 #@! TO.CMPN,Foo \u00E4 \\u005C \\u0025 \\u002A \\u002C*\n",
+            GerberAttribute::componentMpn("Foo\n\u00E4\r\n\\ % * ,")
+                .toGerberString()
+                .toStdString());
+}
+
+TEST_F(GerberAttributeTest, testComponentValue) {
+  EXPECT_EQ("G04 #@! TO.CVal,Foo \u00E4 \\u005C \\u0025 \\u002A \\u002C*\n",
+            GerberAttribute::componentValue("Foo\n\u00E4\r\n\\ % * ,")
+                .toGerberString()
+                .toStdString());
+}
+
+TEST_F(GerberAttributeTest, testComponentMountType) {
+  EXPECT_EQ("G04 #@! TO.CMnt,TH*\n",
+            GerberAttribute::componentMountType(GerberAttribute::MountType::Tht)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TO.CMnt,SMD*\n",
+            GerberAttribute::componentMountType(GerberAttribute::MountType::Smt)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ(
+      "G04 #@! TO.CMnt,Fiducial*\n",
+      GerberAttribute::componentMountType(GerberAttribute::MountType::Fiducial)
+          .toGerberString()
+          .toStdString());
+  EXPECT_EQ(
+      "G04 #@! TO.CMnt,Other*\n",
+      GerberAttribute::componentMountType(GerberAttribute::MountType::Other)
+          .toGerberString()
+          .toStdString());
+}
+
+TEST_F(GerberAttributeTest, testComponentFootprint) {
+  EXPECT_EQ("G04 #@! TO.CFtp,Foo \u00E4 \\u005C \\u0025 \\u002A \\u002C*\n",
+            GerberAttribute::componentFootprint("Foo\n\u00E4\r\n\\ % * ,")
                 .toGerberString()
                 .toStdString());
 }

--- a/tests/unittests/core/project/board/boardgerberexporttest.cpp
+++ b/tests/unittests/core/project/board/boardgerberexporttest.cpp
@@ -83,6 +83,12 @@ TEST(BoardGerberExportTest, test) {
                            "/{{PROJECT}}");
   BoardGerberExport grbExport(*board);
   grbExport.exportPcbLayers(config);
+  grbExport.exportComponentLayer(
+      BoardGerberExport::BoardSide::Top,
+      testDataDir.getPathTo("actual/test_project_ASSEMBLY-TOP.gbr"));
+  grbExport.exportComponentLayer(
+      BoardGerberExport::BoardSide::Bottom,
+      testDataDir.getPathTo("actual/test_project_ASSEMBLY-BOTTOM.gbr"));
 
   // replace volatile data in exported files with well-known, constant data
   foreach (const FilePath& fp, grbExport.getWrittenFiles()) {

--- a/tests/unittests/core/project/board/boardgerberexporttest.cpp
+++ b/tests/unittests/core/project/board/boardgerberexporttest.cpp
@@ -81,8 +81,8 @@ TEST(BoardGerberExportTest, test) {
   BoardFabricationOutputSettings config = board->getFabricationOutputSettings();
   config.setOutputBasePath(testDataDir.getPathTo("actual").toStr() %
                            "/{{PROJECT}}");
-  BoardGerberExport grbExport(*board, config);
-  grbExport.exportAllLayers();
+  BoardGerberExport grbExport(*board);
+  grbExport.exportPcbLayers(config);
 
   // replace volatile data in exported files with well-known, constant data
   foreach (const FilePath& fp, grbExport.getWrittenFiles()) {


### PR DESCRIPTION
In addition to the existing CSV pick&place export, this PR adds a Gerber X3 pick&place export which is especially useful for automated assembly because it's a standardized format (in contrast to the CSV).

![image](https://user-images.githubusercontent.com/5374821/189353837-e02bd7f3-ec43-459b-874c-88d3d2c3591d.png)

Closes #830