### PR TITLE
Polish some UI details

### DIFF
--- a/libs/librepcb/editor/dialogs/dxfimportdialog.ui
+++ b/libs/librepcb/editor/dialogs/dxfimportdialog.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">

--- a/libs/librepcb/editor/dialogs/holepropertiesdialog.ui
+++ b/libs/librepcb/editor/dialogs/holepropertiesdialog.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">

--- a/libs/librepcb/editor/dialogs/stroketextpropertiesdialog.ui
+++ b/libs/librepcb/editor/dialogs/stroketextpropertiesdialog.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">

--- a/libs/librepcb/editor/dialogs/textpropertiesdialog.ui
+++ b/libs/librepcb/editor/dialogs/textpropertiesdialog.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -416,6 +416,36 @@ public:
       &categoryEditor,
   };
 
+  EditorCommandCategory categoryTextInput{
+      "categoryTextInput", QT_TR_NOOP("Text Input"), true, &categoryRoot};
+  EditorCommand inputBrowse{
+      "input_browse",  // clang-format break
+      QT_TR_NOOP("Browse"),
+      QT_TR_NOOP("Open file or directory browser"),
+      QIcon(":/img/actions/open.png"),
+      EditorCommand::Flag::OpensPopup,
+      {QKeySequence(Qt::CTRL + Qt::Key_B)},
+      &categoryTextInput,
+  };
+  EditorCommand inputUnitChange{
+      "input_unit_change",  // clang-format break
+      QT_TR_NOOP("Change Unit"),
+      QT_TR_NOOP("Change the measurement unit of the text input"),
+      QIcon(":/img/actions/ruler.png"),
+      EditorCommand::Flag::OpensPopup,
+      {QKeySequence(Qt::CTRL + Qt::Key_M)},
+      &categoryTextInput,
+  };
+  EditorCommand inputRemove{
+      "input_remove",  // clang-format break
+      QT_TR_NOOP("Remove"),
+      QT_TR_NOOP("Remove this item"),
+      QIcon(":/img/actions/delete.png"),
+      EditorCommand::Flags(),
+      {QKeySequence(Qt::CTRL + Qt::Key_Delete)},
+      &categoryTextInput,
+  };
+
   EditorCommandCategory categoryImportExport{
       "categoryImportExport", QT_TR_NOOP("Import/Export"), true, &categoryRoot};
   EditorCommand importDxf{

--- a/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.ui
+++ b/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.ui
@@ -20,6 +20,9 @@
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
    <property name="horizontalSpacing">
     <number>3</number>
    </property>

--- a/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.ui
+++ b/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.ui
@@ -20,6 +20,9 @@
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
    <property name="horizontalSpacing">
     <number>3</number>
    </property>

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -38,8 +38,8 @@
       </size>
      </property>
     </widget>
-  </item>
-  <item>
+   </item>
+   <item>
     <widget class="QWidget" name="errorNotificationWidget" native="true">
      <property name="minimumSize">
       <size>
@@ -160,6 +160,9 @@
      </item>
      <item>
       <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <property name="horizontalSpacing">
         <number>3</number>
        </property>

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1,0">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -38,8 +38,8 @@
       </size>
      </property>
     </widget>
-  </item>
-  <item>
+   </item>
+   <item>
     <widget class="QWidget" name="errorNotificationWidget" native="true">
      <property name="minimumSize">
       <size>
@@ -276,6 +276,9 @@
      </item>
      <item>
       <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <property name="horizontalSpacing">
         <number>3</number>
        </property>

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_chooselibrary.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_chooselibrary.cpp
@@ -23,6 +23,7 @@
 #include "eaglelibraryimportwizardpage_chooselibrary.h"
 
 #include "../../dialogs/filedialog.h"
+#include "../../editorcommandset.h"
 #include "eaglelibraryimportwizardcontext.h"
 #include "ui_eaglelibraryimportwizardpage_chooselibrary.h"
 
@@ -50,19 +51,27 @@ EagleLibraryImportWizardPage_ChooseLibrary::
     mContext(context) {
   mUi->setupUi(this);
   mUi->edtFilePath->setText("-");  // Workaround to force initial library load.
-  connect(mUi->btnChooseFilePath, &QToolButton::clicked, this, [this]() {
-    QString p = mUi->edtFilePath->text();
-    if (p.trimmed().isEmpty()) {
-      p = QDir::homePath();
-    }
-    p = FileDialog::getOpenFileName(this, tr("Choose file"), p, "*.lbr;;*");
-    if (!p.isEmpty()) {
-      mUi->edtFilePath->setText(p);
-    }
-  });
   connect(mUi->edtFilePath, &QLineEdit::textChanged, mContext.get(),
           &EagleLibraryImportWizardContext::setLbrFilePath,
           Qt::QueuedConnection);
+
+  // Add browse action.
+  const EditorCommandSet& cmd = EditorCommandSet::instance();
+  QAction* aBrowse = cmd.inputBrowse.createAction(
+      mUi->edtFilePath, this,
+      [this]() {
+        QString p = mUi->edtFilePath->text();
+        if (p.trimmed().isEmpty()) {
+          p = QDir::homePath();
+        }
+        p = FileDialog::getOpenFileName(this, tr("Choose file"), p, "*.lbr;;*");
+        if (!p.isEmpty()) {
+          mUi->edtFilePath->setText(p);
+        }
+      },
+      EditorCommand::ActionFlag::WidgetShortcut);
+  mUi->edtFilePath->addAction(aBrowse, QLineEdit::TrailingPosition);
+
   connect(mContext.get(), &EagleLibraryImportWizardContext::parseCompleted,
           mUi->lblMessages, &QLabel::setText);
   connect(mContext.get(), &EagleLibraryImportWizardContext::parseCompleted,

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_chooselibrary.ui
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_chooselibrary.ui
@@ -31,32 +31,14 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>0</number>
+    <widget class="QLineEdit" name="edtFilePath">
+     <property name="maxLength">
+      <number>500</number>
      </property>
-     <item>
-      <widget class="QLineEdit" name="edtFilePath">
-       <property name="maxLength">
-        <number>500</number>
-       </property>
-       <property name="placeholderText">
-        <string>Select file with the button to the right</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnChooseFilePath">
-       <property name="text">
-        <string notr="true"/>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="placeholderText">
+      <string>Select file to import</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QScrollArea" name="sclMessages">
@@ -126,7 +108,6 @@
  </widget>
  <tabstops>
   <tabstop>edtFilePath</tabstop>
-  <tabstop>btnChooseFilePath</tabstop>
   <tabstop>sclMessages</tabstop>
  </tabstops>
  <resources/>

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.ui
@@ -283,6 +283,9 @@
      </widget>
      <widget class="QWidget" name="layoutWidget">
       <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <property name="horizontalSpacing">
         <number>3</number>
        </property>

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentproperties.ui
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentproperties.ui
@@ -20,6 +20,9 @@
    <string>Set the component and the package of the new component.</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_entermetadata.ui
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_entermetadata.ui
@@ -20,6 +20,9 @@
    <string>Please specify some metadata about the new element.</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.ui
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,1,0">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -38,8 +38,8 @@
       </size>
      </property>
     </widget>
-  </item>
-  <item>
+   </item>
+   <item>
     <widget class="QWidget" name="errorNotificationWidget" native="true">
      <property name="minimumSize">
       <size>
@@ -140,6 +140,9 @@
      </item>
      <item>
       <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <property name="horizontalSpacing">
         <number>3</number>
        </property>

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.ui
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.ui
@@ -70,6 +70,9 @@
      </item>
      <item>
       <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <property name="horizontalSpacing">
         <number>3</number>
        </property>

--- a/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/sym/symbolpinpropertiesdialog.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="lblName">
        <property name="text">

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
@@ -71,10 +71,12 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
                                      LengthEditBase::Steps::generic(),
                                      settingsPrefix % "/courtyard_offset");
   QPushButton* btnRun =
-      mUi->buttonBox->addButton(tr("Run DRC"), QDialogButtonBox::ActionRole);
+      mUi->buttonBox->addButton(tr("Run DRC"), QDialogButtonBox::AcceptRole);
   btnRun->setDefault(true);  // Allow just pressing the return key to run DRC.
   connect(btnRun, &QPushButton::clicked, this,
           &BoardDesignRuleCheckDialog::btnRunDrcClicked);
+  connect(mUi->buttonBox, &QDialogButtonBox::rejected, this,
+          &BoardDesignRuleCheckDialog::reject);
   connect(mUi->btnSelectAll, &QPushButton::clicked, mUi->cbxRebuildPlanes,
           &QCheckBox::setChecked);
   connect(mUi->btnSelectAll, &QPushButton::clicked,

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
@@ -201,6 +201,9 @@
           <property name="checked">
            <bool>true</bool>
           </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
          </widget>
         </item>
        </layout>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
@@ -22,6 +22,12 @@
         <string>Options</string>
        </property>
        <layout class="QFormLayout" name="formLayout">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+        </property>
+        <property name="labelAlignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
         <item row="0" column="0" colspan="2">
          <widget class="QLabel" name="label_7">
           <property name="font">
@@ -260,38 +266,5 @@
   <tabstop>edtCourtyardOffset</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::editor::BoardDesignRuleCheckDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::editor::BoardDesignRuleCheckDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
@@ -63,6 +63,7 @@ BoardPickPlaceGeneratorDialog::BoardPickPlaceGeneratorDialog(
       "./output/{{VERSION}}/assembly/{{PROJECT}}_PnP-BOT.csv");
   mBtnGenerate =
       mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::ActionRole);
+  mBtnGenerate->setDefault(true);
   connect(mBtnGenerate, &QPushButton::clicked, this,
           &BoardPickPlaceGeneratorDialog::btnGenerateClicked);
   connect(mUi->btnBrowseOutputDir, &QPushButton::clicked, this,

--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
@@ -62,8 +62,10 @@ BoardPickPlaceGeneratorDialog::BoardPickPlaceGeneratorDialog(
   mUi->edtBottomFilePath->setText(
       "./output/{{VERSION}}/assembly/{{PROJECT}}_PnP-BOT.csv");
   mBtnGenerate =
-      mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::ActionRole);
+      mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::AcceptRole);
   mBtnGenerate->setDefault(true);
+  connect(mUi->buttonBox, &QDialogButtonBox::rejected, this,
+          &BoardPickPlaceGeneratorDialog::reject);
   connect(mBtnGenerate, &QPushButton::clicked, this,
           &BoardPickPlaceGeneratorDialog::btnGenerateClicked);
   connect(mUi->btnBrowseOutputDir, &QPushButton::clicked, this,

--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.ui
@@ -14,6 +14,9 @@
    <string>Generate Pick&amp;Place Data</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -151,38 +154,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::editor::BoardPickPlaceGeneratorDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::editor::BoardPickPlaceGeneratorDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.ui
@@ -131,6 +131,9 @@
        <property name="text">
         <string>Browse Output Directory</string>
        </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -54,8 +54,10 @@ FabricationOutputDialog::FabricationOutputDialog(
     mUi(new Ui::FabricationOutputDialog) {
   mUi->setupUi(this);
   mBtnGenerate =
-      mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::ActionRole);
+      mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::AcceptRole);
   mBtnGenerate->setDefault(true);
+  connect(mUi->buttonBox, &QDialogButtonBox::rejected, this,
+          &FabricationOutputDialog::reject);
   connect(mBtnGenerate, &QPushButton::clicked, this,
           &FabricationOutputDialog::btnGenerateClicked);
   connect(mUi->btnDefaultSuffixes, &QPushButton::clicked, this,

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -55,6 +55,7 @@ FabricationOutputDialog::FabricationOutputDialog(
   mUi->setupUi(this);
   mBtnGenerate =
       mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::ActionRole);
+  mBtnGenerate->setDefault(true);
   connect(mBtnGenerate, &QPushButton::clicked, this,
           &FabricationOutputDialog::btnGenerateClicked);
   connect(mUi->btnDefaultSuffixes, &QPushButton::clicked, this,

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
@@ -443,38 +443,5 @@
   <tabstop>cbxSilkBotValues</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::editor::FabricationOutputDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::editor::FabricationOutputDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
@@ -245,12 +245,18 @@
           <property name="text">
            <string>Default (layer encoded in file name)</string>
           </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QPushButton" name="btnProtelSuffixes">
           <property name="text">
            <string>Protel naming (layer encoded in file extension)</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -389,6 +395,9 @@
       <widget class="QPushButton" name="btnBrowseOutputDir">
        <property name="text">
         <string>Browse Output Directory</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.ui
+++ b/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.ui
@@ -31,6 +31,9 @@
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
          <layout class="QFormLayout" name="formLayout">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
           <property name="verticalSpacing">
            <number>3</number>
           </property>
@@ -173,7 +176,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>GraphicsView</class>
+   <class>librepcb::editor::GraphicsView</class>
    <extends>QGraphicsView</extends>
    <header location="global">librepcb/editor/widgets/graphicsview.h</header>
   </customwidget>

--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -60,16 +60,15 @@ BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
     mBom(new Bom(QStringList())),
     mUi(new Ui::BomGeneratorDialog) {
   mUi->setupUi(this);
-  mUi->lblSuccess->hide();
   mUi->btnBrowse->setFixedWidth(mUi->btnBrowse->sizeHint().height());
   mUi->tableWidget->setWordWrap(false);
   mUi->tableWidget->verticalHeader()->setMinimumSectionSize(10);
   mUi->tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
   mUi->tableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
   mUi->edtOutputPath->setText("./output/{{VERSION}}/{{PROJECT}}_BOM.csv");
-  QPushButton* btnGenerate =
-      mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::ActionRole);
-  btnGenerate->setDefault(true);
+  mBtnGenerate =
+      mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::AcceptRole);
+  mBtnGenerate->setDefault(true);
 
   mUi->cbxBoard->addItem(tr("None"));
   foreach (const Board* brd, mProject.getBoards()) {
@@ -88,10 +87,12 @@ BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
           &BomGeneratorDialog::updateBom);
   connect(mUi->btnBrowse, &QToolButton::clicked, this,
           &BomGeneratorDialog::btnChooseOutputPathClicked);
-  connect(mUi->btnOpenDirectory, &QToolButton::clicked, this,
+  connect(mUi->btnBrowseOutputDir, &QPushButton::clicked, this,
           &BomGeneratorDialog::btnOpenOutputDirectoryClicked);
-  connect(btnGenerate, &QPushButton::clicked, this,
+  connect(mBtnGenerate, &QPushButton::clicked, this,
           &BomGeneratorDialog::btnGenerateClicked);
+  connect(mUi->buttonBox, &QDialogButtonBox::rejected, this,
+          &BomGeneratorDialog::reject);
 }
 
 BomGeneratorDialog::~BomGeneratorDialog() noexcept {
@@ -106,7 +107,6 @@ void BomGeneratorDialog::btnChooseOutputPathClicked() noexcept {
       this, tr("Save to"), getOutputFilePath().getParentDir().toStr(), "*.csv");
   if (!fp.isEmpty()) {
     mUi->edtOutputPath->setText(fp);
-    mUi->lblSuccess->hide();
   }
 }
 
@@ -120,9 +120,18 @@ void BomGeneratorDialog::btnGenerateClicked() noexcept {
     BomCsvWriter writer(*mBom);
     std::shared_ptr<CsvFile> csv = writer.generateCsv();  // can throw
     csv->saveToFile(getOutputFilePath());  // can throw
-    mUi->lblSuccess->show();
+
+    QString btnSuccessText = tr("Success!");
+    QString btnGenerateText = mBtnGenerate->text();
+    if (btnGenerateText != btnSuccessText) {
+      mBtnGenerate->setText(btnSuccessText);
+      QTimer::singleShot(500, this, [this, btnGenerateText]() {
+        if (mBtnGenerate) {
+          mBtnGenerate->setText(btnGenerateText);
+        }
+      });
+    }
   } catch (const Exception& e) {
-    mUi->lblSuccess->hide();
     QMessageBox::critical(this, tr("Error"), e.getMsg());
   }
 }
@@ -212,7 +221,6 @@ void BomGeneratorDialog::updateTable() noexcept {
       }
     }
     mUi->tableWidget->resizeRowsToContents();
-    mUi->lblSuccess->hide();
   } catch (Exception& e) {
     qCritical() << "Failed to update BOM table widget:" << e.getMsg();
   }

--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -23,6 +23,7 @@
 #include "bomgeneratordialog.h"
 
 #include "../dialogs/filedialog.h"
+#include "../editorcommandset.h"
 #include "../workspace/desktopservices.h"
 #include "ui_bomgeneratordialog.h"
 
@@ -60,7 +61,6 @@ BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
     mBom(new Bom(QStringList())),
     mUi(new Ui::BomGeneratorDialog) {
   mUi->setupUi(this);
-  mUi->btnBrowse->setFixedWidth(mUi->btnBrowse->sizeHint().height());
   mUi->tableWidget->setWordWrap(false);
   mUi->tableWidget->verticalHeader()->setMinimumSectionSize(10);
   mUi->tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -69,6 +69,15 @@ BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
   mBtnGenerate =
       mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::AcceptRole);
   mBtnGenerate->setDefault(true);
+
+  // Add browse action.
+  const EditorCommandSet& cmd = EditorCommandSet::instance();
+  mUi->edtOutputPath->addAction(
+      cmd.inputBrowse.createAction(
+          mUi->edtOutputPath, this,
+          &BomGeneratorDialog::btnChooseOutputPathClicked,
+          EditorCommand::ActionFlag::WidgetShortcut),
+      QLineEdit::TrailingPosition);
 
   mUi->cbxBoard->addItem(tr("None"));
   foreach (const Board* brd, mProject.getBoards()) {
@@ -85,8 +94,6 @@ BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
       this, &BomGeneratorDialog::updateBom);
   connect(mUi->edtAttributes, &QLineEdit::textEdited, this,
           &BomGeneratorDialog::updateBom);
-  connect(mUi->btnBrowse, &QToolButton::clicked, this,
-          &BomGeneratorDialog::btnChooseOutputPathClicked);
   connect(mUi->btnBrowseOutputDir, &QPushButton::clicked, this,
           &BomGeneratorDialog::btnOpenOutputDirectoryClicked);
   connect(mBtnGenerate, &QPushButton::clicked, this,

--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -69,6 +69,7 @@ BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
   mUi->edtOutputPath->setText("./output/{{VERSION}}/{{PROJECT}}_BOM.csv");
   QPushButton* btnGenerate =
       mUi->buttonBox->addButton(tr("&Generate"), QDialogButtonBox::ActionRole);
+  btnGenerate->setDefault(true);
 
   mUi->cbxBoard->addItem(tr("None"));
   foreach (const Board* brd, mProject.getBoards()) {

--- a/libs/librepcb/editor/project/bomgeneratordialog.h
+++ b/libs/librepcb/editor/project/bomgeneratordialog.h
@@ -85,6 +85,7 @@ private:  // Data
   const Project& mProject;
   std::shared_ptr<Bom> mBom;
   QScopedPointer<Ui::BomGeneratorDialog> mUi;
+  QPointer<QPushButton> mBtnGenerate;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/bomgeneratordialog.ui
+++ b/libs/librepcb/editor/project/bomgeneratordialog.ui
@@ -44,43 +44,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Output File:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="edtOutputPath"/>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnBrowse">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Choose output file</string>
-       </property>
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextOnly</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QTableWidget" name="tableWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -90,7 +61,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QLabel" name="lblMessage">
      <property name="frameShape">
       <enum>QFrame::Box</enum>
@@ -106,7 +77,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="btnBrowseOutputDir">
@@ -130,13 +101,15 @@
      </item>
     </layout>
    </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="edtOutputPath"/>
+   </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>cbxBoard</tabstop>
   <tabstop>edtAttributes</tabstop>
   <tabstop>edtOutputPath</tabstop>
-  <tabstop>btnBrowse</tabstop>
   <tabstop>tableWidget</tabstop>
   <tabstop>btnBrowseOutputDir</tabstop>
  </tabstops>

--- a/libs/librepcb/editor/project/bomgeneratordialog.ui
+++ b/libs/librepcb/editor/project/bomgeneratordialog.ui
@@ -14,6 +14,9 @@
    <string>Generate BOM</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
@@ -24,33 +27,20 @@
    <item row="0" column="1">
     <widget class="QComboBox" name="cbxBoard"/>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QTableWidget" name="tableWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="lblSuccess">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Success!</string>
-     </property>
-     <property name="indent">
-      <number>6</number>
+      <string>Attributes:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="edtAttributes">
+     <property name="text">
+      <string notr="true"/>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+     <property name="placeholderText">
+      <string extracomment="Don't translate the attributes MANUFACTURER and MPN, they must be in English.">Comma-separated list of additional attributes, e.g. &quot;MANUFACTURER, MPN&quot;</string>
      </property>
     </widget>
    </item>
@@ -88,42 +78,15 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QToolButton" name="btnOpenDirectory">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Open output directory</string>
-       </property>
-       <property name="text">
-        <string notr="true"/>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Attributes:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="edtAttributes">
-     <property name="text">
-      <string notr="true"/>
-     </property>
-     <property name="placeholderText">
-      <string extracomment="Don't translate the attributes MANUFACTURER and MPN, they must be in English.">Comma-separated list of additional attributes, e.g. &quot;MANUFACTURER, MPN&quot;</string>
+   <item row="3" column="0" colspan="2">
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>
@@ -143,41 +106,40 @@
      </property>
     </widget>
    </item>
+   <item row="6" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="btnBrowseOutputDir">
+       <property name="text">
+        <string>Browse Output Directory</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cbxBoard</tabstop>
+  <tabstop>edtAttributes</tabstop>
+  <tabstop>edtOutputPath</tabstop>
+  <tabstop>btnBrowse</tabstop>
+  <tabstop>tableWidget</tabstop>
+  <tabstop>btnBrowseOutputDir</tabstop>
+ </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::editor::BomGeneratorDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::editor::BomGeneratorDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/libs/librepcb/editor/project/erc/ercmsgdock.ui
+++ b/libs/librepcb/editor/project/erc/ercmsgdock.ui
@@ -44,9 +44,6 @@
       <property name="editTriggers">
        <set>QAbstractItemView::NoEditTriggers</set>
       </property>
-      <property name="alternatingRowColors">
-       <bool>true</bool>
-      </property>
       <property name="selectionMode">
        <enum>QAbstractItemView::ExtendedSelection</enum>
       </property>

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.cpp
@@ -79,11 +79,6 @@ QString NewProjectWizardPage_Initialization::getSchematicName() const noexcept {
   return mUi->edtSchematicName->text();
 }
 
-QString NewProjectWizardPage_Initialization::getSchematicFileName() const
-    noexcept {
-  return mUi->lblSchematicFileName->text();
-}
-
 bool NewProjectWizardPage_Initialization::getCreateBoard() const noexcept {
   return mUi->cbxAddBoard->isChecked();
 }
@@ -92,29 +87,29 @@ QString NewProjectWizardPage_Initialization::getBoardName() const noexcept {
   return mUi->edtBoardName->text();
 }
 
-QString NewProjectWizardPage_Initialization::getBoardFileName() const noexcept {
-  return mUi->lblBoardFileName->text();
-}
-
 /*******************************************************************************
  *  GUI Action Handlers
  ******************************************************************************/
 
 void NewProjectWizardPage_Initialization::schematicNameChanged(
     const QString& name) noexcept {
-  QString filename = FilePath::cleanFileName(
+  QString dir = FilePath::cleanFileName(
       name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
-  if (!filename.isEmpty()) filename.append(".lp");
-  mUi->lblSchematicFileName->setText(filename);
+  if (!dir.isEmpty()) {
+    dir = "schematics/" % dir % "/";
+  }
+  mUi->lblSchematicDirectory->setText(dir);
   emit completeChanged();
 }
 
 void NewProjectWizardPage_Initialization::boardNameChanged(
     const QString& name) noexcept {
-  QString filename = FilePath::cleanFileName(
+  QString dir = FilePath::cleanFileName(
       name, FilePath::ReplaceSpaces | FilePath::ToLowerCase);
-  if (!filename.isEmpty()) filename.append(".lp");
-  mUi->lblBoardFileName->setText(filename);
+  if (!dir.isEmpty()) {
+    dir = "boards/" % dir % "/";
+  }
+  mUi->lblBoardDirectory->setText(dir);
   emit completeChanged();
 }
 
@@ -128,13 +123,13 @@ bool NewProjectWizardPage_Initialization::isComplete() const noexcept {
 
   // check schematic filename
   if (mUi->cbxAddSchematic->isChecked() &&
-      mUi->lblSchematicFileName->text().isEmpty()) {
+      mUi->lblSchematicDirectory->text().isEmpty()) {
     return false;
   }
 
   // check board filename
   if (mUi->cbxAddBoard->isChecked() &&
-      mUi->lblBoardFileName->text().isEmpty()) {
+      mUi->lblBoardDirectory->text().isEmpty()) {
     return false;
   }
 

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.h
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.h
@@ -58,10 +58,8 @@ public:
   // Getters
   bool getCreateSchematic() const noexcept;
   QString getSchematicName() const noexcept;
-  QString getSchematicFileName() const noexcept;
   bool getCreateBoard() const noexcept;
   QString getBoardName() const noexcept;
-  QString getBoardFileName() const noexcept;
 
   // Operator Overloadings
   NewProjectWizardPage_Initialization& operator=(

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.ui
@@ -49,6 +49,12 @@
       </item>
       <item row="1" column="1">
        <widget class="QLabel" name="lblSchematicFileName">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string notr="true">-</string>
         </property>
@@ -89,6 +95,12 @@
       </item>
       <item row="1" column="1">
        <widget class="QLabel" name="lblBoardFileName">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string notr="true">-</string>
         </property>

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_initialization.ui
@@ -43,12 +43,12 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Filename:</string>
+         <string>Directory:</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QLabel" name="lblSchematicFileName">
+       <widget class="QLabel" name="lblSchematicDirectory">
         <property name="minimumSize">
          <size>
           <width>200</width>
@@ -89,12 +89,12 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Filename:</string>
+         <string>Directory:</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QLabel" name="lblBoardFileName">
+       <widget class="QLabel" name="lblBoardDirectory">
         <property name="minimumSize">
          <size>
           <width>200</width>

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -23,6 +23,7 @@
 #include "newprojectwizardpage_metadata.h"
 
 #include "../../dialogs/filedialog.h"
+#include "../../editorcommandset.h"
 #include "../../workspace/desktopservices.h"
 #include "ui_newprojectwizardpage_metadata.h"
 
@@ -52,13 +53,20 @@ NewProjectWizardPage_Metadata::NewProjectWizardPage_Metadata(
   setPixmap(QWizard::LogoPixmap, QPixmap(":/img/actions/plus_2.png"));
   setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));
 
+  // Add browse action.
+  const EditorCommandSet& cmd = EditorCommandSet::instance();
+  mUi->edtLocation->addAction(
+      cmd.inputBrowse.createAction(
+          mUi->edtLocation, this,
+          &NewProjectWizardPage_Metadata::chooseLocationClicked,
+          EditorCommand::ActionFlag::WidgetShortcut),
+      QLineEdit::TrailingPosition);
+
   // signal/slot connections
   connect(mUi->edtName, &QLineEdit::textChanged, this,
           &NewProjectWizardPage_Metadata::nameChanged);
   connect(mUi->edtLocation, &QLineEdit::textChanged, this,
           &NewProjectWizardPage_Metadata::locationChanged);
-  connect(mUi->btnLocation, &QPushButton::clicked, this,
-          &NewProjectWizardPage_Metadata::chooseLocationClicked);
   connect(mUi->lblLicenseLink, &QLabel::linkActivated, this,
           [this](const QString& url) {
             DesktopServices ds(mWorkspace.getSettings(), this);

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -74,43 +74,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="edtLocation"/>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnLocation">
-       <property name="minimumSize">
-        <size>
-         <width>25</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>25</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Full Path:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QLabel" name="lblFullFilePath">
      <property name="font">
       <font>
@@ -128,14 +99,14 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="label_5">
      <property name="minimumSize">
       <size>
@@ -160,7 +131,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <widget class="QLabel" name="label_9">
      <property name="text">
       <string>A LibrePCB project consists of a whole directory, not only of a single file. Just select the new project's parent directory, and the subdirectory and filename will be set automatically.</string>
@@ -208,6 +179,9 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="edtLocation"/>
    </item>
   </layout>
  </widget>

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -12,7 +12,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>500</width>
+    <width>400</width>
     <height>0</height>
    </size>
   </property>
@@ -23,6 +23,9 @@
    <string>Specify some metadata of the project to be created.</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.ui
@@ -104,6 +104,12 @@
         <string>Boards</string>
        </property>
        <layout class="QFormLayout" name="formLayout_4">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+        </property>
+        <property name="formAlignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
         <item row="0" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
@@ -113,6 +119,12 @@
         </item>
         <item row="0" column="1">
          <widget class="QComboBox" name="cbxPreselectedDevice">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="currentText">
            <string notr="true"/>
           </property>
@@ -136,6 +148,12 @@
         <string>Library Elements</string>
        </property>
        <layout class="QFormLayout" name="formLayout_3">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+        </property>
+        <property name="formAlignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
         <item row="0" column="0">
          <widget class="QLabel" name="label_10">
           <property name="sizePolicy">

--- a/libs/librepcb/editor/widgets/alignmentselector.ui
+++ b/libs/librepcb/editor/widgets/alignmentselector.ui
@@ -10,6 +10,12 @@
     <height>45</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>

--- a/libs/librepcb/editor/widgets/graphicsview.cpp
+++ b/libs/librepcb/editor/widgets/graphicsview.cpp
@@ -76,6 +76,7 @@ GraphicsView::GraphicsView(QWidget* parent,
   setBackgroundBrush(Qt::white);
   setForegroundBrush(Qt::black);
 
+  mOverlayLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
   mOverlayLabel->setFont(qApp->getDefaultMonospaceFont());
   mOverlayLabel->setTextFormat(Qt::RichText);
   mOverlayLabel->move(0, 0);

--- a/libs/librepcb/editor/widgets/lengtheditbase.h
+++ b/libs/librepcb/editor/widgets/lengtheditbase.h
@@ -153,7 +153,7 @@ protected:  // Methods
   virtual void valueChangedImpl(const Length& diff) noexcept = 0;
 
 protected:  // Data
-  QAction* mChangeUnitAction;
+  QPointer<QAction> mChangeUnitAction;
   LengthUnit mDefaultUnit;
   tl::optional<LengthUnit> mSelectedUnit;
   Length mMinimum;

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.ui
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.ui
@@ -70,9 +70,6 @@
           <property name="editTriggers">
            <set>QAbstractItemView::NoEditTriggers</set>
           </property>
-          <property name="alternatingRowColors">
-           <bool>true</bool>
-          </property>
           <property name="rootIsDecorated">
            <bool>true</bool>
           </property>

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_choosesettings.ui
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_choosesettings.ui
@@ -54,11 +54,23 @@
    </item>
    <item row="4" column="1">
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>4</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMinimumSize</enum>
+     </property>
      <item>
       <widget class="QLineEdit" name="edtUserName"/>
      </item>
      <item>
       <widget class="QLabel" name="label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>This name will be used as author when creating new projects or libraries.</string>
        </property>

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_chooseworkspace.cpp
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_chooseworkspace.cpp
@@ -23,6 +23,7 @@
 #include "initializeworkspacewizard_chooseworkspace.h"
 
 #include "../../dialogs/filedialog.h"
+#include "../../editorcommandset.h"
 #include "ui_initializeworkspacewizard_chooseworkspace.h"
 
 #include <librepcb/core/fileio/filepath.h>
@@ -46,13 +47,20 @@ InitializeWorkspaceWizard_ChooseWorkspace::
   mUi->setupUi(this);
   connect(mUi->edtPath, &QLineEdit::textChanged, this,
           &InitializeWorkspaceWizard_ChooseWorkspace::updateWorkspacePath);
-  connect(mUi->btnBrowse, &QPushButton::clicked, this, [this]() {
-    QString filepath = FileDialog::getExistingDirectory(
-        this, tr("Select Workspace Directory"));
-    if (!filepath.isEmpty()) {
-      mUi->edtPath->setText(filepath);
-    }
-  });
+
+  // Add browse action.
+  const EditorCommandSet& cmd = EditorCommandSet::instance();
+  QAction* aBrowse = cmd.inputBrowse.createAction(
+      mUi->edtPath, this,
+      [this]() {
+        QString filepath = FileDialog::getExistingDirectory(
+            this, tr("Select Workspace Directory"));
+        if (!filepath.isEmpty()) {
+          mUi->edtPath->setText(filepath);
+        }
+      },
+      EditorCommand::ActionFlag::WidgetShortcut);
+  mUi->edtPath->addAction(aBrowse, QLineEdit::TrailingPosition);
 }
 
 InitializeWorkspaceWizard_ChooseWorkspace::
@@ -64,8 +72,6 @@ InitializeWorkspaceWizard_ChooseWorkspace::
  ******************************************************************************/
 
 void InitializeWorkspaceWizard_ChooseWorkspace::initializePage() noexcept {
-  mUi->btnBrowse->setFixedWidth(mUi->btnBrowse->height());
-
   // By default, the suggested workspace path is a subdirectory within the
   // user's home folder. However, depending on the deployment method, the
   // home folder might be some kind of sandboxed and/or even deleted when

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_chooseworkspace.ui
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_chooseworkspace.ui
@@ -55,27 +55,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="edtPath"/>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnBrowse">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QLineEdit" name="edtPath"/>
    </item>
    <item>
     <widget class="QLabel" name="lblStatus">

--- a/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.ui
+++ b/libs/librepcb/editor/workspace/librarymanager/addlibrarywidget.ui
@@ -74,6 +74,9 @@
        <string>Create local library</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <item row="0" column="0" colspan="2">
         <widget class="QLabel" name="label_8">
          <property name="text">
@@ -181,7 +184,10 @@
        <item row="7" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0">
          <property name="spacing">
-          <number>0</number>
+          <number>7</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
          </property>
          <item>
           <widget class="QCheckBox" name="cbxLocalCc0License"/>
@@ -250,6 +256,9 @@
        <string>Download manually</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_2">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <item row="0" column="0" colspan="2">
         <widget class="QLabel" name="label_10">
          <property name="text">

--- a/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.ui
+++ b/libs/librepcb/editor/workspace/librarymanager/libraryinfowidget.ui
@@ -60,6 +60,9 @@
    </item>
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
@@ -112,9 +115,6 @@
        <property name="text">
         <string notr="true">TextLabel</string>
        </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
       </widget>
      </item>
      <item row="3" column="0">
@@ -166,9 +166,6 @@
        <property name="text">
         <string notr="true">TextLabel</string>
        </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
       </widget>
      </item>
      <item row="6" column="0">
@@ -182,9 +179,6 @@
       <widget class="QLabel" name="lblDeprecated">
        <property name="text">
         <string notr="true">TextLabel</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -206,9 +200,6 @@
       <widget class="QLabel" name="lblLibType">
        <property name="text">
         <string notr="true">TextLabel</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.ui
+++ b/libs/librepcb/editor/workspace/librarymanager/repositorylibrarylistwidgetitem.ui
@@ -80,8 +80,6 @@
          </property>
          <property name="font">
           <font>
-           <pointsize>10</pointsize>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -110,11 +108,6 @@
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
          </property>
          <property name="layoutDirection">
           <enum>Qt::RightToLeft</enum>

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
@@ -44,6 +44,9 @@
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <property name="spacing">
           <number>3</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
          </property>
          <item>
           <widget class="QComboBox" name="cbxAppLocale">
@@ -95,6 +98,9 @@
         <layout class="QVBoxLayout" name="verticalLayout_7">
          <property name="spacing">
           <number>3</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
          </property>
          <item>
           <widget class="QLineEdit" name="edtUserName">
@@ -174,6 +180,12 @@
        </item>
        <item row="0" column="1">
         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
+         </property>
          <item>
           <widget class="QCheckBox" name="cbxUseOpenGl">
            <property name="text">
@@ -226,6 +238,9 @@
        <string>Library</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_3">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <item row="0" column="0">
         <widget class="QLabel" name="label_11">
          <property name="text">


### PR DESCRIPTION
Fix various small UI issues found during testing. Especially on macOS, since macOS renders various things differently to Linux/Windows.

- Fix some UI layouting issues in dialogs (fixes too small widgets inside a `QFormLayout` on macOS)
- Explicitly specify default button in some dialogs (fixes having the focus on a less important button)
- Disable alternating row colors in some tree views (it looks ugly with a dark theme)
- New project wizard: Fix wrong displayed board/schematic filename
- `GraphicsView`: Pass mouse events through overlay widget
- Replace buttons of text input fields by embedded icons
  There were several `QToolButton` buttons placed just next to a `QLineEdit` text input field (often for choosing a file path, i.e. a button with text "..."). However, depending on the platform, Qt version, theme etc. the layout often looked ugly because of too large spacing, inconsistent heights and non-square buttons.

  Thus removed all these buttons and add `QAction` objects to the `QLineEdit` widgets instead, which now renders the actions as simple icons *within* the text input field -> no more layout issues, and much nicer look.

  In addition, it was now easy to even assign consistent keyboard shortcuts to these actions (useful because these actions can no longer by focused with 'Tab' like the buttons before).

  New shortcuts (only within such widgets): 
  ![image](https://user-images.githubusercontent.com/5374821/193323519-5cb63a14-be3c-4ba7-926b-05d35c644410.png)