### PR TITLE
Add support for slotted pads

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -256,6 +256,8 @@ add_library(
   library/pkg/msg/msgpadclearanceviolation.h
   library/pkg/msg/msgpadoverlapswithplacement.cpp
   library/pkg/msg/msgpadoverlapswithplacement.h
+  library/pkg/msg/msgpadrestringviolation.cpp
+  library/pkg/msg/msgpadrestringviolation.h
   library/pkg/msg/msgwrongfootprinttextlayer.cpp
   library/pkg/msg/msgwrongfootprinttextlayer.h
   library/pkg/package.cpp

--- a/libs/librepcb/core/library/pkg/msg/msgpadrestringviolation.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadrestringviolation.cpp
@@ -17,61 +17,43 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
-
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "msgpadrestringviolation.h"
 
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
-
 /*******************************************************************************
- *  Class PackageCheck
+ *  Constructors / Destructor
  ******************************************************************************/
 
-/**
- * @brief The PackageCheck class
- */
-class PackageCheck : public LibraryElementCheck {
-public:
-  // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+MsgPadRestringViolation::MsgPadRestringViolation(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName,
+    const Length& restring) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        tr("Restring of pad '%1' in '%3'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("Pads should have at least %1 restring (copper around each pad "
+           "hole). Note that this value is just a general recommendation, the "
+           "exact value depends on the capabilities of the PCB manufacturer.")
+            .arg(QString::number(restring.toMm() * 1000) % "μm")),
+    mFootprint(footprint),
+    mPad(pad) {
+}
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
-
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsRestring(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
-};
+MsgPadRestringViolation::~MsgPadRestringViolation() noexcept {
+}
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
 }  // namespace librepcb
-
-#endif

--- a/libs/librepcb/core/library/pkg/msg/msgpadrestringviolation.h
+++ b/libs/librepcb/core/library/pkg/msg/msgpadrestringviolation.h
@@ -17,13 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
+#ifndef LIBREPCB_CORE_MSGPADRESTRINGVIOLATION_H
+#define LIBREPCB_CORE_MSGPADRESTRINGVIOLATION_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "../../../types/length.h"
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
@@ -32,40 +33,42 @@
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
+class Footprint;
+class FootprintPad;
+class Hole;
 
 /*******************************************************************************
- *  Class PackageCheck
+ *  Class MsgPadRestringViolation
  ******************************************************************************/
 
 /**
- * @brief The PackageCheck class
+ * @brief The MsgPadRestringViolation class
  */
-class PackageCheck : public LibraryElementCheck {
+class MsgPadRestringViolation final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadRestringViolation)
+
 public:
   // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+  MsgPadRestringViolation() = delete;
+  MsgPadRestringViolation(std::shared_ptr<const Footprint> footprint,
+                          std::shared_ptr<const FootprintPad> pad,
+                          const QString& pkgPadName,
+                          const Length& restring) noexcept;
+  MsgPadRestringViolation(const MsgPadRestringViolation& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mPad(other.mPad) {}
+  virtual ~MsgPadRestringViolation() noexcept;
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad1() const noexcept { return mPad; }
 
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsRestring(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheck.cpp
@@ -30,6 +30,7 @@
 #include "msg/msgmissingfootprintvalue.h"
 #include "msg/msgpadclearanceviolation.h"
 #include "msg/msgpadoverlapswithplacement.h"
+#include "msg/msgpadrestringviolation.h"
 #include "msg/msgwrongfootprinttextlayer.h"
 #include "package.h"
 
@@ -63,6 +64,7 @@ LibraryElementCheckMessageList PackageCheck::runChecks() const {
   checkWrongTextLayers(msgs);
   checkPadsClearanceToPads(msgs);
   checkPadsClearanceToPlacement(msgs);
+  checkPadsRestring(msgs);
   return msgs;
 }
 
@@ -223,6 +225,65 @@ void PackageCheck::checkPadsClearanceToPlacement(MsgList& msgs) const {
         msgs.append(std::make_shared<MsgPadOverlapsWithPlacement>(
             footprint, pad, pkgPad ? *pkgPad->getName() : QString(),
             clearance));
+      }
+    }
+  }
+}
+
+void PackageCheck::checkPadsRestring(MsgList& msgs) const {
+  const Length restring(150000);  // 150 µm
+  const Length tolerance(10);  // 0.01 µm, to avoid rounding issues
+
+  // Check all footprints.
+  for (auto itFtp = mPackage.getFootprints().begin();
+       itFtp != mPackage.getFootprints().end(); ++itFtp) {
+    std::shared_ptr<const Footprint> footprint = itFtp.ptr();
+
+    // Check all pads.
+    for (auto itPad = (*itFtp).getPads().begin();
+         itPad != (*itFtp).getPads().end(); ++itPad) {
+      std::shared_ptr<const FootprintPad> pad = itPad.ptr();
+      std::shared_ptr<const PackagePad> pkgPad = pad->getPackagePadUuid()
+          ? mPackage.getPads().find(*pad->getPackagePadUuid())
+          : nullptr;
+      const QPainterPath padPathPx = pad->getOutline().toQPainterPathPx();
+
+      // Check all holes.
+      bool emitWarning = false;
+      for (auto itHole1 = (*itPad).getHoles().begin();
+           itHole1 != (*itPad).getHoles().end(); ++itHole1) {
+        std::shared_ptr<const Hole> hole1 = itHole1.ptr();
+        const QVector<Path> hole1Paths = hole1->getPath()->toOutlineStrokes(
+            hole1->getDiameter() + PositiveLength((restring * 2) - tolerance));
+        const QPainterPath hole1PathPx =
+            Path::toQPainterPathPx(hole1Paths, true);
+
+        // Check restrings.
+        if (!padPathPx.contains(hole1PathPx)) {
+          emitWarning = true;
+        } else {
+          // Compare with all holes *after* hole1 to avoid redundant checks.
+          // So, don't initialize the iterator with begin() but with hole1 + 1.
+          auto itHole2 = itHole1;
+          for (++itHole2; itHole2 != (*itPad).getHoles().end(); ++itHole2) {
+            std::shared_ptr<const Hole> hole2 = itHole2.ptr();
+            const QVector<Path> hole2Paths =
+                hole2->getPath()->toOutlineStrokes(hole2->getDiameter());
+            const QPainterPath hole2PathPx =
+                Path::toQPainterPathPx(hole2Paths, true);
+
+            // Now check if the restring is really too small.
+            if (hole1PathPx.intersects(hole2PathPx)) {
+              emitWarning = true;
+            }
+          }
+        }
+      }
+
+      // Only show one warning even if there are multiple violations.
+      if (emitWarning) {
+        msgs.append(std::make_shared<MsgPadRestringViolation>(
+            footprint, pad, pkgPad ? *pkgPad->getName() : QString(), restring));
       }
     }
   }

--- a/libs/librepcb/core/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheck.cpp
@@ -156,9 +156,8 @@ void PackageCheck::checkPadsClearanceToPads(MsgList& msgs) const {
         const QPainterPath pad2PathPx = pad2Path.toQPainterPathPx();
 
         // Only warn if both pads have copper on the same board side.
-        if ((pad1->getBoardSide() == pad2->getBoardSide()) ||
-            (pad1->getBoardSide() == FootprintPad::BoardSide::THT) ||
-            (pad2->getBoardSide() == FootprintPad::BoardSide::THT)) {
+        if ((pad1->getComponentSide() == pad2->getComponentSide()) ||
+            (pad1->isTht()) || (pad2->isTht())) {
           // Only warn if both pads have different net signal, or one of them
           // is unconnected (an unconnected pad is considered as a different
           // net signal).

--- a/libs/librepcb/core/project/board/boardairwiresbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardairwiresbuilder.cpp
@@ -72,11 +72,10 @@ QVector<QPair<Point, Point>> BoardAirWiresBuilder::buildAirWires() const {
       if (&pad->getBoard() != &mBoard) continue;
       const Point& pos = pad->getPosition();
       int id = builder.addPoint(pos);
-      pointLayerMap[id] = std::make_pair(
-          pos,
-          (pad->getLibPad().getBoardSide() == FootprintPad::BoardSide::THT)
-              ? QString()  // on all layers
-              : pad->getLayerName());
+      pointLayerMap[id] = std::make_pair(pos,
+                                         (pad->getLibPad().isTht())
+                                             ? QString()  // on all layers
+                                             : pad->getLayerName());
       anchorMap[pad] = id;
     }
   }

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -121,7 +121,7 @@ void BoardClipperPathGenerator::addHoles(const Length& offset) {
 }
 
 void BoardClipperPathGenerator::addCopper(
-    const QString& layerName, const QVector<const NetSignal*>& netsignals) {
+    const QString& layerName, const QSet<const NetSignal*>& netsignals) {
   // polygons
   foreach (const BI_Polygon* polygon, mBoard.getPolygons()) {
     if (polygon->getPolygon().getLayerName() != layerName) {

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -120,12 +120,14 @@ void BoardClipperPathGenerator::addHoles(const Length& offset) {
   }
 }
 
-void BoardClipperPathGenerator::addCopper(const QString& layerName,
-                                          const NetSignal* netsignal) {
+void BoardClipperPathGenerator::addCopper(
+    const QString& layerName, const QVector<const NetSignal*>& netsignals) {
   // polygons
   foreach (const BI_Polygon* polygon, mBoard.getPolygons()) {
-    if ((polygon->getPolygon().getLayerName() != layerName) ||
-        (netsignal != nullptr)) {
+    if (polygon->getPolygon().getLayerName() != layerName) {
+      continue;
+    }
+    if ((!netsignals.isEmpty()) && (!netsignals.contains(nullptr))) {
       continue;
     }
     // outline
@@ -150,8 +152,10 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
 
   // stroke texts
   foreach (const BI_StrokeText* text, mBoard.getStrokeTexts()) {
-    if ((text->getText().getLayerName() != layerName) ||
-        (netsignal != nullptr)) {
+    if (text->getText().getLayerName() != layerName) {
+      continue;
+    }
+    if ((!netsignals.isEmpty()) && (!netsignals.contains(nullptr))) {
       continue;
     }
     PositiveLength width(qMax(*text->getText().getStrokeWidth(), Length(1)));
@@ -167,8 +171,11 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
 
   // planes
   foreach (const BI_Plane* plane, mBoard.getPlanes()) {
-    if ((plane->getLayerName() != layerName) ||
-        (&plane->getNetSignal() != netsignal)) {
+    if (plane->getLayerName() != layerName) {
+      continue;
+    }
+    if ((!netsignals.isEmpty()) &&
+        (!netsignals.contains(&plane->getNetSignal()))) {
       continue;
     }
     foreach (const Path& p, plane->getFragments()) {
@@ -184,7 +191,10 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
     // polygons
     for (const Polygon& polygon : device->getLibFootprint().getPolygons()) {
       GraphicsLayerName polygonLayer = transform.map(polygon.getLayerName());
-      if ((polygonLayer != layerName) || (netsignal != nullptr)) {
+      if (polygonLayer != layerName) {
+        continue;
+      }
+      if ((!netsignals.isEmpty()) && (!netsignals.contains(nullptr))) {
         continue;
       }
       Path path = transform.map(polygon.getPath());
@@ -208,7 +218,10 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
     // circles
     for (const Circle& circle : device->getLibFootprint().getCircles()) {
       GraphicsLayerName circleLayer = transform.map(circle.getLayerName());
-      if ((circleLayer != layerName) || (netsignal != nullptr)) {
+      if (circleLayer != layerName) {
+        continue;
+      }
+      if ((!netsignals.isEmpty()) && (!netsignals.contains(nullptr))) {
         continue;
       }
       Path path = Path::circle(circle.getDiameter())
@@ -232,8 +245,10 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
     // stroke texts
     foreach (const BI_StrokeText* text, device->getStrokeTexts()) {
       // Do *not* mirror layer since it is independent of the device!
-      if ((*text->getText().getLayerName() != layerName) ||
-          (netsignal != nullptr)) {
+      if (*text->getText().getLayerName() != layerName) {
+        continue;
+      }
+      if ((!netsignals.isEmpty()) && (!netsignals.contains(nullptr))) {
         continue;
       }
       PositiveLength width(qMax(*text->getText().getStrokeWidth(), Length(1)));
@@ -248,8 +263,11 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
 
     // pads
     foreach (const BI_FootprintPad* pad, device->getPads()) {
-      if ((!pad->isOnLayer(layerName)) ||
-          (pad->getCompSigInstNetSignal() != netsignal)) {
+      if (!pad->isOnLayer(layerName)) {
+        continue;
+      }
+      if ((!netsignals.isEmpty()) &&
+          (!netsignals.contains(pad->getCompSigInstNetSignal()))) {
         continue;
       }
       Transform transform(*pad);
@@ -262,7 +280,8 @@ void BoardClipperPathGenerator::addCopper(const QString& layerName,
 
   // net segment items
   foreach (const BI_NetSegment* netsegment, mBoard.getNetSegments()) {
-    if (netsegment->getNetSignal() != netsignal) {
+    if ((!netsignals.isEmpty()) &&
+        (!netsignals.contains(netsegment->getNetSignal()))) {
       continue;
     }
 

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
@@ -60,7 +60,7 @@ public:
   void addBoardOutline();
   void addHoles(const Length& offset);
   void addCopper(const QString& layerName,
-                 const QVector<const NetSignal*>& netsignals);
+                 const QSet<const NetSignal*>& netsignals);
 
 private:  // Data
   Board& mBoard;

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
@@ -59,7 +59,8 @@ public:
   // General Methods
   void addBoardOutline();
   void addHoles(const Length& offset);
-  void addCopper(const QString& layerName, const NetSignal* netsignal);
+  void addCopper(const QString& layerName,
+                 const QVector<const NetSignal*>& netsignals);
 
 private:  // Data
   Board& mBoard;

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -104,11 +104,17 @@ void BoardDesignRuleCheck::execute() {
   if (mOptions.checkPthDrillDiameter) {
     checkMinimumPthDrillDiameter(78, 80);
   }
+  if (mOptions.checkPthSlotWidth) {
+    checkMinimumPthSlotWidth(80, 82);
+  }
   if (mOptions.checkNpthSlotsWarning) {
-    checkWarnNpthSlots(80, 82);
+    checkWarnNpthSlots(82, 83);
+  }
+  if (mOptions.checkPthSlotsWarning) {
+    checkWarnPthSlots(83, 84);
   }
   if (mOptions.checkCourtyardClearance) {
-    checkCourtyardClearances(82, 88);
+    checkCourtyardClearances(84, 88);
   }
   if (mOptions.checkMissingConnections) {
     checkForMissingConnections(88, 90);
@@ -494,7 +500,7 @@ void BoardDesignRuleCheck::checkMinimumNpthDrillDiameter(int progressStart,
       emitMessage(BoardDesignRuleCheckMessage(
           msgTr.arg(formatLength(*hole->getHole().getDiameter()),
                     formatLength(*mOptions.minNpthDrillDiameter)),
-          getHoleLocation(hole->getHole(), Transform())));
+          getHoleLocation(hole->getHole())));
     }
   }
 
@@ -530,7 +536,7 @@ void BoardDesignRuleCheck::checkMinimumNpthSlotWidth(int progressStart,
       emitMessage(BoardDesignRuleCheckMessage(
           msgTr.arg(formatLength(*hole->getHole().getDiameter()),
                     formatLength(*mOptions.minNpthSlotWidth)),
-          getHoleLocation(hole->getHole(), Transform())));
+          getHoleLocation(hole->getHole())));
     }
   }
 
@@ -556,7 +562,7 @@ void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
   Q_UNUSED(progressStart);
   emitStatus(tr("Check minimum PTH drill diameters..."));
 
-  // vias
+  // Vias.
   foreach (const BI_NetSegment* netsegment, mBoard.getNetSegments()) {
     foreach (const BI_Via* via, netsegment->getVias()) {
       if (via->getDrillDiameter() < mOptions.minPthDrillDiameter) {
@@ -571,7 +577,7 @@ void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
     }
   }
 
-  // pads
+  // Pads.
   foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
     foreach (const BI_FootprintPad* pad, device->getPads()) {
       for (const Hole& hole : pad->getLibPad().getHoles()) {
@@ -591,58 +597,111 @@ void BoardDesignRuleCheck::checkMinimumPthDrillDiameter(int progressStart,
   emit progressPercent(progressEnd);
 }
 
+void BoardDesignRuleCheck::checkMinimumPthSlotWidth(int progressStart,
+                                                    int progressEnd) {
+  Q_UNUSED(progressStart);
+  emitStatus(tr("Check minimum PTH slot width..."));
+
+  const QString msgTr =
+      tr("Min. PTH slot width: %1 < %2", "The '<' means 'smaller than'.");
+
+  // Pads.
+  foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
+    Transform devTransform(*device);
+    foreach (const BI_FootprintPad* pad, device->getPads()) {
+      Transform padTransform(pad->getLibPad().getPosition(),
+                             pad->getLibPad().getRotation());
+      for (const Hole& hole : pad->getLibPad().getHoles()) {
+        if ((hole.isSlot()) &&
+            (hole.getDiameter() < *mOptions.minPthSlotWidth)) {
+          emitMessage(BoardDesignRuleCheckMessage(
+              msgTr.arg(formatLength(*hole.getDiameter()),
+                        formatLength(*mOptions.minPthSlotWidth)),
+              getHoleLocation(hole, padTransform, devTransform)));
+        }
+      }
+    }
+  }
+
+  emit progressPercent(progressEnd);
+}
+
 void BoardDesignRuleCheck::checkWarnNpthSlots(int progressStart,
                                               int progressEnd) {
   Q_UNUSED(progressStart);
   emitStatus(tr("Check NPTH slots..."));
 
-  auto checkHole = [this](const Hole& hole, const Transform& transform) {
-    const QString suggestion = "\n" %
-        tr("Either avoid them or check if your PCB manufacturer supports "
-           "them.");
-    const QString checkSlotMode = "\n" %
-        tr("Choose the desired Excellon slot mode when generating the "
-           "production data (G85 vs. G00..G03).");
-    const QString g85NotAvailable = "\n" %
-        tr("The drilled slot mode (G85) will not be available when generating "
-           "production data.");
-    if ((mOptions.npthSlotsWarning >= SlotsWarningLevel::Curved) &&
-        hole.isCurvedSlot()) {
-      emitMessage(BoardDesignRuleCheckMessage(
-          tr("Hole is a slot with curves"), getHoleLocation(hole, transform),
-          tr("Curved slots are a very unusual thing and may cause troubles "
-             "with many PCB manufacturers.") %
-              suggestion % g85NotAvailable));
-    } else if ((mOptions.npthSlotsWarning >= SlotsWarningLevel::MultiSegment) &&
-               hole.isMultiSegmentSlot()) {
-      emitMessage(BoardDesignRuleCheckMessage(
-          tr("Hole is a multi-segment slot"), getHoleLocation(hole, transform),
-          tr("Multi-segment slots are a rather unusual thing and may cause "
-             "troubles with some PCB manufacturers.") %
-              suggestion % checkSlotMode));
-    } else if ((mOptions.npthSlotsWarning >= SlotsWarningLevel::All) &&
-               hole.isSlot()) {
-      emitMessage(BoardDesignRuleCheckMessage(
-          tr("Hole is a slot"), getHoleLocation(hole, transform),
-          tr("Slots may cause troubles with some PCB manufacturers.") %
-              suggestion % checkSlotMode));
-    }
-  };
-
   // Board holes.
   foreach (const BI_Hole* hole, mBoard.getHoles()) {
-    checkHole(hole->getHole(), Transform());
+    processHoleSlotWarning(hole->getHole(), mOptions.npthSlotsWarning);
   }
 
   // Package holes.
   foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
     Transform transform(*device);
     for (const Hole& hole : device->getLibFootprint().getHoles()) {
-      checkHole(hole, transform);
+      processHoleSlotWarning(hole, mOptions.npthSlotsWarning, transform);
     }
   }
 
   emit progressPercent(progressEnd);
+}
+
+void BoardDesignRuleCheck::checkWarnPthSlots(int progressStart,
+                                             int progressEnd) {
+  Q_UNUSED(progressStart);
+  emitStatus(tr("Check PTH slots..."));
+
+  // Pads.
+  foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
+    Transform devTransform(*device);
+    foreach (const BI_FootprintPad* pad, device->getPads()) {
+      Transform padTransform(pad->getLibPad().getPosition(),
+                             pad->getLibPad().getRotation());
+      for (const Hole& hole : pad->getLibPad().getHoles()) {
+        processHoleSlotWarning(hole, mOptions.pthSlotsWarning, padTransform,
+                               devTransform);
+      }
+    }
+  }
+
+  emit progressPercent(progressEnd);
+}
+
+void BoardDesignRuleCheck::processHoleSlotWarning(const Hole& hole,
+                                                  SlotsWarningLevel level,
+                                                  const Transform& transform1,
+                                                  const Transform& transform2) {
+  const QString suggestion = "\n" %
+      tr("Either avoid them or check if your PCB manufacturer supports "
+         "them.");
+  const QString checkSlotMode = "\n" %
+      tr("Choose the desired Excellon slot mode when generating the "
+         "production data (G85 vs. G00..G03).");
+  const QString g85NotAvailable = "\n" %
+      tr("The drilled slot mode (G85) will not be available when generating "
+         "production data.");
+  if ((level >= SlotsWarningLevel::Curved) && hole.isCurvedSlot()) {
+    emitMessage(BoardDesignRuleCheckMessage(
+        tr("Hole is a slot with curves"),
+        getHoleLocation(hole, transform1, transform2),
+        tr("Curved slots are a very unusual thing and may cause troubles "
+           "with many PCB manufacturers.") %
+            suggestion % g85NotAvailable));
+  } else if ((level >= SlotsWarningLevel::MultiSegment) &&
+             hole.isMultiSegmentSlot()) {
+    emitMessage(BoardDesignRuleCheckMessage(
+        tr("Hole is a multi-segment slot"),
+        getHoleLocation(hole, transform1, transform2),
+        tr("Multi-segment slots are a rather unusual thing and may cause "
+           "troubles with some PCB manufacturers.") %
+            suggestion % checkSlotMode));
+  } else if ((level >= SlotsWarningLevel::All) && hole.isSlot()) {
+    emitMessage(BoardDesignRuleCheckMessage(
+        tr("Hole is a slot"), getHoleLocation(hole, transform1, transform2),
+        tr("Slots may cause troubles with some PCB manufacturers.") %
+            suggestion % checkSlotMode));
+  }
 }
 
 const ClipperLib::Paths& BoardDesignRuleCheck::getCopperPaths(
@@ -684,8 +743,10 @@ ClipperLib::Paths BoardDesignRuleCheck::getDeviceCourtyardPaths(
 }
 
 QVector<Path> BoardDesignRuleCheck::getHoleLocation(
-    const Hole& hole, const Transform& transform) const noexcept {
-  return transform.map(hole.getPath())->toOutlineStrokes(hole.getDiameter());
+    const Hole& hole, const Transform& transform1,
+    const Transform& transform2) const noexcept {
+  return transform2.map(
+      transform1.map(hole.getPath())->toOutlineStrokes(hole.getDiameter()));
 }
 
 void BoardDesignRuleCheck::emitStatus(const QString& status) noexcept {

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -156,7 +156,7 @@ private:  // Methods
   void checkMinimumPthDrillDiameter(int progressStart, int progressEnd);
   void checkWarnNpthSlots(int progressStart, int progressEnd);
   const ClipperLib::Paths& getCopperPaths(
-      const GraphicsLayer& layer, const QVector<const NetSignal*>& netsignals);
+      const GraphicsLayer& layer, const QSet<const NetSignal*>& netsignals);
   ClipperLib::Paths getDeviceCourtyardPaths(const BI_Device& device,
                                             const GraphicsLayer* layer);
   QVector<Path> getHoleLocation(const Hole& hole,
@@ -177,8 +177,7 @@ private:  // Data
   Options mOptions;
   QStringList mProgressStatus;
   QList<BoardDesignRuleCheckMessage> mMessages;
-  QHash<const GraphicsLayer*,
-        QHash<QVector<const NetSignal*>, ClipperLib::Paths>>
+  QHash<QPair<const GraphicsLayer*, QSet<const NetSignal*>>, ClipperLib::Paths>
       mCachedPaths;
 };
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../../utils/transform.h"
 #include "boarddesignrulecheckmessage.h"
 
 #include <polyclipping/clipper.hpp>
@@ -39,7 +40,6 @@ class Board;
 class GraphicsLayer;
 class Hole;
 class NetSignal;
-class Transform;
 
 /*******************************************************************************
  *  Class BoardDesignRuleCheck
@@ -87,8 +87,14 @@ public:
     bool checkPthDrillDiameter;
     UnsignedLength minPthDrillDiameter;
 
+    bool checkPthSlotWidth;
+    UnsignedLength minPthSlotWidth;
+
     bool checkNpthSlotsWarning;
     SlotsWarningLevel npthSlotsWarning;
+
+    bool checkPthSlotsWarning;
+    SlotsWarningLevel pthSlotsWarning;
 
     bool checkCourtyardClearance;
     Length courtyardOffset;
@@ -113,8 +119,12 @@ public:
         minNpthSlotWidth(1000000),  // 1mm
         checkPthDrillDiameter(true),
         minPthDrillDiameter(250000),  // 250um
+        checkPthSlotWidth(true),
+        minPthSlotWidth(700000),  // 0.7mm
         checkNpthSlotsWarning(true),
         npthSlotsWarning(SlotsWarningLevel::MultiSegment),
+        checkPthSlotsWarning(true),
+        pthSlotsWarning(SlotsWarningLevel::MultiSegment),
         checkCourtyardClearance(true),
         courtyardOffset(0),  // 0um
         checkMissingConnections(true) {}
@@ -154,13 +164,20 @@ private:  // Methods
   void checkMinimumNpthDrillDiameter(int progressStart, int progressEnd);
   void checkMinimumNpthSlotWidth(int progressStart, int progressEnd);
   void checkMinimumPthDrillDiameter(int progressStart, int progressEnd);
+  void checkMinimumPthSlotWidth(int progressStart, int progressEnd);
   void checkWarnNpthSlots(int progressStart, int progressEnd);
+  void checkWarnPthSlots(int progressStart, int progressEnd);
+  void processHoleSlotWarning(const Hole& hole, SlotsWarningLevel level,
+                              const Transform& transform1 = Transform(),
+                              const Transform& transform2 = Transform());
   const ClipperLib::Paths& getCopperPaths(
       const GraphicsLayer& layer, const QSet<const NetSignal*>& netsignals);
   ClipperLib::Paths getDeviceCourtyardPaths(const BI_Device& device,
                                             const GraphicsLayer* layer);
   QVector<Path> getHoleLocation(const Hole& hole,
-                                const Transform& transform) const noexcept;
+                                const Transform& transform1 = Transform(),
+                                const Transform& transform2 = Transform()) const
+      noexcept;
   void emitStatus(const QString& status) noexcept;
   void emitMessage(const BoardDesignRuleCheckMessage& msg) noexcept;
   QString formatLength(const Length& length) const noexcept;

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -155,8 +155,8 @@ private:  // Methods
   void checkMinimumNpthSlotWidth(int progressStart, int progressEnd);
   void checkMinimumPthDrillDiameter(int progressStart, int progressEnd);
   void checkWarnNpthSlots(int progressStart, int progressEnd);
-  const ClipperLib::Paths& getCopperPaths(const GraphicsLayer* layer,
-                                          const NetSignal* netsignal);
+  const ClipperLib::Paths& getCopperPaths(
+      const GraphicsLayer& layer, const QVector<const NetSignal*>& netsignals);
   ClipperLib::Paths getDeviceCourtyardPaths(const BI_Device& device,
                                             const GraphicsLayer* layer);
   QVector<Path> getHoleLocation(const Hole& hole,
@@ -177,7 +177,8 @@ private:  // Data
   Options mOptions;
   QStringList mProgressStatus;
   QList<BoardDesignRuleCheckMessage> mMessages;
-  QHash<const GraphicsLayer*, QHash<const NetSignal*, ClipperLib::Paths>>
+  QHash<const GraphicsLayer*,
+        QHash<QVector<const NetSignal*>, ClipperLib::Paths>>
       mCachedPaths;
 };
 

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.cpp
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.cpp
@@ -83,7 +83,7 @@ void BGI_FootprintPad::updateCacheAndRepaint() noexcept {
   setToolTip(mPad.getDisplayText());
 
   // set Z value
-  if ((mLibPad.getBoardSide() == FootprintPad::BoardSide::BOTTOM) !=
+  if ((mLibPad.getComponentSide() == FootprintPad::ComponentSide::Bottom) !=
       mPad.getMirrored()) {
     setZValue(Board::ZValue_FootprintPadsBottom);
   } else {
@@ -93,12 +93,13 @@ void BGI_FootprintPad::updateCacheAndRepaint() noexcept {
   // set layers
   disconnectLayerEditedSlots();
   mPadLayer = getLayer(mLibPad.getLayerName());
-  if (mLibPad.getBoardSide() == FootprintPad::BoardSide::THT) {
+  if (mLibPad.isTht()) {
     mTopStopMaskLayer = getLayer(GraphicsLayer::sTopStopMask);
     mBottomStopMaskLayer = getLayer(GraphicsLayer::sBotStopMask);
     mTopCreamMaskLayer = nullptr;
     mBottomCreamMaskLayer = nullptr;
-  } else if (mLibPad.getBoardSide() == FootprintPad::BoardSide::BOTTOM) {
+  } else if (mLibPad.getComponentSide() ==
+             FootprintPad::ComponentSide::Bottom) {
     mTopStopMaskLayer = nullptr;
     mBottomStopMaskLayer = getLayer(GraphicsLayer::sBotStopMask);
     mTopCreamMaskLayer = nullptr;

--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -189,7 +189,7 @@ BI_Device::MountType BI_Device::determineMountType() const noexcept {
     bool hasThtPads = false;
     bool hasSmtPads = false;
     foreach (const BI_FootprintPad* pad, mPads) {
-      if (pad->getLibPad().getDrillDiameter() > 0) {
+      if (pad->getLibPad().isTht()) {
         hasThtPads = true;
       } else {
         hasSmtPads = true;

--- a/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
+++ b/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
@@ -217,8 +217,17 @@ void BI_FootprintPad::updatePosition() noexcept {
   Transform transform(mDevice);
   mPosition = transform.map(mFootprintPad->getPosition());
   mRotation = transform.map(mFootprintPad->getRotation());
+
+  Angle rot = mRotation;
+  if (mDevice.getMirrored()) {
+    rot = Angle::deg180() - rot;
+  }
+
+  QTransform t;
+  if (mDevice.getMirrored()) t.scale(qreal(-1), qreal(1));
+  t.rotate(-rot.toDeg());
+  mGraphicsItem->setTransform(t);
   mGraphicsItem->setPos(mPosition.toPxQPointF());
-  mGraphicsItem->setRotation(-mRotation.toDeg());
   mGraphicsItem->updateCacheAndRepaint();
   foreach (BI_NetLine* netline, mRegisteredNetLines) { netline->updateLine(); }
 }

--- a/libs/librepcb/core/utils/clipperhelpers.h
+++ b/libs/librepcb/core/utils/clipperhelpers.h
@@ -57,10 +57,15 @@ public:
   static void unite(ClipperLib::Paths& subject, const ClipperLib::Paths& clip);
   static std::unique_ptr<ClipperLib::PolyTree> intersect(
       const ClipperLib::Paths& subject, const ClipperLib::Paths& clip);
+  static std::unique_ptr<ClipperLib::PolyTree> intersect(
+      const QList<ClipperLib::Paths>& paths);
   static void subtract(ClipperLib::Paths& subject,
                        const ClipperLib::Paths& clip);
+  static std::unique_ptr<ClipperLib::PolyTree> subtractToTree(
+      const ClipperLib::Paths& subject, const ClipperLib::Paths& clip);
   static void offset(ClipperLib::Paths& paths, const Length& offset,
                      const PositiveLength& maxArcTolerance);
+  static ClipperLib::Paths treeToPaths(const ClipperLib::PolyTree& tree);
   static ClipperLib::Paths flattenTree(const ClipperLib::PolyNode& node);
 
   // Type Conversions

--- a/libs/librepcb/core/utils/transform.h
+++ b/libs/librepcb/core/utils/transform.h
@@ -195,6 +195,26 @@ public:
     return copy;
   }
 
+  /**
+   * @brief Map a given Qt object in pixels to the transformed coordinate system
+   *
+   * @param obj The Qt object (in pixel coordinates) to map, e.g. QPoint,
+   *            QPainterPath, ...).
+   * @return The passed object, rotated by the transformations rotation,
+   *         mirrored horizontally if the transformation is mirroring, and
+   *         translated by the transformation offset.
+   */
+  template <typename T>
+  T mapPx(const T& obj) const noexcept {
+    QTransform t;
+    t.translate(mPosition.toPxQPointF().x(), mPosition.toPxQPointF().y());
+    if (mMirrored) {
+      t.scale(-1, 1);
+    }
+    t.rotate(-mRotation.toDeg());
+    return t.map(obj);
+  }
+
   // Operator Overloadings
   bool operator==(const Transform& rhs) const noexcept {
     return (mPosition == rhs.mPosition) && (mRotation == rhs.mRotation) &&

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -416,9 +416,11 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           shape,  // Shape
           width,  // Width
           height,  // Height
-          UnsignedLength(
-              convertLength(p.getDrillDiameter())),  // Drill diameter
-          FootprintPad::BoardSide::THT  // Side
+          FootprintPad::ComponentSide::Top,  // Side
+          HoleList{std::make_shared<Hole>(
+              Uuid::createRandom(),
+              PositiveLength(convertLength(p.getDrillDiameter())),
+              makeNonEmptyPath(Point(0, 0)))}  // Holes
           ));
 }
 
@@ -426,11 +428,11 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
     EagleTypeConverter::convertSmtPad(const parseagle::SmtPad& p) {
   Uuid uuid = Uuid::createRandom();
   GraphicsLayerName layer = convertLayer(p.getLayer());
-  FootprintPad::BoardSide side;
+  FootprintPad::ComponentSide side;
   if (layer == GraphicsLayer::sTopCopper) {
-    side = FootprintPad::BoardSide::TOP;
+    side = FootprintPad::ComponentSide::Top;
   } else if (layer == GraphicsLayer::sBotCopper) {
-    side = FootprintPad::BoardSide::BOTTOM;
+    side = FootprintPad::ComponentSide::Bottom;
   } else {
     throw RuntimeError(__FILE__, __LINE__,
                        QString("Invalid pad layer: %1").arg(*layer));
@@ -447,8 +449,8 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           FootprintPad::Shape::RECT,  // Shape
           PositiveLength(convertLength(p.getWidth())),  // Width
           PositiveLength(convertLength(p.getHeight())),  // Height
-          UnsignedLength(0),  // Drill diameter
-          side  // Side
+          side,  // Side
+          HoleList{}  // Holes
           ));
 }
 

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -684,6 +684,9 @@ add_library(
   widgets/graphicslayercombobox.h
   widgets/graphicsview.cpp
   widgets/graphicsview.h
+  widgets/holeeditorwidget.cpp
+  widgets/holeeditorwidget.h
+  widgets/holeeditorwidget.ui
   widgets/if_graphicsvieweventhandler.h
   widgets/keysequenceseditorwidget.cpp
   widgets/keysequenceseditorwidget.h

--- a/libs/librepcb/editor/dialogs/holepropertiesdialog.cpp
+++ b/libs/librepcb/editor/dialogs/holepropertiesdialog.cpp
@@ -26,9 +26,6 @@
 #include "../undostack.h"
 #include "ui_holepropertiesdialog.h"
 
-#include <librepcb/core/geometry/hole.h>
-#include <librepcb/core/utils/toolbox.h>
-
 #include <QtCore>
 #include <QtWidgets>
 
@@ -47,60 +44,15 @@ HolePropertiesDialog::HolePropertiesDialog(Hole& hole, UndoStack& undoStack,
     mUndoStack(undoStack),
     mUi(new Ui::HolePropertiesDialog) {
   mUi->setupUi(this);
-  mUi->pathEditorWidget->setFrameShape(QFrame::NoFrame);
-  mUi->edtDiameter->configure(lengthUnit,
-                              LengthEditBase::Steps::drillDiameter(),
-                              settingsPrefix % "/diameter");
-  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
-                          settingsPrefix % "/pos_x");
-  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
-                          settingsPrefix % "/pos_y");
-  mUi->edtCenterX->configure(lengthUnit, LengthEditBase::Steps::generic(),
-                             settingsPrefix % "/center_x");
-  mUi->edtCenterY->configure(lengthUnit, LengthEditBase::Steps::generic(),
-                             settingsPrefix % "/center_y");
-  mUi->edtLength->configure(lengthUnit, LengthEditBase::Steps::generic(),
-                            settingsPrefix % "/length");
-  connect(mUi->edtDiameter, &PositiveLengthEdit::valueChanged, this, [this]() {
-    updateLinearOuterSize(mUi->pathEditorWidget->getPath());
-  });
-  connect(mUi->edtPosX, &LengthEdit::valueChanged, this,
-          &HolePropertiesDialog::updatePathFromCircularTab);
-  connect(mUi->edtPosY, &LengthEdit::valueChanged, this,
-          &HolePropertiesDialog::updatePathFromCircularTab);
-  connect(mUi->edtCenterX, &LengthEdit::valueChanged, this,
-          &HolePropertiesDialog::updatePathFromLinearTab);
-  connect(mUi->edtCenterY, &LengthEdit::valueChanged, this,
-          &HolePropertiesDialog::updatePathFromLinearTab);
-  connect(mUi->edtLength, &UnsignedLengthEdit::valueChanged, this,
-          &HolePropertiesDialog::updatePathFromLinearTab);
-
-  connect(mUi->edtRotation, &AngleEdit::valueChanged, this,
-          &HolePropertiesDialog::updatePathFromLinearTab);
-  connect(mUi->pathEditorWidget, &PathEditorWidget::pathChanged, this,
-          &HolePropertiesDialog::updateCircularTabFromPath);
-  connect(mUi->pathEditorWidget, &PathEditorWidget::pathChanged, this,
-          &HolePropertiesDialog::updateLinearTabFromPath);
-  connect(mUi->pathEditorWidget, &PathEditorWidget::pathChanged, this,
-          &HolePropertiesDialog::updateLinearOuterSize);
+  mUi->holeEditorWidget->configureClientSettings(lengthUnit, settingsPrefix);
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &HolePropertiesDialog::on_buttonBox_clicked);
 
-  // load text attributes
-  mUi->edtDiameter->setValue(mHole.getDiameter());
-  mUi->pathEditorWidget->setPath(*mHole.getPath());
+  // Set properties.
+  mUi->holeEditorWidget->setHole(mHole);
 
-  // Open the most reasonable tab.
-  if (mUi->tabCircular->isEnabled()) {
-    mUi->tabWidget->setCurrentWidget(mUi->tabCircular);
-  } else if (mUi->tabLinear->isEnabled()) {
-    mUi->tabWidget->setCurrentWidget(mUi->tabLinear);
-  } else {
-    mUi->tabWidget->setCurrentWidget(mUi->tabArbitrary);
-  }
-
-  // set focus to diameter so the user can immediately start typing to change it
-  mUi->edtDiameter->setFocus();
+  // Set focus to diameter so the user can immediately start typing to change it
+  mUi->holeEditorWidget->setFocusToDiameterEdit();
 }
 
 HolePropertiesDialog::~HolePropertiesDialog() noexcept {
@@ -111,14 +63,7 @@ HolePropertiesDialog::~HolePropertiesDialog() noexcept {
  ******************************************************************************/
 
 void HolePropertiesDialog::setReadOnly(bool readOnly) noexcept {
-  mUi->edtDiameter->setReadOnly(readOnly);
-  mUi->edtPosX->setReadOnly(readOnly);
-  mUi->edtPosY->setReadOnly(readOnly);
-  mUi->edtCenterX->setReadOnly(readOnly);
-  mUi->edtCenterY->setReadOnly(readOnly);
-  mUi->edtLength->setReadOnly(readOnly);
-  mUi->edtRotation->setReadOnly(readOnly);
-  mUi->pathEditorWidget->setReadOnly(readOnly);
+  mUi->holeEditorWidget->setReadOnly(readOnly);
   if (readOnly) {
     mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
   } else {
@@ -132,99 +77,6 @@ void HolePropertiesDialog::setReadOnly(bool readOnly) noexcept {
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
-
-void HolePropertiesDialog::updatePathFromCircularTab() noexcept {
-  QSignalBlocker blocker(mUi->pathEditorWidget);
-
-  const Path path(
-      {Vertex(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()))});
-  mUi->pathEditorWidget->setPath(path);
-  updateLinearTabFromPath(path);
-  updateLinearOuterSize(path);
-}
-
-void HolePropertiesDialog::updatePathFromLinearTab() noexcept {
-  QSignalBlocker blocker(mUi->pathEditorWidget);
-
-  const Point center(mUi->edtCenterX->getValue(), mUi->edtCenterY->getValue());
-  const UnsignedLength length = mUi->edtLength->getValue();
-  const Angle rotation = mUi->edtRotation->getValue();
-
-  const Point p1 = center + Point(length / 2, 0).rotated(rotation);
-  const Point p2 = center + Point(length / -2, 0).rotated(rotation);
-  Path path({Vertex(p1)});
-  if (p2 != p1) {
-    path.addVertex(p2);
-  }
-
-  mUi->pathEditorWidget->setPath(path);
-  updateCircularTabFromPath(path);
-  updateLinearOuterSize(path);
-}
-
-void HolePropertiesDialog::updateCircularTabFromPath(
-    const Path& path) noexcept {
-  // Avoid possible endless signal loop.
-  QSignalBlocker blockPosX(mUi->edtPosX);
-  QSignalBlocker blockPosY(mUi->edtPosY);
-
-  const bool isCircular = (path.getVertices().count() == 1);
-  mUi->tabWidget->setTabEnabled(mUi->tabWidget->indexOf(mUi->tabCircular),
-                                isCircular);
-  if (isCircular) {
-    mUi->edtPosX->setValue(path.getVertices().first().getPos().getX());
-    mUi->edtPosY->setValue(path.getVertices().first().getPos().getY());
-  }
-}
-
-void HolePropertiesDialog::updateLinearTabFromPath(const Path& path) noexcept {
-  // Avoid possible endless signal loop.
-  QSignalBlocker blockCenterX(mUi->edtCenterX);
-  QSignalBlocker blockCenterY(mUi->edtCenterY);
-  QSignalBlocker blockLength(mUi->edtLength);
-  QSignalBlocker blockRotation(mUi->edtRotation);
-
-  const bool isCircular = (path.getVertices().count() == 1);
-  const bool isLinear = (path.getVertices().count() == 2) &&
-      (path.getVertices().first().getAngle() == Angle::deg0());
-  mUi->tabWidget->setTabEnabled(mUi->tabWidget->indexOf(mUi->tabLinear),
-                                isCircular || isLinear);
-  if (isCircular || isLinear) {
-    const Point p1 = path.getVertices().first().getPos();
-    const Point p2 = path.getVertices().last().getPos();
-    const Point diff = p2 - p1;
-    const Point center = (p1 + p2) / 2;
-    const UnsignedLength length = (p2 - p1).getLength();
-    const Angle rotation = isCircular
-        ? Angle::deg0()
-        : Angle::fromRad(
-              std::atan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()))
-              .rounded(Angle(1000));
-    mUi->edtCenterX->setValue(center.getX());
-    mUi->edtCenterY->setValue(center.getY());
-    mUi->edtLength->setValue(length);
-    if ((rotation.mappedTo0_360deg() % Angle::deg180()) !=
-        (mUi->edtRotation->getValue().mappedTo0_360deg() % Angle::deg180())) {
-      mUi->edtRotation->setValue(rotation);
-    }
-  }
-}
-
-void HolePropertiesDialog::updateLinearOuterSize(const Path& path) noexcept {
-  QLocale locale;
-  const PositiveLength diameter = mUi->edtDiameter->getValue();
-  const PositiveLength length = path.getTotalStraightLength() + diameter;
-  const LengthUnit& unit = mUi->edtLength->getDisplayedUnit();
-  const int decimals = unit.getReasonableNumberOfDecimals();
-  const qreal width = unit.convertToUnit(*length);
-  const qreal height = unit.convertToUnit(*diameter);
-  mUi->lblOuterSize->setText(
-      tr("Outer Size:") %
-      QString(" %1x%2%3")
-          .arg(Toolbox::floatToString(width, decimals, locale))
-          .arg(Toolbox::floatToString(height, decimals, locale))
-          .arg(unit.toShortStringTr()));
-}
 
 void HolePropertiesDialog::on_buttonBox_clicked(QAbstractButton* button) {
   switch (mUi->buttonBox->buttonRole(button)) {
@@ -247,9 +99,11 @@ void HolePropertiesDialog::on_buttonBox_clicked(QAbstractButton* button) {
 
 bool HolePropertiesDialog::applyChanges() noexcept {
   try {
+    const Hole newHole = mUi->holeEditorWidget->getHole();
+
     QScopedPointer<CmdHoleEdit> cmd(new CmdHoleEdit(mHole));
-    cmd->setDiameter(mUi->edtDiameter->getValue(), false);
-    cmd->setPath(NonEmptyPath(mUi->pathEditorWidget->getPath()), false);
+    cmd->setDiameter(newHole.getDiameter(), false);
+    cmd->setPath(newHole.getPath(), false);
     mUndoStack.execCmd(cmd.take());
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/dialogs/holepropertiesdialog.h
+++ b/libs/librepcb/editor/dialogs/holepropertiesdialog.h
@@ -33,7 +33,6 @@ namespace librepcb {
 
 class Hole;
 class LengthUnit;
-class Path;
 
 namespace editor {
 
@@ -70,11 +69,6 @@ public:
   HolePropertiesDialog& operator=(const HolePropertiesDialog& rhs) = delete;
 
 private:  // Methods
-  void updatePathFromCircularTab() noexcept;
-  void updatePathFromLinearTab() noexcept;
-  void updateCircularTabFromPath(const Path& path) noexcept;
-  void updateLinearTabFromPath(const Path& path) noexcept;
-  void updateLinearOuterSize(const Path& path) noexcept;
   void on_buttonBox_clicked(QAbstractButton* button);
   bool applyChanges() noexcept;
 

--- a/libs/librepcb/editor/dialogs/holepropertiesdialog.ui
+++ b/libs/librepcb/editor/dialogs/holepropertiesdialog.ui
@@ -13,140 +13,9 @@
   <property name="windowTitle">
    <string>Hole Properties</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Diameter:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="librepcb::editor::PositiveLengthEdit" name="edtDiameter" native="true"/>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>1</number>
-     </property>
-     <widget class="QWidget" name="tabCircular">
-      <attribute name="title">
-       <string>Circular Drill</string>
-      </attribute>
-      <layout class="QFormLayout" name="formLayout_2">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Position:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
-         </item>
-         <item>
-          <widget class="librepcb::editor::LengthEdit" name="edtPosY" native="true"/>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabLinear">
-      <attribute name="title">
-       <string>Linear Slot</string>
-      </attribute>
-      <layout class="QFormLayout" name="formLayout_3">
-       <item row="1" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="librepcb::editor::LengthEdit" name="edtCenterX" native="true"/>
-         </item>
-         <item>
-          <widget class="librepcb::editor::LengthEdit" name="edtCenterY" native="true"/>
-         </item>
-        </layout>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_8">
-         <property name="text">
-          <string>Rotation:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Center:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
-       </item>
-       <item row="3" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,1">
-         <item>
-          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtLength" native="true"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="lblOuterSize">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true"/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>Length:</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabArbitrary">
-      <attribute name="title">
-       <string>Arbitrary Slot</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="librepcb::editor::PathEditorWidget" name="pathEditorWidget" native="true"/>
-       </item>
-      </layout>
-     </widget>
-    </widget>
+    <widget class="librepcb::editor::HoleEditorWidget" name="holeEditorWidget" native="true"/>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -162,41 +31,12 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>librepcb::editor::PositiveLengthEdit</class>
+   <class>librepcb::editor::HoleEditorWidget</class>
    <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::editor::PathEditorWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/patheditorwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::editor::LengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/lengthedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::editor::AngleEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/angleedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::editor::UnsignedLengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
+   <header location="global">librepcb/editor/widgets/holeeditorwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>edtDiameter</tabstop>
-  <tabstop>edtPosX</tabstop>
-  <tabstop>edtPosY</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
@@ -39,8 +39,8 @@ CmdFootprintPadEdit::CmdFootprintPadEdit(FootprintPad& pad) noexcept
     mPad(pad),
     mOldPackagePadUuid(pad.getPackagePadUuid()),
     mNewPackagePadUuid(mOldPackagePadUuid),
-    mOldBoardSide(pad.getBoardSide()),
-    mNewBoardSide(mOldBoardSide),
+    mOldComponentSide(pad.getComponentSide()),
+    mNewComponentSide(mOldComponentSide),
     mOldShape(pad.getShape()),
     mNewShape(mOldShape),
     mOldWidth(pad.getWidth()),
@@ -51,8 +51,8 @@ CmdFootprintPadEdit::CmdFootprintPadEdit(FootprintPad& pad) noexcept
     mNewPos(mOldPos),
     mOldRotation(pad.getRotation()),
     mNewRotation(mOldRotation),
-    mOldDrillDiameter(pad.getDrillDiameter()),
-    mNewDrillDiameter(mOldDrillDiameter) {
+    mOldHoles(pad.getHoles()),
+    mNewHoles(mOldHoles) {
 }
 
 CmdFootprintPadEdit::~CmdFootprintPadEdit() noexcept {
@@ -76,11 +76,11 @@ void CmdFootprintPadEdit::setPackagePadUuid(const tl::optional<Uuid>& pad,
   if (immediate) mPad.setPackagePadUuid(mNewPackagePadUuid);
 }
 
-void CmdFootprintPadEdit::setBoardSide(FootprintPad::BoardSide side,
-                                       bool immediate) noexcept {
+void CmdFootprintPadEdit::setComponentSide(FootprintPad::ComponentSide side,
+                                           bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewBoardSide = side;
-  if (immediate) mPad.setBoardSide(mNewBoardSide);
+  mNewComponentSide = side;
+  if (immediate) mPad.setComponentSide(mNewComponentSide);
 }
 
 void CmdFootprintPadEdit::setShape(FootprintPad::Shape shape,
@@ -102,13 +102,6 @@ void CmdFootprintPadEdit::setHeight(const PositiveLength& height,
   Q_ASSERT(!wasEverExecuted());
   mNewHeight = height;
   if (immediate) mPad.setHeight(mNewHeight);
-}
-
-void CmdFootprintPadEdit::setDrillDiameter(const UnsignedLength& dia,
-                                           bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewDrillDiameter = dia;
-  if (immediate) mPad.setDrillDiameter(mNewDrillDiameter);
 }
 
 void CmdFootprintPadEdit::setPosition(const Point& pos,
@@ -165,18 +158,22 @@ void CmdFootprintPadEdit::mirrorGeometry(Qt::Orientation orientation,
 }
 
 void CmdFootprintPadEdit::mirrorLayer(bool immediate) noexcept {
-  switch (mNewBoardSide) {
-    case FootprintPad::BoardSide::BOTTOM:
-      mNewBoardSide = FootprintPad::BoardSide::TOP;
-      break;
-    case FootprintPad::BoardSide::TOP:
-      mNewBoardSide = FootprintPad::BoardSide::BOTTOM;
-      break;
-    default:
-      break;
+  if (mNewComponentSide == FootprintPad::ComponentSide::Top) {
+    mNewComponentSide = FootprintPad::ComponentSide::Bottom;
+  } else {
+    mNewComponentSide = FootprintPad::ComponentSide::Top;
   }
   if (immediate) {
-    mPad.setBoardSide(mNewBoardSide);
+    mPad.setComponentSide(mNewComponentSide);
+  }
+}
+
+void CmdFootprintPadEdit::setHoles(const HoleList& holes,
+                                   bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewHoles = holes;
+  if (immediate) {
+    mPad.getHoles() = holes;
   }
 }
 
@@ -188,36 +185,36 @@ bool CmdFootprintPadEdit::performExecute() {
   performRedo();  // can throw
 
   if (mNewPackagePadUuid != mOldPackagePadUuid) return true;
-  if (mNewBoardSide != mOldBoardSide) return true;
+  if (mNewComponentSide != mOldComponentSide) return true;
   if (mNewShape != mOldShape) return true;
   if (mNewWidth != mOldWidth) return true;
   if (mNewHeight != mOldHeight) return true;
   if (mNewPos != mOldPos) return true;
   if (mNewRotation != mOldRotation) return true;
-  if (mNewDrillDiameter != mOldDrillDiameter) return true;
+  if (mNewHoles != mOldHoles) return true;
   return false;
 }
 
 void CmdFootprintPadEdit::performUndo() {
   mPad.setPackagePadUuid(mOldPackagePadUuid);
-  mPad.setBoardSide(mOldBoardSide);
+  mPad.setComponentSide(mOldComponentSide);
   mPad.setShape(mOldShape);
   mPad.setWidth(mOldWidth);
   mPad.setHeight(mOldHeight);
   mPad.setPosition(mOldPos);
   mPad.setRotation(mOldRotation);
-  mPad.setDrillDiameter(mOldDrillDiameter);
+  mPad.getHoles() = mOldHoles;
 }
 
 void CmdFootprintPadEdit::performRedo() {
   mPad.setPackagePadUuid(mNewPackagePadUuid);
-  mPad.setBoardSide(mNewBoardSide);
+  mPad.setComponentSide(mNewComponentSide);
   mPad.setShape(mNewShape);
   mPad.setWidth(mNewWidth);
   mPad.setHeight(mNewHeight);
   mPad.setPosition(mNewPos);
   mPad.setRotation(mNewRotation);
-  mPad.setDrillDiameter(mNewDrillDiameter);
+  mPad.getHoles() = mNewHoles;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
@@ -56,11 +56,11 @@ public:
   // Setters
   void setPackagePadUuid(const tl::optional<Uuid>& pad,
                          bool immediate) noexcept;
-  void setBoardSide(FootprintPad::BoardSide side, bool immediate) noexcept;
+  void setComponentSide(FootprintPad::ComponentSide side,
+                        bool immediate) noexcept;
   void setShape(FootprintPad::Shape shape, bool immediate) noexcept;
   void setWidth(const PositiveLength& width, bool immediate) noexcept;
   void setHeight(const PositiveLength& height, bool immediate) noexcept;
-  void setDrillDiameter(const UnsignedLength& dia, bool immediate) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
@@ -69,6 +69,7 @@ public:
   void mirrorGeometry(Qt::Orientation orientation, const Point& center,
                       bool immediate) noexcept;
   void mirrorLayer(bool immediate) noexcept;
+  void setHoles(const HoleList& holes, bool immediate) noexcept;
 
   // Operator Overloadings
   CmdFootprintPadEdit& operator=(const CmdFootprintPadEdit& rhs) = delete;
@@ -93,8 +94,8 @@ private:
   // General Attributes
   tl::optional<Uuid> mOldPackagePadUuid;
   tl::optional<Uuid> mNewPackagePadUuid;
-  FootprintPad::BoardSide mOldBoardSide;
-  FootprintPad::BoardSide mNewBoardSide;
+  FootprintPad::ComponentSide mOldComponentSide;
+  FootprintPad::ComponentSide mNewComponentSide;
   FootprintPad::Shape mOldShape;
   FootprintPad::Shape mNewShape;
   PositiveLength mOldWidth;
@@ -105,8 +106,8 @@ private:
   Point mNewPos;
   Angle mOldRotation;
   Angle mNewRotation;
-  UnsignedLength mOldDrillDiameter;
-  UnsignedLength mNewDrillDiameter;
+  HoleList mOldHoles;
+  HoleList mNewHoles;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
@@ -101,8 +101,8 @@ bool CmdPasteFootprintItems::performExecute() {
         pkgPad ? pkgPad->getUuid() : tl::optional<Uuid>();
     std::shared_ptr<FootprintPad> copy = std::make_shared<FootprintPad>(
         uuid, pkgPadUuid, pad.getPosition() + mPosOffset, pad.getRotation(),
-        pad.getShape(), pad.getWidth(), pad.getHeight(), pad.getDrillDiameter(),
-        pad.getBoardSide());
+        pad.getShape(), pad.getWidth(), pad.getHeight(), pad.getComponentSide(),
+        pad.getHoles());
     execNewChildCmd(new CmdFootprintPadInsert(mFootprint.getPads(), copy));
     if (auto graphicsItem = mGraphicsItem.getGraphicsItem(copy)) {
       graphicsItem->setSelected(true);

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -228,7 +228,7 @@ void NewElementWizardContext::copyElement(ElementType type,
           newFootprint->getPads().append(std::make_shared<FootprintPad>(
               Uuid::createRandom(), pkgPad, pad.getPosition(),
               pad.getRotation(), pad.getShape(), pad.getWidth(),
-              pad.getHeight(), pad.getDrillDiameter(), pad.getBoardSide()));
+              pad.getHeight(), pad.getComponentSide(), pad.getHoles()));
         }
         // copy polygons but generate new UUIDs
         for (const Polygon& polygon : footprint.getPolygons()) {

--- a/libs/librepcb/editor/library/pkg/boardsideselectorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/boardsideselectorwidget.cpp
@@ -69,11 +69,11 @@ BoardSideSelectorWidget::~BoardSideSelectorWidget() noexcept {
  *  Getters
  ******************************************************************************/
 
-FootprintPad::BoardSide BoardSideSelectorWidget::getCurrentBoardSide() const
+FootprintPad::ComponentSide BoardSideSelectorWidget::getCurrentBoardSide() const
     noexcept {
-  if (mBtnTop->isChecked()) return FootprintPad::BoardSide::TOP;
-  if (mBtnBottom->isChecked()) return FootprintPad::BoardSide::BOTTOM;
-  return FootprintPad::BoardSide::TOP;
+  if (mBtnTop->isChecked()) return FootprintPad::ComponentSide::Top;
+  if (mBtnBottom->isChecked()) return FootprintPad::ComponentSide::Bottom;
+  return FootprintPad::ComponentSide::Top;
 }
 
 /*******************************************************************************
@@ -81,9 +81,9 @@ FootprintPad::BoardSide BoardSideSelectorWidget::getCurrentBoardSide() const
  ******************************************************************************/
 
 void BoardSideSelectorWidget::setCurrentBoardSide(
-    FootprintPad::BoardSide side) noexcept {
-  mBtnTop->setChecked(side == FootprintPad::BoardSide::TOP);
-  mBtnBottom->setChecked(side == FootprintPad::BoardSide::BOTTOM);
+    FootprintPad::ComponentSide side) noexcept {
+  mBtnTop->setChecked(side == FootprintPad::ComponentSide::Top);
+  mBtnBottom->setChecked(side == FootprintPad::ComponentSide::Bottom);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/pkg/boardsideselectorwidget.h
+++ b/libs/librepcb/editor/library/pkg/boardsideselectorwidget.h
@@ -51,15 +51,15 @@ public:
   ~BoardSideSelectorWidget() noexcept;
 
   // Getters
-  FootprintPad::BoardSide getCurrentBoardSide() const noexcept;
+  FootprintPad::ComponentSide getCurrentBoardSide() const noexcept;
 
   // Setters
-  void setCurrentBoardSide(FootprintPad::BoardSide side) noexcept;
+  void setCurrentBoardSide(FootprintPad::ComponentSide side) noexcept;
   void setBoardSideTop() noexcept {
-    setCurrentBoardSide(FootprintPad::BoardSide::TOP);
+    setCurrentBoardSide(FootprintPad::ComponentSide::Top);
   }
   void setBoardSideBottom() noexcept {
-    setCurrentBoardSide(FootprintPad::BoardSide::BOTTOM);
+    setCurrentBoardSide(FootprintPad::ComponentSide::Bottom);
   }
 
   // Operator Overloadings
@@ -67,7 +67,7 @@ public:
       delete;
 
 signals:
-  void currentBoardSideChanged(FootprintPad::BoardSide side);
+  void currentBoardSideChanged(FootprintPad::ComponentSide side);
 
 private:  // Methods
   void btnTopToggled(bool checked) noexcept;

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -156,11 +156,14 @@ void FootprintPadGraphicsItem::padEdited(const FootprintPad& pad,
     case FootprintPad::Event::ShapeChanged:
     case FootprintPad::Event::WidthChanged:
     case FootprintPad::Event::HeightChanged:
-    case FootprintPad::Event::DrillDiameterChanged:
       setShape(pad.toQPainterPathPx());
       break;
-    case FootprintPad::Event::BoardSideChanged:
+    case FootprintPad::Event::ComponentSideChanged:
       setLayerName(pad.getLayerName());
+      break;
+    case FootprintPad::Event::HolesEdited:
+      setLayerName(pad.getLayerName());
+      setShape(pad.toQPainterPathPx());
       break;
     default:
       qWarning()

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/core/geometry/hole.h>
+
 #include <QtCore>
 #include <QtWidgets>
 
@@ -74,12 +76,19 @@ public:
       const FootprintPadPropertiesDialog& rhs) = delete;
 
 private:  // Methods
+  void addHole() noexcept;
+  void removeSelectedHole() noexcept;
+  void removeAllHoles() noexcept;
+  void updateGeneralTabHoleWidgets() noexcept;
+  void setSelectedHole(int index) noexcept;
   void on_buttonBox_clicked(QAbstractButton* button);
   bool applyChanges() noexcept;
 
 private:  // Data
   FootprintPad& mPad;
   UndoStack& mUndoStack;
+  HoleList mHoles;
+  int mSelectedHoleIndex;
   QScopedPointer<Ui::FootprintPadPropertiesDialog> mUi;
 };
 

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>330</width>
-    <height>226</height>
+    <width>510</width>
+    <height>325</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,167 +15,299 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Package Pad:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="cbxPackagePad"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Board Side:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QWidget" name="boardSideWidget" native="true">
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QRadioButton" name="rbtnBoardSideTht">
-          <property name="text">
-           <string>THT</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="rbtnBoardSideTop">
-          <property name="text">
-           <string>Top</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="rbtnBoardSideBottom">
-          <property name="text">
-           <string>Bottom</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Shape:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QWidget" name="shapeWidget" native="true">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QRadioButton" name="rbtnShapeRound">
-          <property name="text">
-           <string>Round</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="rbtnShapeRect">
-          <property name="text">
-           <string>Rect</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="rbtnShapeOctagon">
-          <property name="text">
-           <string>Octagon</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Drill Diameter:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Size:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <item>
-        <widget class="librepcb::editor::PositiveLengthEdit" name="edtWidth" native="true"/>
+     <widget class="QWidget" name="tabGeneral">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Package Pad:</string>
+         </property>
+        </widget>
        </item>
-       <item>
-        <widget class="librepcb::editor::PositiveLengthEdit" name="edtHeight" native="true"/>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="cbxPackagePad"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Component Side:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QWidget" name="boardSideWidget" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="rbtnComponentSideTop">
+            <property name="text">
+             <string>Top</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="rbtnComponentSideBottom">
+            <property name="text">
+             <string>Bottom</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Shape:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QWidget" name="shapeWidget" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="rbtnShapeRound">
+            <property name="text">
+             <string>Round</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="rbtnShapeRect">
+            <property name="text">
+             <string>Rect</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="rbtnShapeOctagon">
+            <property name="text">
+             <string>Octagon</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Hole Diameter:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="librepcb::editor::PositiveLengthEdit" name="edtHoleDiameter" native="true"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblHoleDetails">
+           <property name="text">
+            <string>Multiple holes, see &lt;a href=&quot;tab&quot;&gt;here&lt;/a&gt;.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnConvertToSmt">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Convert to SMT</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnConvertToTht">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">Convert to THT</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Size:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="librepcb::editor::PositiveLengthEdit" name="edtWidth" native="true"/>
+         </item>
+         <item>
+          <widget class="librepcb::editor::PositiveLengthEdit" name="edtHeight" native="true"/>
+         </item>
+        </layout>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Position:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
+         </item>
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtPosY" native="true"/>
+         </item>
+        </layout>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Rotation:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
        </item>
       </layout>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Position:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
+     </widget>
+     <widget class="QWidget" name="tabHoles">
+      <attribute name="title">
+       <string>Plated Holes</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,1,0">
        <item>
-        <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="lblSelectedHole">
+           <property name="text">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnPreviousHole">
+           <property name="toolTip">
+            <string>Select previous hole</string>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="arrowType">
+            <enum>Qt::LeftArrow</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnNextHole">
+           <property name="toolTip">
+            <string>Select next hole</string>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="arrowType">
+            <enum>Qt::RightArrow</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnRemoveHole">
+           <property name="toolTip">
+            <string>Remove current hole</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/minus.png</normaloff>:/img/actions/minus.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnAddHole">
+           <property name="toolTip">
+            <string>Add new hole</string>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/add.png</normaloff>:/img/actions/add.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
-        <widget class="librepcb::editor::LengthEdit" name="edtPosY" native="true"/>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="librepcb::editor::HoleEditorWidget" name="holeEditorWidget" native="true"/>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Rotation:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="librepcb::editor::UnsignedLengthEdit" name="edtDrillDiameter" native="true"/>
-     </item>
-     <item row="6" column="1">
-      <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -203,15 +335,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>librepcb::editor::UnsignedLengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>librepcb::editor::PositiveLengthEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::HoleEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/holeeditorwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -219,7 +351,6 @@
   <tabstop>cbxPackagePad</tabstop>
   <tabstop>boardSideWidget</tabstop>
   <tabstop>shapeWidget</tabstop>
-  <tabstop>edtDrillDiameter</tabstop>
   <tabstop>edtWidth</tabstop>
   <tabstop>edtHeight</tabstop>
   <tabstop>edtPosX</tabstop>

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.h
@@ -91,11 +91,11 @@ private:  // Methods
   void selectNextFreePadInComboBox() noexcept;
   void packagePadComboBoxCurrentPadChanged(tl::optional<Uuid> pad) noexcept;
   void boardSideSelectorCurrentSideChanged(
-      FootprintPad::BoardSide side) noexcept;
+      FootprintPad::ComponentSide side) noexcept;
   void shapeSelectorCurrentShapeChanged(FootprintPad::Shape shape) noexcept;
   void widthEditValueChanged(const PositiveLength& value) noexcept;
   void heightEditValueChanged(const PositiveLength& value) noexcept;
-  void drillDiameterEditValueChanged(const UnsignedLength& value) noexcept;
+  void drillDiameterEditValueChanged(const PositiveLength& value) noexcept;
 
 private:  // Types / Data
   PadType mPadType;

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
@@ -70,10 +70,14 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
   mUi->edtMinPthDrillDiameter->configure(
       lengthUnit, LengthEditBase::Steps::drillDiameter(),
       settingsPrefix % "/min_pth_drill_diameter");
+  mUi->edtMinPthSlotWidth->configure(lengthUnit,
+                                     LengthEditBase::Steps::drillDiameter(),
+                                     settingsPrefix % "/min_pth_slot_width");
   mUi->edtCourtyardOffset->configure(lengthUnit,
                                      LengthEditBase::Steps::generic(),
                                      settingsPrefix % "/courtyard_offset");
-  for (QComboBox* cbx : {mUi->cbxWarnNpthSlotsConfig}) {
+  for (QComboBox* cbx :
+       {mUi->cbxWarnNpthSlotsConfig, mUi->cbxWarnPthSlotsConfig}) {
     cbx->addItem(
         tr("Only Curved"),
         QVariant::fromValue(BoardDesignRuleCheck::SlotsWarningLevel::Curved));
@@ -101,7 +105,9 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
     mUi->cbxMinNpthDrillDiameter->setChecked(checked);
     mUi->cbxMinNpthSlotWidth->setChecked(checked);
     mUi->cbxMinPthDrillDiameter->setChecked(checked);
+    mUi->cbxMinPthSlotWidth->setChecked(checked);
     mUi->cbxWarnNpthSlots->setChecked(checked);
+    mUi->cbxWarnPthSlots->setChecked(checked);
     mUi->cbxCourtyardOffset->setChecked(checked);
     mUi->cbxMissingConnections->setChecked(checked);
   });
@@ -124,10 +130,16 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
   mUi->edtMinNpthSlotWidth->setValue(options.minNpthSlotWidth);
   mUi->cbxMinPthDrillDiameter->setChecked(options.checkPthDrillDiameter);
   mUi->edtMinPthDrillDiameter->setValue(options.minPthDrillDiameter);
+  mUi->cbxMinPthSlotWidth->setChecked(options.checkPthSlotWidth);
+  mUi->edtMinPthSlotWidth->setValue(options.minPthSlotWidth);
   mUi->cbxWarnNpthSlots->setChecked(options.checkNpthSlotsWarning);
   mUi->cbxWarnNpthSlotsConfig->setCurrentIndex(
       mUi->cbxWarnNpthSlotsConfig->findData(
           QVariant::fromValue(options.npthSlotsWarning)));
+  mUi->cbxWarnPthSlots->setChecked(options.checkPthSlotsWarning);
+  mUi->cbxWarnPthSlotsConfig->setCurrentIndex(
+      mUi->cbxWarnPthSlotsConfig->findData(
+          QVariant::fromValue(options.pthSlotsWarning)));
   mUi->cbxCourtyardOffset->setChecked(options.checkCourtyardClearance);
   mUi->edtCourtyardOffset->setValue(options.courtyardOffset);
   mUi->cbxMissingConnections->setChecked(options.checkMissingConnections);
@@ -169,9 +181,15 @@ BoardDesignRuleCheck::Options BoardDesignRuleCheckDialog::getOptions() const
   options.minNpthSlotWidth = mUi->edtMinNpthSlotWidth->getValue();
   options.checkPthDrillDiameter = mUi->cbxMinPthDrillDiameter->isChecked();
   options.minPthDrillDiameter = mUi->edtMinPthDrillDiameter->getValue();
+  options.checkPthSlotWidth = mUi->cbxMinPthSlotWidth->isChecked();
+  options.minPthSlotWidth = mUi->edtMinPthSlotWidth->getValue();
   options.checkNpthSlotsWarning = mUi->cbxWarnNpthSlots->isChecked();
   options.npthSlotsWarning =
       mUi->cbxWarnNpthSlotsConfig->currentData()
+          .value<BoardDesignRuleCheck::SlotsWarningLevel>();
+  options.checkPthSlotsWarning = mUi->cbxWarnPthSlots->isChecked();
+  options.pthSlotsWarning =
+      mUi->cbxWarnPthSlotsConfig->currentData()
           .value<BoardDesignRuleCheck::SlotsWarningLevel>();
   options.checkCourtyardClearance = mUi->cbxCourtyardOffset->isChecked();
   options.courtyardOffset = mUi->edtCourtyardOffset->getValue();

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>780</width>
-    <height>551</height>
+    <width>778</width>
+    <height>594</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -147,7 +147,7 @@
         <item row="9" column="1">
          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinPthDrillDiameter" native="true"/>
         </item>
-        <item row="10" column="0">
+        <item row="11" column="0">
          <widget class="QCheckBox" name="cbxWarnNpthSlots">
           <property name="text">
            <string>Warn About NPTH Slots:</string>
@@ -157,14 +157,14 @@
           </property>
          </widget>
         </item>
-        <item row="10" column="1">
+        <item row="11" column="1">
          <widget class="QComboBox" name="cbxWarnNpthSlotsConfig">
           <property name="insertPolicy">
            <enum>QComboBox::NoInsert</enum>
           </property>
          </widget>
         </item>
-        <item row="11" column="0">
+        <item row="13" column="0">
          <widget class="QCheckBox" name="cbxCourtyardOffset">
           <property name="text">
            <string>Additional Courtyard Offset:</string>
@@ -174,10 +174,10 @@
           </property>
          </widget>
         </item>
-        <item row="11" column="1">
+        <item row="13" column="1">
          <widget class="librepcb::editor::LengthEdit" name="edtCourtyardOffset" native="true"/>
         </item>
-        <item row="12" column="0">
+        <item row="14" column="0">
          <widget class="QCheckBox" name="cbxMissingConnections">
           <property name="text">
            <string>Check for missing connections</string>
@@ -187,7 +187,7 @@
           </property>
          </widget>
         </item>
-        <item row="13" column="0">
+        <item row="15" column="0">
          <widget class="QPushButton" name="btnSelectAll">
           <property name="text">
            <string>Select All/None</string>
@@ -203,7 +203,7 @@
           </property>
          </widget>
         </item>
-        <item row="14" column="0">
+        <item row="16" column="0">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -216,7 +216,7 @@
           </property>
          </spacer>
         </item>
-        <item row="15" column="0" colspan="2">
+        <item row="17" column="0" colspan="2">
          <widget class="QProgressBar" name="prgProgress">
           <property name="value">
            <number>0</number>
@@ -238,6 +238,36 @@
         </item>
         <item row="8" column="1">
          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinNpthSlotWidth" native="true"/>
+        </item>
+        <item row="10" column="0">
+         <widget class="QCheckBox" name="cbxMinPthSlotWidth">
+          <property name="text">
+           <string>Minimum PTH Slot Width:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="1">
+         <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinPthSlotWidth" native="true"/>
+        </item>
+        <item row="12" column="0">
+         <widget class="QCheckBox" name="cbxWarnPthSlots">
+          <property name="text">
+           <string>Warn About PTH Slots:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="1">
+         <widget class="QComboBox" name="cbxWarnPthSlotsConfig">
+          <property name="insertPolicy">
+           <enum>QComboBox::NoInsert</enum>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -300,8 +330,12 @@
   <tabstop>edtMinNpthSlotWidth</tabstop>
   <tabstop>cbxMinPthDrillDiameter</tabstop>
   <tabstop>edtMinPthDrillDiameter</tabstop>
+  <tabstop>cbxMinPthSlotWidth</tabstop>
+  <tabstop>edtMinPthSlotWidth</tabstop>
   <tabstop>cbxWarnNpthSlots</tabstop>
   <tabstop>cbxWarnNpthSlotsConfig</tabstop>
+  <tabstop>cbxWarnPthSlots</tabstop>
+  <tabstop>cbxWarnPthSlotsConfig</tabstop>
   <tabstop>cbxCourtyardOffset</tabstop>
   <tabstop>edtCourtyardOffset</tabstop>
   <tabstop>cbxMissingConnections</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
@@ -481,7 +481,7 @@ bool BoardEditorState_DrawTrace::startPositioning(
         // to pads of no net.
         throwPadNotConnectedException();
       }
-      if (pad->getLibPad().getBoardSide() != FootprintPad::BoardSide::THT) {
+      if (!pad->getLibPad().isTht()) {
         layer = board.getLayerStack().getLayer(pad->getLayerName());
       }
     } else if (BI_NetLine* netline = qobject_cast<BI_NetLine*>(item)) {
@@ -599,8 +599,7 @@ bool BoardEditorState_DrawTrace::addNextNetPoint(Board& board) noexcept {
               {netsignal})) {
         if (mCurrentSnapActive || mTargetPos == pad->getPosition()) {
           otherAnchors.append(pad);
-          if (mAddVia &&
-              pad->getLibPad().getBoardSide() == FootprintPad::BoardSide::THT) {
+          if (mAddVia && pad->getLibPad().isTht()) {
             mCurrentLayerName = mViaLayerName;
           }
         }
@@ -793,8 +792,7 @@ void BoardEditorState_DrawTrace::updateNetpointPositions() noexcept {
       isOnVia = true;
     } else if (BI_FootprintPad* pad = qobject_cast<BI_FootprintPad*>(item)) {
       mTargetPos = pad->getPosition();
-      isOnVia =
-          (pad->getLibPad().getBoardSide() == FootprintPad::BoardSide::THT);
+      isOnVia = (pad->getLibPad().isTht());
     } else if (BI_NetPoint* netpoint = qobject_cast<BI_NetPoint*>(item)) {
       mTargetPos = netpoint->getPosition();
     } else if (BI_NetLine* netline = qobject_cast<BI_NetLine*>(item)) {
@@ -922,8 +920,7 @@ void BoardEditorState_DrawTrace::layerChanged(
     Point startPos = mFixedStartAnchor->getPosition();
     BI_Via* via = dynamic_cast<BI_Via*>(mFixedStartAnchor);
     BI_FootprintPad* pad = dynamic_cast<BI_FootprintPad*>(mFixedStartAnchor);
-    if (pad &&
-        (pad->getLibPad().getBoardSide() != FootprintPad::BoardSide::THT)) {
+    if (pad && (!pad->getLibPad().isTht())) {
       pad = nullptr;
     }
     if (via || pad) {

--- a/libs/librepcb/editor/utils/measuretool.cpp
+++ b/libs/librepcb/editor/utils/measuretool.cpp
@@ -318,9 +318,13 @@ QSet<Point> MeasureTool::snapCandidatesFromFootprint(
     path.addVertex(Point(0, -p.getHeight() / 2));
     candidates |= snapCandidatesFromPath(transform.map(
         path.rotated(p.getRotation()).translated(p.getPosition())));
-    if (p.getDrillDiameter() > 0) {
-      candidates |= snapCandidatesFromCircle(transform.map(p.getPosition()),
-                                             *p.getDrillDiameter());
+    const Transform padTransform(p.getPosition(), p.getRotation());
+    for (const Hole& h : p.getHoles()) {
+      foreach (const Vertex& vertex,
+               padTransform.map(h.getPath())->getVertices()) {
+        candidates |= snapCandidatesFromCircle(transform.map(vertex.getPos()),
+                                               *h.getDiameter());
+      }
     }
   }
   for (const Polygon& p : footprint.getPolygons()) {

--- a/libs/librepcb/editor/widgets/editabletablewidget.h
+++ b/libs/librepcb/editor/widgets/editabletablewidget.h
@@ -51,11 +51,13 @@ public:
   virtual ~EditableTableWidget() noexcept;
 
   // Setters
+  virtual void setModel(QAbstractItemModel* model) noexcept override;
   void setReadOnly(bool readOnly) noexcept;
   void setShowCopyButton(bool show) noexcept { mShowCopyButton = show; }
   void setShowEditButton(bool show) noexcept { mShowEditButton = show; }
   void setShowMoveButtons(bool show) noexcept { mShowMoveButtons = show; }
   void setBrowseButtonColumn(int col) noexcept { mBrowseButtonColumn = col; }
+  void setMinimumRowCount(int count) noexcept;
 
   // Inherited
   using QAbstractItemView::edit;  // Required to override edit() overload below.
@@ -74,6 +76,7 @@ protected:
 
 signals:
   void readOnlyChanged(bool readOnly);
+  void canRemoveChanged(bool canRemove);
   void currentRowChanged(int row);
   void btnAddClicked(const QVariant& data);
   void btnRemoveClicked(const QVariant& data);
@@ -84,12 +87,13 @@ signals:
   void btnBrowseClicked(const QVariant& data);
 
 private:
+  void updateCanRemove() noexcept;
   void installButtons(int row) noexcept;
   QToolButton* createButton(const QString& objectName, const QIcon& icon,
                             const QString& text, const QString& toolTip,
                             int width, int height, Signal clickedSignal,
-                            const QPersistentModelIndex& index,
-                            bool doesModify) noexcept;
+                            const QPersistentModelIndex& index, bool doesModify,
+                            bool doesRemove) noexcept;
   void buttonClickedHandler(Signal clickedSignal,
                             const QPersistentModelIndex& index) noexcept;
 
@@ -97,7 +101,11 @@ private:
   bool mShowEditButton;
   bool mShowMoveButtons;
   int mBrowseButtonColumn;
+  int mMinimumRowCount;
+  bool mCanRemove;
   bool mReadOnly;
+
+  QMetaObject::Connection mRowsRemovedConnection;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/widgets/holeeditorwidget.cpp
+++ b/libs/librepcb/editor/widgets/holeeditorwidget.cpp
@@ -1,0 +1,249 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "holeeditorwidget.h"
+
+#include "ui_holeeditorwidget.h"
+
+#include <librepcb/core/geometry/hole.h>
+#include <librepcb/core/utils/toolbox.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+HoleEditorWidget::HoleEditorWidget(QWidget* parent) noexcept
+  : QWidget(parent),
+    mUi(new Ui::HoleEditorWidget),
+    mHole(Uuid::createRandom(), PositiveLength(1000000),
+          makeNonEmptyPath(Point(0, 0))) {
+  mUi->setupUi(this);
+  mUi->pathEditorWidget->setFrameShape(QFrame::NoFrame);
+  mUi->pathEditorWidget->setMinimumVertexCount(1);
+  connect(mUi->edtDiameter, &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            mHole.setDiameter(value);
+            updateLinearOuterSize(*mHole.getPath());
+            emit holeChanged(mHole);
+          });
+  connect(mUi->edtPosX, &LengthEdit::valueChanged, this,
+          &HoleEditorWidget::updatePathFromCircularTab);
+  connect(mUi->edtPosY, &LengthEdit::valueChanged, this,
+          &HoleEditorWidget::updatePathFromCircularTab);
+  connect(mUi->edtCenterX, &LengthEdit::valueChanged, this,
+          &HoleEditorWidget::updatePathFromLinearTab);
+  connect(mUi->edtCenterY, &LengthEdit::valueChanged, this,
+          &HoleEditorWidget::updatePathFromLinearTab);
+  connect(mUi->edtLength, &UnsignedLengthEdit::valueChanged, this,
+          &HoleEditorWidget::updatePathFromLinearTab);
+  connect(mUi->edtRotation, &AngleEdit::valueChanged, this,
+          &HoleEditorWidget::updatePathFromLinearTab);
+  connect(mUi->pathEditorWidget, &PathEditorWidget::pathChanged, this,
+          [this](const Path& path) {
+            if (!path.getVertices().isEmpty()) {
+              mHole.setPath(NonEmptyPath(path));
+              updateCircularTabFromPath(path);
+              updateLinearTabFromPath(path);
+              updateLinearOuterSize(path);
+              emit holeChanged(mHole);
+            }
+          });
+}
+
+HoleEditorWidget::~HoleEditorWidget() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void HoleEditorWidget::setReadOnly(bool readOnly) noexcept {
+  mUi->edtDiameter->setReadOnly(readOnly);
+  mUi->edtPosX->setReadOnly(readOnly);
+  mUi->edtPosY->setReadOnly(readOnly);
+  mUi->edtCenterX->setReadOnly(readOnly);
+  mUi->edtCenterY->setReadOnly(readOnly);
+  mUi->edtLength->setReadOnly(readOnly);
+  mUi->edtRotation->setReadOnly(readOnly);
+  mUi->pathEditorWidget->setReadOnly(readOnly);
+}
+
+void HoleEditorWidget::setHole(const Hole& hole) noexcept {
+  // Load attributes.
+  mHole = hole;
+  mUi->edtDiameter->setValue(mHole.getDiameter());
+  mUi->pathEditorWidget->setPath(*mHole.getPath());
+
+  // Open the most reasonable tab.
+  if (mUi->tabCircular->isEnabled()) {
+    mUi->tabWidget->setCurrentWidget(mUi->tabCircular);
+  } else if (mUi->tabLinear->isEnabled()) {
+    mUi->tabWidget->setCurrentWidget(mUi->tabLinear);
+  } else {
+    mUi->tabWidget->setCurrentWidget(mUi->tabArbitrary);
+  }
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void HoleEditorWidget::setFocusToDiameterEdit() noexcept {
+  mUi->edtDiameter->setFocus();
+}
+
+void HoleEditorWidget::configureClientSettings(
+    const LengthUnit& lengthUnit, const QString& settingsPrefix) noexcept {
+  mUi->edtDiameter->configure(lengthUnit,
+                              LengthEditBase::Steps::drillDiameter(),
+                              settingsPrefix % "/diameter");
+  mUi->edtPosX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_x");
+  mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                          settingsPrefix % "/pos_y");
+  mUi->edtCenterX->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                             settingsPrefix % "/center_x");
+  mUi->edtCenterY->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                             settingsPrefix % "/center_y");
+  mUi->edtLength->configure(lengthUnit, LengthEditBase::Steps::generic(),
+                            settingsPrefix % "/length");
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void HoleEditorWidget::updatePathFromCircularTab() noexcept {
+  QSignalBlocker blocker(mUi->pathEditorWidget);
+
+  const NonEmptyPath path(Path(
+      {Vertex(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()))}));
+  if (path != mHole.getPath()) {
+    mHole.setPath(path);
+    mUi->pathEditorWidget->setPath(*path);
+    updateLinearTabFromPath(*path);
+    updateLinearOuterSize(*path);
+    emit holeChanged(mHole);
+  }
+}
+
+void HoleEditorWidget::updatePathFromLinearTab() noexcept {
+  QSignalBlocker blocker(mUi->pathEditorWidget);
+
+  const Point center(mUi->edtCenterX->getValue(), mUi->edtCenterY->getValue());
+  const UnsignedLength length = mUi->edtLength->getValue();
+  const Angle rotation = mUi->edtRotation->getValue();
+
+  const Point p1 = center + Point(length / 2, 0).rotated(rotation);
+  const Point p2 = center + Point(length / -2, 0).rotated(rotation);
+  Path path(Path({Vertex(p1)}));
+  if (p2 != p1) {
+    path.addVertex(p2);
+  }
+
+  if (path != *mHole.getPath()) {
+    mHole.setPath(NonEmptyPath(path));
+    mUi->pathEditorWidget->setPath(path);
+    updateCircularTabFromPath(path);
+    updateLinearOuterSize(path);
+    emit holeChanged(mHole);
+  }
+}
+
+void HoleEditorWidget::updateCircularTabFromPath(const Path& path) noexcept {
+  // Avoid possible endless signal loop.
+  QSignalBlocker blockPosX(mUi->edtPosX);
+  QSignalBlocker blockPosY(mUi->edtPosY);
+
+  const bool isCircular = (path.getVertices().count() == 1);
+  mUi->tabWidget->setTabEnabled(mUi->tabWidget->indexOf(mUi->tabCircular),
+                                isCircular);
+  if (isCircular) {
+    mUi->edtPosX->setValue(path.getVertices().first().getPos().getX());
+    mUi->edtPosY->setValue(path.getVertices().first().getPos().getY());
+  }
+}
+
+void HoleEditorWidget::updateLinearTabFromPath(const Path& path) noexcept {
+  // Avoid possible endless signal loop.
+  QSignalBlocker blockCenterX(mUi->edtCenterX);
+  QSignalBlocker blockCenterY(mUi->edtCenterY);
+  QSignalBlocker blockLength(mUi->edtLength);
+  QSignalBlocker blockRotation(mUi->edtRotation);
+
+  const bool isCircular = (path.getVertices().count() == 1);
+  const bool isLinear = (path.getVertices().count() == 2) &&
+      (path.getVertices().first().getAngle() == Angle::deg0());
+  mUi->tabWidget->setTabEnabled(mUi->tabWidget->indexOf(mUi->tabLinear),
+                                isCircular || isLinear);
+  if (isCircular || isLinear) {
+    const Point p1 = path.getVertices().first().getPos();
+    const Point p2 = path.getVertices().last().getPos();
+    const Point diff = p2 - p1;
+    const Point center = (p1 + p2) / 2;
+    const UnsignedLength length = (p2 - p1).getLength();
+    const Angle rotation = isCircular
+        ? Angle::deg0()
+        : Angle::fromRad(
+              std::atan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()))
+              .rounded(Angle(1000));
+    mUi->edtCenterX->setValue(center.getX());
+    mUi->edtCenterY->setValue(center.getY());
+    mUi->edtLength->setValue(length);
+    if ((rotation.mappedTo0_360deg() % Angle::deg180()) !=
+        (mUi->edtRotation->getValue().mappedTo0_360deg() % Angle::deg180())) {
+      mUi->edtRotation->setValue(rotation);
+    }
+  }
+}
+
+void HoleEditorWidget::updateLinearOuterSize(const Path& path) noexcept {
+  QLocale locale;
+  const PositiveLength diameter = mUi->edtDiameter->getValue();
+  const PositiveLength length = path.getTotalStraightLength() + diameter;
+  const LengthUnit& unit = mUi->edtLength->getDisplayedUnit();
+  const int decimals = unit.getReasonableNumberOfDecimals();
+  const qreal width = unit.convertToUnit(*length);
+  const qreal height = unit.convertToUnit(*diameter);
+  mUi->lblOuterSize->setText(
+      tr("Outer Size:") %
+      QString(" %1x%2%3")
+          .arg(Toolbox::floatToString(width, decimals, locale))
+          .arg(Toolbox::floatToString(height, decimals, locale))
+          .arg(unit.toShortStringTr()));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/widgets/holeeditorwidget.h
+++ b/libs/librepcb/editor/widgets/holeeditorwidget.h
@@ -1,0 +1,99 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_HOLEEDITORWIDGET_H
+#define LIBREPCB_EDITOR_HOLEEDITORWIDGET_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/geometry/hole.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class LengthUnit;
+class Path;
+
+namespace editor {
+
+namespace Ui {
+class HoleEditorWidget;
+}
+
+/*******************************************************************************
+ *  Class HoleEditorWidget
+ ******************************************************************************/
+
+/**
+ * @brief The HoleEditorWidget class
+ */
+class HoleEditorWidget : public QWidget {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  HoleEditorWidget() = delete;
+  explicit HoleEditorWidget(QWidget* parent = nullptr) noexcept;
+  HoleEditorWidget(const HoleEditorWidget& other) = delete;
+  virtual ~HoleEditorWidget() noexcept;
+
+  // Getters
+  const Hole& getHole() const noexcept { return mHole; }
+
+  // Setters
+  void setReadOnly(bool readOnly) noexcept;
+  void setHole(const Hole& hole) noexcept;
+
+  // General Methods
+  void setFocusToDiameterEdit() noexcept;
+  void configureClientSettings(const LengthUnit& lengthUnit,
+                               const QString& settingsPrefix) noexcept;
+
+  // Operator Overloadings
+  HoleEditorWidget& operator=(const HoleEditorWidget& rhs) = delete;
+
+signals:
+  void holeChanged(const Hole& hole);
+
+private:  // Methods
+  void updatePathFromCircularTab() noexcept;
+  void updatePathFromLinearTab() noexcept;
+  void updateCircularTabFromPath(const Path& path) noexcept;
+  void updateLinearTabFromPath(const Path& path) noexcept;
+  void updateLinearOuterSize(const Path& path) noexcept;
+
+private:  // Data
+  QScopedPointer<Ui::HoleEditorWidget> mUi;
+  Hole mHole;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/widgets/holeeditorwidget.ui
+++ b/libs/librepcb/editor/widgets/holeeditorwidget.ui
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::editor::HoleEditorWidget</class>
+ <widget class="QWidget" name="librepcb::editor::HoleEditorWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>366</width>
+    <height>206</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Diameter:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="librepcb::editor::PositiveLengthEdit" name="edtDiameter" native="true"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tabCircular">
+      <attribute name="title">
+       <string>Circular Drill</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Position:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
+         </item>
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtPosY" native="true"/>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabLinear">
+      <attribute name="title">
+       <string>Linear Slot</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_3">
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtCenterX" native="true"/>
+         </item>
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtCenterY" native="true"/>
+         </item>
+        </layout>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Rotation:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Center:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
+       </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,1">
+         <item>
+          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtLength" native="true"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblOuterSize">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Length:</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabArbitrary">
+      <attribute name="title">
+       <string>Arbitrary Slot</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="librepcb::editor::PathEditorWidget" name="pathEditorWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::editor::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::AngleEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/angleedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::PathEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/patheditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>edtDiameter</tabstop>
+  <tabstop>edtPosX</tabstop>
+  <tabstop>edtPosY</tabstop>
+  <tabstop>edtCenterX</tabstop>
+  <tabstop>edtCenterY</tabstop>
+  <tabstop>edtLength</tabstop>
+  <tabstop>edtRotation</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/librepcb/editor/widgets/patheditorwidget.cpp
+++ b/libs/librepcb/editor/widgets/patheditorwidget.cpp
@@ -95,6 +95,10 @@ void PathEditorWidget::setReadOnly(bool readOnly) noexcept {
   mView->setReadOnly(readOnly);
 }
 
+void PathEditorWidget::setMinimumVertexCount(int count) noexcept {
+  mView->setMinimumRowCount(count);
+}
+
 void PathEditorWidget::setPath(const Path& path) noexcept {
   mModel->setPath(path);
 }

--- a/libs/librepcb/editor/widgets/patheditorwidget.h
+++ b/libs/librepcb/editor/widgets/patheditorwidget.h
@@ -60,6 +60,7 @@ public:
   // General Methods
   void setFrameShape(QFrame::Shape shape) noexcept;
   void setReadOnly(bool readOnly) noexcept;
+  void setMinimumVertexCount(int count) noexcept;
   void setPath(const Path& path) noexcept;
   const Path& getPath() const noexcept;
   void setLengthUnit(const LengthUnit& unit) noexcept;

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -318,8 +318,10 @@ TEST_F(EagleTypeConverterTest, testConvertThtPad) {
   EXPECT_EQ(FootprintPad::Shape::RECT, out.second->getShape());
   EXPECT_EQ(PositiveLength(2250000), out.second->getWidth());  // 1.5*drill
   EXPECT_EQ(PositiveLength(2250000), out.second->getHeight());  // 1.5*drill
-  EXPECT_EQ(UnsignedLength(1500000), out.second->getDrillDiameter());
-  EXPECT_EQ(FootprintPad::BoardSide::THT, out.second->getBoardSide());
+  EXPECT_EQ(FootprintPad::ComponentSide::Top, out.second->getComponentSide());
+  ASSERT_EQ(1, out.second->getHoles().count());
+  EXPECT_EQ(PositiveLength(1500000),
+            out.second->getHoles().first()->getDiameter());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
@@ -334,8 +336,10 @@ TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
   EXPECT_EQ(FootprintPad::Shape::OCTAGON, out.second->getShape());
   EXPECT_EQ(PositiveLength(2540000), out.second->getWidth());
   EXPECT_EQ(PositiveLength(2540000), out.second->getHeight());
-  EXPECT_EQ(UnsignedLength(1500000), out.second->getDrillDiameter());
-  EXPECT_EQ(FootprintPad::BoardSide::THT, out.second->getBoardSide());
+  EXPECT_EQ(FootprintPad::ComponentSide::Top, out.second->getComponentSide());
+  ASSERT_EQ(1, out.second->getHoles().count());
+  EXPECT_EQ(PositiveLength(1500000),
+            out.second->getHoles().first()->getDiameter());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertSmtPad) {
@@ -349,8 +353,8 @@ TEST_F(EagleTypeConverterTest, testConvertSmtPad) {
   EXPECT_EQ(FootprintPad::Shape::RECT, out.second->getShape());
   EXPECT_EQ(PositiveLength(3000000), out.second->getWidth());
   EXPECT_EQ(PositiveLength(4000000), out.second->getHeight());
-  EXPECT_EQ(UnsignedLength(0), out.second->getDrillDiameter());
-  EXPECT_EQ(FootprintPad::BoardSide::TOP, out.second->getBoardSide());
+  EXPECT_EQ(FootprintPad::ComponentSide::Top, out.second->getComponentSide());
+  EXPECT_EQ(0, out.second->getHoles().count());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertSmtPadRotated) {
@@ -365,8 +369,9 @@ TEST_F(EagleTypeConverterTest, testConvertSmtPadRotated) {
   EXPECT_EQ(FootprintPad::Shape::RECT, out.second->getShape());
   EXPECT_EQ(PositiveLength(3000000), out.second->getWidth());
   EXPECT_EQ(PositiveLength(4000000), out.second->getHeight());
-  EXPECT_EQ(UnsignedLength(0), out.second->getDrillDiameter());
-  EXPECT_EQ(FootprintPad::BoardSide::BOTTOM, out.second->getBoardSide());
+  EXPECT_EQ(FootprintPad::ComponentSide::Bottom,
+            out.second->getComponentSide());
+  EXPECT_EQ(0, out.second->getHoles().count());
 }
 
 /*******************************************************************************

--- a/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
@@ -84,12 +84,14 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
   std::shared_ptr<FootprintPad> footprintPad1 = std::make_shared<FootprintPad>(
       Uuid::createRandom(), packagePad1->getUuid(), Point(12, 34), Angle(56),
       FootprintPad::Shape::OCTAGON, PositiveLength(11), PositiveLength(22),
-      UnsignedLength(0), FootprintPad::BoardSide::TOP);
+      FootprintPad::ComponentSide::Bottom, HoleList{});
 
   std::shared_ptr<FootprintPad> footprintPad2 = std::make_shared<FootprintPad>(
       Uuid::createRandom(), tl::nullopt, Point(12, 34), Angle(56),
       FootprintPad::Shape::RECT, PositiveLength(123), PositiveLength(456),
-      UnsignedLength(789), FootprintPad::BoardSide::THT);
+      FootprintPad::ComponentSide::Top,
+      HoleList{std::make_shared<Hole>(Uuid::createRandom(), PositiveLength(789),
+                                      makeNonEmptyPath(Point(0, 0)))});
 
   std::shared_ptr<Polygon> polygon1 = std::make_shared<Polygon>(
       Uuid::createRandom(), GraphicsLayerName("foo"), UnsignedLength(1), false,


### PR DESCRIPTION
### Summary

Replaces #423 with a different approach, see details in #1071 which did the same but for non-plated holes.

### File Format

So far, a footprint pad object was stored this way:

```lisp
(pad 474059df-640b-4b17-98b2-148e340a7152 (side tht) (shape round)
 (position 2.54 0.0) (rotation 90.0) (size 4.064 2.032) (drill 1.016)
 (package_pad 474059df-640b-4b17-98b2-148e340a7152)
)
```

Now a pad acts as a kind of container which can contain 0..n hole objects as introduced in #1071:

```lisp
(pad 474059df-640b-4b17-98b2-148e340a7152 (side top) (shape round)
 (position 2.54 0.0) (rotation 90.0) (size 4.064 2.032)
 (package_pad 474059df-640b-4b17-98b2-148e340a7152)
 (hole 474059df-640b-4b17-98b2-148e340a7152 (diameter 1.016)
  (vertex (position 0.0 0.0) (angle 0.0))
 )
)
```

A pad without holes is automatically considered as SMT. If there's at least one hole, it's THT. One might wonder why there can be multiple holes in a pad - the implementation of 1 vs. n holes is almost the same and I think there might indeed be some cases where this is useful, so I decided to allow more than 1 hole. The idea to consider a pad as a container of objects might be extended to polygons some day, e.g. to attach a custom solder mask polygon to a pad.

Note that the `(side tht)` is automatically converted to `(side top)` during the file format upgrade. Although this property doesn't make that much sense for a THT pad, I don't like omitting it since this would lead to a different file format for SMT and THT pads. In the GUI I called the property "Component Side", I hope this way it's not too confusing for users (even a THT pad is assembled only from one side).

### Example

Now you can draw plated smileys :joy:

![image](https://user-images.githubusercontent.com/5374821/210389223-f2daa250-d5c0-4df5-af79-f5cc1a72e7f0.png)

### User Interface

The same hole editor widget as introduced in #1071 is reused, and embedded into the footprint pad editor. If there's only one, round hole it can be directly edited as usual:

![image](https://user-images.githubusercontent.com/5374821/210386974-6515420f-77c0-43bc-bcde-33f5f40954a6.png)

For more complex configurations, the new tab needs to be used. If there are multiple holes, you need to iterate through them:

![image](https://user-images.githubusercontent.com/5374821/210387464-44a476c4-4fec-43e2-b957-1aecd3172107.png)

The interface is for sure not the most convenient, but for these *very* rare complex cases it's not worth spending too much time on it. Simple cases (probably >99% of pads are simple) are still very easy to create & modify. 

### Excellon Export

Identical to #1071 (same export option reused).

### DRC

Two new DRC checks added, exactly the same as in #1071 but for plated holes.

### Package Check

Since due to the much higher flexibility of pad holes, it's now easier to create pads which cannot be manufactured. Therefore I implemented a new check in the package editor which now warns when creating any pad with a restring smaller than 150μm (also applies to overlapping holes or holes completely outside the pad).

Fixes #418.