### PR TITLE
Fix possibly unexpected center of rotate/mirror operations

### DIFF
--- a/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
@@ -131,8 +131,11 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
     ++count;
   }
 
-  mCenterPos /= qMax(count, 1);
-  mCenterPos.mapToGrid(grid);
+  // Note: If only 1 item is selected, use its exact position as center.
+  if (count > 1) {
+    mCenterPos /= count;
+    mCenterPos.mapToGrid(grid);
+  }
 }
 
 CmdDragSelectedFootprintItems::~CmdDragSelectedFootprintItems() noexcept {

--- a/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
@@ -111,8 +111,11 @@ CmdDragSelectedSymbolItems::CmdDragSelectedSymbolItems(
     ++count;
   }
 
-  mCenterPos /= qMax(count, 1);
-  mCenterPos.mapToGrid(grid);
+  // Note: If only 1 item is selected, use its exact position as center.
+  if (count > 1) {
+    mCenterPos /= count;
+    mCenterPos.mapToGrid(grid);
+  }
 }
 
 CmdDragSelectedSymbolItems::~CmdDragSelectedSymbolItems() noexcept {

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -1052,11 +1052,11 @@ bool BoardEditorState_Select::rotateSelectedItems(const Angle& angle) noexcept {
 
   try {
     if (mSelectedItemsDragCommand) {
-      mSelectedItemsDragCommand->rotate(angle);
+      mSelectedItemsDragCommand->rotate(angle, true);
     } else {
       QScopedPointer<CmdDragSelectedBoardItems> cmd(
           new CmdDragSelectedBoardItems(*board));
-      cmd->rotate(angle, true);
+      cmd->rotate(angle, false);
       mContext.undoStack.execCmd(cmd.take());
     }
     return true;

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.h
@@ -67,7 +67,7 @@ public:
   void resetAllTexts() noexcept;
   void setCurrentPosition(const Point& pos,
                           const bool gridIncrement = true) noexcept;
-  void rotate(const Angle& angle, bool aroundItemsCenter = false) noexcept;
+  void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
 
 private:
   // Private Methods
@@ -77,6 +77,7 @@ private:
 
   // Private Member Variables
   Board& mBoard;
+  int mItemCount;
   Point mStartPos;
   Point mDeltaPos;
   Point mCenterPos;

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
@@ -61,9 +61,8 @@ public:
 
   // General Methods
   void setCurrentPosition(const Point& pos) noexcept;
-  void rotate(const Angle& angle, bool aroundItemsCenter = false) noexcept;
-  void mirror(Qt::Orientation orientation,
-              bool aroundItemsCenter = false) noexcept;
+  void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
+  void mirror(Qt::Orientation orientation, bool aroundCurrentPosition) noexcept;
 
 private:
   // Private Methods
@@ -73,6 +72,7 @@ private:
 
   // Private Member Variables
   Schematic& mSchematic;
+  int mItemCount;
   Point mStartPos;
   Point mDeltaPos;
   Point mCenterPos;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -663,7 +663,7 @@ bool SchematicEditorState_Select::rotateSelectedItems(
     } else {
       QScopedPointer<CmdDragSelectedSchematicItems> cmd(
           new CmdDragSelectedSchematicItems(*schematic));
-      cmd->rotate(angle, true);
+      cmd->rotate(angle, false);
       execCmd(cmd.take());
     }
     return true;
@@ -684,7 +684,7 @@ bool SchematicEditorState_Select::mirrorSelectedItems(
     } else {
       QScopedPointer<CmdDragSelectedSchematicItems> cmd(
           new CmdDragSelectedSchematicItems(*schematic));
-      cmd->mirror(orientation, true);
+      cmd->mirror(orientation, false);
       execCmd(cmd.take());
     }
     return true;


### PR DESCRIPTION
When rotating/mirroring items in any of the editors, so far the center point of the operation was always mapped to the grid interval. However, this is not expected when only a single item is selected since it moves the item's position if it was not aligned to the grid. Thus now using the item's exact center position (not mapped to grid) if only one is selected. For example rotating a single, unaligned pad now keeps its exact position.

If more than one item is selected, the behavior is not affected by this change.

This also seems to fix a bug (#728) of possibly unaligning a previously aligned device.

Closes #728.