### PR TITLE
Add support for NPTH slots

### DIFF
--- a/libs/librepcb/core/export/excellongenerator.h
+++ b/libs/librepcb/core/export/excellongenerator.h
@@ -24,8 +24,8 @@
  *  Includes
  ******************************************************************************/
 #include "../fileio/filepath.h"
+#include "../geometry/path.h"
 #include "../types/length.h"
-#include "../types/point.h"
 #include "gerberattribute.h"
 
 #include <QtCore>
@@ -35,8 +35,10 @@
  ******************************************************************************/
 namespace librepcb {
 
+class Point;
+
 /*******************************************************************************
- *  Class GerberGenerator
+ *  Class ExcellonGenerator
  ******************************************************************************/
 
 /**
@@ -58,11 +60,16 @@ public:
                     Plating plating, int fromLayer, int toLayer) noexcept;
   ~ExcellonGenerator() noexcept;
 
+  // Setters
+  void setUseG85Slots(bool use) noexcept { mUseG85Slots = use; }
+
   // Getters
   const QString& toStr() const noexcept { return mOutput; }
 
   // General Methods
   void drill(const Point& pos, const PositiveLength& dia, bool plated,
+             Function function) noexcept;
+  void drill(const NonEmptyPath& path, const PositiveLength& dia, bool plated,
              Function function) noexcept;
   void generate();
   void saveToFile(const FilePath& filepath) const;
@@ -73,16 +80,30 @@ public:
 private:
   void printHeader() noexcept;
   void printToolList() noexcept;
-  void printDrills() noexcept;
+  void printDrills();
+  void printPath(const NonEmptyPath& path);
+  void printDrill(const Point& pos) noexcept;
+  void printSlot(const NonEmptyPath& path);
+  void printRout(const NonEmptyPath& path) noexcept;
+  void printMoveTo(const Point& pos) noexcept;
+  void printLinearInterpolation(const Point& pos) noexcept;
+  void printCircularInterpolation(const Point& from, const Point& to,
+                                  const Angle& angle) noexcept;
   void printFooter() noexcept;
+
+  // Types
+  typedef std::tuple<Length, bool, Function> Tool;
 
   // Metadata
   Plating mPlating;
   QVector<GerberAttribute> mFileAttributes;
 
+  // Configuration
+  bool mUseG85Slots;
+
   // Excellon Data
   QString mOutput;
-  QMultiMap<std::tuple<Length, bool, Function>, Point> mDrillList;
+  QMultiMap<Tool, NonEmptyPath> mDrillList;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/hole.h
+++ b/libs/librepcb/core/geometry/hole.h
@@ -23,9 +23,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../geometry/path.h"
 #include "../serialization/serializableobjectlist.h"
 #include "../types/length.h"
-#include "../types/point.h"
 
 #include <QtCore>
 
@@ -48,8 +48,8 @@ public:
   // Signals
   enum class Event {
     UuidChanged,
-    PositionChanged,
     DiameterChanged,
+    PathChanged,
   };
   Signal<Hole, Event> onEdited;
   typedef Slot<Hole, Event> OnEditedSlot;
@@ -58,19 +58,22 @@ public:
   Hole() = delete;
   Hole(const Hole& other) noexcept;
   Hole(const Uuid& uuid, const Hole& other) noexcept;
-  Hole(const Uuid& uuid, const Point& position,
-       const PositiveLength& diameter) noexcept;
+  Hole(const Uuid& uuid, const PositiveLength& diameter,
+       const NonEmptyPath& path) noexcept;
   explicit Hole(const SExpression& node);
   ~Hole() noexcept;
 
   // Getters
   const Uuid& getUuid() const noexcept { return mUuid; }
-  const Point& getPosition() const noexcept { return mPosition; }
   const PositiveLength& getDiameter() const noexcept { return mDiameter; }
+  const NonEmptyPath& getPath() const noexcept { return mPath; }
+  bool isSlot() const noexcept;
+  bool isMultiSegmentSlot() const noexcept;
+  bool isCurvedSlot() const noexcept;
 
   // Setters
-  bool setPosition(const Point& position) noexcept;
   bool setDiameter(const PositiveLength& diameter) noexcept;
+  bool setPath(const NonEmptyPath& path) noexcept;
 
   // General Methods
 
@@ -88,8 +91,8 @@ public:
 
 private:  // Data
   Uuid mUuid;
-  Point mPosition;
   PositiveLength mDiameter;
+  NonEmptyPath mPath;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -60,6 +60,16 @@ bool Path::isClosed() const noexcept {
   }
 }
 
+bool Path::isCurved() const noexcept {
+  // Angle of last vertex is not relevant!
+  for (int i = 0; i < (mVertices.count() - 1); ++i) {
+    if (mVertices.at(i).getAngle() != Angle::deg0()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 UnsignedLength Path::getTotalStraightLength() const noexcept {
   UnsignedLength length(0);
   if (mVertices.count() >= 2) {
@@ -100,13 +110,17 @@ QVector<Path> Path::toOutlineStrokes(const PositiveLength& width) const
     noexcept {
   QVector<Path> paths;
   paths.reserve(mVertices.count());
-  for (int i = 1; i < mVertices.count(); ++i) {  // skip first vertex!
-    const Vertex& v = mVertices.at(i);
-    const Vertex& v0 = mVertices.at(i - 1);
-    if (v0.getAngle() == 0) {
-      paths.append(obround(v0.getPos(), v.getPos(), width));
-    } else {
-      paths.append(arcObround(v0.getPos(), v.getPos(), v0.getAngle(), width));
+  if (mVertices.count() == 1) {
+    paths.append(circle(width).translated(mVertices.first().getPos()));
+  } else {
+    for (int i = 1; i < mVertices.count(); ++i) {  // skip first vertex!
+      const Vertex& v = mVertices.at(i);
+      const Vertex& v0 = mVertices.at(i - 1);
+      if (v0.getAngle() == 0) {
+        paths.append(obround(v0.getPos(), v.getPos(), width));
+      } else {
+        paths.append(arcObround(v0.getPos(), v.getPos(), v0.getAngle(), width));
+      }
     }
   }
   return paths;

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -68,6 +68,7 @@ public:
 
   // Getters
   bool isClosed() const noexcept;
+  bool isCurved() const noexcept;
   QVector<Vertex>& getVertices() noexcept {
     invalidatePainterPath();
     return mVertices;

--- a/libs/librepcb/core/graphics/graphicspainter.cpp
+++ b/libs/librepcb/core/graphics/graphicspainter.cpp
@@ -106,6 +106,14 @@ void GraphicsPainter::drawCircle(const Point& center, const Length& diameter,
   mPainter.drawEllipse(center.toPxQPointF(), radius, radius);
 }
 
+void GraphicsPainter::drawSlot(const Path& path, const PositiveLength& diameter,
+                               const Length& lineWidth, const QColor& lineColor,
+                               const QColor& fillColor) noexcept {
+  for (const Path& segment : path.toOutlineStrokes(diameter)) {
+    drawPath(segment.toQPainterPathPx(), lineWidth, lineColor, fillColor);
+  }
+}
+
 void GraphicsPainter::drawText(const Point& position, const Angle& rotation,
                                const Length& height, const Alignment& alignment,
                                const QString& text, QFont font,

--- a/libs/librepcb/core/graphics/graphicspainter.h
+++ b/libs/librepcb/core/graphics/graphicspainter.h
@@ -68,6 +68,9 @@ public:
   void drawCircle(const Point& center, const Length& diameter,
                   const Length& lineWidth, const QColor& lineColor,
                   const QColor& fillColor) noexcept;
+  void drawSlot(const Path& path, const PositiveLength& diameter,
+                const Length& lineWidth, const QColor& lineColor,
+                const QColor& fillColor) noexcept;
   void drawText(const Point& position, const Angle& rotation,
                 const Length& height, const Alignment& alignment,
                 const QString& text, QFont font, const QColor& color,

--- a/libs/librepcb/core/graphics/holegraphicsitem.h
+++ b/libs/librepcb/core/graphics/holegraphicsitem.h
@@ -24,7 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../geometry/hole.h"
-#include "primitivecirclegraphicsitem.h"
+#include "primitivepathgraphicsitem.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -45,7 +45,7 @@ class OriginCrossGraphicsItem;
  * @brief The HoleGraphicsItem class is the graphical representation of a
  *        librepcb::Hole
  */
-class HoleGraphicsItem final : public PrimitiveCircleGraphicsItem {
+class HoleGraphicsItem final : public PrimitivePathGraphicsItem {
 public:
   // Constructors / Destructor
   HoleGraphicsItem() = delete;
@@ -57,21 +57,21 @@ public:
   // Getters
   const Hole& getHole() noexcept { return mHole; }
 
-  // Inherited from QGraphicsItem
-  QPainterPath shape() const noexcept override;
-
   // Operator Overloadings
   HoleGraphicsItem& operator=(const HoleGraphicsItem& rhs) = delete;
 
 private:  // Methods
   void holeEdited(const Hole& hole, Hole::Event event) noexcept;
+  void setShape(const PositiveLength& diameter,
+                const NonEmptyPath& path) noexcept;
   QVariant itemChange(GraphicsItemChange change,
                       const QVariant& value) noexcept override;
 
 private:  // Data
   const Hole& mHole;
   const IF_GraphicsLayerProvider& mLayerProvider;
-  QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
+  QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItemStart;
+  QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItemEnd;
 
   // Slots
   Hole::OnEditedSlot mOnEditedSlot;

--- a/libs/librepcb/core/library/pkg/footprintpainter.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpainter.cpp
@@ -108,15 +108,15 @@ void FootprintPainter::paint(QPainter& painter,
 
     // Draw holes.
     foreach (const Hole& hole, content.holes) {
-      p.drawCircle(hole.getPosition(), *hole.getDiameter(), Length(0),
-                   settings.getColor(layer), QColor());
+      p.drawSlot(*hole.getPath(), hole.getDiameter(), Length(0),
+                 settings.getColor(layer), QColor());
     }
 
     // Draw pad holes.
     if (drawPadHoles) {
       foreach (const Hole& hole, content.padHoles) {
-        p.drawCircle(hole.getPosition(), *hole.getDiameter(), Length(0),
-                     settings.getColor(layer), QColor());
+        p.drawSlot(*hole.getPath(), hole.getDiameter(), Length(0),
+                   settings.getColor(layer), QColor());
       }
     }
 
@@ -180,8 +180,8 @@ void FootprintPainter::initContentByLayer() const noexcept {
       // Also add the hole for THT pads.
       if ((pad.getBoardSide() == FootprintPad::BoardSide::THT) &&
           (pad.getDrillDiameter() > 0)) {
-        Hole hole(pad.getUuid(), pad.getPosition(),
-                  PositiveLength(*pad.getDrillDiameter()));
+        Hole hole(pad.getUuid(), PositiveLength(*pad.getDrillDiameter()),
+                  makeNonEmptyPath(pad.getPosition()));
         mContentByLayer[GraphicsLayer::sBoardDrillsNpth].padHoles.append(hole);
       }
     }

--- a/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
+++ b/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
@@ -55,6 +55,7 @@ BoardFabricationOutputSettings::BoardFabricationOutputSettings() noexcept
     mSilkscreenLayersBot(
         {GraphicsLayer::sBotPlacement, GraphicsLayer::sBotNames}),
     mMergeDrillFiles(false),
+    mUseG85SlotCommand(false),
     mEnableSolderPasteTop(false),
     mEnableSolderPasteBot(false) {
 }
@@ -87,6 +88,7 @@ BoardFabricationOutputSettings::BoardFabricationOutputSettings(
     mSilkscreenLayersTop(),  // Initialized below.
     mSilkscreenLayersBot(),  // Initialized below.
     mMergeDrillFiles(deserialize<bool>(node.getChild("drills/merge/@0"))),
+    mUseG85SlotCommand(deserialize<bool>(node.getChild("drills/g85_slots/@0"))),
     mEnableSolderPasteTop(
         deserialize<bool>(node.getChild("solderpaste_top/create/@0"))),
     mEnableSolderPasteBot(
@@ -156,6 +158,8 @@ void BoardFabricationOutputSettings::serialize(SExpression& root) const {
   drills.ensureLineBreak();
   drills.appendChild("suffix_merged", mSuffixDrills);
   drills.ensureLineBreak();
+  drills.appendChild("g85_slots", mUseG85SlotCommand);
+  drills.ensureLineBreak();
   root.ensureLineBreak();
 
   SExpression& solderPasteTop = root.appendList("solderpaste_top");
@@ -192,6 +196,7 @@ BoardFabricationOutputSettings& BoardFabricationOutputSettings::operator=(
   mSilkscreenLayersTop = rhs.mSilkscreenLayersTop;
   mSilkscreenLayersBot = rhs.mSilkscreenLayersBot;
   mMergeDrillFiles = rhs.mMergeDrillFiles;
+  mUseG85SlotCommand = rhs.mUseG85SlotCommand;
   mEnableSolderPasteTop = rhs.mEnableSolderPasteTop;
   mEnableSolderPasteBot = rhs.mEnableSolderPasteBot;
   return *this;
@@ -216,6 +221,7 @@ bool BoardFabricationOutputSettings::operator==(
   if (mSilkscreenLayersTop != rhs.mSilkscreenLayersTop) return false;
   if (mSilkscreenLayersBot != rhs.mSilkscreenLayersBot) return false;
   if (mMergeDrillFiles != rhs.mMergeDrillFiles) return false;
+  if (mUseG85SlotCommand != rhs.mUseG85SlotCommand) return false;
   if (mEnableSolderPasteTop != rhs.mEnableSolderPasteTop) return false;
   if (mEnableSolderPasteBot != rhs.mEnableSolderPasteBot) return false;
   return true;

--- a/libs/librepcb/core/project/board/boardfabricationoutputsettings.h
+++ b/libs/librepcb/core/project/board/boardfabricationoutputsettings.h
@@ -92,6 +92,7 @@ public:
     return mSilkscreenLayersBot;
   }
   bool getMergeDrillFiles() const noexcept { return mMergeDrillFiles; }
+  bool getUseG85SlotCommand() const noexcept { return mUseG85SlotCommand; }
   bool getEnableSolderPasteTop() const noexcept {
     return mEnableSolderPasteTop;
   }
@@ -135,6 +136,7 @@ public:
     mSilkscreenLayersBot = l;
   }
   void setMergeDrillFiles(bool m) noexcept { mMergeDrillFiles = m; }
+  void setUseG85SlotCommand(bool u) noexcept { mUseG85SlotCommand = u; }
   void setEnableSolderPasteTop(bool e) noexcept { mEnableSolderPasteTop = e; }
   void setEnableSolderPasteBot(bool e) noexcept { mEnableSolderPasteBot = e; }
 
@@ -173,6 +175,7 @@ private:  // Data
   QStringList mSilkscreenLayersTop;
   QStringList mSilkscreenLayersBot;
   bool mMergeDrillFiles;
+  bool mUseG85SlotCommand;
   bool mEnableSolderPasteTop;
   bool mEnableSolderPasteBot;
 };

--- a/libs/librepcb/core/project/board/boardgerberexport.h
+++ b/libs/librepcb/core/project/board/boardgerberexport.h
@@ -24,10 +24,13 @@
  *  Includes
  ******************************************************************************/
 #include "../../attribute/attributeprovider.h"
+#include "../../export/excellongenerator.h"
 #include "../../fileio/filepath.h"
 #include "../../types/length.h"
 
 #include <QtCore>
+
+#include <memory>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -40,7 +43,6 @@ class BI_Via;
 class Board;
 class BoardFabricationOutputSettings;
 class Circle;
-class ExcellonGenerator;
 class GerberGenerator;
 class Polygon;
 class Project;
@@ -124,6 +126,9 @@ private:
   void drawFootprintPad(GerberGenerator& gen, const BI_FootprintPad& pad,
                         const QString& layerName) const;
 
+  std::unique_ptr<ExcellonGenerator> createExcellonGenerator(
+      const BoardFabricationOutputSettings& settings,
+      ExcellonGenerator::Plating plating) const;
   FilePath getOutputFilePath(QString path) const noexcept;
 
   // Static Methods

--- a/libs/librepcb/core/project/board/boardpainter.cpp
+++ b/libs/librepcb/core/project/board/boardpainter.cpp
@@ -159,15 +159,15 @@ void BoardPainter::paint(QPainter& painter,
 
     // Draw holes.
     foreach (const Hole& hole, content.holes) {
-      p.drawCircle(hole.getPosition(), *hole.getDiameter(), Length(0),
-                   settings.getColor(layer), QColor());
+      p.drawSlot(*hole.getPath(), hole.getDiameter(), Length(0),
+                 settings.getColor(layer), QColor());
     }
 
     // Draw pad holes.
     if (drawPadHoles) {
       foreach (const Hole& hole, content.padHoles) {
-        p.drawCircle(hole.getPosition(), *hole.getDiameter(), Length(0),
-                     settings.getColor(layer), QColor());
+        p.drawSlot(*hole.getPath(), hole.getDiameter(), Length(0),
+                   settings.getColor(layer), QColor());
       }
     }
 
@@ -207,7 +207,7 @@ void BoardPainter::initContentByLayer() const noexcept {
 
       // Footprint holes.
       foreach (Hole hole, footprint.holes) {
-        hole.setPosition(footprint.transform.map(hole.getPosition()));
+        hole.setPath(NonEmptyPath(footprint.transform.map(hole.getPath())));
         mContentByLayer[GraphicsLayer::sBoardDrillsNpth].holes.append(hole);
       }
 
@@ -241,8 +241,9 @@ void BoardPainter::initContentByLayer() const noexcept {
         // Also add the hole for THT pads.
         if ((pad.getBoardSide() == FootprintPad::BoardSide::THT) &&
             (pad.getDrillDiameter() > 0)) {
-          Hole hole(pad.getUuid(), footprint.transform.map(pad.getPosition()),
-                    PositiveLength(*pad.getDrillDiameter()));
+          Hole hole(
+              pad.getUuid(), PositiveLength(*pad.getDrillDiameter()),
+              makeNonEmptyPath(footprint.transform.map(pad.getPosition())));
           mContentByLayer[GraphicsLayer::sBoardDrillsNpth].padHoles.append(
               hole);
         }

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -93,10 +93,12 @@ void BoardClipperPathGenerator::addHoles(const Length& offset) {
     if (diameter <= 0) {
       continue;
     }
-    Path path =
-        Path::circle(PositiveLength(diameter)).translated(hole->getPosition());
-    ClipperHelpers::unite(mPaths,
-                          ClipperHelpers::convert(path, mMaxArcTolerance));
+    const QVector<Path> areas =
+        hole->getHole().getPath()->toOutlineStrokes(PositiveLength(diameter));
+    foreach (const Path& area, areas) {
+      ClipperHelpers::unite(mPaths,
+                            ClipperHelpers::convert(area, mMaxArcTolerance));
+    }
   }
 
   // footprint holes
@@ -107,10 +109,13 @@ void BoardClipperPathGenerator::addHoles(const Length& offset) {
       if (diameter <= 0) {
         continue;
       }
-      Path path = transform.map(Path::circle(PositiveLength(diameter))
-                                    .translated(hole.getPosition()));
-      ClipperHelpers::unite(mPaths,
-                            ClipperHelpers::convert(path, mMaxArcTolerance));
+      const QVector<Path> areas =
+          transform.map(hole.getPath())
+              ->toOutlineStrokes(PositiveLength(diameter));
+      foreach (const Path& area, areas) {
+        ClipperHelpers::unite(mPaths,
+                              ClipperHelpers::convert(area, mMaxArcTolerance));
+      }
     }
   }
 }

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -490,8 +490,9 @@ void BoardDesignRuleCheck::checkMinimumNpthDrillDiameter(int progressStart,
   foreach (const BI_Hole* hole, mBoard.getHoles()) {
     if (hole->getHole().getDiameter() < mOptions.minNpthDrillDiameter) {
       QString msg = msgTr.arg(formatLength(*hole->getHole().getDiameter()));
-      Path location = Path::circle(hole->getHole().getDiameter())
-                          .translated(hole->getPosition());
+      const QVector<Path> location =
+          hole->getHole().getPath()->toOutlineStrokes(
+              hole->getHole().getDiameter());
       emitMessage(BoardDesignRuleCheckMessage(msg, location));
     }
   }
@@ -502,8 +503,8 @@ void BoardDesignRuleCheck::checkMinimumNpthDrillDiameter(int progressStart,
     for (const Hole& hole : device->getLibFootprint().getHoles()) {
       if (hole.getDiameter() < *mOptions.minNpthDrillDiameter) {
         QString msg = msgTr.arg(formatLength(*hole.getDiameter()));
-        Path location = Path::circle(hole.getDiameter())
-                            .translated(transform.map(hole.getPosition()));
+        const QVector<Path> location =
+            transform.map(hole.getPath())->toOutlineStrokes(hole.getDiameter());
         emitMessage(BoardDesignRuleCheckMessage(msg, location));
       }
     }

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -95,14 +95,20 @@ void BoardDesignRuleCheck::execute() {
   if (mOptions.checkPthRestring) {
     checkMinimumPthRestring(72, 74);
   }
-  if (mOptions.checkPthDrillDiameter) {
-    checkMinimumPthDrillDiameter(74, 76);
-  }
   if (mOptions.checkNpthDrillDiameter) {
-    checkMinimumNpthDrillDiameter(76, 78);
+    checkMinimumNpthDrillDiameter(74, 76);
+  }
+  if (mOptions.checkNpthSlotWidth) {
+    checkMinimumNpthSlotWidth(76, 78);
+  }
+  if (mOptions.checkPthDrillDiameter) {
+    checkMinimumPthDrillDiameter(78, 80);
+  }
+  if (mOptions.checkNpthSlotsWarning) {
+    checkWarnNpthSlots(80, 82);
   }
   if (mOptions.checkCourtyardClearance) {
-    checkCourtyardClearances(78, 88);
+    checkCourtyardClearances(82, 88);
   }
   if (mOptions.checkMissingConnections) {
     checkForMissingConnections(88, 90);
@@ -436,6 +442,78 @@ void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
   emit progressPercent(progressEnd);
 }
 
+void BoardDesignRuleCheck::checkMinimumNpthDrillDiameter(int progressStart,
+                                                         int progressEnd) {
+  Q_UNUSED(progressStart);
+  emitStatus(tr("Check minimum NPTH drill diameters..."));
+
+  const QString msgTr =
+      tr("Min. hole diameter: %1 < %2", "The '<' means 'smaller than'.");
+
+  // Board holes.
+  foreach (const BI_Hole* hole, mBoard.getHoles()) {
+    if ((!hole->getHole().isSlot()) &&
+        (hole->getHole().getDiameter() < mOptions.minNpthDrillDiameter)) {
+      emitMessage(BoardDesignRuleCheckMessage(
+          msgTr.arg(formatLength(*hole->getHole().getDiameter()),
+                    formatLength(*mOptions.minNpthDrillDiameter)),
+          getHoleLocation(hole->getHole(), Transform())));
+    }
+  }
+
+  // Package holes.
+  foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
+    Transform transform(*device);
+    for (const Hole& hole : device->getLibFootprint().getHoles()) {
+      if ((!hole.isSlot()) &&
+          (hole.getDiameter() < *mOptions.minNpthDrillDiameter)) {
+        emitMessage(BoardDesignRuleCheckMessage(
+            msgTr.arg(formatLength(*hole.getDiameter()),
+                      formatLength(*mOptions.minNpthDrillDiameter)),
+            getHoleLocation(hole, transform)));
+      }
+    }
+  }
+
+  emit progressPercent(progressEnd);
+}
+
+void BoardDesignRuleCheck::checkMinimumNpthSlotWidth(int progressStart,
+                                                     int progressEnd) {
+  Q_UNUSED(progressStart);
+  emitStatus(tr("Check minimum NPTH slot width..."));
+
+  const QString msgTr =
+      tr("Min. NPTH slot width: %1 < %2", "The '<' means 'smaller than'.");
+
+  // Board holes.
+  foreach (const BI_Hole* hole, mBoard.getHoles()) {
+    if ((hole->getHole().isSlot()) &&
+        (hole->getHole().getDiameter() < mOptions.minNpthSlotWidth)) {
+      emitMessage(BoardDesignRuleCheckMessage(
+          msgTr.arg(formatLength(*hole->getHole().getDiameter()),
+                    formatLength(*mOptions.minNpthSlotWidth)),
+          getHoleLocation(hole->getHole(), Transform())));
+    }
+  }
+
+  // Package holes.
+  foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
+    Transform transform(*device);
+    for (const Hole& hole : device->getLibFootprint().getHoles()) {
+      if ((hole.isSlot()) &&
+          (hole.getDiameter() < *mOptions.minNpthSlotWidth)) {
+        emitMessage(BoardDesignRuleCheckMessage(
+            msgTr.arg(formatLength(*hole.getDiameter()),
+                      formatLength(*mOptions.minNpthSlotWidth)),
+            getHoleLocation(hole, transform)));
+      }
+    }
+  }
+
+  emit progressPercent(progressEnd);
+}
+
 void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
                                                         int progressEnd) {
   Q_UNUSED(progressStart);
@@ -479,34 +557,54 @@ void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
   emit progressPercent(progressEnd);
 }
 
-void BoardDesignRuleCheck::checkMinimumNpthDrillDiameter(int progressStart,
-                                                         int progressEnd) {
+void BoardDesignRuleCheck::checkWarnNpthSlots(int progressStart,
+                                              int progressEnd) {
   Q_UNUSED(progressStart);
-  emitStatus(tr("Check minimum NPTH drill diameters..."));
+  emitStatus(tr("Check NPTH slots..."));
 
-  QString msgTr = tr("Min. hole diameter: %1", "Placeholder is drill diameter");
-
-  // board holes
-  foreach (const BI_Hole* hole, mBoard.getHoles()) {
-    if (hole->getHole().getDiameter() < mOptions.minNpthDrillDiameter) {
-      QString msg = msgTr.arg(formatLength(*hole->getHole().getDiameter()));
-      const QVector<Path> location =
-          hole->getHole().getPath()->toOutlineStrokes(
-              hole->getHole().getDiameter());
-      emitMessage(BoardDesignRuleCheckMessage(msg, location));
+  auto checkHole = [this](const Hole& hole, const Transform& transform) {
+    const QString suggestion = "\n" %
+        tr("Either avoid them or check if your PCB manufacturer supports "
+           "them.");
+    const QString checkSlotMode = "\n" %
+        tr("Choose the desired Excellon slot mode when generating the "
+           "production data (G85 vs. G00..G03).");
+    const QString g85NotAvailable = "\n" %
+        tr("The drilled slot mode (G85) will not be available when generating "
+           "production data.");
+    if ((mOptions.npthSlotsWarning >= SlotsWarningLevel::Curved) &&
+        hole.isCurvedSlot()) {
+      emitMessage(BoardDesignRuleCheckMessage(
+          tr("Hole is a slot with curves"), getHoleLocation(hole, transform),
+          tr("Curved slots are a very unusual thing and may cause troubles "
+             "with many PCB manufacturers.") %
+              suggestion % g85NotAvailable));
+    } else if ((mOptions.npthSlotsWarning >= SlotsWarningLevel::MultiSegment) &&
+               hole.isMultiSegmentSlot()) {
+      emitMessage(BoardDesignRuleCheckMessage(
+          tr("Hole is a multi-segment slot"), getHoleLocation(hole, transform),
+          tr("Multi-segment slots are a rather unusual thing and may cause "
+             "troubles with some PCB manufacturers.") %
+              suggestion % checkSlotMode));
+    } else if ((mOptions.npthSlotsWarning >= SlotsWarningLevel::All) &&
+               hole.isSlot()) {
+      emitMessage(BoardDesignRuleCheckMessage(
+          tr("Hole is a slot"), getHoleLocation(hole, transform),
+          tr("Slots may cause troubles with some PCB manufacturers.") %
+              suggestion % checkSlotMode));
     }
+  };
+
+  // Board holes.
+  foreach (const BI_Hole* hole, mBoard.getHoles()) {
+    checkHole(hole->getHole(), Transform());
   }
 
-  // package holes
+  // Package holes.
   foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
     Transform transform(*device);
     for (const Hole& hole : device->getLibFootprint().getHoles()) {
-      if (hole.getDiameter() < *mOptions.minNpthDrillDiameter) {
-        QString msg = msgTr.arg(formatLength(*hole.getDiameter()));
-        const QVector<Path> location =
-            transform.map(hole.getPath())->toOutlineStrokes(hole.getDiameter());
-        emitMessage(BoardDesignRuleCheckMessage(msg, location));
-      }
+      checkHole(hole, transform);
     }
   }
 
@@ -548,6 +646,11 @@ ClipperLib::Paths BoardDesignRuleCheck::getDeviceCourtyardPaths(
                                 maxArcTolerance()));
   }
   return paths;
+}
+
+QVector<Path> BoardDesignRuleCheck::getHoleLocation(
+    const Hole& hole, const Transform& transform) const noexcept {
+  return transform.map(hole.getPath())->toOutlineStrokes(hole.getDiameter());
 }
 
 void BoardDesignRuleCheck::emitStatus(const QString& status) noexcept {

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessage.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessage.cpp
@@ -34,13 +34,15 @@ namespace librepcb {
  ******************************************************************************/
 
 BoardDesignRuleCheckMessage::BoardDesignRuleCheckMessage(
-    const QString& message, const Path& location) noexcept
-  : BoardDesignRuleCheckMessage(message, QVector<Path>{location}) {
+    const QString& message, const Path& location,
+    const QString& description) noexcept
+  : BoardDesignRuleCheckMessage(message, QVector<Path>{location}, description) {
 }
 
 BoardDesignRuleCheckMessage::BoardDesignRuleCheckMessage(
-    const QString& message, const QVector<Path>& locations) noexcept
-  : mMessage(message), mLocations(locations) {
+    const QString& message, const QVector<Path>& locations,
+    const QString& description) noexcept
+  : mMessage(message), mLocations(locations), mDescription(description) {
 }
 
 BoardDesignRuleCheckMessage::~BoardDesignRuleCheckMessage() noexcept {

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessage.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessage.h
@@ -43,19 +43,22 @@ namespace librepcb {
 class BoardDesignRuleCheckMessage final {
 public:
   // Constructors / Destructor
+  BoardDesignRuleCheckMessage(const QString& message, const Path& location,
+                              const QString& description = QString()) noexcept;
   BoardDesignRuleCheckMessage(const QString& message,
-                              const Path& location) noexcept;
-  BoardDesignRuleCheckMessage(const QString& message,
-                              const QVector<Path>& locations) noexcept;
+                              const QVector<Path>& locations,
+                              const QString& description = QString()) noexcept;
   ~BoardDesignRuleCheckMessage() noexcept;
 
   // Getters
   const QString& getMessage() const noexcept { return mMessage; }
   const QVector<Path>& getLocations() const noexcept { return mLocations; }
+  const QString& getDescription() const noexcept { return mDescription; }
 
 private:  // Data
   QString mMessage;
   QVector<Path> mLocations;
+  QString mDescription;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_device.cpp
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_device.cpp
@@ -86,9 +86,9 @@ BGI_Device::BGI_Device(BI_Device& device) noexcept
 
   for (auto& obj : mDevice.getLibFootprint().getHoles().values()) {
     Q_ASSERT(obj);
-    auto i = std::make_shared<PrimitiveCircleGraphicsItem>(this);
-    i->setPosition(obj->getPosition());
-    i->setDiameter(positiveToUnsigned(obj->getDiameter()));
+    auto i = std::make_shared<PrimitivePathGraphicsItem>(this);
+    i->setPath(Path::toQPainterPathPx(
+        obj->getPath()->toOutlineStrokes(obj->getDiameter()), false));
     i->setLineLayer(getLayer(GraphicsLayer::sBoardDrillsNpth));
     i->setFlag(QGraphicsItem::ItemIsSelectable, true);
     i->setFlag(QGraphicsItem::ItemStacksBehindParent, true);

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_device.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_device.h
@@ -82,7 +82,7 @@ private:  // Data
   std::shared_ptr<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
   QVector<std::shared_ptr<PrimitiveCircleGraphicsItem>> mCircleGraphicsItems;
   QVector<std::shared_ptr<PrimitivePathGraphicsItem>> mPolygonGraphicsItems;
-  QVector<std::shared_ptr<PrimitiveCircleGraphicsItem>> mHoleGraphicsItems;
+  QVector<std::shared_ptr<PrimitivePathGraphicsItem>> mHoleGraphicsItems;
   QRectF mBoundingRect;
   QPainterPath mShape;
 

--- a/libs/librepcb/core/project/board/items/bi_hole.cpp
+++ b/libs/librepcb/core/project/board/items/bi_hole.cpp
@@ -72,10 +72,6 @@ void BI_Hole::removeFromBoard() {
  *  Inherited from BI_Base
  ******************************************************************************/
 
-const Point& BI_Hole::getPosition() const noexcept {
-  return mHole->getPosition();
-}
-
 QPainterPath BI_Hole::getGrabAreaScenePx() const noexcept {
   return mGraphicsItem->sceneTransform().map(mGraphicsItem->shape());
 }

--- a/libs/librepcb/core/project/board/items/bi_hole.h
+++ b/libs/librepcb/core/project/board/items/bi_hole.h
@@ -59,7 +59,6 @@ public:
   const Hole& getHole() const noexcept { return *mHole; }
   const Uuid& getUuid() const
       noexcept;  // convenience function, e.g. for template usage
-  const Point& getPosition() const noexcept;
   bool isSelectable() const noexcept override;
 
   // General Methods

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -186,6 +186,23 @@ void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir) {
       dir.write(fp, root.toByteArray());
     }
   }
+
+  // Boards.
+  foreach (const QString& dirName, dir.getDirs("boards")) {
+    const QString fp = "boards/" % dirName % "/board.lp";
+    if (dir.fileExists(fp)) {
+      SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+
+      // Fabrication output settings.
+      {
+        SExpression& node = root.getChild("fabrication_output_settings");
+        SExpression& drillNode = node.getChild("drills");
+        drillNode.appendChild("g85_slots", false);
+      }
+
+      dir.write(fp, root.toByteArray());
+    }
+  }
 }
 
 void FileFormatMigrationV01::upgradeWorkspaceData(TransactionalDirectory& dir) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -112,6 +112,9 @@ void FileFormatMigrationV01::upgradePackage(TransactionalDirectory& dir) {
         const Uuid uuid = deserialize<Uuid>(padNode->getChild("@0"));
         padNode->appendChild("package_pad", uuid);
       }
+
+      // Holes.
+      upgradeHoles(*fptNode);
     }
 
     dir.write(fp, root.toByteArray());
@@ -200,6 +203,9 @@ void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir) {
         drillNode.appendChild("g85_slots", false);
       }
 
+      // Holes.
+      upgradeHoles(root);
+
       dir.write(fp, root.toByteArray());
     }
   }
@@ -223,6 +229,19 @@ void FileFormatMigrationV01::upgradeWorkspaceData(TransactionalDirectory& dir) {
               << librariesDir.getAbsPath(fileName).toNative();
       librariesDir.removeFile(fileName);
     }
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void FileFormatMigrationV01::upgradeHoles(SExpression& node) {
+  for (SExpression* holeNode : node.getChildren("hole")) {
+    const Point pos(holeNode->getChild("position"));
+    SExpression& vertexNode = holeNode->appendList("vertex");
+    pos.serialize(vertexNode.appendList("position"));
+    vertexNode.appendChild("angle", Angle::deg0());
   }
 }
 

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -63,6 +63,9 @@ public:
 
   // Operator Overloadings
   FileFormatMigrationV01& operator=(const FileFormatMigrationV01& rhs) = delete;
+
+private:  // Methods
+  void upgradeHoles(SExpression& node);
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/utils/transform.h
+++ b/libs/librepcb/core/utils/transform.h
@@ -150,6 +150,16 @@ public:
   Path map(const Path& path) const noexcept;
 
   /**
+   * @brief Map a given path to the transformed coordinate system
+   *
+   * @param path  The path to map.
+   * @return The passed path, rotated by the transformations rotation,
+   *         mirrored horizontally if the transformation is mirroring, and
+   *         translated by the transformation offset.
+   */
+  NonEmptyPath map(const NonEmptyPath& path) const noexcept;
+
+  /**
    * @brief Map a given layer name to the transformed coordinate system
    *
    * @param layerName The layer to map.

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -314,8 +314,8 @@ std::shared_ptr<Hole> EagleTypeConverter::convertHole(
     const parseagle::Hole& h) {
   return std::make_shared<Hole>(
       Uuid::createRandom(),  // UUID
-      convertPoint(h.getPosition()),  // Position
-      PositiveLength(convertLength(h.getDiameter()))  // Diameter
+      PositiveLength(convertLength(h.getDiameter())),  // Diameter
+      makeNonEmptyPath(convertPoint(h.getPosition()))  // Path
   );
 }
 

--- a/libs/librepcb/editor/cmd/cmdholeedit.h
+++ b/libs/librepcb/editor/cmd/cmdholeedit.h
@@ -59,7 +59,7 @@ public:
   ~CmdHoleEdit() noexcept;
 
   // Setters
-  void setPosition(const Point& pos, bool immediate) noexcept;
+  void setPath(const NonEmptyPath& path, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
@@ -88,8 +88,8 @@ private:
   Hole& mHole;
 
   // General Attributes
-  Point mOldPosition;
-  Point mNewPosition;
+  NonEmptyPath mOldPath;
+  NonEmptyPath mNewPath;
   PositiveLength mOldDiameter;
   PositiveLength mNewDiameter;
 };

--- a/libs/librepcb/editor/dialogs/holepropertiesdialog.h
+++ b/libs/librepcb/editor/dialogs/holepropertiesdialog.h
@@ -33,6 +33,7 @@ namespace librepcb {
 
 class Hole;
 class LengthUnit;
+class Path;
 
 namespace editor {
 
@@ -69,6 +70,11 @@ public:
   HolePropertiesDialog& operator=(const HolePropertiesDialog& rhs) = delete;
 
 private:  // Methods
+  void updatePathFromCircularTab() noexcept;
+  void updatePathFromLinearTab() noexcept;
+  void updateCircularTabFromPath(const Path& path) noexcept;
+  void updateLinearTabFromPath(const Path& path) noexcept;
+  void updateLinearOuterSize(const Path& path) noexcept;
   void on_buttonBox_clicked(QAbstractButton* button);
   bool applyChanges() noexcept;
 

--- a/libs/librepcb/editor/dialogs/holepropertiesdialog.ui
+++ b/libs/librepcb/editor/dialogs/holepropertiesdialog.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>304</width>
-    <height>91</height>
+    <width>465</width>
+    <height>278</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Hole Properties</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <item>
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
@@ -26,27 +26,127 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Position:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
-       </item>
-       <item>
-        <widget class="librepcb::editor::LengthEdit" name="edtPosY" native="true"/>
-       </item>
-      </layout>
-     </item>
      <item row="0" column="1">
       <widget class="librepcb::editor::PositiveLengthEdit" name="edtDiameter" native="true"/>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="tabCircular">
+      <attribute name="title">
+       <string>Circular Drill</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Position:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
+         </item>
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtPosY" native="true"/>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabLinear">
+      <attribute name="title">
+       <string>Linear Slot</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_3">
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtCenterX" native="true"/>
+         </item>
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtCenterY" native="true"/>
+         </item>
+        </layout>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Rotation:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Center:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
+       </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,1">
+         <item>
+          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtLength" native="true"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblOuterSize">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Length:</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabArbitrary">
+      <attribute name="title">
+       <string>Arbitrary Slot</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="librepcb::editor::PathEditorWidget" name="pathEditorWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -62,15 +162,33 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>librepcb::editor::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::PathEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/patheditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>librepcb::editor::LengthEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/lengthedit.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>librepcb::editor::PositiveLengthEdit</class>
+   <class>librepcb::editor::AngleEdit</class>
    <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <header location="global">librepcb/editor/widgets/angleedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
@@ -123,8 +123,9 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
     // Note: The const_cast<> is a bit ugly, but it was by far the easiest
     // way and is safe since here we know that we're allowed to modify the hole.
     mHoleEditCmds.append(new CmdHoleEdit(const_cast<Hole&>(hole->getHole())));
-    mCenterPos += hole->getHole().getPosition();
-    if (!hole->getHole().getPosition().isOnGrid(grid)) {
+    const Point pos = hole->getHole().getPath()->getVertices().first().getPos();
+    mCenterPos += pos;
+    if (!pos.isOnGrid(grid)) {
       mHasOffTheGridElements = true;
     }
     ++count;

--- a/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
@@ -173,7 +173,8 @@ bool CmdPasteFootprintItems::performExecute() {
       uuid = Uuid::createRandom();
     }
     std::shared_ptr<Hole> copy = std::make_shared<Hole>(
-        uuid, hole.getPosition() + mPosOffset, hole.getDiameter());
+        uuid, hole.getDiameter(),
+        NonEmptyPath(hole.getPath()->translated(mPosOffset)));
     execNewChildCmd(new CmdHoleInsert(mFootprint.getHoles(), copy));
     if (auto graphicsItem = mGraphicsItem.getGraphicsItem(copy)) {
       graphicsItem->setSelected(true);

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -256,7 +256,7 @@ void NewElementWizardContext::copyElement(ElementType type,
         // copy holes but generate new UUIDs
         for (const Hole& hole : footprint.getHoles()) {
           newFootprint->getHoles().append(std::make_shared<Hole>(
-              Uuid::createRandom(), hole.getPosition(), hole.getDiameter()));
+              Uuid::createRandom(), hole.getDiameter(), hole.getPath()));
         }
         mPackageFootprints.append(newFootprint);
       }

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.cpp
@@ -118,7 +118,7 @@ bool PackageEditorState_AddHoles::processGraphicsSceneMouseMoved(
   if (mCurrentHole) {
     Point currentPos =
         Point::fromPx(e.scenePos()).mappedToGrid(getGridInterval());
-    mEditCmd->setPosition(currentPos, true);
+    mEditCmd->setPath(makeNonEmptyPath(currentPos), true);
     return true;
   } else {
     return false;
@@ -142,8 +142,8 @@ bool PackageEditorState_AddHoles::processGraphicsSceneLeftMouseButtonPressed(
 bool PackageEditorState_AddHoles::startAddHole(const Point& pos) noexcept {
   try {
     mContext.undoStack.beginCmdGroup(tr("Add hole"));
-    mCurrentHole =
-        std::make_shared<Hole>(Uuid::createRandom(), pos, mLastDiameter);
+    mCurrentHole = std::make_shared<Hole>(Uuid::createRandom(), mLastDiameter,
+                                          makeNonEmptyPath(pos));
     mContext.undoStack.appendToCmdGroup(
         new CmdHoleInsert(mContext.currentFootprint->getHoles(), mCurrentHole));
     mEditCmd.reset(new CmdHoleEdit(*mCurrentHole));
@@ -163,7 +163,7 @@ bool PackageEditorState_AddHoles::startAddHole(const Point& pos) noexcept {
 
 bool PackageEditorState_AddHoles::finishAddHole(const Point& pos) noexcept {
   try {
-    mEditCmd->setPosition(pos, true);
+    mEditCmd->setPath(makeNonEmptyPath(pos), true);
     mCurrentGraphicsItem->setSelected(false);
     mCurrentGraphicsItem.reset();
     mCurrentHole.reset();

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -567,8 +567,9 @@ bool PackageEditorState_Select::processImportDxf() noexcept {
     }
     for (const auto& circle : import.getCircles()) {
       if (dialog.getImportCirclesAsDrills()) {
-        data->getHoles().append(std::make_shared<Hole>(
-            Uuid::createRandom(), circle.position, circle.diameter));
+        data->getHoles().append(
+            std::make_shared<Hole>(Uuid::createRandom(), circle.diameter,
+                                   makeNonEmptyPath(circle.position)));
       } else {
         data->getPolygons().append(std::make_shared<Polygon>(
             Uuid::createRandom(), dialog.getLayerName(), dialog.getLineWidth(),

--- a/libs/librepcb/editor/modelview/pathmodel.cpp
+++ b/libs/librepcb/editor/modelview/pathmodel.cpp
@@ -46,9 +46,12 @@ PathModel::~PathModel() noexcept {
  ******************************************************************************/
 
 void PathModel::setPath(const Path& path) noexcept {
-  emit beginResetModel();
-  mPath = path;
-  emit endResetModel();
+  if (path != mPath) {
+    emit beginResetModel();
+    mPath = path;
+    emit endResetModel();
+    emit pathChanged(mPath);
+  }
 }
 
 /*******************************************************************************
@@ -61,6 +64,7 @@ void PathModel::addItem(const QVariant& editData) noexcept {
                   mPath.getVertices().count());
   mPath.addVertex(mNewVertex);
   endInsertRows();
+  emit pathChanged(mPath);
 }
 
 void PathModel::copyItem(const QVariant& editData) noexcept {
@@ -69,6 +73,7 @@ void PathModel::copyItem(const QVariant& editData) noexcept {
     beginInsertRows(QModelIndex(), index, index);
     mPath.insertVertex(index, mPath.getVertices().value(index));
     endInsertRows();
+    emit pathChanged(mPath);
   } else {
     qWarning() << "Invalid index in PathModel::copyItem():" << index;
   }
@@ -80,6 +85,7 @@ void PathModel::removeItem(const QVariant& editData) noexcept {
     beginRemoveRows(QModelIndex(), index, index);
     mPath.getVertices().remove(index);
     endRemoveRows();
+    emit pathChanged(mPath);
   } else {
     qWarning() << "Invalid index in PathModel::removeItem():" << index;
   }
@@ -91,6 +97,7 @@ void PathModel::moveItemUp(const QVariant& editData) noexcept {
     beginMoveRows(QModelIndex(), index, index, QModelIndex(), index - 1);
     mPath.getVertices().insert(index - 1, mPath.getVertices().takeAt(index));
     endMoveRows();
+    emit pathChanged(mPath);
   }
 }
 
@@ -102,6 +109,7 @@ void PathModel::moveItemDown(const QVariant& editData) noexcept {
     beginMoveRows(QModelIndex(), index, index, QModelIndex(), index + 2);
     mPath.getVertices().insert(index + 1, mPath.getVertices().takeAt(index));
     endMoveRows();
+    emit pathChanged(mPath);
   }
 }
 
@@ -267,6 +275,9 @@ bool PathModel::setData(const QModelIndex& index, const QVariant& value,
       return false;
     }
     emit dataChanged(index, index);
+    if (vertex) {
+      emit pathChanged(mPath);
+    }
     return true;
   } catch (const Exception& e) {
     QMessageBox::critical(0, tr("Error"), e.getMsg());

--- a/libs/librepcb/editor/modelview/pathmodel.h
+++ b/libs/librepcb/editor/modelview/pathmodel.h
@@ -83,6 +83,9 @@ public:
   // Operator Overloadings
   PathModel& operator=(const PathModel& rhs) noexcept;
 
+signals:
+  void pathChanged(const Path& path);
+
 private:  // Data
   Path mPath;
   Vertex mNewVertex;

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>780</width>
-    <height>520</height>
+    <height>551</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -43,6 +43,16 @@
           </property>
           <property name="margin">
            <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cbxRebuildPlanes">
+          <property name="text">
+           <string>Rebuild planes before running checks</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -112,19 +122,6 @@
          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinPthRestring" native="true"/>
         </item>
         <item row="7" column="0">
-         <widget class="QCheckBox" name="cbxMinPthDrillDiameter">
-          <property name="text">
-           <string>Minimum PTH Drill Diameter:</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinPthDrillDiameter" native="true"/>
-        </item>
-        <item row="8" column="0">
          <widget class="QCheckBox" name="cbxMinNpthDrillDiameter">
           <property name="text">
            <string>Minimum NPTH Drill Diameter:</string>
@@ -134,10 +131,40 @@
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
+        <item row="7" column="1">
          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinNpthDrillDiameter" native="true"/>
         </item>
         <item row="9" column="0">
+         <widget class="QCheckBox" name="cbxMinPthDrillDiameter">
+          <property name="text">
+           <string>Minimum PTH Drill Diameter:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinPthDrillDiameter" native="true"/>
+        </item>
+        <item row="10" column="0">
+         <widget class="QCheckBox" name="cbxWarnNpthSlots">
+          <property name="text">
+           <string>Warn About NPTH Slots:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="1">
+         <widget class="QComboBox" name="cbxWarnNpthSlotsConfig">
+          <property name="insertPolicy">
+           <enum>QComboBox::NoInsert</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="0">
          <widget class="QCheckBox" name="cbxCourtyardOffset">
           <property name="text">
            <string>Additional Courtyard Offset:</string>
@@ -147,10 +174,10 @@
           </property>
          </widget>
         </item>
-        <item row="9" column="1">
+        <item row="11" column="1">
          <widget class="librepcb::editor::LengthEdit" name="edtCourtyardOffset" native="true"/>
         </item>
-        <item row="10" column="0">
+        <item row="12" column="0">
          <widget class="QCheckBox" name="cbxMissingConnections">
           <property name="text">
            <string>Check for missing connections</string>
@@ -160,43 +187,7 @@
           </property>
          </widget>
         </item>
-        <item row="12" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="cbxRebuildPlanes">
-          <property name="text">
-           <string>Rebuild planes before running checks</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="13" column="0" colspan="2">
-         <widget class="QProgressBar" name="prgProgress">
-          <property name="value">
-           <number>0</number>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="format">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="0">
+        <item row="13" column="0">
          <widget class="QPushButton" name="btnSelectAll">
           <property name="text">
            <string>Select All/None</string>
@@ -211,6 +202,42 @@
            <bool>false</bool>
           </property>
          </widget>
+        </item>
+        <item row="14" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="15" column="0" colspan="2">
+         <widget class="QProgressBar" name="prgProgress">
+          <property name="value">
+           <number>0</number>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="format">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QCheckBox" name="cbxMinNpthSlotWidth">
+          <property name="text">
+           <string>Minimum NPTH Slot Width:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinNpthSlotWidth" native="true"/>
         </item>
        </layout>
       </widget>
@@ -256,14 +283,30 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>cbxRebuildPlanes</tabstop>
+  <tabstop>cbxClearanceCopperCopper</tabstop>
   <tabstop>edtClearanceCopperCopper</tabstop>
+  <tabstop>cbxClearanceCopperBoard</tabstop>
   <tabstop>edtClearanceCopperBoard</tabstop>
+  <tabstop>cbxClearanceCopperNpth</tabstop>
   <tabstop>edtClearanceCopperNpth</tabstop>
+  <tabstop>cbxMinCopperWidth</tabstop>
   <tabstop>edtMinCopperWidth</tabstop>
+  <tabstop>cbxMinPthRestring</tabstop>
   <tabstop>edtMinPthRestring</tabstop>
-  <tabstop>edtMinPthDrillDiameter</tabstop>
+  <tabstop>cbxMinNpthDrillDiameter</tabstop>
   <tabstop>edtMinNpthDrillDiameter</tabstop>
+  <tabstop>cbxMinNpthSlotWidth</tabstop>
+  <tabstop>edtMinNpthSlotWidth</tabstop>
+  <tabstop>cbxMinPthDrillDiameter</tabstop>
+  <tabstop>edtMinPthDrillDiameter</tabstop>
+  <tabstop>cbxWarnNpthSlots</tabstop>
+  <tabstop>cbxWarnNpthSlotsConfig</tabstop>
+  <tabstop>cbxCourtyardOffset</tabstop>
   <tabstop>edtCourtyardOffset</tabstop>
+  <tabstop>cbxMissingConnections</tabstop>
+  <tabstop>btnSelectAll</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckmessagesdock.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckmessagesdock.cpp
@@ -103,7 +103,9 @@ void BoardDesignRuleCheckMessagesDock::setMessages(
   bool signalsBlocked = mUi->lstMessages->blockSignals(true);
   mUi->lstMessages->clear();
   foreach (const BoardDesignRuleCheckMessage& message, mMessages) {
-    mUi->lstMessages->addItem(message.getMessage());
+    QListWidgetItem* item = new QListWidgetItem(message.getMessage());
+    item->setToolTip(message.getDescription());
+    mUi->lstMessages->addItem(item);
   }
   mUi->lstMessages->blockSignals(signalsBlocked);
 

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -123,6 +123,7 @@ FabricationOutputDialog::FabricationOutputDialog(
   mUi->edtSuffixSolderPasteTop->setText(s.getSuffixSolderPasteTop());
   mUi->edtSuffixSolderPasteBot->setText(s.getSuffixSolderPasteBot());
   mUi->cbxDrillsMerge->setChecked(s.getMergeDrillFiles());
+  mUi->cbxUseG85Slots->setChecked(s.getUseG85SlotCommand());
   mUi->cbxSolderPasteTop->setChecked(s.getEnableSolderPasteTop());
   mUi->cbxSolderPasteBot->setChecked(s.getEnableSolderPasteBot());
 
@@ -222,6 +223,7 @@ void FabricationOutputDialog::btnGenerateClicked() {
     s.setSilkscreenLayersTop(getTopSilkscreenLayers());
     s.setSilkscreenLayersBot(getBotSilkscreenLayers());
     s.setMergeDrillFiles(mUi->cbxDrillsMerge->isChecked());
+    s.setUseG85SlotCommand(mUi->cbxUseG85Slots->isChecked());
     s.setEnableSolderPasteTop(mUi->cbxSolderPasteTop->isChecked());
     s.setEnableSolderPasteBot(mUi->cbxSolderPasteBot->isChecked());
     if (s != mBoard.getFabricationOutputSettings()) {

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
@@ -46,22 +46,52 @@
       <string>Output Files</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="4" column="1">
-       <widget class="QLineEdit" name="edtSuffixSoldermaskTop">
+      <item row="5" column="3">
+       <widget class="QLineEdit" name="edtSuffixSilkscreenBot">
         <property name="maxLength">
          <number>255</number>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_12">
+      <item row="9" column="0">
+       <widget class="QCheckBox" name="cbxSolderPasteTop">
         <property name="text">
-         <string>Drills NPTH:</string>
+         <string>Top Paste Mask
+(Top Stencil):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="2">
+       <widget class="QCheckBox" name="cbxSolderPasteBot">
+        <property name="text">
+         <string>Bottom Paste Mask
+(Bottom Stencil):</string>
         </property>
        </widget>
       </item>
       <item row="5" column="1">
        <widget class="QLineEdit" name="edtSuffixSilkscreenTop">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="3">
+       <widget class="QLineEdit" name="edtBasePath">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Bottom Silkscreen:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QLineEdit" name="edtSuffixSoldermaskBot">
         <property name="maxLength">
          <number>255</number>
         </property>
@@ -74,21 +104,22 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
-       <widget class="QLineEdit" name="edtSuffixSolderPasteTop">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="edtSuffixSoldermaskTop">
         <property name="maxLength">
          <number>255</number>
         </property>
        </widget>
       </item>
-      <item row="8" column="3">
-       <widget class="QLineEdit" name="edtSuffixSolderPasteBot">
-        <property name="enabled">
-         <bool>false</bool>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Top Silkscreen:</string>
         </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="edtSuffixDrillsNpth">
         <property name="maxLength">
          <number>255</number>
         </property>
@@ -104,6 +135,16 @@
         </property>
        </widget>
       </item>
+      <item row="9" column="3">
+       <widget class="QLineEdit" name="edtSuffixSolderPasteBot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
       <item row="7" column="0" colspan="2">
        <widget class="QCheckBox" name="cbxDrillsMerge">
         <property name="text">
@@ -111,64 +152,18 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_8">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Outlines:</string>
+         <string>Base Path:</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="3">
-       <widget class="QLineEdit" name="edtSuffixSilkscreenBot">
-        <property name="maxLength">
-         <number>255</number>
+      <item row="9" column="1">
+       <widget class="QLineEdit" name="edtSuffixSolderPasteTop">
+        <property name="enabled">
+         <bool>false</bool>
         </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Top Silkscreen:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="2">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Drills Merged:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>Bottom Soldermask:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="3">
-       <widget class="QLineEdit" name="edtBasePath">
-        <property name="maxLength">
-         <number>255</number>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>Top Soldermask:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="3">
-       <widget class="QLineEdit" name="edtSuffixSoldermaskBot">
-        <property name="maxLength">
-         <number>255</number>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="3">
-       <widget class="QLineEdit" name="edtSuffixDrillsPth">
         <property name="maxLength">
          <number>255</number>
         </property>
@@ -181,53 +176,24 @@
         </property>
        </widget>
       </item>
+      <item row="6" column="3">
+       <widget class="QLineEdit" name="edtSuffixDrillsPth">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Drills Merged:</string>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="2">
        <widget class="QLabel" name="label_13">
         <property name="text">
          <string>Drills PTH:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Base Path:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="2">
-       <widget class="QCheckBox" name="cbxSolderPasteBot">
-        <property name="text">
-         <string>Bottom Paste Mask
-(Bottom Stencil):</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <widget class="QLineEdit" name="edtSuffixCopperInner">
-        <property name="maxLength">
-         <number>255</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="edtSuffixOutlines">
-        <property name="maxLength">
-         <number>255</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_14">
-        <property name="text">
-         <string>Predefined configs:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QLineEdit" name="edtSuffixDrillsNpth">
-        <property name="maxLength">
-         <number>255</number>
         </property>
        </widget>
       </item>
@@ -262,11 +228,38 @@
         </item>
        </layout>
       </item>
-      <item row="8" column="0">
-       <widget class="QCheckBox" name="cbxSolderPasteTop">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_14">
         <property name="text">
-         <string>Top Paste Mask
-(Top Stencil):</string>
+         <string>Predefined configs:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Top Soldermask:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="text">
+         <string>Drills NPTH:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Bottom Soldermask:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="edtSuffixOutlines">
+        <property name="maxLength">
+         <number>255</number>
         </property>
        </widget>
       </item>
@@ -277,10 +270,10 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="2">
-       <widget class="QLabel" name="label_5">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Bottom Silkscreen:</string>
+         <string>Outlines:</string>
         </property>
        </widget>
       </item>
@@ -288,6 +281,25 @@
        <widget class="QLabel" name="label_9">
         <property name="text">
          <string>Inner Copper:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLineEdit" name="edtSuffixCopperInner">
+        <property name="maxLength">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="4">
+       <widget class="QCheckBox" name="cbxUseG85Slots">
+        <property name="toolTip">
+         <string>Export slots as drilled (G85) instead of routed (G00..G03).
+Not recommended unless the G00..G03 are causing troubles with the PCB manufacturer.
+Attention: Curved slots are not supported in G85 mode (will raise an error).</string>
+        </property>
+        <property name="text">
+         <string>Use drilled slot command in Excellon files (G85)</string>
         </property>
        </widget>
       </item>
@@ -431,6 +443,7 @@
   <tabstop>edtSuffixDrillsPth</tabstop>
   <tabstop>cbxDrillsMerge</tabstop>
   <tabstop>edtSuffixDrills</tabstop>
+  <tabstop>cbxUseG85Slots</tabstop>
   <tabstop>cbxSolderPasteTop</tabstop>
   <tabstop>edtSuffixSolderPasteTop</tabstop>
   <tabstop>cbxSolderPasteBot</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
@@ -249,7 +249,8 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
 
   if (flags.testFlag(FindFlag::Holes)) {
     foreach (BI_Hole* hole, board->getHoles()) {
-      processItem(hole, hole->getPosition(), 5);
+      processItem(hole,
+                  hole->getHole().getPath()->getVertices().first().getPos(), 5);
     }
   }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addhole.cpp
@@ -139,8 +139,9 @@ bool BoardEditorState_AddHole::addHole(const Point& pos) noexcept {
   try {
     mContext.undoStack.beginCmdGroup(tr("Add hole to board"));
     mIsUndoCmdActive = true;
-    mCurrentHoleToPlace =
-        new BI_Hole(*board, Hole(Uuid::createRandom(), pos, mLastDiameter));
+    mCurrentHoleToPlace = new BI_Hole(
+        *board,
+        Hole(Uuid::createRandom(), mLastDiameter, makeNonEmptyPath(pos)));
     QScopedPointer<CmdBoardHoleAdd> cmdAdd(
         new CmdBoardHoleAdd(*mCurrentHoleToPlace));
     mContext.undoStack.appendToCmdGroup(cmdAdd.take());
@@ -155,7 +156,7 @@ bool BoardEditorState_AddHole::addHole(const Point& pos) noexcept {
 
 bool BoardEditorState_AddHole::updatePosition(const Point& pos) noexcept {
   if (mCurrentHoleEditCmd) {
-    mCurrentHoleEditCmd->setPosition(pos, true);
+    mCurrentHoleEditCmd->setPath(makeNonEmptyPath(pos), true);
     return true;  // Event handled
   } else {
     return false;
@@ -167,7 +168,7 @@ bool BoardEditorState_AddHole::fixPosition(const Point& pos) noexcept {
 
   try {
     if (mCurrentHoleEditCmd) {
-      mCurrentHoleEditCmd->setPosition(pos, false);
+      mCurrentHoleEditCmd->setPath(makeNonEmptyPath(pos), false);
       mContext.undoStack.appendToCmdGroup(mCurrentHoleEditCmd.take());
     }
     mContext.undoStack.commitCmdGroup();

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -176,8 +176,9 @@ bool BoardEditorState_Select::processImportDxf() noexcept {
       }
       for (const auto& circle : import.getCircles()) {
         if (dialog.getImportCirclesAsDrills()) {
-          data->getHoles().append(std::make_shared<Hole>(
-              Uuid::createRandom(), circle.position, circle.diameter));
+          data->getHoles().append(
+              std::make_shared<Hole>(Uuid::createRandom(), circle.diameter,
+                                     makeNonEmptyPath(circle.position)));
         } else {
           data->getPolygons().append(std::make_shared<Polygon>(
               Uuid::createRandom(), dialog.getLayerName(),
@@ -976,7 +977,8 @@ bool BoardEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
       case BI_Base::Type_t::Hole: {
         BI_Hole* hole = dynamic_cast<BI_Hole*>(selectedItem);
         Q_ASSERT(hole);
-        const Point pos = hole->getPosition();
+        const Point pos =
+            hole->getHole().getPath()->getVertices().first().getPos();
 
         mb.addAction(
             cmd.properties.createAction(

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
@@ -132,7 +132,7 @@ CmdDragSelectedBoardItems::CmdDragSelectedBoardItems(
   }
   foreach (BI_Hole* hole, query->getHoles()) {
     Q_ASSERT(hole);
-    mCenterPos += hole->getPosition();
+    mCenterPos += hole->getHole().getPath()->getVertices().first().getPos();
     ++count;
     CmdHoleEdit* cmd = new CmdHoleEdit(hole->getHole());
     mHoleEditCmds.append(cmd);

--- a/libs/librepcb/editor/project/cmd/cmdflipselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdflipselectedboarditems.cpp
@@ -137,7 +137,7 @@ bool CmdFlipSelectedBoardItems::performExecute() {
     }
   }
   foreach (BI_Hole* hole, query->getHoles()) {
-    center += hole->getPosition();
+    center += hole->getHole().getPath()->getVertices().first().getPos();
     ++count;
   }
   if (count > 0) {
@@ -235,10 +235,10 @@ bool CmdFlipSelectedBoardItems::performExecute() {
     execNewChildCmd(cmd.take());  // can throw
   }
 
-  // move all holes
+  // mirror all holes
   foreach (BI_Hole* hole, query->getHoles()) {
     QScopedPointer<CmdHoleEdit> cmd(new CmdHoleEdit(hole->getHole()));
-    cmd->setPosition(hole->getPosition().mirrored(mOrientation, center), false);
+    cmd->mirror(mOrientation, center, false);
     execNewChildCmd(cmd.take());  // can throw
   }
 

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -282,7 +282,7 @@ bool CmdPasteBoardItems::performExecute() {
   // Paste holes
   for (const Hole& hole : mData->getHoles()) {
     Hole copy(Uuid::createRandom(), hole);  // assign new UUID
-    copy.setPosition(copy.getPosition() + mPosOffset);  // move
+    copy.setPath(NonEmptyPath(copy.getPath()->translated(mPosOffset)));  // move
     BI_Hole* item = new BI_Hole(mBoard, copy);
     item->setSelected(true);
     execNewChildCmd(new CmdBoardHoleAdd(*item));

--- a/libs/librepcb/editor/utils/measuretool.cpp
+++ b/libs/librepcb/editor/utils/measuretool.cpp
@@ -158,8 +158,10 @@ void MeasureTool::setBoard(const Board* board) noexcept {
       mSnapCandidates.insert(text->getPosition());
     }
     foreach (const BI_Hole* hole, board->getHoles()) {
-      mSnapCandidates |= snapCandidatesFromCircle(
-          hole->getPosition(), *hole->getHole().getDiameter());
+      foreach (const Vertex& vertex, hole->getHole().getPath()->getVertices()) {
+        mSnapCandidates |= snapCandidatesFromCircle(
+            vertex.getPos(), *hole->getHole().getDiameter());
+      }
     }
   }
 }
@@ -332,8 +334,10 @@ QSet<Point> MeasureTool::snapCandidatesFromFootprint(
     candidates.insert(transform.map(s.getPosition()));
   }
   for (const Hole& h : footprint.getHoles()) {
-    candidates |= snapCandidatesFromCircle(transform.map(h.getPosition()),
-                                           *h.getDiameter());
+    foreach (const Vertex& vertex, h.getPath()->getVertices()) {
+      candidates |= snapCandidatesFromCircle(transform.map(vertex.getPos()),
+                                             *h.getDiameter());
+    }
   }
   return candidates;
 }

--- a/libs/librepcb/editor/widgets/patheditorwidget.cpp
+++ b/libs/librepcb/editor/widgets/patheditorwidget.cpp
@@ -75,6 +75,9 @@ PathEditorWidget::PathEditorWidget(QWidget* parent) noexcept
   QVBoxLayout* layout = new QVBoxLayout(this);
   layout->setContentsMargins(0, 0, 0, 0);
   layout->addWidget(mView.data());
+
+  connect(mModel.data(), &PathModel::pathChanged, this,
+          &PathEditorWidget::pathChanged);
 }
 
 PathEditorWidget::~PathEditorWidget() noexcept {
@@ -83,6 +86,10 @@ PathEditorWidget::~PathEditorWidget() noexcept {
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+void PathEditorWidget::setFrameShape(QFrame::Shape shape) noexcept {
+  mView->setFrameShape(shape);
+}
 
 void PathEditorWidget::setReadOnly(bool readOnly) noexcept {
   mView->setReadOnly(readOnly);

--- a/libs/librepcb/editor/widgets/patheditorwidget.h
+++ b/libs/librepcb/editor/widgets/patheditorwidget.h
@@ -58,6 +58,7 @@ public:
   ~PathEditorWidget() noexcept;
 
   // General Methods
+  void setFrameShape(QFrame::Shape shape) noexcept;
   void setReadOnly(bool readOnly) noexcept;
   void setPath(const Path& path) noexcept;
   const Path& getPath() const noexcept;
@@ -65,6 +66,9 @@ public:
 
   // Operator Overloadings
   PathEditorWidget& operator=(const PathEditorWidget& rhs) = delete;
+
+signals:
+  void pathChanged(const Path& path);
 
 private:  // Data
   QScopedPointer<PathModel> mModel;

--- a/tests/cli/open_project/test_export_pcb_fabrication_data.py
+++ b/tests/cli/open_project/test_export_pcb_fabrication_data.py
@@ -364,6 +364,7 @@ def test_export_with_custom_settings(cli, project):
           (suffix_pth "DRILLS-PTH.drl")
           (suffix_npth "DRILLS-NPTH.drl")
           (suffix_merged "DRILLS.drl")
+          (g85_slots false)
         )
         (solderpaste_top (create true) (suffix "SOLDERPASTE-TOP.gbr"))
         (solderpaste_bot (create true) (suffix "SOLDERPASTE-BOTTOM.gbr"))

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   core/attribute/attributetest.cpp
   core/attribute/attributetypetest.cpp
   core/attribute/attributeunittest.cpp
+  core/export/excellongeneratortest.cpp
   core/export/gerberaperturelisttest.cpp
   core/export/gerberattributetest.cpp
   core/export/gerberattributewritertest.cpp

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(
   core/fileio/filepathtest.cpp
   core/fileio/transactionaldirectorytest.cpp
   core/fileio/transactionalfilesystemtest.cpp
+  core/geometry/holetest.cpp
   core/geometry/pathtest.cpp
   core/geometry/polygontest.cpp
   core/geometry/stroketexttest.cpp

--- a/tests/unittests/core/export/excellongeneratortest.cpp
+++ b/tests/unittests/core/export/excellongeneratortest.cpp
@@ -1,0 +1,206 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/core/export/excellongenerator.h>
+#include <librepcb/core/fileio/fileutils.h>
+#include <librepcb/core/types/uuid.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class ExcellonGeneratorTest : public ::testing::Test {
+protected:
+  std::string makeComparable(QString str) const noexcept {
+    // replace volatile data in exported files with well-known, constant data
+    str.replace(QRegularExpression(
+                    "TF\\.GenerationSoftware,LibrePCB,LibrePCB,[^\\s\\*]*"),
+                "TF.GenerationSoftware,LibrePCB,LibrePCB,0.1.2");
+    str.replace(QRegularExpression("TF\\.CreationDate,[^\\s\\*]*"),
+                "TF.CreationDate,2019-01-02T03:04:05");
+    return str.toStdString();
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(ExcellonGeneratorTest, testCircularDrills) {
+  ExcellonGenerator gen(
+      QDateTime(QDate(2000, 2, 1), QTime(1, 2, 3, 4), Qt::OffsetFromUTC, 3600),
+      "My Project", Uuid::fromString("bdf7bea5-b88e-41b2-be85-c1604e8ddfca"),
+      "1.0", ExcellonGenerator::Plating::Mixed, 1, 4);
+
+  gen.drill(Point(111, 222), PositiveLength(500000), true,
+            ExcellonGenerator::Function::ComponentDrill);
+  gen.drill(Point(333, 444), PositiveLength(600000), false,
+            ExcellonGenerator::Function::MechanicalDrill);
+  gen.drill(makeNonEmptyPath(Point(555, 666)), PositiveLength(500000), true,
+            ExcellonGenerator::Function::ComponentDrill);
+
+  gen.generate();
+  EXPECT_EQ(
+      "M48\n"
+      "; #@! TF.GenerationSoftware,LibrePCB,LibrePCB,0.1.2\n"
+      "; #@! TF.CreationDate,2019-01-02T03:04:05\n"
+      "; #@! TF.ProjectId,My Project,bdf7bea5-b88e-41b2-be85-c1604e8ddfca,1.0\n"
+      "; #@! TF.Part,Single\n"
+      "; #@! TF.SameCoordinates\n"
+      "; #@! TF.FileFunction,MixedPlating,1,4\n"
+      "FMAT,2\n"
+      "METRIC,TZ\n"
+      "; #@! TA.AperFunction,Plated,PTH,ComponentDrill\n"
+      "T1C0.5\n"
+      "; #@! TA.AperFunction,NonPlated,NPTH,MechanicalDrill\n"
+      "T2C0.6\n"
+      "%\n"
+      "G90\n"
+      "G05\n"
+      "M71\n"
+      "T1\n"
+      "X0.000555Y0.000666\n"
+      "X0.000111Y0.000222\n"
+      "T2\n"
+      "X0.000333Y0.000444\n"
+      "T0\n"
+      "M30\n",
+      makeComparable(gen.toStr()));
+}
+
+TEST_F(ExcellonGeneratorTest, testSlotRout) {
+  ExcellonGenerator gen(
+      QDateTime(QDate(2000, 2, 1), QTime(1, 2, 3, 4), Qt::OffsetFromUTC, 3600),
+      "My Project", Uuid::fromString("bdf7bea5-b88e-41b2-be85-c1604e8ddfca"),
+      "1.0", ExcellonGenerator::Plating::Mixed, 1, 4);
+
+  gen.drill(NonEmptyPath(Path({
+                Vertex(Point(111, 222), Angle::deg90()),
+                Vertex(Point(333, 444), Angle::deg0()),
+                Vertex(Point(555, 666), Angle::deg0()),
+            })),
+            PositiveLength(500000), false,
+            ExcellonGenerator::Function::MechanicalDrill);
+
+  gen.generate();
+  EXPECT_EQ(
+      "M48\n"
+      "; #@! TF.GenerationSoftware,LibrePCB,LibrePCB,0.1.2\n"
+      "; #@! TF.CreationDate,2019-01-02T03:04:05\n"
+      "; #@! TF.ProjectId,My Project,bdf7bea5-b88e-41b2-be85-c1604e8ddfca,1.0\n"
+      "; #@! TF.Part,Single\n"
+      "; #@! TF.SameCoordinates\n"
+      "; #@! TF.FileFunction,MixedPlating,1,4\n"
+      "FMAT,2\n"
+      "METRIC,TZ\n"
+      "; #@! TA.AperFunction,NonPlated,NPTH,MechanicalDrill\n"
+      "T1C0.5\n"
+      "%\n"
+      "G90\n"
+      "G05\n"
+      "M71\n"
+      "T1\n"
+      "G00X0.000111Y0.000222\n"
+      "M15\n"
+      "G03X0.000333Y0.000444A0.000222\n"
+      "G01X0.000555Y0.000666\n"
+      "M16\n"
+      "G05\n"
+      "T0\n"
+      "M30\n",
+      makeComparable(gen.toStr()));
+}
+
+TEST_F(ExcellonGeneratorTest, testSlotG85) {
+  ExcellonGenerator gen(
+      QDateTime(QDate(2000, 2, 1), QTime(1, 2, 3, 4), Qt::OffsetFromUTC, 3600),
+      "My Project", Uuid::fromString("bdf7bea5-b88e-41b2-be85-c1604e8ddfca"),
+      "1.0", ExcellonGenerator::Plating::Mixed, 1, 4);
+  gen.setUseG85Slots(true);
+
+  gen.drill(NonEmptyPath(Path({
+                Vertex(Point(111, 222), Angle::deg0()),
+                Vertex(Point(333, 444), Angle::deg0()),
+                Vertex(Point(555, 666), Angle::deg0()),
+            })),
+            PositiveLength(500000), false,
+            ExcellonGenerator::Function::MechanicalDrill);
+
+  gen.generate();
+  EXPECT_EQ(
+      "M48\n"
+      "; #@! TF.GenerationSoftware,LibrePCB,LibrePCB,0.1.2\n"
+      "; #@! TF.CreationDate,2019-01-02T03:04:05\n"
+      "; #@! TF.ProjectId,My Project,bdf7bea5-b88e-41b2-be85-c1604e8ddfca,1.0\n"
+      "; #@! TF.Part,Single\n"
+      "; #@! TF.SameCoordinates\n"
+      "; #@! TF.FileFunction,MixedPlating,1,4\n"
+      "FMAT,2\n"
+      "METRIC,TZ\n"
+      "; #@! TA.AperFunction,NonPlated,NPTH,MechanicalDrill\n"
+      "T1C0.5\n"
+      "%\n"
+      "G90\n"
+      "G05\n"
+      "M71\n"
+      "T1\n"
+      "X0.000111Y0.000222G85X0.000333Y0.000444\n"
+      "X0.000333Y0.000444G85X0.000555Y0.000666\n"
+      "T0\n"
+      "M30\n",
+      makeComparable(gen.toStr()));
+}
+
+TEST_F(ExcellonGeneratorTest, testCurvedSlotG85) {
+  ExcellonGenerator gen(
+      QDateTime(QDate(2000, 2, 1), QTime(1, 2, 3, 4), Qt::OffsetFromUTC, 3600),
+      "My Project", Uuid::fromString("bdf7bea5-b88e-41b2-be85-c1604e8ddfca"),
+      "1.0", ExcellonGenerator::Plating::Mixed, 1, 4);
+  gen.setUseG85Slots(true);
+
+  gen.drill(NonEmptyPath(Path({
+                Vertex(Point(111, 222), Angle::deg90()),
+                Vertex(Point(333, 444), Angle::deg0()),
+                Vertex(Point(555, 666), Angle::deg0()),
+            })),
+            PositiveLength(500000), false,
+            ExcellonGenerator::Function::MechanicalDrill);
+
+  EXPECT_THROW(gen.generate(), RuntimeError);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -52,6 +52,40 @@ TEST_F(PathTest, testDefaultConstructorCreatesEmptyPath) {
   EXPECT_EQ(0, path.getVertices().count());
 }
 
+TEST_F(PathTest, testIsCurvedFalse) {
+  EXPECT_FALSE(Path().isCurved());
+  EXPECT_FALSE(Path({
+                        Vertex(Point(0, 0)),
+                    })
+                   .isCurved());
+  EXPECT_FALSE(Path({
+                        Vertex(Point(0, 0)),
+                        Vertex(Point(1, 1)),
+                    })
+                   .isCurved());
+}
+
+// Ensure that the angle of the last vertex is not relevant.
+TEST_F(PathTest, testIsCurvedLastVertexFalse) {
+  EXPECT_FALSE(Path({
+                        Vertex(Point(1, 1), Angle::deg90()),
+                    })
+                   .isCurved());
+  EXPECT_FALSE(Path({
+                        Vertex(Point(0, 0)),
+                        Vertex(Point(1, 1), Angle::deg90()),
+                    })
+                   .isCurved());
+}
+
+TEST_F(PathTest, testIsCurvedTrue) {
+  EXPECT_TRUE(Path({
+                       Vertex(Point(0, 0), Angle::deg90()),
+                       Vertex(Point(1, 1)),
+                   })
+                  .isCurved());
+}
+
 TEST_F(PathTest, testGetTotalStraightLength) {
   QVector<Vertex> vertices;
   EXPECT_EQ(UnsignedLength(0), Path(vertices).getTotalStraightLength());

--- a/tests/unittests/core/project/board/boardfabricationoutputsettingstest.cpp
+++ b/tests/unittests/core/project/board/boardfabricationoutputsettingstest.cpp
@@ -61,6 +61,7 @@ TEST_F(BoardFabricationOutputSettingsTest, testSerializeAndDeserialize) {
   obj1.setSilkscreenLayersTop({"o", "p"});
   obj1.setSilkscreenLayersBot({"q", "r"});
   obj1.setMergeDrillFiles(!obj1.getMergeDrillFiles());
+  obj1.setUseG85SlotCommand(!obj1.getUseG85SlotCommand());
   obj1.setEnableSolderPasteTop(!obj1.getEnableSolderPasteTop());
   obj1.setEnableSolderPasteBot(!obj1.getEnableSolderPasteBot());
   SExpression sexpr1 = SExpression::createList("obj");

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -241,8 +241,10 @@ TEST_F(EagleTypeConverterTest, testConvertCircleFilled) {
 TEST_F(EagleTypeConverterTest, testConvertHole) {
   QString xml = "<hole x=\"1\" y=\"2\" drill=\"3.5\"/>";
   auto out = C::convertHole(parseagle::Hole(dom(xml)));
-  EXPECT_EQ(Point(1000000, 2000000), out->getPosition());
   EXPECT_EQ(PositiveLength(3500000), out->getDiameter());
+  EXPECT_EQ(1, out->getPath()->getVertices().count());
+  EXPECT_EQ(Point(1000000, 2000000),
+            out->getPath()->getVertices().first().getPos());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertTextValue) {

--- a/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
@@ -123,10 +123,11 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       Alignment(HAlign::center(), VAlign::bottom()), true, false);
 
   std::shared_ptr<Hole> hole1 = std::make_shared<Hole>(
-      Uuid::createRandom(), Point(1, 2), PositiveLength(3));
+      Uuid::createRandom(), PositiveLength(3), makeNonEmptyPath(Point(1, 2)));
 
-  std::shared_ptr<Hole> hole2 = std::make_shared<Hole>(
-      Uuid::createRandom(), Point(10, 20), PositiveLength(30));
+  std::shared_ptr<Hole> hole2 =
+      std::make_shared<Hole>(Uuid::createRandom(), PositiveLength(30),
+                             makeNonEmptyPath(Point(10, 20)));
 
   // Create object
   FootprintClipboardData obj1(uuid, packagePads, pos);

--- a/tests/unittests/editor/project/boardeditor/boardclipboarddatatest.cpp
+++ b/tests/unittests/editor/project/boardeditor/boardclipboarddatatest.cpp
@@ -180,10 +180,11 @@ TEST(BoardClipboardDataTest, testToFromMimeDataPopulated) {
                                       Vertex(Point(40, 50), Angle(60))}));
 
   std::shared_ptr<Hole> hole1 = std::make_shared<Hole>(
-      Uuid::createRandom(), Point(1, 2), PositiveLength(3));
+      Uuid::createRandom(), PositiveLength(3), makeNonEmptyPath(Point(1, 2)));
 
-  std::shared_ptr<Hole> hole2 = std::make_shared<Hole>(
-      Uuid::createRandom(), Point(10, 20), PositiveLength(30));
+  std::shared_ptr<Hole> hole2 =
+      std::make_shared<Hole>(Uuid::createRandom(), PositiveLength(30),
+                             makeNonEmptyPath(Point(10, 20)));
 
   // Create object
   BoardClipboardData obj1(uuid, pos);


### PR DESCRIPTION
### Summary

Replaces #510. But instead of specifying slots with just a width and height property (as originally intended by a `DrillSize` class), I decided to make slots even more flexible. Since the Excellon file format supports creating arbitrary slots by movement commands (G00..G03), let's reflect that flexibility in LibrePCB as well.

### File Format

So far, a hole object was stored this way:

```lisp
(hole 4ab2be01-222a-4f59-b239-e1de803ba96d (diameter 3.0) (position 2.54 2.54))
```

Now a hole is specified by vertices (exactly the same way as for polygons):

```lisp
(hole 4ab2be01-222a-4f59-b239-e1de803ba96d (diameter 3.0)
 (vertex (position 2.54 2.54) (angle 0.0))
)
```

Holes with only one vertex are circular. Holes with multiple vertices are slots. They can even be curved (`angle` != 0):

```lisp
(hole 4ab2be01-222a-4f59-b239-e1de803ba96d (diameter 1.6)
 (vertex (position 20.691974 1.641974) (angle 90.0))
 (vertex (position 22.0 3.438026) (angle 0.0))
 (vertex (position 23.0 5.0) (angle -90.0))
 (vertex (position 24.0 8.0) (angle 0.0))
)
```

### User Interface

The hole properties dialog allows to specify holes either as circular drills, simple linear slots, or arbitrary slots:

![librepcb-npth-slots](https://user-images.githubusercontent.com/5374821/206858611-e3fc218a-bc91-4233-b960-b463a75054a9.gif)

The editors do not yet contain a tool to draw slots. Currently you can just add circular holes and and then convert them to slots by modifying their properties. A slot tool could be added later without needing any file format change.

### Excellon Export

By default, slotted holes are exported with commands G00..G03 in the Excellon drill file. This seems to be the recommended way (KiCad doesn't recommend G85 and the [XNC Specs](https://www.ucamco.com/files/downloads/file_en/452/xnc-format-specification-revision-2021-11_en.pdf?2ccd0fdd6dd78e87ed52185bbd06038b) from Ucamco doesn't even mention G85; see also https://github.com/LibrePCB/LibrePCB/pull/510#issuecomment-528586891).

However, there might be manufacturers which require slots exported as G85 slot commands. Even Gerbv does only render G85 correctly, but not G00..G03 which is quite a shame. Therefore I made it configurable which command to use:

![image](https://user-images.githubusercontent.com/5374821/206860196-3d68feff-13ca-411f-aeae-734bad664e6f.png)

Since G85 cannot draw arcs, it can be used only for boards which do not contain curved slots. If there are curved slots, an error occurs during the export.

### DRC

The support of curved slots unfortunately varies between different PCB manufacturers. Multi-segment slots maybe too, I'm not sure. And whether G85 shall be used or not, also depends on the manufacturer. To avoid surprises during production, I added a new DRC rule which allows to warn if slots of a particular style are used in a board:

![image](https://user-images.githubusercontent.com/5374821/206862565-486a361d-a4b7-40b5-94a6-71e5647c9d0f.png)

Fixes #505.