### PR TITLE
Center text in all progress bars

### DIFF
--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.ui
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.ui
@@ -144,6 +144,9 @@
      <property name="value">
       <number>0</number>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
      <property name="format">
       <string notr="true"/>
      </property>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
@@ -182,6 +182,9 @@
           <property name="value">
            <number>0</number>
           </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
           <property name="format">
            <string/>
           </property>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckmessagesdock.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckmessagesdock.ui
@@ -53,6 +53,9 @@
       </item>
       <item>
        <widget class="QProgressBar" name="prgProgress">
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
         <property name="format">
          <string/>
         </property>

--- a/libs/librepcb/editor/project/orderpcbdialog.ui
+++ b/libs/librepcb/editor/project/orderpcbdialog.ui
@@ -125,6 +125,9 @@
      <property name="value">
       <number>0</number>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
     </widget>
    </item>
    <item>

--- a/libs/librepcb/editor/widgets/statusbar.cpp
+++ b/libs/librepcb/editor/widgets/statusbar.cpp
@@ -64,6 +64,7 @@ StatusBar::StatusBar(QWidget* parent) noexcept
   mProgressBar->setFixedWidth(200);
   mProgressBar->setMinimum(0);
   mProgressBar->setMaximum(100);
+  mProgressBar->setAlignment(Qt::AlignCenter);
   addPermanentWidget(mProgressBar.data());
 
   // progress bar placeholder to reserve space

--- a/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.ui
+++ b/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.ui
@@ -318,6 +318,9 @@
            <property name="value">
             <number>0</number>
            </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
           </widget>
          </item>
          <item>

--- a/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.ui
+++ b/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.ui
@@ -168,6 +168,9 @@
          <property name="value">
           <number>0</number>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
At least on Windows (not on my Linux system) the status text of each `QProgressBar` was shown *beside* the bar, making the bar smaller than expected. Let's explicitly center the texts with `QProgressBar::setAlignment()` since this looks way better.