### PR TITLE
Schematic: Detach symbol texts to make them editable

### DIFF
--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -256,6 +256,7 @@ void BI_Device::addStrokeText(BI_StrokeText& text) {
     text.addToBoard();  // can throw
   }
   mStrokeTexts.insert(text.getUuid(), &text);
+  text.setSelected(isSelected());
 }
 
 void BI_Device::removeStrokeText(BI_StrokeText& text) {

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -380,7 +380,10 @@ void ProjectLoader::loadSchematicSymbol(Schematic& s, const SExpression& node) {
                     deserialize<Uuid>(node.getChild("lib_gate/@0")),
                     Point(node.getChild("position")),
                     deserialize<Angle>(node.getChild("rotation/@0")),
-                    deserialize<bool>(node.getChild("mirror/@0")));
+                    deserialize<bool>(node.getChild("mirror/@0")), false);
+  foreach (const SExpression* child, node.getChildren("text")) {
+    symbol->addText(*new SI_Text(s, Text(*child)));
+  }
   s.addSymbol(*symbol);
 }
 

--- a/libs/librepcb/core/project/schematic/items/si_symbol.h
+++ b/libs/librepcb/core/project/schematic/items/si_symbol.h
@@ -26,6 +26,7 @@
 #include "../../../attribute/attributeprovider.h"
 #include "../graphicsitems/sgi_symbol.h"
 #include "si_base.h"
+#include "si_text.h"
 
 #include <QtCore>
 
@@ -54,10 +55,10 @@ public:
   // Constructors / Destructor
   SI_Symbol() = delete;
   SI_Symbol(const SI_Symbol& other) = delete;
-  explicit SI_Symbol(Schematic& schematic, const Uuid& uuid,
-                     ComponentInstance& cmpInstance, const Uuid& symbolItem,
-                     const Point& position = Point(),
-                     const Angle& rotation = Angle(), bool mirrored = false);
+  SI_Symbol(Schematic& schematic, const Uuid& uuid,
+            ComponentInstance& cmpInstance, const Uuid& symbolItem,
+            const Point& position, const Angle& rotation, bool mirrored,
+            bool loadInitialTexts);
   ~SI_Symbol() noexcept;
 
   // Getters
@@ -83,6 +84,12 @@ public:
   void setPosition(const Point& newPos) noexcept;
   void setRotation(const Angle& newRotation) noexcept;
   void setMirrored(bool newMirrored) noexcept;
+
+  // Text Methods
+  TextList getDefaultTexts() const noexcept;
+  const QMap<Uuid, SI_Text*>& getTexts() const noexcept { return mTexts; }
+  void addText(SI_Text& text);
+  void removeText(SI_Text& text);
 
   // General Methods
   void addToSchematic() override;
@@ -122,6 +129,7 @@ private:
   const ComponentSymbolVariantItem* mSymbVarItem;
   const Symbol* mSymbol;
   QHash<Uuid, SI_SymbolPin*> mPins;  ///< key: symbol pin UUID
+  QMap<Uuid, SI_Text*> mTexts;  ///< key: text UUID
   QScopedPointer<SGI_Symbol> mGraphicsItem;
 
   // Attributes

--- a/libs/librepcb/core/project/schematic/items/si_text.h
+++ b/libs/librepcb/core/project/schematic/items/si_text.h
@@ -25,6 +25,7 @@
  ******************************************************************************/
 #include "../../../geometry/text.h"
 #include "si_base.h"
+#include "si_symbol.h"
 
 #include <QtCore>
 
@@ -33,6 +34,8 @@
  ******************************************************************************/
 namespace librepcb {
 
+class AttributeProvider;
+class LineGraphicsItem;
 class Schematic;
 class TextGraphicsItem;
 
@@ -61,6 +64,10 @@ public:
   const Text& getText() const noexcept { return mText; }
 
   // General Methods
+  SI_Symbol* getSymbol() const noexcept { return mSymbol; }
+  void setSymbol(SI_Symbol* symbol) noexcept;
+  const AttributeProvider* getAttributeProvider() const noexcept;
+  void updateAnchor() noexcept;
   void addToSchematic() override;
   void removeFromSchematic() override;
 
@@ -73,11 +80,17 @@ public:
   SI_Text& operator=(const SI_Text& rhs) = delete;
 
 private:  // Methods
-  void schematicAttributesChanged() noexcept;
+  void schematicOrSymbolAttributesChanged() noexcept;
+  void textEdited(const Text& text, Text::Event event) noexcept;
 
 private:  // Attributes
+  QPointer<SI_Symbol> mSymbol;
   Text mText;
   QScopedPointer<TextGraphicsItem> mGraphicsItem;
+  QScopedPointer<LineGraphicsItem> mAnchorGraphicsItem;
+
+  // Slots
+  Text::OnEditedSlot mOnTextEditedSlot;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/schematic.h
+++ b/libs/librepcb/core/project/schematic/schematic.h
@@ -94,6 +94,7 @@ public:
    */
   enum ItemZValue {
     ZValue_Default = 0,  ///< this is the default value (behind all other items)
+    ZValue_TextAnchors,  ///< Z value for ::librepcb::SI_Text anchor lines
     ZValue_Symbols,  ///< Z value for ::librepcb::SI_Symbol items
     ZValue_SymbolPins,  ///< Z value for ::librepcb::SI_SymbolPin items
     ZValue_Polygons,  ///< Z value for ::librepcb::SI_Polygon items

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -76,10 +76,10 @@ SchematicPainter::SchematicPainter(const Schematic& schematic) noexcept {
     for (const Circle& circle : symbol->getLibSymbol().getCircles()) {
       sym.circles.append(circle);
     }
-    for (const Text& text : symbol->getLibSymbol().getTexts()) {
-      Text copy(text);
+    for (const SI_Text* text : symbol->getTexts()) {
+      Text copy(text->getText());
       copy.setText(AttributeSubstitutor::substitute(copy.getText(), symbol));
-      sym.texts.append(copy);
+      mTexts.append(copy);
     }
     mSymbols.append(sym);
   }
@@ -147,18 +147,6 @@ void SchematicPainter::paint(QPainter& painter,
             settings.getFillColor(*circle.getLayerName(), circle.isFilled(),
                                   circle.isGrabArea()));
       }
-    }
-
-    // Draw Symbol Texts.
-    foreach (const Text& text, symbol.texts) {
-      Alignment alignment = text.getAlign();
-      if (symbol.transform.getMirrored()) {
-        alignment.mirrorV();
-      }
-      p.drawText(symbol.transform.map(text.getPosition()),
-                 symbol.transform.map(text.getRotation()), *text.getHeight(),
-                 alignment, text.getText(), qApp->getDefaultSansSerifFont(),
-                 settings.getColor(*text.getLayerName()), true, false);
     }
 
     // Draw Symbol Pins.

--- a/libs/librepcb/core/project/schematic/schematicselectionquery.cpp
+++ b/libs/librepcb/core/project/schematic/schematicselectionquery.cpp
@@ -133,10 +133,20 @@ void SchematicSelectionQuery::addSelectedPolygons() noexcept {
   }
 }
 
-void SchematicSelectionQuery::addSelectedTexts() noexcept {
+void SchematicSelectionQuery::addSelectedSchematicTexts() noexcept {
   foreach (SI_Text* text, mTexts) {
     if (text->isSelected()) {
       mResultTexts.insert(text);
+    }
+  }
+}
+
+void SchematicSelectionQuery::addSelectedSymbolTexts() noexcept {
+  foreach (SI_Symbol* symbol, mSymbols) {
+    foreach (SI_Text* text, symbol->getTexts()) {
+      if (text->isSelected()) {
+        mResultTexts.insert(text);
+      }
     }
   }
 }

--- a/libs/librepcb/core/project/schematic/schematicselectionquery.h
+++ b/libs/librepcb/core/project/schematic/schematicselectionquery.h
@@ -103,7 +103,8 @@ public:
   void addSelectedNetLines() noexcept;
   void addSelectedNetLabels() noexcept;
   void addSelectedPolygons() noexcept;
-  void addSelectedTexts() noexcept;
+  void addSelectedSchematicTexts() noexcept;
+  void addSelectedSymbolTexts() noexcept;
   /**
    * @brief Add net points of the selected net lines
    *

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -23,6 +23,11 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../graphics/graphicslayername.h"
+#include "../types/alignment.h"
+#include "../types/angle.h"
+#include "../types/point.h"
+#include "../types/uuid.h"
 #include "fileformatmigration.h"
 
 #include <QtCore>
@@ -43,6 +48,46 @@ class SExpression;
  */
 class FileFormatMigrationV01 final : public FileFormatMigration {
   Q_OBJECT
+
+  struct Text {
+    Uuid uuid;
+    GraphicsLayerName layerName;
+    QString text;
+    Point position;
+    Angle rotation;
+    PositiveLength height;
+    Alignment align;
+  };
+
+  struct Symbol {
+    QList<Text> texts;
+  };
+
+  struct Gate {
+    Uuid uuid;
+    Uuid symbolUuid;
+  };
+
+  struct ComponentSymbolVariant {
+    Uuid uuid;
+    QList<Gate> gates;
+  };
+
+  struct Component {
+    QList<ComponentSymbolVariant> symbolVariants;
+    ;
+  };
+
+  struct ComponentInstance {
+    Uuid libCmpUuid;
+    Uuid libSymbVarUuid;
+  };
+
+  struct LoadedData {
+    QHash<Uuid, Symbol> symbols;
+    QHash<Uuid, Component> components;
+    QMap<Uuid, ComponentInstance> componentInstances;
+  };
 
 public:
   // Constructors / Destructor

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -571,8 +571,12 @@ add_library(
   project/cmd/cmdsymbolinstanceadd.h
   project/cmd/cmdsymbolinstanceedit.cpp
   project/cmd/cmdsymbolinstanceedit.h
+  project/cmd/cmdsymbolinstanceeditall.cpp
+  project/cmd/cmdsymbolinstanceeditall.h
   project/cmd/cmdsymbolinstanceremove.cpp
   project/cmd/cmdsymbolinstanceremove.h
+  project/cmd/cmdsymbolinstancetextremove.cpp
+  project/cmd/cmdsymbolinstancetextremove.h
   project/erc/ercmsgdock.cpp
   project/erc/ercmsgdock.h
   project/erc/ercmsgdock.ui

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -575,8 +575,12 @@ add_library(
   project/cmd/cmdsymbolinstanceeditall.h
   project/cmd/cmdsymbolinstanceremove.cpp
   project/cmd/cmdsymbolinstanceremove.h
+  project/cmd/cmdsymbolinstancetextadd.cpp
+  project/cmd/cmdsymbolinstancetextadd.h
   project/cmd/cmdsymbolinstancetextremove.cpp
   project/cmd/cmdsymbolinstancetextremove.h
+  project/cmd/cmdsymbolinstancetextsreset.cpp
+  project/cmd/cmdsymbolinstancetextsreset.h
   project/erc/ercmsgdock.cpp
   project/erc/ercmsgdock.h
   project/erc/ercmsgdock.ui

--- a/libs/librepcb/editor/project/cmd/cmdaddsymboltoschematic.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdaddsymboltoschematic.cpp
@@ -101,10 +101,9 @@ bool CmdAddSymbolToSchematic::performExecute() {
   }
 
   // create the new symbol (schematic takes ownership)
-  mSymbolInstance =
-      new SI_Symbol(mSchematic, Uuid::createRandom(), mComponentInstance,
-                    mSymbolItemUuid, mPosition,
-                    mAngle);  // can throw
+  mSymbolInstance = new SI_Symbol(mSchematic, Uuid::createRandom(),
+                                  mComponentInstance, mSymbolItemUuid,
+                                  mPosition, mAngle, false, true);  // can throw
 
   // add a new symbol instance to the schematic
   execNewChildCmd(new CmdSymbolInstanceAdd(*mSymbolInstance));  // can throw

--- a/libs/librepcb/editor/project/cmd/cmddeviceinstanceedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddeviceinstanceedit.cpp
@@ -37,7 +37,7 @@ namespace editor {
  ******************************************************************************/
 
 CmdDeviceInstanceEdit::CmdDeviceInstanceEdit(BI_Device& dev) noexcept
-  : UndoCommand(tr("Edit device instance")),
+  : UndoCommand(tr("Edit Device")),
     mDevice(dev),
     mOldPos(mDevice.getPosition()),
     mNewPos(mOldPos),

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
@@ -71,7 +71,8 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
   query->addSelectedNetLines();
   query->addSelectedNetLabels();
   query->addSelectedPolygons();
-  query->addSelectedTexts();
+  query->addSelectedSchematicTexts();
+  query->addSelectedSymbolTexts();
   query->addNetPointsOfNetLines();
 
   // Find the center of all elements and create undo commands.
@@ -102,8 +103,12 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
     mPolygonEditCmds.append(cmd);
   }
   foreach (SI_Text* text, query->getTexts()) {
-    mCenterPos += text->getPosition();
-    ++mItemCount;
+    // do not count texts of symbols if the symbol is selected too
+    if ((!text->getSymbol()) ||
+        (!query->getSymbols().contains(text->getSymbol()))) {
+      mCenterPos += text->getPosition();
+      ++mItemCount;
+    }
     CmdTextEdit* cmd = new CmdTextEdit(text->getText());
     mTextEditCmds.append(cmd);
   }

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -141,7 +141,9 @@ bool CmdPasteBoardItems::performExecute() {
         mBoard, *cmpInst, dev.libDeviceUuid, dev.libFootprintUuid,
         dev.position + mPosOffset, dev.rotation, dev.mirrored, false));
     for (const StrokeText& text : dev.strokeTexts) {
-      StrokeText copy(Uuid::createRandom(), text);  // assign new UUID
+      // Note: Keep the UUID since it acts as a reference to the original
+      // library footprint text.
+      StrokeText copy(text);
       copy.setPosition(copy.getPosition() + mPosOffset);  // move
       BI_StrokeText* item = new BI_StrokeText(mBoard, copy);
       item->setSelected(true);

--- a/libs/librepcb/editor/project/cmd/cmdpasteschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteschematicitems.cpp
@@ -156,12 +156,21 @@ bool CmdPasteSchematicItems::performExecute() {
                                        Uuid::createRandom()));
     if (!cmpInst) throw LogicError(__FILE__, __LINE__);
 
-    QScopedPointer<SI_Symbol> copy(new SI_Symbol(
+    QScopedPointer<SI_Symbol> symbol(new SI_Symbol(
         mSchematic, Uuid::createRandom(), *cmpInst, sym.symbolVariantItemUuid,
-        sym.position + mPosOffset, sym.rotation, sym.mirrored));
-    copy->setSelected(true);
-    symbolMap.insert(sym.uuid, copy->getUuid());
-    execNewChildCmd(new CmdSymbolInstanceAdd(*copy.take()));
+        sym.position + mPosOffset, sym.rotation, sym.mirrored, false));
+    for (const Text& text : sym.texts) {
+      // Note: Keep the UUID since it acts as a reference to the original
+      // library symbol text.
+      Text copy(text);
+      copy.setPosition(copy.getPosition() + mPosOffset);  // move
+      SI_Text* item = new SI_Text(mSchematic, copy);
+      item->setSelected(true);
+      symbol->addText(*item);
+    }
+    symbol->setSelected(true);
+    symbolMap.insert(sym.uuid, symbol->getUuid());
+    execNewChildCmd(new CmdSymbolInstanceAdd(*symbol.take()));
   }
 
   // Paste net segments

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
@@ -37,7 +37,7 @@ namespace editor {
  ******************************************************************************/
 
 CmdSymbolInstanceEdit::CmdSymbolInstanceEdit(SI_Symbol& symbol) noexcept
-  : UndoCommand(tr("Edit symbol instance")),
+  : UndoCommand(tr("Edit Symbol")),
     mSymbol(symbol),
     mOldPos(symbol.getPosition()),
     mNewPos(mOldPos),

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.h
@@ -85,6 +85,8 @@ private:
   Angle mNewRotation;
   bool mOldMirrored;
   bool mNewMirrored;
+
+  friend class CmdSymbolInstanceEditAll;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.cpp
@@ -1,0 +1,120 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdsymbolinstanceeditall.h"
+
+#include "../../cmd/cmdtextedit.h"
+#include "cmdsymbolinstanceedit.h"
+
+#include <librepcb/core/project/schematic/items/si_symbol.h>
+#include <librepcb/core/project/schematic/items/si_text.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdSymbolInstanceEditAll::CmdSymbolInstanceEditAll(SI_Symbol& symbol) noexcept
+  : UndoCommandGroup(tr("Drag Symbol")), mSymEditCmd(nullptr) {
+  mSymEditCmd = new CmdSymbolInstanceEdit(symbol);
+  appendChild(mSymEditCmd);
+
+  foreach (SI_Text* text, symbol.getTexts()) {
+    CmdTextEdit* cmd = new CmdTextEdit(text->getText());
+    mTextEditCmds.append(cmd);
+    appendChild(cmd);
+  }
+}
+
+CmdSymbolInstanceEditAll::~CmdSymbolInstanceEditAll() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void CmdSymbolInstanceEditAll::setPosition(const Point& pos,
+                                           bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  translate(pos - mSymEditCmd->mNewPos, immediate);
+}
+
+void CmdSymbolInstanceEditAll::translate(const Point& deltaPos,
+                                         bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mSymEditCmd->translate(deltaPos, immediate);
+  foreach (CmdTextEdit* cmd, mTextEditCmds) {
+    cmd->translate(deltaPos, immediate);
+  }
+}
+
+void CmdSymbolInstanceEditAll::setRotation(const Angle& angle,
+                                           bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  const Angle delta = mSymEditCmd->mNewMirrored
+      ? (mSymEditCmd->mNewRotation - angle)  // Mirrored -> inverted rotation!
+      : (angle - mSymEditCmd->mNewRotation);
+  mSymEditCmd->setRotation(angle, immediate);
+  foreach (CmdTextEdit* cmd, mTextEditCmds) {
+    cmd->rotate(delta, mSymEditCmd->mNewPos, immediate);
+  }
+}
+
+void CmdSymbolInstanceEditAll::rotate(const Angle& angle, const Point& center,
+                                      bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mSymEditCmd->rotate(angle, center, immediate);
+  foreach (CmdTextEdit* cmd, mTextEditCmds) {
+    cmd->rotate(angle, center, immediate);
+  }
+}
+
+void CmdSymbolInstanceEditAll::setMirrored(bool mirrored, bool immediate) {
+  Q_ASSERT(!wasEverExecuted());
+  if (mirrored != mSymEditCmd->mNewMirrored) {
+    mirror(mSymEditCmd->mNewPos, Qt::Horizontal, immediate);  // can throw
+  }
+}
+
+void CmdSymbolInstanceEditAll::mirror(const Point& center,
+                                      Qt::Orientation orientation,
+                                      bool immediate) {
+  Q_ASSERT(!wasEverExecuted());
+  mSymEditCmd->mirror(center, orientation, immediate);  // can throw
+  foreach (CmdTextEdit* cmd, mTextEditCmds) {
+    cmd->mirror(orientation, center, immediate);
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.h
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.h
@@ -17,99 +17,61 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_SCHEMATICPAINTER_H
-#define LIBREPCB_CORE_SCHEMATICPAINTER_H
+#ifndef LIBREPCB_EDITOR_CMDSYMBOLINSTANCEEDITALL_H
+#define LIBREPCB_EDITOR_CMDSYMBOLINSTANCEEDITALL_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../../export/graphicsexport.h"
-#include "../../types/alignment.h"
-#include "../../types/length.h"
-#include "../../utils/transform.h"
+#include "../../undocommandgroup.h"
 
 #include <QtCore>
-#include <QtGui>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 
-class Circle;
-class Path;
-class Polygon;
-class Schematic;
-class Text;
+class Angle;
+class Point;
+class SI_Symbol;
+
+namespace editor {
+
+class CmdSymbolInstanceEdit;
+class CmdTextEdit;
 
 /*******************************************************************************
- *  Class SchematicPainter
+ *  Class CmdSymbolInstanceEditAll
  ******************************************************************************/
 
 /**
- * @brief Paints a ::librepcb::Schematic to a QPainter
- *
- * Used for ::librepcb::GraphicsExport.
+ * @brief The CmdSymbolInstanceEditAll class
  */
-class SchematicPainter final : public GraphicsPagePainter {
-  struct Pin {
-    Point position;
-    Angle rotation;
-    UnsignedLength length;
-    QString name;
-    Point namePosition;
-    Angle nameRotation;
-    PositiveLength nameHeight;
-    Alignment nameAlignment;
-  };
-
-  struct Line {
-    Point startPosition;
-    Point endPosition;
-    UnsignedLength width;
-  };
-
-  struct Label {
-    Point position;
-    Angle rotation;
-    bool mirrored;
-    QString text;
-  };
-
-  struct Symbol {
-    Transform transform;
-    QList<Pin> pins;
-    QList<Polygon> polygons;
-    QList<Circle> circles;
-  };
-
+class CmdSymbolInstanceEditAll final : public UndoCommandGroup {
 public:
   // Constructors / Destructor
-  SchematicPainter() = delete;
-  explicit SchematicPainter(const Schematic& schematic) noexcept;
-  SchematicPainter(const SchematicPainter& other) = delete;
-  ~SchematicPainter() noexcept;
+  explicit CmdSymbolInstanceEditAll(SI_Symbol& symbol) noexcept;
+  ~CmdSymbolInstanceEditAll() noexcept;
 
   // General Methods
-  void paint(QPainter& painter, const GraphicsExportSettings& settings) const
-      noexcept override;
+  void setPosition(const Point& pos, bool immediate) noexcept;
+  void translate(const Point& deltaPos, bool immediate) noexcept;
+  void setRotation(const Angle& angle, bool immediate) noexcept;
+  void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
+  void setMirrored(bool mirrored, bool immediate);
+  void mirror(const Point& center, Qt::Orientation orientation, bool immediate);
 
-  // Operator Overloadings
-  SchematicPainter& operator=(const SchematicPainter& rhs) = delete;
-
-private:  // Data
-  QList<Symbol> mSymbols;
-  QList<Point> mJunctions;
-  QList<Line> mNetLines;
-  QList<Label> mNetLabels;
-  QList<Polygon> mPolygons;
-  QList<Text> mTexts;
+private:
+  CmdSymbolInstanceEdit* mSymEditCmd;
+  QVector<CmdTextEdit*> mTextEditCmds;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace librepcb
 
 #endif

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextadd.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextadd.cpp
@@ -1,0 +1,70 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdsymbolinstancetextadd.h"
+
+#include <librepcb/core/project/schematic/items/si_symbol.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdSymbolInstanceTextAdd::CmdSymbolInstanceTextAdd(SI_Symbol& symbol,
+                                                   SI_Text& text) noexcept
+  : UndoCommand(tr("Add symbol text")), mSymbol(symbol), mText(text) {
+}
+
+CmdSymbolInstanceTextAdd::~CmdSymbolInstanceTextAdd() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdSymbolInstanceTextAdd::performExecute() {
+  performRedo();  // can throw
+
+  return true;
+}
+
+void CmdSymbolInstanceTextAdd::performUndo() {
+  mSymbol.removeText(mText);  // can throw
+}
+
+void CmdSymbolInstanceTextAdd::performRedo() {
+  mSymbol.addText(mText);  // can throw
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextadd.h
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextadd.h
@@ -17,16 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_CMDDRAGSELECTEDSCHEMATICITEMS_H
-#define LIBREPCB_EDITOR_CMDDRAGSELECTEDSCHEMATICITEMS_H
+#ifndef LIBREPCB_EDITOR_CMDSYMBOLINSTANCETEXTADD_H
+#define LIBREPCB_EDITOR_CMDSYMBOLINSTANCETEXTADD_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../../undocommandgroup.h"
-
-#include <librepcb/core/types/angle.h>
-#include <librepcb/core/types/point.h>
+#include "../../undocommand.h"
 
 #include <QtCore>
 
@@ -35,36 +32,23 @@
  ******************************************************************************/
 namespace librepcb {
 
-class Schematic;
+class SI_Symbol;
+class SI_Text;
 
 namespace editor {
 
-class CmdPolygonEdit;
-class CmdSchematicNetLabelEdit;
-class CmdSchematicNetPointEdit;
-class CmdSymbolInstanceEdit;
-class CmdSymbolInstanceTextsReset;
-class CmdTextEdit;
-
 /*******************************************************************************
- *  Class CmdDragSelectedSchematicItems
+ *  Class CmdSymbolInstanceTextAdd
  ******************************************************************************/
 
 /**
- * @brief The CmdDragSelectedSchematicItems class
+ * @brief The CmdSymbolInstanceTextAdd class
  */
-class CmdDragSelectedSchematicItems final : public UndoCommandGroup {
+class CmdSymbolInstanceTextAdd final : public UndoCommand {
 public:
   // Constructors / Destructor
-  CmdDragSelectedSchematicItems(Schematic& schematic,
-                                const Point& startPos = Point()) noexcept;
-  ~CmdDragSelectedSchematicItems() noexcept;
-
-  // General Methods
-  void resetAllTexts() noexcept;
-  void setCurrentPosition(const Point& pos) noexcept;
-  void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
-  void mirror(Qt::Orientation orientation, bool aroundCurrentPosition) noexcept;
+  CmdSymbolInstanceTextAdd(SI_Symbol& symbol, SI_Text& text) noexcept;
+  ~CmdSymbolInstanceTextAdd() noexcept;
 
 private:
   // Private Methods
@@ -72,23 +56,17 @@ private:
   /// @copydoc ::librepcb::editor::UndoCommand::performExecute()
   bool performExecute() override;
 
-  // Private Member Variables
-  Schematic& mSchematic;
-  int mItemCount;
-  Point mStartPos;
-  Point mDeltaPos;
-  Point mCenterPos;
-  Angle mDeltaAngle;
-  bool mMirrored;
-  bool mTextsReset;
+  /// @copydoc ::librepcb::editor::UndoCommand::performUndo()
+  void performUndo() override;
 
-  // Move commands
-  QList<CmdSymbolInstanceEdit*> mSymbolEditCmds;
-  QList<CmdSymbolInstanceTextsReset*> mSymbolTextsResetCmds;
-  QList<CmdSchematicNetPointEdit*> mNetPointEditCmds;
-  QList<CmdSchematicNetLabelEdit*> mNetLabelEditCmds;
-  QList<CmdPolygonEdit*> mPolygonEditCmds;
-  QList<CmdTextEdit*> mTextEditCmds;
+  /// @copydoc ::librepcb::editor::UndoCommand::performRedo()
+  void performRedo() override;
+
+  // Private Member Variables
+
+  // Attributes from the constructor
+  SI_Symbol& mSymbol;
+  SI_Text& mText;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextremove.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextremove.cpp
@@ -17,70 +17,54 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_SGI_SYMBOL_H
-#define LIBREPCB_CORE_SGI_SYMBOL_H
-
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "sgi_base.h"
+#include "cmdsymbolinstancetextremove.h"
+
+#include <librepcb/core/project/schematic/items/si_symbol.h>
 
 #include <QtCore>
-#include <QtWidgets>
 
 /*******************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ******************************************************************************/
 namespace librepcb {
-
-class CircleGraphicsItem;
-class GraphicsLayer;
-class OriginCrossGraphicsItem;
-class PolygonGraphicsItem;
-class SI_Symbol;
+namespace editor {
 
 /*******************************************************************************
- *  Class SGI_Symbol
+ *  Constructors / Destructor
  ******************************************************************************/
 
-/**
- * @brief The SGI_Symbol class
- */
-class SGI_Symbol final : public SGI_Base {
-public:
-  // Constructors / Destructor
-  SGI_Symbol() = delete;
-  SGI_Symbol(const SGI_Symbol& other) = delete;
-  explicit SGI_Symbol(SI_Symbol& symbol) noexcept;
-  ~SGI_Symbol() noexcept;
+CmdSymbolInstanceTextRemove::CmdSymbolInstanceTextRemove(SI_Symbol& symbol,
+                                                         SI_Text& text) noexcept
+  : UndoCommand(tr("Remove symbol text")), mSymbol(symbol), mText(text) {
+}
 
-  // General Methods
-  void setPosition(const Point& pos) noexcept;
-  void setSelected(bool selected) noexcept;
-  void updateRotationAndMirror() noexcept;
+CmdSymbolInstanceTextRemove::~CmdSymbolInstanceTextRemove() noexcept {
+}
 
-  // Inherited from QGraphicsItem
-  QRectF boundingRect() const noexcept override { return mBoundingRect; }
-  QPainterPath shape() const noexcept override { return mShape; }
-  void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-             QWidget* widget = 0) noexcept override;
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
 
-  // Operator Overloadings
-  SGI_Symbol& operator=(const SGI_Symbol& rhs) = delete;
+bool CmdSymbolInstanceTextRemove::performExecute() {
+  performRedo();  // can throw
 
-private:  // Data
-  SI_Symbol& mSymbol;
-  std::shared_ptr<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
-  QVector<std::shared_ptr<CircleGraphicsItem>> mCircleGraphicsItems;
-  QVector<std::shared_ptr<PolygonGraphicsItem>> mPolygonGraphicsItems;
-  QRectF mBoundingRect;
-  QPainterPath mShape;
-};
+  return true;
+}
+
+void CmdSymbolInstanceTextRemove::performUndo() {
+  mSymbol.addText(mText);  // can throw
+}
+
+void CmdSymbolInstanceTextRemove::performRedo() {
+  mSymbol.removeText(mText);  // can throw
+}
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace librepcb
-
-#endif

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextremove.h
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextremove.h
@@ -17,99 +17,63 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_SCHEMATICPAINTER_H
-#define LIBREPCB_CORE_SCHEMATICPAINTER_H
+#ifndef LIBREPCB_EDITOR_CMDSYMBOLINSTANCETEXTREMOVE_H
+#define LIBREPCB_EDITOR_CMDSYMBOLINSTANCETEXTREMOVE_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../../export/graphicsexport.h"
-#include "../../types/alignment.h"
-#include "../../types/length.h"
-#include "../../utils/transform.h"
+#include "../../undocommand.h"
 
 #include <QtCore>
-#include <QtGui>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 
-class Circle;
-class Path;
-class Polygon;
-class Schematic;
-class Text;
+class SI_Symbol;
+class SI_Text;
+
+namespace editor {
 
 /*******************************************************************************
- *  Class SchematicPainter
+ *  Class CmdSymbolInstanceTextRemove
  ******************************************************************************/
 
 /**
- * @brief Paints a ::librepcb::Schematic to a QPainter
- *
- * Used for ::librepcb::GraphicsExport.
+ * @brief The CmdSymbolInstanceTextRemove class
  */
-class SchematicPainter final : public GraphicsPagePainter {
-  struct Pin {
-    Point position;
-    Angle rotation;
-    UnsignedLength length;
-    QString name;
-    Point namePosition;
-    Angle nameRotation;
-    PositiveLength nameHeight;
-    Alignment nameAlignment;
-  };
-
-  struct Line {
-    Point startPosition;
-    Point endPosition;
-    UnsignedLength width;
-  };
-
-  struct Label {
-    Point position;
-    Angle rotation;
-    bool mirrored;
-    QString text;
-  };
-
-  struct Symbol {
-    Transform transform;
-    QList<Pin> pins;
-    QList<Polygon> polygons;
-    QList<Circle> circles;
-  };
-
+class CmdSymbolInstanceTextRemove final : public UndoCommand {
 public:
   // Constructors / Destructor
-  SchematicPainter() = delete;
-  explicit SchematicPainter(const Schematic& schematic) noexcept;
-  SchematicPainter(const SchematicPainter& other) = delete;
-  ~SchematicPainter() noexcept;
+  CmdSymbolInstanceTextRemove(SI_Symbol& symbol, SI_Text& text) noexcept;
+  ~CmdSymbolInstanceTextRemove() noexcept;
 
-  // General Methods
-  void paint(QPainter& painter, const GraphicsExportSettings& settings) const
-      noexcept override;
+private:
+  // Private Methods
 
-  // Operator Overloadings
-  SchematicPainter& operator=(const SchematicPainter& rhs) = delete;
+  /// @copydoc ::librepcb::editor::UndoCommand::performExecute()
+  bool performExecute() override;
 
-private:  // Data
-  QList<Symbol> mSymbols;
-  QList<Point> mJunctions;
-  QList<Line> mNetLines;
-  QList<Label> mNetLabels;
-  QList<Polygon> mPolygons;
-  QList<Text> mTexts;
+  /// @copydoc ::librepcb::editor::UndoCommand::performUndo()
+  void performUndo() override;
+
+  /// @copydoc ::librepcb::editor::UndoCommand::performRedo()
+  void performRedo() override;
+
+  // Private Member Variables
+
+  // Attributes from the constructor
+  SI_Symbol& mSymbol;
+  SI_Text& mText;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
+}  // namespace editor
 }  // namespace librepcb
 
 #endif

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextsreset.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextsreset.cpp
@@ -1,0 +1,75 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdsymbolinstancetextsreset.h"
+
+#include "cmdsymbolinstancetextadd.h"
+#include "cmdsymbolinstancetextremove.h"
+
+#include <librepcb/core/project/schematic/items/si_symbol.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdSymbolInstanceTextsReset::CmdSymbolInstanceTextsReset(
+    SI_Symbol& symbol) noexcept
+  : UndoCommandGroup(tr("Reset symbol texts")), mSymbol(symbol) {
+}
+
+CmdSymbolInstanceTextsReset::~CmdSymbolInstanceTextsReset() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdSymbolInstanceTextsReset::performExecute() {
+  // Remove all texts
+  foreach (SI_Text* text, mSymbol.getTexts()) {
+    appendChild(new CmdSymbolInstanceTextRemove(mSymbol, *text));
+  }
+
+  // Create new texts
+  for (const Text& text : mSymbol.getDefaultTexts()) {
+    appendChild(new CmdSymbolInstanceTextAdd(
+        mSymbol, *new SI_Text(mSymbol.getSchematic(), text)));
+  }
+
+  // execute all child commands
+  return UndoCommandGroup::performExecute();  // can throw
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextsreset.h
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstancetextsreset.h
@@ -17,16 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_CMDDRAGSELECTEDSCHEMATICITEMS_H
-#define LIBREPCB_EDITOR_CMDDRAGSELECTEDSCHEMATICITEMS_H
+#ifndef LIBREPCB_EDITOR_CMDSYMBOLINSTANCETEXTSRESET_H
+#define LIBREPCB_EDITOR_CMDSYMBOLINSTANCETEXTSRESET_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
 #include "../../undocommandgroup.h"
-
-#include <librepcb/core/types/angle.h>
-#include <librepcb/core/types/point.h>
 
 #include <QtCore>
 
@@ -35,36 +32,22 @@
  ******************************************************************************/
 namespace librepcb {
 
-class Schematic;
+class SI_Symbol;
 
 namespace editor {
 
-class CmdPolygonEdit;
-class CmdSchematicNetLabelEdit;
-class CmdSchematicNetPointEdit;
-class CmdSymbolInstanceEdit;
-class CmdSymbolInstanceTextsReset;
-class CmdTextEdit;
-
 /*******************************************************************************
- *  Class CmdDragSelectedSchematicItems
+ *  Class CmdSymbolInstanceTextsReset
  ******************************************************************************/
 
 /**
- * @brief The CmdDragSelectedSchematicItems class
+ * @brief The CmdSymbolInstanceTextsReset class
  */
-class CmdDragSelectedSchematicItems final : public UndoCommandGroup {
+class CmdSymbolInstanceTextsReset final : public UndoCommandGroup {
 public:
   // Constructors / Destructor
-  CmdDragSelectedSchematicItems(Schematic& schematic,
-                                const Point& startPos = Point()) noexcept;
-  ~CmdDragSelectedSchematicItems() noexcept;
-
-  // General Methods
-  void resetAllTexts() noexcept;
-  void setCurrentPosition(const Point& pos) noexcept;
-  void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
-  void mirror(Qt::Orientation orientation, bool aroundCurrentPosition) noexcept;
+  CmdSymbolInstanceTextsReset(SI_Symbol& symbol) noexcept;
+  ~CmdSymbolInstanceTextsReset() noexcept;
 
 private:
   // Private Methods
@@ -73,22 +56,7 @@ private:
   bool performExecute() override;
 
   // Private Member Variables
-  Schematic& mSchematic;
-  int mItemCount;
-  Point mStartPos;
-  Point mDeltaPos;
-  Point mCenterPos;
-  Angle mDeltaAngle;
-  bool mMirrored;
-  bool mTextsReset;
-
-  // Move commands
-  QList<CmdSymbolInstanceEdit*> mSymbolEditCmds;
-  QList<CmdSymbolInstanceTextsReset*> mSymbolTextsResetCmds;
-  QList<CmdSchematicNetPointEdit*> mNetPointEditCmds;
-  QList<CmdSchematicNetLabelEdit*> mNetLabelEditCmds;
-  QList<CmdPolygonEdit*> mPolygonEditCmds;
-  QList<CmdTextEdit*> mTextEditCmds;
+  SI_Symbol& mSymbol;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
@@ -206,6 +206,15 @@ bool SchematicEditorFsm::processMirror(Qt::Orientation orientation) noexcept {
   return false;
 }
 
+bool SchematicEditorFsm::processResetAllTexts() noexcept {
+  if (SchematicEditorState* state = getCurrentStateObj()) {
+    if (state->processResetAllTexts()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool SchematicEditorFsm::processRemove() noexcept {
   if (SchematicEditorState* state = getCurrentStateObj()) {
     if (state->processRemove()) {

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
@@ -113,6 +113,7 @@ public:
   bool processMove(const Point& delta) noexcept;
   bool processRotate(const Angle& rotation) noexcept;
   bool processMirror(Qt::Orientation orientation) noexcept;
+  bool processResetAllTexts() noexcept;
   bool processRemove() noexcept;
   bool processEditProperties() noexcept;
   bool processKeyPressed(const QKeyEvent& e) noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.cpp
@@ -226,7 +226,7 @@ QList<SI_Base*> SchematicEditorState::findItemsAtPos(
 
   if (flags &
       (FindFlag::Symbols | FindFlag::SymbolPins |
-       FindFlag::SymbolPinsWithComponentSignal)) {
+       FindFlag::SymbolPinsWithComponentSignal | FindFlag::Texts)) {
     foreach (SI_Symbol* symbol, schematic->getSymbols()) {
       if (flags.testFlag(FindFlag::Symbols)) {
         processItem(symbol, symbol->getPosition(), 40);
@@ -238,6 +238,11 @@ QList<SI_Base*> SchematicEditorState::findItemsAtPos(
               (pin->getComponentSignalInstance())) {
             processItem(pin, pin->getPosition(), 50);
           }
+        }
+      }
+      if (flags.testFlag(FindFlag::Texts)) {
+        foreach (SI_Text* text, symbol->getTexts()) {
+          processItem(text, text->getPosition(), 70);
         }
       }
     }

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
@@ -119,6 +119,7 @@ public:
     Q_UNUSED(orientation);
     return false;
   }
+  virtual bool processResetAllTexts() noexcept { return false; }
   virtual bool processRemove() noexcept { return false; }
   virtual bool processEditProperties() noexcept { return false; }
   virtual bool processAbortCommand() noexcept { return false; }

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -29,7 +29,7 @@
 #include "../../addcomponentdialog.h"
 #include "../../cmd/cmdaddcomponenttocircuit.h"
 #include "../../cmd/cmdaddsymboltoschematic.h"
-#include "../../cmd/cmdsymbolinstanceedit.h"
+#include "../../cmd/cmdsymbolinstanceeditall.h"
 #include "../schematiceditor.h"
 
 #include <librepcb/core/attribute/attributetype.h>
@@ -266,7 +266,7 @@ bool SchematicEditorState_AddComponent::
       // add command to move the current symbol
       Q_ASSERT(mCurrentSymbolEditCommand == nullptr);
       mCurrentSymbolEditCommand =
-          new CmdSymbolInstanceEdit(*mCurrentSymbolToPlace);
+          new CmdSymbolInstanceEditAll(*mCurrentSymbolToPlace);
       mCurrentSymbolEditCommand->setRotation(mLastAngle, true);
       mCurrentSymbolEditCommand->setMirrored(mLastMirrored, true);
     } else {
@@ -409,7 +409,7 @@ void SchematicEditorState_AddComponent::startAddingComponent(
     // add command to move the current symbol
     Q_ASSERT(mCurrentSymbolEditCommand == nullptr);
     mCurrentSymbolEditCommand =
-        new CmdSymbolInstanceEdit(*mCurrentSymbolToPlace);
+        new CmdSymbolInstanceEditAll(*mCurrentSymbolToPlace);
     mCurrentSymbolEditCommand->setRotation(mLastAngle, true);
     mCurrentSymbolEditCommand->setMirrored(mLastMirrored, true);
   } catch (Exception& e) {

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.h
@@ -47,7 +47,7 @@ namespace editor {
 
 class AddComponentDialog;
 class AttributeUnitComboBox;
-class CmdSymbolInstanceEdit;
+class CmdSymbolInstanceEditAll;
 
 /*******************************************************************************
  *  Class SchematicEditorState_AddComponent
@@ -118,7 +118,7 @@ private:  // Data
   ComponentInstance* mCurrentComponent;
   int mCurrentSymbVarItemIndex;
   SI_Symbol* mCurrentSymbolToPlace;
-  CmdSymbolInstanceEdit* mCurrentSymbolEditCommand;
+  CmdSymbolInstanceEditAll* mCurrentSymbolEditCommand;
 
   // Widgets for the command toolbar
   QPointer<QComboBox> mValueComboBox;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -202,7 +202,8 @@ bool SchematicEditorState_Select::processEditProperties() noexcept {
   query->addSelectedSymbols();
   query->addSelectedNetLabels();
   query->addSelectedPolygons();
-  query->addSelectedTexts();
+  query->addSelectedSchematicTexts();
+  query->addSelectedSymbolTexts();
   foreach (auto ptr, query->getSymbols()) { return openPropertiesDialog(ptr); }
   foreach (auto ptr, query->getNetLabels()) {
     return openPropertiesDialog(ptr);

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.h
@@ -79,6 +79,7 @@ public:
   virtual bool processMove(const Point& delta) noexcept override;
   virtual bool processRotate(const Angle& rotation) noexcept override;
   virtual bool processMirror(Qt::Orientation orientation) noexcept override;
+  virtual bool processResetAllTexts() noexcept override;
   virtual bool processRemove() noexcept override;
   virtual bool processEditProperties() noexcept override;
   virtual bool processAbortCommand() noexcept override;
@@ -104,6 +105,7 @@ private:  // Methods
   bool moveSelectedItems(const Point& delta) noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems(Qt::Orientation orientation) noexcept;
+  bool resetAllTextsOfSelectedItems() noexcept;
   bool removeSelectedItems() noexcept;
   void removePolygonVertices(Polygon& polygon,
                              const QVector<int> vertices) noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.h
@@ -129,18 +129,20 @@ public:
     Point position;
     Angle rotation;
     bool mirrored;
+    TextList texts;
 
     Signal<SymbolInstance> onEdited;  ///< Dummy event, not used
 
     SymbolInstance(const Uuid& uuid, const Uuid& componentInstanceUuid,
                    const Uuid& symbolVariantItemUuid, const Point& position,
-                   const Angle& rotation, bool mirrored)
+                   const Angle& rotation, bool mirrored, const TextList& texts)
       : uuid(uuid),
         componentInstanceUuid(componentInstanceUuid),
         symbolVariantItemUuid(symbolVariantItemUuid),
         position(position),
         rotation(rotation),
         mirrored(mirrored),
+        texts(texts),
         onEdited(*this) {}
 
     explicit SymbolInstance(const SExpression& node)
@@ -150,6 +152,7 @@ public:
         position(node.getChild("position")),
         rotation(deserialize<Angle>(node.getChild("rotation/@0"))),
         mirrored(deserialize<bool>(node.getChild("mirror/@0"))),
+        texts(node),
         onEdited(*this) {}
 
     void serialize(SExpression& root) const {
@@ -163,6 +166,8 @@ public:
       root.appendChild("rotation", rotation);
       root.appendChild("mirror", mirrored);
       root.ensureLineBreak();
+      texts.serialize(root);
+      root.ensureLineBreak();
     }
 
     bool operator!=(const SymbolInstance& rhs) noexcept {
@@ -170,7 +175,7 @@ public:
           (componentInstanceUuid != rhs.componentInstanceUuid) ||
           (symbolVariantItemUuid != rhs.symbolVariantItemUuid) ||
           (position != rhs.position) || (rotation != rhs.rotation) ||
-          (mirrored != rhs.mirrored);
+          (mirrored != rhs.mirrored) || (texts != rhs.texts);
     }
   };
 

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<SchematicClipboardData> SchematicClipboardDataBuilder::generate(
   query->addSelectedNetLines();
   query->addSelectedNetLabels();
   query->addSelectedPolygons();
-  query->addSelectedTexts();
+  query->addSelectedSchematicTexts();
   query->addNetPointsOfNetLines();
 
   // Add components
@@ -114,11 +114,15 @@ std::unique_ptr<SchematicClipboardData> SchematicClipboardDataBuilder::generate(
     if (dir->getFiles().isEmpty()) {
       symbol->getLibSymbol().getDirectory().copyTo(*dir);
     }
+    TextList texts;
+    foreach (const SI_Text* t, symbol->getTexts()) {
+      texts.append(std::make_shared<Text>(t->getText()));
+    }
     data->getSymbolInstances().append(
         std::make_shared<SchematicClipboardData::SymbolInstance>(
             symbol->getUuid(), symbol->getComponentInstance().getUuid(),
             symbol->getCompSymbVarItem().getUuid(), symbol->getPosition(),
-            symbol->getRotation(), symbol->getMirrored()));
+            symbol->getRotation(), symbol->getMirrored(), texts));
   }
 
   // Add (splitted) net segments including netpoints, netlines and netlabels

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -446,6 +446,8 @@ void SchematicEditor::createActions() noexcept {
       this, this, [this]() { mFsm->processMirror(Qt::Horizontal); }));
   mActionMirrorVertical.reset(cmd.mirrorVertical.createAction(
       this, this, [this]() { mFsm->processMirror(Qt::Vertical); }));
+  mActionResetAllTexts.reset(cmd.deviceResetTextAll.createAction(
+      this, mFsm.data(), &SchematicEditorFsm::processResetAllTexts));
   mActionProperties.reset(cmd.properties.createAction(
       this, mFsm.data(), &SchematicEditorFsm::processEditProperties));
   mActionRemove.reset(cmd.remove.createAction(
@@ -727,6 +729,7 @@ void SchematicEditor::createMenus() noexcept {
   mb.addAction(mActionRotateCw);
   mb.addAction(mActionMirrorHorizontal);
   mb.addAction(mActionMirrorVertical);
+  mb.addAction(mActionResetAllTexts);
   mb.addSeparator();
   mb.addAction(mActionFind);
   mb.addAction(mActionFindNext);

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -179,6 +179,7 @@ private:
   QScopedPointer<QAction> mActionRotateCw;
   QScopedPointer<QAction> mActionMirrorHorizontal;
   QScopedPointer<QAction> mActionMirrorVertical;
+  QScopedPointer<QAction> mActionResetAllTexts;
   QScopedPointer<QAction> mActionProperties;
   QScopedPointer<QAction> mActionRemove;
   QScopedPointer<QAction> mActionAbort;

--- a/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/symbolinstancepropertiesdialog.cpp
@@ -23,7 +23,7 @@
 #include "symbolinstancepropertiesdialog.h"
 
 #include "../../project/cmd/cmdcomponentinstanceedit.h"
-#include "../../project/cmd/cmdsymbolinstanceedit.h"
+#include "../../project/cmd/cmdsymbolinstanceeditall.h"
 #include "../../undocommand.h"
 #include "../../undostack.h"
 #include "../../workspace/desktopservices.h"
@@ -236,8 +236,8 @@ bool SymbolInstancePropertiesDialog::applyChanges() noexcept {
 
     // Symbol Instance
     bool mirrored = mUi->cbxMirror->isChecked();
-    QScopedPointer<CmdSymbolInstanceEdit> cmdSym(
-        new CmdSymbolInstanceEdit(mSymbol));
+    QScopedPointer<CmdSymbolInstanceEditAll> cmdSym(
+        new CmdSymbolInstanceEditAll(mSymbol));
     cmdSym->setPosition(Point(mUi->edtSymbInstPosX->getValue(),
                               mUi->edtSymbInstPosY->getValue()),
                         false);

--- a/tests/unittests/editor/project/schematiceditor/schematicclipboarddatatest.cpp
+++ b/tests/unittests/editor/project/schematiceditor/schematicclipboarddatatest.cpp
@@ -79,6 +79,15 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
       AttributeKey("A2"), AttrTypeVoltage::instance(), "4.2",
       AttrTypeVoltage::instance().getUnitFromString("millivolt"));
 
+  std::shared_ptr<Text> text1 = std::make_shared<Text>(
+      Uuid::createRandom(), GraphicsLayerName("foo"), "text 1", Point(1, 2),
+      Angle(3), PositiveLength(4), Alignment(HAlign::left(), VAlign::top()));
+
+  std::shared_ptr<Text> text2 = std::make_shared<Text>(
+      Uuid::createRandom(), GraphicsLayerName("bar"), "text 2", Point(10, 20),
+      Angle(30), PositiveLength(40),
+      Alignment(HAlign::center(), VAlign::bottom()));
+
   std::shared_ptr<SchematicClipboardData::ComponentInstance> component1 =
       std::make_shared<SchematicClipboardData::ComponentInstance>(
           Uuid::createRandom(), Uuid::createRandom(), Uuid::createRandom(),
@@ -94,12 +103,12 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
   std::shared_ptr<SchematicClipboardData::SymbolInstance> symbol1 =
       std::make_shared<SchematicClipboardData::SymbolInstance>(
           Uuid::createRandom(), Uuid::createRandom(), Uuid::createRandom(),
-          Point(123, 456), Angle(789), false);
+          Point(123, 456), Angle(789), false, TextList{text2, text1});
 
   std::shared_ptr<SchematicClipboardData::SymbolInstance> symbol2 =
       std::make_shared<SchematicClipboardData::SymbolInstance>(
           Uuid::createRandom(), Uuid::createRandom(), Uuid::createRandom(),
-          Point(321, 987), Angle(555), true);
+          Point(321, 987), Angle(555), true, TextList{text1, text2});
 
   std::shared_ptr<SchematicClipboardData::NetSegment> netSegment1 =
       std::make_shared<SchematicClipboardData::NetSegment>(
@@ -151,15 +160,6 @@ TEST(SchematicClipboardDataTest, testToFromMimeDataPopulated) {
                                 UnsignedLength(10), true, false,
                                 Path({Vertex(Point(10, 20), Angle(30)),
                                       Vertex(Point(40, 50), Angle(60))}));
-
-  std::shared_ptr<Text> text1 = std::make_shared<Text>(
-      Uuid::createRandom(), GraphicsLayerName("foo"), "text 1", Point(1, 2),
-      Angle(3), PositiveLength(4), Alignment(HAlign::left(), VAlign::top()));
-
-  std::shared_ptr<Text> text2 = std::make_shared<Text>(
-      Uuid::createRandom(), GraphicsLayerName("bar"), "text 2", Point(10, 20),
-      Angle(30), PositiveLength(40),
-      Alignment(HAlign::center(), VAlign::bottom()));
 
   // Create object
   SchematicClipboardData obj1(uuid, pos);


### PR DESCRIPTION
Just like in the board editor, this makes symbol texts (e.g. `{{NAME}}` and `{{VALUE}}`) movable, editable and can even be removed. In addition, there's now also a "Reset All Texts" (context) menu item which restores the original text properties from the library symbols.

Affects the file format of schematics since the text objects are now copied from the symbols into the schematics.

Closes #515