### PR TITLE
Control panel: Allow to hide/dismiss message banners

### DIFF
--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -56,7 +56,8 @@ WorkspaceSettings::WorkspaceSettings(QObject* parent)
                                 QStringList(), this),
     externalPdfReaderCommands("external_pdf_reader", "command", QStringList(),
                               this),
-    keyboardShortcuts(this) {
+    keyboardShortcuts(this),
+    dismissedMessages("dismissed_messages", "message", QSet<QString>(), this) {
 }
 
 WorkspaceSettings::~WorkspaceSettings() noexcept {

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -253,6 +253,18 @@ public:
    * @see ::librepcb::WorkspaceSettingsItem_KeyboardShortcuts
    */
   WorkspaceSettingsItem_KeyboardShortcuts keyboardShortcuts;
+
+  /**
+   * @brief Dismissed messages
+   *
+   * List of messages which the user dismissed with "do not show again". It's
+   * just a generic list of strings, where each message is identified by some
+   * locale-independent string. It's recommended to use UPPER_SNAKE_CASE
+   * strings, For example: "WORKSPACE_V0.1_HAS_NO_LIBRARIES".
+   *
+   * Default: []
+   */
+  WorkspaceSettingsItem_GenericValueList<QSet<QString>> dismissedMessages;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -691,6 +691,8 @@ add_library(
   widgets/lengthedit.h
   widgets/lengtheditbase.cpp
   widgets/lengtheditbase.h
+  widgets/messagewidget.cpp
+  widgets/messagewidget.h
   widgets/numbereditbase.cpp
   widgets/numbereditbase.h
   widgets/patheditorwidget.cpp

--- a/libs/librepcb/editor/widgets/messagewidget.cpp
+++ b/libs/librepcb/editor/widgets/messagewidget.cpp
@@ -1,0 +1,164 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "messagewidget.h"
+
+#include <librepcb/core/workspace/workspace.h>
+#include <librepcb/core/workspace/workspacesettings.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+MessageWidget::MessageWidget(QWidget* parent) noexcept
+  : QWidget(parent),
+    mLayout(new QHBoxLayout()),
+    mMessageLabel(new QLabel()),
+    mDismissLabel(new QLabel()),
+    mHideLabel(new QLabel()),
+    mWorkspace(),
+    mDismissKey(),
+    mActive(true),
+    mTemporarilyHidden(false) {
+  setAttribute(Qt::WA_StyledBackground, true);
+  setStyleSheet("background-color: rgb(255, 255, 127);");
+  mLayout->setContentsMargins(9, 5, 9, 5);
+  setLayout(mLayout);
+
+  // Setup message label.
+  QFont font = mMessageLabel->font();
+  font.setBold(true);
+  mMessageLabel->setFont(font);
+  mMessageLabel->setStyleSheet("color: rgb(170, 0, 0);");
+  mMessageLabel->setWordWrap(true);
+  connect(mMessageLabel.data(), &QLabel::linkActivated, this,
+          &MessageWidget::linkActivated);
+  mLayout->addWidget(mMessageLabel.data());
+
+  // Setup "don't show again" label.
+  mDismissLabel->setText("<small><a href='x'>" % tr("Don't show again") %
+                         "</a></small>");
+  mDismissLabel->setToolTip(
+      tr("Permanently hide this message.\n"
+         "This can be reverted in the workspace settings dialog."));
+  mDismissLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+  mDismissLabel->setIndent(7);
+  connect(mDismissLabel.data(), &QLabel::linkActivated, this, [this]() {
+    try {
+      if (mWorkspace && (!mDismissKey.isEmpty())) {
+        mWorkspace->getSettings().dismissedMessages.add(mDismissKey);
+        mWorkspace->saveSettings();  // can throw
+        updateVisibility();
+      }
+    } catch (const Exception& e) {
+      qCritical().noquote() << "Failed to dismiss message:" << e.getMsg();
+    }
+  });
+  mLayout->addWidget(mDismissLabel.data());
+
+  // Setup "hide" label.
+  mHideLabel->setText(
+      "<h3><a href='x' style='text-decoration:none;'>✖</a></h3>");
+  mHideLabel->setToolTip(tr("Temporarily hide this message."));
+  mHideLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+  mHideLabel->setIndent(4);
+  connect(mHideLabel.data(), &QLabel::linkActivated, this, [this]() {
+    mTemporarilyHidden = true;
+    updateVisibility();
+  });
+  mLayout->addWidget(mHideLabel.data());
+}
+
+MessageWidget::~MessageWidget() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void MessageWidget::init(const QString& message, bool active) noexcept {
+  setWorkspace(nullptr);
+  mDismissKey.clear();
+  mMessageLabel->setText(message);
+  mDismissLabel->hide();
+  setActive(active);
+}
+
+void MessageWidget::init(Workspace& workspace, const QString& dismissKey,
+                         const QString& message, bool active) noexcept {
+  setWorkspace(&workspace);
+  mDismissKey = dismissKey;
+  mMessageLabel->setText(message);
+  mDismissLabel->show();
+  setActive(active);
+}
+
+void MessageWidget::setActive(bool active) noexcept {
+  mActive = active;
+  if (!active) {
+    mTemporarilyHidden = false;
+  }
+  updateVisibility();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void MessageWidget::setWorkspace(Workspace* workspace) noexcept {
+  if (mWorkspace) {
+    disconnect(&mWorkspace->getSettings().dismissedMessages,
+               &WorkspaceSettingsItem::edited, this,
+               &MessageWidget::updateVisibility);
+  }
+  mWorkspace = workspace;
+  if (mWorkspace) {
+    connect(&mWorkspace->getSettings().dismissedMessages,
+            &WorkspaceSettingsItem::edited, this,
+            &MessageWidget::updateVisibility);
+  }
+}
+
+void MessageWidget::updateVisibility() noexcept {
+  bool isVisible = mActive && (!mTemporarilyHidden);
+  if (isVisible && mWorkspace && (!mDismissKey.isEmpty()) &&
+      mWorkspace->getSettings().dismissedMessages.contains(mDismissKey)) {
+    isVisible = false;
+  }
+  setVisible(isVisible);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/widgets/messagewidget.h
+++ b/libs/librepcb/editor/widgets/messagewidget.h
@@ -1,0 +1,133 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_MESSAGEWIDGET_H
+#define LIBREPCB_EDITOR_MESSAGEWIDGET_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class Workspace;
+
+namespace editor {
+
+/*******************************************************************************
+ *  Class MessageWidget
+ ******************************************************************************/
+
+/**
+ * @brief A widget containing a hidable, optionally dismissable message label
+ *
+ * This is a QLabel to show a custom message in the GUI, with a "hide" and
+ * "don't show again" label on the right side to allow hiding it. The
+ * "don't show again" feature is implemented with
+ * ::librepcb::WorkspaceSettings::dismissedMessages and is therefore only
+ * available if the Workspace is set.
+ *
+ * You have to call one of the #init() methods to make this widget working.
+ * Do not call `QWidget::show()`, `QWidget::hide()` or `QWidget::setVisible()`
+ * manually!
+ */
+class MessageWidget final : public QWidget {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit MessageWidget(QWidget* parent = nullptr) noexcept;
+  MessageWidget(const MessageWidget& other) = delete;
+  ~MessageWidget() noexcept;
+
+  /**
+   * @brief Initialize widget without the "don't show again" feature
+   *
+   * Allows only temporary dismissing, but not permanently.
+   *
+   * @param message   The message to show.
+   * @param active    Whether the message should currently be shown or not.
+   */
+  void init(const QString& message, bool active) noexcept;
+
+  /**
+   * @brief Initialize widget with the "don't show again" feature
+   *
+   * Allows both, temporary or permanently dismissing the message.
+   *
+   * @param workspace   The workspace to use for the persistent settings.
+   * @param dismissKey  The unique identifier for this message, see details at
+   *                    ::librepcb::WorkspaceSettings::dismissedMessages.
+   * @param message     The message to show.
+   * @param active      Whether the message should currently be shown or not.
+   */
+  void init(Workspace& workspace, const QString& dismissKey,
+            const QString& message, bool active) noexcept;
+
+  /**
+   * @brief Set whether the message should be shown (if not dismissed) or not
+   *
+   * The widget will be visible only if `true` is passed and the message was
+   * not dismissed.
+   *
+   * @param active    Whether the message should currently be shown or not.
+   */
+  void setActive(bool active) noexcept;
+
+  // Operator Overloadings
+  MessageWidget& operator=(const MessageWidget& rhs) = delete;
+
+signals:
+  /**
+   * @brief A link in the message label has been clicked
+   *
+   * @param link  The clicked link.
+   */
+  void linkActivated(const QString& link);
+
+private:  // Methods
+  void setWorkspace(Workspace* workspace) noexcept;
+  void dismissedMessagesModified() noexcept;
+  void updateVisibility() noexcept;
+
+private:  // Data
+  QPointer<QHBoxLayout> mLayout;
+  QScopedPointer<QLabel> mMessageLabel;
+  QScopedPointer<QLabel> mDismissLabel;
+  QScopedPointer<QLabel> mHideLabel;
+
+  QPointer<Workspace> mWorkspace;
+  QString mDismissKey;
+  bool mActive;
+  bool mTemporarilyHidden;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -89,16 +89,39 @@ ControlPanel::ControlPanel(Workspace& workspace, bool fileFormatIsOutdated)
 
   // Show warning if the workspace has already been opened with a higher
   // file format version.
-  mUi->lblWarnForNewerAppVersions->setVisible(fileFormatIsOutdated);
+  mUi->msgWarnForNewerAppVersions->init(
+      mWorkspace,
+      QString("WORKSPACE_V%1_OPENED_WITH_NEWER_VERSION")
+          .arg(qApp->getFileFormatVersion().toStr()),
+      tr("This workspace was already used with a newer version of LibrePCB. "
+         "All changes in libraries and workspace settings will not be "
+         "available in newer versions of LibrePCB."),
+      fileFormatIsOutdated);
 
-  // hide warning about missing libraries, but update visibility each time the
-  // workspace library was scanned
-  mUi->lblWarnForNoLibraries->setVisible(false);
-  connect(mUi->lblWarnForNoLibraries, &QLabel::linkActivated, this,
+  // Setup warning about missing libraries, and update visibility each time the
+  // workspace library was scanned.
+  mUi->msgWarnForNoLibraries->init(
+      mWorkspace,
+      QString("WORKSPACE_V%1_HAS_NO_LIBRARIES")
+          .arg(qApp->getFileFormatVersion().toStr()),
+      tr("This workspace does not contain any libraries, which are essential "
+         "to create and modify projects. You should <a href=\"%1\">open the "
+         "library manager</a> to add some libraries.")
+          .arg("library-manager"),
+      false);
+  connect(mUi->msgWarnForNoLibraries, &MessageWidget::linkActivated, this,
           &ControlPanel::openLibraryManager);
-  connect(&mWorkspace.getLibraryDb(),
-          &WorkspaceLibraryDb::scanLibraryListUpdated, this,
-          &ControlPanel::updateNoLibrariesWarningVisibility);
+  connect(
+      &mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanLibraryListUpdated,
+      this, [this]() {
+        bool showWarning = false;
+        try {
+          showWarning = mWorkspace.getLibraryDb().getAll<Library>().isEmpty();
+        } catch (const Exception& e) {
+          qCritical() << "Failed to get workspace library list:" << e.getMsg();
+        }
+        mUi->msgWarnForNoLibraries->setActive(showWarning);
+      });
 
   // connect some actions which are created with the Qt Designer
   connect(mUi->openProjectButton, &QPushButton::clicked,
@@ -318,16 +341,6 @@ void ControlPanel::loadSettings() {
   }
 
   clientSettings.endGroup();
-}
-
-void ControlPanel::updateNoLibrariesWarningVisibility() noexcept {
-  bool showWarning = false;
-  try {
-    showWarning = mWorkspace.getLibraryDb().getAll<Library>().isEmpty();
-  } catch (const Exception& e) {
-    qCritical() << "Failed to get workspace library list:" << e.getMsg();
-  }
-  mUi->lblWarnForNoLibraries->setVisible(showWarning);
 }
 
 void ControlPanel::openLibraryManager() noexcept {

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -113,7 +113,6 @@ private:
   void createMenus() noexcept;
   void saveSettings();
   void loadSettings();
-  void updateNoLibrariesWarningVisibility() noexcept;
   void openLibraryManager() noexcept;
   void switchWorkspace() noexcept;
   void showProjectReadmeInBrowser(const FilePath& projectFilePath) noexcept;

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.ui
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.ui
@@ -35,63 +35,10 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QLabel" name="lblWarnForNewerAppVersions">
-      <property name="font">
-       <font>
-        <weight>75</weight>
-        <bold>true</bold>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QLabel {
-	background-color: rgb(255, 255, 127);
-
-	color: rgb(170, 0, 0);
-};</string>
-      </property>
-      <property name="text">
-       <string>This workspace was already used with a newer version of LibrePCB. All changes in libraries and workspace settings will not be available in newer versions of LibrePCB.</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="margin">
-       <number>10</number>
-      </property>
-     </widget>
+     <widget class="librepcb::editor::MessageWidget" name="msgWarnForNewerAppVersions" native="true"/>
     </item>
     <item>
-     <widget class="QLabel" name="lblWarnForNoLibraries">
-      <property name="font">
-       <font>
-        <pointsize>13</pointsize>
-        <weight>75</weight>
-        <bold>true</bold>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QLabel {
-	background-color: rgb(255, 255, 127);
-
-	color: rgb(170, 0, 0);
-};</string>
-      </property>
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This workspace does not contain any libraries, which are essential to create and modify projects. You should open the library manager to add some libraries. &lt;a href=&quot;LibraryManager&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Click here to open the library manager&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="margin">
-       <number>10</number>
-      </property>
-     </widget>
+     <widget class="librepcb::editor::MessageWidget" name="msgWarnForNoLibraries" native="true"/>
     </item>
     <item>
      <widget class="QSplitter" name="splitter_h">
@@ -116,6 +63,9 @@
           </property>
           <property name="contextMenuPolicy">
            <enum>Qt::CustomContextMenu</enum>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
           </property>
           <property name="editTriggers">
            <set>QAbstractItemView::NoEditTriggers</set>
@@ -442,6 +392,12 @@ QListView::item
    <class>librepcb::editor::StatusBar</class>
    <extends>QStatusBar</extends>
    <header location="global">librepcb/editor/widgets/statusbar.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::MessageWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/messagewidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -80,6 +80,19 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
     }
   }
 
+  // Initialize "reset dismissed messages" button
+  updateDismissedMessagesCount();
+  connect(mUi->btnResetDismissedMessages, &QPushButton::clicked, this,
+          [this]() {
+            try {
+              mSettings.dismissedMessages.restoreDefault();
+              mWorkspace.saveSettings();  // can throw
+            } catch (const Exception& e) {
+              QMessageBox::critical(this, tr("Error"), e.getMsg());
+            }
+            updateDismissedMessagesCount();
+          });
+
   // Initialize library locale order widgets
   {
     QList<QLocale> locales = QLocale::matchingLocales(
@@ -400,6 +413,18 @@ void WorkspaceSettingsDialog::externalApplicationListIndexChanged(
   }
   placeholdersText += "</ul></p>";
   mUi->lblExternalApplicationsPlaceholders->setText(placeholdersText);
+}
+
+void WorkspaceSettingsDialog::updateDismissedMessagesCount() noexcept {
+  const int count = mSettings.dismissedMessages.get().count();
+  mUi->btnResetDismissedMessages->setText(tr("Reset") % " (" %
+                                          QString::number(count) % ")");
+  mUi->btnResetDismissedMessages->setToolTip(
+      tr("Reset all permanently dismissed messages (something like \"do not "
+         "show again\") to make them appear again.") %
+      "\n\n" %
+      tr("Currently there are %1 dismissed message(s).", nullptr, count)
+          .arg(count));
 }
 
 void WorkspaceSettingsDialog::loadSettings() noexcept {

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.h
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.h
@@ -85,6 +85,7 @@ private:
   void buttonBoxClicked(QAbstractButton* button) noexcept;
   void keyPressEvent(QKeyEvent* event) noexcept override;
   void externalApplicationListIndexChanged(int index) noexcept;
+  void updateDismissedMessagesCount() noexcept;
   void loadSettings() noexcept;
   void saveSettings() noexcept;
 

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
@@ -199,6 +199,26 @@
          </item>
         </layout>
        </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Dismissed Messages:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QPushButton" name="btnResetDismissedMessages">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string notr="true">Reset</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="libraryTab">

--- a/tests/unittests/core/workspace/workspacesettingstest.cpp
+++ b/tests/unittests/core/workspace/workspacesettingstest.cpp
@@ -107,6 +107,10 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
       " (external_pdf_reader\n"
       "  (command \"evince \\\"{{FILEPATH}}\\\"\")\n"
       " )\n"
+      " (dismissed_messages\n"
+      "  (message \"SOME_MESSAGE: foo\")\n"
+      "  (message \"SOME_MESSAGE: bar\")\n"
+      " )\n"
       ")",
       FilePath());
 
@@ -127,6 +131,8 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpressionCurrentVersion) {
             obj.externalFileManagerCommands.get());
   EXPECT_EQ(QStringList{"evince \"{{FILEPATH}}\""},
             obj.externalPdfReaderCommands.get());
+  EXPECT_EQ((QSet<QString>{"SOME_MESSAGE: foo", "SOME_MESSAGE: bar"}),
+            obj.dismissedMessages.get());
 }
 
 TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
@@ -143,6 +149,7 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   obj1.externalWebBrowserCommands.set({"foo", "bar"});
   obj1.externalFileManagerCommands.set({"file", "manager"});
   obj1.externalPdfReaderCommands.set({"pdf", "reader"});
+  obj1.dismissedMessages.set({"foo", "bar"});
   const SExpression root1 = obj1.serialize();
 
   // Load
@@ -165,6 +172,7 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
             obj2.externalFileManagerCommands.get());
   EXPECT_EQ(obj1.externalPdfReaderCommands.get(),
             obj2.externalPdfReaderCommands.get());
+  EXPECT_EQ(obj1.dismissedMessages.get(), obj2.dismissedMessages.get());
   const SExpression root2 = obj2.serialize();
 
   // Check if serialization of loaded settings leads to same file content


### PR DESCRIPTION
The banners can be quite annoying, so let's allow to either temporarily or permanently hide them. Added this feature to the workspace settings to store dismissed messages, and allowing to reset them all with a new button in the workspace settings dialog:

![librepcb-dismiss-messages](https://user-images.githubusercontent.com/5374821/192171619-2f000f57-4d6f-4bc6-ab74-a786dfdbe0c5.gif)