### PR TITLE
Remove transparency of symbol grab areas

### DIFF
--- a/libs/librepcb/core/graphics/graphicslayer.cpp
+++ b/libs/librepcb/core/graphics/graphicslayer.cpp
@@ -187,7 +187,7 @@ void GraphicsLayer::getDefaultValues(const QString& name, QString& nameTr,
     h.insert(sSchematicGuide,           {tr("Guide"),                 Qt::darkYellow,             Qt::yellow,                 true});
     // symbol
     h.insert(sSymbolOutlines,           {tr("Outlines"),              Qt::darkRed,                Qt::red,                    true});
-    h.insert(sSymbolGrabAreas,          {tr("Grab Areas"),            QColor(255, 255, 0, 30),    QColor(255, 255, 0, 50),    true});
+    h.insert(sSymbolGrabAreas,          {tr("Grab Areas"),            QColor(255, 255, 225, 255), QColor(255, 255, 205, 255), true});
     h.insert(sSymbolHiddenGrabAreas,    {tr("Hidden Grab Areas"),     QColor(0, 0, 255, 30),      QColor(0, 0, 255, 50),      false});
     h.insert(sSymbolNames,              {tr("Names"),                 QColor(32, 32, 32, 255),    Qt::darkGray,               true});
     h.insert(sSymbolValues,             {tr("Values"),                QColor(80, 80, 80, 255),    Qt::gray,                   true});

--- a/libs/librepcb/core/library/sym/symbolpainter.cpp
+++ b/libs/librepcb/core/library/sym/symbolpainter.cpp
@@ -68,22 +68,28 @@ void SymbolPainter::paint(QPainter& painter,
   GraphicsPainter p(painter);
   p.setMinLineWidth(settings.getMinLineWidth());
 
-  // Draw Polygons.
-  foreach (const Polygon& polygon, mPolygons) {
-    p.drawPolygon(
-        polygon.getPath(), *polygon.getLineWidth(),
-        settings.getColor(*polygon.getLayerName()),
-        settings.getFillColor(*polygon.getLayerName(), polygon.isFilled(),
-                              polygon.isGrabArea()));
-  }
+  // Draw grab areas first to make them appearing behind every other graphics
+  // item. Otherwise they might completely cover (hide) other items.
+  for (bool grabArea : {true, false}) {
+    // Draw Polygons.
+    foreach (const Polygon& polygon, mPolygons) {
+      if (polygon.isGrabArea() != grabArea) continue;
+      p.drawPolygon(
+          polygon.getPath(), *polygon.getLineWidth(),
+          settings.getColor(*polygon.getLayerName()),
+          settings.getFillColor(*polygon.getLayerName(), polygon.isFilled(),
+                                polygon.isGrabArea()));
+    }
 
-  // Draw Circles.
-  foreach (const Circle& circle, mCircles) {
-    p.drawCircle(circle.getCenter(), *circle.getDiameter(),
-                 *circle.getLineWidth(),
-                 settings.getColor(*circle.getLayerName()),
-                 settings.getFillColor(*circle.getLayerName(),
-                                       circle.isFilled(), circle.isGrabArea()));
+    // Draw Circles.
+    foreach (const Circle& circle, mCircles) {
+      if (circle.isGrabArea() != grabArea) continue;
+      p.drawCircle(
+          circle.getCenter(), *circle.getDiameter(), *circle.getLineWidth(),
+          settings.getColor(*circle.getLayerName()),
+          settings.getFillColor(*circle.getLayerName(), circle.isFilled(),
+                                circle.isGrabArea()));
+    }
   }
 
   // Draw Texts.

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -125,22 +125,28 @@ void SchematicPainter::paint(QPainter& painter,
 
   // Draw Symbols.
   foreach (const Symbol& symbol, mSymbols) {
-    // Draw Symbol Polygons.
-    foreach (const Polygon& polygon, symbol.polygons) {
-      p.drawPolygon(
-          symbol.transform.map(polygon.getPath()), *polygon.getLineWidth(),
-          settings.getColor(*polygon.getLayerName()),
-          settings.getFillColor(*polygon.getLayerName(), polygon.isFilled(),
-                                polygon.isGrabArea()));
-    }
+    // Draw grab areas first to make them appearing behind every other graphics
+    // item. Otherwise they might completely cover (hide) other items.
+    for (bool grabArea : {true, false}) {
+      // Draw Symbol Polygons.
+      foreach (const Polygon& polygon, symbol.polygons) {
+        if (polygon.isGrabArea() != grabArea) continue;
+        p.drawPolygon(
+            symbol.transform.map(polygon.getPath()), *polygon.getLineWidth(),
+            settings.getColor(*polygon.getLayerName()),
+            settings.getFillColor(*polygon.getLayerName(), polygon.isFilled(),
+                                  polygon.isGrabArea()));
+      }
 
-    // Draw Symbol Circles.
-    foreach (const Circle& circle, symbol.circles) {
-      p.drawCircle(
-          symbol.transform.map(circle.getCenter()), *circle.getDiameter(),
-          *circle.getLineWidth(), settings.getColor(*circle.getLayerName()),
-          settings.getFillColor(*circle.getLayerName(), circle.isFilled(),
-                                circle.isGrabArea()));
+      // Draw Symbol Circles.
+      foreach (const Circle& circle, symbol.circles) {
+        if (circle.isGrabArea() != grabArea) continue;
+        p.drawCircle(
+            symbol.transform.map(circle.getCenter()), *circle.getDiameter(),
+            *circle.getLineWidth(), settings.getColor(*circle.getLayerName()),
+            settings.getFillColor(*circle.getLayerName(), circle.isFilled(),
+                                  circle.isGrabArea()));
+      }
     }
 
     // Draw Symbol Texts.


### PR DESCRIPTION
Changing the symbol grab area alpha value to 255 (no transparency) while keeping exactly the same color as currently with white background. This ensures the schematic grid is not visible anymore within symbols, which looks better in my opinion (feedback about your opinion welcome!).

With transparency (old):

![1](https://user-images.githubusercontent.com/5374821/212460161-43c75785-9d34-4675-95e7-e6df979f1647.png)

Without transparency (new):

![2](https://user-images.githubusercontent.com/5374821/212460168-e42d496a-8abf-4331-98c0-bb539a0366be.png)

It also helps to implement #515 since an anchor line from the text origin to the symbol origin can be put *behind* the symbol to avoid an ugly overlap with the symbol.

However, unfortunately this reminded me about a weakness of the current symbol graphics items concept: So far we do not have a user-defined z-order of symbol graphics items, it is completely hardcoded (determined by item type & UUID). As the grab area is no longer transparent, some graphics items may no longer be visible now, for example (parts of) the USB logo:

![image](https://user-images.githubusercontent.com/5374821/212460382-d879705e-afa4-4852-bd3d-2d1d6d0dfee6.png)

For now I changed the hardcoded z-order to always draw grab area polygons/circles in the background which fixes that issue, but it might still be an issue in some other cases (e.g. nested grab area polygons). I'll open a separate issue for that, but I think the current workaround is good enough for now...