### PR TITLE
Library manager: Support keyboard navigation in library lists

### DIFF
--- a/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
@@ -62,6 +62,14 @@ AddLibraryWidget::AddLibraryWidget(Workspace& ws) noexcept
   connect(mUi->btnRepoLibsDownload, &QPushButton::clicked, this,
           &AddLibraryWidget::downloadLibrariesFromRepositoryButtonClicked);
 
+  // Hide text in library list since text is displayed with custom item
+  // widgets, but list item texts are still set for keyboard navigation.
+  mUi->lstRepoLibs->setStyleSheet(
+      "QListWidget::item{"
+      "  color: transparent;"
+      "  selection-color: transparent;"
+      "}");
+
   // tab "create local library": set placeholder texts
   mUi->edtLocalName->setPlaceholderText("My Library");
   mUi->edtLocalAuthor->setPlaceholderText(
@@ -360,6 +368,10 @@ void AddLibraryWidget::repositoryLibraryListReceived(
     connect(widget, &RepositoryLibraryListWidgetItem::checkedChanged, this,
             &AddLibraryWidget::repoLibraryDownloadCheckedChanged);
     QListWidgetItem* item = new QListWidgetItem(mUi->lstRepoLibs);
+    // Set item text to make searching by keyboard working (type to find
+    // library). However, the text would mess up the look, thus it is made
+    // hidden with a stylesheet set in the constructor (see above).
+    item->setText(widget->getName());
     item->setSizeHint(widget->sizeHint());
     mUi->lstRepoLibs->setItemWidget(item, widget);
   }

--- a/libs/librepcb/editor/workspace/librarymanager/librarymanager.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/librarymanager.cpp
@@ -58,6 +58,14 @@ LibraryManager::LibraryManager(Workspace& ws, QWidget* parent) noexcept
   connect(mUi->lstLibraries, &QListWidget::currentItemChanged, this,
           &LibraryManager::currentListItemChanged);
 
+  // Hide text in library list since text is displayed with custom item
+  // widgets, but list item texts are still set for keyboard navigation.
+  mUi->lstLibraries->setStyleSheet(
+      "QListWidget::item{"
+      "  color: transparent;"
+      "  selection-color: transparent;"
+      "}");
+
   mAddLibraryWidget.reset(new AddLibraryWidget(mWorkspace));
   mUi->verticalLayout->insertWidget(0, mAddLibraryWidget.data());
   connect(mAddLibraryWidget.data(), &AddLibraryWidget::libraryAdded, this,
@@ -156,6 +164,10 @@ void LibraryManager::updateLibraryList() noexcept {
     LibraryListWidgetItem* widget = widgets.at(i);
     Q_ASSERT(widget);
     QListWidgetItem* item = new QListWidgetItem(mUi->lstLibraries);
+    // Set item text to make searching by keyboard working (type to find
+    // library). However, the text would mess up the look, thus it is made
+    // hidden with a stylesheet set in the constructor (see above).
+    item->setText(widget->getName());
     item->setSizeHint(widget->sizeHint());
     mUi->lstLibraries->setItemWidget(item, widget);
     if (widget->getLibraryFilePath() == selectedLibrary) {

--- a/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -59,8 +59,7 @@ RepositoryLibraryListWidgetItem::RepositoryLibraryListWidgetItem(
   mUuid = Uuid::tryFromString(mJsonObject.value("uuid").toString());
   mVersion = Version::tryFromString(mJsonObject.value("version").toString());
   mIsRecommended = mJsonObject.value("recommended").toBool();
-  QString name =
-      mJsonObject.value("name").toObject().value("default").toString();
+  mName = mJsonObject.value("name").toObject().value("default").toString();
   QString desc =
       mJsonObject.value("description").toObject().value("default").toString();
   QString author = mJsonObject.value("author").toString();
@@ -76,7 +75,7 @@ RepositoryLibraryListWidgetItem::RepositoryLibraryListWidgetItem(
   }
 
   mUi->lblName->setText(
-      QString("%1 v%2").arg(name, mVersion ? mVersion->toStr() : QString()));
+      QString("%1 v%2").arg(mName, mVersion ? mVersion->toStr() : QString()));
   mUi->lblDescription->setText(desc);
   mUi->lblAuthor->setText(QString("Author: %1").arg(author));
 

--- a/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.h
+++ b/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.h
@@ -66,6 +66,7 @@ public:
 
   // Getters
   const tl::optional<Uuid>& getUuid() const noexcept { return mUuid; }
+  const QString& getName() const noexcept { return mName; }
   const QSet<Uuid>& getDependencies() const noexcept { return mDependencies; }
   bool isChecked() const noexcept;
 
@@ -91,6 +92,7 @@ private:  // Data
   Workspace& mWorkspace;
   QJsonObject mJsonObject;
   tl::optional<Uuid> mUuid;
+  QString mName;
   tl::optional<Version> mVersion;
   bool mIsRecommended;
   QSet<Uuid> mDependencies;


### PR DESCRIPTION
Support finding libraries in the library manager by typing their name on the keyboard.

Fixes #780