### PR TITLE
Make project library updater a real dialog

### DIFF
--- a/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.cpp
+++ b/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.cpp
@@ -53,7 +53,7 @@ namespace editor {
 ProjectLibraryUpdater::ProjectLibraryUpdater(Workspace& ws,
                                              const FilePath& project,
                                              ControlPanel& cp) noexcept
-  : QMainWindow(nullptr),
+  : QDialog(nullptr),
     mWorkspace(ws),
     mProjectFilePath(project),
     mControlPanel(cp),
@@ -133,8 +133,8 @@ void ProjectLibraryUpdater::btnUpdateClicked() {
       mControlPanel.openProject(mProjectFilePath);
       // bring this window to front again (with some delay to make it working
       // properly)
-      QTimer::singleShot(500, this, &QMainWindow::raise);
-      QTimer::singleShot(500, this, &QMainWindow::activateWindow);
+      QTimer::singleShot(500, this, &QDialog::raise);
+      QTimer::singleShot(500, this, &QDialog::activateWindow);
     }
   }
 

--- a/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.h
+++ b/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.h
@@ -59,7 +59,7 @@ class ProjectLibraryUpdater;
  * The whole project library update concept needs to be refactored some time to
  * provide an updater with much more functionality and higher reliability.
  */
-class ProjectLibraryUpdater : public QMainWindow {
+class ProjectLibraryUpdater : public QDialog {
   Q_OBJECT
 
 public:

--- a/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.ui
+++ b/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>librepcb::editor::ProjectLibraryUpdater</class>
- <widget class="QMainWindow" name="librepcb::editor::ProjectLibraryUpdater">
+ <widget class="QDialog" name="librepcb::editor::ProjectLibraryUpdater">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -13,24 +13,27 @@
   <property name="windowTitle">
    <string>Project Library Updater</string>
   </property>
-  <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QLabel" name="label_2">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QLabel {
+  <property name="windowIcon">
+   <iconset>
+    <normaloff>:/img/actions/refresh.png</normaloff>:/img/actions/refresh.png</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel {
 	background-color: rgb(255, 255, 127);
 	color: rgb(170, 0, 0);
 };</string>
-      </property>
-      <property name="text">
-       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+     </property>
+     <property name="text">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -42,37 +45,36 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;  - Partial updates are not possible. Either all or no library elements will be updated.&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;  - Breaking changes in library elements can cause the update to fail (i.e. no elements will be updated).&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;  - The update cannot be undone. It's recommended to first create a backup of the project!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="margin">
-       <number>3</number>
-      </property>
-      <property name="openExternalLinks">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="btnUpdate">
-      <property name="text">
-       <string>Update library of &quot;%1&quot;!</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QListWidget" name="log"/>
-    </item>
-    <item>
-     <widget class="QDialogButtonBox" name="buttonBox">
-      <property name="standardButtons">
-       <set>QDialogButtonBox::Close</set>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>3</number>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnUpdate">
+     <property name="text">
+      <string>Update library of &quot;%1&quot;!</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="log"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections>


### PR DESCRIPTION
It was derived from `QMainWindow` although it is used like a dialog. Thus now changed its base class to `QDialog`.

Fixes #1030 (at least I ope so...)