### PR TITLE
Show waiting spinner in tree/list views during library scan

### DIFF
--- a/libs/librepcb/core/workspace/workspacelibrarydb.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.cpp
@@ -99,6 +99,10 @@ WorkspaceLibraryDb::~WorkspaceLibraryDb() noexcept {
  *  Getters
  ******************************************************************************/
 
+int WorkspaceLibraryDb::getScanProgressPercent() const noexcept {
+  return mLibraryScanner->getProgressPercent();
+}
+
 bool WorkspaceLibraryDb::getLibraryMetadata(const FilePath libDir,
                                             QPixmap* icon) const {
   QSqlQuery query = mDb->prepareQuery(

--- a/libs/librepcb/core/workspace/workspacelibrarydb.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.h
@@ -81,6 +81,22 @@ public:
   const FilePath& getFilePath() const noexcept { return mFilePath; }
 
   /**
+   * @brief Check if there is currently a library scan in progress
+   *
+   * @return Whether a scan is in progress or not.
+   */
+  bool isScanInProgress() const noexcept {
+    return getScanProgressPercent() < 100;
+  }
+
+  /**
+   * @brief Get the current progress of the library rescan
+   *
+   * @return Progress in percent (100 = finished).
+   */
+  int getScanProgressPercent() const noexcept;
+
+  /**
    * @brief Get elements, optionally matching some criteria
    *
    * @tparam ElementType  Type of the library element.

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -51,7 +51,11 @@ WorkspaceLibraryScanner::WorkspaceLibraryScanner(
     mLibrariesPath(librariesPath),
     mDbFilePath(dbFilePath),
     mSemaphore(0),
-    mAbort(false) {
+    mAbort(false),
+    mLastProgressPercent(100) {
+  connect(this, &WorkspaceLibraryScanner::scanProgressUpdate, this,
+          [this](int percent) { mLastProgressPercent = percent; },
+          Qt::QueuedConnection);
   start();
 }
 

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.h
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.h
@@ -60,6 +60,9 @@ public:
   WorkspaceLibraryScanner(const WorkspaceLibraryScanner& other) = delete;
   ~WorkspaceLibraryScanner() noexcept;
 
+  // Getters
+  int getProgressPercent() const noexcept { return mLastProgressPercent; }
+
   // General Methods
   void startScan() noexcept;
 
@@ -104,6 +107,7 @@ private:  // Data
   const FilePath mDbFilePath;  ///< Path to the SQLite database file.
   QSemaphore mSemaphore;
   volatile bool mAbort;
+  int mLastProgressPercent;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -715,6 +715,8 @@ add_library(
   widgets/unsignedlengthedit.h
   widgets/unsignedratioedit.cpp
   widgets/unsignedratioedit.h
+  widgets/waitingspinnerwidget.cpp
+  widgets/waitingspinnerwidget.h
   workspace/categorytreemodel.cpp
   workspace/categorytreemodel.h
   workspace/controlpanel/controlpanel.cpp

--- a/libs/librepcb/editor/library/cat/categorychooserdialog.cpp
+++ b/libs/librepcb/editor/library/cat/categorychooserdialog.cpp
@@ -22,9 +22,11 @@
  ******************************************************************************/
 #include "categorychooserdialog.h"
 
+#include "../../widgets/waitingspinnerwidget.h"
 #include "ui_categorychooserdialog.h"
 
 #include <librepcb/core/workspace/workspace.h>
+#include <librepcb/core/workspace/workspacelibrarydb.h>
 #include <librepcb/core/workspace/workspacesettings.h>
 
 #include <QtCore>
@@ -52,6 +54,14 @@ CategoryChooserDialog::CategoryChooserDialog(const Workspace& ws,
       ws.getLibraryDb(), ws.getSettings().libraryLocaleOrder.get(), filters));
   mUi->treeView->setModel(mModel.data());
   mUi->treeView->setRootIndex(QModelIndex());
+
+  // Add waiting spinner during workspace library scan.
+  WaitingSpinnerWidget* spinner = new WaitingSpinnerWidget(mUi->treeView);
+  connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanStarted, spinner,
+          &WaitingSpinnerWidget::show);
+  connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanFinished, spinner,
+          &WaitingSpinnerWidget::hide);
+  spinner->setVisible(ws.getLibraryDb().isScanInProgress());
 }
 
 CategoryChooserDialog::~CategoryChooserDialog() noexcept {

--- a/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
+++ b/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "componentchooserdialog.h"
 
+#include "../../widgets/waitingspinnerwidget.h"
 #include "../../workspace/categorytreemodel.h"
 #include "../sym/symbolgraphicsitem.h"
 #include "ui_componentchooserdialog.h"
@@ -71,6 +72,18 @@ ComponentChooserDialog::ComponentChooserDialog(
           &ComponentChooserDialog::listComponents_itemDoubleClicked);
   connect(mUi->edtSearch, &QLineEdit::textChanged, this,
           &ComponentChooserDialog::searchEditTextChanged);
+
+  // Add waiting spinner during workspace library scan.
+  auto addSpinner = [&ws](QWidget* widget) {
+    WaitingSpinnerWidget* spinner = new WaitingSpinnerWidget(widget);
+    connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanStarted, spinner,
+            &WaitingSpinnerWidget::show);
+    connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanFinished, spinner,
+            &WaitingSpinnerWidget::hide);
+    spinner->setVisible(ws.getLibraryDb().isScanInProgress());
+  };
+  addSpinner(mUi->treeCategories);
+  addSpinner(mUi->listComponents);
 
   setSelectedComponent(tl::nullopt);
 }

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.h
@@ -103,7 +103,7 @@ signals:
   void removeElementTriggered(const FilePath& fp);
 
 private:  // Methods
-  void createListWidgetActions(QListWidget* listWidget) noexcept;
+  void setupListWidget(QListWidget* listWidget) noexcept;
   void updateMetadata() noexcept;
   QString commitMetadata() noexcept;
   bool isInterfaceBroken() const noexcept override { return false; }

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -88,6 +88,8 @@ LibraryEditor::LibraryEditor(Workspace& ws, const FilePath& libFp,
   connect(&mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanProgressUpdate,
           mUi->statusBar, &StatusBar::setProgressBarPercent,
           Qt::QueuedConnection);
+  mUi->statusBar->setProgressBarPercent(
+      mWorkspace.getLibraryDb().getScanProgressPercent());
 
   // Add all required schematic layers.
   addLayer(GraphicsLayer::sSchematicReferences);

--- a/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "packagechooserdialog.h"
 
+#include "../../widgets/waitingspinnerwidget.h"
 #include "../../workspace/categorytreemodel.h"
 #include "footprintgraphicsitem.h"
 #include "ui_packagechooserdialog.h"
@@ -73,6 +74,18 @@ PackageChooserDialog::PackageChooserDialog(
           &PackageChooserDialog::listPackages_itemDoubleClicked);
   connect(mUi->edtSearch, &QLineEdit::textChanged, this,
           &PackageChooserDialog::searchEditTextChanged);
+
+  // Add waiting spinner during workspace library scan.
+  auto addSpinner = [&ws](QWidget* widget) {
+    WaitingSpinnerWidget* spinner = new WaitingSpinnerWidget(widget);
+    connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanStarted, spinner,
+            &WaitingSpinnerWidget::show);
+    connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanFinished, spinner,
+            &WaitingSpinnerWidget::hide);
+    spinner->setVisible(ws.getLibraryDb().isScanInProgress());
+  };
+  addSpinner(mUi->treeCategories);
+  addSpinner(mUi->listPackages);
 
   setSelectedPackage(tl::nullopt);
 }

--- a/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
+++ b/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "symbolchooserdialog.h"
 
+#include "../../widgets/waitingspinnerwidget.h"
 #include "../../workspace/categorytreemodel.h"
 #include "symbolgraphicsitem.h"
 #include "ui_symbolchooserdialog.h"
@@ -71,6 +72,18 @@ SymbolChooserDialog::SymbolChooserDialog(
           &SymbolChooserDialog::listSymbols_itemDoubleClicked);
   connect(mUi->edtSearch, &QLineEdit::textChanged, this,
           &SymbolChooserDialog::searchEditTextChanged);
+
+  // Add waiting spinner during workspace library scan.
+  auto addSpinner = [&ws](QWidget* widget) {
+    WaitingSpinnerWidget* spinner = new WaitingSpinnerWidget(widget);
+    connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanStarted, spinner,
+            &WaitingSpinnerWidget::show);
+    connect(&ws.getLibraryDb(), &WorkspaceLibraryDb::scanFinished, spinner,
+            &WaitingSpinnerWidget::hide);
+    spinner->setVisible(ws.getLibraryDb().isScanInProgress());
+  };
+  addSpinner(mUi->treeCategories);
+  addSpinner(mUi->listSymbols);
 
   setSelectedSymbol(FilePath());
 }

--- a/libs/librepcb/editor/project/addcomponentdialog.cpp
+++ b/libs/librepcb/editor/project/addcomponentdialog.cpp
@@ -26,6 +26,7 @@
 #include "../library/pkg/footprintgraphicsitem.h"
 #include "../library/sym/symbolgraphicsitem.h"
 #include "../widgets/graphicsview.h"
+#include "../widgets/waitingspinnerwidget.h"
 #include "../workspace/categorytreemodel.h"
 #include "ui_addcomponentdialog.h"
 
@@ -110,6 +111,18 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
   connect(mUi->treeCategories->selectionModel(),
           &QItemSelectionModel::currentChanged, this,
           &AddComponentDialog::treeCategories_currentItemChanged);
+
+  // Add waiting spinner during workspace library scan.
+  auto addSpinner = [&db](QWidget* widget) {
+    WaitingSpinnerWidget* spinner = new WaitingSpinnerWidget(widget);
+    connect(&db, &WorkspaceLibraryDb::scanStarted, spinner,
+            &WaitingSpinnerWidget::show);
+    connect(&db, &WorkspaceLibraryDb::scanFinished, spinner,
+            &WaitingSpinnerWidget::hide);
+    spinner->setVisible(db.isScanInProgress());
+  };
+  addSpinner(mUi->treeCategories);
+  addSpinner(mUi->treeComponents);
 
   // Reset GUI to state of nothing selected.
   setSelectedComponent(nullptr);

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -118,6 +118,8 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
           &WorkspaceLibraryDb::scanProgressUpdate, mUi->statusbar,
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);
+  mUi->statusbar->setProgressBarPercent(
+      mProjectEditor.getWorkspace().getLibraryDb().getScanProgressPercent());
 
   // Set window title.
   QString filenameStr = mProject.getFilepath().getFilename();

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -98,6 +98,8 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   connect(&mProjectEditor.getWorkspace().getLibraryDb(),
           &WorkspaceLibraryDb::scanProgressUpdate, mUi->statusbar,
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);
+  mUi->statusbar->setProgressBarPercent(
+      mProjectEditor.getWorkspace().getLibraryDb().getScanProgressPercent());
 
   // Set window title.
   QString filenameStr = mProject.getFilepath().getFilename();

--- a/libs/librepcb/editor/widgets/waitingspinnerwidget.cpp
+++ b/libs/librepcb/editor/widgets/waitingspinnerwidget.cpp
@@ -1,0 +1,144 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "waitingspinnerwidget.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+WaitingSpinnerWidget::WaitingSpinnerWidget(QWidget* parent) noexcept
+  : QWidget(parent),
+    mTotalRotations(7),
+    mCurrentRotation(0),
+    mCircleDiameter(14),
+    mDotDiameter(5),
+    mMargin(4),
+    mTimer(new QTimer(this)) {
+  setAttribute(Qt::WA_TransparentForMouseEvents);
+  setAttribute(Qt::WA_TranslucentBackground);
+
+  mTimer->setInterval(100);
+  connect(mTimer.data(), &QTimer::timeout, this, [this]() {
+    mCurrentRotation = (mCurrentRotation + 1) % mTotalRotations;
+    update();
+  });
+
+  if (QAbstractScrollArea* sa = qobject_cast<QAbstractScrollArea*>(parent)) {
+    // Avoid painting on the scrollbars.
+    mEventFilterObject = sa->viewport();
+  } else if (parent) {
+    mEventFilterObject = parent;
+  }
+  if (mEventFilterObject) {
+    mEventFilterObject->installEventFilter(this);
+  }
+
+  updateSize();
+  updatePosition();
+}
+
+WaitingSpinnerWidget::~WaitingSpinnerWidget() noexcept {
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+void WaitingSpinnerWidget::showEvent(QShowEvent* e) noexcept {
+  mTimer->start();
+  QWidget::showEvent(e);
+}
+
+void WaitingSpinnerWidget::hideEvent(QHideEvent* e) noexcept {
+  mTimer->stop();
+  QWidget::hideEvent(e);
+}
+
+void WaitingSpinnerWidget::paintEvent(QPaintEvent* e) noexcept {
+  Q_UNUSED(e);
+
+  const qreal center = calculateSize() / qreal(2);
+  QColor color = palette().color(QPalette::Text);
+
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setBrush(Qt::NoBrush);
+  painter.translate(center, center);
+  painter.rotate(qreal(360) * mCurrentRotation / mTotalRotations);
+  for (int i = 0; i < mTotalRotations; ++i) {
+    const qreal dotDiameter =
+        mDotDiameter * (qreal(mTotalRotations - i) / mTotalRotations);
+    painter.setPen(QPen(color, dotDiameter, Qt::SolidLine, Qt::RoundCap));
+    painter.drawPoint(QPointF(mCircleDiameter / qreal(2), 0));
+    painter.rotate(qreal(-360) / mTotalRotations);
+    color.setAlphaF(color.alphaF() * 0.8);
+  }
+}
+
+bool WaitingSpinnerWidget::eventFilter(QObject* watched,
+                                       QEvent* event) noexcept {
+  if ((watched == mEventFilterObject) && (event->type() == QEvent::Resize)) {
+    updatePosition();
+  }
+  return QWidget::eventFilter(watched, event);
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+int WaitingSpinnerWidget::calculateSize() const noexcept {
+  return mCircleDiameter + mDotDiameter + (mMargin * 2);
+}
+
+void WaitingSpinnerWidget::updateSize() noexcept {
+  const int size = calculateSize();
+  setFixedSize(size, size);
+}
+
+void WaitingSpinnerWidget::updatePosition() noexcept {
+  if (QWidget* parent = parentWidget()) {
+    int parentWidth = parent->width();
+    if (mEventFilterObject && (parent != mEventFilterObject)) {
+      QPoint topRight = mEventFilterObject->geometry().topRight();
+      parentWidth = mEventFilterObject->mapTo(parent, topRight).x();
+    }
+    move(parentWidth - width(), 0);
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/widgets/waitingspinnerwidget.h
+++ b/libs/librepcb/editor/widgets/waitingspinnerwidget.h
@@ -1,0 +1,92 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_WAITINGSPINNERWIDGET_H
+#define LIBREPCB_EDITOR_WAITINGSPINNERWIDGET_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Class WaitingSpinnerWidget
+ ******************************************************************************/
+
+/**
+ * @brief A widget drawing a rotating spinner to indicate an ongoing operation
+ *
+ * Usage:
+ *   - Pass the widget where the spinner shall be shown as the parent widget
+ *     to the constructor. Important: Do NOT change the parent afterwards!
+ *   - Call either `show()`, `hide()` or `setVisible()` to make the spinner
+ *     visible or not.
+ *   - Do not set a widget size or position manually, this is controlled by the
+ *     widget itself.
+ *
+ * Memory management is done by the Qt parent-child mechanism.
+ */
+class WaitingSpinnerWidget final : public QWidget {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit WaitingSpinnerWidget(QWidget* parent = nullptr) noexcept;
+  WaitingSpinnerWidget(const WaitingSpinnerWidget& other) = delete;
+  ~WaitingSpinnerWidget() noexcept;
+
+  // Operator Overloadings
+  WaitingSpinnerWidget& operator=(const WaitingSpinnerWidget& rhs) = delete;
+
+protected:  // Methods
+  void showEvent(QShowEvent* e) noexcept override;
+  void hideEvent(QHideEvent* e) noexcept override;
+  void paintEvent(QPaintEvent* e) noexcept override;
+  bool eventFilter(QObject* watched, QEvent* event) noexcept override;
+
+private:  // Methods
+  int calculateSize() const noexcept;
+  void updateSize() noexcept;
+  void updatePosition() noexcept;
+
+private:  // Data
+  int mTotalRotations;
+  int mCurrentRotation;
+  int mCircleDiameter;
+  int mDotDiameter;
+  int mMargin;
+  QScopedPointer<QTimer> mTimer;
+  QPointer<QWidget> mEventFilterObject;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -82,6 +82,8 @@ ControlPanel::ControlPanel(Workspace& workspace, bool fileFormatIsOutdated)
   connect(&mWorkspace.getLibraryDb(), &WorkspaceLibraryDb::scanProgressUpdate,
           mUi->statusBar, &StatusBar::setProgressBarPercent,
           Qt::QueuedConnection);
+  mUi->statusBar->setProgressBarPercent(
+      mWorkspace.getLibraryDb().getScanProgressPercent());
 
   // Setup actions and menus.
   createActions();

--- a/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "addlibrarywidget.h"
 
+#include "../../widgets/waitingspinnerwidget.h"
 #include "../desktopservices.h"
 #include "librarydownload.h"
 #include "repositorylibrarylistwidgetitem.h"
@@ -114,6 +115,15 @@ void AddLibraryWidget::updateRepositoryLibraryList() noexcept {
             &AddLibraryWidget::repositoryLibraryListReceived);
     connect(repo.get(), &Repository::errorWhileFetchingLibraryList, this,
             &AddLibraryWidget::errorWhileFetchingLibraryList);
+
+    // Add waiting spinner during library list download.
+    WaitingSpinnerWidget* spinner = new WaitingSpinnerWidget(mUi->lstRepoLibs);
+    connect(repo.get(), &Repository::libraryListReceived, spinner,
+            &WaitingSpinnerWidget::deleteLater);
+    connect(repo.get(), &Repository::errorWhileFetchingLibraryList, spinner,
+            &WaitingSpinnerWidget::deleteLater);
+    spinner->show();
+
     repo->requestLibraryList();
     mRepositories.append(repo);
   }


### PR DESCRIPTION
In all tree views and list views which show content from the workspace library database (e.g. categories, symbols, components, ...), show a spinner during the scan to indicate that the content might be outdated and will be updated soon.

This should help to avoid confusion when users add libraries or library elements, but then can't find those things in the tree/list views. Especially after installing a new library, the whole library seems to be empty for quite some time - with the spinner, it should be clear that some update is in progress:

![librepcb-waiting-spinner](https://user-images.githubusercontent.com/5374821/192519137-3da3e065-c478-4bfd-89da-2e3bce32a926.gif)

In addition, another similar improvement: If the workspace library background scan is in progress while a new window is opened, the progress bar in the status bar did not appear immediately but only on the next progress update event (could be several seconds later). Now the progress bar is shown immediately when opening a window while the scan is in progress.