### PR TITLE
Force applying locale to editor commands text/description

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -257,6 +257,7 @@ static int openWorkspace(FilePath& path) {
     QLocale locale(ws.getSettings().applicationLocale.get());
     QLocale::setDefault(locale);
     qApp->setTranslationLocale(locale);
+    EditorCommandSet::instance().updateTranslations();
   }
 
   // Apply keyboard shortcuts from workspace settings globally.

--- a/libs/librepcb/editor/editorcommand.cpp
+++ b/libs/librepcb/editor/editorcommand.cpp
@@ -43,13 +43,14 @@ EditorCommand::EditorCommand(const QString& identifier, const char* text,
   : QObject(parent),
     mIdentifier(identifier),
     mTextNoTr(text),
-    // Note: Translations are done within the EditorCommandSet context.
-    mText(QCoreApplication::translate("EditorCommandSet", text)),
-    mDescription(QCoreApplication::translate("EditorCommandSet", description)),
+    mText(text),
+    mDescriptionNoTr(description),
+    mDescription(description),
     mIcon(icon),
     mFlags(flags),
     mDefaultKeySequences(defaultKeySequences),
     mKeySequences(defaultKeySequences) {
+  updateTranslations();
 }
 
 EditorCommand::~EditorCommand() noexcept {
@@ -70,6 +71,13 @@ void EditorCommand::setKeySequences(
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+void EditorCommand::updateTranslations() noexcept {
+  // Note: Translations are done within the EditorCommandSet context.
+  mText = QCoreApplication::translate("EditorCommandSet", mTextNoTr);
+  mDescription =
+      QCoreApplication::translate("EditorCommandSet", mDescriptionNoTr);
+}
 
 QAction* EditorCommand::createAction(QObject* parent, ActionFlags flags) const
     noexcept {

--- a/libs/librepcb/editor/editorcommand.h
+++ b/libs/librepcb/editor/editorcommand.h
@@ -91,6 +91,7 @@ public:
   void setKeySequences(const QList<QKeySequence>& sequences) noexcept;
 
   // General Methods
+  void updateTranslations() noexcept;
   QAction* createAction(QObject* parent,
                         ActionFlags flags = ActionFlags()) const noexcept;
   template <typename TContext, typename TSlot>
@@ -119,6 +120,7 @@ private:  // Data
   QString mIdentifier;
   const char* mTextNoTr;
   QString mText;
+  const char* mDescriptionNoTr;
   QString mDescription;
   QIcon mIcon;
   Flags mFlags;

--- a/libs/librepcb/editor/editorcommandcategory.h
+++ b/libs/librepcb/editor/editorcommandcategory.h
@@ -50,10 +50,10 @@ public:
                         bool configurable, QObject* parent = nullptr) noexcept
     : QObject(parent),
       mTextNoTr(text),
-      // Note: Translations are done within the EditorCommandSet context.
-      mText(QCoreApplication::translate("EditorCommandSet", text)),
+      mText(text),
       mConfigurable(configurable) {
     setObjectName(objectName);
+    updateTranslations();
   }
   ~EditorCommandCategory() noexcept {}
 
@@ -61,6 +61,12 @@ public:
   const char* getTextNoTr() const noexcept { return mTextNoTr; }
   const QString& getText() const noexcept { return mText; }
   bool isConfigurable() const noexcept { return mConfigurable; }
+
+  // General Methods
+  void updateTranslations() noexcept {
+    // Note: Translations are done within the EditorCommandSet context.
+    mText = QCoreApplication::translate("EditorCommandSet", mTextNoTr);
+  }
 
   // Operator Overloadings
   EditorCommandCategory& operator=(const EditorCommandCategory& rhs) = delete;

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -61,6 +61,15 @@ public:
     static EditorCommandSet obj;
     return obj;
   }
+  void updateTranslations() noexcept {
+    // Required to be called when the application's locale has changed.
+    foreach (EditorCommandCategory* cat, getCategories()) {
+      cat->updateTranslations();
+      foreach (EditorCommand* cmd, getCommands(cat)) {
+        cmd->updateTranslations();
+      }
+    }
+  }
   QList<EditorCommandCategory*> getCategories() noexcept {
     return categoryRoot.findChildren<EditorCommandCategory*>();
   }


### PR DESCRIPTION
Fixes a regression of #1043 which lead to missing translations of menu/toolbar entries.