### PR TITLE
Make polygon/plane vertex handle size independent of zoom

### DIFF
--- a/libs/librepcb/core/graphics/polygongraphicsitem.h
+++ b/libs/librepcb/core/graphics/polygongraphicsitem.h
@@ -86,6 +86,9 @@ public:
   // Inherited Methods
   QVariant itemChange(GraphicsItemChange change,
                       const QVariant& value) noexcept override;
+  QPainterPath shape() const noexcept override;
+  void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+             QWidget* widget = 0) noexcept override;
 
   // Operator Overloadings
   PolygonGraphicsItem& operator=(const PolygonGraphicsItem& rhs) = delete;
@@ -93,15 +96,21 @@ public:
 private:  // Methods
   void polygonEdited(const Polygon& polygon, Polygon::Event event) noexcept;
   void updateFillLayer() noexcept;
-  void updateVertexGraphicsItems() noexcept;
+  void updatePath() noexcept;
+  void updateBoundingRectMargin() noexcept;
 
 private:  // Data
   Polygon& mPolygon;
   const IF_GraphicsLayerProvider& mLayerProvider;
   bool mEditable;
 
-  /// The square graphics items to drag each vertex
-  QList<std::shared_ptr<PrimitivePathGraphicsItem>> mVertexGraphicsItems;
+  // Cached attributes
+  qreal mVertexHandleRadiusPx;
+  struct VertexHandle {
+    Point pos;
+    qreal maxGlowRadiusPx;
+  };
+  QVector<VertexHandle> mVertexHandles;
 
   // Slots
   Polygon::OnEditedSlot mOnEditedSlot;

--- a/libs/librepcb/core/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/primitivepathgraphicsitem.cpp
@@ -42,6 +42,7 @@ PrimitivePathGraphicsItem::PrimitivePathGraphicsItem(
     mLineLayer(nullptr),
     mFillLayer(nullptr),
     mShapeMode(ShapeMode::STROKE_AND_AREA_BY_LAYER),
+    mBoundingRectMarginPx(0),
     mOnLayerEditedSlot(*this, &PrimitivePathGraphicsItem::layerEdited) {
   mPen.setCapStyle(Qt::RoundCap);
   mPenHighlighted.setCapStyle(Qt::RoundCap);

--- a/libs/librepcb/core/graphics/primitivepathgraphicsitem.h
+++ b/libs/librepcb/core/graphics/primitivepathgraphicsitem.h
@@ -72,7 +72,11 @@ public:
   void setShapeMode(ShapeMode mode) noexcept;
 
   // Inherited from QGraphicsItem
-  QRectF boundingRect() const noexcept override { return mBoundingRect; }
+  QRectF boundingRect() const noexcept override {
+    return mBoundingRect +
+        QMarginsF(mBoundingRectMarginPx, mBoundingRectMarginPx,
+                  mBoundingRectMarginPx, mBoundingRectMarginPx);
+  }
   QPainterPath shape() const noexcept override { return mShape; }
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
              QWidget* widget = 0) noexcept override;
@@ -98,6 +102,7 @@ protected:  // Data
   QBrush mBrushHighlighted;
   QPainterPath mPainterPath;
   QRectF mBoundingRect;
+  qreal mBoundingRectMarginPx;
   QPainterPath mShape;
 
   // Slots

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_plane.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_plane.h
@@ -75,10 +75,16 @@ public:
   void updateCacheAndRepaint() noexcept;
 
   // Inherited from QGraphicsItem
-  QRectF boundingRect() const noexcept { return mBoundingRect; }
-  QPainterPath shape() const noexcept { return mShape; }
+  QVariant itemChange(GraphicsItemChange change,
+                      const QVariant& value) noexcept override;
+  QRectF boundingRect() const noexcept override {
+    return mBoundingRect +
+        QMarginsF(mBoundingRectMarginPx, mBoundingRectMarginPx,
+                  mBoundingRectMarginPx, mBoundingRectMarginPx);
+  }
+  QPainterPath shape() const noexcept override;
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-             QWidget* widget = 0);
+             QWidget* widget = 0) noexcept override;
 
   // Operator Overloadings
   BGI_Plane& operator=(const BGI_Plane& rhs) = delete;
@@ -88,6 +94,7 @@ private:  // Methods
   void layerEdited(const GraphicsLayer& layer,
                    GraphicsLayer::Event event) noexcept;
   void updateVisibility() noexcept;
+  void updateBoundingRectMargin() noexcept;
 
 private:  // Data
   // General Attributes
@@ -96,11 +103,17 @@ private:  // Data
   // Cached Attributes
   GraphicsLayer* mLayer;
   QRectF mBoundingRect;
+  qreal mBoundingRectMarginPx;
   QPainterPath mShape;
   QPainterPath mOutline;
   QVector<QPainterPath> mAreas;
   qreal mLineWidthPx;
-  qreal mVertexRadiusPx;
+  qreal mVertexHandleRadiusPx;
+  struct VertexHandle {
+    Point pos;
+    qreal maxGlowRadiusPx;
+  };
+  QVector<VertexHandle> mVertexHandles;
 
   // Slots
   GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;

--- a/libs/librepcb/core/project/board/items/bi_plane.cpp
+++ b/libs/librepcb/core/project/board/items/bi_plane.cpp
@@ -263,7 +263,7 @@ bool BI_Plane::isSelectable() const noexcept {
 
 void BI_Plane::setSelected(bool selected) noexcept {
   BI_Base::setSelected(selected);
-  mGraphicsItem->update();
+  mGraphicsItem->setSelected(selected);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
- Keep polygon/plane vertex handle size constant in terms of screen size instead of scene size, i.e. they are no longer scaled when zooming.
- Reduce size of vertex handled which are close to each other, without affecting the (invisible) area where the vertices can be grabbed. This avoids overlapping handles (which look ugly) while still allow easy dragging.
- When clicking in between two vertices which are very close to each other, do no longer grab *both* vertices (which would merge them together), but only grab the vertex which is closer to the cursor.
- Since the visual handles do no longer always correspond to the actual grab areas, the handles are now drawn blurry. This makes it clear to the user that the grab area is not always just a simple circle, but rather suggests "the nearer, the better".

I'm not fully happy with the look (didn't have a better idea), but the usability is clearly **way** better than before :slightly_smiling_face: 

![librepcb-vertex-handles](https://user-images.githubusercontent.com/5374821/190868879-3ae1f184-c42d-4516-8d62-42b8132dc965.gif)

Fixes #846
Fixes #910