### PR TITLE
Schematic editor: Show info banner if schematic is empty

### DIFF
--- a/libs/librepcb/core/project/schematic/schematic.cpp
+++ b/libs/librepcb/core/project/schematic/schematic.cpp
@@ -229,6 +229,7 @@ void Schematic::addSymbol(SI_Symbol& symbol) {
   // add to schematic
   symbol.addToSchematic();  // can throw
   mSymbols.append(&symbol);
+  emit symbolAdded(symbol);
 }
 
 void Schematic::removeSymbol(SI_Symbol& symbol) {
@@ -238,6 +239,7 @@ void Schematic::removeSymbol(SI_Symbol& symbol) {
   // remove from schematic
   symbol.removeFromSchematic();  // can throw
   mSymbols.removeOne(&symbol);
+  emit symbolRemoved(symbol);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/schematic.h
+++ b/libs/librepcb/core/project/schematic/schematic.h
@@ -193,6 +193,8 @@ public:
                            const ElementName& name);
 
 signals:
+  void symbolAdded(SI_Symbol& symbol);
+  void symbolRemoved(SI_Symbol& symbol);
 
   /// @copydoc AttributeProvider::attributesChanged()
   void attributesChanged() override;

--- a/libs/librepcb/editor/project/addcomponentdialog.h
+++ b/libs/librepcb/editor/project/addcomponentdialog.h
@@ -111,6 +111,9 @@ public:
   void setLocaleOrder(const QStringList& order) noexcept;
   void setNormOrder(const QStringList& order) noexcept { mNormOrder = order; }
 
+  // General Methods
+  void selectComponentByKeyword(const QString keyword) noexcept;
+
 private slots:
   void searchEditTextChanged(const QString& text) noexcept;
   void treeCategories_currentItemChanged(const QModelIndex& current,
@@ -123,7 +126,7 @@ private slots:
 
 private:
   // Private Methods
-  void searchComponents(const QString& input);
+  void searchComponents(const QString& input, bool selectFirstResult = false);
   SearchResult searchComponentsAndDevices(const QString& input);
   void setSelectedCategory(const tl::optional<Uuid>& categoryUuid);
   void setSelectedComponent(const Component* cmp);
@@ -141,6 +144,7 @@ private:
   QScopedPointer<GraphicsScene> mDevicePreviewScene;
   QScopedPointer<DefaultGraphicsLayerProvider> mGraphicsLayerProvider;
   QScopedPointer<CategoryTreeModel> mCategoryTreeModel;
+  QString mCurrentSearchTerm;
 
   // Attributes
   tl::optional<Uuid> mSelectedCategoryUuid;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
@@ -82,13 +82,14 @@ bool SchematicEditorFsm::processSelect() noexcept {
   return setNextState(State::SELECT);
 }
 
-bool SchematicEditorFsm::processAddComponent() noexcept {
+bool SchematicEditorFsm::processAddComponent(
+    const QString& searchTerm) noexcept {
   State oldState = mCurrentState;
   if (!setNextState(State::ADD_COMPONENT)) {
     return false;
   }
   if (SchematicEditorState* state = getCurrentStateObj()) {
-    if (state->processAddComponent()) {
+    if (state->processAddComponent(searchTerm)) {
       return true;
     }
   }

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
@@ -98,7 +98,7 @@ public:
 
   // Event Handlers
   bool processSelect() noexcept;
-  bool processAddComponent() noexcept;
+  bool processAddComponent(const QString& searchTerm = QString()) noexcept;
   bool processAddComponent(const Uuid& cmp, const Uuid& symbVar) noexcept;
   bool processAddNetLabel() noexcept;
   bool processDrawPolygon() noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
@@ -92,7 +92,11 @@ public:
   virtual bool exit() noexcept { return true; }
 
   // Event Handlers
-  virtual bool processAddComponent() noexcept { return false; }
+  virtual bool processAddComponent(
+      const QString& searchTerm = QString()) noexcept {
+    Q_UNUSED(searchTerm);
+    return false;
+  }
   virtual bool processAddComponent(const Uuid& cmp,
                                    const Uuid& symbVar) noexcept {
     Q_UNUSED(cmp);

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.h
@@ -72,7 +72,8 @@ public:
   virtual bool exit() noexcept override;
 
   // Event Handlers
-  virtual bool processAddComponent() noexcept override;
+  virtual bool processAddComponent(
+      const QString& searchTerm = QString()) noexcept override;
   virtual bool processAddComponent(const Uuid& cmp,
                                    const Uuid& symbVar) noexcept override;
   virtual bool processRotate(const Angle& rotation) noexcept override;
@@ -95,6 +96,7 @@ private:  // Methods
   void startAddingComponent(const tl::optional<Uuid>& cmp = tl::nullopt,
                             const tl::optional<Uuid>& symbVar = tl::nullopt,
                             const tl::optional<Uuid>& dev = tl::nullopt,
+                            const QString& searchTerm = QString(),
                             bool keepValue = false);
   bool abortCommand(bool showErrMsgBox) noexcept;
   std::shared_ptr<const Attribute> getToolbarAttribute() const noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -131,6 +131,26 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   createDockWidgets();
   createMenus();  // Depends on dock widgets!
 
+  // Setup "empty schematic" message.
+  mUi->msgEmptySchematic->init(
+      mProjectEditor.getWorkspace(), "SCHEMATIC_HAS_NO_SYMBOLS",
+      tr("This schematic doesn't contain any components yet. Use the "
+         "<a href='%1'>Add Component</a> dialog to populate it. A good idea "
+         "is to <a href='%2'>add a schematic frame</a> first.")
+          .arg("dialog")
+          .arg("frame"),
+      false);
+  connect(mUi->msgEmptySchematic, &MessageWidget::linkActivated, this,
+          [this](const QString& link) {
+            if (mFsm) {
+              if (link == "frame") {
+                mFsm->processAddComponent("schematic frame");
+              } else {
+                mFsm->processAddComponent();
+              }
+            }
+          });
+
   // Restore window geometry.
   QSettings clientSettings;
   restoreGeometry(
@@ -189,6 +209,9 @@ bool SchematicEditor::setActiveSchematicIndex(int index) noexcept {
     // save current view scene rect
     schematic->saveViewSceneRect(mUi->graphicsView->getVisibleSceneRect());
   }
+  while (!mSchematicConnections.isEmpty()) {
+    disconnect(mSchematicConnections.takeLast());
+  }
   schematic = mProject.getSchematicByIndex(index);
   if (schematic) {
     // show scene, restore view scene rect, set grid properties
@@ -196,6 +219,12 @@ bool SchematicEditor::setActiveSchematicIndex(int index) noexcept {
     mUi->graphicsView->setVisibleSceneRect(schematic->restoreViewSceneRect());
     mUi->graphicsView->setGridProperties(schematic->getGridProperties());
     mUi->statusbar->setLengthUnit(schematic->getGridProperties().getUnit());
+    mSchematicConnections.append(
+        connect(schematic, &Schematic::symbolAdded, this,
+                &SchematicEditor::updateEmptySchematicMessage));
+    mSchematicConnections.append(
+        connect(schematic, &Schematic::symbolRemoved, this,
+                &SchematicEditor::updateEmptySchematicMessage));
   } else {
     mUi->graphicsView->setScene(nullptr);
   }
@@ -208,6 +237,7 @@ bool SchematicEditor::setActiveSchematicIndex(int index) noexcept {
   // schematic page has changed!
   mActiveSchematicIndex = index;
   emit activeSchematicChanged(mActiveSchematicIndex);
+  updateEmptySchematicMessage();
   return true;
 }
 
@@ -991,6 +1021,12 @@ void SchematicEditor::goToSymbol(const QString& name, int index) noexcept {
       mUi->graphicsView->zoomToRect(rect);
     }
   }
+}
+
+void SchematicEditor::updateEmptySchematicMessage() noexcept {
+  Schematic* schematic = getActiveSchematic();
+  mUi->msgEmptySchematic->setActive(schematic &&
+                                    schematic->getSymbols().isEmpty());
 }
 
 void SchematicEditor::updateComponentToolbarIcons() noexcept {

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -110,6 +110,7 @@ private:
   QList<SI_Symbol*> getSearchCandidates() noexcept;
   QStringList getSearchToolBarCompleterList() noexcept;
   void goToSymbol(const QString& name, int index) noexcept;
+  void updateEmptySchematicMessage() noexcept;
   void updateComponentToolbarIcons() noexcept;
   void setGridProperties(const GridProperties& grid,
                          bool applyToSchematics) noexcept;
@@ -213,6 +214,9 @@ private:
   // Docks
   QScopedPointer<SchematicPagesDock> mDockPages;
   QScopedPointer<ErcMsgDock> mDockErc;
+
+  // Connections
+  QVector<QMetaObject::Connection> mSchematicConnections;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.ui
@@ -18,7 +18,7 @@
     <normaloff>:/img/actions/schematic.png</normaloff>:/img/actions/schematic.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QHBoxLayout" name="horizontalLayout">
+   <layout class="QVBoxLayout" name="verticalLayout">
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -31,6 +31,9 @@
     <property name="bottomMargin">
      <number>0</number>
     </property>
+    <item>
+     <widget class="librepcb::editor::MessageWidget" name="msgEmptySchematic" native="true"/>
+    </item>
     <item>
      <widget class="librepcb::editor::GraphicsView" name="graphicsView">
       <property name="frameShape">
@@ -62,6 +65,12 @@
    <class>librepcb::editor::GraphicsView</class>
    <extends>QGraphicsView</extends>
    <header location="global">librepcb/editor/widgets/graphicsview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::MessageWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/messagewidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
When opened an empty schematic (which is the case after creating a new project), show a banner in the schematic editor with a hint how to add components to the schematic. The banner sugests to first add a schematic frame and provides a hyperlink to directly open the "Add Component" dialog with components filtered by the term "schematic frame". If the official base library is installed, the user will directly see the available schematic frames.

![librepcb-empty-schematic-banner](https://user-images.githubusercontent.com/5374821/192587000-e8488fbd-1dd6-4e39-9018-1406594c7551.gif)

Intended to help users getting started with LibrePCB.

See also #1039 which might some day provide a better solution for adding a frame, but for now I think this banner is already very helpful.