### PR TITLE
Library editor: Fix possible crash when closing tabs

### DIFF
--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_packagepads.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_packagepads.cpp
@@ -67,7 +67,7 @@ int NewElementWizardPage_PackagePads::nextId() const noexcept {
 
 void NewElementWizardPage_PackagePads::initializePage() noexcept {
   QWizardPage::initializePage();
-  mUi->padListEditorWidget->setReferences(mContext.mPackagePads, nullptr);
+  mUi->padListEditorWidget->setReferences(&mContext.mPackagePads, nullptr);
 }
 
 void NewElementWizardPage_PackagePads::cleanupPage() noexcept {

--- a/libs/librepcb/editor/library/pkg/footprintlisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintlisteditorwidget.cpp
@@ -78,10 +78,10 @@ void FootprintListEditorWidget::setReadOnly(bool readOnly) noexcept {
   mView->setReadOnly(readOnly);
 }
 
-void FootprintListEditorWidget::setReferences(FootprintList& list,
-                                              UndoStack& stack) noexcept {
-  mModel->setFootprintList(&list);
-  mModel->setUndoStack(&stack);
+void FootprintListEditorWidget::setReferences(FootprintList* list,
+                                              UndoStack* stack) noexcept {
+  mModel->setFootprintList(list);
+  mModel->setUndoStack(stack);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/pkg/footprintlisteditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/footprintlisteditorwidget.h
@@ -56,7 +56,7 @@ public:
 
   // Setters
   void setReadOnly(bool readOnly) noexcept;
-  void setReferences(FootprintList& list, UndoStack& stack) noexcept;
+  void setReferences(FootprintList* list, UndoStack* stack) noexcept;
 
   // Operator Overloadings
   FootprintListEditorWidget& operator=(const FootprintListEditorWidget& rhs) =

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.h
@@ -131,11 +131,13 @@ private:  // Data
   QScopedPointer<CategoryListEditorWidget> mCategoriesEditorWidget;
   QScopedPointer<GraphicsScene> mGraphicsScene;
   QScopedPointer<Package> mPackage;
-  QScopedPointer<PackageEditorFsm> mFsm;
 
   // broken interface detection
   QSet<Uuid> mOriginalPadUuids;
   FootprintList mOriginalFootprints;
+
+  /// Editor state machine
+  QScopedPointer<PackageEditorFsm> mFsm;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/pkg/packagepadlisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packagepadlisteditorwidget.cpp
@@ -73,9 +73,9 @@ void PackagePadListEditorWidget::setReadOnly(bool readOnly) noexcept {
   mView->setReadOnly(readOnly);
 }
 
-void PackagePadListEditorWidget::setReferences(PackagePadList& list,
+void PackagePadListEditorWidget::setReferences(PackagePadList* list,
                                                UndoStack* stack) noexcept {
-  mModel->setPadList(&list);
+  mModel->setPadList(list);
   mModel->setUndoStack(stack);
 }
 

--- a/libs/librepcb/editor/library/pkg/packagepadlisteditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/packagepadlisteditorwidget.h
@@ -57,7 +57,7 @@ public:
 
   // Setters
   void setReadOnly(bool readOnly) noexcept;
-  void setReferences(PackagePadList& list, UndoStack* stack) noexcept;
+  void setReferences(PackagePadList* list, UndoStack* stack) noexcept;
 
   // Operator Overloadings
   PackagePadListEditorWidget& operator=(const PackagePadListEditorWidget& rhs) =

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
@@ -162,6 +162,14 @@ SymbolEditorWidget::SymbolEditorWidget(const Context& context,
 }
 
 SymbolEditorWidget::~SymbolEditorWidget() noexcept {
+  // Clean up the state machine nicely to avoid unexpected behavior. Triggering
+  // abort (Esc) two times is usually sufficient to leave any active tool, so
+  // let's call it three times to be on the safe side. Unfortunately there's
+  // no clean way to forcible and guaranteed leaving a tool.
+  mFsm->processAbortCommand();
+  mFsm->processAbortCommand();
+  mFsm->processAbortCommand();
+  mFsm.reset();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.h
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.h
@@ -127,10 +127,12 @@ private:  // Data
   QScopedPointer<GraphicsScene> mGraphicsScene;
   QScopedPointer<Symbol> mSymbol;
   QScopedPointer<SymbolGraphicsItem> mGraphicsItem;
-  QScopedPointer<SymbolEditorFsm> mFsm;
 
-  // broken interface detection
+  /// Broken interface detection
   QSet<Uuid> mOriginalSymbolPinUuids;
+
+  /// Editor state machine
+  QScopedPointer<SymbolEditorFsm> mFsm;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
If a command was active while closing a library editor tab, in some cases it could lead to a crash due to unintended recursion during object destruction (at least in the symbol editor). Fixed by a more explicit cleanup procedure.