### PR TITLE
Remove support for non-circular vias

### DIFF
--- a/libs/librepcb/core/geometry/via.h
+++ b/libs/librepcb/core/geometry/via.h
@@ -54,29 +54,24 @@ public:
   enum class Event {
     UuidChanged,
     PositionChanged,
-    ShapeChanged,
     SizeChanged,
     DrillDiameterChanged,
   };
   Signal<Via, Event> onEdited;
   typedef Slot<Via, Event> OnEditedSlot;
 
-  // Public Types
-  enum class Shape { Round, Square, Octagon };
-
   // Constructors / Destructor
   Via() = delete;
   Via(const Via& other) noexcept;
   Via(const Uuid& uuid, const Via& other) noexcept;
-  Via(const Uuid& uuid, const Point& position, Shape shape,
-      const PositiveLength& size, const PositiveLength& drillDiameter) noexcept;
+  Via(const Uuid& uuid, const Point& position, const PositiveLength& size,
+      const PositiveLength& drillDiameter) noexcept;
   explicit Via(const SExpression& node);
   ~Via() noexcept;
 
   // Getters
   const Uuid& getUuid() const noexcept { return mUuid; }
   const Point& getPosition() const noexcept { return mPosition; }
-  Shape getShape() const noexcept { return mShape; }
   const PositiveLength& getSize() const noexcept { return mSize; }
   const PositiveLength& getDrillDiameter() const noexcept {
     return mDrillDiameter;
@@ -89,7 +84,6 @@ public:
   // Setters
   bool setUuid(const Uuid& uuid) noexcept;
   bool setPosition(const Point& position) noexcept;
-  bool setShape(Shape shape) noexcept;
   bool setSize(const PositiveLength& size) noexcept;
   bool setDrillDiameter(const PositiveLength& diameter) noexcept;
 
@@ -110,7 +104,6 @@ public:
 private:  // Data
   Uuid mUuid;
   Point mPosition;
-  Shape mShape;
   PositiveLength mSize;
   PositiveLength mDrillDiameter;
 };

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -626,26 +626,8 @@ void BoardGerberExport::drawVia(GerberGenerator& gen, const BI_Via& via,
       net = netName;
     }
 
-    switch (via.getShape()) {
-      case Via::Shape::Round: {
-        gen.flashCircle(via.getPosition(), outerDiameter, function, net,
-                        QString(), QString(), QString());
-        break;
-      }
-      case Via::Shape::Square: {
-        gen.flashRect(via.getPosition(), outerDiameter, outerDiameter, radius,
-                      Angle::deg0(), function, net, QString(), QString(),
-                      QString());
-        break;
-      }
-      case Via::Shape::Octagon: {
-        gen.flashOctagon(via.getPosition(), outerDiameter, outerDiameter,
-                         radius, Angle::deg0(), function, net, QString(),
-                         QString(), QString());
-        break;
-      }
-      default: { throw LogicError(__FILE__, __LINE__); }
-    }
+    gen.flashCircle(via.getPosition(), outerDiameter, function, net, QString(),
+                    QString(), QString());
   }
 }
 

--- a/libs/librepcb/core/project/board/items/bi_via.cpp
+++ b/libs/librepcb/core/project/board/items/bi_via.cpp
@@ -81,12 +81,6 @@ void BI_Via::setPosition(const Point& position) noexcept {
   }
 }
 
-void BI_Via::setShape(Via::Shape shape) noexcept {
-  if (mVia.setShape(shape)) {
-    mGraphicsItem->updateCacheAndRepaint();
-  }
-}
-
 void BI_Via::setSize(const PositiveLength& size) noexcept {
   if (mVia.setSize(size)) {
     mGraphicsItem->updateCacheAndRepaint();

--- a/libs/librepcb/core/project/board/items/bi_via.h
+++ b/libs/librepcb/core/project/board/items/bi_via.h
@@ -57,7 +57,6 @@ public:
   BI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
   const Via& getVia() const noexcept { return mVia; }
   const Uuid& getUuid() const noexcept { return mVia.getUuid(); }
-  Via::Shape getShape() const noexcept { return mVia.getShape(); }
   const PositiveLength& getDrillDiameter() const noexcept {
     return mVia.getDrillDiameter();
   }
@@ -69,7 +68,6 @@ public:
 
   // Setters
   void setPosition(const Point& position) noexcept;
-  void setShape(Via::Shape shape) noexcept;
   void setSize(const PositiveLength& size) noexcept;
   void setDrillDiameter(const PositiveLength& diameter) noexcept;
 

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -376,6 +376,26 @@ void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir,
         drillNode.appendChild("g85_slots", false);
       }
 
+      // Net segments.
+      int nonRoundViaCount = 0;
+      for (SExpression* segNode : root.getChildren("netsegment")) {
+        // Vias.
+        for (SExpression* viaNode : segNode->getChildren("via")) {
+          SExpression& shapeNode = viaNode->getChild("shape");
+          if (shapeNode.getChild("@0").getValue() != "round") {
+            ++nonRoundViaCount;
+          }
+          viaNode->removeChild(shapeNode);
+        }
+      }
+      if (nonRoundViaCount > 0) {
+        messages.append(
+            buildMessage(Message::Severity::Warning,
+                         tr("Non-circular via shapes are no longer supported, "
+                            "all vias were changed to circular now."),
+                         nonRoundViaCount));
+      }
+
       // Holes.
       upgradeHoles(root);
 

--- a/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.cpp
@@ -80,13 +80,6 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(
             }
           });
 
-  // shape combobox
-  mUi->cbxShape->addItem(tr("Round"), static_cast<int>(Via::Shape::Round));
-  mUi->cbxShape->addItem(tr("Square"), static_cast<int>(Via::Shape::Square));
-  mUi->cbxShape->addItem(tr("Octagon"), static_cast<int>(Via::Shape::Octagon));
-  mUi->cbxShape->setCurrentIndex(
-      mUi->cbxShape->findData(static_cast<int>(mVia.getShape())));
-
   // Position spinboxes
   mUi->edtPosX->setValue(mVia.getPosition().getX());
   mUi->edtPosY->setValue(mVia.getPosition().getY());
@@ -138,8 +131,6 @@ void BoardViaPropertiesDialog::accept() {
 bool BoardViaPropertiesDialog::applyChanges() noexcept {
   try {
     QScopedPointer<CmdBoardViaEdit> cmd(new CmdBoardViaEdit(mVia));
-    cmd->setShape(static_cast<Via::Shape>(mUi->cbxShape->currentData().toInt()),
-                  false);
     cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
                      false);
     cmd->setSize(mUi->edtSize->getValue(), false);

--- a/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardviapropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>346</width>
-    <height>168</height>
+    <height>142</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,23 +34,13 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Shape:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="cbxShape"/>
-     </item>
-     <item row="2" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Position:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
@@ -60,14 +50,17 @@
        </item>
       </layout>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Outer Size:</string>
+        <string>Outer Diameter:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="2" column="1">
+      <widget class="librepcb::editor::PositiveLengthEdit" name="edtSize" native="true"/>
+     </item>
+     <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Drill Diameter:</string>
@@ -75,9 +68,6 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="librepcb::editor::PositiveLengthEdit" name="edtSize" native="true"/>
-     </item>
-     <item row="4" column="1">
       <widget class="librepcb::editor::PositiveLengthEdit" name="edtDrillDiameter" native="true"/>
      </item>
     </layout>
@@ -109,7 +99,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>cbxShape</tabstop>
   <tabstop>edtPosX</tabstop>
   <tabstop>edtPosY</tabstop>
   <tabstop>edtSize</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -65,7 +65,6 @@ BoardEditorState_AddVia::BoardEditorState_AddVia(
     mIsUndoCmdActive(false),
     mLastViaProperties(Uuid::createRandom(),  // UUID is not relevant here
                        Point(),  // Position is not relevant here
-                       Via::Shape::Round,  // Default shape
                        PositiveLength(700000),  // Default size
                        PositiveLength(300000)  // Default drill diameter
                        ),
@@ -91,31 +90,6 @@ bool BoardEditorState_AddVia::entry() noexcept {
   if (!addVia(pos)) return false;
 
   EditorCommandSet& cmd = EditorCommandSet::instance();
-
-  // Add shape actions to the "command" toolbar
-  std::unique_ptr<QActionGroup> shapeActionGroup(
-      new QActionGroup(&mContext.commandToolBar));
-  QAction* aShapeRound = cmd.thtShapeRound.createAction(
-      shapeActionGroup.get(), this,
-      [this]() { shapeChanged(Via::Shape::Round); });
-  aShapeRound->setCheckable(true);
-  aShapeRound->setChecked(mLastViaProperties.getShape() == Via::Shape::Round);
-  aShapeRound->setActionGroup(shapeActionGroup.get());
-  QAction* aShapeRect = cmd.thtShapeRectangular.createAction(
-      shapeActionGroup.get(), this,
-      [this]() { shapeChanged(Via::Shape::Square); });
-  aShapeRect->setCheckable(true);
-  aShapeRect->setChecked(mLastViaProperties.getShape() == Via::Shape::Square);
-  aShapeRect->setActionGroup(shapeActionGroup.get());
-  QAction* aShapeOctagon = cmd.thtShapeOctagonal.createAction(
-      shapeActionGroup.get(), this,
-      [this]() { shapeChanged(Via::Shape::Octagon); });
-  aShapeOctagon->setCheckable(true);
-  aShapeOctagon->setChecked(mLastViaProperties.getShape() ==
-                            Via::Shape::Octagon);
-  aShapeOctagon->setActionGroup(shapeActionGroup.get());
-  mContext.commandToolBar.addActionGroup(std::move(shapeActionGroup));
-  mContext.commandToolBar.addSeparator();
 
   // Add the size edit to the toolbar
   mContext.commandToolBar.addLabel(tr("Size:"), 10);
@@ -385,13 +359,6 @@ bool BoardEditorState_AddVia::abortCommand(bool showErrMsgBox) noexcept {
       QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
     }
     return false;
-  }
-}
-
-void BoardEditorState_AddVia::shapeChanged(Via::Shape shape) noexcept {
-  mLastViaProperties.setShape(shape);
-  if (mCurrentViaEditCmd) {
-    mCurrentViaEditCmd->setShape(mLastViaProperties.getShape(), true);
   }
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.h
@@ -82,7 +82,6 @@ private:  // Methods
   void setNetSignal(NetSignal* netsignal) noexcept;
   bool fixPosition(Board& board, const Point& pos) noexcept;
   bool abortCommand(bool showErrMsgBox) noexcept;
-  void shapeChanged(Via::Shape shape) noexcept;
   void sizeEditValueChanged(const PositiveLength& value) noexcept;
   void drillDiameterEditValueChanged(const PositiveLength& value) noexcept;
   void applySelectedNetSignal() noexcept;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
@@ -69,7 +69,6 @@ BoardEditorState_DrawTrace::BoardEditorState_DrawTrace(
     mTempVia(nullptr),
     mCurrentViaProperties(Uuid::createRandom(),  // UUID is not relevant here
                           Point(),  // Position is not relevant here
-                          Via::Shape::Round,  // Default shape
                           PositiveLength(700000),  // Default size
                           PositiveLength(300000)  // Default drill diameter
                           ),
@@ -177,33 +176,6 @@ bool BoardEditorState_DrawTrace::entry() noexcept {
           &BoardEditorState_DrawTrace::layerChanged);
   mContext.commandToolBar.addWidget(
       std::unique_ptr<GraphicsLayerComboBox>(mLayerComboBox));
-
-  // Add shape actions to the "command" toolbar
-  std::unique_ptr<QActionGroup> shapeActionGroup(
-      new QActionGroup(&mContext.commandToolBar));
-  QAction* aShapeRound = cmd.thtShapeRound.createAction(
-      shapeActionGroup.get(), this,
-      [this]() { viaShapeChanged(Via::Shape::Round); });
-  aShapeRound->setCheckable(true);
-  aShapeRound->setChecked(mCurrentViaProperties.getShape() ==
-                          Via::Shape::Round);
-  aShapeRound->setActionGroup(shapeActionGroup.get());
-  QAction* aShapeRect = cmd.thtShapeRectangular.createAction(
-      shapeActionGroup.get(), this,
-      [this]() { viaShapeChanged(Via::Shape::Square); });
-  aShapeRect->setCheckable(true);
-  aShapeRect->setChecked(mCurrentViaProperties.getShape() ==
-                         Via::Shape::Square);
-  aShapeRect->setActionGroup(shapeActionGroup.get());
-  QAction* aShapeOctagon = cmd.thtShapeOctagonal.createAction(
-      shapeActionGroup.get(), this,
-      [this]() { viaShapeChanged(Via::Shape::Octagon); });
-  aShapeOctagon->setCheckable(true);
-  aShapeOctagon->setChecked(mCurrentViaProperties.getShape() ==
-                            Via::Shape::Octagon);
-  aShapeOctagon->setActionGroup(shapeActionGroup.get());
-  mContext.commandToolBar.addActionGroup(std::move(shapeActionGroup));
-  mContext.commandToolBar.addSeparator();
 
   // Add the size edit to the toolbar
   mContext.commandToolBar.addLabel(tr("Size:"), 10);
@@ -857,7 +829,6 @@ void BoardEditorState_DrawTrace::showVia(bool isVisible) noexcept {
     } else if (mTempVia) {
       mTempVia->setPosition(mTargetPos);
       mTempVia->setSize(mCurrentViaProperties.getSize());
-      mTempVia->setShape(mCurrentViaProperties.getShape());
       mTempVia->setDrillDiameter(mCurrentViaProperties.getDrillDiameter());
     }
   } catch (const Exception& e) {
@@ -938,11 +909,6 @@ void BoardEditorState_DrawTrace::layerChanged(
     showVia(false);
     mCurrentLayerName = *layer;
   }
-}
-
-void BoardEditorState_DrawTrace::viaShapeChanged(Via::Shape shape) noexcept {
-  mCurrentViaProperties.setShape(shape);
-  updateNetpointPositions();
 }
 
 void BoardEditorState_DrawTrace::sizeEditValueChanged(

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.h
@@ -174,7 +174,6 @@ private:
   // Callback Functions for the Gui elements
   void wireModeChanged(WireMode mode) noexcept;
   void layerChanged(const GraphicsLayerName& layer) noexcept;
-  void viaShapeChanged(Via::Shape shape) noexcept;
   void sizeEditValueChanged(const PositiveLength& value) noexcept;
   void drillDiameterEditValueChanged(const PositiveLength& value) noexcept;
   void wireWidthEditValueChanged(const PositiveLength& value) noexcept;

--- a/libs/librepcb/editor/project/cmd/cmdboardviaedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardviaedit.cpp
@@ -41,8 +41,6 @@ CmdBoardViaEdit::CmdBoardViaEdit(BI_Via& via) noexcept
     mVia(via),
     mOldPos(via.getPosition()),
     mNewPos(mOldPos),
-    mOldShape(via.getShape()),
-    mNewShape(mOldShape),
     mOldSize(via.getSize()),
     mNewSize(mOldSize),
     mOldDrillDiameter(via.getDrillDiameter()),
@@ -52,7 +50,6 @@ CmdBoardViaEdit::CmdBoardViaEdit(BI_Via& via) noexcept
 CmdBoardViaEdit::~CmdBoardViaEdit() noexcept {
   if (!wasEverExecuted()) {
     mVia.setPosition(mOldPos);
-    mVia.setShape(mOldShape);
     mVia.setSize(mOldSize);
     mVia.setDrillDiameter(mOldDrillDiameter);
   }
@@ -86,13 +83,6 @@ void CmdBoardViaEdit::rotate(const Angle& angle, const Point& center,
   mNewPos.rotate(angle, center);
   if (immediate) mVia.setPosition(mNewPos);
 }
-
-void CmdBoardViaEdit::setShape(Via::Shape shape, bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewShape = shape;
-  if (immediate) mVia.setShape(mNewShape);
-}
-
 void CmdBoardViaEdit::setSize(const PositiveLength& size,
                               bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
@@ -115,7 +105,6 @@ bool CmdBoardViaEdit::performExecute() {
   performRedo();  // can throw
 
   if (mNewPos != mOldPos) return true;
-  if (mNewShape != mOldShape) return true;
   if (mNewSize != mOldSize) return true;
   if (mNewDrillDiameter != mOldDrillDiameter) return true;
   return false;
@@ -123,14 +112,12 @@ bool CmdBoardViaEdit::performExecute() {
 
 void CmdBoardViaEdit::performUndo() {
   mVia.setPosition(mOldPos);
-  mVia.setShape(mOldShape);
   mVia.setSize(mOldSize);
   mVia.setDrillDiameter(mOldDrillDiameter);
 }
 
 void CmdBoardViaEdit::performRedo() {
   mVia.setPosition(mNewPos);
-  mVia.setShape(mNewShape);
   mVia.setSize(mNewSize);
   mVia.setDrillDiameter(mNewDrillDiameter);
 }

--- a/libs/librepcb/editor/project/cmd/cmdboardviaedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardviaedit.h
@@ -57,7 +57,6 @@ public:
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
-  void setShape(Via::Shape shape, bool immediate) noexcept;
   void setSize(const PositiveLength& size, bool immediate) noexcept;
   void setDrillDiameter(const PositiveLength& diameter,
                         bool immediate) noexcept;
@@ -82,8 +81,6 @@ private:
   // General Attributes
   Point mOldPos;
   Point mNewPos;
-  Via::Shape mOldShape;
-  Via::Shape mNewShape;
   PositiveLength mOldSize;
   PositiveLength mNewSize;
   PositiveLength mOldDrillDiameter;

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -193,8 +193,8 @@ bool CmdPasteBoardItems::performExecute() {
       QHash<Uuid, BI_Via*> viaMap;
       for (const Via& v : segment.vias) {
         BI_Via* via = cmdAddElements->addVia(
-            Via(Uuid::createRandom(), v.getPosition() + mPosOffset,
-                v.getShape(), v.getSize(), v.getDrillDiameter()));
+            Via(Uuid::createRandom(), v.getPosition() + mPosOffset, v.getSize(),
+                v.getDrillDiameter()));
         via->setSelected(true);
         viaMap.insert(v.getUuid(), via);
       }

--- a/tests/unittests/core/geometry/viatest.cpp
+++ b/tests/unittests/core/geometry/viatest.cpp
@@ -43,7 +43,7 @@ class ViaTest : public ::testing::Test {};
 TEST_F(ViaTest, testConstructFromSExpression) {
   SExpression sexpr = SExpression::parse(
       "(via b9445237-8982-4a9f-af06-bfc6c507e010 (position 1.234 2.345) "
-      "(size 0.9) (drill 0.4) (shape round))",
+      "(size 0.9) (drill 0.4))",
       FilePath());
   Via obj(sexpr);
   EXPECT_EQ(Uuid::fromString("b9445237-8982-4a9f-af06-bfc6c507e010"),
@@ -51,12 +51,11 @@ TEST_F(ViaTest, testConstructFromSExpression) {
   EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
   EXPECT_EQ(PositiveLength(900000), obj.getSize());
   EXPECT_EQ(PositiveLength(400000), obj.getDrillDiameter());
-  EXPECT_EQ(Via::Shape::Round, obj.getShape());
 }
 
 TEST_F(ViaTest, testSerializeAndDeserialize) {
-  Via obj1(Uuid::createRandom(), Point(123, 456), Via::Shape::Octagon,
-           PositiveLength(789), PositiveLength(321));
+  Via obj1(Uuid::createRandom(), Point(123, 456), PositiveLength(789),
+           PositiveLength(321));
   SExpression sexpr1 = SExpression::createList("obj");
   obj1.serialize(sexpr1);
 

--- a/tests/unittests/editor/project/boardeditor/boardclipboarddatatest.cpp
+++ b/tests/unittests/editor/project/boardeditor/boardclipboarddatatest.cpp
@@ -110,12 +110,12 @@ TEST(BoardClipboardDataTest, testToFromMimeDataPopulated) {
   std::shared_ptr<BoardClipboardData::NetSegment> netSegment1 =
       std::make_shared<BoardClipboardData::NetSegment>(
           CircuitIdentifier("net1"));
-  netSegment1->vias.append(std::make_shared<Via>(
-      Uuid::createRandom(), Point(1, 2), Via::Shape::Round, PositiveLength(10),
-      PositiveLength(3)));
-  netSegment1->vias.append(std::make_shared<Via>(
-      Uuid::createRandom(), Point(10, 20), Via::Shape::Square,
-      PositiveLength(100), PositiveLength(30)));
+  netSegment1->vias.append(
+      std::make_shared<Via>(Uuid::createRandom(), Point(1, 2),
+                            PositiveLength(10), PositiveLength(3)));
+  netSegment1->vias.append(
+      std::make_shared<Via>(Uuid::createRandom(), Point(10, 20),
+                            PositiveLength(100), PositiveLength(30)));
   netSegment1->junctions.append(
       std::make_shared<Junction>(Uuid::createRandom(), Point(1, 2)));
   netSegment1->junctions.append(
@@ -132,12 +132,12 @@ TEST(BoardClipboardDataTest, testToFromMimeDataPopulated) {
   std::shared_ptr<BoardClipboardData::NetSegment> netSegment2 =
       std::make_shared<BoardClipboardData::NetSegment>(
           CircuitIdentifier("net2"));
-  netSegment2->vias.append(std::make_shared<Via>(
-      Uuid::createRandom(), Point(1, 2), Via::Shape::Round, PositiveLength(10),
-      PositiveLength(3)));
-  netSegment2->vias.append(std::make_shared<Via>(
-      Uuid::createRandom(), Point(10, 20), Via::Shape::Square,
-      PositiveLength(100), PositiveLength(30)));
+  netSegment2->vias.append(
+      std::make_shared<Via>(Uuid::createRandom(), Point(1, 2),
+                            PositiveLength(10), PositiveLength(3)));
+  netSegment2->vias.append(
+      std::make_shared<Via>(Uuid::createRandom(), Point(10, 20),
+                            PositiveLength(100), PositiveLength(30)));
   netSegment2->junctions.append(
       std::make_shared<Junction>(Uuid::createRandom(), Point(1, 2)));
   netSegment2->junctions.append(


### PR DESCRIPTION
So far it was possible to add vias with circular, square or octagon shape. However, vias did not support a rotation parameter so square and octagon vias could not be rotated like everything else in a board which was kind of inconsistent (for circular vias, rotation is not needed of course).

However, I think square and octagon vias do not make sense at all anyway. The only reasonable (because most space efficient) via shape is circular. In contrast to pads, no soldering is done so the shape doesn't matter (and is usually covered with soldermask anyway). So to keep things simple and intuitive, I decided to remove support for square and octagon vias. Btw, KiCad also doesn't support via shapes other than circular.

During the 0.1->0.2 file format upgrade, all non-circular vias will be converted to circular and a corresponding message appears in the upgrade log (see #1087).

Based on #1087.