### PR TITLE
CI: Patch AppImages with static runtime appimagetool

### DIFF
--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -11,7 +11,7 @@ jobs:
       Ubuntu_1604_GCC:
         IMAGE: librepcb/librepcb-dev:ubuntu-16.04-4
       Ubuntu_1604_Qt_5_15_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.15.2-1
+        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.15.2-2
         DEPLOY: true
         NO_HOEDOWN: true
       Ubuntu_1804_Clang:


### PR DESCRIPTION
Patching our official AppImage binaries with an experimental version of `appimagetool` which now uses a statically linked runtime not depending on `libfuse2` anymore. This makes the AppImages running on Ubuntu 22.04 without needing to install `libfuse2`, and while still working on older distributions. See details in https://github.com/AppImage/AppImageKit/issues/877.

Tested on Ubuntu 22.04, Ubuntu 16.04 and Manjaro - seems to work fine :muscle: 

Docker image update: https://github.com/LibrePCB/docker-librepcb-dev/pull/22

Fixes #980