### PR TITLE
CLI: Add open-project option "--remove-other-boards"

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -66,8 +66,8 @@ private:  // Methods
                    const QStringList& exportPnpTopFiles,
                    const QStringList& exportPnpBottomFiles,
                    const QStringList& boardNames,
-                   const QStringList& boardIndices, bool save,
-                   bool strict) const noexcept;
+                   const QStringList& boardIndices, bool removeOtherBoards,
+                   bool save, bool strict) const noexcept;
   bool openLibrary(const QString& libDir, bool all, bool save,
                    bool strict) const noexcept;
   void processLibraryElement(const QString& libDir, TransactionalFileSystem& fs,

--- a/tests/cli/open_project/test_parser.py
+++ b/tests/cli/open_project/test_parser.py
@@ -52,6 +52,12 @@ Options:
                                      boards are exported.
   --board-index <index>              Same as '--board', but allows to specify
                                      boards by index instead of by name.
+  --remove-other-boards              Remove all boards not specified with
+                                     '--board[-index]' from the project before
+                                     executing all the other actions. If
+                                     '--board[-index]' is not passed, all boards
+                                     will be removed. Pass '--save' to save the
+                                     modified project to disk.
   --save                             Save project before closing it (useful to
                                      upgrade file format).
   --strict                           Fail if the project files are not strictly

--- a/tests/cli/open_project/test_remove_other_boards.py
+++ b/tests/cli/open_project/test_remove_other_boards.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import params
+import pytest
+
+"""
+Test command "open-project --remove-other-boards"
+"""
+
+
+@pytest.mark.parametrize("project", [
+    params.PROJECT_WITH_TWO_BOARDS_LPP_PARAM,
+    params.PROJECT_WITH_TWO_BOARDS_LPPZ_PARAM,
+])
+def test_project_with_two_boards_remove_both_volatile(cli, project):
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    # Without passing '--save', the removal is not persistent.
+    for _ in range(2):
+        code, stdout, stderr = cli.run('open-project',
+                                       '--remove-other-boards',
+                                       project.path)
+        assert stderr == ''
+        assert stdout == \
+            "Open project '{project.path}'...\n" \
+            "Remove other boards...\n" \
+            "  - 'default'\n" \
+            "  - 'copy'\n" \
+            "SUCCESS\n".format(project=project)
+        assert code == 0
+
+
+@pytest.mark.parametrize("project", [
+    params.PROJECT_WITH_TWO_BOARDS_LPP_PARAM,
+    params.PROJECT_WITH_TWO_BOARDS_LPPZ_PARAM,
+])
+def test_project_with_two_boards_remove_one_and_save(cli, project):
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    removed_dir = cli.abspath(project.dir + '/boards/default')
+    if not project.is_lppz:
+        assert os.path.exists(removed_dir)
+    code, stdout, stderr = cli.run('open-project',
+                                   '--board=copy',
+                                   '--remove-other-boards',
+                                   '--save',
+                                   project.path)
+    assert stderr == ''
+    assert stdout == \
+        "Open project '{project.path}'...\n" \
+        "Remove other boards...\n" \
+        "  - 'default'\n" \
+        "Save project...\n" \
+        "SUCCESS\n".format(project=project)
+    assert code == 0
+    if not project.is_lppz:
+        assert os.path.exists(removed_dir) is False
+
+    # Open again to check that the removed board is not loaded anymore.
+    code, stdout, stderr = cli.run('open-project',
+                                   '--board=copy',
+                                   '--remove-other-boards',
+                                   project.path)
+    assert stderr == ''
+    assert stdout == \
+        "Open project '{project.path}'...\n" \
+        "Remove other boards...\n" \
+        "SUCCESS\n".format(project=project)
+    assert code == 0


### PR DESCRIPTION
If this flag is passed to the `open-project` command, all boards not specified with `--board` or `--board-index` will be removed from the project. The modified project might then be saved with `--save` to persist the modification.

This feature is probably a bit specific for the fab.librepcb.org use-case, but the implementation is very trivial and helps a lot to make the webservice faster and more robust. So I'd say it's worth to add it to the CLI.

See #999.