### PR TITLE
Clear selection with 'Esc' key (all editors)

### DIFF
--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.cpp
@@ -31,7 +31,6 @@
 
 #include <librepcb/core/geometry/hole.h>
 #include <librepcb/core/graphics/graphicslayer.h>
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/graphics/holegraphicsitem.h>
 #include <librepcb/core/library/pkg/footprint.h>
 
@@ -65,8 +64,6 @@ PackageEditorState_AddHoles::~PackageEditorState_AddHoles() noexcept {
  ******************************************************************************/
 
 bool PackageEditorState_AddHoles::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   // populate command toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
   mContext.commandToolBar.addLabel(tr("Diameter:"), 10);

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
@@ -33,7 +33,6 @@
 #include "../packageeditorwidget.h"
 #include "../packagepadcombobox.h"
 
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/library/pkg/footprint.h>
 #include <librepcb/core/library/pkg/package.h>
 
@@ -81,8 +80,6 @@ PackageEditorState_AddPads::~PackageEditorState_AddPads() noexcept {
  ******************************************************************************/
 
 bool PackageEditorState_AddPads::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   // populate command toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawcircle.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawcircle.cpp
@@ -33,7 +33,6 @@
 #include <librepcb/core/geometry/circle.h>
 #include <librepcb/core/graphics/circlegraphicsitem.h>
 #include <librepcb/core/graphics/graphicslayer.h>
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/library/pkg/footprint.h>
 
 #include <QtCore>
@@ -69,8 +68,6 @@ PackageEditorState_DrawCircle::~PackageEditorState_DrawCircle() noexcept {
  ******************************************************************************/
 
 bool PackageEditorState_DrawCircle::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   // populate command toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
   mContext.commandToolBar.addLabel(tr("Layer:"));

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -33,7 +33,6 @@
 
 #include <librepcb/core/geometry/polygon.h>
 #include <librepcb/core/graphics/graphicslayer.h>
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/graphics/polygongraphicsitem.h>
 #include <librepcb/core/library/pkg/footprint.h>
 
@@ -75,8 +74,6 @@ PackageEditorState_DrawPolygonBase::
  ******************************************************************************/
 
 bool PackageEditorState_DrawPolygonBase::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   // populate command toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
   mContext.commandToolBar.addLabel(tr("Layer:"));

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -35,7 +35,6 @@
 
 #include <librepcb/core/geometry/stroketext.h>
 #include <librepcb/core/graphics/graphicslayer.h>
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/graphics/stroketextgraphicsitem.h>
 #include <librepcb/core/library/pkg/footprint.h>
 
@@ -75,8 +74,6 @@ PackageEditorState_DrawTextBase::~PackageEditorState_DrawTextBase() noexcept {
  ******************************************************************************/
 
 bool PackageEditorState_DrawTextBase::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   // populate command toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
   if (mMode == Mode::TEXT) {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -93,17 +93,14 @@ bool PackageEditorState_Select::exit() noexcept {
 QSet<EditorWidgetBase::Feature>
     PackageEditorState_Select::getAvailableFeatures() const noexcept {
   QSet<EditorWidgetBase::Feature> features;
+  // The abort command is always enabled to clear the selection.
+  features |= EditorWidgetBase::Feature::Abort;
   if (mState != SubState::PASTING) {
     features |= EditorWidgetBase::Feature::SelectGraphics;
     if (!mContext.editorContext.readOnly) {
       features |= EditorWidgetBase::Feature::ImportGraphics;
       features |= EditorWidgetBase::Feature::Paste;
     }
-  }
-  if (((mState == SubState::MOVING) && (mCmdDragSelectedItems)) ||
-      (mState == SubState::PASTING) ||
-      ((mState == SubState::MOVING_POLYGON_VERTEX) && (mCmdPolygonEdit))) {
-    features |= EditorWidgetBase::Feature::Abort;
   }
   if (mContext.currentGraphicsItem) {
     CmdDragSelectedFootprintItems cmd(mContext);
@@ -613,7 +610,10 @@ bool PackageEditorState_Select::processAbortCommand() noexcept {
         return false;
       }
     }
-    default: { return false; }
+    default: {
+      clearSelectionRect(true);  // Clear selection, if any.
+      return true;
+    }
   }
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -83,6 +83,10 @@ PackageEditorState_Select::~PackageEditorState_Select() noexcept {
 
 bool PackageEditorState_Select::exit() noexcept {
   processAbortCommand();
+
+  // Avoid propagating the selection to other, non-selectable tools.
+  clearSelectionRect(true);
+
   return true;
 }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.cpp
@@ -30,7 +30,6 @@
 #include "../symbolgraphicsitem.h"
 #include "../symbolpingraphicsitem.h"
 
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/library/sym/symbol.h>
 #include <librepcb/core/library/sym/symbolpin.h>
 
@@ -65,8 +64,6 @@ SymbolEditorState_AddPins::~SymbolEditorState_AddPins() noexcept {
  ******************************************************************************/
 
 bool SymbolEditorState_AddPins::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // populate command toolbar

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawcircle.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawcircle.cpp
@@ -33,7 +33,6 @@
 #include <librepcb/core/geometry/circle.h>
 #include <librepcb/core/graphics/circlegraphicsitem.h>
 #include <librepcb/core/graphics/graphicslayer.h>
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/library/sym/symbol.h>
 
 #include <QtCore>
@@ -69,8 +68,6 @@ SymbolEditorState_DrawCircle::~SymbolEditorState_DrawCircle() noexcept {
  ******************************************************************************/
 
 bool SymbolEditorState_DrawCircle::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   // populate command toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
   mContext.commandToolBar.addLabel(tr("Layer:"));

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -33,7 +33,6 @@
 
 #include <librepcb/core/geometry/polygon.h>
 #include <librepcb/core/graphics/graphicslayer.h>
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/graphics/polygongraphicsitem.h>
 #include <librepcb/core/library/sym/symbol.h>
 
@@ -75,8 +74,6 @@ SymbolEditorState_DrawPolygonBase::
  ******************************************************************************/
 
 bool SymbolEditorState_DrawPolygonBase::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   // populate command toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
   mContext.commandToolBar.addLabel(tr("Layer:"));

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -34,7 +34,6 @@
 
 #include <librepcb/core/geometry/text.h>
 #include <librepcb/core/graphics/graphicslayer.h>
-#include <librepcb/core/graphics/graphicsscene.h>
 #include <librepcb/core/graphics/textgraphicsitem.h>
 #include <librepcb/core/library/sym/symbol.h>
 
@@ -72,8 +71,6 @@ SymbolEditorState_DrawTextBase::~SymbolEditorState_DrawTextBase() noexcept {
  ******************************************************************************/
 
 bool SymbolEditorState_DrawTextBase::entry() noexcept {
-  mContext.graphicsScene.setSelectionArea(QPainterPath());  // clear selection
-
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // populate command toolbar

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -82,6 +82,10 @@ SymbolEditorState_Select::~SymbolEditorState_Select() noexcept {
 
 bool SymbolEditorState_Select::exit() noexcept {
   processAbortCommand();
+
+  // Avoid propagating the selection to other, non-selectable tools.
+  clearSelectionRect(true);
+
   return true;
 }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -92,17 +92,14 @@ bool SymbolEditorState_Select::exit() noexcept {
 QSet<EditorWidgetBase::Feature> SymbolEditorState_Select::getAvailableFeatures()
     const noexcept {
   QSet<EditorWidgetBase::Feature> features;
+  // The abort command is always enabled to clear the selection.
+  features |= EditorWidgetBase::Feature::Abort;
   if (mState != SubState::PASTING) {
     features |= EditorWidgetBase::Feature::SelectGraphics;
     if (!mContext.editorContext.readOnly) {
       features |= EditorWidgetBase::Feature::ImportGraphics;
       features |= EditorWidgetBase::Feature::Paste;
     }
-  }
-  if (((mState == SubState::MOVING) && (mCmdDragSelectedItems)) ||
-      (mState == SubState::PASTING) ||
-      ((mState == SubState::MOVING_POLYGON_VERTEX) && (mCmdPolygonEdit))) {
-    features |= EditorWidgetBase::Feature::Abort;
   }
   CmdDragSelectedSymbolItems cmd(mContext);
   if (cmd.getSelectedItemsCount() > 0) {
@@ -570,7 +567,10 @@ bool SymbolEditorState_Select::processAbortCommand() noexcept {
         return false;
       }
     }
-    default: { return false; }
+    default: {
+      clearSelectionRect(true);  // Clear selection, if any.
+      return true;
+    }
   }
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.cpp
@@ -68,8 +68,6 @@ bool BoardEditorState_AddHole::entry() noexcept {
   Board* board = getActiveBoard();
   if (!board) return false;
 
-  // Clear board selection because selection does not make sense in this state
-  board->clearSelection();
   makeLayerVisible();
 
   // Add a new hole

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addstroketext.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addstroketext.cpp
@@ -83,8 +83,6 @@ bool BoardEditorState_AddStrokeText::entry() noexcept {
   Board* board = getActiveBoard();
   if (!board) return false;
 
-  // Clear board selection because selection does not make sense in this state
-  board->clearSelection();
   makeLayerVisible();
 
   // Add a new stroke text

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -88,9 +88,6 @@ bool BoardEditorState_AddVia::entry() noexcept {
   Board* board = getActiveBoard();
   if (!board) return false;
 
-  // Clear board selection because selection does not make sense in this state
-  board->clearSelection();
-
   // Add a new via
   Point pos = mContext.editorGraphicsView.mapGlobalPosToScenePos(QCursor::pos(),
                                                                  true, true);

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
@@ -86,9 +86,6 @@ bool BoardEditorState_DrawPlane::entry() noexcept {
     return false;
   }
 
-  // Clear board selection because selection does not make sense in this state
-  board->clearSelection();
-
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // Add the netsignals combobox to the toolbar

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.cpp
@@ -79,9 +79,6 @@ bool BoardEditorState_DrawPolygon::entry() noexcept {
   Board* board = getActiveBoard();
   if (!board) return false;
 
-  // Clear board selection because selection does not make sense in this state
-  board->clearSelection();
-
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // Add the layers combobox to the toolbar

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
@@ -100,9 +100,6 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
   Board* board = getActiveBoard();
   if (!board) return false;
 
-  // Clear board selection because selection does not make sense in this state
-  board->clearSelection();
-
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // Add wire mode actions to the "command" toolbar

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -368,7 +368,11 @@ bool BoardEditorState_Select::processEditProperties() noexcept {
 }
 
 bool BoardEditorState_Select::processAbortCommand() noexcept {
-  return abortCommand(true);
+  abortCommand(true);
+  if (Board* board = getActiveBoard()) {
+    board->clearSelection();
+  }
+  return true;
 }
 
 bool BoardEditorState_Select::processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -119,6 +119,12 @@ bool BoardEditorState_Select::exit() noexcept {
   // Abort the currently active command
   if (!abortCommand(true)) return false;
 
+  // Avoid propagating the selection to other, non-selectable tools, thus
+  // clearing the selection on *all* boards.
+  foreach (Board* board, mContext.project.getBoards()) {
+    board->clearSelection();
+  }
+
   return true;
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.cpp
@@ -78,10 +78,6 @@ bool SchematicEditorState_AddText::entry() noexcept {
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
-  // Clear schematic selection because selection does not make sense in this
-  // state
-  schematic->clearSelection();
-
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // Add a new stroke text

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.cpp
@@ -79,10 +79,6 @@ bool SchematicEditorState_DrawPolygon::entry() noexcept {
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
-  // Clear schematic selection because selection does not make sense in this
-  // state
-  schematic->clearSelection();
-
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // Add the layers combobox to the toolbar

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
@@ -83,12 +83,6 @@ SchematicEditorState_DrawWire::~SchematicEditorState_DrawWire() noexcept {
 bool SchematicEditorState_DrawWire::entry() noexcept {
   Q_ASSERT(mSubState == SubState::IDLE);
 
-  // clear schematic selection because selection does not make sense in this
-  // state
-  if (Schematic* schematic = getActiveSchematic()) {
-    schematic->clearSelection();
-  }
-
   // Add wire mode actions to the "command" toolbar
   EditorCommandSet& cmd = EditorCommandSet::instance();
   mWireModeActionGroup = new QActionGroup(&mContext.commandToolBar);

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -192,6 +192,12 @@ bool SchematicEditorState_Select::processEditProperties() noexcept {
 bool SchematicEditorState_Select::processAbortCommand() noexcept {
   try {
     switch (mSubState) {
+      case SubState::IDLE: {
+        if (Schematic* schematic = getActiveSchematic()) {
+          schematic->clearSelection();
+        }
+        return true;
+      }
       case SubState::PASTING: {
         Q_ASSERT(!mSelectedItemsDragCommand.isNull());
         mContext.undoStack.abortCmdGroup();

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -92,6 +92,13 @@ bool SchematicEditorState_Select::exit() noexcept {
   mSelectedItemsDragCommand.reset();
   mCmdPolygonEdit.reset();
   mSubState = SubState::IDLE;
+
+  // Avoid propagating the selection to other, non-selectable tools, thus
+  // clearing the selection on *all* schematics.
+  foreach (Schematic* schematic, mContext.project.getSchematics()) {
+    schematic->clearSelection();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
I think it's convenient and intuitive to clear the selection with the "abort" command ('Esc' key by default). Many other software out there do this as well. At least I think it shouldn't hurt to add this.

In addition: Clear selection when leaving "select" tool

In all editors, the selection was currently cleared when *entering* any tool since selection makes no sense in any tool other than the "select" tool. However, in some tools this code was missing. Fixed by clearing the selection now when *leaving* the "select" tool and removing the corresponding code from all the other tools -> less code, less error-prone.
