### PR TITLE
Implement IPC-D-356A netlist export for boards

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -69,6 +69,7 @@ private:  // Methods
                    const QString& pcbFabricationSettingsPath,
                    const QStringList& exportPnpTopFiles,
                    const QStringList& exportPnpBottomFiles,
+                   const QStringList& exportNetlistFiles,
                    const QStringList& boardNames,
                    const QStringList& boardIndices, bool removeOtherBoards,
                    bool save, bool strict) const noexcept;

--- a/dev/README.md
+++ b/dev/README.md
@@ -18,3 +18,5 @@ Useful Links:
 - Official Reference Gerber Viewer: https://gerber.ucamco.com/index.html
 - Online 3D PCB Viewer: http://mayhewlabs.com/webGerber/
 - [DXF Specifications](http://images.autodesk.com/adsk/files/autocad_2012_pdf_dxf-reference_enu.pdf)
+- [IPC-D-356A Netlist Format](https://web.pa.msu.edu/hep/atlas/l1calo/hub/hardware/components/circuit_board/ipc_356a_net_list.pdf)
+- [IPC-D-356 Simplified](https://www.downstreamtech.com/downloads/IPCD356_Simplified.pdf)

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library(
   export/bom.h
   export/bomcsvwriter.cpp
   export/bomcsvwriter.h
+  export/d356netlistgenerator.cpp
+  export/d356netlistgenerator.h
   export/excellongenerator.cpp
   export/excellongenerator.h
   export/gerberaperturelist.cpp

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -279,6 +279,8 @@ add_library(
   project/board/board.h
   project/board/boardairwiresbuilder.cpp
   project/board/boardairwiresbuilder.h
+  project/board/boardd356netlistexport.cpp
+  project/board/boardd356netlistexport.h
   project/board/boarddesignrules.cpp
   project/board/boarddesignrules.h
   project/board/boardfabricationoutputsettings.cpp

--- a/libs/librepcb/core/export/d356netlistgenerator.cpp
+++ b/libs/librepcb/core/export/d356netlistgenerator.cpp
@@ -1,0 +1,223 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "d356netlistgenerator.h"
+
+#include "../types/angle.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+D356NetlistGenerator::D356NetlistGenerator(
+    const QString& projName, const QString& projRevision,
+    const QString& brdName, const QDateTime& generationDate) noexcept
+  : mComments(), mRecords() {
+  mComments.append("IPC-D-356A Netlist");
+  mComments.append("");
+  mComments.append("Project Name:        " % projName);
+  mComments.append("Project Version:     " % projRevision);
+  mComments.append("Board Name:          " % brdName);
+  mComments.append("Generation Software: LibrePCB " %
+                   qApp->applicationVersion());
+  mComments.append("Generation Date:     " %
+                   generationDate.toString(Qt::ISODate));
+  mComments.append("");
+  mComments.append(
+      "Note that due to limitations of this file format, LibrePCB");
+  mComments.append("applies the following operations during the export:");
+  mComments.append("  - suffix net names with unique numbers within braces");
+  mComments.append(
+      "  - truncate long net names (uniqueness guaranteed by suffix)");
+  mComments.append(
+      "  - truncate long component names (uniqueness not guaranteed)");
+  mComments.append("  - truncate long pad names (uniqueness not guaranteed)");
+  mComments.append("  - clip drill/pad sizes to 9.999mm");
+  mComments.append("");
+}
+
+D356NetlistGenerator::~D356NetlistGenerator() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void D356NetlistGenerator::smtPad(const QString& netName,
+                                  const QString& cmpName,
+                                  const QString& padName, const Point& position,
+                                  const PositiveLength& width,
+                                  const PositiveLength& height,
+                                  const Angle& rotation, int layer) {
+  mRecords.append(Record{
+      OperationCode::SurfaceMount, netName, checkedComponentName(cmpName),
+      padName, false, tl::nullopt, layer, position, width, height, rotation,
+      (layer == 1) ? SolderMask::SecondarySide : SolderMask::PrimarySide});
+}
+
+void D356NetlistGenerator::thtPad(const QString& netName,
+                                  const QString& cmpName,
+                                  const QString& padName, const Point& position,
+                                  const PositiveLength& width,
+                                  const PositiveLength& height,
+                                  const Angle& rotation,
+                                  const PositiveLength& drillDiameter) {
+  mRecords.append(Record{OperationCode::ThroughHole, netName,
+                         checkedComponentName(cmpName), padName, false,
+                         std::make_pair(drillDiameter, true), 0, position,
+                         width, height, rotation, SolderMask::None});
+}
+
+void D356NetlistGenerator::via(const QString& netName, const Point& position,
+                               const PositiveLength& width,
+                               const PositiveLength& height,
+                               const Angle& rotation,
+                               const PositiveLength& drillDiameter,
+                               bool solderMaskCovered) {
+  mRecords.append(Record{
+      OperationCode::ThroughHole, netName, "VIA", QString(), true,
+      std::make_pair(drillDiameter, true), 0, position, width, height, rotation,
+      solderMaskCovered ? SolderMask::BothSides : SolderMask::None});
+}
+
+QByteArray D356NetlistGenerator::generate() const {
+  QStringList lines;
+
+  // Add header.
+  foreach (const QString& comment, mComments) {
+    // Limit length to 80 characters in total (with or without newline?).
+    lines.append(cleanString("C  " % comment).left(79));
+  }
+  lines.append("P  UNITS CUST 1");  // Millimeters / degrees
+
+  // Guarantee unique signal names by adding their index as a suffix.
+  QHash<QString, QString> signalNameMap;
+  const int signalNameLength = 14;
+  foreach (const Record& record, mRecords) {
+    QString name = record.signalName;
+    if (!signalNameMap.contains(name)) {
+      if (name.isEmpty()) {
+        name = "N/C";
+      } else {
+        const QString nbr = QString("{%1}").arg(signalNameMap.count() + 1);
+        name = cleanString(name).left(signalNameLength - nbr.length()) % nbr;
+      }
+      signalNameMap[record.signalName] = name;
+    }
+  }
+
+  // Add records.
+  foreach (const Record& record, mRecords) {
+    QString line;
+    line += QString("%1").arg(static_cast<int>(record.code), 3, 10,
+                              QLatin1Char('0'));
+    line +=
+        QString("%1").arg(signalNameMap[record.signalName], -signalNameLength);
+    line += "   ";
+    line += QString("%1").arg(cleanString(record.componentName).left(6), -6);
+    line += record.padName.isEmpty() ? " " : "-";
+    line += QString("%1").arg(cleanString(record.padName).left(4), -4);
+    line += record.midPoint ? "M" : " ";
+    if (const auto hole = record.hole) {
+      line += QString("D%1%2")
+                  .arg(formatLength(*hole->first, false, 4))
+                  .arg(hole->second ? "P" : "U");
+    } else {
+      line += "      ";
+    }
+    line += QString("A%1").arg(record.accessCode, 2, 10, QLatin1Char('0'));
+    line += QString("X%1Y%2")
+                .arg(formatLength(record.position.getX(), true, 6))
+                .arg(formatLength(record.position.getY(), true, 6));
+    line += QString("X%1Y%2")
+                .arg(formatLength(*record.width, false, 4))
+                .arg(formatLength(*record.height, false, 4));
+    line += QString("R%1").arg(record.rotation.mappedTo0_360deg().toDeg(), 3,
+                               'f', 0, '0');
+    line += " ";
+    line += QString("S%1").arg(static_cast<int>(record.solderMask));
+    lines.append(line);
+  }
+
+  // Add footer, including a final linebreak.
+  lines.append("999\n");
+
+  // Make sure there are no non-ASCII characters in the file.
+  return lines.join("\n").toLatin1();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+QString D356NetlistGenerator::cleanString(QString str) noexcept {
+  // Remove CRLF newlines.
+  str.remove('\r');
+
+  // Replace newlines by spaces.
+  str.replace('\n', ' ');
+
+  // Perform compatibility decomposition (NFKD).
+  str = str.normalized(QString::NormalizationForm_KD);
+
+  // Remove all invalid characters for maximum compatibility with readers.
+  const QString validChars("-a-zA-Z0-9_+/!?<>\"'(){}.|&@# ,;$:=~");
+  str.remove(QRegularExpression(QString("[^%1]").arg(validChars)));
+
+  return str;
+}
+
+QString D356NetlistGenerator::checkedComponentName(
+    const QString& name) noexcept {
+  if (name.toLower() == "via") {
+    return name % "_";
+  } else {
+    return name;
+  }
+}
+
+QString D356NetlistGenerator::formatLength(const Length& value, bool isSigned,
+                                           int digits) noexcept {
+  QString str =
+      QString("%1").arg(value.abs().toMicrometers(), digits, 'f', 0, '0');
+  if (str.length() > digits) {
+    qWarning() << "Too large number in IPC-D-356A export clipped!";
+    str = QString("9").repeated(digits);
+  }
+  if (isSigned) {
+    str.prepend((value < 0) ? "-" : "+");
+  }
+  return str;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/export/d356netlistgenerator.h
+++ b/libs/librepcb/core/export/d356netlistgenerator.h
@@ -1,0 +1,119 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_D356NETLISTGENERATOR_H
+#define LIBREPCB_CORE_D356NETLISTGENERATOR_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../types/angle.h"
+#include "../types/point.h"
+
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class D356NetlistGenerator
+ ******************************************************************************/
+
+/**
+ * @brief The D356NetlistGenerator class
+ */
+class D356NetlistGenerator final {
+  Q_DECLARE_TR_FUNCTIONS(D356NetlistGenerator)
+
+public:
+  // Constructors / Destructor
+  D356NetlistGenerator() = delete;
+  D356NetlistGenerator(const D356NetlistGenerator& other) = delete;
+  D356NetlistGenerator(const QString& projName, const QString& projRevision,
+                       const QString& brdName,
+                       const QDateTime& generationDate) noexcept;
+  ~D356NetlistGenerator() noexcept;
+
+  // General Methods
+  void smtPad(const QString& netName, const QString& cmpName,
+              const QString& padName, const Point& position,
+              const PositiveLength& width, const PositiveLength& height,
+              const Angle& rotation, int layer);
+  void thtPad(const QString& netName, const QString& cmpName,
+              const QString& padName, const Point& position,
+              const PositiveLength& width, const PositiveLength& height,
+              const Angle& rotation, const PositiveLength& drillDiameter);
+  void via(const QString& netName, const Point& position,
+           const PositiveLength& width, const PositiveLength& height,
+           const Angle& rotation, const PositiveLength& drillDiameter,
+           bool solderMaskCovered);
+  QByteArray generate() const;
+
+  // Operator Overloadings
+  D356NetlistGenerator& operator=(const D356NetlistGenerator& rhs) = delete;
+
+private:  // Methods
+  static QString cleanString(QString str) noexcept;
+  static QString checkedComponentName(const QString& name) noexcept;
+  static QString formatLength(const Length& value, bool isSigned,
+                              int digits) noexcept;
+
+private:  // Data
+  enum class OperationCode : int {
+    ThroughHole = 317,
+    SurfaceMount = 327,
+  };
+
+  enum class SolderMask : int {
+    None = 0,
+    PrimarySide = 1,
+    SecondarySide = 2,
+    BothSides = 3,
+  };
+
+  struct Record {
+    OperationCode code;
+    QString signalName;
+    QString componentName;
+    QString padName;
+    bool midPoint;
+    tl::optional<std::pair<PositiveLength, bool>> hole;
+    int accessCode;
+    Point position;
+    PositiveLength width;
+    PositiveLength height;
+    Angle rotation;
+    SolderMask solderMask;
+  };
+
+  QStringList mComments;
+  QList<Record> mRecords;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/core/project/board/boardd356netlistexport.cpp
+++ b/libs/librepcb/core/project/board/boardd356netlistexport.cpp
@@ -1,0 +1,126 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "board.h"
+
+#include "../../export/d356netlistgenerator.h"
+#include "../../graphics/graphicslayer.h"
+#include "../../library/pkg/footprintpad.h"
+#include "../../library/pkg/packagepad.h"
+#include "../circuit/componentinstance.h"
+#include "../circuit/netsignal.h"
+#include "../project.h"
+#include "boardd356netlistexport.h"
+#include "boarddesignrules.h"
+#include "boardlayerstack.h"
+#include "items/bi_device.h"
+#include "items/bi_footprintpad.h"
+#include "items/bi_netsegment.h"
+#include "items/bi_via.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BoardD356NetlistExport::BoardD356NetlistExport(const Board& board) noexcept
+  : mBoard(board), mCreationDateTime(QDateTime::currentDateTime()) {
+}
+
+BoardD356NetlistExport::~BoardD356NetlistExport() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+QByteArray BoardD356NetlistExport::generate() const {
+  D356NetlistGenerator gen(*mBoard.getProject().getName(),
+                           mBoard.getProject().getVersion(), *mBoard.getName(),
+                           mCreationDateTime);
+
+  // Vias.
+  foreach (const BI_NetSegment* segment, mBoard.getNetSegments()) {
+    QString netName;
+    if (const NetSignal* netSignal = segment->getNetSignal()) {
+      netName = *netSignal->getName();
+    }
+    foreach (const BI_Via* via, segment->getVias()) {
+      const bool solderMaskCovered =
+          !mBoard.getDesignRules().doesViaRequireStopMask(
+              *via->getDrillDiameter());
+      gen.via(netName, via->getPosition(), via->getSize(), via->getSize(),
+              Angle::deg0(), via->getDrillDiameter(), solderMaskCovered);
+    }
+  }
+
+  // Footprint Pads.
+  foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
+    foreach (const BI_FootprintPad* pad, device->getPads()) {
+      QString netName;
+      if (const NetSignal* netSignal = pad->getCompSigInstNetSignal()) {
+        netName = *netSignal->getName();
+      }
+      const QString cmpName = *device->getComponentInstance().getName();
+      QString padName;
+      if (const PackagePad* pkgPad = pad->getLibPackagePad()) {
+        padName = *pkgPad->getName();
+      }
+      if (pad->getLibPad().isTht()) {
+        // THT pad. Not sure if we really need to export all holes, if there
+        // are multiple. Also slots are probably not supported by IPC-D-356A.
+        // I suspect it's good enough to export only a single, circular hole?
+        gen.thtPad(netName, cmpName, padName, pad->getPosition(),
+                   pad->getLibPad().getWidth(), pad->getLibPad().getHeight(),
+                   pad->getRotation(),
+                   pad->getLibPad().getHoles().first()->getDiameter());
+      } else {
+        // SMT pad.
+        const int layerNumber =
+            (pad->getLayerName() == GraphicsLayer::sTopCopper)
+            ? 1
+            : (mBoard.getLayerStack().getInnerLayerCount() + 2);
+        gen.smtPad(netName, cmpName, padName, pad->getPosition(),
+                   pad->getLibPad().getWidth(), pad->getLibPad().getHeight(),
+                   pad->getRotation(), layerNumber);
+      }
+    }
+  }
+
+  return gen.generate();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/project/board/boardd356netlistexport.h
+++ b/libs/librepcb/core/project/board/boardd356netlistexport.h
@@ -1,0 +1,68 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_BOARDD356NETLISTEXPORT_H
+#define LIBREPCB_CORE_BOARDD356NETLISTEXPORT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class Board;
+class FilePath;
+
+/*******************************************************************************
+ *  Class BoardD356NetlistExport
+ ******************************************************************************/
+
+/**
+ * @brief The BoardD356NetlistExport class
+ */
+class BoardD356NetlistExport final {
+public:
+  // Constructors / Destructor
+  BoardD356NetlistExport() = delete;
+  BoardD356NetlistExport(const BoardD356NetlistExport& other) = delete;
+  explicit BoardD356NetlistExport(const Board& board) noexcept;
+  ~BoardD356NetlistExport() noexcept;
+
+  // General Methods
+  QByteArray generate() const;
+
+  // Operator Overloadings
+  BoardD356NetlistExport& operator=(const BoardD356NetlistExport& rhs) = delete;
+
+private:
+  const Board& mBoard;
+  QDateTime mCreationDateTime;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/core/types/length.h
+++ b/libs/librepcb/core/types/length.h
@@ -221,6 +221,15 @@ public:
   QString toNmString() const noexcept { return QString::number(toNm()); }
 
   /**
+   * @brief Get the length in micrometers
+   *
+   * @return The length in micrometers
+   *
+   * @warning Be careful with this method, as it can decrease the precision!
+   */
+  qreal toMicrometers() const noexcept { return (qreal)mNanometers / 1e3; }
+
+  /**
    * @brief Get the length in millimeters
    *
    * @return The length in millimeters

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -529,6 +529,15 @@ public:
       {QKeySequence(Qt::Key_F11)},
       &categoryImportExport,
   };
+  EditorCommand generateD356Netlist{
+      "generate_d356_netlist",  // clang-format break
+      QT_TR_NOOP("Generate IPC-D-356A Netlist"),
+      QT_TR_NOOP("Generate netlist file for automated PCB testing"),
+      QIcon(":/img/actions/generate_bom.png"),  // No netlist icon yet.
+      EditorCommand::Flag::OpensPopup,
+      {},
+      &categoryImportExport,
+  };
   EditorCommand orderPcb{
       "order_pcb",  // clang-format break
       QT_TR_NOOP("Order PCB"),

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.h
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.h
@@ -134,6 +134,7 @@ private:
   void execBoardSetupDialog(bool switchToDrcSettings = false) noexcept;
   void execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                 const QString& settingsKey) noexcept;
+  void execD356NetlistExportDialog() noexcept;
 
   // General Attributes
   ProjectEditor& mProjectEditor;
@@ -176,6 +177,7 @@ private:
   QScopedPointer<QAction> mActionGenerateBom;
   QScopedPointer<QAction> mActionGenerateFabricationData;
   QScopedPointer<QAction> mActionGeneratePickPlace;
+  QScopedPointer<QAction> mActionGenerateD356Netlist;
   QScopedPointer<QAction> mActionOrderPcb;
   QScopedPointer<QAction> mActionNewBoard;
   QScopedPointer<QAction> mActionCopyBoard;

--- a/tests/cli/open_project/test_export_netlist.py
+++ b/tests/cli/open_project/test_export_netlist.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import params
+import pytest
+
+"""
+Test command "open-project --export-netlist"
+"""
+
+
+@pytest.mark.parametrize("project", [params.EMPTY_PROJECT_LPP_PARAM])
+def test_if_project_without_boards_succeeds(cli, project):
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+
+    # remove all boards first
+    with open(cli.abspath(project.dir + '/boards/boards.lp'), 'w') as f:
+        f.write('(librepcb_boards)')
+
+    relpath = project.output_dir + '/netlist/netlist.d356'
+    abspath = cli.abspath(relpath)
+    assert not os.path.exists(abspath)
+    code, stdout, stderr = cli.run('open-project',
+                                   '--export-netlist=' + relpath,
+                                   project.path)
+    assert stderr == ''
+    assert stdout == \
+        "Open project '{project.path}'...\n" \
+        "Export netlist to 'Empty Project/output/v1/netlist/netlist.d356'...\n" \
+        "SUCCESS\n".format(project=project)
+    assert code == 0
+    assert not os.path.exists(abspath)  # nothing exported
+
+
+@pytest.mark.parametrize("project", [
+    params.PROJECT_WITH_TWO_BOARDS_LPP_PARAM,
+    params.PROJECT_WITH_TWO_BOARDS_LPPZ_PARAM,
+])
+def test_export_project_with_two_boards_implicit(cli, project):
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    fp = project.output_dir + '/netlist/{{BOARD}}.d356'
+    dir = cli.abspath(project.output_dir + '/netlist')
+    assert not os.path.exists(dir)
+    code, stdout, stderr = cli.run('open-project',
+                                   '--export-netlist=' + fp,
+                                   project.path)
+    assert stderr == ''
+    assert stdout == \
+        "Open project '{project.path}'...\n" \
+        "Export netlist to '{project.output_dir}/netlist/{{{{BOARD}}}}.d356'...\n" \
+        "  - 'default' => '{project.output_dir_native}//netlist//default.d356'\n" \
+        "  - 'copy' => '{project.output_dir_native}//netlist//copy.d356'\n" \
+        "SUCCESS\n".format(project=project).replace('//', os.sep)
+    assert code == 0
+    assert os.path.exists(dir)
+    assert len(os.listdir(dir)) == 2
+
+
+@pytest.mark.parametrize("project", [
+    params.PROJECT_WITH_TWO_BOARDS_LPP_PARAM,
+    params.PROJECT_WITH_TWO_BOARDS_LPPZ_PARAM,
+])
+def test_export_project_with_two_boards_explicit_one(cli, project):
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    fp = project.output_dir + '/netlist/{{BOARD}}.d356'
+    dir = cli.abspath(project.output_dir + '/netlist')
+    assert not os.path.exists(dir)
+    code, stdout, stderr = cli.run('open-project',
+                                   '--export-netlist', fp,
+                                   '--board=copy',
+                                   project.path)
+    assert stderr == ''
+    assert stdout == \
+        "Open project '{project.path}'...\n" \
+        "Export netlist to '{project.output_dir}/netlist/{{{{BOARD}}}}.d356'...\n" \
+        "  - 'copy' => '{project.output_dir_native}//netlist//copy.d356'\n" \
+        "SUCCESS\n".format(project=project).replace('//', os.sep)
+    assert code == 0
+    assert os.path.exists(dir)
+    assert os.listdir(dir) == ['copy.d356']
+
+
+@pytest.mark.parametrize("project", [params.PROJECT_WITH_TWO_BOARDS_LPP])
+def test_export_project_with_two_conflicting_boards_fails(cli, project):
+    cli.add_project(project.dir, as_lppz=project.is_lppz)
+    fp = project.output_dir + '/netlist.d356'
+    code, stdout, stderr = cli.run('open-project',
+                                   '--export-netlist=' + fp,
+                                   project.path)
+    assert stderr == \
+        "ERROR: The file '{project.output_dir_native}//netlist.d356' was " \
+        "written multiple times!\n" \
+        "NOTE: To avoid writing files multiple times, make sure to pass " \
+        "unique filepaths to all export functions. For board output files, " \
+        "you could either add the placeholder '{{{{BOARD}}}}' to the path " \
+        "or specify the boards to export with the '--board' argument.\n" \
+        .format(project=project).replace('//', os.sep)
+    assert stdout == \
+        "Open project '{project.path}'...\n" \
+        "Export netlist to '{project.output_dir}/netlist.d356'...\n" \
+        "  - 'default' => '{project.output_dir_native}//netlist.d356'\n" \
+        "  - 'copy' => '{project.output_dir_native}//netlist.d356'\n" \
+        "Finished with errors!\n".format(project=project).replace('//', os.sep)
+    assert code == 1

--- a/tests/cli/open_project/test_parser.py
+++ b/tests/cli/open_project/test_parser.py
@@ -55,6 +55,10 @@ Options:
                                      assembly of the bottom board side. Existing
                                      files will be overwritten. Supported file
                                      extensions: csv, gbr
+  --export-netlist <file>            Export netlist file for automated PCB
+                                     testing. Existing files will be
+                                     overwritten. Supported file extensions:
+                                     d356
   --board <name>                     The name of the board(s) to export. Can be
                                      given multiple times. If not set, all
                                      boards are exported.

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   core/attribute/attributetest.cpp
   core/attribute/attributetypetest.cpp
   core/attribute/attributeunittest.cpp
+  core/export/d356netlistgeneratortest.cpp
   core/export/excellongeneratortest.cpp
   core/export/gerberaperturelisttest.cpp
   core/export/gerberattributetest.cpp

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(
   core/network/filedownloadtest.cpp
   core/network/networkrequestbasesignalreceiver.h
   core/network/networkrequesttest.cpp
+  core/project/board/boardd356netlistexporttest.cpp
   core/project/board/boarddesignrulestest.cpp
   core/project/board/boardfabricationoutputsettingstest.cpp
   core/project/board/boardgerberexporttest.cpp

--- a/tests/unittests/core/export/d356netlistgeneratortest.cpp
+++ b/tests/unittests/core/export/d356netlistgeneratortest.cpp
@@ -1,0 +1,152 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/export/d356netlistgenerator.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+static const QString sHeader =
+    "C  IPC-D-356A Netlist\n"
+    "C  \n"
+    "C  Project Name:        My Project\n"
+    "C  Project Version:     1.0\n"
+    "C  Board Name:          My Board\n"
+    "C  Generation Software: LibrePCB 0.1.2\n"
+    "C  Generation Date:     2019-01-02T03:04:05+01:00\n"
+    "C  \n"
+    "C  Note that due to limitations of this file format, LibrePCB\n"
+    "C  applies the following operations during the export:\n"
+    "C    - suffix net names with unique numbers within braces\n"
+    "C    - truncate long net names (uniqueness guaranteed by suffix)\n"
+    "C    - truncate long component names (uniqueness not guaranteed)\n"
+    "C    - truncate long pad names (uniqueness not guaranteed)\n"
+    "C    - clip drill/pad sizes to 9.999mm\n"
+    "C  \n"
+    "P  UNITS CUST 1\n";
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class D356NetlistGeneratorTest : public ::testing::Test {
+protected:
+  std::string makeComparable(QString str) const noexcept {
+    // Replace volatile data in exported file with well-known, constant data.
+    str.replace(QRegularExpression("Generation Software: LibrePCB (.*)"),
+                "Generation Software: LibrePCB 0.1.2");
+    return str.toStdString();
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(D356NetlistGeneratorTest, testSmtPad) {
+  D356NetlistGenerator gen(
+      "My Project", "1.0", "My Board",
+      QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5, 6), Qt::OffsetFromUTC, 3600));
+
+  gen.smtPad(QString(), QString(), QString(), Point(1111, -2222),
+             PositiveLength(123456), PositiveLength(654321), Angle::deg0(), 1);
+  gen.smtPad("N/C", "U1", "42", Point(-11111, 22222), PositiveLength(234567),
+             PositiveLength(765432), Angle::deg90(), 1);
+  gen.smtPad("N/C", "U2", "1337", Point(-11111, 22222), PositiveLength(234567),
+             PositiveLength(765432), -Angle::deg90(), 5);
+  gen.smtPad("TooooLooogName", "AlsoTooLong", "AsWell", Point(55555, -66666),
+             PositiveLength(20000000), PositiveLength(30000000),
+             -Angle::deg180(), 5);
+
+  const QString expected = sHeader %  // clang-format off
+  "327N/C                                A01X+000001Y-000002X0123Y0654R000 S2\n"
+  "327N/C{2}           U1    -42         A01X-000011Y+000022X0235Y0765R090 S2\n"
+  "327N/C{2}           U2    -1337       A05X-000011Y+000022X0235Y0765R270 S1\n"
+  "327TooooLooogN{3}   AlsoTo-AsWe       A05X+000056Y-000067X9999Y9999R180 S1\n"
+  "999\n";  // clang-format on
+  EXPECT_EQ(expected.toStdString(), makeComparable(gen.generate()));
+}
+
+TEST_F(D356NetlistGeneratorTest, testThtPad) {
+  D356NetlistGenerator gen(
+      "My Project", "1.0", "My Board",
+      QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5, 6), Qt::OffsetFromUTC, 3600));
+
+  gen.thtPad(QString(), QString(), QString(), Point(1111, -2222),
+             PositiveLength(123456), PositiveLength(654321), Angle::deg0(),
+             PositiveLength(1300000));
+  gen.thtPad("N/C", "U1", "42", Point(-11111, 22222), PositiveLength(234567),
+             PositiveLength(765432), Angle::deg90(), PositiveLength(444444));
+  gen.thtPad("N/C", "U2", "1337", Point(-11111, 22222), PositiveLength(234567),
+             PositiveLength(765432), -Angle::deg90(), PositiveLength(555555));
+  gen.thtPad("TooooLooogName", "AlsoTooLong", "AsWell", Point(55555, -66666),
+             PositiveLength(20000000), PositiveLength(30000000),
+             -Angle::deg180(), PositiveLength(20000000));
+
+  const QString expected = sHeader %  // clang-format off
+  "317N/C                          D1300PA00X+000001Y-000002X0123Y0654R000 S0\n"
+  "317N/C{2}           U1    -42   D0444PA00X-000011Y+000022X0235Y0765R090 S0\n"
+  "317N/C{2}           U2    -1337 D0556PA00X-000011Y+000022X0235Y0765R270 S0\n"
+  "317TooooLooogN{3}   AlsoTo-AsWe D9999PA00X+000056Y-000067X9999Y9999R180 S0\n"
+  "999\n";  // clang-format on
+  EXPECT_EQ(expected.toStdString(), makeComparable(gen.generate()));
+}
+
+TEST_F(D356NetlistGeneratorTest, testVia) {
+  D356NetlistGenerator gen(
+      "My Project", "1.0", "My Board",
+      QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5, 6), Qt::OffsetFromUTC, 3600));
+
+  gen.via(QString(), Point(1111, -2222), PositiveLength(123456),
+          PositiveLength(654321), Angle::deg0(), PositiveLength(1300000),
+          false);
+  gen.via("N/C", Point(-11111, 22222), PositiveLength(234567),
+          PositiveLength(765432), Angle::deg90(), PositiveLength(444444),
+          false);
+  gen.via("N/C", Point(-11111, 22222), PositiveLength(234567),
+          PositiveLength(765432), -Angle::deg90(), PositiveLength(555555),
+          true);
+  gen.via("TooooLooogName", Point(55555, -66666), PositiveLength(20000000),
+          PositiveLength(30000000), -Angle::deg180(), PositiveLength(20000000),
+          true);
+
+  const QString expected = sHeader %  // clang-format off
+  "317N/C              VIA        MD1300PA00X+000001Y-000002X0123Y0654R000 S0\n"
+  "317N/C{2}           VIA        MD0444PA00X-000011Y+000022X0235Y0765R090 S0\n"
+  "317N/C{2}           VIA        MD0556PA00X-000011Y+000022X0235Y0765R270 S3\n"
+  "317TooooLooogN{3}   VIA        MD9999PA00X+000056Y-000067X9999Y9999R180 S3\n"
+  "999\n";  // clang-format on
+  EXPECT_EQ(expected.toStdString(), makeComparable(gen.generate()));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/core/project/board/boardd356netlistexporttest.cpp
+++ b/tests/unittests/core/project/board/boardd356netlistexporttest.cpp
@@ -1,0 +1,87 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/fileio/fileutils.h>
+#include <librepcb/core/fileio/transactionaldirectory.h>
+#include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/project/board/boardd356netlistexport.h>
+#include <librepcb/core/project/project.h>
+#include <librepcb/core/project/projectloader.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class BoardD356NetlistExportTest : public ::testing::Test {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(BoardD356NetlistExportTest, test) {
+  FilePath testDataDir(TEST_DATA_DIR
+                       "/unittests/librepcbproject/BoardD356NetlistExportTest");
+
+  // Open project from test data directory.
+  FilePath projectFp(TEST_DATA_DIR "/projects/Gerber Test/project.lpp");
+  std::shared_ptr<TransactionalFileSystem> projectFs =
+      TransactionalFileSystem::openRO(projectFp.getParentDir());
+  ProjectLoader loader;
+  std::unique_ptr<Project> project =
+      loader.open(std::unique_ptr<TransactionalDirectory>(
+                      new TransactionalDirectory(projectFs)),
+                  projectFp.getFilename());  // can throw
+
+  // Export netlist.
+  const FilePath fp = testDataDir.getPathTo("actual/netlist.d356");
+  Board* board = project->getBoards().first();
+  BoardD356NetlistExport exp(*board);
+  QString content = exp.generate();  // can throw
+
+  // Replace volatile data in exported files with well-known, constant data.
+  content.replace(QRegularExpression("Generation Software: LibrePCB (.*)"),
+                  "Generation Software:");
+  content.replace(QRegularExpression("Generation Date: (.*)"),
+                  "Generation Date:");
+  FileUtils::writeFile(fp, content.toUtf8());
+
+  // Compare generated file with expected content.
+  const QString expected = FileUtils::readFile(
+      testDataDir.getPathTo("expected").getPathTo(fp.getFilename()));
+  EXPECT_EQ(expected.toStdString(), content.toStdString());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb


### PR DESCRIPTION
## User Interface

- In the board editor, a new menu item *File > Production Data > Generate IPC-D-356A Netlist...* has been added. It just opens a file save dialog to specify the output file (no export options needed).
- For the CLI, the option `--export-netlist=FILE` has been added to export the netlist to the given filepath. The file extension needs to be `d356` (implemented an export format auto-detection as already done for exporting schematics etc.).

## Example

How the generated file looks:

```
C  IPC-D-356A Netlist
C  
C  Project Name:        test_project
C  Project Version:     v1
C  Board Name:          default
C  Generation Software: LibrePCB 0.2-unstable
C  Generation Date:     2023-01-10T10:30:05+01:00
C  
C  Note that due to limitations of this file format, LibrePCB
C  applies the following operations during the export:
C    - suffix net names with unique numbers within braces
C    - truncate long net names (uniqueness guaranteed by suffix)
C    - truncate long component names (uniqueness not guaranteed)
C    - truncate long pad names (uniqueness not guaranteed)
C    - clip drill/pad sizes to 9.999mm
C  
P  UNITS CUST 1
317GND{1}           VIA        MD1000PA00X+016000Y+046000X2000Y2000R000 S0
317GND{1}           VIA        MD1000PA00X+020000Y+046000X2000Y2000R000 S0
317GND{1}           VIA        MD1000PA00X+012000Y+046000X2000Y2000R000 S0
317N/C              D2    -4    D0800PA00X+060013Y+041971X2540Y1270R280 S0
317N3{3}            D2    -2    D0800PA00X+055613Y+039431X2540Y1270R300 S0
327Hello{4}         D2    -7          A02X+062893Y+031902X2000Y1000R280 S1
327N/C              D2    -5          A02X+058494Y+029362X2000Y1000R300 S1
327N/C              D2    -8          A01X+065093Y+033172X2000Y1000R280 S2
317N3{3}            D2    -1    D0800PA00X+053414Y+038161X2540Y1270R300 S0
317GND{1}           D2    -3    D0400PA00X+057813Y+040701X2000Y3000R320 S0
327Hello{4}         D2    -6          A02X+060693Y+030632X2000Y1000R210 S1
317N3{3}            D1    -4    D0800PA00X-000620Y+039140X2540Y1270R200 S0
317N/C              D1    -2    D0800PA00X-000620Y+034060X2540Y1270R180 S0
327FOO{5}           D1    -7          A01X-010780Y+036600X2000Y1000R200 S2
327N/C              D1    -5          A01X-010780Y+031520X2000Y1000R180 S2
327Hello{4}         D1    -8          A02X-010780Y+039140X2000Y1000R200 S1
317FOO{5}           D1    -1    D0800PA00X-000620Y+031520X2540Y1270R180 S0
317VCC{6}           D1    -3    D0400PA00X-000620Y+036600X2000Y3000R160 S0
327FOO{5}           D1    -6          A01X-010780Y+034060X2000Y1000R270 S2
999
```

## Open Questions

### Units

There are both metric and imperial units supported by the file format, thus of course I have chosen metric (like for Gerber, PnP, ...). However, I don't know if this is widely supported by CAM software. In the [KiCad source code](https://gitlab.com/kicad/code/kicad/-/blob/9298defd3fed52b8c88b11918764f57bfbc086b2/pcbnew/exporters/export_d356.cpp#L358-359) I found a comment that this might be a problem:

> // Code 00 AFAIK is ASCII, CUST 0 is decimils/degrees
> // CUST 1 would be metric but gerbtool simply ignores it!

Not sure how we should proceed now. Maybe just go with metric for now, and if it causes any problems change it to imperial in a later release? Not that nice, but I also don't like switching to imperial if it's not really needed.

### Other Parameters

KiCad sets two more parameters in the exported file but I have no idea what they actually mean:

```
P  CODE 00
P  arrayDim   N
```

### Uniqueness of names

In addition, I'm not sure if component names and pad names need to be unique within that file. Due to truncation, uniqueness is currently not guaranteed (see comment in the example file above). Since these names are not related to any net signal, I suspect this shouldn't be an issue...

### File Extension

I set the file extension to `d356` since KiCad uses that, but I didn't check yet what extensions other EDA tools use...

## References

Implemented according [this document](https://web.pa.msu.edu/hep/atlas/l1calo/hub/hardware/components/circuit_board/ipc_356a_net_list.pdf).

Closes #1077 