### PR TITLE
CLI: Use -v for --verbose instead of --version.

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -90,7 +90,7 @@ int CommandLineInterface::execute() noexcept {
   // option which we don't need, and the OS-dependent option "-?".
   const QCommandLineOption helpOption({"h", "help"}, tr("Print this message."));
   parser.addOption(helpOption);
-  const QCommandLineOption versionOption({"V","version"},tr("Show version."));
+  const QCommandLineOption versionOption({"V","version"},tr("Displays version information."));
   parser.addOption(versionOption);
   QCommandLineOption verboseOption({"v","verbose"}, tr("Verbose output."));
   parser.addOption(verboseOption);

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -90,9 +90,10 @@ int CommandLineInterface::execute() noexcept {
   // option which we don't need, and the OS-dependent option "-?".
   const QCommandLineOption helpOption({"h", "help"}, tr("Print this message."));
   parser.addOption(helpOption);
-  const QCommandLineOption versionOption({"V","version"},tr("Displays version information."));
+  const QCommandLineOption versionOption({"V", "version"},
+                                         tr("Displays version information."));
   parser.addOption(versionOption);
-  QCommandLineOption verboseOption({"v","verbose"}, tr("Verbose output."));
+  QCommandLineOption verboseOption({"v", "verbose"}, tr("Verbose output."));
   parser.addOption(verboseOption);
   parser.addPositionalArgument("command",
                                tr("The command to execute (see list below)."));

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -90,8 +90,9 @@ int CommandLineInterface::execute() noexcept {
   // option which we don't need, and the OS-dependent option "-?".
   const QCommandLineOption helpOption({"h", "help"}, tr("Print this message."));
   parser.addOption(helpOption);
-  const QCommandLineOption versionOption = parser.addVersionOption();
-  QCommandLineOption verboseOption("verbose", tr("Verbose output."));
+  const QCommandLineOption versionOption({"V","version"},tr("Show Version.")); // = parser.addVersionOption();
+  parser.addOption(versionOption);
+  QCommandLineOption verboseOption({"v","verbose"}, tr("Verbose output."));
   parser.addOption(verboseOption);
   parser.addPositionalArgument("command",
                                tr("The command to execute (see list below)."));

--- a/tests/cli/open_library/test_parser.py
+++ b/tests/cli/open_library/test_parser.py
@@ -11,8 +11,8 @@ LibrePCB Command Line Interface
 
 Options:
   -h, --help     Print this message.
-  -v, --version  Displays version information.
-  --verbose      Verbose output.
+  -V, --version  Displays version information.
+  -v, --verbose  Verbose output.
   --all          Perform the selected action(s) on all elements contained in
                  the opened library.
   --save         Save library (and contained elements if '--all' is given)

--- a/tests/cli/open_project/test_parser.py
+++ b/tests/cli/open_project/test_parser.py
@@ -13,8 +13,8 @@ LibrePCB Command Line Interface
 
 Options:
   -h, --help                         Print this message.
-  -v, --version                      Displays version information.
-  --verbose                          Verbose output.
+  -V, --version                      Displays version information.
+  -v, --verbose                      Verbose output.
   --erc                              Run the electrical rule check, print all
                                      non-approved warnings/errors and report
                                      failure (exit code = 1) if there are

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -15,8 +15,8 @@ LibrePCB Command Line Interface
 
 Options:
   -h, --help     Print this message.
-  -v, --version  Displays version information.
-  --verbose      Verbose output.
+  -V, --version  Displays version information.
+  -v, --verbose  Verbose output.
 
 Arguments:
   command        The command to execute (see list below).


### PR DESCRIPTION
Use -v for --verbose instead of --version.
Added -V for --version.

This is my first pull request for this project. Let me know if I missed something :)

Fixes #1008