### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# 2018-09-28: Initial clang-format reformatting
+05a59de4341d53a5d4d942992eafb77bf3fbf006
+
+# 2018-12-09: Reformat with clang-format
+ac1452693f88e6a995eedb0b6aea5242a513eb9d
+
+# 2020-08-30: Reformat with clang-format
+d6d93815095230db700ab1377b18a426b3bfef53
+
+# 2020-09-17: Reformat with clang-format
+7078a0fff181d167a1b45776dbbd2e9c27eccd2b


### PR DESCRIPTION
I learned a new git trick today: https://www.michaelheap.com/git-ignore-rev/ (Inspired by https://github.com/microsoft/TypeScript/pull/51387) By using the `.git-blame-ignore-revs` file, you won't have reformatting commits polluting your blame output.

To use it, invoke `git blame` like this:

    git blame --ignore-revs-file .git-blame-ignore-revs

Alternatively, make this the default:

    git config [--global] blame.ignoreRevsFile .git-blame-ignore-revs