### PR TITLE
Remove obsolete workspace settings after file format upgrade

### DIFF
--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -121,6 +121,11 @@ private:  // Data
    */
   QMap<QString, SExpression> mFileContent;
 
+  /**
+   * @brief Whether #mFileContent needs to be upgraded or not
+   */
+  bool mUpgradeRequired;
+
 public:
   // All settings item objects below. The order is not relevant for saving,
   // it should be ordered logically.


### PR DESCRIPTION
Remove obsolete workspace settings after upgrading the workspace to a higher major file format version. This avoids having entries in the `settings.lp` file where we have no clue what file format version they have. And it simply helps to keep that file clean instead of cluttering it up with obsolete entries.