### PR TITLE
Build and show list of project file format upgrade messages

### DIFF
--- a/libs/librepcb/core/project/projectloader.h
+++ b/libs/librepcb/core/project/projectloader.h
@@ -23,6 +23,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../serialization/fileformatmigration.h"
+
+#include <optional/tl/optional.hpp>
+
 #include <QtCore>
 
 #include <memory>
@@ -59,6 +63,10 @@ public:
   std::unique_ptr<Project> open(
       std::unique_ptr<TransactionalDirectory> directory,
       const QString& filename);
+  const tl::optional<QList<FileFormatMigration::Message>>& getUpgradeMessages()
+      const noexcept {
+    return mUpgradeMessages;
+  }
 
   // Operator Overloadings
   ProjectLoader& operator=(const ProjectLoader& rhs) = delete;
@@ -83,6 +91,9 @@ private:  // Methods
   void loadBoardPlane(Board& b, const SExpression& node);
   void loadBoardUserSettings(Board& b);
   void restoreApprovedErcMessages(Project& p);
+
+private:  // Data
+  tl::optional<QList<FileFormatMigration::Message>> mUpgradeMessages;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/fileformatmigration.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigration.cpp
@@ -36,6 +36,23 @@
 namespace librepcb {
 
 /*******************************************************************************
+ *  Class FileFormatMigration::Message
+ ******************************************************************************/
+
+QString FileFormatMigration::Message::getSeverityStrTr() const noexcept {
+  switch (severity) {
+    case Severity::Note:
+      return tr("NOTE");
+    case Severity::Warning:
+      return tr("WARNING");
+    case Severity::Critical:
+      return tr("CRITICAL");
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/*******************************************************************************
  *  Constructors / Destructor
  ******************************************************************************/
 
@@ -64,6 +81,17 @@ QList<std::shared_ptr<FileFormatMigration>> FileFormatMigration::getMigrations(
 /*******************************************************************************
  *  Protected Methods
  ******************************************************************************/
+
+FileFormatMigration::Message FileFormatMigration::buildMessage(
+    Message::Severity severity, const QString& message, int affectedItems) const
+    noexcept {
+  const Message msg{mFromVersion, mToVersion, severity, affectedItems, message};
+  const QString multiplier =
+      affectedItems > 0 ? QString(" (%1x)").arg(affectedItems) : "";
+  qInfo().nospace().noquote()
+      << "UPGRADE " << msg.getSeverityStrTr() << multiplier << ": " << message;
+  return msg;
+}
 
 void FileFormatMigration::upgradeVersionFile(TransactionalDirectory& dir,
                                              const QString& fileName) {

--- a/libs/librepcb/core/serialization/fileformatmigration.h
+++ b/libs/librepcb/core/serialization/fileformatmigration.h
@@ -47,6 +47,18 @@ class FileFormatMigration : public QObject {
   Q_OBJECT
 
 public:
+  // Types
+  struct Message {
+    enum class Severity : int { Note = 0, Warning = 1, Critical = 2 };
+    Version fromVersion;
+    Version toVersion;
+    Severity severity;
+    int affectedItems;
+    QString message;
+
+    QString getSeverityStrTr() const noexcept;
+  };
+
   // Constructors / Destructor
   FileFormatMigration() = delete;
   explicit FileFormatMigration(const Version& fromVersion,
@@ -67,7 +79,8 @@ public:
   virtual void upgradeComponent(TransactionalDirectory& dir) = 0;
   virtual void upgradeDevice(TransactionalDirectory& dir) = 0;
   virtual void upgradeLibrary(TransactionalDirectory& dir) = 0;
-  virtual void upgradeProject(TransactionalDirectory& dir) = 0;
+  virtual void upgradeProject(TransactionalDirectory& dir,
+                              QList<Message>& messages) = 0;
   virtual void upgradeWorkspaceData(TransactionalDirectory& dir) = 0;
 
   // Static Methods
@@ -78,6 +91,8 @@ public:
   FileFormatMigration& operator=(const FileFormatMigration& rhs) = delete;
 
 protected:  // Methods
+  Message buildMessage(Message::Severity severity, const QString& message,
+                       int affectedItems = -1) const noexcept;
   void upgradeVersionFile(TransactionalDirectory& dir, const QString& fileName);
 
 protected:  // Data

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -159,7 +159,8 @@ void FileFormatMigrationV01::upgradeLibrary(TransactionalDirectory& dir) {
   upgradeVersionFile(dir, ".librepcb-lib");
 }
 
-void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir) {
+void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir,
+                                            QList<Message>& messages) {
   LoadedData data;
 
   // Version File.
@@ -377,6 +378,20 @@ void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir) {
 
       // Holes.
       upgradeHoles(root);
+
+      // Planes.
+      int planeCount = 0;
+      for (SExpression* planeNode : root.getChildren("plane")) {
+        Q_UNUSED(planeNode);
+        ++planeCount;
+      }
+      if (planeCount > 0) {
+        messages.append(buildMessage(
+            Message::Severity::Note,
+            tr("Plane area calculations have been adjusted, manual review and "
+               "running the DRC is recommended."),
+            planeCount));
+      }
 
       dir.write(fp, root.toByteArray());
     }

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -103,7 +103,8 @@ public:
   virtual void upgradeComponent(TransactionalDirectory& dir) override;
   virtual void upgradeDevice(TransactionalDirectory& dir) override;
   virtual void upgradeLibrary(TransactionalDirectory& dir) override;
-  virtual void upgradeProject(TransactionalDirectory& dir) override;
+  virtual void upgradeProject(TransactionalDirectory& dir,
+                              QList<Message>& messages) override;
   virtual void upgradeWorkspaceData(TransactionalDirectory& dir) override;
 
   // Operator Overloadings

--- a/libs/librepcb/editor/project/projecteditor.cpp
+++ b/libs/librepcb/editor/project/projecteditor.cpp
@@ -48,7 +48,9 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-ProjectEditor::ProjectEditor(Workspace& workspace, Project& project)
+ProjectEditor::ProjectEditor(
+    Workspace& workspace, Project& project,
+    const tl::optional<QList<FileFormatMigration::Message> >& upgradeMessages)
   : QObject(nullptr),
     mWorkspace(workspace),
     mProject(project),
@@ -61,7 +63,7 @@ ProjectEditor::ProjectEditor(Workspace& workspace, Project& project)
     mLastAutosaveStateId = mUndoStack->getUniqueStateId();
 
     // create the whole schematic/board editor GUI inclusive FSM and so on
-    mSchematicEditor = new SchematicEditor(*this, mProject);
+    mSchematicEditor = new SchematicEditor(*this, mProject, upgradeMessages);
     mBoardEditor = new BoardEditor(*this, mProject);
   } catch (...) {
     // free the allocated memory in the reverse order of their allocation...
@@ -257,6 +259,7 @@ bool ProjectEditor::saveProject() noexcept {
 
     // saving was successful --> clean the undo stack
     mUndoStack->setClean();
+    emit projectSavedToDisk();
     qDebug() << "Successfully saved project.";
     return true;
   } catch (Exception& exc) {

--- a/libs/librepcb/editor/project/projecteditor.h
+++ b/libs/librepcb/editor/project/projecteditor.h
@@ -24,6 +24,8 @@
  *  Includes
  ******************************************************************************/
 #include <librepcb/core/attribute/attributeprovider.h>
+#include <librepcb/core/serialization/fileformatmigration.h>
+#include <optional/tl/optional.hpp>
 
 #include <QtCore>
 
@@ -67,7 +69,9 @@ public:
   /**
    * @brief The constructor
    */
-  ProjectEditor(Workspace& workspace, Project& project);
+  ProjectEditor(Workspace& workspace, Project& project,
+                const tl::optional<QList<FileFormatMigration::Message> >&
+                    upgradeMessages);
 
   /**
    * @brief The destructor
@@ -222,7 +226,7 @@ public slots:
   bool closeAndDestroy(bool askForSave, QWidget* msgBoxParent = 0) noexcept;
 
 signals:
-
+  void projectSavedToDisk();
   void showControlPanelClicked();
   void openProjectLibraryUpdaterClicked(const FilePath& fp);
   void projectEditorClosed();

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -27,6 +27,8 @@
 #include "../../widgets/if_graphicsvieweventhandler.h"
 #include "ui_schematiceditor.h"
 
+#include <librepcb/core/serialization/fileformatmigration.h>
+
 #include <QtCore>
 #include <QtWidgets>
 
@@ -71,7 +73,9 @@ public:
   // Constructors / Destructor
   SchematicEditor() = delete;
   SchematicEditor(const SchematicEditor& other) = delete;
-  explicit SchematicEditor(ProjectEditor& projectEditor, Project& project);
+  explicit SchematicEditor(
+      ProjectEditor& projectEditor, Project& project,
+      const tl::optional<QList<FileFormatMigration::Message>>& upgradeMessages);
   ~SchematicEditor();
 
   // Getters
@@ -119,6 +123,8 @@ private:
   void execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                 const QString& settingsKey) noexcept;
   bool useIeee315Symbols() const noexcept;
+  void showUpgradeMessages(
+      QList<FileFormatMigration::Message> messages) noexcept;
 
   // General Attributes
   ProjectEditor& mProjectEditor;

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.ui
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.ui
@@ -32,6 +32,9 @@
      <number>0</number>
     </property>
     <item>
+     <widget class="librepcb::editor::MessageWidget" name="msgProjectUpgraded" native="true"/>
+    </item>
+    <item>
      <widget class="librepcb::editor::MessageWidget" name="msgEmptySchematic" native="true"/>
     </item>
     <item>

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -125,16 +125,6 @@ private:
    * @brief Open a project with the editor (or bring an already opened editor to
    * front)
    *
-   * @param project       An already opened project (but without the editor)
-   *
-   * @return The pointer to the opened project editor (nullptr on error)
-   */
-  ProjectEditor* openProject(Project& project) noexcept;
-
-  /**
-   * @brief Open a project with the editor (or bring an already opened editor to
-   * front)
-   *
    * @param filepath  The filepath to the *.lpp project file to open. If invalid
    *                  (the default), a file dialog will be shown to select it.
    *


### PR DESCRIPTION
The file format upgrade procedure can affect projects in several ways (e.g. modifying plane calculations, conversions due to obsolete features, ...) so it would be important to inform the user about such changes.

Thus the file format upgrade mechanism is now able to build upgrade notes for each particular project and the schematic editor shows a banner to inform the user about the upgrade. A hyperlink then opens the detailed list of messages:

![image](https://user-images.githubusercontent.com/5374821/214619697-14c6d680-427c-4e3d-b45c-0188f9f06222.png)

The banner automatically disappears when saving the project since the upgrade is non-reversible then (before saving, the user could decide to close the project, effectively keeping the old file format).

In addition, the CLI now also prints these messages to stdout.