### PR TITLE
New project wizard: Remove recommendation about licenses

### DIFF
--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -67,10 +67,9 @@ NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(
 
   // insert values
   mUi->edtAuthor->setText(ws.getSettings().userName.get());
-  mUi->cbxLicense->addItem(QString("No License (not recommended)"), QString());
-  mUi->cbxLicense->addItem(
-      tr("CC0-1.0 (no restrictions, recommended for open hardware projects)"),
-      QString("licenses/cc0-1.0.txt"));
+  mUi->cbxLicense->addItem(tr("None"), QString());
+  mUi->cbxLicense->addItem(tr("CC0-1.0 (no restrictions)"),
+                           QString("licenses/cc0-1.0.txt"));
   mUi->cbxLicense->addItem(tr("CC-BY-4.0 (requires attribution)"),
                            QString("licenses/cc-by-4.0.txt"));
   mUi->cbxLicense->addItem(


### PR DESCRIPTION
When creating a new project, the wizard provided the following entries in the license selector dropdown:

```
- No License (not recommended)
- CC0-1.0 (no restrictions, recommended for open hardware projects)
- CC-BY-4.0 (requires attribution)
- CC-BY-SA-4.0 (requires attribution + share alike)
```

With the first entry set as default. However, it is strange to use a default value which is actually not recommended (already got that feedback from users, and I agree). In addition, choosing no license is probably the typical use-case and totally fine for non-public projects (both private and commercial).

To avoid users struggling with the license selection, let's simply remove our personal recommendations and rename the dropdown entries to:

```
- None
- CC0-1.0 (no restrictions)
- CC-BY-4.0 (requires attribution)
- CC-BY-SA-4.0 (requires attribution + share alike)
```

In the end, I think users should think about and choose their preferred license on their own, without LibrePCB influencing their decision. Other opinions welcome :slightly_smiling_face: 

![image](https://user-images.githubusercontent.com/5374821/192115481-600ee9be-4402-487b-9a7b-8e7a196c83a2.png)