### PR TITLE
Library editor: Fix possibly unrelated search results

### DIFF
--- a/libs/librepcb/editor/library/cmp/componentchooserdialog.h
+++ b/libs/librepcb/editor/library/cmp/componentchooserdialog.h
@@ -96,6 +96,7 @@ private:  // Data
   const IF_GraphicsLayerProvider* mLayerProvider;
   QScopedPointer<Ui::ComponentChooserDialog> mUi;
   QScopedPointer<QAbstractItemModel> mCategoryTreeModel;
+  bool mCategorySelected;
   tl::optional<Uuid> mSelectedCategoryUuid;
   tl::optional<Uuid> mSelectedComponentUuid;
 

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_copyfrom.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_copyfrom.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "newelementwizardpage_copyfrom.h"
 
+#include "../../widgets/waitingspinnerwidget.h"
 #include "../../workspace/categorytreemodel.h"
 #include "ui_newelementwizardpage_copyfrom.h"
 
@@ -55,6 +56,21 @@ NewElementWizardPage_CopyFrom::NewElementWizardPage_CopyFrom(
           &NewElementWizardPage_CopyFrom::listWidget_currentItemChanged);
   connect(mUi->listWidget, &QListWidget::itemDoubleClicked, this,
           &NewElementWizardPage_CopyFrom::listWidget_itemDoubleClicked);
+
+  // Add waiting spinner during workspace library scan.
+  auto addSpinner = [&context](QWidget* widget) {
+    WaitingSpinnerWidget* spinner = new WaitingSpinnerWidget(widget);
+    connect(&context.getWorkspace().getLibraryDb(),
+            &WorkspaceLibraryDb::scanStarted, spinner,
+            &WaitingSpinnerWidget::show);
+    connect(&context.getWorkspace().getLibraryDb(),
+            &WorkspaceLibraryDb::scanFinished, spinner,
+            &WaitingSpinnerWidget::hide);
+    spinner->setVisible(
+        context.getWorkspace().getLibraryDb().isScanInProgress());
+  };
+  addSpinner(mUi->treeView);
+  addSpinner(mUi->listWidget);
 }
 
 NewElementWizardPage_CopyFrom::~NewElementWizardPage_CopyFrom() noexcept {

--- a/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
@@ -54,7 +54,8 @@ PackageChooserDialog::PackageChooserDialog(
   : QDialog(parent),
     mWorkspace(ws),
     mLayerProvider(layerProvider),
-    mUi(new Ui::PackageChooserDialog) {
+    mUi(new Ui::PackageChooserDialog),
+    mCategorySelected(false) {
   mUi->setupUi(this);
 
   mGraphicsScene.reset(new GraphicsScene());
@@ -140,7 +141,9 @@ void PackageChooserDialog::listPackages_itemDoubleClicked(
 }
 
 void PackageChooserDialog::searchPackages(const QString& input) {
-  setSelectedCategory(tl::nullopt);
+  setSelectedPackage(tl::nullopt);
+  mUi->listPackages->clear();
+  mCategorySelected = false;
 
   // min. 2 chars to avoid freeze on entering first character due to huge result
   if (input.length() > 1) {
@@ -160,12 +163,12 @@ void PackageChooserDialog::searchPackages(const QString& input) {
 
 void PackageChooserDialog::setSelectedCategory(
     const tl::optional<Uuid>& uuid) noexcept {
-  if (uuid && (uuid == mSelectedCategoryUuid)) return;
+  if ((mCategorySelected) && (uuid == mSelectedCategoryUuid)) return;
 
   setSelectedPackage(tl::nullopt);
   mUi->listPackages->clear();
-
   mSelectedCategoryUuid = uuid;
+  mCategorySelected = true;
 
   try {
     QSet<Uuid> packages =

--- a/libs/librepcb/editor/library/pkg/packagechooserdialog.h
+++ b/libs/librepcb/editor/library/pkg/packagechooserdialog.h
@@ -93,6 +93,7 @@ private:  // Data
   const IF_GraphicsLayerProvider* mLayerProvider;
   QScopedPointer<Ui::PackageChooserDialog> mUi;
   QScopedPointer<QAbstractItemModel> mCategoryTreeModel;
+  bool mCategorySelected;
   tl::optional<Uuid> mSelectedCategoryUuid;
   tl::optional<Uuid> mSelectedPackageUuid;
 

--- a/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
+++ b/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
@@ -54,7 +54,8 @@ SymbolChooserDialog::SymbolChooserDialog(
     mWorkspace(ws),
     mLayerProvider(layerProvider),
     mUi(new Ui::SymbolChooserDialog),
-    mPreviewScene(new GraphicsScene()) {
+    mPreviewScene(new GraphicsScene()),
+    mCategorySelected(false) {
   mUi->setupUi(this);
   mUi->graphicsView->setScene(mPreviewScene.data());
   mUi->graphicsView->setOriginCrossVisible(false);
@@ -156,7 +157,9 @@ void SymbolChooserDialog::listSymbols_itemDoubleClicked(
 }
 
 void SymbolChooserDialog::searchSymbols(const QString& input) {
-  setSelectedCategory(tl::nullopt);
+  setSelectedSymbol(FilePath());
+  mUi->listSymbols->clear();
+  mCategorySelected = false;
 
   // min. 2 chars to avoid freeze on entering first character due to huge result
   if (input.length() > 1) {
@@ -176,12 +179,12 @@ void SymbolChooserDialog::searchSymbols(const QString& input) {
 
 void SymbolChooserDialog::setSelectedCategory(
     const tl::optional<Uuid>& uuid) noexcept {
-  if (uuid && (uuid == mSelectedCategoryUuid)) return;
+  if ((mCategorySelected) && (uuid == mSelectedCategoryUuid)) return;
 
   setSelectedSymbol(FilePath());
   mUi->listSymbols->clear();
-
   mSelectedCategoryUuid = uuid;
+  mCategorySelected = true;
 
   try {
     QSet<Uuid> symbols =

--- a/libs/librepcb/editor/library/sym/symbolchooserdialog.h
+++ b/libs/librepcb/editor/library/sym/symbolchooserdialog.h
@@ -93,6 +93,7 @@ private:  // Data
   QScopedPointer<Ui::SymbolChooserDialog> mUi;
   QScopedPointer<QAbstractItemModel> mCategoryTreeModel;
   QScopedPointer<GraphicsScene> mPreviewScene;
+  bool mCategorySelected;
   tl::optional<Uuid> mSelectedCategoryUuid;
   QScopedPointer<Symbol> mSelectedSymbol;
   QScopedPointer<SymbolGraphicsItem> mGraphicsItem;


### PR DESCRIPTION
The symbol-, component- and package search dialogs in the library editor by accident listed all library elements without a category when typing a search keyword, i.e. there were too many, unrelated search results. This was caused by using `nullopt` for representing "no category" and for "without category", so it was ambiguous.
