### PR TITLE
Use rounded corners for all expanded pad/via shapes

### DIFF
--- a/libs/librepcb/core/export/gerberaperturelist.cpp
+++ b/libs/librepcb/core/export/gerberaperturelist.cpp
@@ -125,41 +125,74 @@ int GerberApertureList::addObround(const PositiveLength& w,
 }
 
 int GerberApertureList::addRect(const PositiveLength& w,
-                                const PositiveLength& h, const Angle& rot,
+                                const PositiveLength& h,
+                                const UnsignedLength& r, const Angle& rot,
                                 Function function) noexcept {
-  if (rot % Angle::deg180() == 0) {
+  // Handle simple cases first.
+  if ((r == 0) && (rot % Angle::deg180() == 0)) {
     return addAperture(
         QString("%ADD{}R,%1X%2*%\n").arg(w->toMmString(), h->toMmString()),
         function);
-  } else if (rot % Angle::deg90() == 0) {
+  } else if ((r == 0) && (rot % Angle::deg90() == 0)) {
     return addAperture(
         QString("%ADD{}R,%1X%2*%\n").arg(h->toMmString(), w->toMmString()),
         function);
   } else if (w < h) {
-    // Same as condition below, but swap width and height and rotate by 90° to
-    // simplify calculations and to merge all combinations of parameters
-    // leading in the same image.
-    return addRect(h, w, rot + Angle::deg90(), function);
-  } else {
-    // Rotation is not a multiple of 90 degrees --> we need to use an aperture
-    // macro. But don't use the "Center Line (Code 21)" since some Gerber
-    // parsers interpret the rotation parameter in the wrong way! See Gerber
-    // specs for details. Let's use the "Vector Line (Code 20)" macro instead.
+    // Swap width and height and rotate by 90° to simplify calculations and
+    // to merge all combinations of parameters leading in the same image.
+    return addRect(h, w, r, rot + Angle::deg90(), function);
+  }
 
-    // Normalize the rotation to a range of 0..180° to avoid generating
-    // multiple different apertures which represent exactly the same image.
-    Angle uniqueRotatation = rot.mappedTo0_360deg() % Angle::deg180();
+  // Normalize the rotation to a range of 0..90° (w==h) resp. 0..180° (w!=h)
+  // to avoid generating multiple different apertures which represent exactly
+  // the same image.
+  const Angle rotationModulo = (w == h) ? Angle::deg90() : Angle::deg180();
+  const Angle uniqueRotatation = rot.mappedTo0_360deg() % rotationModulo;
+
+  // More complex cases --> we need to use an aperture macro. But don't use
+  // the "Center Line (Code 21)" since some Gerber parsers interpret the
+  // rotation parameter in the wrong way! See Gerber specs for details.
+  // Let's use the "Vector Line (Code 20)" macro instead.
+  if (r == 0) {
+    // Corners are not rounded.
     QString s = "%AMROTATEDRECT{}";
     s += QString("*20,1,%1,%2,0.0,%3,0.0,%4*%\n")
              .arg(h->toMmString(), (-w / 2).toMmString(), (w / 2).toMmString(),
                   uniqueRotatation.toDegString());
     s += "%ADD{}ROTATEDRECT{}*%\n";
     return addAperture(s, function);
+  } else if (r >= std::min(w, h) / 2) {
+    // The radius is too large for the given size, it's actually an obround.
+    return addObround(w, h, rot, function);
+  } else {
+    // Corners are rounded, build a macro with two rects and four circles.
+    const QVector<Point> circlePositions = {
+        Point(r - (w / 2), (h / 2) - r).rotated(uniqueRotatation),
+        Point((w / 2) - r, (h / 2) - r).rotated(uniqueRotatation),
+        Point((w / 2) - r, r - (h / 2)).rotated(uniqueRotatation),
+        Point(r - (w / 2), r - (h / 2)).rotated(uniqueRotatation),
+    };
+    QString s = "%AMROUNDEDRECT{}*";
+    s += QString("20,1,%1,%2,0.0,%3,0.0,%4*")
+             .arg(h->toMmString(), (r - (w / 2)).toMmString(),
+                  ((w / 2) - r).toMmString(), uniqueRotatation.toDegString());
+    s += QString("20,1,%1,%2,0.0,%3,0.0,%4*")
+             .arg((h - (r * 2)).toMmString(), (-w / 2).toMmString(),
+                  (w / 2).toMmString(), uniqueRotatation.toDegString());
+    foreach (const Point& p, circlePositions) {
+      s += QString("1,1,%1,%2,%3*")
+               .arg((r * 2).toMmString(), p.getX().toMmString(),
+                    p.getY().toMmString());
+    }
+    s += "%\n";
+    s += "%ADD{}ROUNDEDRECT{}*%\n";
+    return addAperture(s, function);
   }
 }
 
 int GerberApertureList::addOctagon(const PositiveLength& w,
-                                   const PositiveLength& h, const Angle& rot,
+                                   const PositiveLength& h,
+                                   const UnsignedLength& r, const Angle& rot,
                                    Function function) noexcept {
   // Note: If w==h, we could theoretically use the "Gegular Polygon (P)"
   // aperture. However, it seems some CAM software render such polygons the
@@ -172,19 +205,46 @@ int GerberApertureList::addOctagon(const PositiveLength& w,
   // So let's always use an outline macro for octagons, probably this is more
   // compatible with CAM software.
 
+  // Normalize the rotation to a range of 0..45° (w==h) resp. 0..180° (w!=h)
+  // to avoid generating multiple different apertures which represent exactly
+  // the same image.
+  const Angle rotationModulo = (w == h) ? Angle::deg45() : Angle::deg180();
+  const Angle uniqueRotatation = rot.mappedTo0_360deg() % rotationModulo;
+  const Length innerWidth = w - (r * 2);
+  const Length innerHeight = h - (r * 2);
+
   if (w < h) {
     // Same as condition below, but swap width and height and rotate by 90° to
     // simplify calculations and to merge all combinations of parameters
     // leading in the same image.
-    return addOctagon(h, w, rot + Angle::deg90(), function);
+    return addOctagon(h, w, r, rot + Angle::deg90(), function);
+  } else if (r == 0) {
+    return addOutline("ROTATEDOCTAGON", Path::octagon(w, h, r),
+                      uniqueRotatation, function);
+  } else if ((innerWidth <= 0) || (innerHeight <= 0)) {
+    // The radius is too large for the given size, it's actually an obround.
+    return addObround(w, h, rot, function);
   } else {
-    // Normalize the rotation to a range of 0..45° (w==h) resp. 0..180° (w!=h)
-    // to avoid generating multiple different apertures which represent exactly
-    // the same image.
-    Angle rotationModulo = (w == h) ? Angle::deg45() : Angle::deg180();
-    Angle uniqueRotatation = rot.mappedTo0_360deg() % rotationModulo;
-    return addOutline("ROTATEDOCTAGON", Path::octagon(w, h), uniqueRotatation,
-                      function);
+    // Corners are rounded, build a macro with four rects and eight circles.
+    QString s = "%AMROUNDEDOCTAGON{}*";
+    Path octagonWithoutArcs;
+    foreach (const Vertex& v, Path::octagon(w, h, r).getVertices()) {
+      octagonWithoutArcs.addVertex(v.getPos());
+    }
+    s += buildOutlineMacro(octagonWithoutArcs, uniqueRotatation);
+    const Path innerOctagon =
+        Path::octagon(PositiveLength(innerWidth), PositiveLength(innerHeight),
+                      UnsignedLength(0))
+            .rotated(uniqueRotatation);
+    for (int i = 1; i < innerOctagon.getVertices().count(); ++i) {  // Skip [0]!
+      const Point p = innerOctagon.getVertices().at(i).getPos();
+      s += QString("1,1,%1,%2,%3*")
+               .arg((r * 2).toMmString(), p.getX().toMmString(),
+                    p.getY().toMmString());
+    }
+    s += "%\n";
+    s += "%ADD{}ROUNDEDOCTAGON{}*%\n";
+    return addAperture(s, function);
   }
 }
 
@@ -211,21 +271,28 @@ int GerberApertureList::addComponentPin(bool isPin1) noexcept {
  *  Private Methods
  ******************************************************************************/
 
-int GerberApertureList::addOutline(const QString& name, Path path,
+int GerberApertureList::addOutline(const QString& name, const Path& path,
                                    const Angle& rot,
                                    Function function) noexcept {
+  QString s = QString("%AM%1{}*").arg(name);
+  s += buildOutlineMacro(path, rot);
+  s += QString("%\n").arg(rot.toDegString());
+  s += QString("%ADD{}%1{}*%\n").arg(name);
+  return addAperture(s, function);
+}
+
+QString GerberApertureList::buildOutlineMacro(Path path, const Angle& rot) const
+    noexcept {
   path.close();
   Q_ASSERT(path.getVertices().count() >= 4);
-  QString s =
-      QString("%AM%1{}*4,1,%2,").arg(name).arg(path.getVertices().count() - 1);
+  QString s = QString("4,1,%2,").arg(path.getVertices().count() - 1);
   foreach (const Vertex& v, path.getVertices()) {
     Q_ASSERT(v.getAngle() == 0);
     s += QString("%1,%2,").arg(v.getPos().getX().toMmString(),
                                v.getPos().getY().toMmString());
   }
-  s += QString("%1*%\n").arg(rot.toDegString());
-  s += QString("%ADD{}%1{}*%\n").arg(name);
-  return addAperture(s, function);
+  s += QString("%1*").arg(rot.toDegString());
+  return s;
 }
 
 int GerberApertureList::addAperture(QString aperture,

--- a/libs/librepcb/core/export/gerberaperturelist.h
+++ b/libs/librepcb/core/export/gerberaperturelist.h
@@ -119,26 +119,30 @@ public:
    *
    * @param w         Width.
    * @param h         Height.
+   * @param r         Corner radius.
    * @param rot       Rotation.
    * @param function  Function attribute.
    *
    * @return Aperture number.
    */
   int addRect(const PositiveLength& w, const PositiveLength& h,
-              const Angle& rot, Function function) noexcept;
+              const UnsignedLength& r, const Angle& rot,
+              Function function) noexcept;
 
   /**
    * @brief Add an octagon aperture
    *
    * @param w         Width.
    * @param h         Height.
+   * @param r         Corner radius.
    * @param rot       Rotation.
    * @param function  Function attribute.
    *
    * @return Aperture number.
    */
   int addOctagon(const PositiveLength& w, const PositiveLength& h,
-                 const Angle& rot, Function function) noexcept;
+                 const UnsignedLength& r, const Angle& rot,
+                 Function function) noexcept;
 
   /**
    * @brief Add a component main aperture (for component layers only)
@@ -177,8 +181,20 @@ private:  // Methods
    *
    * @return Aperture number.
    */
-  int addOutline(const QString& name, Path path, const Angle& rot,
+  int addOutline(const QString& name, const Path& path, const Angle& rot,
                  Function function) noexcept;
+
+  /**
+   * @brief Internal helper for #addOutline()
+   *
+   * @param path      The vertices. ATTENTION: After closing the path, it must
+   *                  contain at least 4 vertices and it must not contain any
+   *                  arc segment (i.e. all angles must be zero)!!!
+   * @param rot       Rotation.
+   *
+   * @return Aperture macro content.
+   */
+  QString buildOutlineMacro(Path path, const Angle& rot) const noexcept;
 
   /**
    * @brief Helper method to actually add a new or get an existing aperture

--- a/libs/librepcb/core/export/gerbergenerator.cpp
+++ b/libs/librepcb/core/export/gerbergenerator.cpp
@@ -255,12 +255,13 @@ void GerberGenerator::flashCircle(const Point& pos, const PositiveLength& dia,
 }
 
 void GerberGenerator::flashRect(const Point& pos, const PositiveLength& w,
-                                const PositiveLength& h, const Angle& rot,
+                                const PositiveLength& h,
+                                const UnsignedLength& radius, const Angle& rot,
                                 Function function,
                                 const tl::optional<QString>& net,
                                 const QString& component, const QString& pin,
                                 const QString& signal) noexcept {
-  setCurrentAperture(mApertureList->addRect(w, h, rot, function));
+  setCurrentAperture(mApertureList->addRect(w, h, radius, rot, function));
   setCurrentAttributes(tl::nullopt,  // Aperture: Function
                        net,  // Object: Net name
                        component,  // Object: Component designator
@@ -299,12 +300,13 @@ void GerberGenerator::flashObround(const Point& pos, const PositiveLength& w,
 }
 
 void GerberGenerator::flashOctagon(const Point& pos, const PositiveLength& w,
-                                   const PositiveLength& h, const Angle& rot,
-                                   Function function,
+                                   const PositiveLength& h,
+                                   const UnsignedLength& radius,
+                                   const Angle& rot, Function function,
                                    const tl::optional<QString>& net,
                                    const QString& component, const QString& pin,
                                    const QString& signal) noexcept {
-  setCurrentAperture(mApertureList->addOctagon(w, h, rot, function));
+  setCurrentAperture(mApertureList->addOctagon(w, h, radius, rot, function));
   setCurrentAttributes(tl::nullopt,  // Aperture: Function
                        net,  // Object: Net name
                        component,  // Object: Component designator

--- a/libs/librepcb/core/export/gerbergenerator.h
+++ b/libs/librepcb/core/export/gerbergenerator.h
@@ -98,7 +98,8 @@ public:
                    const QString& component, const QString& pin,
                    const QString& signal) noexcept;
   void flashRect(const Point& pos, const PositiveLength& w,
-                 const PositiveLength& h, const Angle& rot, Function function,
+                 const PositiveLength& h, const UnsignedLength& radius,
+                 const Angle& rot, Function function,
                  const tl::optional<QString>& net, const QString& component,
                  const QString& pin, const QString& signal) noexcept;
   void flashObround(const Point& pos, const PositiveLength& w,
@@ -107,10 +108,10 @@ public:
                     const QString& component, const QString& pin,
                     const QString& signal) noexcept;
   void flashOctagon(const Point& pos, const PositiveLength& w,
-                    const PositiveLength& h, const Angle& rot,
-                    Function function, const tl::optional<QString>& net,
-                    const QString& component, const QString& pin,
-                    const QString& signal) noexcept;
+                    const PositiveLength& h, const UnsignedLength& radius,
+                    const Angle& rot, Function function,
+                    const tl::optional<QString>& net, const QString& component,
+                    const QString& pin, const QString& signal) noexcept;
   void flashComponent(const Point& pos, const Angle& rot,
                       const QString& designator, const QString& value,
                       MountType mountType, const QString& manufacturer,

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -140,10 +140,12 @@ public:
   static Path arcObround(const Point& p1, const Point& p2, const Angle& angle,
                          const PositiveLength& width) noexcept;
   static Path rect(const Point& p1, const Point& p2) noexcept;
-  static Path centeredRect(const PositiveLength& width,
-                           const PositiveLength& height) noexcept;
-  static Path octagon(const PositiveLength& width,
-                      const PositiveLength& height) noexcept;
+  static Path centeredRect(
+      const PositiveLength& width, const PositiveLength& height,
+      const UnsignedLength& cornerRadius = UnsignedLength(0)) noexcept;
+  static Path octagon(
+      const PositiveLength& width, const PositiveLength& height,
+      const UnsignedLength& cornerRadius = UnsignedLength(0)) noexcept;
   static Path flatArc(const Point& p1, const Point& p2, const Angle& angle,
                       const PositiveLength& maxTolerance) noexcept;
 

--- a/libs/librepcb/core/geometry/via.cpp
+++ b/libs/librepcb/core/geometry/via.cpp
@@ -109,14 +109,15 @@ Via::~Via() noexcept {
 Path Via::getOutline(const Length& expansion) const noexcept {
   Length size = mSize + (expansion * 2);
   if (size > 0) {
-    PositiveLength pSize(size);
+    const PositiveLength pSize(size);
+    const UnsignedLength cornerRadius(std::max(expansion, Length(0)));
     switch (mShape) {
       case Shape::Round:
         return Path::circle(pSize);
       case Shape::Square:
-        return Path::centeredRect(pSize, pSize);
+        return Path::centeredRect(pSize, pSize, cornerRadius);
       case Shape::Octagon:
-        return Path::octagon(pSize, pSize);
+        return Path::octagon(pSize, pSize, cornerRadius);
       default:
         Q_ASSERT(false);
         break;

--- a/libs/librepcb/core/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpad.cpp
@@ -177,18 +177,19 @@ bool FootprintPad::isOnLayer(const QString& name) const noexcept {
 }
 
 Path FootprintPad::getOutline(const Length& expansion) const noexcept {
-  Length width = mWidth + (expansion * 2);
-  Length height = mHeight + (expansion * 2);
+  const Length width = mWidth + (expansion * 2);
+  const Length height = mHeight + (expansion * 2);
   if (width > 0 && height > 0) {
-    PositiveLength pWidth(width);
-    PositiveLength pHeight(height);
+    const PositiveLength pWidth(width);
+    const PositiveLength pHeight(height);
+    const UnsignedLength cornerRadius(std::max(expansion, Length(0)));
     switch (mShape) {
       case Shape::ROUND:
         return Path::obround(pWidth, pHeight);
       case Shape::RECT:
-        return Path::centeredRect(pWidth, pHeight);
+        return Path::centeredRect(pWidth, pHeight, cornerRadius);
       case Shape::OCTAGON:
-        return Path::octagon(pWidth, pHeight);
+        return Path::octagon(pWidth, pHeight, cornerRadius);
       default:
         Q_ASSERT(false);
         break;

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -633,14 +633,14 @@ void BoardGerberExport::drawVia(GerberGenerator& gen, const BI_Via& via,
       }
       case Via::Shape::Square: {
         gen.flashRect(via.getPosition(), outerDiameter, outerDiameter,
-                      Angle::deg0(), function, net, QString(), QString(),
-                      QString());
+                      UnsignedLength(0), Angle::deg0(), function, net,
+                      QString(), QString(), QString());
         break;
       }
       case Via::Shape::Octagon: {
         gen.flashOctagon(via.getPosition(), outerDiameter, outerDiameter,
-                         Angle::deg0(), function, net, QString(), QString(),
-                         QString());
+                         UnsignedLength(0), Angle::deg0(), function, net,
+                         QString(), QString(), QString());
         break;
       }
       default: { throw LogicError(__FILE__, __LINE__); }
@@ -794,13 +794,14 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator& gen,
       break;
     }
     case FootprintPad::Shape::RECT: {
-      gen.flashRect(pad.getPosition(), pWidth, pHeight, pad.getRotation(),
-                    function, net, component, pin, signal);
+      gen.flashRect(pad.getPosition(), pWidth, pHeight, UnsignedLength(0),
+                    pad.getRotation(), function, net, component, pin, signal);
       break;
     }
     case FootprintPad::Shape::OCTAGON: {
-      gen.flashOctagon(pad.getPosition(), pWidth, pHeight, pad.getRotation(),
-                       function, net, component, pin, signal);
+      gen.flashOctagon(pad.getPosition(), pWidth, pHeight, UnsignedLength(0),
+                       pad.getRotation(), function, net, component, pin,
+                       signal);
       break;
     }
     default: { throw LogicError(__FILE__, __LINE__); }

--- a/tests/unittests/core/export/gerberaperturelisttest.cpp
+++ b/tests/unittests/core/export/gerberaperturelisttest.cpp
@@ -68,19 +68,37 @@ protected:
           l.addObround(PositiveLength(200000), PositiveLength(100000), rot,
                        function);
 
-          l.addRect(PositiveLength(100000), PositiveLength(100000), rot,
-                    function);
-          l.addRect(PositiveLength(100000), PositiveLength(200000), rot,
-                    function);
-          l.addRect(PositiveLength(200000), PositiveLength(100000), rot,
-                    function);
+          // No rounded corners.
+          l.addRect(PositiveLength(100000), PositiveLength(100000),
+                    UnsignedLength(0), rot, function);
+          l.addRect(PositiveLength(100000), PositiveLength(200000),
+                    UnsignedLength(0), rot, function);
+          l.addRect(PositiveLength(200000), PositiveLength(100000),
+                    UnsignedLength(0), rot, function);
 
-          l.addOctagon(PositiveLength(100000), PositiveLength(100000), rot,
-                       function);
-          l.addOctagon(PositiveLength(100000), PositiveLength(200000), rot,
-                       function);
-          l.addOctagon(PositiveLength(200000), PositiveLength(100000), rot,
-                       function);
+          // Rounded corners.
+          l.addRect(PositiveLength(100000), PositiveLength(100000),
+                    UnsignedLength(20000), rot, function);
+          l.addRect(PositiveLength(100000), PositiveLength(200000),
+                    UnsignedLength(20000), rot, function);
+          l.addRect(PositiveLength(200000), PositiveLength(100000),
+                    UnsignedLength(20000), rot, function);
+
+          // No rounded corners.
+          l.addOctagon(PositiveLength(100000), PositiveLength(100000),
+                       UnsignedLength(0), rot, function);
+          l.addOctagon(PositiveLength(100000), PositiveLength(200000),
+                       UnsignedLength(0), rot, function);
+          l.addOctagon(PositiveLength(200000), PositiveLength(100000),
+                       UnsignedLength(0), rot, function);
+
+          // Rounded corners.
+          l.addOctagon(PositiveLength(100000), PositiveLength(100000),
+                       UnsignedLength(20000), rot, function);
+          l.addOctagon(PositiveLength(100000), PositiveLength(200000),
+                       UnsignedLength(20000), rot, function);
+          l.addOctagon(PositiveLength(200000), PositiveLength(100000),
+                       UnsignedLength(20000), rot, function);
         }
       }
       s = l.generateString();
@@ -389,7 +407,7 @@ TEST_F(GerberApertureListTest, testHighObround0deg) {
   GerberApertureList l;
   PositiveLength w(100000);
   PositiveLength h(200000);
-  QVector<Angle> rot = {
+  QVector<Angle> rotations = {
       -Angle::deg180(),
       Angle::deg0(),
       Angle::deg180(),
@@ -397,8 +415,8 @@ TEST_F(GerberApertureListTest, testHighObround0deg) {
 
   const char* expected = "%ADD10O,0.1X0.2*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addObround(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -409,7 +427,7 @@ TEST_F(GerberApertureListTest, testWideObround0deg) {
   GerberApertureList l;
   PositiveLength w(200000);
   PositiveLength h(100000);
-  QVector<Angle> rot = {
+  QVector<Angle> rotations = {
       -Angle::deg180(),
       Angle::deg0(),
       Angle::deg180(),
@@ -417,8 +435,8 @@ TEST_F(GerberApertureListTest, testWideObround0deg) {
 
   const char* expected = "%ADD10O,0.2X0.1*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addObround(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -429,7 +447,7 @@ TEST_F(GerberApertureListTest, testHighObround90deg) {
   GerberApertureList l;
   PositiveLength w(100000);
   PositiveLength h(200000);
-  QVector<Angle> rot = {
+  QVector<Angle> rotations = {
       -Angle::deg270(),
       -Angle::deg90(),
       Angle::deg90(),
@@ -438,8 +456,8 @@ TEST_F(GerberApertureListTest, testHighObround90deg) {
 
   const char* expected = "%ADD10O,0.2X0.1*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addObround(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -450,7 +468,7 @@ TEST_F(GerberApertureListTest, testWideObround90deg) {
   GerberApertureList l;
   PositiveLength w(200000);
   PositiveLength h(100000);
-  QVector<Angle> rot = {
+  QVector<Angle> rotations = {
       -Angle::deg270(),
       -Angle::deg90(),
       Angle::deg90(),
@@ -459,8 +477,8 @@ TEST_F(GerberApertureListTest, testWideObround90deg) {
 
   const char* expected = "%ADD10O,0.1X0.2*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addObround(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -471,7 +489,7 @@ TEST_F(GerberApertureListTest, testHighObround10deg) {
   GerberApertureList l;
   PositiveLength w(100000);
   PositiveLength h(150000);
-  QVector<Angle> rot = {
+  QVector<Angle> rotations = {
       Angle(-350000000),
       Angle(-170000000),
       Angle(10000000),
@@ -487,8 +505,8 @@ TEST_F(GerberApertureListTest, testHighObround10deg) {
       "20,1,0.1,0.004341,-0.02462,-0.004341,0.02462,0*%\n"
       "%ADD10ROTATEDOBROUND10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addObround(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -499,7 +517,7 @@ TEST_F(GerberApertureListTest, testWideObround10deg) {
   GerberApertureList l;
   PositiveLength w(150000);
   PositiveLength h(100000);
-  QVector<Angle> rot = {
+  QVector<Angle> rotations = {
       Angle(-350000000),
       Angle(-170000000),
       Angle(10000000),
@@ -515,8 +533,8 @@ TEST_F(GerberApertureListTest, testWideObround10deg) {
       "20,1,0.1,-0.02462,-0.004341,0.02462,0.004341,0*%\n"
       "%ADD10ROTATEDOBROUND10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addObround(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -527,7 +545,8 @@ TEST_F(GerberApertureListTest, testHighRect0deg) {
   GerberApertureList l;
   PositiveLength w(100000);
   PositiveLength h(150000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       -Angle::deg180(),
       Angle::deg0(),
       Angle::deg180(),
@@ -535,8 +554,8 @@ TEST_F(GerberApertureListTest, testHighRect0deg) {
 
   const char* expected = "%ADD10R,0.1X0.15*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addRect(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -547,7 +566,8 @@ TEST_F(GerberApertureListTest, testWideRect0deg) {
   GerberApertureList l;
   PositiveLength w(150000);
   PositiveLength h(100000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       -Angle::deg180(),
       Angle::deg0(),
       Angle::deg180(),
@@ -555,8 +575,8 @@ TEST_F(GerberApertureListTest, testWideRect0deg) {
 
   const char* expected = "%ADD10R,0.15X0.1*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addRect(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -567,7 +587,8 @@ TEST_F(GerberApertureListTest, testHighRect90deg) {
   GerberApertureList l;
   PositiveLength w(100000);
   PositiveLength h(150000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       -Angle::deg270(),
       -Angle::deg90(),
       Angle::deg90(),
@@ -576,8 +597,8 @@ TEST_F(GerberApertureListTest, testHighRect90deg) {
 
   const char* expected = "%ADD10R,0.15X0.1*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addRect(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -588,7 +609,8 @@ TEST_F(GerberApertureListTest, testWideRect90deg) {
   GerberApertureList l;
   PositiveLength w(150000);
   PositiveLength h(100000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       -Angle::deg270(),
       -Angle::deg90(),
       Angle::deg90(),
@@ -597,8 +619,8 @@ TEST_F(GerberApertureListTest, testWideRect90deg) {
 
   const char* expected = "%ADD10R,0.1X0.15*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addRect(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -609,7 +631,8 @@ TEST_F(GerberApertureListTest, testHighRect10deg) {
   GerberApertureList l;
   PositiveLength w(100000);
   PositiveLength h(150000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       Angle(-350000000),
       Angle(-170000000),
       Angle(10000000),
@@ -623,8 +646,8 @@ TEST_F(GerberApertureListTest, testHighRect10deg) {
       "20,1,0.1,-0.075,0.0,0.075,0.0,100.0*%\n"
       "%ADD10ROTATEDRECT10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addRect(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -635,7 +658,8 @@ TEST_F(GerberApertureListTest, testWideRect10deg) {
   GerberApertureList l;
   PositiveLength w(150000);
   PositiveLength h(100000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       Angle(-350000000),
       Angle(-170000000),
       Angle(10000000),
@@ -649,8 +673,121 @@ TEST_F(GerberApertureListTest, testWideRect10deg) {
       "20,1,0.1,-0.075,0.0,0.075,0.0,10.0*%\n"
       "%ADD10ROTATEDRECT10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addRect(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
+    EXPECT_EQ(expected, l.generateString().toStdString());
+  }
+}
+
+// Test if a rounded rect with height>width and rotation=10°;190°;-170°;-350°
+// is exported as a macro.
+TEST_F(GerberApertureListTest, testHighRoundedRect10deg) {
+  GerberApertureList l;
+  PositiveLength w(100000);
+  PositiveLength h(150000);
+  UnsignedLength r(20000);
+  QVector<Angle> rotations = {
+      Angle(-350000000),
+      Angle(-170000000),
+      Angle(10000000),
+      Angle(190000000),
+  };
+
+  // ATTENTION: DO NOT USE THE CENTER LINE (Code 21)!!! It is buggy in some
+  // CAM software!!!
+  const char* expected =
+      "%AMROUNDEDRECT10*"
+      "20,1,0.1,-0.055,0.0,0.055,0.0,100.0*"
+      "20,1,0.06,-0.075,0.0,0.075,0.0,100.0*"
+      "1,1,0.04,-0.019994,-0.059374*"
+      "1,1,0.04,-0.039095,0.048955*"
+      "1,1,0.04,0.019994,0.059374*"
+      "1,1,0.04,0.039095,-0.048955*%\n"
+      "%ADD10ROUNDEDRECT10*%\n";
+
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
+    EXPECT_EQ(expected, l.generateString().toStdString());
+  }
+}
+
+// Test if a rounded rect with height<width and rotation=10°;190°;-170°;-350°
+// is exported as a macro.
+TEST_F(GerberApertureListTest, testWideRoundedRect10deg) {
+  GerberApertureList l;
+  PositiveLength w(150000);
+  PositiveLength h(100000);
+  UnsignedLength r(20000);
+  QVector<Angle> rotations = {
+      Angle(-350000000),
+      Angle(-170000000),
+      Angle(10000000),
+      Angle(190000000),
+  };
+
+  // ATTENTION: DO NOT USE THE CENTER LINE (Code 21)!!! It is buggy in some
+  // CAM software!!!
+  const char* expected =
+      "%AMROUNDEDRECT10*"
+      "20,1,0.1,-0.055,0.0,0.055,0.0,10.0*"
+      "20,1,0.06,-0.075,0.0,0.075,0.0,10.0*"
+      "1,1,0.04,-0.059374,0.019994*"
+      "1,1,0.04,0.048955,0.039095*"
+      "1,1,0.04,0.059374,-0.019994*"
+      "1,1,0.04,-0.048955,-0.039095*%\n"
+      "%ADD10ROUNDEDRECT10*%\n";
+
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
+    EXPECT_EQ(expected, l.generateString().toStdString());
+  }
+}
+
+// Test if a rounded rect with rotations of a multiple of 180° and with a too
+// large radius is converted into an obround.
+TEST_F(GerberApertureListTest, testObroundRoundedRect0deg) {
+  GerberApertureList l;
+  PositiveLength w(150000);
+  PositiveLength h(100000);
+  UnsignedLength r(50000);
+  QVector<Angle> rotations = {
+      -Angle::deg180(),
+      Angle::deg0(),
+      Angle::deg180(),
+  };
+
+  const char* expected = "%ADD10O,0.15X0.1*%\n";
+
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
+    EXPECT_EQ(expected, l.generateString().toStdString());
+  }
+}
+
+// Test if a rounded rect with a too large radius is converted into an obround.
+TEST_F(GerberApertureListTest, testObroundRoundedRect10deg) {
+  GerberApertureList l;
+  PositiveLength w(150000);
+  PositiveLength h(100000);
+  UnsignedLength r(60000);
+  QVector<Angle> rotations = {
+      Angle(-350000000),
+      Angle(-170000000),
+      Angle(10000000),
+      Angle(190000000),
+  };
+
+  const char* expected =
+      "%AMROTATEDOBROUND10*"
+      "1,1,0.1,-0.02462,-0.004341*"
+      "1,1,0.1,0.02462,0.004341*"
+      "20,1,0.1,-0.02462,-0.004341,0.02462,0.004341,0*%\n"
+      "%ADD10ROTATEDOBROUND10*%\n";
+
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addRect(w, h, r, rot, tl::nullopt));
+    EXPECT_EQ(10, l.addObround(w, h, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -661,7 +798,8 @@ TEST_F(GerberApertureListTest, testRegularOctagon0deg) {
   GerberApertureList l;
   PositiveLength w(500000);
   PositiveLength h(500000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       -Angle::deg315(), -Angle::deg270(), -Angle::deg225(), -Angle::deg180(),
       -Angle::deg135(), -Angle::deg90(),  -Angle::deg45(),  Angle::deg0(),
       Angle::deg45(),   Angle::deg90(),   Angle::deg135(),  Angle::deg180(),
@@ -685,8 +823,8 @@ TEST_F(GerberApertureListTest, testRegularOctagon0deg) {
       "0.0*%\n"
       "%ADD10ROTATEDOCTAGON10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addOctagon(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addOctagon(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -697,7 +835,8 @@ TEST_F(GerberApertureListTest, testRegularOctagon10deg) {
   GerberApertureList l;
   PositiveLength w(500000);
   PositiveLength h(500000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       Angle(-350000000), Angle(-305000000), Angle(-260000000),
       Angle(-215000000), Angle(-170000000), Angle(-125000000),
       Angle(-80000000),  Angle(-35000000),  Angle(10000000),
@@ -723,8 +862,8 @@ TEST_F(GerberApertureListTest, testRegularOctagon10deg) {
       "10.0*%\n"
       "%ADD10ROTATEDOCTAGON10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addOctagon(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addOctagon(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -735,7 +874,8 @@ TEST_F(GerberApertureListTest, testHighOctagon0deg) {
   GerberApertureList l;
   PositiveLength w(500000);
   PositiveLength h(900000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       -Angle::deg180(),
       Angle::deg0(),
       Angle::deg180(),
@@ -756,8 +896,8 @@ TEST_F(GerberApertureListTest, testHighOctagon0deg) {
       "90.0*%\n"
       "%ADD10ROTATEDOCTAGON10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addOctagon(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addOctagon(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -768,7 +908,8 @@ TEST_F(GerberApertureListTest, testWideOctagon0deg) {
   GerberApertureList l;
   PositiveLength w(900000);
   PositiveLength h(500000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       -Angle::deg180(),
       Angle::deg0(),
       Angle::deg180(),
@@ -789,8 +930,8 @@ TEST_F(GerberApertureListTest, testWideOctagon0deg) {
       "0.0*%\n"
       "%ADD10ROTATEDOCTAGON10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addOctagon(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addOctagon(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -801,7 +942,8 @@ TEST_F(GerberApertureListTest, testHighOctagon100deg) {
   GerberApertureList l;
   PositiveLength w(500000);
   PositiveLength h(900000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       Angle(-260000000),
       Angle(-80000000),
       Angle(100000000),
@@ -823,8 +965,8 @@ TEST_F(GerberApertureListTest, testHighOctagon100deg) {
       "10.0*%\n"
       "%ADD10ROTATEDOCTAGON10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addOctagon(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addOctagon(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }
@@ -835,7 +977,8 @@ TEST_F(GerberApertureListTest, testWideOctagon100deg) {
   GerberApertureList l;
   PositiveLength w(900000);
   PositiveLength h(500000);
-  QVector<Angle> rot = {
+  UnsignedLength r(0);
+  QVector<Angle> rotations = {
       Angle(-260000000),
       Angle(-80000000),
       Angle(100000000),
@@ -857,8 +1000,8 @@ TEST_F(GerberApertureListTest, testWideOctagon100deg) {
       "100.0*%\n"
       "%ADD10ROTATEDOCTAGON10*%\n";
 
-  for (const Angle& r : rot) {
-    EXPECT_EQ(10, l.addOctagon(w, h, r, tl::nullopt));
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addOctagon(w, h, r, rot, tl::nullopt));
     EXPECT_EQ(expected, l.generateString().toStdString());
   }
 }

--- a/tests/unittests/core/export/gerbergeneratortest.cpp
+++ b/tests/unittests/core/export/gerbergeneratortest.cpp
@@ -101,15 +101,27 @@ protected:
                 for (int i = -355; i <= 355; i += 5) {
                   Angle rot = Angle(i * 1000000);  // -355..+355° in 5° steps
 
+                  // Rounded corners.
                   gen.flashRect(Point(100, 200), PositiveLength(100000),
-                                PositiveLength(100000), rot, function, net,
-                                component, pin, signal);
+                                PositiveLength(100000), UnsignedLength(0), rot,
+                                function, net, component, pin, signal);
                   gen.flashRect(Point(100, 200), PositiveLength(100000),
-                                PositiveLength(200000), rot, function, net,
-                                component, pin, signal);
+                                PositiveLength(200000), UnsignedLength(0), rot,
+                                function, net, component, pin, signal);
                   gen.flashRect(Point(100, 200), PositiveLength(200000),
-                                PositiveLength(100000), rot, function, net,
-                                component, pin, signal);
+                                PositiveLength(100000), UnsignedLength(0), rot,
+                                function, net, component, pin, signal);
+
+                  // Rounded corners.
+                  gen.flashRect(Point(100, 200), PositiveLength(100000),
+                                PositiveLength(100000), UnsignedLength(20000),
+                                rot, function, net, component, pin, signal);
+                  gen.flashRect(Point(100, 200), PositiveLength(100000),
+                                PositiveLength(200000), UnsignedLength(20000),
+                                rot, function, net, component, pin, signal);
+                  gen.flashRect(Point(100, 200), PositiveLength(200000),
+                                PositiveLength(100000), UnsignedLength(20000),
+                                rot, function, net, component, pin, signal);
 
                   gen.flashObround(Point(100, 200), PositiveLength(100000),
                                    PositiveLength(100000), rot, function, net,
@@ -121,14 +133,29 @@ protected:
                                    PositiveLength(100000), rot, function, net,
                                    component, pin, signal);
 
+                  // No rounded corners.
                   gen.flashOctagon(Point(100, 200), PositiveLength(100000),
-                                   PositiveLength(100000), rot, function, net,
+                                   PositiveLength(100000), UnsignedLength(0),
+                                   rot, function, net, component, pin, signal);
+                  gen.flashOctagon(Point(100, 200), PositiveLength(100000),
+                                   PositiveLength(200000), UnsignedLength(0),
+                                   rot, function, net, component, pin, signal);
+                  gen.flashOctagon(Point(100, 200), PositiveLength(200000),
+                                   PositiveLength(100000), UnsignedLength(0),
+                                   rot, function, net, component, pin, signal);
+
+                  // Rounded corners.
+                  gen.flashOctagon(Point(100, 200), PositiveLength(100000),
+                                   PositiveLength(100000),
+                                   UnsignedLength(20000), rot, function, net,
                                    component, pin, signal);
                   gen.flashOctagon(Point(100, 200), PositiveLength(100000),
-                                   PositiveLength(200000), rot, function, net,
+                                   PositiveLength(200000),
+                                   UnsignedLength(20000), rot, function, net,
                                    component, pin, signal);
                   gen.flashOctagon(Point(100, 200), PositiveLength(200000),
-                                   PositiveLength(100000), rot, function, net,
+                                   PositiveLength(100000),
+                                   UnsignedLength(20000), rot, function, net,
                                    component, pin, signal);
 
                   gen.flashComponent(Point(100, 200), rot, component, "",

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -193,6 +193,37 @@ TEST_F(PathTest, testCircle) {
   EXPECT_TRUE(path.isClosed());
 }
 
+TEST_F(PathTest, testCenteredRectRoundedCorners) {
+  Path expected = Path({
+      Vertex(Point(-30000, 75000), Angle::deg0()),
+      Vertex(Point(30000, 75000), -Angle::deg90()),
+      Vertex(Point(50000, 55000), Angle::deg0()),
+      Vertex(Point(50000, -55000), -Angle::deg90()),
+      Vertex(Point(30000, -75000), Angle::deg0()),
+      Vertex(Point(-30000, -75000), -Angle::deg90()),
+      Vertex(Point(-50000, -55000), Angle::deg0()),
+      Vertex(Point(-50000, 55000), -Angle::deg90()),
+      Vertex(Point(-30000, 75000), Angle::deg0()),
+  });
+  Path actual = Path::centeredRect(
+      PositiveLength(100000), PositiveLength(150000), UnsignedLength(20000));
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(PathTest, testCenteredRectRoundedCornersSaturation) {
+  Path expected = Path::obround(PositiveLength(100000), PositiveLength(150000));
+  Path actual = Path::centeredRect(
+      PositiveLength(100000), PositiveLength(150000), UnsignedLength(60000));
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(PathTest, testOctagonRoundedCornersSaturation) {
+  Path expected = Path::obround(PositiveLength(100000), PositiveLength(150000));
+  Path actual = Path::octagon(PositiveLength(100000), PositiveLength(150000),
+                              UnsignedLength(60000));
+  EXPECT_EQ(str(expected), str(actual));
+}
+
 // Test to reproduce https://github.com/LibrePCB/LibrePCB/issues/974
 TEST_F(PathTest, testFlatArc) {
   Path expected = Path({


### PR DESCRIPTION
Instead of expanding pad/via shapes by keeping the same shape (i.e. sharp corners), this will expand them by maintaining a constant clearance around the whole shape (i.e. make corners rounded). It affects vias and pads with either a rectangular or octagon shape, in particular:

- Cutouts of vias/pads in copper planes (see #597).
- Stop mask / cream mask via/pad shapes if their expansion is > 0.
- Both of these things will have an effect on the Gerber output.

It's not a big thing, but it is slightly more space efficient (useful for dense boards) and ensures the plane area is as large as possible. A drawback is that the generated Gerber apertures are quite some more complicated now (there are no builtin apertures for rounded rects/octagons) but I think that should not be an issue.

![image](https://user-images.githubusercontent.com/5374821/211471253-9c0ea4a6-a42f-44e8-b006-945b940fd33c.png)

Closes #597.