### PR TITLE
CMake: Fix & improve unbundling of GTest/GMock

### DIFF
--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -19,9 +19,9 @@ jobs:
         CC: clang
         CXX: clang++
       Ubuntu_2004_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-6
+        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-7
       Ubuntu_2004_Unbundled:
-        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-6
+        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-7
         UNBUNDLE_DXFLIB: true
         UNBUNDLE_MUPARSER: true
         #UNBUNDLE_QUAZIP: true  # Note: Does not ship quazip 1.x yet

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -23,6 +23,7 @@ jobs:
       Ubuntu_2004_Unbundled:
         IMAGE: librepcb/librepcb-dev:ubuntu-20.04-7
         UNBUNDLE_DXFLIB: true
+        UNBUNDLE_GTEST: true
         UNBUNDLE_MUPARSER: true
         #UNBUNDLE_QUAZIP: true  # Note: Does not ship quazip 1.x yet
         UNBUNDLE_POLYCLIPPING: true
@@ -44,6 +45,9 @@ jobs:
   - bash: rm -rf libs/dxflib
     displayName: Remove bundled dxflib lib
     condition: and(succeeded(), eq(variables['UNBUNDLE_DXFLIB'], 'true'))
+  - bash: rm -rf libs/googletest
+    displayName: Remove bundled googletest lib
+    condition: and(succeeded(), eq(variables['UNBUNDLE_GTEST'], 'true'))
   - bash: rm -rf libs/muparser
     displayName: Remove bundled muparser lib
     condition: and(succeeded(), eq(variables['UNBUNDLE_MUPARSER'], 'true'))

--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -20,11 +20,21 @@ if(EXISTS "${GTEST_SUBMODULE_BASEPATH}"
 endif()
 
 # Otherwise, try to find shared library on the system
+# Note: GMock might be contained within the GTest package, so we don't fail
+#       if the GMock package was not found. We just try to create the alias.
 
-find_package(GTest)
-find_package(GMock)
-if(GTest_FOUND AND GMock_FOUND)
+find_package(GTest CONFIG)
+find_package(GMock CONFIG)
+if(GTest_FOUND)
   message(STATUS "Using system GoogleTest / GoogleMock")
+
+  # Add uppercase alias if only the lowercase target is defined
+  if(NOT TARGET GTest::GTest)
+    add_library(GTest::GTest ALIAS GTest::gtest)
+  endif()
+  if(NOT TARGET GTest::GMock)
+    add_library(GTest::GMock ALIAS GTest::gmock)
+  endif()
 
   # Stop here, we're done
   return()

--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -40,4 +40,17 @@ if(GTest_FOUND)
   return()
 endif()
 
+# Otherwise, try to find shared library on the system via pkg-config
+find_package(PkgConfig QUIET)
+if(PKGCONFIG_FOUND)
+  pkg_check_modules(GTest GLOBAL IMPORTED_TARGET gtest)
+  pkg_check_modules(GMock GLOBAL IMPORTED_TARGET gmock)
+endif()
+if(GTest_FOUND)
+  message(STATUS "Using system GTest / GMock (via pkg-config)")
+  add_library(GTest::GTest ALIAS PkgConfig::GTest)
+  add_library(GTest::GMock ALIAS PkgConfig::GMock)
+  return()
+endif()
+
 message(FATAL_ERROR "Did not find GoogleTest / GoogleMock system libraries")

--- a/dev/doxygen/pages/building.md
+++ b/dev/doxygen/pages/building.md
@@ -135,7 +135,7 @@ Right now, the following libraries can be unbundled:
 | [fontobene-qt5] | `UNBUNDLE_FONTOBENE_QT5` | `pkg-config`, `find_path` |
 | [googletest] | `UNBUNDLE_GTEST` | `cmake`, `pkg-config` |
 | [hoedown] ¹ | `UNBUNDLE_HOEDOWN` | `pkg-config` |
-| [muparser] | `UNBUNDLE_MUPARSER` | `cmake` |
+| [muparser] | `UNBUNDLE_MUPARSER` | `cmake`, `pkg-config` |
 | [polyclipping] | `UNBUNDLE_POLYCLIPPING` | `pkg-config` |
 | [quazip] ² | `UNBUNDLE_QUAZIP` | `cmake` |
 

--- a/dev/doxygen/pages/building.md
+++ b/dev/doxygen/pages/building.md
@@ -133,7 +133,7 @@ Right now, the following libraries can be unbundled:
 |-|-|-|
 | [dxflib] | `UNBUNDLE_DXFLIB` | `pkg-config` |
 | [fontobene-qt5] | `UNBUNDLE_FONTOBENE_QT5` | `pkg-config`, `find_path` |
-| [googletest] | `UNBUNDLE_GTEST` | `cmake` |
+| [googletest] | `UNBUNDLE_GTEST` | `cmake`, `pkg-config` |
 | [hoedown] ¹ | `UNBUNDLE_HOEDOWN` | `pkg-config` |
 | [muparser] | `UNBUNDLE_MUPARSER` | `cmake` |
 | [polyclipping] | `UNBUNDLE_POLYCLIPPING` | `pkg-config` |

--- a/dev/doxygen/pages/mainpage.md
+++ b/dev/doxygen/pages/mainpage.md
@@ -5,6 +5,7 @@ LibrePCB Developers Documentation {#mainpage}
 
 # Documentation {#doc_main_pages}
 
+- @ref doc_building
 - @ref doc_developers
 - @ref doc_code_style_guide
 - @ref doc_release_workflow


### PR DESCRIPTION
Adding `CONFIG` to the `find_package()` seems to fix the endless recursion which was reported in #933. I don't understand what `CONFIG` means exactly, but at least [in this](https://chromium.googlesource.com/external/github.com/pwnall/googletest/+/HEAD/googletest/README.md) documentation they also do it this way. And local testing shows that this seems to fix the problem.

In addition, I adjusted `FindGTest.cmake` to proceed even if `find_package(GMock)` failed - `find_package(GTest)` should be sufficient since GTest usually also contains GMock, so no separate package is needed for GMock.

I also extended CI to test unbundling of GTest/GMock. However, since Ubuntu doesn't provide a cmake config, I extended `FindGTest.cmake` to also search with `pkg-config` which is then used on Ubuntu. I hope it works (waiting for the pipeline...).

See also the Docker image update: https://github.com/LibrePCB/docker-librepcb-dev/pull/20

Fixes #933