### PR TITLE
Board editor: Fix adding vertices to last plane edge

### DIFF
--- a/libs/librepcb/core/project/board/graphicsitems/bgi_plane.cpp
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_plane.cpp
@@ -73,10 +73,11 @@ int BGI_Plane::getLineIndexAtPosition(const Point& pos) const noexcept {
   // implement and seems to work nicely... ;-)
   const UnsignedLength width(std::max(
       Length::fromPx(mLineWidthPx), Length::fromPx(mVertexHandleRadiusPx * 2)));
-  for (int i = 1; i < mPlane.getOutline().getVertices().count(); ++i) {
+  const Path outline = mPlane.getOutline().toClosedPath();  // Add last segment.
+  for (int i = 1; i < outline.getVertices().count(); ++i) {
     Path path;
-    path.addVertex(mPlane.getOutline().getVertices()[i - 1]);
-    path.addVertex(mPlane.getOutline().getVertices()[i]);
+    path.addVertex(outline.getVertices()[i - 1]);
+    path.addVertex(outline.getVertices()[i]);
 
     PrimitivePathGraphicsItem item(const_cast<BGI_Plane*>(this));
     item.setPath(path.toQPainterPathPx());

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
@@ -75,11 +75,16 @@ bool BoardEditorState_DrawPlane::entry() noexcept {
   if (!board) return false;
 
   // Get most used net signal
-  if (!mLastNetSignal) {
+  if ((!mLastNetSignal) || (!mLastNetSignal->isAddedToCircuit())) {
     mLastNetSignal =
         mContext.project.getCircuit().getNetSignalWithMostElements();
   }
-  if (!mLastNetSignal) return false;
+  if (!mLastNetSignal) {
+    QMessageBox::warning(&mContext.editor, tr("No net available"),
+                         tr("Your circuit doesn't contain any net, please add "
+                            "one in the schematic editor first."));
+    return false;
+  }
 
   // Clear board selection because selection does not make sense in this state
   board->clearSelection();


### PR DESCRIPTION
...and in addition, also improve the "no net" error message when adding planes while there is no net available (see #828).

Fixes #828.