### PR TITLE
Respect external applications settings for hyperlinks

### DIFF
--- a/libs/librepcb/editor/project/boardeditor/deviceinstancepropertiesdialog.h
+++ b/libs/librepcb/editor/project/boardeditor/deviceinstancepropertiesdialog.h
@@ -36,6 +36,7 @@ namespace librepcb {
 class BI_Device;
 class LengthUnit;
 class Project;
+class WorkspaceSettings;
 
 namespace editor {
 
@@ -61,7 +62,8 @@ public:
   DeviceInstancePropertiesDialog() = delete;
   DeviceInstancePropertiesDialog(const DeviceInstancePropertiesDialog& other) =
       delete;
-  DeviceInstancePropertiesDialog(Project& project, BI_Device& device,
+  DeviceInstancePropertiesDialog(const WorkspaceSettings& settings,
+                                 Project& project, BI_Device& device,
                                  UndoStack& undoStack,
                                  const LengthUnit& lengthUnit,
                                  const QString& settingsPrefix,
@@ -79,6 +81,7 @@ private:  // Methods
   bool applyChanges() noexcept;
 
 private:  // Data
+  const WorkspaceSettings& mSettings;
   Project& mProject;
   BI_Device& mDevice;
   UndoStack& mUndoStack;

--- a/libs/librepcb/editor/project/boardeditor/deviceinstancepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/deviceinstancepropertiesdialog.ui
@@ -117,9 +117,6 @@
           <property name="textFormat">
            <enum>Qt::RichText</enum>
           </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
@@ -152,9 +149,6 @@
           <property name="textFormat">
            <enum>Qt::RichText</enum>
           </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
@@ -186,9 +180,6 @@
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
           </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -62,6 +62,11 @@ FabricationOutputDialog::FabricationOutputDialog(
           mUi->edtSuffixSolderPasteTop, &QLineEdit::setEnabled);
   connect(mUi->cbxSolderPasteBot, &QCheckBox::toggled,
           mUi->edtSuffixSolderPasteBot, &QLineEdit::setEnabled);
+  connect(mUi->lblNotes, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mSettings, this);
+            ds.openWebUrl(QUrl(url));
+          });
 
   BoardFabricationOutputSettings s = mBoard.getFabricationOutputSettings();
   mUi->edtBasePath->setText(s.getOutputBasePath());

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
@@ -18,7 +18,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="lblNotes">
      <property name="styleSheet">
       <string notr="true">QLabel {
 	background-color: rgb(255, 255, 127);
@@ -33,9 +33,6 @@
      </property>
      <property name="margin">
       <number>3</number>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -1481,7 +1481,8 @@ bool BoardEditorState_Select::openPropertiesDialog(BI_Base* item) {
 void BoardEditorState_Select::openDevicePropertiesDialog(
     BI_Device& device) noexcept {
   DeviceInstancePropertiesDialog dialog(
-      mContext.project, device, mContext.undoStack, getDefaultLengthUnit(),
+      mContext.workspace.getSettings(), mContext.project, device,
+      mContext.undoStack, getDefaultLengthUnit(),
       "board_editor/device_properties_dialog", parentWidget());
   dialog.exec();
 }

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -23,6 +23,7 @@
 #include "newprojectwizardpage_metadata.h"
 
 #include "../../dialogs/filedialog.h"
+#include "../../workspace/desktopservices.h"
 #include "ui_newprojectwizardpage_metadata.h"
 
 #include <librepcb/core/application.h>
@@ -44,7 +45,9 @@ namespace editor {
 
 NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(
     const Workspace& ws, QWidget* parent) noexcept
-  : QWizardPage(parent), mUi(new Ui::NewProjectWizardPage_Metadata) {
+  : QWizardPage(parent),
+    mWorkspace(ws),
+    mUi(new Ui::NewProjectWizardPage_Metadata) {
   mUi->setupUi(this);
   setPixmap(QWizard::LogoPixmap, QPixmap(":/img/actions/plus_2.png"));
   setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));
@@ -56,6 +59,11 @@ NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(
           &NewProjectWizardPage_Metadata::locationChanged);
   connect(mUi->btnLocation, &QPushButton::clicked, this,
           &NewProjectWizardPage_Metadata::chooseLocationClicked);
+  connect(mUi->lblLicenseLink, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mWorkspace.getSettings(), this);
+            ds.openWebUrl(QUrl(url));
+          });
 
   // insert values
   mUi->edtAuthor->setText(ws.getSettings().userName.get());

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.h
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.h
@@ -84,6 +84,7 @@ private:  // Methods
   bool validatePage() noexcept override;
 
 private:  // Data
+  const Workspace& mWorkspace;
   QScopedPointer<Ui::NewProjectWizardPage_Metadata> mUi;
   FilePath mFullFilePath;
 };

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -180,7 +180,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="lblLicenseLink">
        <property name="minimumSize">
         <size>
          <width>25</width>
@@ -197,12 +197,9 @@
         <string>https://en.wikipedia.org/wiki/Creative_Commons_license</string>
        </property>
        <property name="text">
-        <string>&lt;a href=&quot;https://en.wikipedia.org/wiki/Creative_Commons_license&quot;&gt;&lt;img src=&quot;:/img/status/info.png&quot; width=&quot;25&quot; height=&quot;25&quot;/&gt;&lt;/a&gt;</string>
+        <string notr="true">&lt;a href=&quot;https://en.wikipedia.org/wiki/Creative_Commons_license&quot;&gt;&lt;img src=&quot;:/img/status/info.png&quot; width=&quot;25&quot; height=&quot;25&quot;/&gt;&lt;/a&gt;</string>
        </property>
        <property name="scaledContents">
-        <bool>true</bool>
-       </property>
-       <property name="openExternalLinks">
         <bool>true</bool>
        </property>
       </widget>

--- a/libs/librepcb/editor/project/orderpcbdialog.cpp
+++ b/libs/librepcb/editor/project/orderpcbdialog.cpp
@@ -59,11 +59,26 @@ OrderPcbDialog::OrderPcbDialog(const WorkspaceSettings& settings,
   mUi->imgError->hide();
   connect(mUi->btnUpload, &QPushButton::clicked, this,
           &OrderPcbDialog::uploadButtonClicked);
+  connect(mUi->lblMoreInformation, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mSettings, this);
+            ds.openWebUrl(QUrl(url));
+          });
+  connect(mUi->lblStatus, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mSettings, this);
+            ds.openWebUrl(QUrl(url));
+          });
 
   // Replace placeholder in the note label.
   QString forumLink = "<a href=\"https://librepcb.discourse.group/\">" %
       tr("discussion forum") % "</a>";
   mUi->lblNote->setText(mUi->lblNote->text().arg(forumLink));
+  connect(mUi->lblNote, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mSettings, this);
+            ds.openWebUrl(QUrl(url));
+          });
 
   // Load the window geometry and settings.
   // Note: Do not use restoreGeometry(), only store the window size (but not

--- a/libs/librepcb/editor/project/orderpcbdialog.ui
+++ b/libs/librepcb/editor/project/orderpcbdialog.ui
@@ -51,9 +51,6 @@
        <property name="margin">
         <number>3</number>
        </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
       </widget>
      </item>
     </layout>
@@ -76,9 +73,6 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
    <item>
@@ -90,9 +84,6 @@
       <enum>Qt::RichText</enum>
      </property>
      <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="openExternalLinks">
       <bool>true</bool>
      </property>
     </widget>
@@ -175,9 +166,6 @@
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
        <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="openExternalLinks">
         <bool>true</bool>
        </property>
        <property name="textInteractionFlags">

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -26,6 +26,7 @@
 #include "../../project/cmd/cmdsymbolinstanceedit.h"
 #include "../../undocommand.h"
 #include "../../undostack.h"
+#include "../../workspace/desktopservices.h"
 #include "ui_symbolinstancepropertiesdialog.h"
 
 #include <librepcb/core/attribute/attributetype.h>
@@ -91,8 +92,7 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
           mComponentInstance.getLibComponent()
               .getDirectory()
               .getAbsPath()
-              .toQUrl()
-              .toString(),
+              .toStr(),
           *mComponentInstance.getLibComponent().getNames().value(localeOrder)) +
       " (" +
       tr("symbol variant \"%1\"")
@@ -107,6 +107,11 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
           .getDirectory()
           .getAbsPath()
           .toNative());
+  connect(mUi->lblCompLibName, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mWorkspace.getSettings(), this);
+            ds.openLocalPath(FilePath(url));
+          });
 
   // Symbol Instance Attributes
   mUi->lblSymbInstName->setText(mSymbol.getName());
@@ -116,12 +121,17 @@ SymbolInstancePropertiesDialog::SymbolInstancePropertiesDialog(
   mUi->cbxMirror->setChecked(mSymbol.getMirrored());
 
   // Symbol Library Element Attributes
-  mUi->lblSymbLibName->setText(htmlLink.arg(
-      mSymbol.getLibSymbol().getDirectory().getAbsPath().toQUrl().toString(),
-      *mSymbol.getLibSymbol().getNames().value(localeOrder)));
+  mUi->lblSymbLibName->setText(
+      htmlLink.arg(mSymbol.getLibSymbol().getDirectory().getAbsPath().toStr(),
+                   *mSymbol.getLibSymbol().getNames().value(localeOrder)));
   mUi->lblSymbLibName->setToolTip(
       mSymbol.getLibSymbol().getDescriptions().value(localeOrder) + "<p>" +
       mSymbol.getLibSymbol().getDirectory().getAbsPath().toNative());
+  connect(mUi->lblSymbLibName, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mWorkspace.getSettings(), this);
+            ds.openLocalPath(FilePath(url));
+          });
 
   // List Devices
   try {

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -163,9 +163,6 @@
           <property name="textFormat">
            <enum>Qt::RichText</enum>
           </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
           </property>
@@ -197,9 +194,6 @@
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
           </property>
           <property name="textInteractionFlags">
            <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -109,6 +109,15 @@ ControlPanel::ControlPanel(Workspace& workspace, bool fileFormatIsOutdated)
           mActionLibraryManager.data(), &QAction::trigger);
   connect(mLibraryManager.data(), &LibraryManager::openLibraryEditorTriggered,
           this, &ControlPanel::openLibraryEditor);
+  connect(mUi->textBrowser, &QTextBrowser::anchorClicked, this,
+          [this](QUrl url) {
+            const QStringList searchPaths = mUi->textBrowser->searchPaths();
+            if (url.isRelative() && (!searchPaths.isEmpty())) {
+              url.setPath(searchPaths.first() % "/" % url.path());
+            }
+            DesktopServices ds(mWorkspace.getSettings(), this);
+            ds.openWebUrl(url);
+          });
 
   // load project models
   mRecentProjectsModel.reset(new RecentProjectsModel(mWorkspace));

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.ui
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.ui
@@ -409,8 +409,8 @@ QListView::item
               <property name="frameShape">
                <enum>QFrame::NoFrame</enum>
               </property>
-              <property name="openExternalLinks">
-               <bool>true</bool>
+              <property name="openLinks">
+               <bool>false</bool>
               </property>
              </widget>
             </item>

--- a/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "addlibrarywidget.h"
 
+#include "../desktopservices.h"
 #include "librarydownload.h"
 #include "repositorylibrarylistwidgetitem.h"
 #include "ui_addlibrarywidget.h"
@@ -61,6 +62,11 @@ AddLibraryWidget::AddLibraryWidget(Workspace& ws) noexcept
           &AddLibraryWidget::downloadZipUrlLineEditTextChanged);
   connect(mUi->btnRepoLibsDownload, &QPushButton::clicked, this,
           &AddLibraryWidget::downloadLibrariesFromRepositoryButtonClicked);
+  connect(mUi->lblLicenseLink, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mWorkspace.getSettings(), this);
+            ds.openWebUrl(QUrl(url));
+          });
 
   // Hide text in library list since text is displayed with custom item
   // widgets, but list item texts are still set for keyboard navigation.

--- a/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.ui
+++ b/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.ui
@@ -203,7 +203,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_9">
+          <widget class="QLabel" name="lblLicenseLink">
            <property name="minimumSize">
             <size>
              <width>25</width>
@@ -220,12 +220,9 @@
             <string>https://en.wikipedia.org/wiki/Creative_Commons_license</string>
            </property>
            <property name="text">
-            <string>&lt;a href=&quot;https://en.wikipedia.org/wiki/Creative_Commons_license&quot;&gt;&lt;img src=&quot;:/img/status/info.png&quot; width=&quot;25&quot; height=&quot;25&quot;/&gt;&lt;/a&gt;</string>
+            <string notr="true">&lt;a href=&quot;https://en.wikipedia.org/wiki/Creative_Commons_license&quot;&gt;&lt;img src=&quot;:/img/status/info.png&quot; width=&quot;25&quot; height=&quot;25&quot;/&gt;&lt;/a&gt;</string>
            </property>
            <property name="scaledContents">
-            <bool>true</bool>
-           </property>
-           <property name="openExternalLinks">
             <bool>true</bool>
            </property>
           </widget>

--- a/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "libraryinfowidget.h"
 
+#include "../desktopservices.h"
 #include "ui_libraryinfowidget.h"
 
 #include <librepcb/core/fileio/fileutils.h>
@@ -79,6 +80,11 @@ LibraryInfoWidget::LibraryInfoWidget(Workspace& ws, const FilePath& libDir)
   mUi->lblUrl->setText(
       QString("<a href='%1'>%2</a>")
           .arg(lib.getUrl().toEncoded(), lib.getUrl().toDisplayString()));
+  connect(mUi->lblUrl, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mWorkspace.getSettings(), this);
+            ds.openWebUrl(QUrl(url));
+          });
   mUi->lblCreated->setText(lib.getCreated().toString(Qt::TextDate));
   mUi->lblDeprecated->setText(
       lib.isDeprecated() ? tr("Yes - Consider switching to another library.")
@@ -103,9 +109,13 @@ LibraryInfoWidget::LibraryInfoWidget(Workspace& ws, const FilePath& libDir)
   mUi->lblDependencies->setText(dependencies);
   mUi->lblDirectory->setText(
       QString("<a href='%1'>%2</a>")
-          .arg(mLibDir.toQUrl().toLocalFile(),
-               mLibDir.toRelative(ws.getLibrariesPath())));
+          .arg(mLibDir.toStr(), mLibDir.toRelative(ws.getLibrariesPath())));
   mUi->lblDirectory->setToolTip(mLibDir.toNative());
+  connect(mUi->lblDirectory, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mWorkspace.getSettings(), this);
+            ds.openLocalPath(FilePath(url));
+          });
 }
 
 LibraryInfoWidget::~LibraryInfoWidget() noexcept {

--- a/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.ui
+++ b/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.ui
@@ -149,9 +149,6 @@
        <property name="wordWrap">
         <bool>true</bool>
        </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
        <property name="textInteractionFlags">
         <set>Qt::TextBrowserInteraction</set>
        </property>
@@ -248,9 +245,6 @@
         <string notr="true">TextLabel</string>
        </property>
        <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="openExternalLinks">
         <bool>true</bool>
        </property>
        <property name="textInteractionFlags">

--- a/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.ui
+++ b/libs/librepcb/editor/workspace/projectlibraryupdater/projectlibraryupdater.ui
@@ -52,9 +52,6 @@ p, li { white-space: pre-wrap; }
      <property name="margin">
       <number>3</number>
      </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
    <item>

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -29,6 +29,7 @@
 #include "../modelview/keyboardshortcutsmodel.h"
 #include "../modelview/keysequencedelegate.h"
 #include "../utils/editortoolbox.h"
+#include "desktopservices.h"
 #include "ui_workspacesettingsdialog.h"
 
 #include <librepcb/core/application.h>
@@ -148,6 +149,11 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
             mRepositoryUrlsModel.data(), &RepositoryUrlModel::moveItemUp);
     connect(mUi->tblRepositoryUrls, &EditableTableWidget::btnMoveDownClicked,
             mRepositoryUrlsModel.data(), &RepositoryUrlModel::moveItemDown);
+    connect(mUi->lblRepositoriesInfo, &QLabel::linkActivated, this,
+            [this](const QString& url) {
+              DesktopServices ds(mWorkspace.getSettings(), this);
+              ds.openWebUrl(QUrl(url));
+            });
   }
 
   // Initialize external applications widgets

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
@@ -256,12 +256,9 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="lblRepositoriesInfo">
          <property name="text">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Repositories are used to browse, download and update libraries.&lt;br/&gt;You can add any server to this list which implements the LibrePCB API.&lt;br/&gt;The official LibrePCB server is &lt;a href=&quot;https://api.librepcb.org&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;https://api.librepcb.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
There were many hyperlinks created with `QLabel` widgets with the property `openExternalLinks` set to `true` to let Qt handle opening the hyperlinks. However, this way the links were opened with `QDesktopServices`, which does not respect the external application settings from the workspace.

Fixed by disabling `openExternalLinks` and handle the `linkActivated()` signal to open the links with our own `DesktopServices` class, and thus taking the workspace settings into account.