### PR TITLE
Automatically abort blocking tool in other editor

### DIFF
--- a/libs/librepcb/core/project/circuit/componentinstance.h
+++ b/libs/librepcb/core/project/circuit/componentinstance.h
@@ -98,6 +98,7 @@ public:
   int getUnplacedOptionalSymbolsCount() const noexcept;
   int getRegisteredElementsCount() const noexcept;
   bool isUsed() const noexcept;
+  bool isAddedToCircuit() const noexcept { return mIsAddedToCircuit; }
 
   // Setters
 

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.h
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.h
@@ -89,6 +89,7 @@ public:
 
   // General Methods
   void abortAllCommands() noexcept;
+  void abortBlockingToolsInOtherEditors() noexcept;
 
   // Operator Overloadings
   BoardEditor& operator=(const BoardEditor& rhs) = delete;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
@@ -102,6 +102,10 @@ QList<GraphicsLayer*> BoardEditorState::getAllowedGeometryLayers(
   });
 }
 
+void BoardEditorState::abortBlockingToolsInOtherEditors() noexcept {
+  mContext.editor.abortBlockingToolsInOtherEditors();
+}
+
 bool BoardEditorState::execCmd(UndoCommand* cmd) {
   return mContext.undoStack.execCmd(cmd);
 }

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.h
@@ -156,6 +156,7 @@ protected:  // Methods
   const LengthUnit& getDefaultLengthUnit() const noexcept;
   QList<GraphicsLayer*> getAllowedGeometryLayers(const Board& board) const
       noexcept;
+  void abortBlockingToolsInOtherEditors() noexcept;
   bool execCmd(UndoCommand* cmd);
   QWidget* parentWidget() noexcept;
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_adddevice.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_adddevice.cpp
@@ -30,6 +30,7 @@
 
 #include <librepcb/core/project/board/board.h>
 #include <librepcb/core/project/board/items/bi_device.h>
+#include <librepcb/core/project/circuit/componentinstance.h>
 
 #include <QtCore>
 
@@ -151,8 +152,15 @@ bool BoardEditorState_AddDevice::processGraphicsSceneRightMouseButtonReleased(
 bool BoardEditorState_AddDevice::addDevice(ComponentInstance& cmp,
                                            const Uuid& dev,
                                            const Uuid& fpt) noexcept {
+  QPointer<ComponentInstance> cmpPtr = &cmp;
+
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
+  // Discarding temporary changes could have deleted the component, so let's
+  // check it again.
   Board* board = getActiveBoard();
-  if (!board) return false;
+  if ((!board) || (!cmpPtr) || (!cmp.isAddedToCircuit())) return false;
 
   try {
     // start a new command

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.h
@@ -75,7 +75,7 @@ public:
       delete;
 
 private:  // Methods
-  bool addHole(Board& board, const Point& pos) noexcept;
+  bool addHole(const Point& pos) noexcept;
   bool updatePosition(const Point& pos) noexcept;
   bool fixPosition(const Point& pos) noexcept;
   bool abortCommand(bool showErrMsgBox) noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addstroketext.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addstroketext.h
@@ -81,7 +81,7 @@ public:
       const BoardEditorState_AddStrokeText& rhs) = delete;
 
 private:  // Methods
-  bool addText(Board& board, const Point& pos) noexcept;
+  bool addText(const Point& pos) noexcept;
   bool rotateText(const Angle& angle) noexcept;
   bool flipText(Qt::Orientation orientation) noexcept;
   bool updatePosition(const Point& pos) noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.h
@@ -77,7 +77,7 @@ public:
       delete;
 
 private:  // Methods
-  bool addVia(Board& board, const Point& pos) noexcept;
+  bool addVia(const Point& pos) noexcept;
   bool updatePosition(Board& board, const Point& pos) noexcept;
   void setNetSignal(NetSignal* netsignal) noexcept;
   bool fixPosition(Board& board, const Point& pos) noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.h
@@ -80,7 +80,7 @@ public:
       delete;
 
 private:  // Methods
-  bool startAddPlane(Board& board, const Point& pos) noexcept;
+  bool startAddPlane(const Point& pos) noexcept;
   bool addSegment(const Point& pos) noexcept;
   bool updateLastVertexPosition(const Point& pos) noexcept;
   void setNetSignal(NetSignal* netsignal) noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawpolygon.h
@@ -81,7 +81,7 @@ public:
       const BoardEditorState_DrawPolygon& rhs) = delete;
 
 private:  // Methods
-  bool startAddPolygon(Board& board, const Point& pos) noexcept;
+  bool startAddPolygon(const Point& pos) noexcept;
   bool addSegment(const Point& pos) noexcept;
   bool updateLastVertexPosition(const Point& pos) noexcept;
   bool abortCommand(bool showErrMsgBox) noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -133,6 +133,9 @@ bool BoardEditorState_Select::exit() noexcept {
  ******************************************************************************/
 
 bool BoardEditorState_Select::processImportDxf() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Board* board = getActiveBoard();
   if ((!mIsUndoCmdActive) && (!mSelectedItemsDragCommand) &&
       (!mCmdPolygonEdit) && (!mCmdPlaneEdit) && (board)) {
@@ -232,6 +235,9 @@ bool BoardEditorState_Select::processSelectAll() noexcept {
 }
 
 bool BoardEditorState_Select::processCut() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if ((!mIsUndoCmdActive) && (!mSelectedItemsDragCommand) &&
       (!mCmdPolygonEdit) && (!mCmdPlaneEdit)) {
     if (copySelectedItemsToClipboard()) {
@@ -244,6 +250,9 @@ bool BoardEditorState_Select::processCut() noexcept {
 }
 
 bool BoardEditorState_Select::processCopy() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if ((!mIsUndoCmdActive) && (!mSelectedItemsDragCommand) &&
       (!mCmdPolygonEdit) && (!mCmdPlaneEdit)) {
     return copySelectedItemsToClipboard();
@@ -253,6 +262,9 @@ bool BoardEditorState_Select::processCopy() noexcept {
 }
 
 bool BoardEditorState_Select::processPaste() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Board* board = getActiveBoard();
   if ((!mIsUndoCmdActive) && (!mSelectedItemsDragCommand) &&
       (!mCmdPolygonEdit) && (!mCmdPlaneEdit) && (board)) {
@@ -291,6 +303,9 @@ bool BoardEditorState_Select::processPaste() noexcept {
 }
 
 bool BoardEditorState_Select::processMove(const Point& delta) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if ((!mIsUndoCmdActive) && (!mSelectedItemsDragCommand) &&
       (!mCmdPolygonEdit) && (!mCmdPlaneEdit)) {
     return moveSelectedItems(delta);
@@ -299,6 +314,9 @@ bool BoardEditorState_Select::processMove(const Point& delta) noexcept {
 }
 
 bool BoardEditorState_Select::processRotate(const Angle& rotation) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if ((!mCmdPolygonEdit) && (!mCmdPlaneEdit)) {
     return rotateSelectedItems(rotation);
   }
@@ -308,6 +326,9 @@ bool BoardEditorState_Select::processRotate(const Angle& rotation) noexcept {
 
 bool BoardEditorState_Select::processFlip(
     Qt::Orientation orientation) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mIsUndoCmdActive || mSelectedItemsDragCommand || mCmdPolygonEdit ||
       mCmdPlaneEdit) {
     return false;
@@ -316,6 +337,9 @@ bool BoardEditorState_Select::processFlip(
 }
 
 bool BoardEditorState_Select::processSnapToGrid() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mIsUndoCmdActive || mSelectedItemsDragCommand || mCmdPolygonEdit ||
       mCmdPlaneEdit) {
     return false;
@@ -324,6 +348,9 @@ bool BoardEditorState_Select::processSnapToGrid() noexcept {
 }
 
 bool BoardEditorState_Select::processResetAllTexts() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mIsUndoCmdActive || mSelectedItemsDragCommand || mCmdPolygonEdit ||
       mCmdPlaneEdit) {
     return false;
@@ -332,6 +359,9 @@ bool BoardEditorState_Select::processResetAllTexts() noexcept {
 }
 
 bool BoardEditorState_Select::processRemove() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mIsUndoCmdActive || mSelectedItemsDragCommand || mCmdPolygonEdit ||
       mCmdPlaneEdit) {
     return false;
@@ -340,6 +370,9 @@ bool BoardEditorState_Select::processRemove() noexcept {
 }
 
 bool BoardEditorState_Select::processEditProperties() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Board* board = getActiveBoard();
   if ((!board) || mIsUndoCmdActive || mSelectedItemsDragCommand ||
       mCmdPolygonEdit || mCmdPlaneEdit) {
@@ -421,6 +454,9 @@ bool BoardEditorState_Select::processGraphicsSceneMouseMoved(
 
 bool BoardEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
     QGraphicsSceneMouseEvent& e) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Board* board = getActiveBoard();
   if (!board) return false;
 
@@ -534,6 +570,9 @@ bool BoardEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
 
 bool BoardEditorState_Select::processGraphicsSceneLeftMouseButtonDoubleClicked(
     QGraphicsSceneMouseEvent& e) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Board* board = getActiveBoard();
   if (!board) return false;
 
@@ -552,6 +591,9 @@ bool BoardEditorState_Select::processGraphicsSceneLeftMouseButtonDoubleClicked(
 
 bool BoardEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
     QGraphicsSceneMouseEvent& e) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Board* board = getActiveBoard();
   if (!board) return false;
 

--- a/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
@@ -424,6 +424,8 @@ void UnplacedComponentsDock::setSelectedFootprintUuid(
 void UnplacedComponentsDock::setSelectedDeviceAsDefault() noexcept {
   if (mBoard && mSelectedComponent && mSelectedDeviceUuid) {
     try {
+      // Release undo stack.
+      mProjectEditor.abortBlockingToolsInOtherEditors(this);
       QScopedPointer<CmdComponentInstanceEdit> cmd(new CmdComponentInstanceEdit(
           mProject.getCircuit(), *mSelectedComponent));
       if (mSelectedComponent->getDefaultDeviceUuid() == mSelectedDeviceUuid) {
@@ -486,6 +488,7 @@ void UnplacedComponentsDock::autoAddDevicesToBoard(
     bool onlyWithPreSelectedDevice,
     const tl::optional<Uuid>& libCmpUuidFilter) noexcept {
   Q_ASSERT(mBoard);
+  mProjectEditor.abortBlockingToolsInOtherEditors(this);  // Release undo stack.
   QScopedPointer<UndoCommandGroup> cmd(
       new UndoCommandGroup(tr("Add devices to board")));
 

--- a/libs/librepcb/editor/project/projecteditor.cpp
+++ b/libs/librepcb/editor/project/projecteditor.cpp
@@ -124,6 +124,21 @@ const LengthUnit& ProjectEditor::getDefaultLengthUnit() const noexcept {
  *  General Methods
  ******************************************************************************/
 
+void ProjectEditor::abortBlockingToolsInOtherEditors(QWidget* editor) noexcept {
+  if (mUndoStack->isCommandGroupActive()) {
+    if (mSchematicEditor && (editor != mSchematicEditor)) {
+      mSchematicEditor->abortAllCommands();
+    }
+    if (mBoardEditor && (editor != mBoardEditor)) {
+      mBoardEditor->abortAllCommands();
+    }
+    if (mUndoStack->isCommandGroupActive()) {
+      qWarning() << "Requested to abort tools in other editors, but there is "
+                    "still an active undo command group.";
+    }
+  }
+}
+
 bool ProjectEditor::windowIsAboutToClose(QMainWindow& window) noexcept {
   if (getCountOfVisibleEditorWindows() > 1) {
     // this is not the last open window, so no problem to close it...

--- a/libs/librepcb/editor/project/projecteditor.h
+++ b/libs/librepcb/editor/project/projecteditor.h
@@ -90,6 +90,19 @@ public:
   // General Methods
 
   /**
+   * @brief Abort any active (blocking) tools in other editors
+   *
+   * If an undo command group is already active while starting a new tool, try
+   * to abort any active tool in other editors since it is annoying to block
+   * one editor by another editor (an error message would appear). However, do
+   * NOT abort tools in the own editor since this could lead to
+   * unexpected/wrong behavior (e.g. recursion)!
+   *
+   * @param editor  The calling editor, which will not be aborted.
+   */
+  void abortBlockingToolsInOtherEditors(QWidget* editor) noexcept;
+
+  /**
    * @brief Inform the editor that a project related window is about to close
    *
    * The project must be closed and destroyed automatically after the last

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.cpp
@@ -83,6 +83,10 @@ QList<GraphicsLayer*> SchematicEditorState::getAllowedGeometryLayers() const
   });
 }
 
+void SchematicEditorState::abortBlockingToolsInOtherEditors() noexcept {
+  mContext.editor.abortBlockingToolsInOtherEditors();
+}
+
 bool SchematicEditorState::execCmd(UndoCommand* cmd) {
   return mContext.undoStack.execCmd(cmd);
 }

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
@@ -144,6 +144,7 @@ protected:  // Methods
   PositiveLength getGridInterval() const noexcept;
   const LengthUnit& getDefaultLengthUnit() const noexcept;
   QList<GraphicsLayer*> getAllowedGeometryLayers() const noexcept;
+  void abortBlockingToolsInOtherEditors() noexcept;
   bool execCmd(UndoCommand* cmd);
   QWidget* parentWidget() noexcept;
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -322,8 +322,11 @@ bool SchematicEditorState_AddComponent::
 void SchematicEditorState_AddComponent::startAddingComponent(
     const tl::optional<Uuid>& cmp, const tl::optional<Uuid>& symbVar,
     const tl::optional<Uuid>& dev, bool keepValue) {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Schematic* schematic = getActiveSchematic();
-  if (!schematic) throw LogicError(__FILE__, __LINE__);
+  if (!schematic) return;
 
   try {
     // start a new command

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addnetlabel.cpp
@@ -63,9 +63,6 @@ SchematicEditorState_AddNetLabel::~SchematicEditorState_AddNetLabel() noexcept {
 bool SchematicEditorState_AddNetLabel::entry() noexcept {
   Q_ASSERT(mUndoCmdActive == false);
 
-  Schematic* schematic = getActiveSchematic();
-  if (!schematic) return false;
-
   mContext.editorGraphicsView.setCursor(Qt::CrossCursor);
   return true;
 }
@@ -100,30 +97,24 @@ bool SchematicEditorState_AddNetLabel::processGraphicsSceneMouseMoved(
 bool SchematicEditorState_AddNetLabel::
     processGraphicsSceneLeftMouseButtonPressed(
         QGraphicsSceneMouseEvent& e) noexcept {
-  Schematic* schematic = getActiveSchematic();
-  if (!schematic) return false;
-
   Point pos = Point::fromPx(e.scenePos());
 
   if (mUndoCmdActive) {
     return fixLabel(pos);
   } else {
-    return addLabel(*schematic, pos);
+    return addLabel(pos);
   }
 }
 
 bool SchematicEditorState_AddNetLabel::
     processGraphicsSceneLeftMouseButtonDoubleClicked(
         QGraphicsSceneMouseEvent& e) noexcept {
-  Schematic* schematic = getActiveSchematic();
-  if (!schematic) return false;
-
   Point pos = Point::fromPx(e.scenePos());
 
   if (mUndoCmdActive) {
     return fixLabel(pos);
   } else {
-    return addLabel(*schematic, pos);
+    return addLabel(pos);
   }
 }
 
@@ -174,13 +165,17 @@ bool SchematicEditorState_AddNetLabel::processMirror(
  *  Private Methods
  ******************************************************************************/
 
-bool SchematicEditorState_AddNetLabel::addLabel(Schematic& schematic,
-                                                const Point& pos) noexcept {
+bool SchematicEditorState_AddNetLabel::addLabel(const Point& pos) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Q_ASSERT(mUndoCmdActive == false);
+  Schematic* schematic = getActiveSchematic();
+  if (!schematic) return false;
 
   try {
     QList<SI_NetLine*> netlinesUnderCursor =
-        schematic.getNetLinesAtScenePos(pos);
+        schematic->getNetLinesAtScenePos(pos);
     if (netlinesUnderCursor.isEmpty()) return false;
     SI_NetSegment& netsegment = netlinesUnderCursor.first()->getNetSegment();
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addnetlabel.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addnetlabel.h
@@ -81,7 +81,7 @@ public:
       const SchematicEditorState_AddNetLabel& rhs) = delete;
 
 private:  // Methods
-  bool addLabel(Schematic& schematic, const Point& pos) noexcept;
+  bool addLabel(const Point& pos) noexcept;
   bool updateLabel(const Point& pos) noexcept;
   bool fixLabel(const Point& pos) noexcept;
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.h
@@ -84,7 +84,7 @@ public:
       const SchematicEditorState_AddText& rhs) = delete;
 
 private:  // Methods
-  bool addText(Schematic& schematic, const Point& pos) noexcept;
+  bool addText(const Point& pos) noexcept;
   bool rotateText(const Angle& angle) noexcept;
   bool updatePosition(const Point& pos) noexcept;
   bool fixPosition(const Point& pos) noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawpolygon.h
@@ -81,7 +81,7 @@ public:
       const SchematicEditorState_DrawPolygon& rhs) = delete;
 
 private:  // Methods
-  bool startAddPolygon(Schematic& schematic, const Point& pos) noexcept;
+  bool startAddPolygon(const Point& pos) noexcept;
   bool addSegment(const Point& pos) noexcept;
   bool updateLastVertexPosition(const Point& pos) noexcept;
   bool abortCommand(bool showErrMsgBox) noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
@@ -205,6 +205,9 @@ bool SchematicEditorState_DrawWire::processGraphicsSceneMouseMoved(
 
 bool SchematicEditorState_DrawWire::processGraphicsSceneLeftMouseButtonPressed(
     QGraphicsSceneMouseEvent& e) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -117,6 +117,9 @@ bool SchematicEditorState_Select::processSelectAll() noexcept {
 }
 
 bool SchematicEditorState_Select::processCut() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mSubState == SubState::IDLE) {
     return copySelectedItemsToClipboard() && removeSelectedItems();
   }
@@ -124,6 +127,9 @@ bool SchematicEditorState_Select::processCut() noexcept {
 }
 
 bool SchematicEditorState_Select::processCopy() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mSubState == SubState::IDLE) {
     return copySelectedItemsToClipboard();
   }
@@ -131,6 +137,9 @@ bool SchematicEditorState_Select::processCopy() noexcept {
 }
 
 bool SchematicEditorState_Select::processPaste() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mSubState == SubState::IDLE) {
     return pasteFromClipboard();
   }
@@ -138,6 +147,9 @@ bool SchematicEditorState_Select::processPaste() noexcept {
 }
 
 bool SchematicEditorState_Select::processMove(const Point& delta) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mSubState == SubState::IDLE) {
     return moveSelectedItems(delta);
   }
@@ -146,6 +158,9 @@ bool SchematicEditorState_Select::processMove(const Point& delta) noexcept {
 
 bool SchematicEditorState_Select::processRotate(
     const Angle& rotation) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (!mCmdPolygonEdit) {
     return rotateSelectedItems(rotation);
   }
@@ -154,6 +169,9 @@ bool SchematicEditorState_Select::processRotate(
 
 bool SchematicEditorState_Select::processMirror(
     Qt::Orientation orientation) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (!mCmdPolygonEdit) {
     return mirrorSelectedItems(orientation);
   }
@@ -161,6 +179,9 @@ bool SchematicEditorState_Select::processMirror(
 }
 
 bool SchematicEditorState_Select::processRemove() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mSubState == SubState::IDLE) {
     removeSelectedItems();
     return true;
@@ -169,6 +190,9 @@ bool SchematicEditorState_Select::processRemove() noexcept {
 }
 
 bool SchematicEditorState_Select::processEditProperties() noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Schematic* schematic = getActiveSchematic();
   if ((!schematic) || (mSubState != SubState::IDLE)) {
     return false;
@@ -264,6 +288,9 @@ bool SchematicEditorState_Select::processGraphicsSceneMouseMoved(
 
 bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
     QGraphicsSceneMouseEvent& mouseEvent) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
@@ -329,6 +356,9 @@ bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
 
 bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
     QGraphicsSceneMouseEvent& e) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
@@ -367,6 +397,9 @@ bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
 bool SchematicEditorState_Select::
     processGraphicsSceneLeftMouseButtonDoubleClicked(
         QGraphicsSceneMouseEvent& e) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   Schematic* schematic = getActiveSchematic();
   if (!schematic) return false;
 
@@ -387,6 +420,9 @@ bool SchematicEditorState_Select::
 
 bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
     QGraphicsSceneMouseEvent& e) noexcept {
+  // Discard any temporary changes and release undo stack.
+  abortBlockingToolsInOtherEditors();
+
   if (mSelectedItemsDragCommand) {
     return rotateSelectedItems(Angle::deg90());
   }

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -220,6 +220,10 @@ void SchematicEditor::abortAllCommands() noexcept {
   mFsm->processAbortCommand();
 }
 
+void SchematicEditor::abortBlockingToolsInOtherEditors() noexcept {
+  mProjectEditor.abortBlockingToolsInOtherEditors(this);
+}
+
 /*******************************************************************************
  *  Inherited Methods
  ******************************************************************************/
@@ -271,6 +275,7 @@ void SchematicEditor::createActions() noexcept {
       this, &mProjectEditor, &ProjectEditor::showControlPanelClicked));
   mActionProjectProperties.reset(
       cmd.projectProperties.createAction(this, this, [this]() {
+        abortBlockingToolsInOtherEditors();  // Release undo stack.
         ProjectPropertiesEditorDialog dialog(
             mProject.getMetadata(), mProjectEditor.getUndoStack(), this);
         dialog.exec();
@@ -888,6 +893,7 @@ void SchematicEditor::addSchematic() noexcept {
   if (!ok) return;
 
   try {
+    abortBlockingToolsInOtherEditors();  // Release undo stack.
     CmdSchematicAdd* cmd =
         new CmdSchematicAdd(mProject, ElementName(name));  // can throw
     mProjectEditor.getUndoStack().execCmd(cmd);
@@ -902,6 +908,7 @@ void SchematicEditor::removeSchematic(int index) noexcept {
   if (!schematic) return;
 
   try {
+    abortBlockingToolsInOtherEditors();  // Release undo stack.
     CmdSchematicRemove* cmd = new CmdSchematicRemove(mProject, *schematic);
     mProjectEditor.getUndoStack().execCmd(cmd);
   } catch (Exception& e) {
@@ -920,6 +927,7 @@ void SchematicEditor::renameSchematic(int index) noexcept {
   if (!ok) return;
 
   try {
+    abortBlockingToolsInOtherEditors();  // Release undo stack.
     QScopedPointer<CmdSchematicEdit> cmd(new CmdSchematicEdit(*schematic));
     cmd->setName(ElementName(cleanElementName(name)));  // can throw
     mProjectEditor.getUndoStack().execCmd(cmd.take());

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -85,6 +85,7 @@ public:
 
   // General Methods
   void abortAllCommands() noexcept;
+  void abortBlockingToolsInOtherEditors() noexcept;
 
   // Operator Overloadings
   SchematicEditor& operator=(const SchematicEditor& rhs) = delete;


### PR DESCRIPTION
When you start a tool in either the schematic- or board editor which blocks the undo command stack (due to intermediate changes, e.g. while drawing a line), and then starting such a tool in the other editor (e.g. switching from schematic- to board editor), currently you get the error "Another command is active at the moment." so you had to exit the other tool first.

This can be a bit annoying and confusing. It would be much more convenient if the blocking tool gets aborted automatically and no error appears. So this commit applies this change.