### PR TITLE
Gerber export: Generate NPTH drill file even if empty

### DIFF
--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -286,16 +286,18 @@ void BoardGerberExport::exportDrillsNpth(
                         mProject.getMetadata().getVersion(),
                         ExcellonGenerator::Plating::No, 1,
                         mBoard.getLayerStack().getInnerLayerCount() + 2);
-  int count = drawNpthDrills(gen);
-  if (count > 0) {
-    // Some PCB manufacturers don't like to have separate drill files for PTH
-    // and NPTH. As many boards don't have non-plated holes anyway, we create
-    // this file only if it's really needed. Maybe this avoids unnecessary
-    // issues with manufacturers...
-    gen.generate();
-    gen.saveToFile(fp);
-    mWrittenFiles.append(fp);
-  }
+  drawNpthDrills(gen);
+
+  // Note that separate NPTH drill files could lead to issues with some PCB
+  // manufacturers, even if it's empty in many cases. However, we generate the
+  // NPTH file even if there are no NPTH drills since it could also lead to
+  // unexpected behavior if the file is generated only conditionally. See
+  // https://github.com/LibrePCB/LibrePCB/issues/998. If the PCB manufacturer
+  // doesn't support a separate NPTH file, the user shall enable the
+  // "merge PTH and NPTH drills"  option.
+  gen.generate();
+  gen.saveToFile(fp);
+  mWrittenFiles.append(fp);
 }
 
 void BoardGerberExport::exportDrillsPth(

--- a/tests/cli/open-project/test_everything.py
+++ b/tests/cli/open-project/test_everything.py
@@ -68,7 +68,7 @@ def test_everything(cli, project):
 
     # check "--export-pcb-fabrication-data"
     assert os.path.exists(gerber_dir)
-    assert len(os.listdir(gerber_dir)) == project.board_count * 8
+    assert len(os.listdir(gerber_dir)) == project.board_count * 9
 
     # check "--save"
     assert os.path.getsize(path) != original_filesize

--- a/tests/cli/open-project/test_export_pcb_fabrication_data.py
+++ b/tests/cli/open-project/test_export_pcb_fabrication_data.py
@@ -50,7 +50,7 @@ def test_export_project_with_one_board_implicit(cli, project):
     assert len(stdout) > 0
     assert stdout[-1] == 'SUCCESS'
     assert os.path.exists(dir)
-    assert len(os.listdir(dir)) == 8
+    assert len(os.listdir(dir)) == 9
 
 
 @pytest.mark.parametrize("project", [
@@ -70,7 +70,7 @@ def test_export_project_with_one_board_explicit(cli, project):
     assert len(stdout) > 0
     assert stdout[-1] == 'SUCCESS'
     assert os.path.exists(dir)
-    assert len(os.listdir(dir)) == 8
+    assert len(os.listdir(dir)) == 9
 
 
 @pytest.mark.parametrize("project", [
@@ -109,7 +109,7 @@ def test_export_project_with_two_boards_implicit(cli, project):
     assert len(stdout) > 0
     assert stdout[-1] == 'SUCCESS'
     assert os.path.exists(dir)
-    assert len(os.listdir(dir)) == 16
+    assert len(os.listdir(dir)) == 18
 
 
 @pytest.mark.parametrize("project", [
@@ -129,7 +129,7 @@ def test_export_project_with_two_boards_explicit_one(cli, project):
     assert len(stdout) > 0
     assert stdout[-1] == 'SUCCESS'
     assert os.path.exists(dir)
-    assert len(os.listdir(dir)) == 8
+    assert len(os.listdir(dir)) == 9
 
 
 @pytest.mark.parametrize("project", [
@@ -150,7 +150,7 @@ def test_export_project_with_two_boards_explicit_two(cli, project):
     assert len(stdout) > 0
     assert stdout[-1] == 'SUCCESS'
     assert os.path.exists(dir)
-    assert len(os.listdir(dir)) == 16
+    assert len(os.listdir(dir)) == 18
 
 
 @pytest.mark.parametrize("project", [
@@ -199,7 +199,7 @@ def test_export_project_with_two_conflicting_boards_succeeds_explicit(cli, proje
     assert len(stdout) > 0
     assert stdout[-1] == 'SUCCESS'
     assert os.path.exists(dir)
-    assert len(os.listdir(dir)) == 8
+    assert len(os.listdir(dir)) == 9
 
 
 @pytest.mark.parametrize("project", [


### PR DESCRIPTION
Always generate the NPTH drill file, even if there are no NPTH drills. This avoids possibly outdated NPTH drill files after removing drills from the board. If the separate drill file causes issues with PCB manufacturers, the "merge PTH and NPTH drill files" option should be used. See #998.

Fixes #998.