### PR TITLE
Cleanup board design rules

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -252,12 +252,12 @@ add_library(
   library/pkg/msg/msgmissingfootprintname.h
   library/pkg/msg/msgmissingfootprintvalue.cpp
   library/pkg/msg/msgmissingfootprintvalue.h
+  library/pkg/msg/msgpadannularringviolation.cpp
+  library/pkg/msg/msgpadannularringviolation.h
   library/pkg/msg/msgpadclearanceviolation.cpp
   library/pkg/msg/msgpadclearanceviolation.h
   library/pkg/msg/msgpadoverlapswithplacement.cpp
   library/pkg/msg/msgpadoverlapswithplacement.h
-  library/pkg/msg/msgpadrestringviolation.cpp
-  library/pkg/msg/msgpadrestringviolation.h
   library/pkg/msg/msgwrongfootprinttextlayer.cpp
   library/pkg/msg/msgwrongfootprinttextlayer.h
   library/pkg/package.cpp

--- a/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.cpp
@@ -20,7 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "msgpadrestringviolation.h"
+#include "msgpadannularringviolation.h"
 
 #include "../footprint.h"
 
@@ -33,23 +33,23 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-MsgPadRestringViolation::MsgPadRestringViolation(
+MsgPadAnnularRingViolation::MsgPadAnnularRingViolation(
     std::shared_ptr<const Footprint> footprint,
     std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName,
-    const Length& restring) noexcept
+    const Length& annularRing) noexcept
   : LibraryElementCheckMessage(
         Severity::Warning,
-        tr("Restring of pad '%1' in '%3'")
+        tr("Annular ring of pad '%1' in '%3'")
             .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
-        tr("Pads should have at least %1 restring (copper around each pad "
+        tr("Pads should have at least %1 annular ring (copper around each pad "
            "hole). Note that this value is just a general recommendation, the "
            "exact value depends on the capabilities of the PCB manufacturer.")
-            .arg(QString::number(restring.toMm() * 1000) % "μm")),
+            .arg(QString::number(annularRing.toMm() * 1000) % "μm")),
     mFootprint(footprint),
     mPad(pad) {
 }
 
-MsgPadRestringViolation::~MsgPadRestringViolation() noexcept {
+MsgPadAnnularRingViolation::~MsgPadAnnularRingViolation() noexcept {
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.h
+++ b/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_MSGPADRESTRINGVIOLATION_H
-#define LIBREPCB_CORE_MSGPADRESTRINGVIOLATION_H
+#ifndef LIBREPCB_CORE_MSGPADANNULARRINGVIOLATION_H
+#define LIBREPCB_CORE_MSGPADANNULARRINGVIOLATION_H
 
 /*******************************************************************************
  *  Includes
@@ -38,27 +38,27 @@ class FootprintPad;
 class Hole;
 
 /*******************************************************************************
- *  Class MsgPadRestringViolation
+ *  Class MsgPadAnnularRingViolation
  ******************************************************************************/
 
 /**
- * @brief The MsgPadRestringViolation class
+ * @brief The MsgPadAnnularRingViolation class
  */
-class MsgPadRestringViolation final : public LibraryElementCheckMessage {
-  Q_DECLARE_TR_FUNCTIONS(MsgPadRestringViolation)
+class MsgPadAnnularRingViolation final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadAnnularRingViolation)
 
 public:
   // Constructors / Destructor
-  MsgPadRestringViolation() = delete;
-  MsgPadRestringViolation(std::shared_ptr<const Footprint> footprint,
-                          std::shared_ptr<const FootprintPad> pad,
-                          const QString& pkgPadName,
-                          const Length& restring) noexcept;
-  MsgPadRestringViolation(const MsgPadRestringViolation& other) noexcept
+  MsgPadAnnularRingViolation() = delete;
+  MsgPadAnnularRingViolation(std::shared_ptr<const Footprint> footprint,
+                             std::shared_ptr<const FootprintPad> pad,
+                             const QString& pkgPadName,
+                             const Length& annularRing) noexcept;
+  MsgPadAnnularRingViolation(const MsgPadAnnularRingViolation& other) noexcept
     : LibraryElementCheckMessage(other),
       mFootprint(other.mFootprint),
       mPad(other.mPad) {}
-  virtual ~MsgPadRestringViolation() noexcept;
+  virtual ~MsgPadAnnularRingViolation() noexcept;
 
   // Getters
   std::shared_ptr<const Footprint> getFootprint() const noexcept {

--- a/libs/librepcb/core/library/pkg/packagecheck.h
+++ b/libs/librepcb/core/library/pkg/packagecheck.h
@@ -62,7 +62,7 @@ protected:  // Methods
   void checkWrongTextLayers(MsgList& msgs) const;
   void checkPadsClearanceToPads(MsgList& msgs) const;
   void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsRestring(MsgList& msgs) const;
+  void checkPadsAnnularRing(MsgList& msgs) const;
 
 private:  // Data
   const Package& mPackage;

--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -41,10 +41,10 @@ BoardDesignRules::BoardDesignRules() noexcept
     mStopMaskClearanceMin(100000),  // 0.1mm
     mStopMaskClearanceMax(100000),  // 0.1mm
     mStopMaskMaxViaDrillDiameter(500000),  // 0.5mm
-    // cream mask
-    mCreamMaskClearanceRatio(Ratio::percent100() / 10),  // 10%
-    mCreamMaskClearanceMin(0),  // 0.0mm
-    mCreamMaskClearanceMax(1000000),  // 1.0mm
+    // solder paste
+    mSolderPasteClearanceRatio(Ratio::percent100() / 10),  // 10%
+    mSolderPasteClearanceMin(0),  // 0.0mm
+    mSolderPasteClearanceMax(1000000),  // 1.0mm
     // pad annular ring
     mPadAnnularRingRatio(Ratio::percent100() / 4),  // 25%
     mPadAnnularRingMin(250000),  // 0.25mm
@@ -71,13 +71,13 @@ BoardDesignRules::BoardDesignRules(const SExpression& node)
         node.getChild("stopmask_clearance_max/@0"))),
     mStopMaskMaxViaDrillDiameter(deserialize<UnsignedLength>(
         node.getChild("stopmask_max_via_drill_diameter/@0"))),
-    // cream mask
-    mCreamMaskClearanceRatio(deserialize<UnsignedRatio>(
-        node.getChild("creammask_clearance_ratio/@0"))),
-    mCreamMaskClearanceMin(deserialize<UnsignedLength>(
-        node.getChild("creammask_clearance_min/@0"))),
-    mCreamMaskClearanceMax(deserialize<UnsignedLength>(
-        node.getChild("creammask_clearance_max/@0"))),
+    // solder paste
+    mSolderPasteClearanceRatio(deserialize<UnsignedRatio>(
+        node.getChild("solderpaste_clearance_ratio/@0"))),
+    mSolderPasteClearanceMin(deserialize<UnsignedLength>(
+        node.getChild("solderpaste_clearance_min/@0"))),
+    mSolderPasteClearanceMax(deserialize<UnsignedLength>(
+        node.getChild("solderpaste_clearance_max/@0"))),
     // pad annular ring
     mPadAnnularRingRatio(
         deserialize<UnsignedRatio>(node.getChild("pad_annular_ring_ratio/@0"))),
@@ -95,7 +95,8 @@ BoardDesignRules::BoardDesignRules(const SExpression& node)
   // force validating properties, throw exception on error
   try {
     setStopMaskClearanceBounds(mStopMaskClearanceMin, mStopMaskClearanceMax);
-    setCreamMaskClearanceBounds(mCreamMaskClearanceMin, mCreamMaskClearanceMax);
+    setSolderPasteClearanceBounds(mSolderPasteClearanceMin,
+                                  mSolderPasteClearanceMax);
     setPadAnnularRingBounds(mPadAnnularRingMin, mPadAnnularRingMax);
     setViaAnnularRingBounds(mViaAnnularRingMin, mViaAnnularRingMax);
   } catch (const Exception& e) {
@@ -122,14 +123,14 @@ void BoardDesignRules::setStopMaskClearanceBounds(const UnsignedLength& min,
   }
 }
 
-void BoardDesignRules::setCreamMaskClearanceBounds(const UnsignedLength& min,
-                                                   const UnsignedLength& max) {
+void BoardDesignRules::setSolderPasteClearanceBounds(
+    const UnsignedLength& min, const UnsignedLength& max) {
   if (max >= min) {
-    mCreamMaskClearanceMin = min;
-    mCreamMaskClearanceMax = max;
+    mSolderPasteClearanceMin = min;
+    mSolderPasteClearanceMax = max;
   } else {
     throw RuntimeError(__FILE__, __LINE__,
-                       tr("Cream mask clearance: MAX must be >= MIN"));
+                       tr("Solder paste clearance: MAX must be >= MIN"));
   }
 }
 
@@ -174,13 +175,13 @@ void BoardDesignRules::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("stopmask_max_via_drill_diameter",
                    mStopMaskMaxViaDrillDiameter);
-  // cream mask
+  // solder paste
   root.ensureLineBreak();
-  root.appendChild("creammask_clearance_ratio", mCreamMaskClearanceRatio);
+  root.appendChild("solderpaste_clearance_ratio", mSolderPasteClearanceRatio);
   root.ensureLineBreak();
-  root.appendChild("creammask_clearance_min", mCreamMaskClearanceMin);
+  root.appendChild("solderpaste_clearance_min", mSolderPasteClearanceMin);
   root.ensureLineBreak();
-  root.appendChild("creammask_clearance_max", mCreamMaskClearanceMax);
+  root.appendChild("solderpaste_clearance_max", mSolderPasteClearanceMax);
   // pad annular ring
   root.ensureLineBreak();
   root.appendChild("pad_annular_ring_ratio", mPadAnnularRingRatio);
@@ -215,12 +216,12 @@ UnsignedLength BoardDesignRules::calcStopMaskClearance(
              *mStopMaskClearanceMax));
 }
 
-UnsignedLength BoardDesignRules::calcCreamMaskClearance(
+UnsignedLength BoardDesignRules::calcSolderPasteClearance(
     const Length& padSize) const noexcept {
   return UnsignedLength(
-      qBound(*mCreamMaskClearanceMin,
-             padSize.scaled(mCreamMaskClearanceRatio->toNormalized()),
-             *mCreamMaskClearanceMax));
+      qBound(*mSolderPasteClearanceMin,
+             padSize.scaled(mSolderPasteClearanceRatio->toNormalized()),
+             *mSolderPasteClearanceMax));
 }
 
 UnsignedLength BoardDesignRules::calcPadAnnularRing(
@@ -250,10 +251,10 @@ BoardDesignRules& BoardDesignRules::operator=(
   mStopMaskClearanceMin = rhs.mStopMaskClearanceMin;
   mStopMaskClearanceMax = rhs.mStopMaskClearanceMax;
   mStopMaskMaxViaDrillDiameter = rhs.mStopMaskMaxViaDrillDiameter;
-  // cream mask
-  mCreamMaskClearanceRatio = rhs.mCreamMaskClearanceRatio;
-  mCreamMaskClearanceMin = rhs.mCreamMaskClearanceMin;
-  mCreamMaskClearanceMax = rhs.mCreamMaskClearanceMax;
+  // solder paste
+  mSolderPasteClearanceRatio = rhs.mSolderPasteClearanceRatio;
+  mSolderPasteClearanceMin = rhs.mSolderPasteClearanceMin;
+  mSolderPasteClearanceMax = rhs.mSolderPasteClearanceMax;
   // pad annular ring
   mPadAnnularRingRatio = rhs.mPadAnnularRingRatio;
   mPadAnnularRingMin = rhs.mPadAnnularRingMin;

--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -45,13 +45,14 @@ BoardDesignRules::BoardDesignRules() noexcept
     mCreamMaskClearanceRatio(Ratio::percent100() / 10),  // 10%
     mCreamMaskClearanceMin(0),  // 0.0mm
     mCreamMaskClearanceMax(1000000),  // 1.0mm
-    // restring
-    mRestringPadRatio(Ratio::percent100() / 4),  // 25%
-    mRestringPadMin(250000),  // 0.25mm
-    mRestringPadMax(2000000),  // 2.0mm
-    mRestringViaRatio(Ratio::percent100() / 4),  // 25%
-    mRestringViaMin(200000),  // 0.2mm
-    mRestringViaMax(2000000)  // 2.0mm
+    // pad annular ring
+    mPadAnnularRingRatio(Ratio::percent100() / 4),  // 25%
+    mPadAnnularRingMin(250000),  // 0.25mm
+    mPadAnnularRingMax(2000000),  // 2.0mm
+    // via annular ring
+    mViaAnnularRingRatio(Ratio::percent100() / 4),  // 25%
+    mViaAnnularRingMin(200000),  // 0.2mm
+    mViaAnnularRingMax(2000000)  // 2.0mm
 {
 }
 
@@ -77,25 +78,26 @@ BoardDesignRules::BoardDesignRules(const SExpression& node)
         node.getChild("creammask_clearance_min/@0"))),
     mCreamMaskClearanceMax(deserialize<UnsignedLength>(
         node.getChild("creammask_clearance_max/@0"))),
-    // restring
-    mRestringPadRatio(
-        deserialize<UnsignedRatio>(node.getChild("restring_pad_ratio/@0"))),
-    mRestringPadMin(
-        deserialize<UnsignedLength>(node.getChild("restring_pad_min/@0"))),
-    mRestringPadMax(
-        deserialize<UnsignedLength>(node.getChild("restring_pad_max/@0"))),
-    mRestringViaRatio(
-        deserialize<UnsignedRatio>(node.getChild("restring_via_ratio/@0"))),
-    mRestringViaMin(
-        deserialize<UnsignedLength>(node.getChild("restring_via_min/@0"))),
-    mRestringViaMax(
-        deserialize<UnsignedLength>(node.getChild("restring_via_max/@0"))) {
+    // pad annular ring
+    mPadAnnularRingRatio(
+        deserialize<UnsignedRatio>(node.getChild("pad_annular_ring_ratio/@0"))),
+    mPadAnnularRingMin(
+        deserialize<UnsignedLength>(node.getChild("pad_annular_ring_min/@0"))),
+    mPadAnnularRingMax(
+        deserialize<UnsignedLength>(node.getChild("pad_annular_ring_max/@0"))),
+    // via annular ring
+    mViaAnnularRingRatio(
+        deserialize<UnsignedRatio>(node.getChild("via_annular_ring_ratio/@0"))),
+    mViaAnnularRingMin(
+        deserialize<UnsignedLength>(node.getChild("via_annular_ring_min/@0"))),
+    mViaAnnularRingMax(
+        deserialize<UnsignedLength>(node.getChild("via_annular_ring_max/@0"))) {
   // force validating properties, throw exception on error
   try {
     setStopMaskClearanceBounds(mStopMaskClearanceMin, mStopMaskClearanceMax);
     setCreamMaskClearanceBounds(mCreamMaskClearanceMin, mCreamMaskClearanceMax);
-    setRestringPadBounds(mRestringPadMin, mRestringPadMax);
-    setRestringViaBounds(mRestringViaMin, mRestringViaMax);
+    setPadAnnularRingBounds(mPadAnnularRingMin, mPadAnnularRingMax);
+    setViaAnnularRingBounds(mViaAnnularRingMin, mViaAnnularRingMax);
   } catch (const Exception& e) {
     throw RuntimeError(__FILE__, __LINE__,
                        tr("Invalid design rules: %1").arg(e.getMsg()));
@@ -131,25 +133,25 @@ void BoardDesignRules::setCreamMaskClearanceBounds(const UnsignedLength& min,
   }
 }
 
-void BoardDesignRules::setRestringPadBounds(const UnsignedLength& min,
-                                            const UnsignedLength& max) {
+void BoardDesignRules::setPadAnnularRingBounds(const UnsignedLength& min,
+                                               const UnsignedLength& max) {
   if (max >= min) {
-    mRestringPadMin = min;
-    mRestringPadMax = max;
+    mPadAnnularRingMin = min;
+    mPadAnnularRingMax = max;
   } else {
     throw RuntimeError(__FILE__, __LINE__,
-                       tr("Restring pads: MAX must be >= MIN"));
+                       tr("Pads annular ring: MAX must be >= MIN"));
   }
 }
 
-void BoardDesignRules::setRestringViaBounds(const UnsignedLength& min,
-                                            const UnsignedLength& max) {
+void BoardDesignRules::setViaAnnularRingBounds(const UnsignedLength& min,
+                                               const UnsignedLength& max) {
   if (max >= min) {
-    mRestringViaMin = min;
-    mRestringViaMax = max;
+    mViaAnnularRingMin = min;
+    mViaAnnularRingMax = max;
   } else {
     throw RuntimeError(__FILE__, __LINE__,
-                       tr("Restring vias: MAX must be >= MIN"));
+                       tr("Vias annular ring: MAX must be >= MIN"));
   }
 }
 
@@ -179,19 +181,20 @@ void BoardDesignRules::serialize(SExpression& root) const {
   root.appendChild("creammask_clearance_min", mCreamMaskClearanceMin);
   root.ensureLineBreak();
   root.appendChild("creammask_clearance_max", mCreamMaskClearanceMax);
-  // restring
+  // pad annular ring
   root.ensureLineBreak();
-  root.appendChild("restring_pad_ratio", mRestringPadRatio);
+  root.appendChild("pad_annular_ring_ratio", mPadAnnularRingRatio);
   root.ensureLineBreak();
-  root.appendChild("restring_pad_min", mRestringPadMin);
+  root.appendChild("pad_annular_ring_min", mPadAnnularRingMin);
   root.ensureLineBreak();
-  root.appendChild("restring_pad_max", mRestringPadMax);
+  root.appendChild("pad_annular_ring_max", mPadAnnularRingMax);
+  // via annular ring
   root.ensureLineBreak();
-  root.appendChild("restring_via_ratio", mRestringViaRatio);
+  root.appendChild("via_annular_ring_ratio", mViaAnnularRingRatio);
   root.ensureLineBreak();
-  root.appendChild("restring_via_min", mRestringViaMin);
+  root.appendChild("via_annular_ring_min", mViaAnnularRingMin);
   root.ensureLineBreak();
-  root.appendChild("restring_via_max", mRestringViaMax);
+  root.appendChild("via_annular_ring_max", mViaAnnularRingMax);
   root.ensureLineBreak();
 }
 
@@ -220,18 +223,20 @@ UnsignedLength BoardDesignRules::calcCreamMaskClearance(
              *mCreamMaskClearanceMax));
 }
 
-UnsignedLength BoardDesignRules::calcPadRestring(const Length& drillDia) const
-    noexcept {
-  return UnsignedLength(qBound(
-      *mRestringPadMin, drillDia.scaled(mRestringPadRatio->toNormalized()),
-      *mRestringPadMax));
+UnsignedLength BoardDesignRules::calcPadAnnularRing(
+    const Length& drillDia) const noexcept {
+  return UnsignedLength(
+      qBound(*mPadAnnularRingMin,
+             drillDia.scaled(mPadAnnularRingRatio->toNormalized()),
+             *mPadAnnularRingMax));
 }
 
-UnsignedLength BoardDesignRules::calcViaRestring(const Length& drillDia) const
-    noexcept {
-  return UnsignedLength(qBound(
-      *mRestringViaMin, drillDia.scaled(mRestringViaRatio->toNormalized()),
-      *mRestringViaMax));
+UnsignedLength BoardDesignRules::calcViaAnnularRing(
+    const Length& drillDia) const noexcept {
+  return UnsignedLength(
+      qBound(*mViaAnnularRingMin,
+             drillDia.scaled(mViaAnnularRingRatio->toNormalized()),
+             *mViaAnnularRingMax));
 }
 
 /*******************************************************************************
@@ -249,13 +254,14 @@ BoardDesignRules& BoardDesignRules::operator=(
   mCreamMaskClearanceRatio = rhs.mCreamMaskClearanceRatio;
   mCreamMaskClearanceMin = rhs.mCreamMaskClearanceMin;
   mCreamMaskClearanceMax = rhs.mCreamMaskClearanceMax;
-  // restring
-  mRestringPadRatio = rhs.mRestringPadRatio;
-  mRestringPadMin = rhs.mRestringPadMin;
-  mRestringPadMax = rhs.mRestringPadMax;
-  mRestringViaRatio = rhs.mRestringViaRatio;
-  mRestringViaMin = rhs.mRestringViaMin;
-  mRestringViaMax = rhs.mRestringViaMax;
+  // pad annular ring
+  mPadAnnularRingRatio = rhs.mPadAnnularRingRatio;
+  mPadAnnularRingMin = rhs.mPadAnnularRingMin;
+  mPadAnnularRingMax = rhs.mPadAnnularRingMax;
+  // via annular ring
+  mViaAnnularRingRatio = rhs.mViaAnnularRingRatio;
+  mViaAnnularRingMin = rhs.mViaAnnularRingMin;
+  mViaAnnularRingMax = rhs.mViaAnnularRingMax;
   return *this;
 }
 

--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -22,6 +22,8 @@
  ******************************************************************************/
 #include "boarddesignrules.h"
 
+#include "../../serialization/sexpression.h"
+
 #include <QtCore>
 
 /*******************************************************************************
@@ -34,10 +36,7 @@ namespace librepcb {
  ******************************************************************************/
 
 BoardDesignRules::BoardDesignRules() noexcept
-  :  // general attributes
-    mName(tr("LibrePCB Default Design Rules")),
-    mDescription(),
-    // stop mask
+  :  // stop mask
     mStopMaskClearanceRatio(Ratio::percent0()),  // 0%
     mStopMaskClearanceMin(100000),  // 0.1mm
     mStopMaskClearanceMax(100000),  // 0.1mm
@@ -62,10 +61,7 @@ BoardDesignRules::BoardDesignRules(const BoardDesignRules& other)
 }
 
 BoardDesignRules::BoardDesignRules(const SExpression& node)
-  :  // general attributes
-    mName(deserialize<ElementName>(node.getChild("name/@0"))),
-    mDescription(node.getChild("description/@0").getValue()),
-    // stop mask
+  :  // stop mask
     mStopMaskClearanceRatio(deserialize<UnsignedRatio>(
         node.getChild("stopmask_clearance_ratio/@0"))),
     mStopMaskClearanceMin(deserialize<UnsignedLength>(
@@ -166,13 +162,8 @@ void BoardDesignRules::restoreDefaults() noexcept {
 }
 
 void BoardDesignRules::serialize(SExpression& root) const {
-  // general attributes
-  root.ensureLineBreak();
-  root.appendChild("name", mName);
-  root.ensureLineBreak();
-  root.appendChild("description", mDescription);
-  root.ensureLineBreak();
   // stop mask
+  root.ensureLineBreak();
   root.appendChild("stopmask_clearance_ratio", mStopMaskClearanceRatio);
   root.ensureLineBreak();
   root.appendChild("stopmask_clearance_min", mStopMaskClearanceMin);
@@ -181,15 +172,15 @@ void BoardDesignRules::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("stopmask_max_via_drill_diameter",
                    mStopMaskMaxViaDrillDiameter);
-  root.ensureLineBreak();
   // cream mask
+  root.ensureLineBreak();
   root.appendChild("creammask_clearance_ratio", mCreamMaskClearanceRatio);
   root.ensureLineBreak();
   root.appendChild("creammask_clearance_min", mCreamMaskClearanceMin);
   root.ensureLineBreak();
   root.appendChild("creammask_clearance_max", mCreamMaskClearanceMax);
-  root.ensureLineBreak();
   // restring
+  root.ensureLineBreak();
   root.appendChild("restring_pad_ratio", mRestringPadRatio);
   root.ensureLineBreak();
   root.appendChild("restring_pad_min", mRestringPadMin);
@@ -249,9 +240,6 @@ UnsignedLength BoardDesignRules::calcViaRestring(const Length& drillDia) const
 
 BoardDesignRules& BoardDesignRules::operator=(
     const BoardDesignRules& rhs) noexcept {
-  // general attributes
-  mName = rhs.mName;
-  mDescription = rhs.mDescription;
   // stop mask
   mStopMaskClearanceRatio = rhs.mStopMaskClearanceRatio;
   mStopMaskClearanceMin = rhs.mStopMaskClearanceMin;

--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -37,10 +37,10 @@ namespace librepcb {
 
 BoardDesignRules::BoardDesignRules() noexcept
   :  // stop mask
+    mStopMaskMaxViaDrillDiameter(500000),  // 0.5mm
     mStopMaskClearanceRatio(Ratio::percent0()),  // 0%
     mStopMaskClearanceMin(100000),  // 0.1mm
     mStopMaskClearanceMax(100000),  // 0.1mm
-    mStopMaskMaxViaDrillDiameter(500000),  // 0.5mm
     // solder paste
     mSolderPasteClearanceRatio(Ratio::percent100() / 10),  // 10%
     mSolderPasteClearanceMin(0),  // 0.0mm
@@ -63,42 +63,45 @@ BoardDesignRules::BoardDesignRules(const BoardDesignRules& other)
 
 BoardDesignRules::BoardDesignRules(const SExpression& node)
   :  // stop mask
-    mStopMaskClearanceRatio(deserialize<UnsignedRatio>(
-        node.getChild("stopmask_clearance_ratio/@0"))),
-    mStopMaskClearanceMin(deserialize<UnsignedLength>(
-        node.getChild("stopmask_clearance_min/@0"))),
-    mStopMaskClearanceMax(deserialize<UnsignedLength>(
-        node.getChild("stopmask_clearance_max/@0"))),
     mStopMaskMaxViaDrillDiameter(deserialize<UnsignedLength>(
         node.getChild("stopmask_max_via_drill_diameter/@0"))),
+    mStopMaskClearanceRatio(deserialize<UnsignedRatio>(
+        node.getChild("stopmask_clearance/ratio/@0"))),
+    mStopMaskClearanceMin(deserialize<UnsignedLength>(
+        node.getChild("stopmask_clearance/min/@0"))),
+    mStopMaskClearanceMax(deserialize<UnsignedLength>(
+        node.getChild("stopmask_clearance/max/@0"))),
     // solder paste
     mSolderPasteClearanceRatio(deserialize<UnsignedRatio>(
-        node.getChild("solderpaste_clearance_ratio/@0"))),
+        node.getChild("solderpaste_clearance/ratio/@0"))),
     mSolderPasteClearanceMin(deserialize<UnsignedLength>(
-        node.getChild("solderpaste_clearance_min/@0"))),
+        node.getChild("solderpaste_clearance/min/@0"))),
     mSolderPasteClearanceMax(deserialize<UnsignedLength>(
-        node.getChild("solderpaste_clearance_max/@0"))),
+        node.getChild("solderpaste_clearance/max/@0"))),
     // pad annular ring
     mPadAnnularRingRatio(
-        deserialize<UnsignedRatio>(node.getChild("pad_annular_ring_ratio/@0"))),
+        deserialize<UnsignedRatio>(node.getChild("pad_annular_ring/ratio/@0"))),
     mPadAnnularRingMin(
-        deserialize<UnsignedLength>(node.getChild("pad_annular_ring_min/@0"))),
+        deserialize<UnsignedLength>(node.getChild("pad_annular_ring/min/@0"))),
     mPadAnnularRingMax(
-        deserialize<UnsignedLength>(node.getChild("pad_annular_ring_max/@0"))),
+        deserialize<UnsignedLength>(node.getChild("pad_annular_ring/max/@0"))),
     // via annular ring
     mViaAnnularRingRatio(
-        deserialize<UnsignedRatio>(node.getChild("via_annular_ring_ratio/@0"))),
+        deserialize<UnsignedRatio>(node.getChild("via_annular_ring/ratio/@0"))),
     mViaAnnularRingMin(
-        deserialize<UnsignedLength>(node.getChild("via_annular_ring_min/@0"))),
+        deserialize<UnsignedLength>(node.getChild("via_annular_ring/min/@0"))),
     mViaAnnularRingMax(
-        deserialize<UnsignedLength>(node.getChild("via_annular_ring_max/@0"))) {
+        deserialize<UnsignedLength>(node.getChild("via_annular_ring/max/@0"))) {
   // force validating properties, throw exception on error
   try {
-    setStopMaskClearanceBounds(mStopMaskClearanceMin, mStopMaskClearanceMax);
-    setSolderPasteClearanceBounds(mSolderPasteClearanceMin,
-                                  mSolderPasteClearanceMax);
-    setPadAnnularRingBounds(mPadAnnularRingMin, mPadAnnularRingMax);
-    setViaAnnularRingBounds(mViaAnnularRingMin, mViaAnnularRingMax);
+    setStopMaskClearance(mStopMaskClearanceRatio, mStopMaskClearanceMin,
+                         mStopMaskClearanceMax);
+    setSolderPasteClearance(mSolderPasteClearanceRatio,
+                            mSolderPasteClearanceMin, mSolderPasteClearanceMax);
+    setPadAnnularRing(mPadAnnularRingRatio, mPadAnnularRingMin,
+                      mPadAnnularRingMax);
+    setViaAnnularRing(mViaAnnularRingRatio, mViaAnnularRingMin,
+                      mViaAnnularRingMax);
   } catch (const Exception& e) {
     throw RuntimeError(__FILE__, __LINE__,
                        tr("Invalid design rules: %1").arg(e.getMsg()));
@@ -112,9 +115,11 @@ BoardDesignRules::~BoardDesignRules() noexcept {
  *  Setters
  ******************************************************************************/
 
-void BoardDesignRules::setStopMaskClearanceBounds(const UnsignedLength& min,
-                                                  const UnsignedLength& max) {
+void BoardDesignRules::setStopMaskClearance(const UnsignedRatio& ratio,
+                                            const UnsignedLength& min,
+                                            const UnsignedLength& max) {
   if (max >= min) {
+    mStopMaskClearanceRatio = ratio;
     mStopMaskClearanceMin = min;
     mStopMaskClearanceMax = max;
   } else {
@@ -123,9 +128,11 @@ void BoardDesignRules::setStopMaskClearanceBounds(const UnsignedLength& min,
   }
 }
 
-void BoardDesignRules::setSolderPasteClearanceBounds(
-    const UnsignedLength& min, const UnsignedLength& max) {
+void BoardDesignRules::setSolderPasteClearance(const UnsignedRatio& ratio,
+                                               const UnsignedLength& min,
+                                               const UnsignedLength& max) {
   if (max >= min) {
+    mSolderPasteClearanceRatio = ratio;
     mSolderPasteClearanceMin = min;
     mSolderPasteClearanceMax = max;
   } else {
@@ -134,9 +141,11 @@ void BoardDesignRules::setSolderPasteClearanceBounds(
   }
 }
 
-void BoardDesignRules::setPadAnnularRingBounds(const UnsignedLength& min,
-                                               const UnsignedLength& max) {
+void BoardDesignRules::setPadAnnularRing(const UnsignedRatio& ratio,
+                                         const UnsignedLength& min,
+                                         const UnsignedLength& max) {
   if (max >= min) {
+    mPadAnnularRingRatio = ratio;
     mPadAnnularRingMin = min;
     mPadAnnularRingMax = max;
   } else {
@@ -145,9 +154,11 @@ void BoardDesignRules::setPadAnnularRingBounds(const UnsignedLength& min,
   }
 }
 
-void BoardDesignRules::setViaAnnularRingBounds(const UnsignedLength& min,
-                                               const UnsignedLength& max) {
+void BoardDesignRules::setViaAnnularRing(const UnsignedRatio& ratio,
+                                         const UnsignedLength& min,
+                                         const UnsignedLength& max) {
   if (max >= min) {
+    mViaAnnularRingRatio = ratio;
     mViaAnnularRingMin = min;
     mViaAnnularRingMax = max;
   } else {
@@ -166,36 +177,44 @@ void BoardDesignRules::restoreDefaults() noexcept {
 
 void BoardDesignRules::serialize(SExpression& root) const {
   // stop mask
-  root.ensureLineBreak();
-  root.appendChild("stopmask_clearance_ratio", mStopMaskClearanceRatio);
-  root.ensureLineBreak();
-  root.appendChild("stopmask_clearance_min", mStopMaskClearanceMin);
-  root.ensureLineBreak();
-  root.appendChild("stopmask_clearance_max", mStopMaskClearanceMax);
-  root.ensureLineBreak();
-  root.appendChild("stopmask_max_via_drill_diameter",
-                   mStopMaskMaxViaDrillDiameter);
+  {
+    root.ensureLineBreak();
+    root.appendChild("stopmask_max_via_drill_diameter",
+                     mStopMaskMaxViaDrillDiameter);
+    root.ensureLineBreak();
+    SExpression& node = root.appendList("stopmask_clearance");
+    node.appendChild("ratio", mStopMaskClearanceRatio);
+    node.appendChild("min", mStopMaskClearanceMin);
+    node.appendChild("max", mStopMaskClearanceMax);
+  }
+
   // solder paste
-  root.ensureLineBreak();
-  root.appendChild("solderpaste_clearance_ratio", mSolderPasteClearanceRatio);
-  root.ensureLineBreak();
-  root.appendChild("solderpaste_clearance_min", mSolderPasteClearanceMin);
-  root.ensureLineBreak();
-  root.appendChild("solderpaste_clearance_max", mSolderPasteClearanceMax);
+  {
+    root.ensureLineBreak();
+    SExpression& node = root.appendList("solderpaste_clearance");
+    node.appendChild("ratio", mSolderPasteClearanceRatio);
+    node.appendChild("min", mSolderPasteClearanceMin);
+    node.appendChild("max", mSolderPasteClearanceMax);
+  }
+
   // pad annular ring
-  root.ensureLineBreak();
-  root.appendChild("pad_annular_ring_ratio", mPadAnnularRingRatio);
-  root.ensureLineBreak();
-  root.appendChild("pad_annular_ring_min", mPadAnnularRingMin);
-  root.ensureLineBreak();
-  root.appendChild("pad_annular_ring_max", mPadAnnularRingMax);
+  {
+    root.ensureLineBreak();
+    SExpression& node = root.appendList("pad_annular_ring");
+    node.appendChild("ratio", mPadAnnularRingRatio);
+    node.appendChild("min", mPadAnnularRingMin);
+    node.appendChild("max", mPadAnnularRingMax);
+  }
+
   // via annular ring
-  root.ensureLineBreak();
-  root.appendChild("via_annular_ring_ratio", mViaAnnularRingRatio);
-  root.ensureLineBreak();
-  root.appendChild("via_annular_ring_min", mViaAnnularRingMin);
-  root.ensureLineBreak();
-  root.appendChild("via_annular_ring_max", mViaAnnularRingMax);
+  {
+    root.ensureLineBreak();
+    SExpression& node = root.appendList("via_annular_ring");
+    node.appendChild("ratio", mViaAnnularRingRatio);
+    node.appendChild("min", mViaAnnularRingMin);
+    node.appendChild("max", mViaAnnularRingMax);
+  }
+
   root.ensureLineBreak();
 }
 
@@ -247,10 +266,10 @@ UnsignedLength BoardDesignRules::calcViaAnnularRing(
 BoardDesignRules& BoardDesignRules::operator=(
     const BoardDesignRules& rhs) noexcept {
   // stop mask
+  mStopMaskMaxViaDrillDiameter = rhs.mStopMaskMaxViaDrillDiameter;
   mStopMaskClearanceRatio = rhs.mStopMaskClearanceRatio;
   mStopMaskClearanceMin = rhs.mStopMaskClearanceMin;
   mStopMaskClearanceMax = rhs.mStopMaskClearanceMax;
-  mStopMaskMaxViaDrillDiameter = rhs.mStopMaskMaxViaDrillDiameter;
   // solder paste
   mSolderPasteClearanceRatio = rhs.mSolderPasteClearanceRatio;
   mSolderPasteClearanceMin = rhs.mSolderPasteClearanceMin;

--- a/libs/librepcb/core/project/board/boarddesignrules.h
+++ b/libs/librepcb/core/project/board/boarddesignrules.h
@@ -53,6 +53,9 @@ public:
   ~BoardDesignRules() noexcept;
 
   // Getters: Stop Mask
+  const UnsignedLength& getStopMaskMaxViaDiameter() const noexcept {
+    return mStopMaskMaxViaDrillDiameter;
+  }
   const UnsignedRatio& getStopMaskClearanceRatio() const noexcept {
     return mStopMaskClearanceRatio;
   }
@@ -61,9 +64,6 @@ public:
   }
   const UnsignedLength& getStopMaskClearanceMax() const noexcept {
     return mStopMaskClearanceMax;
-  }
-  const UnsignedLength& getStopMaskMaxViaDiameter() const noexcept {
-    return mStopMaskMaxViaDrillDiameter;
   }
 
   // Getters: Solder Paste
@@ -99,36 +99,20 @@ public:
     return mViaAnnularRingMax;
   }
 
-  // Setters: Stop Mask
-  void setStopMaskClearanceRatio(const UnsignedRatio& ratio) noexcept {
-    mStopMaskClearanceRatio = ratio;
-  }
-  void setStopMaskClearanceBounds(const UnsignedLength& min,
-                                  const UnsignedLength& max);
+  // Setters
   void setStopMaskMaxViaDiameter(const UnsignedLength& dia) noexcept {
     mStopMaskMaxViaDrillDiameter = dia;
   }
-
-  // Setters: Clear Mask
-  void setSolderPasteClearanceRatio(const UnsignedRatio& ratio) noexcept {
-    mSolderPasteClearanceRatio = ratio;
-  }
-  void setSolderPasteClearanceBounds(const UnsignedLength& min,
-                                     const UnsignedLength& max);
-
-  // Setters: Pad Annular Ring
-  void setPadAnnularRingRatio(const UnsignedRatio& ratio) noexcept {
-    mPadAnnularRingRatio = ratio;
-  }
-  void setPadAnnularRingBounds(const UnsignedLength& min,
+  void setStopMaskClearance(const UnsignedRatio& ratio,
+                            const UnsignedLength& min,
+                            const UnsignedLength& max);
+  void setSolderPasteClearance(const UnsignedRatio& ratio,
+                               const UnsignedLength& min,
                                const UnsignedLength& max);
-
-  // Setters: Via Annular Ring
-  void setViaAnnularRingRatio(const UnsignedRatio& ratio) noexcept {
-    mViaAnnularRingRatio = ratio;
-  }
-  void setViaAnnularRingBounds(const UnsignedLength& min,
-                               const UnsignedLength& max);
+  void setPadAnnularRing(const UnsignedRatio& ratio, const UnsignedLength& min,
+                         const UnsignedLength& max);
+  void setViaAnnularRing(const UnsignedRatio& ratio, const UnsignedLength& min,
+                         const UnsignedLength& max);
 
   // General Methods
   void restoreDefaults() noexcept;
@@ -152,10 +136,10 @@ public:
 
 private:
   // Stop Mask
+  UnsignedLength mStopMaskMaxViaDrillDiameter;
   UnsignedRatio mStopMaskClearanceRatio;
   UnsignedLength mStopMaskClearanceMin;
   UnsignedLength mStopMaskClearanceMax;
-  UnsignedLength mStopMaskMaxViaDrillDiameter;
 
   // Solder Paste
   UnsignedRatio mSolderPasteClearanceRatio;

--- a/libs/librepcb/core/project/board/boarddesignrules.h
+++ b/libs/librepcb/core/project/board/boarddesignrules.h
@@ -66,15 +66,15 @@ public:
     return mStopMaskMaxViaDrillDiameter;
   }
 
-  // Getters: Cream Mask
-  const UnsignedRatio& getCreamMaskClearanceRatio() const noexcept {
-    return mCreamMaskClearanceRatio;
+  // Getters: Solder Paste
+  const UnsignedRatio& getSolderPasteClearanceRatio() const noexcept {
+    return mSolderPasteClearanceRatio;
   }
-  const UnsignedLength& getCreamMaskClearanceMin() const noexcept {
-    return mCreamMaskClearanceMin;
+  const UnsignedLength& getSolderPasteClearanceMin() const noexcept {
+    return mSolderPasteClearanceMin;
   }
-  const UnsignedLength& getCreamMaskClearanceMax() const noexcept {
-    return mCreamMaskClearanceMax;
+  const UnsignedLength& getSolderPasteClearanceMax() const noexcept {
+    return mSolderPasteClearanceMax;
   }
 
   // Getters: Pad Annular Ring
@@ -110,11 +110,11 @@ public:
   }
 
   // Setters: Clear Mask
-  void setCreamMaskClearanceRatio(const UnsignedRatio& ratio) noexcept {
-    mCreamMaskClearanceRatio = ratio;
+  void setSolderPasteClearanceRatio(const UnsignedRatio& ratio) noexcept {
+    mSolderPasteClearanceRatio = ratio;
   }
-  void setCreamMaskClearanceBounds(const UnsignedLength& min,
-                                   const UnsignedLength& max);
+  void setSolderPasteClearanceBounds(const UnsignedLength& min,
+                                     const UnsignedLength& max);
 
   // Setters: Pad Annular Ring
   void setPadAnnularRingRatio(const UnsignedRatio& ratio) noexcept {
@@ -143,7 +143,7 @@ public:
   // Helper Methods
   bool doesViaRequireStopMask(const Length& drillDia) const noexcept;
   UnsignedLength calcStopMaskClearance(const Length& padSize) const noexcept;
-  UnsignedLength calcCreamMaskClearance(const Length& padSize) const noexcept;
+  UnsignedLength calcSolderPasteClearance(const Length& padSize) const noexcept;
   UnsignedLength calcPadAnnularRing(const Length& drillDia) const noexcept;
   UnsignedLength calcViaAnnularRing(const Length& drillDia) const noexcept;
 
@@ -157,10 +157,10 @@ private:
   UnsignedLength mStopMaskClearanceMax;
   UnsignedLength mStopMaskMaxViaDrillDiameter;
 
-  // Cream Mask
-  UnsignedRatio mCreamMaskClearanceRatio;
-  UnsignedLength mCreamMaskClearanceMin;
-  UnsignedLength mCreamMaskClearanceMax;
+  // Solder Paste
+  UnsignedRatio mSolderPasteClearanceRatio;
+  UnsignedLength mSolderPasteClearanceMin;
+  UnsignedLength mSolderPasteClearanceMax;
 
   // Pad Annular Ring
   UnsignedRatio mPadAnnularRingRatio;  /// Percentage of the drill diameter

--- a/libs/librepcb/core/project/board/boarddesignrules.h
+++ b/libs/librepcb/core/project/board/boarddesignrules.h
@@ -77,24 +77,26 @@ public:
     return mCreamMaskClearanceMax;
   }
 
-  // Getters: Restring
-  const UnsignedRatio& getRestringPadRatio() const noexcept {
-    return mRestringPadRatio;
+  // Getters: Pad Annular Ring
+  const UnsignedRatio& getPadAnnularRingRatio() const noexcept {
+    return mPadAnnularRingRatio;
   }
-  const UnsignedLength& getRestringPadMin() const noexcept {
-    return mRestringPadMin;
+  const UnsignedLength& getPadAnnularRingMin() const noexcept {
+    return mPadAnnularRingMin;
   }
-  const UnsignedLength& getRestringPadMax() const noexcept {
-    return mRestringPadMax;
+  const UnsignedLength& getPadAnnularRingMax() const noexcept {
+    return mPadAnnularRingMax;
   }
-  const UnsignedRatio& getRestringViaRatio() const noexcept {
-    return mRestringViaRatio;
+
+  // Getters: Via Annular Ring
+  const UnsignedRatio& getViaAnnularRingRatio() const noexcept {
+    return mViaAnnularRingRatio;
   }
-  const UnsignedLength& getRestringViaMin() const noexcept {
-    return mRestringViaMin;
+  const UnsignedLength& getViaAnnularRingMin() const noexcept {
+    return mViaAnnularRingMin;
   }
-  const UnsignedLength& getRestringViaMax() const noexcept {
-    return mRestringViaMax;
+  const UnsignedLength& getViaAnnularRingMax() const noexcept {
+    return mViaAnnularRingMax;
   }
 
   // Setters: Stop Mask
@@ -114,17 +116,19 @@ public:
   void setCreamMaskClearanceBounds(const UnsignedLength& min,
                                    const UnsignedLength& max);
 
-  // Setters: Restring
-  void setRestringPadRatio(const UnsignedRatio& ratio) noexcept {
-    mRestringPadRatio = ratio;
+  // Setters: Pad Annular Ring
+  void setPadAnnularRingRatio(const UnsignedRatio& ratio) noexcept {
+    mPadAnnularRingRatio = ratio;
   }
-  void setRestringPadBounds(const UnsignedLength& min,
-                            const UnsignedLength& max);
-  void setRestringViaRatio(const UnsignedRatio& ratio) noexcept {
-    mRestringViaRatio = ratio;
+  void setPadAnnularRingBounds(const UnsignedLength& min,
+                               const UnsignedLength& max);
+
+  // Setters: Via Annular Ring
+  void setViaAnnularRingRatio(const UnsignedRatio& ratio) noexcept {
+    mViaAnnularRingRatio = ratio;
   }
-  void setRestringViaBounds(const UnsignedLength& min,
-                            const UnsignedLength& max);
+  void setViaAnnularRingBounds(const UnsignedLength& min,
+                               const UnsignedLength& max);
 
   // General Methods
   void restoreDefaults() noexcept;
@@ -140,8 +144,8 @@ public:
   bool doesViaRequireStopMask(const Length& drillDia) const noexcept;
   UnsignedLength calcStopMaskClearance(const Length& padSize) const noexcept;
   UnsignedLength calcCreamMaskClearance(const Length& padSize) const noexcept;
-  UnsignedLength calcPadRestring(const Length& drillDia) const noexcept;
-  UnsignedLength calcViaRestring(const Length& drillDia) const noexcept;
+  UnsignedLength calcPadAnnularRing(const Length& drillDia) const noexcept;
+  UnsignedLength calcViaAnnularRing(const Length& drillDia) const noexcept;
 
   // Operator Overloadings
   BoardDesignRules& operator=(const BoardDesignRules& rhs) noexcept;
@@ -158,13 +162,15 @@ private:
   UnsignedLength mCreamMaskClearanceMin;
   UnsignedLength mCreamMaskClearanceMax;
 
-  // Restring
-  UnsignedRatio mRestringPadRatio;
-  UnsignedLength mRestringPadMin;
-  UnsignedLength mRestringPadMax;
-  UnsignedRatio mRestringViaRatio;
-  UnsignedLength mRestringViaMin;
-  UnsignedLength mRestringViaMax;
+  // Pad Annular Ring
+  UnsignedRatio mPadAnnularRingRatio;  /// Percentage of the drill diameter
+  UnsignedLength mPadAnnularRingMin;
+  UnsignedLength mPadAnnularRingMax;
+
+  // Via Annular Ring
+  UnsignedRatio mViaAnnularRingRatio;  /// Percentage of the drill diameter
+  UnsignedLength mViaAnnularRingMin;
+  UnsignedLength mViaAnnularRingMax;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/boarddesignrules.h
+++ b/libs/librepcb/core/project/board/boarddesignrules.h
@@ -23,7 +23,6 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../../types/elementname.h"
 #include "../../types/length.h"
 #include "../../types/ratio.h"
 
@@ -33,6 +32,8 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class SExpression;
 
 /*******************************************************************************
  *  Class BoardDesignRules
@@ -50,10 +51,6 @@ public:
   BoardDesignRules(const BoardDesignRules& other);
   explicit BoardDesignRules(const SExpression& node);
   ~BoardDesignRules() noexcept;
-
-  // Getters : General Attributes
-  const ElementName& getName() const noexcept { return mName; }
-  const QString& getDescription() const noexcept { return mDescription; }
 
   // Getters: Stop Mask
   const UnsignedRatio& getStopMaskClearanceRatio() const noexcept {
@@ -99,10 +96,6 @@ public:
   const UnsignedLength& getRestringViaMax() const noexcept {
     return mRestringViaMax;
   }
-
-  // Setters: General Attributes
-  void setName(const ElementName& name) noexcept { mName = name; }
-  void setDescription(const QString& desc) noexcept { mDescription = desc; }
 
   // Setters: Stop Mask
   void setStopMaskClearanceRatio(const UnsignedRatio& ratio) noexcept {
@@ -154,10 +147,6 @@ public:
   BoardDesignRules& operator=(const BoardDesignRules& rhs) noexcept;
 
 private:
-  // General Attributes
-  ElementName mName;
-  QString mDescription;
-
   // Stop Mask
   UnsignedRatio mStopMaskClearanceRatio;
   UnsignedLength mStopMaskClearanceMin;

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -734,7 +734,7 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator& gen,
     height += radius * 2;
   } else if (isOnSolderPasteTop || isOnSolderPasteBottom) {
     Length size = qMin(width, height);
-    Length clearance = -mBoard.getDesignRules().calcCreamMaskClearance(size);
+    Length clearance = -mBoard.getDesignRules().calcSolderPasteClearance(size);
     width += clearance * 2;
     height += clearance * 2;
     if (clearance > 0) {

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -92,8 +92,8 @@ void BoardDesignRuleCheck::execute() {
   if (mOptions.checkCopperWidth) {
     checkMinimumCopperWidth(70, 72);
   }
-  if (mOptions.checkPthRestring) {
-    checkMinimumPthRestring(72, 74);
+  if (mOptions.checkPthAnnularRing) {
+    checkMinimumPthAnnularRing(72, 74);
   }
   if (mOptions.checkNpthDrillDiameter) {
     checkMinimumNpthDrillDiameter(74, 76);
@@ -400,10 +400,10 @@ void BoardDesignRuleCheck::checkMinimumCopperWidth(int progressStart,
   emit progressPercent(progressEnd);
 }
 
-void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
-                                                   int progressEnd) {
+void BoardDesignRuleCheck::checkMinimumPthAnnularRing(int progressStart,
+                                                      int progressEnd) {
   Q_UNUSED(progressStart);
-  emitStatus(tr("Check minimum PTH restrings..."));
+  emitStatus(tr("Check minimum PTH annular rings..."));
 
   // Determine tha areas where copper is available on *all* layers.
   QList<ClipperLib::Paths> thtCopperAreas;
@@ -417,12 +417,12 @@ void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
   const ClipperLib::Paths thtCopperAreaPaths =
       ClipperHelpers::treeToPaths(*thtCopperAreaIntersections);
 
-  // Check via restrings.
+  // Check via annular rings.
   foreach (const BI_NetSegment* netsegment, mBoard.getNetSegments()) {
     foreach (const BI_Via* via, netsegment->getVias()) {
-      // Determine via area including minimum restring.
+      // Determine via area including minimum annular ring.
       const Length diameter =
-          via->getDrillDiameter() + (*mOptions.minPthRestring * 2) - 1;
+          via->getDrillDiameter() + (*mOptions.minPthAnnularRing * 2) - 1;
       if (diameter <= 0) {
         continue;
       }
@@ -436,25 +436,25 @@ void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
       const ClipperLib::Paths remainingAreas =
           ClipperHelpers::flattenTree(*remainingAreasTree);
       if (!remainingAreas.empty()) {
-        QString msg = tr("Restring of via '%1' < %2",
-                         "Placeholders are net name + restring width")
+        QString msg = tr("Annular ring of via '%1' < %2",
+                         "Placeholders are net name + annular ring width")
                           .arg(netsegment->getNetNameToDisplay(true),
-                               formatLength(*mOptions.minPthRestring));
+                               formatLength(*mOptions.minPthAnnularRing));
         const QVector<Path> location = ClipperHelpers::convert(remainingAreas);
         emitMessage(BoardDesignRuleCheckMessage(msg, location));
       }
     }
   }
 
-  // Check pad restrings.
+  // Check pad annular rings.
   foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
     foreach (const BI_FootprintPad* pad, device->getPads()) {
-      // Determine hole areas including minimum restring.
+      // Determine hole areas including minimum annular ring.
       const Transform transform(*pad);
       ClipperLib::Paths areas;
       for (const Hole& hole : pad->getLibPad().getHoles()) {
         const Length diameter =
-            hole.getDiameter() + (*mOptions.minPthRestring * 2) - 1;
+            hole.getDiameter() + (*mOptions.minPthAnnularRing * 2) - 1;
         if (diameter <= 0) {
           continue;
         }
@@ -472,10 +472,10 @@ void BoardDesignRuleCheck::checkMinimumPthRestring(int progressStart,
       const ClipperLib::Paths remainingAreas =
           ClipperHelpers::flattenTree(*remainingAreasTree);
       if (!remainingAreas.empty()) {
-        QString msg = tr("Restring of pad '%1' < %2",
-                         "Placeholders are pad name + restring width")
+        QString msg = tr("Annular ring of pad '%1' < %2",
+                         "Placeholders are pad name + annular ring width")
                           .arg(pad->getDisplayText().simplified(),
-                               formatLength(*mOptions.minPthRestring));
+                               formatLength(*mOptions.minPthAnnularRing));
         const QVector<Path> location = ClipperHelpers::convert(remainingAreas);
         emitMessage(BoardDesignRuleCheckMessage(msg, location));
       }

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -75,8 +75,8 @@ public:
     bool checkCopperNpthClearance;
     UnsignedLength minCopperNpthClearance;
 
-    bool checkPthRestring;
-    UnsignedLength minPthRestring;
+    bool checkPthAnnularRing;
+    UnsignedLength minPthAnnularRing;
 
     bool checkNpthDrillDiameter;
     UnsignedLength minNpthDrillDiameter;
@@ -111,8 +111,8 @@ public:
         minCopperBoardClearance(300000),  // 300um
         checkCopperNpthClearance(true),
         minCopperNpthClearance(200000),  // 200um
-        checkPthRestring(true),
-        minPthRestring(150000),  // 150um
+        checkPthAnnularRing(true),
+        minPthAnnularRing(150000),  // 150um
         checkNpthDrillDiameter(true),
         minNpthDrillDiameter(250000),  // 250um
         checkNpthSlotWidth(true),
@@ -160,7 +160,7 @@ private:  // Methods
   void checkCopperCopperClearances(int progressStart, int progressEnd);
   void checkCourtyardClearances(int progressStart, int progressEnd);
   void checkMinimumCopperWidth(int progressStart, int progressEnd);
-  void checkMinimumPthRestring(int progressStart, int progressEnd);
+  void checkMinimumPthAnnularRing(int progressStart, int progressEnd);
   void checkMinimumNpthDrillDiameter(int progressStart, int progressEnd);
   void checkMinimumNpthSlotWidth(int progressStart, int progressEnd);
   void checkMinimumPthDrillDiameter(int progressStart, int progressEnd);

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.h
@@ -85,12 +85,12 @@ private:  // Data
   GraphicsLayer* mPadLayer;
   GraphicsLayer* mTopStopMaskLayer;
   GraphicsLayer* mBottomStopMaskLayer;
-  GraphicsLayer* mTopCreamMaskLayer;
-  GraphicsLayer* mBottomCreamMaskLayer;
+  GraphicsLayer* mTopSolderPasteLayer;
+  GraphicsLayer* mBottomSolderPasteLayer;
   QPainterPath mShape;
   QPainterPath mCopper;
   QPainterPath mStopMask;
-  QPainterPath mCreamMask;
+  QPainterPath mSolderPaste;
   QRectF mBoundingRect;
   QFont mFont;
 

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_via.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_via.h
@@ -86,7 +86,6 @@ private:  // Data
   QPainterPath mShape;
   QPainterPath mCopper;
   QPainterPath mStopMask;
-  QPainterPath mCreamMask;
   QRectF mBoundingRect;
   QFont mFont;
 

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -98,6 +98,7 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                QList<Message>& messages) {
   Q_UNUSED(root);
   Q_UNUSED(messages);
+  upgradeBoardDesignRules(root);
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -410,6 +410,7 @@ void FileFormatMigrationV01::upgradeSchematic(LoadedData& data,
 void FileFormatMigrationV01::upgradeBoard(SExpression& root,
                                           QList<Message>& messages) {
   upgradeGrid(root);
+  upgradeBoardDesignRules(root);
 
   // Fabrication output settings.
   {
@@ -465,6 +466,12 @@ void FileFormatMigrationV01::upgradeBoardUserSettings(SExpression& root) {
       }
     }
   }
+}
+
+void FileFormatMigrationV01::upgradeBoardDesignRules(SExpression& root) {
+  SExpression& node = root.getChild("design_rules");
+  node.removeChild(node.getChild("name"));
+  node.removeChild(node.getChild("description"));
 }
 
 void FileFormatMigrationV01::upgradeGrid(SExpression& node) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -476,6 +476,7 @@ void FileFormatMigrationV01::upgradeBoardDesignRules(SExpression& root) {
     QString name = child->getName();
     name.replace("restring_pad_", "pad_annular_ring_");
     name.replace("restring_via_", "via_annular_ring_");
+    name.replace("creammask_", "solderpaste_");
     child->setName(name);
   }
 }

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -479,6 +479,15 @@ void FileFormatMigrationV01::upgradeBoardDesignRules(SExpression& root) {
     name.replace("creammask_", "solderpaste_");
     child->setName(name);
   }
+  for (const QString param : {"stopmask_clearance", "solderpaste_clearance",
+                              "pad_annular_ring", "via_annular_ring"}) {
+    SExpression& newChild = node.appendList(param);
+    for (const QString property : {"ratio", "min", "max"}) {
+      SExpression& oldChild = node.getChild(param % "_" % property);
+      newChild.appendChild(property, oldChild.getChild("@0"));
+      node.removeChild(oldChild);
+    }
+  }
 }
 
 void FileFormatMigrationV01::upgradeGrid(SExpression& node) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -472,6 +472,12 @@ void FileFormatMigrationV01::upgradeBoardDesignRules(SExpression& root) {
   SExpression& node = root.getChild("design_rules");
   node.removeChild(node.getChild("name"));
   node.removeChild(node.getChild("description"));
+  for (SExpression* child : node.getChildren(SExpression::Type::List)) {
+    QString name = child->getName();
+    name.replace("restring_pad_", "pad_annular_ring_");
+    name.replace("restring_via_", "via_annular_ring_");
+    child->setName(name);
+  }
 }
 
 void FileFormatMigrationV01::upgradeGrid(SExpression& node) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -115,6 +115,7 @@ protected:  // Methods
   virtual void upgradeSchematic(LoadedData& data, SExpression& root);
   virtual void upgradeBoard(SExpression& root, QList<Message>& messages);
   virtual void upgradeBoardUserSettings(SExpression& root);
+  virtual void upgradeBoardDesignRules(SExpression& root);
   virtual void upgradeGrid(SExpression& node);
   virtual void upgradeHoles(SExpression& node);
 };

--- a/libs/librepcb/core/serialization/sexpression.cpp
+++ b/libs/librepcb/core/serialization/sexpression.cpp
@@ -162,6 +162,18 @@ const SExpression* SExpression::tryGetChild(const QString& path) const
 }
 
 /*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void SExpression::setName(const QString& name) {
+  if (mType == Type::List) {
+    mValue = name;
+  } else {
+    throw LogicError(__FILE__, __LINE__);
+  }
+}
+
+/*******************************************************************************
  *  General Methods
  ******************************************************************************/
 

--- a/libs/librepcb/core/serialization/sexpression.h
+++ b/libs/librepcb/core/serialization/sexpression.h
@@ -157,6 +157,9 @@ public:
   SExpression* tryGetChild(const QString& path) noexcept;
   const SExpression* tryGetChild(const QString& path) const noexcept;
 
+  // Setters
+  void setName(const QString& name);
+
   // General Methods
   void ensureLineBreak();
   SExpression& appendList(const QString& name);

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
@@ -58,9 +58,9 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
   mUi->edtMinCopperWidth->configure(lengthUnit,
                                     LengthEditBase::Steps::generic(),
                                     settingsPrefix % "/min_copper_width");
-  mUi->edtMinPthRestring->configure(lengthUnit,
-                                    LengthEditBase::Steps::generic(),
-                                    settingsPrefix % "/min_pth_restring");
+  mUi->edtMinPthAnnularRing->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/min_pth_annular_ring");
   mUi->edtMinNpthDrillDiameter->configure(
       lengthUnit, LengthEditBase::Steps::drillDiameter(),
       settingsPrefix % "/min_npth_drill_diameter");
@@ -101,7 +101,7 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
     mUi->cbxClearanceCopperBoard->setChecked(checked);
     mUi->cbxClearanceCopperNpth->setChecked(checked);
     mUi->cbxMinCopperWidth->setChecked(checked);
-    mUi->cbxMinPthRestring->setChecked(checked);
+    mUi->cbxMinPthAnnularRing->setChecked(checked);
     mUi->cbxMinNpthDrillDiameter->setChecked(checked);
     mUi->cbxMinNpthSlotWidth->setChecked(checked);
     mUi->cbxMinPthDrillDiameter->setChecked(checked);
@@ -122,8 +122,8 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
   mUi->edtClearanceCopperNpth->setValue(options.minCopperNpthClearance);
   mUi->cbxMinCopperWidth->setChecked(options.checkCopperWidth);
   mUi->edtMinCopperWidth->setValue(options.minCopperWidth);
-  mUi->cbxMinPthRestring->setChecked(options.checkPthRestring);
-  mUi->edtMinPthRestring->setValue(options.minPthRestring);
+  mUi->cbxMinPthAnnularRing->setChecked(options.checkPthAnnularRing);
+  mUi->edtMinPthAnnularRing->setValue(options.minPthAnnularRing);
   mUi->cbxMinNpthDrillDiameter->setChecked(options.checkNpthDrillDiameter);
   mUi->edtMinNpthDrillDiameter->setValue(options.minNpthDrillDiameter);
   mUi->cbxMinNpthSlotWidth->setChecked(options.checkNpthSlotWidth);
@@ -173,8 +173,8 @@ BoardDesignRuleCheck::Options BoardDesignRuleCheckDialog::getOptions() const
   options.minCopperNpthClearance = mUi->edtClearanceCopperNpth->getValue();
   options.checkCopperWidth = mUi->cbxMinCopperWidth->isChecked();
   options.minCopperWidth = mUi->edtMinCopperWidth->getValue();
-  options.checkPthRestring = mUi->cbxMinPthRestring->isChecked();
-  options.minPthRestring = mUi->edtMinPthRestring->getValue();
+  options.checkPthAnnularRing = mUi->cbxMinPthAnnularRing->isChecked();
+  options.minPthAnnularRing = mUi->edtMinPthAnnularRing->getValue();
   options.checkNpthDrillDiameter = mUi->cbxMinNpthDrillDiameter->isChecked();
   options.minNpthDrillDiameter = mUi->edtMinNpthDrillDiameter->getValue();
   options.checkNpthSlotWidth = mUi->cbxMinNpthSlotWidth->isChecked();

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
@@ -109,9 +109,9 @@
          <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinCopperWidth" native="true"/>
         </item>
         <item row="6" column="0">
-         <widget class="QCheckBox" name="cbxMinPthRestring">
+         <widget class="QCheckBox" name="cbxMinPthAnnularRing">
           <property name="text">
-           <string>Minimum PTH Restring:</string>
+           <string>Minimum PTH Annular Ring:</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -119,7 +119,7 @@
          </widget>
         </item>
         <item row="6" column="1">
-         <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinPthRestring" native="true"/>
+         <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinPthAnnularRing" native="true"/>
         </item>
         <item row="7" column="0">
          <widget class="QCheckBox" name="cbxMinNpthDrillDiameter">
@@ -300,15 +300,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>librepcb::editor::UnsignedLengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>librepcb::editor::LengthEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::UnsignedLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -322,8 +322,8 @@
   <tabstop>edtClearanceCopperNpth</tabstop>
   <tabstop>cbxMinCopperWidth</tabstop>
   <tabstop>edtMinCopperWidth</tabstop>
-  <tabstop>cbxMinPthRestring</tabstop>
-  <tabstop>edtMinPthRestring</tabstop>
+  <tabstop>cbxMinPthAnnularRing</tabstop>
+  <tabstop>edtMinPthAnnularRing</tabstop>
   <tabstop>cbxMinNpthDrillDiameter</tabstop>
   <tabstop>edtMinNpthDrillDiameter</tabstop>
   <tabstop>cbxMinNpthSlotWidth</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
@@ -59,20 +59,20 @@ BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
   mUi->edtCreamMaskClrMax->configure(
       lengthUnit, LengthEditBase::Steps::generic(),
       settingsPrefix % "/creammask_clearance_max");
-  mUi->edtRestringPadsRatio->setSingleStep(5.0);  // [%]
-  mUi->edtRestringPadsMin->configure(lengthUnit,
-                                     LengthEditBase::Steps::generic(),
-                                     settingsPrefix % "/restring_pads_min");
-  mUi->edtRestringPadsMax->configure(lengthUnit,
-                                     LengthEditBase::Steps::generic(),
-                                     settingsPrefix % "/restring_pads_max");
-  mUi->edtRestringViasRatio->setSingleStep(5.0);  // [%]
-  mUi->edtRestringViasMin->configure(lengthUnit,
-                                     LengthEditBase::Steps::generic(),
-                                     settingsPrefix % "/restring_vias_min");
-  mUi->edtRestringViasMax->configure(lengthUnit,
-                                     LengthEditBase::Steps::generic(),
-                                     settingsPrefix % "/restring_vias_max");
+  mUi->edtPadAnnularRingRatio->setSingleStep(5.0);  // [%]
+  mUi->edtPadAnnularRingMin->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/pad_annular_ring_min");
+  mUi->edtPadAnnularRingMax->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/pad_annular_ring_max");
+  mUi->edtViaAnnularRingRatio->setSingleStep(5.0);  // [%]
+  mUi->edtViaAnnularRingMin->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/via_annular_ring_min");
+  mUi->edtViaAnnularRingMax->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/via_annular_ring_max");
 
   updateWidgets();
 }
@@ -120,13 +120,14 @@ void BoardDesignRulesDialog::updateWidgets() noexcept {
       mDesignRules.getCreamMaskClearanceRatio());
   mUi->edtCreamMaskClrMin->setValue(mDesignRules.getCreamMaskClearanceMin());
   mUi->edtCreamMaskClrMax->setValue(mDesignRules.getCreamMaskClearanceMax());
-  // restring
-  mUi->edtRestringPadsRatio->setValue(mDesignRules.getRestringPadRatio());
-  mUi->edtRestringPadsMin->setValue(mDesignRules.getRestringPadMin());
-  mUi->edtRestringPadsMax->setValue(mDesignRules.getRestringPadMax());
-  mUi->edtRestringViasRatio->setValue(mDesignRules.getRestringViaRatio());
-  mUi->edtRestringViasMin->setValue(mDesignRules.getRestringViaMin());
-  mUi->edtRestringViasMax->setValue(mDesignRules.getRestringViaMax());
+  // pad annular ring
+  mUi->edtPadAnnularRingRatio->setValue(mDesignRules.getPadAnnularRingRatio());
+  mUi->edtPadAnnularRingMin->setValue(mDesignRules.getPadAnnularRingMin());
+  mUi->edtPadAnnularRingMax->setValue(mDesignRules.getPadAnnularRingMax());
+  // via annular ring
+  mUi->edtViaAnnularRingRatio->setValue(mDesignRules.getViaAnnularRingRatio());
+  mUi->edtViaAnnularRingMin->setValue(mDesignRules.getViaAnnularRingMin());
+  mUi->edtViaAnnularRingMax->setValue(mDesignRules.getViaAnnularRingMax());
 }
 
 void BoardDesignRulesDialog::applyRules() noexcept {
@@ -145,15 +146,18 @@ void BoardDesignRulesDialog::applyRules() noexcept {
     mDesignRules.setCreamMaskClearanceBounds(
         mUi->edtCreamMaskClrMin->getValue(),
         mUi->edtCreamMaskClrMax->getValue());  // can throw
-    // restring
-    mDesignRules.setRestringPadRatio(mUi->edtRestringPadsRatio->getValue());
-    mDesignRules.setRestringPadBounds(
-        mUi->edtRestringPadsMin->getValue(),
-        mUi->edtRestringPadsMax->getValue());  // can throw
-    mDesignRules.setRestringViaRatio(mUi->edtRestringViasRatio->getValue());
-    mDesignRules.setRestringViaBounds(
-        mUi->edtRestringViasMin->getValue(),
-        mUi->edtRestringViasMax->getValue());  // can throw
+    // pad annular ring
+    mDesignRules.setPadAnnularRingRatio(
+        mUi->edtPadAnnularRingRatio->getValue());
+    mDesignRules.setPadAnnularRingBounds(
+        mUi->edtPadAnnularRingMin->getValue(),
+        mUi->edtPadAnnularRingMax->getValue());  // can throw
+    // via annular ring
+    mDesignRules.setViaAnnularRingRatio(
+        mUi->edtViaAnnularRingRatio->getValue());
+    mDesignRules.setViaAnnularRingBounds(
+        mUi->edtViaAnnularRingMin->getValue(),
+        mUi->edtViaAnnularRingMax->getValue());  // can throw
   } catch (const Exception& e) {
     QMessageBox::warning(this, tr("Could not apply settings"), e.getMsg());
   }

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
@@ -75,9 +75,6 @@ BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
                                      settingsPrefix % "/restring_vias_max");
 
   updateWidgets();
-
-  // set focus to name so the user can immediately start typing to change it
-  mUi->edtName->setFocus();
 }
 
 BoardDesignRulesDialog::~BoardDesignRulesDialog() {
@@ -113,9 +110,6 @@ void BoardDesignRulesDialog::on_buttonBox_clicked(QAbstractButton* button) {
  ******************************************************************************/
 
 void BoardDesignRulesDialog::updateWidgets() noexcept {
-  // general attributes
-  mUi->edtName->setText(*mDesignRules.getName());
-  mUi->txtDescription->setPlainText(mDesignRules.getDescription());
   // stop mask
   mUi->edtStopMaskClrRatio->setValue(mDesignRules.getStopMaskClearanceRatio());
   mUi->edtStopMaskClrMin->setValue(mDesignRules.getStopMaskClearanceMin());
@@ -137,9 +131,6 @@ void BoardDesignRulesDialog::updateWidgets() noexcept {
 
 void BoardDesignRulesDialog::applyRules() noexcept {
   try {
-    // general attributes
-    mDesignRules.setName(ElementName(mUi->edtName->text()));  // can throw
-    mDesignRules.setDescription(mUi->txtDescription->toPlainText());
     // stop mask
     mDesignRules.setStopMaskClearanceRatio(
         mUi->edtStopMaskClrRatio->getValue());

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
@@ -134,30 +134,22 @@ void BoardDesignRulesDialog::updateWidgets() noexcept {
 
 void BoardDesignRulesDialog::applyRules() noexcept {
   try {
-    // stop mask
-    mDesignRules.setStopMaskClearanceRatio(
-        mUi->edtStopMaskClrRatio->getValue());
-    mDesignRules.setStopMaskClearanceBounds(
-        mUi->edtStopMaskClrMin->getValue(),
-        mUi->edtStopMaskClrMax->getValue());  // can throw
     mDesignRules.setStopMaskMaxViaDiameter(
         mUi->edtStopMaskMaxViaDia->getValue());
-    // solder paste
-    mDesignRules.setSolderPasteClearanceRatio(
-        mUi->edtSolderPasteClrRatio->getValue());
-    mDesignRules.setSolderPasteClearanceBounds(
+    mDesignRules.setStopMaskClearance(
+        mUi->edtStopMaskClrRatio->getValue(),
+        mUi->edtStopMaskClrMin->getValue(),
+        mUi->edtStopMaskClrMax->getValue());  // can throw
+    mDesignRules.setSolderPasteClearance(
+        mUi->edtSolderPasteClrRatio->getValue(),
         mUi->edtSolderPasteClrMin->getValue(),
         mUi->edtSolderPasteClrMax->getValue());  // can throw
-    // pad annular ring
-    mDesignRules.setPadAnnularRingRatio(
-        mUi->edtPadAnnularRingRatio->getValue());
-    mDesignRules.setPadAnnularRingBounds(
+    mDesignRules.setPadAnnularRing(
+        mUi->edtPadAnnularRingRatio->getValue(),
         mUi->edtPadAnnularRingMin->getValue(),
         mUi->edtPadAnnularRingMax->getValue());  // can throw
-    // via annular ring
-    mDesignRules.setViaAnnularRingRatio(
-        mUi->edtViaAnnularRingRatio->getValue());
-    mDesignRules.setViaAnnularRingBounds(
+    mDesignRules.setViaAnnularRing(
+        mUi->edtViaAnnularRingRatio->getValue(),
         mUi->edtViaAnnularRingMin->getValue(),
         mUi->edtViaAnnularRingMax->getValue());  // can throw
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
@@ -52,13 +52,13 @@ BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
   mUi->edtStopMaskMaxViaDia->configure(
       lengthUnit, LengthEditBase::Steps::generic(),
       settingsPrefix % "/stopmask_max_via_diameter");
-  mUi->edtCreamMaskClrRatio->setSingleStep(5.0);  // [%]
-  mUi->edtCreamMaskClrMin->configure(
+  mUi->edtSolderPasteClrRatio->setSingleStep(5.0);  // [%]
+  mUi->edtSolderPasteClrMin->configure(
       lengthUnit, LengthEditBase::Steps::generic(),
-      settingsPrefix % "/creammask_clearance_min");
-  mUi->edtCreamMaskClrMax->configure(
+      settingsPrefix % "/solderpaste_clearance_min");
+  mUi->edtSolderPasteClrMax->configure(
       lengthUnit, LengthEditBase::Steps::generic(),
-      settingsPrefix % "/creammask_clearance_max");
+      settingsPrefix % "/solderpaste_clearance_max");
   mUi->edtPadAnnularRingRatio->setSingleStep(5.0);  // [%]
   mUi->edtPadAnnularRingMin->configure(
       lengthUnit, LengthEditBase::Steps::generic(),
@@ -115,11 +115,13 @@ void BoardDesignRulesDialog::updateWidgets() noexcept {
   mUi->edtStopMaskClrMin->setValue(mDesignRules.getStopMaskClearanceMin());
   mUi->edtStopMaskClrMax->setValue(mDesignRules.getStopMaskClearanceMax());
   mUi->edtStopMaskMaxViaDia->setValue(mDesignRules.getStopMaskMaxViaDiameter());
-  // cream mask
-  mUi->edtCreamMaskClrRatio->setValue(
-      mDesignRules.getCreamMaskClearanceRatio());
-  mUi->edtCreamMaskClrMin->setValue(mDesignRules.getCreamMaskClearanceMin());
-  mUi->edtCreamMaskClrMax->setValue(mDesignRules.getCreamMaskClearanceMax());
+  // solder paste
+  mUi->edtSolderPasteClrRatio->setValue(
+      mDesignRules.getSolderPasteClearanceRatio());
+  mUi->edtSolderPasteClrMin->setValue(
+      mDesignRules.getSolderPasteClearanceMin());
+  mUi->edtSolderPasteClrMax->setValue(
+      mDesignRules.getSolderPasteClearanceMax());
   // pad annular ring
   mUi->edtPadAnnularRingRatio->setValue(mDesignRules.getPadAnnularRingRatio());
   mUi->edtPadAnnularRingMin->setValue(mDesignRules.getPadAnnularRingMin());
@@ -140,12 +142,12 @@ void BoardDesignRulesDialog::applyRules() noexcept {
         mUi->edtStopMaskClrMax->getValue());  // can throw
     mDesignRules.setStopMaskMaxViaDiameter(
         mUi->edtStopMaskMaxViaDia->getValue());
-    // cream mask
-    mDesignRules.setCreamMaskClearanceRatio(
-        mUi->edtCreamMaskClrRatio->getValue());
-    mDesignRules.setCreamMaskClearanceBounds(
-        mUi->edtCreamMaskClrMin->getValue(),
-        mUi->edtCreamMaskClrMax->getValue());  // can throw
+    // solder paste
+    mDesignRules.setSolderPasteClearanceRatio(
+        mUi->edtSolderPasteClrRatio->getValue());
+    mDesignRules.setSolderPasteClearanceBounds(
+        mUi->edtSolderPasteClrMin->getValue(),
+        mUi->edtSolderPasteClrMax->getValue());  // can throw
     // pad annular ring
     mDesignRules.setPadAnnularRingRatio(
         mUi->edtPadAnnularRingRatio->getValue());

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="4" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringPadsMax" native="true"/>
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtPadAnnularRingMax" native="true"/>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_3">
@@ -49,15 +49,15 @@
     <widget class="librepcb::editor::UnsignedRatioEdit" name="edtStopMaskClrRatio" native="true"/>
    </item>
    <item row="5" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRestringViasRatio" native="true"/>
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtViaAnnularRingRatio" native="true"/>
    </item>
    <item row="5" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringViasMin" native="true"/>
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtViaAnnularRingMin" native="true"/>
    </item>
    <item row="4" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>Restring THT Pads:</string>
+      <string>Pads Annular Ring:</string>
      </property>
     </widget>
    </item>
@@ -90,12 +90,12 @@
    <item row="5" column="0">
     <widget class="QLabel" name="label_10">
      <property name="text">
-      <string>Restring Vias:</string>
+      <string>Vias Annular Ring:</string>
      </property>
     </widget>
    </item>
    <item row="5" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringViasMax" native="true"/>
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtViaAnnularRingMax" native="true"/>
    </item>
    <item row="0" column="1">
     <widget class="QLabel" name="label_4">
@@ -105,7 +105,7 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringPadsMin" native="true"/>
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtPadAnnularRingMin" native="true"/>
    </item>
    <item row="3" column="1">
     <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCreamMaskClrMin" native="true"/>
@@ -117,7 +117,7 @@
     <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMin" native="true"/>
    </item>
    <item row="4" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRestringPadsRatio" native="true"/>
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtPadAnnularRingRatio" native="true"/>
    </item>
   </layout>
  </widget>
@@ -143,12 +143,12 @@
   <tabstop>edtCreamMaskClrMin</tabstop>
   <tabstop>edtCreamMaskClrRatio</tabstop>
   <tabstop>edtCreamMaskClrMax</tabstop>
-  <tabstop>edtRestringPadsMin</tabstop>
-  <tabstop>edtRestringPadsRatio</tabstop>
-  <tabstop>edtRestringPadsMax</tabstop>
-  <tabstop>edtRestringViasMin</tabstop>
-  <tabstop>edtRestringViasRatio</tabstop>
-  <tabstop>edtRestringViasMax</tabstop>
+  <tabstop>edtPadAnnularRingMin</tabstop>
+  <tabstop>edtPadAnnularRingRatio</tabstop>
+  <tabstop>edtPadAnnularRingMax</tabstop>
+  <tabstop>edtViaAnnularRingMin</tabstop>
+  <tabstop>edtViaAnnularRingRatio</tabstop>
+  <tabstop>edtViaAnnularRingMax</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
@@ -27,7 +27,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>Cream Mask Clearance:</string>
+      <string>Solder Paste Clearance:</string>
      </property>
     </widget>
    </item>
@@ -65,7 +65,7 @@
     <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMax" native="true"/>
    </item>
    <item row="3" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCreamMaskClrMax" native="true"/>
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtSolderPasteClrMax" native="true"/>
    </item>
    <item row="6" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -108,10 +108,10 @@
     <widget class="librepcb::editor::UnsignedLengthEdit" name="edtPadAnnularRingMin" native="true"/>
    </item>
    <item row="3" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCreamMaskClrMin" native="true"/>
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtSolderPasteClrMin" native="true"/>
    </item>
    <item row="3" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtCreamMaskClrRatio" native="true"/>
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtSolderPasteClrRatio" native="true"/>
    </item>
    <item row="2" column="1">
     <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMin" native="true"/>
@@ -140,9 +140,9 @@
   <tabstop>edtStopMaskClrMin</tabstop>
   <tabstop>edtStopMaskClrRatio</tabstop>
   <tabstop>edtStopMaskClrMax</tabstop>
-  <tabstop>edtCreamMaskClrMin</tabstop>
-  <tabstop>edtCreamMaskClrRatio</tabstop>
-  <tabstop>edtCreamMaskClrMax</tabstop>
+  <tabstop>edtSolderPasteClrMin</tabstop>
+  <tabstop>edtSolderPasteClrRatio</tabstop>
+  <tabstop>edtSolderPasteClrMax</tabstop>
   <tabstop>edtPadAnnularRingMin</tabstop>
   <tabstop>edtPadAnnularRingRatio</tabstop>
   <tabstop>edtPadAnnularRingMax</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
@@ -6,85 +6,68 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>539</width>
-    <height>396</height>
+    <width>579</width>
+    <height>188</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Board Design Rules</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Name:</string>
-     </property>
-    </widget>
+   <item row="4" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringPadsMax" native="true"/>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Description:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Minimum</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Ratio (% of diam.)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Maximum</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Stop Mask Max. Via Diam.:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Stop Mask Clearance:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>Cream Mask Clearance:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Stop Mask Max. Via Diam.:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Ratio (% of diam.)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtStopMaskClrRatio" native="true"/>
+   </item>
+   <item row="5" column="2">
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRestringViasRatio" native="true"/>
+   </item>
+   <item row="5" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringViasMin" native="true"/>
+   </item>
+   <item row="4" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Restring THT Pads:</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Restring Vias:</string>
-     </property>
-    </widget>
+   <item row="2" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMax" native="true"/>
    </item>
-   <item row="8" column="0" colspan="4">
+   <item row="3" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCreamMaskClrMax" native="true"/>
+   </item>
+   <item row="6" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -94,54 +77,47 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="3">
-    <widget class="QPlainTextEdit" name="txtDescription">
-     <property name="tabChangesFocus">
-      <bool>true</bool>
+   <item row="1" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskMaxViaDia" native="true"/>
+   </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Maximum</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="3">
-    <widget class="QLineEdit" name="edtName"/>
-   </item>
-   <item row="3" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskMaxViaDia" native="true"/>
-   </item>
-   <item row="4" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMin" native="true"/>
-   </item>
-   <item row="5" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCreamMaskClrMin" native="true"/>
-   </item>
-   <item row="6" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringPadsMin" native="true"/>
-   </item>
-   <item row="7" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringViasMin" native="true"/>
-   </item>
-   <item row="4" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMax" native="true"/>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Restring Vias:</string>
+     </property>
+    </widget>
    </item>
    <item row="5" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCreamMaskClrMax" native="true"/>
-   </item>
-   <item row="6" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringPadsMax" native="true"/>
-   </item>
-   <item row="7" column="3">
     <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringViasMax" native="true"/>
    </item>
-   <item row="4" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtStopMaskClrRatio" native="true"/>
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Minimum</string>
+     </property>
+    </widget>
    </item>
-   <item row="5" column="2">
+   <item row="4" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRestringPadsMin" native="true"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCreamMaskClrMin" native="true"/>
+   </item>
+   <item row="3" column="2">
     <widget class="librepcb::editor::UnsignedRatioEdit" name="edtCreamMaskClrRatio" native="true"/>
    </item>
-   <item row="6" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRestringPadsRatio" native="true"/>
+   <item row="2" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMin" native="true"/>
    </item>
-   <item row="7" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRestringViasRatio" native="true"/>
+   <item row="4" column="2">
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRestringPadsRatio" native="true"/>
    </item>
   </layout>
  </widget>
@@ -160,8 +136,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>edtName</tabstop>
-  <tabstop>txtDescription</tabstop>
   <tabstop>edtStopMaskMaxViaDia</tabstop>
   <tabstop>edtStopMaskClrMin</tabstop>
   <tabstop>edtStopMaskClrRatio</tabstop>

--- a/tests/unittests/core/project/board/boarddesignrulestest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulestest.cpp
@@ -50,12 +50,12 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
       " (creammask_clearance_ratio 0.3)\n"
       " (creammask_clearance_min 1.3)\n"
       " (creammask_clearance_max 2.3)\n"
-      " (restring_pad_ratio 0.4)\n"
-      " (restring_pad_min 1.4)\n"
-      " (restring_pad_max 2.4)\n"
-      " (restring_via_ratio 0.5)\n"
-      " (restring_via_min 1.5)\n"
-      " (restring_via_max 2.5)\n"
+      " (pad_annular_ring_ratio 0.4)\n"
+      " (pad_annular_ring_min 1.4)\n"
+      " (pad_annular_ring_max 2.4)\n"
+      " (via_annular_ring_ratio 0.5)\n"
+      " (via_annular_ring_min 1.5)\n"
+      " (via_annular_ring_max 2.5)\n"
       ")",
       FilePath());
   BoardDesignRules obj(sexpr);
@@ -66,12 +66,12 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
   EXPECT_EQ(UnsignedRatio(Ratio(300000)), obj.getCreamMaskClearanceRatio());
   EXPECT_EQ(UnsignedLength(1300000), obj.getCreamMaskClearanceMin());
   EXPECT_EQ(UnsignedLength(2300000), obj.getCreamMaskClearanceMax());
-  EXPECT_EQ(UnsignedRatio(Ratio(400000)), obj.getRestringPadRatio());
-  EXPECT_EQ(UnsignedLength(1400000), obj.getRestringPadMin());
-  EXPECT_EQ(UnsignedLength(2400000), obj.getRestringPadMax());
-  EXPECT_EQ(UnsignedRatio(Ratio(500000)), obj.getRestringViaRatio());
-  EXPECT_EQ(UnsignedLength(1500000), obj.getRestringViaMin());
-  EXPECT_EQ(UnsignedLength(2500000), obj.getRestringViaMax());
+  EXPECT_EQ(UnsignedRatio(Ratio(400000)), obj.getPadAnnularRingRatio());
+  EXPECT_EQ(UnsignedLength(1400000), obj.getPadAnnularRingMin());
+  EXPECT_EQ(UnsignedLength(2400000), obj.getPadAnnularRingMax());
+  EXPECT_EQ(UnsignedRatio(Ratio(500000)), obj.getViaAnnularRingRatio());
+  EXPECT_EQ(UnsignedLength(1500000), obj.getViaAnnularRingMin());
+  EXPECT_EQ(UnsignedLength(2500000), obj.getViaAnnularRingMax());
 }
 
 TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
@@ -81,10 +81,10 @@ TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
   obj1.setStopMaskMaxViaDiameter(UnsignedLength(44));
   obj1.setCreamMaskClearanceRatio(UnsignedRatio(Ratio(55)));
   obj1.setCreamMaskClearanceBounds(UnsignedLength(66), UnsignedLength(77));
-  obj1.setRestringPadRatio(UnsignedRatio(Ratio(88)));
-  obj1.setRestringPadBounds(UnsignedLength(99), UnsignedLength(111));
-  obj1.setRestringViaRatio(UnsignedRatio(Ratio(222)));
-  obj1.setRestringViaBounds(UnsignedLength(333), UnsignedLength(444));
+  obj1.setPadAnnularRingRatio(UnsignedRatio(Ratio(88)));
+  obj1.setPadAnnularRingBounds(UnsignedLength(99), UnsignedLength(111));
+  obj1.setViaAnnularRingRatio(UnsignedRatio(Ratio(222)));
+  obj1.setViaAnnularRingBounds(UnsignedLength(333), UnsignedLength(444));
   SExpression sexpr1 = SExpression::createList("obj");
   obj1.serialize(sexpr1);
 

--- a/tests/unittests/core/project/board/boarddesignrulestest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulestest.cpp
@@ -47,9 +47,9 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
       " (stopmask_clearance_min 1.1)\n"
       " (stopmask_clearance_max 2.1)\n"
       " (stopmask_max_via_drill_diameter 0.2)\n"
-      " (creammask_clearance_ratio 0.3)\n"
-      " (creammask_clearance_min 1.3)\n"
-      " (creammask_clearance_max 2.3)\n"
+      " (solderpaste_clearance_ratio 0.3)\n"
+      " (solderpaste_clearance_min 1.3)\n"
+      " (solderpaste_clearance_max 2.3)\n"
       " (pad_annular_ring_ratio 0.4)\n"
       " (pad_annular_ring_min 1.4)\n"
       " (pad_annular_ring_max 2.4)\n"
@@ -63,9 +63,9 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
   EXPECT_EQ(UnsignedLength(1100000), obj.getStopMaskClearanceMin());
   EXPECT_EQ(UnsignedLength(2100000), obj.getStopMaskClearanceMax());
   EXPECT_EQ(UnsignedLength(200000), obj.getStopMaskMaxViaDiameter());
-  EXPECT_EQ(UnsignedRatio(Ratio(300000)), obj.getCreamMaskClearanceRatio());
-  EXPECT_EQ(UnsignedLength(1300000), obj.getCreamMaskClearanceMin());
-  EXPECT_EQ(UnsignedLength(2300000), obj.getCreamMaskClearanceMax());
+  EXPECT_EQ(UnsignedRatio(Ratio(300000)), obj.getSolderPasteClearanceRatio());
+  EXPECT_EQ(UnsignedLength(1300000), obj.getSolderPasteClearanceMin());
+  EXPECT_EQ(UnsignedLength(2300000), obj.getSolderPasteClearanceMax());
   EXPECT_EQ(UnsignedRatio(Ratio(400000)), obj.getPadAnnularRingRatio());
   EXPECT_EQ(UnsignedLength(1400000), obj.getPadAnnularRingMin());
   EXPECT_EQ(UnsignedLength(2400000), obj.getPadAnnularRingMax());
@@ -79,8 +79,8 @@ TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
   obj1.setStopMaskClearanceRatio(UnsignedRatio(Ratio(11)));
   obj1.setStopMaskClearanceBounds(UnsignedLength(22), UnsignedLength(33));
   obj1.setStopMaskMaxViaDiameter(UnsignedLength(44));
-  obj1.setCreamMaskClearanceRatio(UnsignedRatio(Ratio(55)));
-  obj1.setCreamMaskClearanceBounds(UnsignedLength(66), UnsignedLength(77));
+  obj1.setSolderPasteClearanceRatio(UnsignedRatio(Ratio(55)));
+  obj1.setSolderPasteClearanceBounds(UnsignedLength(66), UnsignedLength(77));
   obj1.setPadAnnularRingRatio(UnsignedRatio(Ratio(88)));
   obj1.setPadAnnularRingBounds(UnsignedLength(99), UnsignedLength(111));
   obj1.setViaAnnularRingRatio(UnsignedRatio(Ratio(222)));

--- a/tests/unittests/core/project/board/boarddesignrulestest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulestest.cpp
@@ -43,26 +43,18 @@ class BoardDesignRulesTest : public ::testing::Test {};
 TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
   SExpression sexpr = SExpression::parse(
       "(design_rules\n"
-      " (stopmask_clearance_ratio 0.1)\n"
-      " (stopmask_clearance_min 1.1)\n"
-      " (stopmask_clearance_max 2.1)\n"
       " (stopmask_max_via_drill_diameter 0.2)\n"
-      " (solderpaste_clearance_ratio 0.3)\n"
-      " (solderpaste_clearance_min 1.3)\n"
-      " (solderpaste_clearance_max 2.3)\n"
-      " (pad_annular_ring_ratio 0.4)\n"
-      " (pad_annular_ring_min 1.4)\n"
-      " (pad_annular_ring_max 2.4)\n"
-      " (via_annular_ring_ratio 0.5)\n"
-      " (via_annular_ring_min 1.5)\n"
-      " (via_annular_ring_max 2.5)\n"
+      " (stopmask_clearance (ratio 0.1) (min 1.1) (max 2.1))\n"
+      " (solderpaste_clearance (ratio 0.3) (min 1.3) (max 2.3))\n"
+      " (pad_annular_ring (ratio 0.4) (min 1.4) (max 2.4))\n"
+      " (via_annular_ring (ratio 0.5) (min 1.5) (max 2.5))\n"
       ")",
       FilePath());
   BoardDesignRules obj(sexpr);
+  EXPECT_EQ(UnsignedLength(200000), obj.getStopMaskMaxViaDiameter());
   EXPECT_EQ(UnsignedRatio(Ratio(100000)), obj.getStopMaskClearanceRatio());
   EXPECT_EQ(UnsignedLength(1100000), obj.getStopMaskClearanceMin());
   EXPECT_EQ(UnsignedLength(2100000), obj.getStopMaskClearanceMax());
-  EXPECT_EQ(UnsignedLength(200000), obj.getStopMaskMaxViaDiameter());
   EXPECT_EQ(UnsignedRatio(Ratio(300000)), obj.getSolderPasteClearanceRatio());
   EXPECT_EQ(UnsignedLength(1300000), obj.getSolderPasteClearanceMin());
   EXPECT_EQ(UnsignedLength(2300000), obj.getSolderPasteClearanceMax());
@@ -76,15 +68,15 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
 
 TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
   BoardDesignRules obj1;
-  obj1.setStopMaskClearanceRatio(UnsignedRatio(Ratio(11)));
-  obj1.setStopMaskClearanceBounds(UnsignedLength(22), UnsignedLength(33));
   obj1.setStopMaskMaxViaDiameter(UnsignedLength(44));
-  obj1.setSolderPasteClearanceRatio(UnsignedRatio(Ratio(55)));
-  obj1.setSolderPasteClearanceBounds(UnsignedLength(66), UnsignedLength(77));
-  obj1.setPadAnnularRingRatio(UnsignedRatio(Ratio(88)));
-  obj1.setPadAnnularRingBounds(UnsignedLength(99), UnsignedLength(111));
-  obj1.setViaAnnularRingRatio(UnsignedRatio(Ratio(222)));
-  obj1.setViaAnnularRingBounds(UnsignedLength(333), UnsignedLength(444));
+  obj1.setStopMaskClearance(UnsignedRatio(Ratio(11)), UnsignedLength(22),
+                            UnsignedLength(33));
+  obj1.setSolderPasteClearance(UnsignedRatio(Ratio(55)), UnsignedLength(66),
+                               UnsignedLength(77));
+  obj1.setPadAnnularRing(UnsignedRatio(Ratio(88)), UnsignedLength(99),
+                         UnsignedLength(111));
+  obj1.setViaAnnularRing(UnsignedRatio(Ratio(222)), UnsignedLength(333),
+                         UnsignedLength(444));
   SExpression sexpr1 = SExpression::createList("obj");
   obj1.serialize(sexpr1);
 

--- a/tests/unittests/core/project/board/boarddesignrulestest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulestest.cpp
@@ -43,8 +43,6 @@ class BoardDesignRulesTest : public ::testing::Test {};
 TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
   SExpression sexpr = SExpression::parse(
       "(design_rules\n"
-      " (name \"Foo Bar\")\n"
-      " (description \"Hello World\")\n"
       " (stopmask_clearance_ratio 0.1)\n"
       " (stopmask_clearance_min 1.1)\n"
       " (stopmask_clearance_max 2.1)\n"
@@ -61,8 +59,6 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
       ")",
       FilePath());
   BoardDesignRules obj(sexpr);
-  EXPECT_EQ("Foo Bar", obj.getName());
-  EXPECT_EQ("Hello World", obj.getDescription());
   EXPECT_EQ(UnsignedRatio(Ratio(100000)), obj.getStopMaskClearanceRatio());
   EXPECT_EQ(UnsignedLength(1100000), obj.getStopMaskClearanceMin());
   EXPECT_EQ(UnsignedLength(2100000), obj.getStopMaskClearanceMax());
@@ -80,8 +76,6 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
 
 TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
   BoardDesignRules obj1;
-  obj1.setName(ElementName("foo bar"));
-  obj1.setDescription("Foo Bar");
   obj1.setStopMaskClearanceRatio(UnsignedRatio(Ratio(11)));
   obj1.setStopMaskClearanceBounds(UnsignedLength(22), UnsignedLength(33));
   obj1.setStopMaskMaxViaDiameter(UnsignedLength(44));


### PR DESCRIPTION
### Remove name and description from board design rules

In my experience these attributes are not really useful but just clutter up the GUI, so let's get rid of them. If we ever need a place for such user-defined text, I'd rather add a general purpose description field to the board itself.

### Rename term "restring" to "annular ring" everywhere

The term annular ring seems to be used much more commonly than restring (e.g. in PCB manufacturers capabilities sheets), so let's use it in LibrePCB as well.

### Rename term "cream mask" to "solder paste" everywhere

For consistency and to avoid confusion due to different terms for the same thing.

### Make file format of board design rules more compact

Just slightly rearranging the S-Expressions of the board design rules to make them logically grouped and more compact...