### PR TITLE
Improve formatting & consistency of logging messages

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
   // Stop network access manager thread
   networkAccessManager.reset();
 
-  qDebug() << "Exit application with code" << retval;
+  qDebug().nospace() << "Exit application with code " << retval << ".";
   return retval;
 }
 
@@ -135,20 +135,20 @@ static void configureApplicationSettings() noexcept {
 
 static void writeLogHeader() noexcept {
   // write application name and version to log
-  qInfo() << QString("LibrePCB %1 (%2)")
-                 .arg(qApp->applicationVersion(), qApp->getGitRevision());
+  qInfo().noquote() << QString("LibrePCB %1 (%2)")
+                           .arg(qApp->applicationVersion(),
+                                qApp->getGitRevision());
 
   // write Qt version to log
-  qInfo() << QString("Qt version: %1 (compiled against %2)")
-                 .arg(qVersion(), QT_VERSION_STR);
+  qInfo().noquote() << QString("Qt version: %1 (compiled against %2)")
+                           .arg(qVersion(), QT_VERSION_STR);
 
   // write resources directory path to log
-  qInfo() << QString("Resources directory: %1")
-                 .arg(qApp->getResourcesDir().toNative());
+  qInfo() << "Resources directory:" << qApp->getResourcesDir().toNative();
 
   // write application settings directory to log (nice to know for users)
-  qInfo() << QString("Application settings: %1")
-                 .arg(FilePath(QSettings().fileName()).toNative());
+  qInfo() << "Application settings:"
+          << FilePath(QSettings().fileName()).toNative();
 }
 
 /*******************************************************************************

--- a/dev/doxygen/pages/code_style_guide.md
+++ b/dev/doxygen/pages/code_style_guide.md
@@ -11,6 +11,8 @@ This page describes the code style guide for LibrePCB developers.
 - All files must have UNIX line endings (CI rejects Windows line endings).
 - Always use spaces, never tabulators (CI rejects tabulators).
 - Generally just follow the style of existing code and it will be fine :-)
+- For QtCreator, there's a coding style configuration file
+  `dev/CodingStyle_QtCreator.xml` which you can import.
 - In the repository root there is a `.clang-format` file with the exact rules.
   You can use [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
   (version 6.0.0) to automatically format files according these rules. Use the
@@ -32,33 +34,42 @@ This page describes the code style guide for LibrePCB developers.
 - C++11
 - Use strongly typed enums (`enum class`, C++11) whenever reasonable
 - Use `nullptr` instead of `NULL` or `0`
-- Use keywords like `const`, `constexpr`, `final`, `override`, ... whenever possible
+- Use keywords like `const`, `constexpr`, `final`, `override`, ... whenever
+  possible
 - Use noexcept specifier in method declarations that never throw exceptions:
 
       void foo() noexcept;    // this method never throws exceptions
 
-- Use Qt's smart pointers `QScopedPointer` and `QSharedPointer` for object ownership (instead of raw pointers)
+- Use smart pointers `QScopedPointer`, `std::unique_ptr` or `std::shared_ptr`
+  for object ownership (instead of raw pointers). But don't use
+  `QSharedPointer`!
 
 
 # Header Files {#doc_code_style_guide_header_files}
 
-- Use nearly always forward declarations when possible. Includes in header files are allowed:
-    - for all Qt header files (like QtCore, QtWidgets,...)
-    - when the header file uses other types by value (by reference/pointer --> use forward declaration)
-    - when the header file highly depends on other types, even if only by reference/pointer
+- Use nearly always forward declarations when possible. Includes in header
+  files are allowed:
+    - for all Qt header files (like `QtCore`, `QtWidgets`,...)
+    - when the header file uses other types by value (by
+      reference/pointer --> use forward declaration)
+    - when the header file highly depends on other types, even if only by
+      reference/pointer
 
 
 # Naming {#doc_code_style_guide_naming}
 
-- File Names: Exactly same naming as classes, but all characters lowercase. Example: `lengthunit.cpp`, `lengthunit.h`
-- Include guards: Use the namespace as prefix before the class name. Example: `NAMESPACE_CLASSNAME_H`
-- Namespaces: lowercase (with underline as separator if needed)
+- File Names: Exactly same naming as classes, but all characters lowercase.
+  Example: `lengthunit.cpp`, `lengthunit.h`
+- Namespaces: lowercase (with underline as separator if needed).
 - Classes: UpperCamelCase (for common prefixes, use the underline as separator.
-  Example: librepcb::project::editor::SchematicEditorState_Select)
-- Interfaces: Like Classes, but with prefix "IF_". Example: librepcb::IF_GraphicsViewEventHandler
+  Example: `librepcb::project::editor::SchematicEditorState_Select`)
+- Interfaces: Like classes, but with prefix `IF_`.
+  Example: `librepcb::IF_GraphicsViewEventHandler`
 - Functions/Methods: lowerCamelCase
-- Member Variables: lowerCamelCase, beginning with a 'm'. Example: `mSomeMemberVariable`
-- Static Variables: lowerCamelCase, beginning with a 's'. Example: `sSomeStaticVariable`
+- Member Variables: lowerCamelCase, beginning with a 'm'.
+  Example: `mSomeMemberVariable`
+- Static Variables: lowerCamelCase, beginning with a 's'.
+  Example: `sSomeStaticVariable`
 - Function Parameters: lowerCamelCase
 - Local Variables: lowerCamelCase
 - Macros: uppercase, with underline as separator
@@ -72,31 +83,63 @@ This page describes the code style guide for LibrePCB developers.
 
 # Types {#doc_code_style_guide_types}
 
-- If you need integer types with fixed width, us Qt's typedefs (for example `qint32`) instead of the
-  types from `<stdint.h>` (for example `int32_t`).
-- For floating point numbers, use Qt's typedef `qreal` instead of `float` or `double` whenever possible.
-  This way the application should work also on ARM platforms with single precision FPU quite well.
+- If you need integer types with fixed width, us Qt's typedefs (for example
+  `qint32`) instead of the types from `<stdint.h>` (for example `int32_t`).
+- For floating point numbers, use Qt's typedef `qreal` instead of `float` or
+  `double` whenever possible. This way the application should work also on ARM
+  platforms with single precision FPU quite well.
+
+
+# Exceptions {#doc_code_style_exceptions}
+
+- Use always our own exception types (`librepcb::Exception` and derived
+  classes), see [exceptions.h].
+- Never use other exception types (like `std::exception`).
+- Exceptions from 3rd-party libraries must be translated into our own
+  exceptions in a wrapper class.
 
 
 # QObject {#doc_code_style_guide_qt_qobject}
 
-- Inherit from `QObject` only when needed (for example if you only need `QObject::tr()`, see note to
-  `Q_DECLARE_TR_FUNCTIONS()` in @ref doc_code_style_guide_qt_macros)
-- Try to avoid using `QObject::connect()` with Qt's `SIGNAL()` and `SLOT()` macros. Use function
-  addresses instead (whenever possible). This way, signals and slots are checked on compile-time
-  instead of runtime.
+- Inherit from `QObject` only when needed (for example if you only need
+  `QObject::tr()`, see note to `Q_DECLARE_TR_FUNCTIONS()` in
+  @ref doc_code_style_guide_qt_macros)
+- Try to avoid using `QObject::connect()` with Qt's `SIGNAL()` and `SLOT()`
+  macros. Use function addresses instead (whenever possible). This way,
+  signals and slots are checked on compile-time instead of runtime.
 
-      connect(&myTimer, SIGNAL(timeout()), this, SLOT(mySlot()));     // uses runtime check --> avoid this!
-      connect(&myTimer, &QTimer::timeout, this, &MyClass::anyMethod); // uses compile-time check (and any method can be used as slots!) --> much better!
-      connect(&mAutoSaveTimer, &QTimer::timeout, [this](){doSomething();});   // Using C++11 lambda functions as slots is also possible
-                                                                              // --> can be very useful, but use it carefully (dangling pointers, ...)
+      // Runtime check --> avoid this!
+      connect(&myTimer, SIGNAL(timeout()), this, SLOT(mySlot()));
+
+      // Compile-time check (and any method can be used as slots!) --> use this!
+      connect(&myTimer, &QTimer::timeout, this, &MyClass::anyMethod);
+
+      // Using C++11 lambda functions as slots is also possible.
+      // This can be very useful, but use it carefully (dangling pointers, ...)!
+      connect(&mAutoSaveTimer, &QTimer::timeout, [this](){doSomething();});
 
 
 # Qt Macros {#doc_code_style_guide_qt_macros}
 
-- Do not use `Q_CHECK_PTR()` because it throws a `std::bad_alloc` exception which we will never
-  catch (we only catch our own exception types). Use `Q_ASSERT()` instead.
-- The macro `Q_DECLARE_TR_FUNCTIONS()` is very useful to use the translation method `QObject::tr()`
-  (resp. `tr()`) also in classes which do not inherit from `QObject` (but do *NOT* use this macro in
-  interface classes because of possible multiple inheritance --> use `QCoreApplication::translate()`
-  instead in this case). See http://doc.qt.io/qt-5/qcoreapplication.html#Q_DECLARE_TR_FUNCTIONS
+- Do not use `Q_CHECK_PTR()` because it throws a `std::bad_alloc` exception
+  which we will never catch (we only catch our own exception types). Use
+  `Q_ASSERT()` instead.
+- The macro `Q_DECLARE_TR_FUNCTIONS()` is very useful to use the translation
+  method `QObject::tr()` (resp. `tr()`) also in classes which do not inherit
+  from `QObject` (but do *NOT* use this macro in interface classes because of
+  possible multiple inheritance --> use `QCoreApplication::translate()`
+  instead in this case).
+  See http://doc.qt.io/qt-5/qcoreapplication.html#Q_DECLARE_TR_FUNCTIONS.
+
+
+# Logging Messages {#doc_code_style_guide_logging}
+
+- For logging, use `qDebug()`, `qInfo()`, `qWarning()` and `qCritical()`.
+- Logging messages shall not be translated, i.e. don't use `tr()` for them.
+- Output real sentences, starting with uppercase letter and ending with a
+  period. Exceptions are allowed for something like "Invalid parameter: foo".
+- Try to output messages *before* the corresponding operation is performed.
+  This helps to debug crashes since you see the last started operation. Use
+  imperative language and end such messages with "...", for example
+  "Save project...".
+- Output native file paths, not UNIX filepaths.

--- a/dev/doxygen/pages/developers.md
+++ b/dev/doxygen/pages/developers.md
@@ -87,13 +87,6 @@ problem! LibrePCB maintainers can help you in several ways:
   license. This applies to all kinds of resources (images, symbols, text, sound, source code, ...).
 
 
-# Exceptions {#doc_developers_exceptions}
-
-- Use always our own exception types (librepcb::Exception and derivated classes), see [exceptions.h].
-- Never use other exception types (like `std::exception`).
-- Exceptions from 3rd-party libraries must be translated into our own exceptions in a wrapper class.
-
-
 # Deployment {#doc_developers_deployment}
 
 - Where to put our files on UNIX/Linux?: http://unix.stackexchange.com/questions/114407/deploying-my-application

--- a/libs/librepcb/core/application.cpp
+++ b/libs/librepcb/core/application.cpp
@@ -124,7 +124,7 @@ Application::Application(int& argc, char** argv) noexcept
     QString fp = info.absoluteFilePath();
     int id = QFontDatabase::addApplicationFont(fp);
     if (id < 0) {
-      qCritical() << "Failed to load font" << fp;
+      qCritical().nospace() << "Failed to register font " << fp << ".";
     }
   }
 
@@ -179,8 +179,8 @@ const StrokeFont& Application::getDefaultStrokeFont() const noexcept {
   try {
     return mStrokeFontPool->getFont(getDefaultStrokeFontName());
   } catch (const Exception& e) {
-    qFatal("Default stroke font could not be loaded!");  // aborts the
-                                                         // application!!!
+    // Abort the application!!!
+    qFatal("Default stroke font could not be loaded, terminating application!");
   }
 }
 

--- a/libs/librepcb/core/debug.cpp
+++ b/libs/librepcb/core/debug.cpp
@@ -86,8 +86,9 @@ void Debug::setDebugLevelLogFile(DebugLevel_t level) {
       mDebugLevelLogFile = level;  // activate logging to file immediately!
       qDebug() << "Enabled logging to file:" << mLogFilepath.toNative();
     } else {
-      qWarning() << "Cannot enable logging to file" << mLogFilepath.toNative();
-      qWarning() << "Error message:" << mLogFile->errorString();
+      qWarning().nospace() << "Failed to enable logging to file "
+                           << mLogFilepath.toNative() << ": "
+                           << mLogFile->errorString();
       delete mLogFile;
       mLogFile = 0;
     }

--- a/libs/librepcb/core/debug.cpp
+++ b/libs/librepcb/core/debug.cpp
@@ -118,13 +118,14 @@ void Debug::print(DebugLevel_t level, const QString& msg, const char* file,
                   int line) {
   QMutexLocker locker(&mMutex);
 
+  // If there is nothing to print, return immediately from this function.
   if ((mDebugLevelStderr < level) &&
-      ((mDebugLevelLogFile < level) || (!mLogFile)))
-    return;  // if there is nothing to print, we will return immediately from
-             // this function
+      ((mDebugLevelLogFile < level) || (!mLogFile))) {
+    return;
+  }
 
-  const char* levelStr =
-      "---------";  // the debug level string has always 9 characters
+  // The debug level string has always 9 characters.
+  const char* levelStr = "---------";
   switch (level) {
     case DebugLevel_t::DebugMsg:
       levelStr = "DEBUG-MSG";
@@ -148,9 +149,11 @@ void Debug::print(DebugLevel_t level, const QString& msg, const char* file,
       break;
   }
 
-  QString logMsg = QString("[%1] %2 (%3:%4)")
-                       .arg(levelStr, msg.toLocal8Bit().constData(), file)
-                       .arg(line);
+  QString logMsg = QString("[%1] %2").arg(levelStr).arg(msg);
+  if (file || line) {
+    // Avoid printing useless "(:0)" in release builds.
+    logMsg += QString(" (%1:%2)").arg(file).arg(line);
+  }
 
   if (mDebugLevelStderr >= level) {
     // write to stderr

--- a/libs/librepcb/core/export/excellongenerator.cpp
+++ b/libs/librepcb/core/export/excellongenerator.cpp
@@ -67,7 +67,9 @@ ExcellonGenerator::ExcellonGenerator(const QDateTime& creationDate,
       break;
     }
     default: {
-      qCritical() << "ExcellonGenerator: Invalid plating enum value.";
+      qCritical()
+          << "Unhandled switch-case in ExcellonGenerator::ExcellonGenerator():"
+          << static_cast<int>(plating);
       break;
     }
   }

--- a/libs/librepcb/core/export/gerberattribute.cpp
+++ b/libs/librepcb/core/export/gerberattribute.cpp
@@ -187,7 +187,9 @@ GerberAttribute GerberAttribute::fileFunctionCopper(int layer,
       break;
     }
     default: {
-      qCritical() << "Unknown Gerber copper side:" << static_cast<int>(side);
+      qCritical()
+          << "Unhandled switch-case in GerberAttribute::fileFunctionCopper():"
+          << static_cast<int>(side);
       return GerberAttribute();
     }
   }
@@ -206,7 +208,9 @@ GerberAttribute GerberAttribute::fileFunctionSolderMask(
                              {"Soldermask", "Bot"});
     }
     default: {
-      qCritical() << "Unknown Gerber board side:" << static_cast<int>(side);
+      qCritical() << "Unhandled switch-case in "
+                     "GerberAttribute::fileFunctionSolderMask():"
+                  << static_cast<int>(side);
       return GerberAttribute();
     }
   }
@@ -221,7 +225,9 @@ GerberAttribute GerberAttribute::fileFunctionLegend(BoardSide side) noexcept {
       return GerberAttribute(Type::File, ".FileFunction", {"Legend", "Bot"});
     }
     default: {
-      qCritical() << "Unknown Gerber board side:" << static_cast<int>(side);
+      qCritical()
+          << "Unhandled switch-case in GerberAttribute::fileFunctionLegend():"
+          << static_cast<int>(side);
       return GerberAttribute();
     }
   }
@@ -236,7 +242,9 @@ GerberAttribute GerberAttribute::fileFunctionPaste(BoardSide side) noexcept {
       return GerberAttribute(Type::File, ".FileFunction", {"Paste", "Bot"});
     }
     default: {
-      qCritical() << "Unknown Gerber board side:" << static_cast<int>(side);
+      qCritical()
+          << "Unhandled switch-case in GerberAttribute::fileFunctionPaste():"
+          << static_cast<int>(side);
       return GerberAttribute();
     }
   }
@@ -281,7 +289,9 @@ GerberAttribute GerberAttribute::fileFunctionComponent(
                              {"Component", layerStr, "Bot"});
     }
     default: {
-      qCritical() << "Unknown Gerber board side:" << static_cast<int>(side);
+      qCritical() << "Unhandled switch-case in "
+                     "GerberAttribute::fileFunctionComponent():"
+                  << static_cast<int>(side);
       return GerberAttribute();
     }
   }
@@ -296,7 +306,7 @@ GerberAttribute GerberAttribute::filePolarity(Polarity polarity) noexcept {
       return GerberAttribute(Type::File, ".FilePolarity", {"Negative"});
     }
     default: {
-      qCritical() << "Unknown Gerber file polarity:"
+      qCritical() << "Unhandled switch-case in GerberAttribute::filePolarity():"
                   << static_cast<int>(polarity);
       return GerberAttribute();
     }
@@ -360,8 +370,9 @@ GerberAttribute GerberAttribute::apertureFunction(
                              {"ComponentOutline", "Courtyard"});
     }
     default: {
-      qCritical() << "Unknown Gerber aperture function attribute:"
-                  << static_cast<int>(function);
+      qCritical()
+          << "Unhandled switch-case in GerberAttribute::apertureFunction():"
+          << static_cast<int>(function);
       return GerberAttribute();
     }
   }
@@ -434,8 +445,9 @@ GerberAttribute GerberAttribute::componentMountType(MountType type) noexcept {
       return GerberAttribute(Type::Object, ".CMnt", {"Other"});
     }
     default: {
-      qCritical() << "Unknown Gerber component mount type attribute:"
-                  << static_cast<int>(type);
+      qCritical()
+          << "Unhandled switch-case in GerberAttribute::componentMountType():"
+          << static_cast<int>(type);
       return GerberAttribute();
     }
   }

--- a/libs/librepcb/core/export/gerbergenerator.cpp
+++ b/libs/librepcb/core/export/gerbergenerator.cpp
@@ -107,7 +107,9 @@ void GerberGenerator::setLayerPolarity(Polarity p) noexcept {
       mContent.append("%LPC*%\n");
       break;
     default:
-      qCritical() << "Invalid Layer Polarity:" << static_cast<int>(p);
+      qCritical()
+          << "Unhandled siwtch-case in GerberGenerator::setLayerPolarity():"
+          << static_cast<int>(p);
       break;
   }
 }

--- a/libs/librepcb/core/fileio/directorylock.cpp
+++ b/libs/librepcb/core/fileio/directorylock.cpp
@@ -51,7 +51,8 @@ DirectoryLock::~DirectoryLock() noexcept {
   try {
     unlockIfLocked();  // can throw
   } catch (const Exception& e) {
-    qCritical() << "Could not remove lock file:" << e.getMsg();
+    qCritical().nospace() << "Failed to remove lock file "
+                          << mLockFilePath.toNative() << ": " << e.getMsg();
   }
 }
 
@@ -152,14 +153,16 @@ void DirectoryLock::tryLock(LockHandlerCallback lockHandler) {
   LockStatus status = getStatus(&user);  // can throw
   switch (status) {
     case LockStatus::StaleLock:
-      qWarning() << "Overriding stale lock on directory:" << mDirToLock;
+      qWarning().nospace() << "Override stale lock on directory "
+                           << mDirToLock.toNative() << "...";
       // fallthrough
     case LockStatus::Unlocked:
       lock();  // can throw
       break;
     default:  // Locked!
       if (lockHandler && lockHandler(mDirToLock, status, user)) {
-        qInfo() << "Overriding lock on directory:" << mDirToLock;
+        qInfo().nospace() << "Override lock on directory "
+                          << mDirToLock.toNative() << "...";
         lock();  // can throw
         break;
       }

--- a/libs/librepcb/core/fileio/fileutils.cpp
+++ b/libs/librepcb/core/fileio/fileutils.cpp
@@ -62,7 +62,7 @@ void FileUtils::writeFile(const FilePath& filepath, const QByteArray& content) {
   }
   qint64 written = file.write(content);
   if (written != content.size()) {
-    qDebug() << "only" << written << "of" << content.size() << "bytes written";
+    qDebug() << "Only" << written << "of" << content.size() << "bytes written.";
     throw RuntimeError(__FILE__, __LINE__,
                        tr("Could not write to file \"%1\": %2")
                            .arg(filepath.toNative(), file.errorString()));

--- a/libs/librepcb/core/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/core/fileio/transactionalfilesystem.cpp
@@ -50,7 +50,7 @@ TransactionalFileSystem::TransactionalFileSystem(
   // Load the backup if there is one (i.e. last save operation has failed).
   FilePath backupFile = mFilePath.getPathTo(".backup/backup.lp");
   if (backupFile.isExistingFile()) {
-    qDebug() << "Restoring file system from backup:" << backupFile.toNative();
+    qDebug() << "Restore file system from backup:" << backupFile.toNative();
     loadDiff(backupFile);  // can throw
   }
 
@@ -64,7 +64,7 @@ TransactionalFileSystem::TransactionalFileSystem(
   FilePath autosaveFile = mFilePath.getPathTo(".autosave/autosave.lp");
   if (autosaveFile.isExistingFile()) {
     if (restoreCallback && restoreCallback(mFilePath)) {  // can throw
-      qDebug() << "Restoring file system from autosave backup:"
+      qDebug() << "Restore file system from autosave backup:"
                << autosaveFile.toNative();
       loadDiff(autosaveFile);  // can throw
       mRestoredFromAutosave = true;
@@ -82,7 +82,7 @@ TransactionalFileSystem::~TransactionalFileSystem() noexcept {
     try {
       removeDiff("autosave");  // can throw
     } catch (const Exception& e) {
-      qWarning() << "Could not remove autosave directory:" << e.getMsg();
+      qWarning() << "Failed to remove autosave directory:" << e.getMsg();
     }
   }
 }

--- a/libs/librepcb/core/font/strokefont.cpp
+++ b/libs/librepcb/core/font/strokefont.cpp
@@ -43,7 +43,8 @@ StrokeFont::StrokeFont(const FilePath& fontFilePath,
                        const QByteArray& content) noexcept
   : QObject(nullptr), mFilePath(fontFilePath) {
   // load the font in another thread because it takes some time to load it
-  qDebug() << "Start loading font" << mFilePath.toNative();
+  qDebug() << "Start loading stroke font " << mFilePath.toNative()
+           << "in worker thread...";
   mFuture = QtConcurrent::run([content]() {
     QTextStream s(content);
     return fb::Font(s);
@@ -187,7 +188,7 @@ QVector<Path> StrokeFont::strokeGlyph(const QChar& glyph,
     spacing = convertLength(height, glyphSpacing);
     return polylines2paths(polylines, height);
   } catch (const fb::Exception& e) {
-    qWarning() << "Failed to load stroke font glyph" << glyph;
+    qWarning().nospace() << "Failed to load stroke font glyph " << glyph << ".";
     spacing = 0;
     return QVector<Path>();
   }
@@ -205,12 +206,12 @@ const fb::GlyphListAccessor& StrokeFont::accessor() const noexcept {
   if (!mFont) {
     try {
       mFont.reset(new fb::Font(mFuture.result()));  // can throw
-      qDebug() << "Successfully loaded font" << mFilePath.toNative() << "with"
-               << mFont->glyphs.count() << "glyphs";
+      qDebug() << "Successfully loaded stroke font" << mFilePath.toNative()
+               << "with" << mFont->glyphs.count() << "glyphs.";
     } catch (const fb::Exception& e) {
       mFont.reset(new fb::Font());
-      qCritical() << "Failed to load font" << mFilePath.toNative();
-      qCritical() << "Error:" << e.msg();
+      qCritical().nospace() << "Failed to load stroke font "
+                            << mFilePath.toNative() << ": " << e.msg();
     }
 
     mGlyphListCache.reset(new fb::GlyphListCache(mFont->glyphs));

--- a/libs/librepcb/core/font/strokefontpool.cpp
+++ b/libs/librepcb/core/font/strokefontpool.cpp
@@ -40,14 +40,14 @@ StrokeFontPool::StrokeFontPool(const FileSystem& directory) noexcept {
     FilePath fp = directory.getAbsPath(filename);
     if (fp.getSuffix() != "bene") continue;
     try {
-      qDebug() << "Load stroke font:" << filename;
+      qDebug() << "Found stroke font:" << filename;
       mFonts.insert(
           filename,
           std::make_shared<StrokeFont>(fp,
                                        directory.read(filename)));  // can throw
     } catch (const Exception& e) {
-      qCritical() << "Failed to load stroke font" << fp.toNative() << ":"
-                  << e.getMsg();
+      qCritical().nospace() << "Failed to load stroke font " << fp.toNative()
+                            << ": " << e.getMsg();
     }
   }
 }

--- a/libs/librepcb/core/graphics/circlegraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/circlegraphicsitem.cpp
@@ -83,7 +83,8 @@ void CircleGraphicsItem::circleEdited(const Circle& circle,
       break;
     default:
       qWarning()
-          << "Unhandled switch-case in CircleGraphicsItem::circleEdited()";
+          << "Unhandled switch-case in CircleGraphicsItem::circleEdited():"
+          << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/graphicslayer.cpp
+++ b/libs/librepcb/core/graphics/graphicslayer.cpp
@@ -267,7 +267,8 @@ void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr,
           hlColor = QColor("#C09739BF");
           break;
         default:
-          qWarning() << "Invalid remainder!";
+          qWarning()
+              << "Unhandled switch-case in GraphicsLayer::getDefaultValues().";
           color = QColor("#FFFF00FF");
           hlColor = QColor("#FFFF00FF");
       }

--- a/libs/librepcb/core/graphics/holegraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/holegraphicsitem.cpp
@@ -91,7 +91,8 @@ void HoleGraphicsItem::holeEdited(const Hole& hole,
                                         UnsignedLength(500000));
       break;
     default:
-      qWarning() << "Unhandled switch-case in HoleGraphicsItem::holeEdited()";
+      qWarning() << "Unhandled switch-case in HoleGraphicsItem::holeEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/linegraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/linegraphicsitem.cpp
@@ -128,7 +128,8 @@ void LineGraphicsItem::layerEdited(const GraphicsLayer& layer,
       setLayer(nullptr);
       break;
     default:
-      qWarning() << "Unhandled switch-case in LineGraphicsItem::layerEdited()";
+      qWarning() << "Unhandled switch-case in LineGraphicsItem::layerEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/origincrossgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/origincrossgraphicsitem.cpp
@@ -127,7 +127,8 @@ void OriginCrossGraphicsItem::layerEdited(const GraphicsLayer& layer,
       break;
     default:
       qWarning()
-          << "Unhandled switch-case in OriginCrossGraphicsItem::layerEdited()";
+          << "Unhandled switch-case in OriginCrossGraphicsItem::layerEdited():"
+          << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/polygongraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/polygongraphicsitem.cpp
@@ -189,8 +189,9 @@ void PolygonGraphicsItem::polygonEdited(const Polygon& polygon,
       updateFillLayer();  // path "closed" might have changed
       break;
     default:
-      qWarning() << "Unhandled switch-case in "
-                    "PolygonGraphicsItem::polygonEdited()";
+      qWarning()
+          << "Unhandled switch-case in PolygonGraphicsItem::polygonEdited():"
+          << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/primitivecirclegraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/primitivecirclegraphicsitem.cpp
@@ -142,7 +142,8 @@ void PrimitiveCircleGraphicsItem::layerEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "PrimitiveCircleGraphicsItem::layerEdited()";
+                    "PrimitiveCircleGraphicsItem::layerEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/primitivepathgraphicsitem.cpp
@@ -156,7 +156,8 @@ void PrimitivePathGraphicsItem::layerEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "PrimitivePathGraphicsItem::layerEdited()";
+                    "PrimitivePathGraphicsItem::layerEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/primitivetextgraphicsitem.cpp
@@ -94,8 +94,9 @@ void PrimitiveTextGraphicsItem::setFont(Font font) noexcept {
       mFont = qApp->getDefaultMonospaceFont();
       break;
     default: {
-      Q_ASSERT(false);
-      qCritical() << "Unknown font:" << static_cast<int>(font);
+      qCritical()
+          << "Unhandled switch-case in PrimitiveTextGraphicsItem::setFont():"
+          << static_cast<int>(font);
       break;
     }
   }
@@ -159,7 +160,8 @@ void PrimitiveTextGraphicsItem::layerEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "PrimitiveTextGraphicsItem::layerEdited()";
+                    "PrimitiveTextGraphicsItem::layerEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/stroketextgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/stroketextgraphicsitem.cpp
@@ -137,7 +137,8 @@ void StrokeTextGraphicsItem::strokeTextEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "StrokeTextGraphicsItem::strokeTextEdited()";
+                    "StrokeTextGraphicsItem::strokeTextEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/graphics/textgraphicsitem.cpp
+++ b/libs/librepcb/core/graphics/textgraphicsitem.cpp
@@ -127,7 +127,8 @@ void TextGraphicsItem::textEdited(const Text& text,
       setRotationAndAlignment(text.getRotation(), text.getAlign());
       break;
     default:
-      qWarning() << "Unhandled switch-case in TextGraphicsItem::textEdited()";
+      qWarning() << "Unhandled switch-case in TextGraphicsItem::textEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/import/dxfreader.cpp
+++ b/libs/librepcb/core/import/dxfreader.cpp
@@ -85,7 +85,8 @@ public:
       mReader.mCircles.append(
           DxfReader::Circle{point(data.cx, data.cy), PositiveLength(diameter)});
     } else {
-      qWarning() << "Circle in DXF file ignored due to invalid diameter.";
+      qWarning() << "Circle in DXF file ignored due to invalid radius:"
+                 << data.radius;
     }
   }
 

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -130,7 +130,7 @@ void Library::save() {
 void Library::moveTo(TransactionalDirectory& dest) {
   // check directory suffix
   if (dest.getAbsPath().getSuffix() != "lplib") {
-    qDebug() << dest.getAbsPath().toNative();
+    qDebug() << "Invalid library:" << dest.getAbsPath().toNative();
     throw RuntimeError(
         __FILE__, __LINE__,
         tr("A library directory name must have the suffix '.lplib'."));
@@ -149,7 +149,7 @@ QStringList Library::searchForElements() const noexcept {
     if (isValidElementDirectory<ElementType>(*mDirectory, dirPath)) {
       list.append(dirPath);
     } else {
-      qWarning() << "Directory is not a valid library element:"
+      qWarning() << "Directory is not a valid library element, ignoring it:"
                  << mDirectory->getAbsPath(dirPath).toNative();
     }
   }

--- a/libs/librepcb/core/library/librarybaseelement.cpp
+++ b/libs/librepcb/core/library/librarybaseelement.cpp
@@ -136,7 +136,7 @@ LibraryBaseElement::LibraryBaseElement(
 
   // check if the UUID equals to the directory basename
   if (mDirectoryNameMustBeUuid && (mUuid.toStr() != dirUuidStr)) {
-    qDebug() << mUuid.toStr() << "!=" << dirUuidStr;
+    qDebug() << "UUID mismatch:" << mUuid.toStr() << "!=" << dirUuidStr;
     throw RuntimeError(
         __FILE__, __LINE__,
         QString(

--- a/libs/librepcb/core/library/msg/msgnamenottitlecase.cpp
+++ b/libs/librepcb/core/library/msg/msgnamenottitlecase.cpp
@@ -73,7 +73,8 @@ ElementName MsgNameNotTitleCase::getFixedName(
   try {
     return ElementName(newName);  // Could throw, but should really not!
   } catch (const Exception& e) {
-    qCritical() << "Could not fixup invalid name:" << e.getMsg();
+    qCritical().nospace() << "Could not fixup invalid name " << (*name) << ": "
+                          << e.getMsg();
     return name;
   }
 }

--- a/libs/librepcb/core/network/filedownload.cpp
+++ b/libs/librepcb/core/network/filedownload.cpp
@@ -126,7 +126,8 @@ void FileDownload::finalizeRequest() {
     QString result = hash.result().toHex();
     QString expected = mExpectedChecksum.toHex();
     if (result != expected) {
-      qDebug() << "expected" << expected << "but got" << result;
+      qDebug().nospace() << "Expected checksum " << expected << " but got "
+                         << result << ".";
       throw RuntimeError(
           __FILE__, __LINE__,
           tr("Checksum verification of downloaded file failed!"));

--- a/libs/librepcb/core/network/networkaccessmanager.cpp
+++ b/libs/librepcb/core/network/networkaccessmanager.cpp
@@ -106,13 +106,13 @@ NetworkAccessManager* NetworkAccessManager::instance() noexcept {
 
 void NetworkAccessManager::run() noexcept {
   Q_ASSERT(QThread::currentThread() == this);
-  qDebug() << "Started network access manager thread.";
+  qDebug() << "Network access manager thread started.";
   mManager = new QNetworkAccessManager();
   mThreadStartSemaphore.release();
   try {
     exec();  // event loop (blocking)
   } catch (...) {
-    qCritical() << "Exception thrown in network access manager event loop!!!";
+    qCritical() << "Network access manager event loop aborted by exception!";
     // do NOT exit the thread to avoid further problems due to deleted
     // QNetworkAccessManager
     while (true) {
@@ -121,17 +121,18 @@ void NetworkAccessManager::run() noexcept {
   }
   delete mManager;
   mManager = nullptr;
-  qDebug() << "Stopped network access manager thread.";
+  qDebug() << "Network access manager thread stopped.";
 }
 
 void NetworkAccessManager::stop() noexcept {
   Q_ASSERT(QThread::currentThread() != this);
   quit();
   if (!wait(5000)) {
-    qWarning() << "Could not quit the network access manager thread!";
+    qWarning() << "Failed to quit the network access manager thread, trying to "
+                  "terminate it...";
     terminate();
     if (!wait(1000)) {
-      qCritical() << "Could not terminate the network access manager thread!";
+      qCritical() << "Failed to terminate the network access manager thread!";
     }
   }
 }

--- a/libs/librepcb/core/network/networkrequestbase.cpp
+++ b/libs/librepcb/core/network/networkrequestbase.cpp
@@ -253,8 +253,8 @@ void NetworkRequestBase::replyFinishedSlot() noexcept {
       return;
     } else {
       // follow redirection
-      qDebug() << "Redirect from" << mUrl.toString() << "to"
-               << redirectUrl.toString();
+      qDebug().nospace() << "Redirect from " << mUrl.toString() << " to "
+                         << redirectUrl.toString() << ".";
       emit progressState(tr("Redirect to %1...").arg(redirectUrl.toString()));
       mReply.take()->deleteLater();
       mRedirectedUrls.append(mUrl);
@@ -297,8 +297,8 @@ void NetworkRequestBase::finalize(const QString& errorMsg) noexcept {
     emit aborted();
     emit finished(false);
   } else {
-    qDebug() << "Request failed:" << mUrl.toString();
-    qDebug() << "Network error:" << errorMsg;
+    qCritical() << "Request failed:" << mUrl.toString();
+    qCritical() << "Network error:" << errorMsg;
     emit progressState(tr("Request failed: %1").arg(errorMsg));
     emit errored(errorMsg);
     emit finished(false);

--- a/libs/librepcb/core/network/repository.cpp
+++ b/libs/librepcb/core/network/repository.cpp
@@ -77,7 +77,8 @@ void Repository::requestedDataReceived(const QByteArray& data) noexcept {
   if (nextResultsLink.isString()) {
     QUrl url = QUrl(nextResultsLink.toString());
     if (url.isValid()) {
-      qDebug() << "Request more results from repository:" << url.toString();
+      qDebug().nospace() << "Request more results from repository "
+                         << url.toString() << "...";
       requestLibraryList(url);
     } else {
       qWarning() << "Invalid URL in received JSON object:"

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -270,7 +270,7 @@ Board::Board(Project& project,
         // an older, now incompatible revision). To avoid frustration, we just
         // ignore these errors and load the default settings instead...
         qCritical() << "Could not open board user settings, defaults will be "
-                       "used instead!";
+                       "used instead.";
         mUserSettings.reset(new BoardUserSettings(*this));
       }
 

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -768,7 +768,7 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator& gen,
   }
 
   if ((width <= 0) || (height <= 0)) {
-    qWarning() << "Pad with zero size ignored in gerber export:"
+    qWarning() << "Pad with zero size ignored in Gerber export:"
                << pad.getLibPadUuid();
     return;
   }

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -73,8 +73,8 @@ QVector<Path> BoardPlaneFragmentsBuilder::buildFragments() noexcept {
     }
     return ClipperHelpers::convert(mResult);
   } catch (const Exception& e) {
-    qCritical() << "Failed to build plane fragments! Leave plane empty...";
-    qCritical() << "Inner error message:" << e.getMsg();
+    qCritical() << "Failed to build plane fragments, leaving plane empty:"
+                << e.getMsg();
     return QVector<Path>();
   }
 }

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_footprint.cpp
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_footprint.cpp
@@ -208,7 +208,8 @@ void BGI_Footprint::layerEdited(const GraphicsLayer& layer,
       prepareGeometryChange();
       break;
     default:
-      qWarning() << "BGI_Footprint: Unhandled switch-case in layerEdited()";
+      qWarning() << "Unhandled switch-case in BGI_Footprint::layerEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -129,7 +129,7 @@ void BI_Device::initDeviceAndPackageAndFootprint(const Uuid& deviceUuid,
   // get device from library
   mLibDevice = mBoard.getProject().getLibrary().getDevice(deviceUuid);
   if (!mLibDevice) {
-    qDebug() << mCompInstance->getUuid();
+    qCritical() << "No device for component:" << mCompInstance->getUuid();
     throw RuntimeError(__FILE__, __LINE__,
                        tr("No device with the UUID \"%1\" found in the "
                           "project's library.")
@@ -149,7 +149,7 @@ void BI_Device::initDeviceAndPackageAndFootprint(const Uuid& deviceUuid,
   Uuid packageUuid = mLibDevice->getPackageUuid();
   mLibPackage = mBoard.getProject().getLibrary().getPackage(packageUuid);
   if (!mLibPackage) {
-    qDebug() << mCompInstance->getUuid();
+    qCritical() << "No package for component:" << mCompInstance->getUuid();
     throw RuntimeError(__FILE__, __LINE__,
                        tr("No package with the UUID \"%1\" found in "
                           "the project's library.")

--- a/libs/librepcb/core/project/circuit/circuit.cpp
+++ b/libs/librepcb/core/project/circuit/circuit.cpp
@@ -46,7 +46,7 @@ Circuit::Circuit(Project& project, const Version& fileFormat, bool create)
   : QObject(&project),
     mProject(project),
     mDirectory(new TransactionalDirectory(project.getDirectory(), "circuit")) {
-  qDebug() << "load circuit...";
+  qDebug() << "Load circuit...";
 
   try {
     if (create) {
@@ -101,7 +101,7 @@ Circuit::Circuit(Project& project, const Version& fileFormat, bool create)
     throw;
   }
 
-  qDebug() << "circuit successfully loaded!";
+  qDebug() << "Successfully loaded circuit.";
 }
 
 Circuit::~Circuit() noexcept {

--- a/libs/librepcb/core/project/circuit/componentinstance.cpp
+++ b/libs/librepcb/core/project/circuit/componentinstance.cpp
@@ -92,7 +92,8 @@ ComponentInstance::ComponentInstance(Circuit& circuit, const SExpression& node,
     mSignals.insert(signal->getCompSignal().getUuid(), signal);
   }
   if (mSignals.count() != mLibComponent->getSignals().count()) {
-    qDebug() << mSignals.count() << "!=" << mLibComponent->getSignals().count();
+    qCritical() << "Signal count mismatch:" << mSignals.count()
+                << "!=" << mLibComponent->getSignals().count();
     throw RuntimeError(
         __FILE__, __LINE__,
         QString("The signal count of the component instance \"%1\" does "

--- a/libs/librepcb/core/project/project.cpp
+++ b/libs/librepcb/core/project/project.cpp
@@ -55,8 +55,8 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
     AttributeProvider(),
     mDirectory(std::move(directory)),
     mFilename(filename) {
-  qDebug() << (create ? "create project:" : "open project:")
-           << getFilepath().toNative();
+  qDebug().nospace() << (create ? "Create project " : "Open project ")
+                     << getFilepath().toNative() << "...";
 
   // Check if the file extension is correct
   if (!mFilename.endsWith(".lpp")) {
@@ -168,7 +168,7 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
         Schematic* schematic = new Schematic(*this, std::move(dir), fileFormat);
         addSchematic(*schematic);
       }
-      qDebug() << mSchematics.count() << "schematics successfully loaded!";
+      qDebug() << "Successfully loaded" << mSchematics.count() << "schematics.";
     }
 
     // Load all boards
@@ -184,7 +184,7 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
         Board* board = new Board(*this, std::move(dir), fileFormat);
         addBoard(*board);
       }
-      qDebug() << mBoards.count() << "boards successfully loaded!";
+      qDebug() << "Successfully loaded" << mBoards.count() << "boards.";
     }
 
     // at this point, the whole circuit with all schematics and boards is
@@ -212,7 +212,7 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
   }
 
   // project successfully opened! :-)
-  qDebug() << "project successfully loaded!";
+  qDebug() << "Successfully loaded project.";
 }
 
 Project::~Project() noexcept {
@@ -236,7 +236,7 @@ Project::~Project() noexcept {
   qDeleteAll(mRemovedSchematics);
   mRemovedSchematics.clear();
 
-  qDebug() << "closed project:" << getFilepath().toNative();
+  qDebug().nospace() << "Closed project " << getFilepath().toNative() << ".";
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/projectlibrary.cpp
+++ b/libs/librepcb/core/project/projectlibrary.cpp
@@ -46,7 +46,7 @@ namespace librepcb {
 ProjectLibrary::ProjectLibrary(
     std::unique_ptr<TransactionalDirectory> directory)
   : mDirectory(std::move(directory)) {
-  qDebug() << "load project library...";
+  qDebug() << "Load project library...";
 
   try {
     // Load all library elements
@@ -60,7 +60,7 @@ ProjectLibrary::ProjectLibrary(
     throw;
   }
 
-  qDebug() << "project library successfully loaded!";
+  qDebug() << "Successfully loaded project library.";
 }
 
 ProjectLibrary::~ProjectLibrary() noexcept {
@@ -148,7 +148,7 @@ void ProjectLibrary::loadElements(const QString& dirname, const QString& type,
 
     // check if directory is a valid library element
     if (!LibraryBaseElement::isValidElementDirectory<ElementType>(*dir, "")) {
-      qWarning() << "Found an invalid directory in the library:"
+      qWarning() << "Invalid directory in project library, ignoring it:"
                  << dir->getAbsPath().toNative();
       continue;
     }
@@ -168,7 +168,8 @@ void ProjectLibrary::loadElements(const QString& dirname, const QString& type,
     mAllElements.insert(element.take());  // Take object from smart pointer!
   }
 
-  qDebug() << "successfully loaded" << elementList.count() << qPrintable(type);
+  qDebug().nospace() << "Successfully loaded " << elementList.count() << " "
+                     << qPrintable(type) << ".";
 }
 
 template <typename ElementType>

--- a/libs/librepcb/core/project/projectmetadata.cpp
+++ b/libs/librepcb/core/project/projectmetadata.cpp
@@ -51,7 +51,7 @@ ProjectMetadata::ProjectMetadata(const Uuid& uuid, const ElementName& name,
 ProjectMetadata::ProjectMetadata(const SExpression& node,
                                  const Version& fileFormat)
   : QObject(nullptr), mUuid(Uuid::createRandom()), mName("Project") {
-  qDebug() << "load project metadata...";
+  qDebug() << "Load project metadata...";
 
   mUuid = deserialize<Uuid>(node.getChild("@0"), fileFormat);
   mName = deserialize<ElementName>(node.getChild("name/@0"), fileFormat);
@@ -62,7 +62,7 @@ ProjectMetadata::ProjectMetadata(const SExpression& node,
 
   mLastModified = QDateTime::currentDateTime();
 
-  qDebug() << "metadata successfully loaded!";
+  qDebug() << "Successfully loaded project metadata.";
 }
 
 ProjectMetadata::~ProjectMetadata() noexcept {

--- a/libs/librepcb/core/project/projectsettings.cpp
+++ b/libs/librepcb/core/project/projectsettings.cpp
@@ -41,7 +41,7 @@ ProjectSettings::ProjectSettings(Project& project, const Version& fileFormat,
   : QObject(nullptr), mProject(project) {
   Q_UNUSED(fileFormat);
 
-  qDebug() << "load settings...";
+  qDebug() << "Load project settings...";
 
   // restore all default values
   restoreDefaults();
@@ -70,7 +70,7 @@ ProjectSettings::ProjectSettings(Project& project, const Version& fileFormat,
 
   triggerSettingsChanged();
 
-  qDebug() << "settings successfully loaded!";
+  qDebug() << "Successfully loaded project settings.";
 }
 
 ProjectSettings::~ProjectSettings() noexcept {

--- a/libs/librepcb/core/serialization/serializableobjectlist.h
+++ b/libs/librepcb/core/serialization/serializableobjectlist.h
@@ -452,8 +452,7 @@ protected:  // Methods
       onElementEdited.notify(index, at(index), args...);
       onEdited.notify(index, at(index), Event::ElementEdited);
     } else {
-      qCritical() << "SerializableObjectList: Received notification from "
-                     "unknown element!";
+      qCritical() << "Received notification from unknown list element!";
     }
   }
   void throwKeyNotFoundException(const Uuid& key) const {

--- a/libs/librepcb/core/sqlitedatabase.cpp
+++ b/libs/librepcb/core/sqlitedatabase.cpp
@@ -51,7 +51,7 @@ SQLiteDatabase::TransactionScopeGuard::~TransactionScopeGuard() noexcept {
     try {
       mDb.rollbackTransaction();  // can throw
     } catch (Exception& e) {
-      qCritical() << "Could not rollback database transaction:" << e.getMsg();
+      qCritical() << "Failed to roll back database transaction:" << e.getMsg();
     }
   }
 }

--- a/libs/librepcb/core/types/lengthunit.cpp
+++ b/libs/librepcb/core/types/lengthunit.cpp
@@ -51,7 +51,8 @@ QString LengthUnit::toStr() const noexcept {
     case LengthUnit_t::Mils:
       return QString("mils");
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in LengthUnit::toStr():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return QString();
   }
@@ -70,7 +71,8 @@ QString LengthUnit::toStringTr() const noexcept {
     case LengthUnit_t::Mils:
       return tr("Mils");
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in LengthUnit::toStringTr():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return QString();
   }
@@ -89,7 +91,8 @@ QString LengthUnit::toShortStringTr() const noexcept {
     case LengthUnit_t::Mils:
       return "mils";
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in LengthUnit::toShortStringTr():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return QString();
   }
@@ -108,7 +111,9 @@ int LengthUnit::getReasonableNumberOfDecimals() const noexcept {
     case LengthUnit_t::Mils:
       return 2;
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in "
+                     "LengthUnit::getReasonableNumberOfDecimals():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return 3;
   }
@@ -127,7 +132,9 @@ QStringList LengthUnit::getUserInputSuffixes() const noexcept {
     case LengthUnit_t::Mils:
       return QStringList{"mils"};
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical()
+          << "Unhandled switch-case in LengthUnit::getUserInputSuffixes():"
+          << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return QStringList();
   }
@@ -146,7 +153,8 @@ qreal LengthUnit::convertToUnit(const Length& length) const noexcept {
     case LengthUnit_t::Mils:
       return length.toMil();
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in LengthUnit::convertToUnit():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return 0;
   }
@@ -165,7 +173,8 @@ QPointF LengthUnit::convertToUnit(const Point& point) const noexcept {
     case LengthUnit_t::Mils:
       return point.toMilQPointF();
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in LengthUnit::convertToUnit():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return QPointF();
   }
@@ -184,7 +193,8 @@ Length LengthUnit::convertFromUnit(qreal length) const {
     case LengthUnit_t::Mils:
       return Length::fromMil(length);
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in LengthUnit::convertFromUnit():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return Length(0);
   }
@@ -203,7 +213,8 @@ Point LengthUnit::convertFromUnit(const QPointF& point) const {
     case LengthUnit_t::Mils:
       return Point::fromMil(point);
     default:
-      qCritical() << "invalid length unit:" << static_cast<int>(mUnit);
+      qCritical() << "Unhandled switch-case in LengthUnit::convertFromUnit():"
+                  << static_cast<int>(mUnit);
       Q_ASSERT(false);
       return Point(Length(0), Length(0));
   }

--- a/libs/librepcb/core/types/uuid.cpp
+++ b/libs/librepcb/core/types/uuid.cpp
@@ -99,7 +99,8 @@ Uuid Uuid::createRandom() noexcept {
   if (isValid(str)) {
     return Uuid(str);
   } else {
-    qFatal("Not able to generate valid random UUID!");  // calls abort()!
+    // Calls abort()!
+    qFatal("Not able to generate valid random UUID, terminating application!");
   }
 }
 

--- a/libs/librepcb/core/utils/clipperhelpers.cpp
+++ b/libs/librepcb/core/utils/clipperhelpers.cpp
@@ -226,7 +226,7 @@ ClipperLib::Paths ClipperHelpers::prepareHoles(
       preparedHoles.push_back(rotateCutInHole(hole));
     } else {
       qWarning() << "Detected invalid hole in path flattening algorithm, "
-                    "ignoring it...";
+                    "ignoring it.";
     }
   }
   // important: sort holes by the y coordinate of their connection point

--- a/libs/librepcb/core/utils/tangentpathjoiner.cpp
+++ b/libs/librepcb/core/utils/tangentpathjoiner.cpp
@@ -170,7 +170,7 @@ void TangentPathJoiner::findAllPaths(QVector<Result>& result,
                                      const Result& prefix) noexcept {
   for (int i = 0; i < paths.count(); ++i) {
     if ((timeoutMs >= 0) && (timer.elapsed() > timeoutMs)) {
-      qWarning() << "TangentPathJoiner aborted due to timeout.";
+      qWarning() << "Tangent path joining algorithm aborted due to timeout.";
       break;
     }
     if (!prefix.indices.contains(i)) {

--- a/libs/librepcb/core/workspace/workspace.cpp
+++ b/libs/librepcb/core/workspace/workspace.cpp
@@ -56,7 +56,8 @@ Workspace::Workspace(const FilePath& wsPath, const QString& dataDirName,
     mFileSystem(),
     mWorkspaceSettings(),
     mLibraryDb() {
-  qDebug() << "Opening workspace data directory:" << mDataPath.toNative();
+  qDebug().nospace() << "Open workspace data directory " << mDataPath.toNative()
+                     << "...";
 
   // Fail if the path is not a valid workspace directory.
   QString errorMsg;
@@ -98,7 +99,7 @@ Workspace::Workspace(const FilePath& wsPath, const QString& dataDirName,
         SExpression::parse(mFileSystem->read(settingsFilePath),
                            mFileSystem->getAbsPath(settingsFilePath));
     mWorkspaceSettings->load(root, loadedFileFormat);
-    qDebug("Workspace settings loaded.");
+    qDebug("Successfully loaded workspace settings.");
   } else {
     qInfo("Workspace settings file not found, default settings will be used.");
   }
@@ -107,7 +108,7 @@ Workspace::Workspace(const FilePath& wsPath, const QString& dataDirName,
   if (loadedFileFormat != qApp->getFileFormatVersion()) {
     qInfo().nospace().noquote()
         << "Workspace data is outdated, will upgrade files from v"
-        << loadedFileFormat.toStr() << ".";
+        << loadedFileFormat.toStr() << "...";
     QFile(mLibrariesPath.getPathTo("library_cache.sqlite").toStr()).remove();
     QFile(mLibrariesPath.getPathTo("cache.sqlite").toStr()).remove();
     QFile(mLibrariesPath.getPathTo("cache_v1.sqlite").toStr()).remove();
@@ -124,7 +125,7 @@ Workspace::Workspace(const FilePath& wsPath, const QString& dataDirName,
   mLibraryDb.reset(new WorkspaceLibraryDb(mLibrariesPath));  // can throw
 
   // Done!
-  qDebug("Workspace successfully opened.");
+  qDebug("Successfully opened workspace.");
 }
 
 Workspace::~Workspace() noexcept {

--- a/libs/librepcb/core/workspace/workspacelibrarydb.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.cpp
@@ -64,7 +64,7 @@ WorkspaceLibraryDb::WorkspaceLibraryDb(const FilePath& librariesPath)
   int dbVersion = getDbVersion();
   if (dbVersion != sCurrentDbVersion) {
     qWarning() << "Library database version" << dbVersion
-               << "not supported, will be reinitialized.";
+               << "is outdated or not supported, reinitializing...";
     mDb.reset();
     QFile(mFilePath.toStr()).remove();
     mDb.reset(new SQLiteDatabase(mFilePath));  // can throw
@@ -89,7 +89,7 @@ WorkspaceLibraryDb::WorkspaceLibraryDb(const FilePath& librariesPath)
   connect(mLibraryScanner.data(), &WorkspaceLibraryScanner::scanFinished, this,
           &WorkspaceLibraryDb::scanFinished, Qt::QueuedConnection);
 
-  qDebug("Workspace library database successfully loaded!");
+  qDebug("Successfully loaded workspace library database.");
 }
 
 WorkspaceLibraryDb::~WorkspaceLibraryDb() noexcept {

--- a/libs/librepcb/editor/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/editor/dialogs/aboutdialog.cpp
@@ -128,8 +128,9 @@ void AboutDialog::formatLabelText(QLabel* label, bool selectable,
   label->setOpenExternalLinks(containsLinks);
   if (selectable) {
     label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    // If text is selectable, external links won't work anymore!
     if (containsLinks) {
-      qWarning() << "If text is selectable, external links won't work anymore!";
+      qWarning() << "Invalid label configuration in about dialog!";
     }
   }
 }

--- a/libs/librepcb/editor/dialogs/dxfimportdialog.cpp
+++ b/libs/librepcb/editor/dialogs/dxfimportdialog.cpp
@@ -90,7 +90,7 @@ DxfImportDialog::DxfImportDialog(QList<GraphicsLayer*> layers,
     restoreGeometry(clientSettings.value(settingsPrefix % "/window_geometry")
                         .toByteArray());
   } catch (const Exception& e) {
-    qCritical() << "Error while initializing DXF import dialog:" << e.getMsg();
+    qCritical() << "Failed to initialize DXF import dialog:" << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/dialogs/graphicsexportdialog.cpp
+++ b/libs/librepcb/editor/dialogs/graphicsexportdialog.cpp
@@ -877,8 +877,8 @@ void GraphicsExportDialog::syncClientSettings(
       }
     }
   } catch (const Exception& e) {
-    qCritical() << "GraphicsExportDialog: Failed to sync client settings.";
-    qCritical() << "GraphicsExportDialog:" << e.getMsg();
+    qCritical() << "Failed to sync graphics export dialog client settings:"
+                << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
@@ -60,7 +60,7 @@ CmdFootprintPadEdit::~CmdFootprintPadEdit() noexcept {
     try {
       performUndo();
     } catch (...) {
-      qCritical() << "Undo failed!";
+      qCritical() << "Undo failed in CmdFootprintPadEdit destructor!";
     }
   }
 }

--- a/libs/librepcb/editor/library/cmd/cmdsymbolpinedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdsymbolpinedit.cpp
@@ -61,7 +61,7 @@ CmdSymbolPinEdit::~CmdSymbolPinEdit() noexcept {
     try {
       performUndo();
     } catch (...) {
-      qCritical() << "Undo failed!";
+      qCritical() << "Undo failed in CmdSymbolPinEdit destructor!";
     }
   }
 }

--- a/libs/librepcb/editor/library/cmp/componentpinsignalmapmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentpinsignalmapmodel.cpp
@@ -343,7 +343,8 @@ void ComponentPinSignalMapModel::symbolItemsEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "ComponentPinSignalMapModel::symbolItemsEdited()";
+                    "ComponentPinSignalMapModel::symbolItemsEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }
@@ -365,7 +366,8 @@ void ComponentPinSignalMapModel::signalListEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "ComponentPinSignalMapModel::signalListEdited()";
+                    "ComponentPinSignalMapModel::signalListEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/cmp/componentsignallistmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsignallistmodel.cpp
@@ -341,7 +341,8 @@ void ComponentSignalListModel::signalListEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "ComponentSignalListModel::signalListEdited()";
+                    "ComponentSignalListModel::signalListEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.cpp
@@ -496,7 +496,8 @@ void ComponentSymbolVariantItemListModel::itemListEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "ComponentSymbolVariantItemListModel::itemListEdited()";
+                    "ComponentSymbolVariantItemListModel::itemListEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistmodel.cpp
@@ -382,7 +382,8 @@ void ComponentSymbolVariantListModel::symbolVariantListEdited(
     default:
       qWarning()
           << "Unhandled switch-case in "
-             "ComponentSymbolVariantListModel::symbolVariantListEdited()";
+             "ComponentSymbolVariantListModel::symbolVariantListEdited():"
+          << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/dev/devicepadsignalmapmodel.cpp
+++ b/libs/librepcb/editor/library/dev/devicepadsignalmapmodel.cpp
@@ -249,7 +249,8 @@ void DevicePadSignalMapModel::padSignalMapEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "DevicePadSignalMapModel::padSignalMapEdited()";
+                    "DevicePadSignalMapModel::padSignalMapEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_selectelements.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_selectelements.cpp
@@ -185,7 +185,10 @@ void EagleLibraryImportWizardPage_SelectElements::treeItemChanged(
         mContext->getImport().setPackageChecked(name, checked);
         break;
       default:
-        qCritical() << "Unknown tree item type.";
+        qCritical()
+            << "Unhandled switch-case in "
+               "EagleLibraryImportWizardPage_SelectElements::treeItemChanged():"
+            << elementType;
         break;
     }
   } else {
@@ -257,7 +260,10 @@ void EagleLibraryImportWizardPage_SelectElements::updateRootNodes() noexcept {
         elementTypeStr = tr("Packages");
         break;
       default:
-        qCritical() << "Unknown root node element type:" << elementTypeInt;
+        qCritical()
+            << "Unhandled switch-case in "
+               "EagleLibraryImportWizardPage_SelectElements::updateRootNodes():"
+            << elementTypeInt;
         break;
     }
     root->setText(0,

--- a/libs/librepcb/editor/library/editorwidgetbase.cpp
+++ b/libs/librepcb/editor/library/editorwidgetbase.cpp
@@ -281,7 +281,7 @@ void EditorWidgetBase::updateCheckMessages() noexcept {
       scheduleLibraryElementChecks();
     }
   } catch (const Exception& e) {
-    qCritical() << "Failed to run checks:" << e.getMsg();
+    qCritical() << "Failed to run library element checks:" << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/library/lib/librarylisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/lib/librarylisteditorwidget.cpp
@@ -91,7 +91,8 @@ LibraryListEditorWidget::LibraryListEditorWidget(const Workspace& ws,
     }
     mModel->setChoices(uuids);
   } catch (const Exception& e) {
-    qCritical() << "Could not load library list.";
+    qCritical() << "Could not load library list in editor widget:"
+                << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
@@ -437,7 +437,7 @@ QHash<QListWidgetItem*, FilePath>
     if (fp.isValid()) {
       itemPaths.insert(item, fp);
     } else {
-      qWarning() << "File path for item is not valid";
+      qWarning() << "Invalid file path of library list widget item ignored.";
     }
   }
   return itemPaths;
@@ -550,7 +550,7 @@ void LibraryOverviewWidget::newItem(QListWidget* list) noexcept {
   } else if (list == mUi->lstDev) {
     emit newDeviceTriggered();
   } else if (list) {
-    qCritical() << "Unknown list widget!";
+    qCritical() << "Unknown list widget in LibraryOverviewWidget::newItem()!";
   }
 }
 
@@ -569,7 +569,8 @@ void LibraryOverviewWidget::duplicateItem(QListWidget* list,
   } else if (list == mUi->lstDev) {
     emit duplicateDeviceTriggered(fp);
   } else if (list) {
-    qCritical() << "Unknown list widget!";
+    qCritical()
+        << "Unknown list widget in LibraryOverviewWidget::duplicateItem()!";
   }
 }
 
@@ -588,7 +589,7 @@ void LibraryOverviewWidget::editItem(QListWidget* list,
   } else if (list == mUi->lstDev) {
     emit editDeviceTriggered(fp);
   } else if (list) {
-    qCritical() << "Unknown list widget!";
+    qCritical() << "Unknown list widget in LibraryOverviewWidget::editItem()!";
   }
 }
 
@@ -665,16 +666,18 @@ void LibraryOverviewWidget::copyElementsToOtherLibrary(
       FilePath destination = libFp.getPathTo(relativePath);
       try {
         if (removeFromSource) {
-          qInfo() << "Move library element from" << itemPath.toNative() << "to"
-                  << destination.toNative();
+          qInfo().nospace()
+              << "Move library element from " << itemPath.toNative() << " to "
+              << destination.toNative() << "...";
           // Emit signal so that the library editor can close any tabs that have
           // opened this item
           emit removeElementTriggered(itemPath);
           FileUtils::move(itemPath, destination);
           delete item;  // Remove from list
         } else {
-          qInfo() << "Copy library element from" << itemPath.toNative() << "to"
-                  << destination.toNative();
+          qInfo().nospace()
+              << "Copy library element from " << itemPath.toNative() << " to "
+              << destination.toNative() << "...";
           FileUtils::copyDirRecursively(itemPath, destination);
         }
       } catch (const Exception& e) {
@@ -705,7 +708,7 @@ QList<LibraryOverviewWidget::LibraryMenuItem>
       }
     }
   } catch (const Exception& e) {
-    qCritical() << "Could not list local libraries:" << e.getMsg();
+    qCritical() << "Failed to list local libraries:" << e.getMsg();
   }
   // sort by name
   std::sort(libs.begin(), libs.end(),

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -412,7 +412,7 @@ bool LibraryEditor::closeTab(int index) noexcept {
       dynamic_cast<EditorWidgetBase*>(mUi->tabWidget->widget(index));
   if (widget == nullptr) {
     qCritical()
-        << "Cannot close tab, widget is not an EditorWidgetBase subclass";
+        << "Cannot close tab, widget is not an EditorWidgetBase subclass.";
     return false;
   }
 
@@ -732,7 +732,7 @@ void LibraryEditor::createToolBars() noexcept {
                     mUi->tabWidget->widget(0))) {
               w->setFilter(text);
             } else {
-              qCritical() << "LibraryEditor: Could not get overview widget.";
+              qCritical() << "Could not get overview widget in library editor.";
             }
           });
 

--- a/libs/librepcb/editor/library/libraryelementcache.cpp
+++ b/libs/librepcb/editor/library/libraryelementcache.cpp
@@ -101,7 +101,7 @@ std::shared_ptr<const T> LibraryElementCache::getElement(
           new TransactionalDirectory(TransactionalFileSystem::openRO(fp))));
       container.insert(uuid, element);
     } catch (const Exception& e) {
-      qWarning() << "Could not open library element:" << e.getMsg();
+      qWarning() << "Failed to open library element:" << e.getMsg();
     }
   }
   return element;

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -139,7 +139,9 @@ void NewElementWizardContext::copyElement(ElementType type,
       break;
     }
     default: {
-      qCritical() << "Unknown enum value:" << static_cast<int>(mElementType);
+      qCritical()
+          << "Unhandled switch-case in NewElementWizardContext::copyElement():"
+          << static_cast<int>(mElementType);
       break;
     }
   }

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_copyfrom.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_copyfrom.cpp
@@ -287,7 +287,8 @@ void NewElementWizardPage_CopyFrom::initializePage() noexcept {
       break;
     }
     default: {
-      qCritical() << "Unknown enum value:"
+      qCritical() << "Unhandled switch-case in "
+                     "NewElementWizardPage_CopyFrom::initializePage():"
                   << static_cast<int>(mContext.mElementType);
       setCategoryTreeModel(nullptr);
       break;

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_entermetadata.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_entermetadata.cpp
@@ -148,8 +148,10 @@ void NewElementWizardPage_EnterMetadata::btnChooseCategoryClicked() noexcept {
       break;
     }
     default: {
-      qCritical() << "Unknown enum value:"
-                  << static_cast<int>(mContext.mElementType);
+      qCritical()
+          << "Unhandled switch-case in "
+             "NewElementWizardPage_EnterMetadata::btnChooseCategoryClicked():"
+          << static_cast<int>(mContext.mElementType);
       return;
     }
   }

--- a/libs/librepcb/editor/library/pkg/footprintlistmodel.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintlistmodel.cpp
@@ -326,7 +326,8 @@ void FootprintListModel::footprintListEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "FootprintListModel::footprintListEdited()";
+                    "FootprintListModel::footprintListEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -164,7 +164,8 @@ void FootprintPadGraphicsItem::padEdited(const FootprintPad& pad,
       break;
     default:
       qWarning()
-          << "Unhandled switch-case in FootprintPadGraphicsItem::padEdited()";
+          << "Unhandled switch-case in FootprintPadGraphicsItem::padEdited():"
+          << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -525,7 +525,9 @@ void PackageEditorState_DrawPolygonBase::updateOverlayText() noexcept {
       break;
     }
     default: {
-      qWarning() << "PackageEditorState_DrawPolygonBase: Unknown mode.";
+      qWarning() << "Unhandled switch-case in "
+                    "PackageEditorState_DrawPolygonBase::updateOverlayText():"
+                 << static_cast<int>(mMode);
       break;
     }
   }

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -399,7 +399,8 @@ bool PackageEditorState_Select::processMove(Qt::ArrowType direction) noexcept {
             break;
           }
           default: {
-            qWarning() << "SymbolEditorState_Select: Unknown move direction:"
+            qWarning() << "Unhandled switch-case in "
+                          "PackageEditorState_Select::processMove():"
                        << direction;
             break;
           }

--- a/libs/librepcb/editor/library/pkg/packagepadlistmodel.cpp
+++ b/libs/librepcb/editor/library/pkg/packagepadlistmodel.cpp
@@ -287,7 +287,8 @@ void PackagePadListModel::padListEdited(
       dataChanged(this->index(index, 0), this->index(index, _COLUMN_COUNT - 1));
       break;
     default:
-      qWarning() << "Unhandled switch-case in PackagePadList::padListEdited()";
+      qWarning() << "Unhandled switch-case in PackagePadList::padListEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -524,7 +524,9 @@ void SymbolEditorState_DrawPolygonBase::updateOverlayText() noexcept {
       break;
     }
     default: {
-      qWarning() << "SymbolEditorState_DrawPolygonBase: Unknown mode.";
+      qWarning() << "Unhandled switch-case in "
+                    "SymbolEditorState_DrawPolygonBase::updateOverlayText():"
+                 << static_cast<int>(mMode);
       break;
     }
   }

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -387,7 +387,8 @@ bool SymbolEditorState_Select::processMove(Qt::ArrowType direction) noexcept {
             break;
           }
           default: {
-            qWarning() << "SymbolEditorState_Select: Unknown move direction:"
+            qWarning() << "Unhandled switch-case in "
+                          "SymbolEditorState_Select::processMove():"
                        << direction;
             break;
           }

--- a/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
@@ -156,10 +156,10 @@ void SymbolPinGraphicsItem::updateText() noexcept {
           text = "(NET)";
         }
       } else {
-        qCritical() << "SymbolPinGraphicsItem: Unknown pin display type!";
+        qCritical() << "Unknown pin display type for pin graphics item!";
       }
     } else {
-      qCritical() << "SymbolPinGraphicsItem: Pin not found in pin-signal map!";
+      qCritical() << "Pin not found in pin-signal map for pin graphics item!";
     }
   } else {
     text = *mPin->getName();
@@ -220,7 +220,8 @@ void SymbolPinGraphicsItem::pinEdited(const SymbolPin& pin,
       break;
     default:
       qWarning()
-          << "Unhandled switch-case in SymbolPinGraphicsItem::pinEdited()";
+          << "Unhandled switch-case in SymbolPinGraphicsItem::pinEdited():"
+          << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/modelview/attributelistmodel.cpp
+++ b/libs/librepcb/editor/modelview/attributelistmodel.cpp
@@ -416,7 +416,8 @@ void AttributeListModel::attributeListEdited(
       break;
     default:
       qWarning() << "Unhandled switch-case in "
-                    "AttributeListModel::attributeListEdited()";
+                    "AttributeListModel::attributeListEdited():"
+                 << static_cast<int>(event);
       break;
   }
 }

--- a/libs/librepcb/editor/modelview/pathmodel.cpp
+++ b/libs/librepcb/editor/modelview/pathmodel.cpp
@@ -70,7 +70,7 @@ void PathModel::copyItem(const QVariant& editData) noexcept {
     mPath.insertVertex(index, mPath.getVertices().value(index));
     endInsertRows();
   } else {
-    qWarning() << "Invalid index in PathModel::copyItem()";
+    qWarning() << "Invalid index in PathModel::copyItem():" << index;
   }
 }
 
@@ -81,7 +81,7 @@ void PathModel::removeItem(const QVariant& editData) noexcept {
     mPath.getVertices().remove(index);
     endRemoveRows();
   } else {
-    qWarning() << "Invalid index in PathModel::removeItem()";
+    qWarning() << "Invalid index in PathModel::removeItem():" << index;
   }
 }
 

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -1008,8 +1008,9 @@ void BoardEditor::toolActionGroupChangeTriggered(
       mFsm->processMeasure();
       break;
     default:
-      Q_ASSERT(false);
-      qCritical() << "Unknown tool triggered!";
+      qCritical() << "Unhandled switch-case in "
+                     "BoardEditor::toolActionGroupChangeTriggered():"
+                  << newTool;
       break;
   }
 }

--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
@@ -184,7 +184,7 @@ void BoardPickPlaceGeneratorDialog::updateTable() noexcept {
     }
     mUi->tableWidget->resizeRowsToContents();
   } catch (Exception& e) {
-    qCritical() << e.getMsg();
+    qCritical() << "Failed to update pick&place table widget:" << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.cpp
@@ -146,7 +146,7 @@ bool BoardPlanePropertiesDialog::applyChanges() noexcept {
     if (netsignal) {
       cmd->setNetSignal(*netsignal);
     } else {
-      qWarning() << "No valid netsignal selected!";
+      qWarning() << "No valid netsignal selected in plane properties dialog!";
     }
 
     // layer

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -1504,7 +1504,7 @@ QList<BoardEditorState_Select::DeviceMenuItem>
           return collator(lhs.name, rhs.name);
         });
   } catch (const Exception& e) {
-    qCritical() << "Could not list devices:" << e.getMsg();
+    qCritical() << "Failed to list devices in context menu:" << e.getMsg();
   }
   return items;
 }

--- a/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
@@ -294,7 +294,7 @@ void UnplacedComponentsDock::currentDeviceIndexChanged(int index) noexcept {
     }
     setSelectedDeviceAndPackage(device.deviceUuid, package, packageOwned);
   } catch (const Exception& e) {
-    qCritical() << e.getMsg();
+    qCritical() << "Failed to load device & package preview:" << e.getMsg();
   }
 }
 
@@ -569,7 +569,7 @@ std::pair<QList<UnplacedComponentsDock::DeviceMetadata>, int>
           DeviceMetadata{deviceUuid, devName, pkgUuid, QString(), false});
     }
   } catch (const Exception& e) {
-    qCritical() << "Error while listing devices in unplaced components dock:"
+    qCritical() << "Failed to list devices in unplaced components dock:"
                 << e.getMsg();
   }
 
@@ -589,9 +589,8 @@ std::pair<QList<UnplacedComponentsDock::DeviceMetadata>, int>
             pkgFp, localeOrder,
             &device.packageName);  // can throw
       } catch (const Exception& e) {
-        qCritical()
-            << "Error while querying packages in unplaced components dock:"
-            << e.getMsg();
+        qCritical() << "Failed to query packages in unplaced components dock:"
+                    << e.getMsg();
       }
     }
     device.selectedInSchematic =
@@ -616,7 +615,7 @@ std::pair<QList<UnplacedComponentsDock::DeviceMetadata>, int>
       }
     }
     qWarning() << "Selected device" << *dev
-               << "not found in library, will use another device.";
+               << "not found in library, will use another device...";
   }
 
   // Prio 2: Use the device already used for the same component before.

--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -213,7 +213,7 @@ void BomGeneratorDialog::updateTable() noexcept {
     mUi->tableWidget->resizeRowsToContents();
     mUi->lblSuccess->hide();
   } catch (Exception& e) {
-    qCritical() << e.getMsg();
+    qCritical() << "Failed to update BOM table widget:" << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/project/cmd/cmddeviceinstanceedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddeviceinstanceedit.cpp
@@ -54,7 +54,7 @@ CmdDeviceInstanceEdit::~CmdDeviceInstanceEdit() noexcept {
       mDevice.setRotation(mOldRotation);
       mDevice.setMirrored(mOldMirrored);  // can throw
     } catch (Exception& e) {
-      qCritical() << "Could not revert all changes:" << e.getMsg();
+      qCritical() << "Failed to revert device instance changes:" << e.getMsg();
     }
   }
 }
@@ -130,7 +130,8 @@ void CmdDeviceInstanceEdit::mirror(const Point& center,
       break;
     }
     default: {
-      qCritical() << "Invalid orientation:" << orientation;
+      qCritical() << "Unhandled switch-case in CmdDeviceInstanceEdit::mirror():"
+                  << orientation;
       break;
     }
   }

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
@@ -120,7 +120,8 @@ void CmdSymbolInstanceEdit::mirror(const Point& center,
       break;
     }
     default: {
-      qCritical() << "Invalid orientation:" << orientation;
+      qCritical() << "Unhandled switch-case in CmdSymbolInstanceEdit::mirror():"
+                  << orientation;
       break;
     }
   }

--- a/libs/librepcb/editor/project/projecteditor.cpp
+++ b/libs/librepcb/editor/project/projecteditor.cpp
@@ -188,7 +188,7 @@ void ProjectEditor::execLppzExportDialog(QWidget* parent) noexcept {
     if (filename.isEmpty()) return;
     if (!filename.endsWith(".lppz")) filename.append(".lppz");
     FilePath fp(filename);
-    qDebug() << "Export project to *.lppz:" << fp.toNative();
+    qDebug().nospace() << "Export project to " << fp.toNative() << "...";
 
     // Usually we save the project to the transactional file system (but not to
     // the disk!) before exporting the *.lppz since the user probably expects
@@ -212,7 +212,7 @@ void ProjectEditor::execLppzExportDialog(QWidget* parent) noexcept {
     };
     mProject.getDirectory().getFileSystem()->exportToZip(fp,
                                                          filter);  // can throw
-    qDebug() << "Project successfully exported.";
+    qDebug() << "Successfully exported project to *.lppz.";
   } catch (const Exception& e) {
     QMessageBox::critical(parent, tr("Error"), e.getMsg());
   }
@@ -248,7 +248,7 @@ bool ProjectEditor::saveProject() noexcept {
 
     // saving was successful --> clean the undo stack
     mUndoStack->setClean();
-    qDebug() << "Project successfully saved";
+    qDebug() << "Successfully saved project.";
     return true;
   } catch (Exception& exc) {
     QMessageBox::critical(0, tr("Error while saving the project"),
@@ -279,7 +279,7 @@ bool ProjectEditor::autosaveProject() noexcept {
     mProject.save();  // can throw
     mProject.getDirectory().getFileSystem()->autosave();  // can throw
     mLastAutosaveStateId = mUndoStack->getUniqueStateId();
-    qDebug() << "Project successfully autosaved";
+    qDebug() << "Successfully autosaved project.";
     return true;
   } catch (Exception& exc) {
     return false;

--- a/libs/librepcb/editor/project/projectsettingsdialog.cpp
+++ b/libs/librepcb/editor/project/projectsettingsdialog.cpp
@@ -109,7 +109,8 @@ void ProjectSettingsDialog::on_buttonBox_clicked(QAbstractButton* button) {
     }
 
     default:
-      qCritical() << "invalid button role:"
+      qCritical() << "Unhandled switch-case in "
+                     "ProjectSettingsDialog::on_buttonBox_clicked():"
                   << mUi->buttonBox->buttonRole(button);
       break;
   }

--- a/libs/librepcb/editor/project/schematiceditor/renamenetsegmentdialog.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/renamenetsegmentdialog.cpp
@@ -194,7 +194,8 @@ void RenameNetSegmentDialog::updateAction() noexcept {
     } else {
       mAction = Action::INVALID_NAME;  // Not correct, but sufficient
       desc = "UNKNOWN ERROR";
-      qCritical() << "Unhandled case in RenameNetSegmentDialog!";
+      qCritical()
+          << "Unhandled case in RenameNetSegmentDialog::updateAction()!";
     }
     mUi->lblDescription->setText(desc);
     mUi->lblDescription->setStyleSheet("");

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -873,8 +873,9 @@ void SchematicEditor::toolActionGroupChangeTriggered(
       mFsm->processMeasure();
       break;
     default:
-      Q_ASSERT(false);
-      qCritical() << "Unknown tool triggered!";
+      qCritical() << "Unhandled switch-case in "
+                     "SchematicEditor::toolActionGroupChangeTriggered():"
+                  << newTool;
       break;
   }
 }

--- a/libs/librepcb/editor/project/schematiceditor/schematicnetsegmentsplitter.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicnetsegmentsplitter.cpp
@@ -179,8 +179,8 @@ Point SchematicNetSegmentSplitter::getAnchorPosition(
       return mJunctions.get(*junctionUuid)->getPosition();
     }
   }
-  qWarning()
-      << "SchematicNetSegmentSplitter: Could not determine position of anchor!";
+  qWarning() << "Failed to determine position of net label anchor while "
+                "splitting segments!";
   return Point();
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -160,7 +160,9 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
         device ? mUi->cbxPreselectedDevice->findData(device->toStr()) : 0);
   } catch (const Exception& e) {
     // If something went wrong, disable the combobox to avoid breaking something
-    qCritical() << "Could not list devices:" << e.getMsg();
+    qCritical()
+        << "Failed to list devices in symbol instance properties dialog:"
+        << e.getMsg();
     mUi->cbxPreselectedDevice->setEnabled(false);
   }
 

--- a/libs/librepcb/editor/undostack.cpp
+++ b/libs/librepcb/editor/undostack.cpp
@@ -51,7 +51,7 @@ UndoStackTransaction::~UndoStackTransaction() noexcept {
     if (mCmdActive)
       mStack.abortCmdGroup();  // can throw, but should really not!
   } catch (...) {
-    qFatal("UndoStack::abortCmdGroup() has thrown an exception!");
+    qFatal("Aborting the undo stack command group threw an exception!");
   }
 }
 
@@ -276,7 +276,7 @@ void UndoStack::abortCmdGroup() {
     delete mCommands.takeLast();  // delete and remove the aborted command group
                                   // from the stack
   } catch (Exception& e) {
-    qCritical() << "UndoCommand::undo() has thrown an exception:" << e.getMsg();
+    qCritical() << "Exception thrown in UndoCommand::undo():" << e.getMsg();
     throw;
   }
 
@@ -299,7 +299,7 @@ void UndoStack::undo() {
     mCommands[mCurrentIndex - 1]->undo();  // can throw (but should usually not)
     mCurrentIndex--;
   } catch (Exception& e) {
-    qCritical() << "UndoCommand::undo() has thrown an exception:" << e.getMsg();
+    qCritical() << "Exception thrown in UndoCommand::undo():" << e.getMsg();
     throw;
   }
 
@@ -321,7 +321,7 @@ void UndoStack::redo() {
     mCommands[mCurrentIndex]->redo();  // can throw (but should usually not)
     mCurrentIndex++;
   } catch (Exception& e) {
-    qCritical() << "UndoCommand::redo() has thrown an exception:" << e.getMsg();
+    qCritical() << "Exception thrown in UndoCommand::redo():" << e.getMsg();
     throw;
   }
 
@@ -343,7 +343,7 @@ void UndoStack::clear() noexcept {
     try {
       abortCmdGroup();
     } catch (...) {
-      qCritical() << "Could not abort the currently active command group!";
+      qCritical() << "Failed to abort the currently active command group!";
     }
   }
 

--- a/libs/librepcb/editor/utils/editortoolbox.cpp
+++ b/libs/librepcb/editor/utils/editortoolbox.cpp
@@ -50,9 +50,8 @@ void EditorToolbox::removeFormLayoutRow(QLabel& label) noexcept {
       }
     }
   }
-  qWarning().nospace()
-      << "EditorToolbox::removeFormLayoutRow() failed to remove row "
-      << label.objectName() << ".";
+  qWarning().nospace() << "Failed to remove form layout row "
+                       << label.objectName() << ".";
 }
 
 void EditorToolbox::deleteLayoutItemRecursively(QLayoutItem* item) noexcept {

--- a/libs/librepcb/editor/widgets/angleedit.cpp
+++ b/libs/librepcb/editor/widgets/angleedit.cpp
@@ -70,7 +70,7 @@ void AngleEdit::spinBoxValueChanged(double value) noexcept {
     emit valueChanged(mValue);
   } catch (const Exception& e) {
     // This should actually never happen, thus no user visible message here.
-    qWarning() << "Invalid angle entered:" << e.getMsg();
+    qWarning() << "Invalid angle entered:" << value;
   }
 }
 

--- a/libs/librepcb/editor/widgets/editabletablewidget.cpp
+++ b/libs/librepcb/editor/widgets/editabletablewidget.cpp
@@ -208,7 +208,7 @@ void EditableTableWidget::buttonClickedHandler(
     (this->*clickedSignal)(data);
   } else {
     qCritical() << "Invalid index received in "
-                   "EditableTableWidget::buttonClickedHandler()";
+                   "EditableTableWidget::buttonClickedHandler().";
   }
 }
 

--- a/libs/librepcb/editor/widgets/graphicsexportpreviewwidget.cpp
+++ b/libs/librepcb/editor/widgets/graphicsexportpreviewwidget.cpp
@@ -198,7 +198,7 @@ void GraphicsExportWidget::setPageContent(
     updateItemPositions();
     updateScale();
   } else {
-    qWarning() << "GraphicsExportWidget: Page index out of bounds.";
+    qWarning() << "Graphics export preview page index out of bounds:" << index;
   }
 }
 

--- a/libs/librepcb/editor/widgets/graphicslayercombobox.cpp
+++ b/libs/librepcb/editor/widgets/graphicslayercombobox.cpp
@@ -64,14 +64,14 @@ GraphicsLayerComboBox::~GraphicsLayerComboBox() noexcept {
 
 tl::optional<GraphicsLayerName> GraphicsLayerComboBox::getCurrentLayerName()
     const noexcept {
+  QString name = mComboBox->currentData(Qt::UserRole).toString();
   try {
-    QString name = mComboBox->currentData(Qt::UserRole).toString();
     if (GraphicsLayerNameConstraint()(name)) {
       return GraphicsLayerName(name);  // can throw
     }
   } catch (const Exception& e) {
     // This should actually never happen, thus no user visible message here.
-    qWarning() << "Invalid graphics layer selected:" << e.getMsg();
+    qWarning() << "Invalid graphics layer selected:" << name;
   }
   return tl::nullopt;
 }

--- a/libs/librepcb/editor/widgets/lengtheditbase.cpp
+++ b/libs/librepcb/editor/widgets/lengtheditbase.cpp
@@ -143,7 +143,7 @@ void LengthEditBase::configureClientSettings(
       mSelectedUnit = tl::nullopt;
     }
   } catch (const Exception& e) {
-    qWarning() << "LengthEditBase: Could not restore unit from user settings:"
+    qWarning() << "Failed to restore length edit unit from user settings:"
                << e.getMsg();
   }
 }
@@ -227,12 +227,13 @@ void LengthEditBase::updateValueFromText(QString text) noexcept {
         valueChangedImpl(diff);
         update();  // step buttons might need to be repainted
       } else {
-        qWarning() << "LengthEditBase: Entered text was a valid number, but "
-                      "outside the allowed range.";
+        qWarning() << "Entered length text was a valid number, but "
+                      "outside the allowed range:"
+                   << text;
       }
     }
   } catch (const Exception&) {
-    qWarning() << "LengthEditBase: Entered text was a valid expression, but "
+    qWarning() << "Entered length text was a valid expression, but "
                   "evaluated to an invalid number:"
                << text;
   }
@@ -249,8 +250,9 @@ void LengthEditBase::updateSingleStep() noexcept {
       break;
     }
     default:
-      Q_ASSERT(false);
-      qCritical() << "Unknown step behavior in LengthEditBase!";
+      qCritical()
+          << "Unhandled switch-case in LengthEditBase::updateSingleStep():"
+          << static_cast<int>(mStepBehavior);
       break;
   }
 }

--- a/libs/librepcb/editor/widgets/ratioedit.cpp
+++ b/libs/librepcb/editor/widgets/ratioedit.cpp
@@ -81,7 +81,7 @@ void RatioEdit::spinBoxValueChanged(double value) noexcept {
     emit valueChanged(mValue);
   } catch (const Exception& e) {
     // This should actually never happen, thus no user visible message here.
-    qWarning() << "Invalid ratio entered:" << e.getMsg();
+    qWarning() << "Invalid ratio entered:" << value;
   }
 }
 

--- a/libs/librepcb/editor/widgets/unsignedratioedit.cpp
+++ b/libs/librepcb/editor/widgets/unsignedratioedit.cpp
@@ -81,7 +81,7 @@ void UnsignedRatioEdit::spinBoxValueChanged(double value) noexcept {
     emit valueChanged(mValue);
   } catch (const Exception& e) {
     // This should actually never happen, thus no user visible message here.
-    qWarning() << "Invalid unsigned ratio entered:" << e.getMsg();
+    qWarning() << "Invalid unsigned ratio entered:" << value;
   }
 }
 

--- a/libs/librepcb/editor/workspace/categorytreemodel.cpp
+++ b/libs/librepcb/editor/workspace/categorytreemodel.cpp
@@ -132,7 +132,7 @@ QVariant CategoryTreeModel::data(const QModelIndex& index, int role) const
  ******************************************************************************/
 
 void CategoryTreeModel::update() noexcept {
-  qDebug() << "CategoryTreeModel update started.";
+  qDebug() << "Update category tree model...";
   QElapsedTimer t;
   t.start();
 
@@ -150,13 +150,13 @@ void CategoryTreeModel::update() noexcept {
                    {}}));
     }
   } catch (const Exception& e) {
-    qCritical() << "CategoryTreeModel failed to update items:" << e.getMsg();
+    qCritical() << "Failed to update category tree model:" << e.getMsg();
   }
 
   // Update tree with new items in a way which keeps the selection in views.
   updateModelItem(mRootItem, items);
 
-  qDebug() << "CategoryTreeModel update finished in" << t.elapsed() << "ms.";
+  qDebug() << "Finished category tree model update in" << t.elapsed() << "ms.";
 }
 
 QVector<std::shared_ptr<CategoryTreeModel::Item>> CategoryTreeModel::getChilds(
@@ -188,7 +188,7 @@ QVector<std::shared_ptr<CategoryTreeModel::Item>> CategoryTreeModel::getChilds(
       }
     }
   } catch (const Exception& e) {
-    qCritical() << "CategoryTreeModel failed to update items:" << e.getMsg();
+    qCritical() << "Failed to update category tree model items:" << e.getMsg();
   }
 
   // Sort items by text.

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -316,7 +316,7 @@ void ControlPanel::updateNoLibrariesWarningVisibility() noexcept {
   try {
     showWarning = mWorkspace.getLibraryDb().getAll<Library>().isEmpty();
   } catch (const Exception& e) {
-    qCritical() << "Could not get library list:" << e.getMsg();
+    qCritical() << "Failed to get workspace library list:" << e.getMsg();
   }
   mUi->lblWarnForNoLibraries->setVisible(showWarning);
 }
@@ -333,7 +333,7 @@ void ControlPanel::switchWorkspace() noexcept {
   try {
     wizard.setWorkspacePath(mWorkspace.getPath());
   } catch (const Exception& e) {
-    qWarning() << "ControlPanel: Failed to set current workspace path.";
+    qWarning() << "Failed to prepare workspace switching:" << e.getMsg();
   }
   if ((wizard.exec() == QDialog::Accepted) &&
       (wizard.getWorkspacePath().isValid())) {

--- a/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
@@ -55,7 +55,7 @@ FavoriteProjectsModel::FavoriteProjectsModel(
       updateVisibleProjects();
     }
   } catch (Exception& e) {
-    qWarning() << "Could not read favorite projects file:" << e.getMsg();
+    qWarning() << "Failed to read favorite projects file:" << e.getMsg();
   }
 }
 
@@ -115,7 +115,7 @@ void FavoriteProjectsModel::save() noexcept {
     root.ensureLineBreakIfMultiLine();
     FileUtils::writeFile(mFilePath, root.toByteArray());  // can throw
   } catch (Exception& e) {
-    qWarning() << "Could not save favorite projects file:" << e.getMsg();
+    qWarning() << "Failed to save favorite projects file:" << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/workspace/controlpanel/recentprojectsmodel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/recentprojectsmodel.cpp
@@ -54,7 +54,7 @@ RecentProjectsModel::RecentProjectsModel(const Workspace& workspace) noexcept
       updateVisibleProjects();
     }
   } catch (Exception& e) {
-    qWarning() << "Could not read recent projects file:" << e.getMsg();
+    qWarning() << "Failed to read recent projects file:" << e.getMsg();
   }
 }
 
@@ -107,7 +107,7 @@ void RecentProjectsModel::save() noexcept {
     root.ensureLineBreakIfMultiLine();
     FileUtils::writeFile(mFilePath, root.toByteArray());  // can throw
   } catch (Exception& e) {
-    qWarning() << "Could not save recent projects file:" << e.getMsg();
+    qWarning() << "Failed to save recent projects file:" << e.getMsg();
   }
 }
 

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard.cpp
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard.cpp
@@ -75,16 +75,16 @@ void InitializeWorkspaceWizard::setWorkspacePath(const FilePath& fp) {
   if (mNeedsToBeShown && (!mForceChoosePath)) {
     switch (startId()) {
       case InitializeWorkspaceWizardContext::ID_Welcome:
-        qInfo() << "No workspace selected, asking for path.";
+        qInfo() << "No workspace selected, asking for path...";
         break;
       case InitializeWorkspaceWizardContext::ID_ChooseWorkspace:
-        qInfo() << "Invalid workspace selected, asking for different path.";
+        qInfo() << "Invalid workspace selected, asking for different path...";
         break;
       case InitializeWorkspaceWizardContext::ID_Upgrade:
-        qInfo() << "Workspace data is outdated, asking for upgrade.";
+        qInfo() << "Workspace data is outdated, asking for upgrade...";
         break;
       case InitializeWorkspaceWizardContext::ID_ChooseSettings:
-        qInfo() << "Workspace data not initialized, asking for settings.";
+        qInfo() << "Workspace data not initialized, asking for settings...";
         break;
       default:
         break;

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_upgrade.cpp
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_upgrade.cpp
@@ -107,14 +107,13 @@ bool InitializeWorkspaceWizard_Upgrade::validatePage() noexcept {
   if (QAbstractButton* btn = wizard()->button(QWizard::BackButton)) {
     btn->setEnabled(false);
   } else {
-    qWarning() << "InitializeWorkspaceWizard_Upgrade: Could not disable back "
-                  "button.";
+    qWarning() << "Could not disable back button in workspace upgrade wizard.";
   }
   if (QAbstractButton* btn = wizard()->button(QWizard::FinishButton)) {
     btn->setEnabled(false);
   } else {
-    qWarning() << "InitializeWorkspaceWizard_Upgrade: Could not disable finish "
-                  "button.";
+    qWarning()
+        << "Could not disable finish button in workspace upgrade wizard.";
   }
   mUi->progressBar->show();
   mCopyOperation->start();

--- a/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
@@ -452,7 +452,7 @@ void AddLibraryWidget::downloadLibrariesFromRepositoryButtonClicked() noexcept {
     if (widget) {
       widget->startDownloadIfSelected();
     } else {
-      qWarning() << "Invalid item widget detected.";
+      qWarning() << "Invalid item widget detected in library manager.";
     }
   }
 }

--- a/libs/librepcb/editor/workspace/librarymanager/librarydownload.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/librarydownload.cpp
@@ -72,7 +72,8 @@ void LibraryDownload::setExpectedZipFileSize(qint64 bytes) noexcept {
   if (mFileDownload) {
     mFileDownload->setExpectedReplyContentSize(bytes);
   } else {
-    qCritical() << "Calling this method after start() is not allowed!";
+    qCritical() << "Calling LibraryDownload::setExpectedZipFileSize() after "
+                   "start() is not allowed!";
   }
 }
 
@@ -82,7 +83,8 @@ void LibraryDownload::setExpectedChecksum(
   if (mFileDownload) {
     mFileDownload->setExpectedChecksum(algorithm, checksum);
   } else {
-    qCritical() << "Calling this method after start() is not allowed!";
+    qCritical() << "Calling LibraryDownload::setExpectedChecksum() after "
+                   "start() is not allowed!";
   }
 }
 
@@ -92,7 +94,8 @@ void LibraryDownload::setExpectedChecksum(
 
 void LibraryDownload::start() noexcept {
   if (!mFileDownload) {
-    qCritical() << "Calling this method multiple times is not allowed!";
+    qCritical()
+        << "Calling LibraryDownload::start() multiple times is not allowed!";
     return;
   }
 

--- a/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.cpp
@@ -70,7 +70,7 @@ RepositoryLibraryListWidgetItem::RepositoryLibraryListWidgetItem(
     if (uuid) {
       mDependencies.insert(*uuid);
     } else {
-      qWarning() << "Invalid dependency UUID:" << value.toString();
+      qWarning() << "Invalid library dependency UUID:" << value.toString();
     }
   }
 
@@ -200,7 +200,8 @@ void RepositoryLibraryListWidgetItem::updateInstalledStatus() noexcept {
         installedVersion = v;
       }
     } catch (const Exception& e) {
-      qCritical() << "Could not determine if library is installed.";
+      qCritical() << "Failed to determine if library is installed: "
+                  << e.getMsg();
     }
     if (installedVersion) {
       if (installedVersion < mVersion) {


### PR DESCRIPTION
### Remove "(:0)" in logging messages of release builds

In release builds, typically `__FILE__` and `__LINE__` are not set. But currently these values are still output on each logging line (i.e. on stderr), which lead to "(:0)". Since this is useless, let's hide this if file/line are unknown.

## Improve formatting & consistency of logging messages

Documented and applied the following guidelines to ensure a consistent look of console output:

- Logging messages shall not be translated, i.e. don't use `tr()` for them.
- Output real sentences, starting with uppercase letter and ending with a period. Exceptions are allowed for something like "Invalid parameter: foo".
- Try to output messages *before* the corresponding operation is performed. This helps to debug crashes since you see the last started operation. Use imperative language and end such messages with "...", for example "Save project...".
- Output native file paths, not UNIX filepaths.

### Example

```
[  INFO   ] LibrePCB 0.2.0-unstable (fec46c039)
[  INFO   ] Qt version: 5.15.5 (compiled against 5.15.5)
[  INFO   ] Resources directory: "/home/me/LibrePCB/share/librepcb"
[  INFO   ] Application settings: "/home/me/.config/LibrePCB/LibrePCB.ini"
[DEBUG-MSG] Network access manager thread started.
[DEBUG-MSG] Successfully loaded stroke font "/home/me/LibrePCB/share/librepcb/fontobene/newstroke.bene" with 2573 glyphs.
[DEBUG-MSG] Recently used workspace: "/home/me/LibrePCB-Workspace"
[DEBUG-MSG] Open workspace data directory "/home/me/LibrePCB-Workspace/data"...
[DEBUG-MSG] Load workspace settings...
[DEBUG-MSG] Successfully loaded workspace settings.
[DEBUG-MSG] Load workspace library database...
[DEBUG-MSG] Successfully loaded workspace library database.
[DEBUG-MSG] Successfully opened workspace.
[DEBUG-MSG] Workspace library scanner thread started.
[DEBUG-MSG] Start workspace library scan in worker thread...
[DEBUG-MSG] Workspace libraries indexed: 42 libraries in 18 ms.
[DEBUG-MSG] Open project "/home/me/LibrePCB-Workspace/projects/can2usb/can2usb.lpp"...
[DEBUG-MSG] Found stroke font: "newstroke.bene"
[DEBUG-MSG] Start loading stroke font  "/home/me/LibrePCB-Workspace/projects/can2usb/resources/fontobene/newstroke.bene" in worker thread...
[DEBUG-MSG] Load project metadata...
[DEBUG-MSG] Successfully loaded project metadata.
[DEBUG-MSG] Load project settings...
[DEBUG-MSG] Successfully loaded project settings.
[DEBUG-MSG] Load project library...
[DEBUG-MSG] Successfully loaded 17 symbols.
[DEBUG-MSG] Successfully loaded 14 packages.
[DEBUG-MSG] Successfully loaded 17 components.
[DEBUG-MSG] Successfully loaded 16 devices.
[DEBUG-MSG] Successfully loaded project library.
[DEBUG-MSG] Load circuit...
[DEBUG-MSG] Successfully loaded circuit.
[DEBUG-MSG] Successfully loaded 1 schematics.
[DEBUG-MSG] Successfully loaded stroke font "/home/me/LibrePCB-Workspace/projects/can2usb/resources/fontobene/newstroke.bene" with 2573 glyphs.
[DEBUG-MSG] Successfully loaded 1 boards.
[DEBUG-MSG] Successfully loaded project.
[DEBUG-MSG] Save project...
[DEBUG-MSG] Save project files to transactional file system...
[DEBUG-MSG] Successfully saved project.
[DEBUG-MSG] Closed project "/home/me/LibrePCB-Workspace/projects/can2usb/can2usb.lpp".
[DEBUG-MSG] Network access manager thread stopped.
[DEBUG-MSG] Workspace library scan aborted after 4706 ms.
[DEBUG-MSG] Workspace library scanner thread stopped.
[DEBUG-MSG] Exit application with code 0.
```