### PR TITLE
Support automatic THT pad annular rings

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -258,6 +258,8 @@ add_library(
   library/pkg/msg/msgpadannularringviolation.h
   library/pkg/msg/msgpadclearanceviolation.cpp
   library/pkg/msg/msgpadclearanceviolation.h
+  library/pkg/msg/msgpadoriginoutsidecopper.cpp
+  library/pkg/msg/msgpadoriginoutsidecopper.h
   library/pkg/msg/msgpadoverlapswithplacement.cpp
   library/pkg/msg/msgpadoverlapswithplacement.h
   library/pkg/msg/msgwrongfootprinttextlayer.cpp

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -135,6 +135,8 @@ add_library(
   geometry/netlabel.h
   geometry/netline.cpp
   geometry/netline.h
+  geometry/padgeometry.cpp
+  geometry/padgeometry.h
   geometry/path.cpp
   geometry/path.h
   geometry/polygon.cpp

--- a/libs/librepcb/core/export/gerberaperturelist.cpp
+++ b/libs/librepcb/core/export/gerberaperturelist.cpp
@@ -248,6 +248,12 @@ int GerberApertureList::addOctagon(const PositiveLength& w,
   }
 }
 
+int GerberApertureList::addOutline(const StraightAreaPath& path,
+                                   const Angle& rot,
+                                   Function function) noexcept {
+  return addOutline("OUTLINE", *path, rot.mappedTo0_360deg(), function);
+}
+
 int GerberApertureList::addComponentMain() noexcept {
   // Note: The aperture shape, size and function is defined in the Gerber
   // specs, do not change them!
@@ -276,7 +282,7 @@ int GerberApertureList::addOutline(const QString& name, const Path& path,
                                    Function function) noexcept {
   QString s = QString("%AM%1{}*").arg(name);
   s += buildOutlineMacro(path, rot);
-  s += QString("%\n").arg(rot.toDegString());
+  s += QString("%\n");
   s += QString("%ADD{}%1{}*%\n").arg(name);
   return addAperture(s, function);
 }

--- a/libs/librepcb/core/export/gerberaperturelist.h
+++ b/libs/librepcb/core/export/gerberaperturelist.h
@@ -145,6 +145,18 @@ public:
                  Function function) noexcept;
 
   /**
+   * @brief Add a custom outline aperture
+   *
+   * @param path      The vertices.
+   * @param rot       Rotation.
+   * @param function  Function attribute.
+   *
+   * @return Aperture number.
+   */
+  int addOutline(const StraightAreaPath& path, const Angle& rot,
+                 Function function) noexcept;
+
+  /**
    * @brief Add a component main aperture (for component layers only)
    *
    * @return Aperture number.
@@ -166,11 +178,6 @@ public:
 private:  // Methods
   /**
    * @brief Add a custom outline aperture
-   *
-   * @note  This is private because it does not implement proper error handling
-   *        yet, so you could create invalid Gerber files when passing invalid
-   *        parameters! Let's implement proper error handling once we need to
-   *        make it public.
    *
    * @param name      Macro name (use only characters A..Z!).
    * @param path      The vertices. ATTENTION: After closing the path, it must

--- a/libs/librepcb/core/export/gerbergenerator.cpp
+++ b/libs/librepcb/core/export/gerbergenerator.cpp
@@ -322,6 +322,28 @@ void GerberGenerator::flashOctagon(const Point& pos, const PositiveLength& w,
   flashAtPosition(pos);
 }
 
+void GerberGenerator::flashOutline(const Point& pos,
+                                   const StraightAreaPath& path,
+                                   const Angle& rot, Function function,
+                                   const tl::optional<QString>& net,
+                                   const QString& component, const QString& pin,
+                                   const QString& signal) noexcept {
+  setCurrentAperture(mApertureList->addOutline(path, rot, function));
+  setCurrentAttributes(tl::nullopt,  // Aperture: Function
+                       net,  // Object: Net name
+                       component,  // Object: Component designator
+                       pin,  // Object: Pin number/name
+                       signal,  // Object: Pin signal
+                       QString(),  // Object: Component value
+                       tl::nullopt,  // Object: Component mount type
+                       QString(),  // Object: Component manufacturer
+                       QString(),  // Object: Component MPN
+                       QString(),  // Object: Component footprint name
+                       tl::nullopt  // Object: Component rotation
+  );
+  flashAtPosition(pos);
+}
+
 void GerberGenerator::flashComponent(const Point& pos, const Angle& rot,
                                      const QString& designator,
                                      const QString& value, MountType mountType,

--- a/libs/librepcb/core/export/gerbergenerator.h
+++ b/libs/librepcb/core/export/gerbergenerator.h
@@ -112,6 +112,10 @@ public:
                     const Angle& rot, Function function,
                     const tl::optional<QString>& net, const QString& component,
                     const QString& pin, const QString& signal) noexcept;
+  void flashOutline(const Point& pos, const StraightAreaPath& path,
+                    const Angle& rot, Function function,
+                    const tl::optional<QString>& net, const QString& component,
+                    const QString& pin, const QString& signal) noexcept;
   void flashComponent(const Point& pos, const Angle& rot,
                       const QString& designator, const QString& value,
                       MountType mountType, const QString& manufacturer,

--- a/libs/librepcb/core/geometry/padgeometry.cpp
+++ b/libs/librepcb/core/geometry/padgeometry.cpp
@@ -1,0 +1,229 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "padgeometry.h"
+
+#include "../utils/clipperhelpers.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PadGeometry::PadGeometry(const PadGeometry& other) noexcept
+  : mShape(other.mShape),
+    mBaseWidth(other.mBaseWidth),
+    mBaseHeight(other.mBaseHeight),
+    mPath(other.mPath),
+    mOffset(other.mOffset),
+    mHoles(other.mHoles) {
+}
+
+PadGeometry::PadGeometry(Shape shape, const Length& width, const Length& height,
+                         const Path& path, const Length& offset,
+                         const HoleList& holes) noexcept
+  : mShape(shape),
+    mBaseWidth(width),
+    mBaseHeight(height),
+    mPath(path),
+    mOffset(offset),
+    mHoles(holes) {
+}
+
+PadGeometry::~PadGeometry() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+QVector<Path> PadGeometry::toOutlines() const {
+  const Length w = getWidth();
+  const Length h = getHeight();
+  const UnsignedLength r = getCornerRadius();
+
+  QVector<Path> result;
+  switch (mShape) {
+    case Shape::Round: {
+      if ((w > 0) && (h > 0)) {
+        result.append(Path::obround(PositiveLength(w), PositiveLength(h)));
+      }
+      break;
+    }
+    case Shape::Rect: {
+      if ((w > 0) && (h > 0)) {
+        result.append(
+            Path::centeredRect(PositiveLength(w), PositiveLength(h), r));
+      }
+      break;
+    }
+    case Shape::Octagon: {
+      if ((w > 0) && (h > 0)) {
+        result.append(Path::octagon(PositiveLength(w), PositiveLength(h), r));
+      }
+      break;
+    }
+    case Shape::Stroke: {
+      if (w > 0) {
+        result = mPath.toOutlineStrokes(PositiveLength(w));
+        // Unite all outlines to get only a single, non-intersecting outline.
+        // Not needed if there's only one straight line segment since it
+        // cannot be self-intersecting.
+        if ((result.count() > 1) ||
+            ((result.count() == 1) &&
+             (mPath.getVertices().first().getAngle() != Angle::deg0()))) {
+          ClipperLib::Paths paths =
+              ClipperHelpers::convert(result, maxArcTolerance());
+          std::unique_ptr<ClipperLib::PolyTree> tree =
+              ClipperHelpers::uniteToTree(paths,
+                                          ClipperLib::pftNonZero);  // can throw
+          paths = ClipperHelpers::flattenTree(*tree);  // can throw
+          result = ClipperHelpers::convert(paths);
+        }
+      }
+      break;
+    }
+    default: {
+      qCritical() << "Unhandled switch-case in PadGeometry::toOutlines():"
+                  << static_cast<int>(mShape);
+      Q_ASSERT(false);
+      break;
+    }
+  }
+  return result;
+}
+
+QPainterPath PadGeometry::toQPainterPathPx() const noexcept {
+  const QPainterPath area = toFilledQPainterPathPx();
+  if (area.isEmpty()) {
+    return QPainterPath();
+  }
+
+  QPainterPath p;
+  p.setFillRule(Qt::OddEvenFill);  // Important to subtract the holes!
+  p.addPath(area);
+  p.addPath(toHolesQPainterPathPx());
+  return p;
+}
+
+QPainterPath PadGeometry::toFilledQPainterPathPx() const noexcept {
+  QPainterPath p;
+  try {
+    foreach (const Path& outline, toOutlines()) {
+      p.addPath(outline.toQPainterPathPx());
+    }
+  } catch (const Exception& e) {
+    qCritical() << "Failed to build pad painter path:" << e.getMsg();
+  }
+  return p;
+}
+
+QPainterPath PadGeometry::toHolesQPainterPathPx() const noexcept {
+  QPainterPath p;
+  p.setFillRule(Qt::WindingFill);
+  for (const Hole& hole : mHoles) {
+    for (const Path& path :
+         hole.getPath()->toOutlineStrokes(hole.getDiameter())) {
+      p.addPath(path.toQPainterPathPx());
+    }
+  }
+  return p;
+}
+
+PadGeometry PadGeometry::withOffset(const Length& offset) const noexcept {
+  return PadGeometry(mShape, mBaseWidth, mBaseHeight, mPath, mOffset + offset,
+                     mHoles);
+}
+
+PadGeometry PadGeometry::withoutHoles() const noexcept {
+  return PadGeometry(mShape, mBaseWidth, mBaseHeight, mPath, mOffset,
+                     HoleList{});
+}
+
+/*******************************************************************************
+ *  Static Methods
+ ******************************************************************************/
+
+PadGeometry PadGeometry::round(const PositiveLength& width,
+                               const PositiveLength& height,
+                               const HoleList& holes) noexcept {
+  return PadGeometry(Shape::Round, *width, *height, Path(), Length(0), holes);
+}
+
+PadGeometry PadGeometry::rect(const PositiveLength& width,
+                              const PositiveLength& height,
+                              const HoleList& holes) noexcept {
+  return PadGeometry(Shape::Rect, *width, *height, Path(), Length(0), holes);
+}
+
+PadGeometry PadGeometry::octagon(const PositiveLength& width,
+                                 const PositiveLength& height,
+                                 const HoleList& holes) noexcept {
+  return PadGeometry(Shape::Octagon, *width, *height, Path(), Length(0), holes);
+}
+
+PadGeometry PadGeometry::stroke(const PositiveLength& diameter,
+                                const NonEmptyPath& path,
+                                const HoleList& holes) noexcept {
+  return PadGeometry(Shape::Stroke, *diameter, Length(0), *path, Length(0),
+                     holes);
+}
+
+/*******************************************************************************
+ *  Operator Overloadings
+ ******************************************************************************/
+
+bool PadGeometry::operator==(const PadGeometry& rhs) const noexcept {
+  if (mShape != rhs.mShape) return false;
+  if (mBaseWidth != rhs.mBaseWidth) return false;
+  if (mBaseHeight != rhs.mBaseHeight) return false;
+  if (mPath != rhs.mPath) return false;
+  if (mOffset != rhs.mOffset) return false;
+  if (mHoles != rhs.mHoles) return false;
+  return true;
+}
+
+PadGeometry& PadGeometry::operator=(const PadGeometry& rhs) noexcept {
+  mShape = rhs.mShape;
+  mBaseWidth = rhs.mBaseWidth;
+  mBaseHeight = rhs.mBaseHeight;
+  mPath = rhs.mPath;
+  mOffset = rhs.mOffset;
+  mHoles = rhs.mHoles;
+  return *this;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/geometry/padgeometry.h
+++ b/libs/librepcb/core/geometry/padgeometry.h
@@ -1,0 +1,130 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_PADGEOMETRY_H
+#define LIBREPCB_CORE_PADGEOMETRY_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "hole.h"
+#include "path.h"
+
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class PadGeometry
+ ******************************************************************************/
+
+/**
+ * @brief The PadGeometry class describes the shape of a pad
+ */
+class PadGeometry final {
+  Q_DECLARE_TR_FUNCTIONS(PadGeometry)
+
+public:
+  // Types
+  enum class Shape {
+    Round,
+    Rect,
+    Octagon,
+    Stroke,
+  };
+
+  // Constructors / Destructor
+  PadGeometry() = delete;
+  PadGeometry(const PadGeometry& other) noexcept;
+  ~PadGeometry() noexcept;
+
+  // Getters
+  Shape getShape() const noexcept { return mShape; }
+  Length getWidth() const noexcept { return mBaseWidth + (mOffset * 2); }
+  Length getHeight() const noexcept { return mBaseHeight + (mOffset * 2); }
+  UnsignedLength getCornerRadius() const noexcept {
+    return UnsignedLength((mOffset >= 0) ? mOffset : 0);
+  }
+  const Path& getPath() const noexcept { return mPath; }
+  const HoleList& getHoles() const noexcept { return mHoles; }
+
+  // General Methods
+  QVector<Path> toOutlines() const;
+  QPainterPath toQPainterPathPx() const noexcept;
+  QPainterPath toFilledQPainterPathPx() const noexcept;
+  QPainterPath toHolesQPainterPathPx() const noexcept;
+  PadGeometry withOffset(const Length& offset) const noexcept;
+  PadGeometry withoutHoles() const noexcept;
+
+  // Static Methods
+  static PadGeometry round(const PositiveLength& width,
+                           const PositiveLength& height,
+                           const HoleList& holes) noexcept;
+  static PadGeometry rect(const PositiveLength& width,
+                          const PositiveLength& height,
+                          const HoleList& holes) noexcept;
+  static PadGeometry octagon(const PositiveLength& width,
+                             const PositiveLength& height,
+                             const HoleList& holes) noexcept;
+  static PadGeometry stroke(const PositiveLength& diameter,
+                            const NonEmptyPath& path,
+                            const HoleList& holes) noexcept;
+
+  // Operator Overloadings
+  bool operator==(const PadGeometry& rhs) const noexcept;
+  bool operator!=(const PadGeometry& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+  PadGeometry& operator=(const PadGeometry& rhs) noexcept;
+
+private:  // Methods
+  PadGeometry(Shape shape, const Length& width, const Length& height,
+              const Path& path, const Length& offset,
+              const HoleList& holes) noexcept;
+
+  /**
+   * Returns the maximum allowed arc tolerance when flattening arcs. Do not
+   * change this if you don't know exactly what you're doing (it might affect
+   * planes in existing boards)!
+   */
+  static PositiveLength maxArcTolerance() noexcept {
+    return PositiveLength(5000);
+  }
+
+private:  // Data
+  Shape mShape;
+  Length mBaseWidth;
+  Length mBaseHeight;
+  Path mPath;
+  Length mOffset;
+  HoleList mHoles;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -227,6 +227,30 @@ Path Path::reversed() const noexcept {
   return Path(*this).reverse();
 }
 
+Path& Path::flattenArcs(const PositiveLength& maxTolerance) noexcept {
+  if (!mVertices.isEmpty()) {
+    mVertices.last().setAngle(Angle::deg0());
+  }
+  for (int i = mVertices.count() - 2; i >= 0; --i) {
+    if (mVertices.at(i).getAngle() != Angle::deg0()) {
+      const Path arc =
+          flatArc(mVertices.at(i).getPos(), mVertices.at(i + 1).getPos(),
+                  mVertices.at(i).getAngle(), maxTolerance);
+      Q_ASSERT(arc.getVertices().count() >= 2);
+      mVertices.insert(i + 1, arc.getVertices().count() - 2, Vertex());
+      for (int k = 0; k < arc.getVertices().count(); ++k) {
+        mVertices[i + k] = arc.getVertices().at(k);
+      }
+    }
+  }
+  invalidatePainterPath();
+  return *this;
+}
+
+Path Path::flattenedArcs(const PositiveLength& maxTolerance) const noexcept {
+  return Path(*this).flattenArcs(maxTolerance);
+}
+
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -94,6 +94,8 @@ public:
                 const Point& center = Point(0, 0)) const noexcept;
   Path& reverse() noexcept;
   Path reversed() const noexcept;
+  Path& flattenArcs(const PositiveLength& maxTolerance) noexcept;
+  Path flattenedArcs(const PositiveLength& maxTolerance) const noexcept;
 
   // General Methods
   void addVertex(const Vertex& vertex) noexcept;

--- a/libs/librepcb/core/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpad.cpp
@@ -176,41 +176,20 @@ bool FootprintPad::isOnLayer(const QString& name) const noexcept {
   }
 }
 
-Path FootprintPad::getOutline(const Length& expansion) const noexcept {
-  const Length width = mWidth + (expansion * 2);
-  const Length height = mHeight + (expansion * 2);
-  if (width > 0 && height > 0) {
-    const PositiveLength pWidth(width);
-    const PositiveLength pHeight(height);
-    const UnsignedLength cornerRadius(std::max(expansion, Length(0)));
-    switch (mShape) {
-      case Shape::ROUND:
-        return Path::obround(pWidth, pHeight);
-      case Shape::RECT:
-        return Path::centeredRect(pWidth, pHeight, cornerRadius);
-      case Shape::OCTAGON:
-        return Path::octagon(pWidth, pHeight, cornerRadius);
-      default:
-        Q_ASSERT(false);
-        break;
-    }
+PadGeometry FootprintPad::getGeometry() const noexcept {
+  switch (mShape) {
+    case Shape::ROUND:
+      return PadGeometry::round(mWidth, mHeight, mHoles);
+    case Shape::RECT:
+      return PadGeometry::rect(mWidth, mHeight, mHoles);
+    case Shape::OCTAGON:
+      return PadGeometry::octagon(mWidth, mHeight, mHoles);
+    default:
+      qCritical() << "Unhandled switch-case in FootprintPad::getGeometry():"
+                  << static_cast<int>(mShape);
+      Q_ASSERT(false);
+      return PadGeometry::round(mWidth, mHeight, mHoles);
   }
-  return Path();
-}
-
-QPainterPath FootprintPad::toQPainterPathPx(const Length& expansion) const
-    noexcept {
-  QPainterPath holesArea;
-  for (const Hole& h : mHoles) {
-    for (const Path& p : h.getPath()->toOutlineStrokes(h.getDiameter())) {
-      holesArea.addPath(p.toQPainterPathPx());
-    }
-  }
-
-  QPainterPath p = getOutline(expansion).toQPainterPathPx();
-  p.setFillRule(Qt::OddEvenFill);  // Important to subtract the holes!
-  p.addPath(holesArea);
-  return p;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/footprintpad.h
+++ b/libs/librepcb/core/library/pkg/footprintpad.h
@@ -25,6 +25,7 @@
  ******************************************************************************/
 #include "../../exceptions.h"
 #include "../../geometry/hole.h"
+#include "../../geometry/padgeometry.h"
 #include "../../geometry/path.h"
 #include "../../serialization/serializableobjectlist.h"
 #include "../../types/angle.h"
@@ -96,9 +97,7 @@ public:
   QString getLayerName() const noexcept;
   bool isTht() const noexcept;
   bool isOnLayer(const QString& name) const noexcept;
-  Path getOutline(const Length& expansion = Length(0)) const noexcept;
-  QPainterPath toQPainterPathPx(const Length& expansion = Length(0)) const
-      noexcept;
+  PadGeometry getGeometry() const noexcept;
 
   // Setters
   bool setPackagePadUuid(const tl::optional<Uuid>& pad) noexcept;

--- a/libs/librepcb/core/library/pkg/footprintpainter.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpainter.cpp
@@ -156,7 +156,8 @@ void FootprintPainter::initContentByLayer() const noexcept {
     // Footprint pads.
     foreach (FootprintPad pad, mPads) {
       const Transform transform(pad.getPosition(), pad.getRotation());
-      const QPainterPath path = transform.mapPx(pad.toQPainterPathPx());
+      const QPainterPath path =
+          transform.mapPx(pad.getGeometry().toQPainterPathPx());
       const QString layer = pad.getLayerName();
       mContentByLayer[layer].areas.append(path);
 

--- a/libs/librepcb/core/library/pkg/msg/msgpadoriginoutsidecopper.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadoriginoutsidecopper.cpp
@@ -17,62 +17,43 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
-
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "msgpadoriginoutsidecopper.h"
 
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
-
 /*******************************************************************************
- *  Class PackageCheck
+ *  Constructors / Destructor
  ******************************************************************************/
 
-/**
- * @brief The PackageCheck class
- */
-class PackageCheck : public LibraryElementCheck {
-public:
-  // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+MsgPadOriginOutsideCopper::MsgPadOriginOutsideCopper(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        tr("Invalid origin of pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("The origin of each pad must be located within its copper area, "
+           "otherwise traces won't be connected properly.\n\n"
+           "For THT pads, the origin must be located within a drill "
+           "hole since on some layers the pad might only have a small annular "
+           "ring instead of the full pad shape.")),
+    mFootprint(footprint),
+    mPad(pad) {
+}
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
-
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsAnnularRing(MsgList& msgs) const;
-  void checkPadsConnectionPoint(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
-};
+MsgPadOriginOutsideCopper::~MsgPadOriginOutsideCopper() noexcept {
+}
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
 }  // namespace librepcb
-
-#endif

--- a/libs/librepcb/core/library/pkg/msg/msgpadoriginoutsidecopper.h
+++ b/libs/librepcb/core/library/pkg/msg/msgpadoriginoutsidecopper.h
@@ -17,13 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
+#ifndef LIBREPCB_CORE_MSGPADORIGINOUTSIDECOPPER_H
+#define LIBREPCB_CORE_MSGPADORIGINOUTSIDECOPPER_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "../../../types/length.h"
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
@@ -32,41 +33,41 @@
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
+class Footprint;
+class FootprintPad;
+class Hole;
 
 /*******************************************************************************
- *  Class PackageCheck
+ *  Class MsgPadOriginOutsideCopper
  ******************************************************************************/
 
 /**
- * @brief The PackageCheck class
+ * @brief The MsgPadOriginOutsideCopper class
  */
-class PackageCheck : public LibraryElementCheck {
+class MsgPadOriginOutsideCopper final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadOriginOutsideCopper)
+
 public:
   // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+  MsgPadOriginOutsideCopper() = delete;
+  MsgPadOriginOutsideCopper(std::shared_ptr<const Footprint> footprint,
+                            std::shared_ptr<const FootprintPad> pad,
+                            const QString& pkgPadName) noexcept;
+  MsgPadOriginOutsideCopper(const MsgPadOriginOutsideCopper& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mPad(other.mPad) {}
+  virtual ~MsgPadOriginOutsideCopper() noexcept;
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
 
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsAnnularRing(MsgList& msgs) const;
-  void checkPadsConnectionPoint(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheck.cpp
@@ -24,6 +24,7 @@
 
 #include "../../graphics/graphicslayer.h"
 #include "../../utils/toolbox.h"
+#include "../../utils/transform.h"
 #include "msg/msgduplicatepadname.h"
 #include "msg/msgmissingfootprint.h"
 #include "msg/msgmissingfootprintname.h"
@@ -141,9 +142,11 @@ void PackageCheck::checkPadsClearanceToPads(MsgList& msgs) const {
       std::shared_ptr<const PackagePad> pkgPad1 = pad1->getPackagePadUuid()
           ? mPackage.getPads().find(*pad1->getPackagePadUuid())
           : nullptr;
-      Path pad1Path = pad1->getOutline(clearance - tolerance);
-      pad1Path.rotate(pad1->getRotation()).translate(pad1->getPosition());
-      const QPainterPath pad1PathPx = pad1Path.toQPainterPathPx();
+      const Transform pad1Transform(pad1->getPosition(), pad1->getRotation());
+      const QPainterPath pad1PathPx =
+          pad1Transform.mapPx(pad1->getGeometry()
+                                  .withOffset(clearance - tolerance)
+                                  .toFilledQPainterPathPx());
 
       // Compare with all pads *after* pad1 to avoid duplicate messages!
       // So, don't initialize the iterator with begin() but with pad1 + 1.
@@ -153,9 +156,9 @@ void PackageCheck::checkPadsClearanceToPads(MsgList& msgs) const {
         std::shared_ptr<const PackagePad> pkgPad2 = pad2->getPackagePadUuid()
             ? mPackage.getPads().find(*pad2->getPackagePadUuid())
             : nullptr;
-        Path pad2Path = pad2->getOutline();
-        pad2Path.rotate(pad2->getRotation()).translate(pad2->getPosition());
-        const QPainterPath pad2PathPx = pad2Path.toQPainterPathPx();
+        const Transform pad2Transform(pad2->getPosition(), pad2->getRotation());
+        const QPainterPath pad2PathPx =
+            pad2Transform.mapPx(pad2->getGeometry().toFilledQPainterPathPx());
 
         // Only warn if both pads have copper on the same board side.
         if ((pad1->getComponentSide() == pad2->getComponentSide()) ||
@@ -212,9 +215,11 @@ void PackageCheck::checkPadsClearanceToPlacement(MsgList& msgs) const {
           : nullptr;
       Length clearance(150000);  // 150 µm
       Length tolerance(10);  // 0.01 µm, to avoid rounding issues
-      Path stopMaskPath = pad->getOutline(clearance - tolerance);
-      stopMaskPath.rotate(pad->getRotation()).translate(pad->getPosition());
-      QPainterPath stopMask = stopMaskPath.toQPainterPathPx();
+      const Transform transform(pad->getPosition(), pad->getRotation());
+      const QPainterPath stopMask =
+          transform.mapPx(pad->getGeometry()
+                              .withOffset(clearance - tolerance)
+                              .toFilledQPainterPathPx());
       if (pad->isOnLayer(GraphicsLayer::sTopCopper) &&
           stopMask.intersects(topPlacement)) {
         msgs.append(std::make_shared<MsgPadOverlapsWithPlacement>(
@@ -246,7 +251,8 @@ void PackageCheck::checkPadsAnnularRing(MsgList& msgs) const {
       std::shared_ptr<const PackagePad> pkgPad = pad->getPackagePadUuid()
           ? mPackage.getPads().find(*pad->getPackagePadUuid())
           : nullptr;
-      const QPainterPath padPathPx = pad->getOutline().toQPainterPathPx();
+      const QPainterPath padPathPx =
+          pad->getGeometry().toFilledQPainterPathPx();
 
       // Check all holes.
       bool emitWarning = false;

--- a/libs/librepcb/core/project/board/boarddesignrules.h
+++ b/libs/librepcb/core/project/board/boarddesignrules.h
@@ -78,6 +78,12 @@ public:
   }
 
   // Getters: Pad Annular Ring
+  bool getPadCmpSideAutoAnnularRing() const noexcept {
+    return mPadCmpSideAutoAnnularRing;
+  }
+  bool getPadInnerAutoAnnularRing() const noexcept {
+    return mPadInnerAutoAnnularRing;
+  }
   const UnsignedRatio& getPadAnnularRingRatio() const noexcept {
     return mPadAnnularRingRatio;
   }
@@ -109,6 +115,8 @@ public:
   void setSolderPasteClearance(const UnsignedRatio& ratio,
                                const UnsignedLength& min,
                                const UnsignedLength& max);
+  void setPadCmpSideAutoAnnularRing(bool enabled) noexcept;
+  void setPadInnerAutoAnnularRing(bool enabled) noexcept;
   void setPadAnnularRing(const UnsignedRatio& ratio, const UnsignedLength& min,
                          const UnsignedLength& max);
   void setViaAnnularRing(const UnsignedRatio& ratio, const UnsignedLength& min,
@@ -134,7 +142,10 @@ public:
   // Operator Overloadings
   BoardDesignRules& operator=(const BoardDesignRules& rhs) noexcept;
 
-private:
+private:  // Methods
+  static bool parsePadAutoAnnular(const SExpression& node);
+
+private:  // Data
   // Stop Mask
   UnsignedLength mStopMaskMaxViaDrillDiameter;
   UnsignedRatio mStopMaskClearanceRatio;
@@ -147,6 +158,8 @@ private:
   UnsignedLength mSolderPasteClearanceMax;
 
   // Pad Annular Ring
+  bool mPadCmpSideAutoAnnularRing;
+  bool mPadInnerAutoAnnularRing;
   UnsignedRatio mPadAnnularRingRatio;  /// Percentage of the drill diameter
   UnsignedLength mPadAnnularRingMin;
   UnsignedLength mPadAnnularRingMax;

--- a/libs/librepcb/core/project/board/boardpainter.h
+++ b/libs/librepcb/core/project/board/boardpainter.h
@@ -25,6 +25,7 @@
  ******************************************************************************/
 #include "../../export/graphicsexport.h"
 #include "../../graphics/graphicslayername.h"
+#include "../../library/pkg/footprintpad.h"
 #include "../../types/length.h"
 #include "../../utils/transform.h"
 
@@ -38,7 +39,6 @@ namespace librepcb {
 
 class Board;
 class Circle;
-class FootprintPad;
 class Hole;
 class Path;
 class Polygon;
@@ -64,9 +64,15 @@ class BoardPainter final : public GraphicsPagePainter {
     PositiveLength width;
   };
 
+  struct Pad {
+    Transform transform;
+    QList<std::pair<QString, PadGeometry>> layerGeometries;
+    QList<Hole> holes;
+  };
+
   struct Footprint {
     Transform transform;
-    QList<FootprintPad> pads;
+    QList<Pad> pads;
     QList<Polygon> polygons;
     QList<Circle> circles;
     QList<Hole> holes;
@@ -79,6 +85,7 @@ class BoardPainter final : public GraphicsPagePainter {
 
   struct LayerContent {
     QList<QPainterPath> areas;
+    QList<QPainterPath> thtPadAreas;  ///< Drawn on GraphicsLayer::sBoardPadsTht
     QList<Trace> traces;
     QList<Polygon> polygons;
     QList<Circle> circles;

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -37,6 +37,7 @@ namespace librepcb {
 class BI_FootprintPad;
 class BI_Plane;
 class BI_Via;
+class Transform;
 
 /*******************************************************************************
  *  Class BoardPlaneFragmentsBuilder
@@ -69,7 +70,9 @@ private:  // Methods
   void removeOrphans();
 
   // Helper Methods
-  ClipperLib::Path createPadCutOut(const BI_FootprintPad& pad) const noexcept;
+  ClipperLib::Paths createPadCutOuts(const Transform& deviceTransform,
+                                     const Transform& padTransform,
+                                     const BI_FootprintPad& pad) const;
   ClipperLib::Path createViaCutOut(const BI_Via& via) const noexcept;
 
   /**

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -270,11 +270,17 @@ void BoardClipperPathGenerator::addCopper(
           (!netsignals.contains(pad->getCompSigInstNetSignal()))) {
         continue;
       }
-      Transform transform(*pad);
-      ClipperHelpers::unite(
-          mPaths,
-          ClipperHelpers::convert(transform.map(pad->getOutline()),
-                                  mMaxArcTolerance));
+      const Transform padTransform(pad->getLibPad().getPosition(),
+                                   pad->getLibPad().getRotation());
+      foreach (const PadGeometry& geometry,
+               pad->getGeometryOnLayer(layerName)) {
+        foreach (const Path& outline, geometry.toOutlines()) {
+          ClipperHelpers::unite(
+              mPaths,
+              ClipperHelpers::convert(transform.map(padTransform.map(outline)),
+                                      mMaxArcTolerance));
+        }
+      }
     }
   }
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -99,6 +99,8 @@ public:
     bool checkCourtyardClearance;
     Length courtyardOffset;
 
+    bool checkBrokenPadConnections;
+
     bool checkMissingConnections;
 
     Options()
@@ -127,6 +129,7 @@ public:
         pthSlotsWarning(SlotsWarningLevel::MultiSegment),
         checkCourtyardClearance(true),
         courtyardOffset(0),  // 0um
+        checkBrokenPadConnections(true),
         checkMissingConnections(true) {}
   };
 
@@ -167,6 +170,7 @@ private:  // Methods
   void checkMinimumPthSlotWidth(int progressStart, int progressEnd);
   void checkWarnNpthSlots(int progressStart, int progressEnd);
   void checkWarnPthSlots(int progressStart, int progressEnd);
+  void checkInvalidPadConnections(int progressStart, int progressEnd);
   void processHoleSlotWarning(const Hole& hole, SlotsWarningLevel level,
                               const Transform& transform1 = Transform(),
                               const Transform& transform2 = Transform());

--- a/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.h
+++ b/libs/librepcb/core/project/board/graphicsitems/bgi_footprintpad.h
@@ -69,7 +69,8 @@ public:
   BGI_FootprintPad& operator=(const BGI_FootprintPad& rhs) = delete;
 
 private:  // Methods
-  GraphicsLayer* getLayer(QString name) const noexcept;
+  GraphicsLayer* getLayer(const QString& name) const noexcept;
+  QSet<GraphicsLayer*> getAllInvolvedLayers() const noexcept;
   void connectLayerEditedSlots() noexcept;
   void disconnectLayerEditedSlots() noexcept;
   void layerEdited(const GraphicsLayer& layer,
@@ -77,20 +78,20 @@ private:  // Methods
   void updateVisibility() noexcept;
 
 private:  // Data
+  struct LayerContent {
+    GraphicsLayer* visibilityLayer;
+    GraphicsLayer* drawLayer;
+    QPainterPath path;
+  };
+
   // General Attributes
   BI_FootprintPad& mPad;
   const FootprintPad& mLibPad;
 
   // Cached Attributes
-  GraphicsLayer* mPadLayer;
-  GraphicsLayer* mTopStopMaskLayer;
-  GraphicsLayer* mBottomStopMaskLayer;
-  GraphicsLayer* mTopSolderPasteLayer;
-  GraphicsLayer* mBottomSolderPasteLayer;
+  GraphicsLayer* mCopperLayer;
+  QVector<LayerContent> mContents;
   QPainterPath mShape;
-  QPainterPath mCopper;
-  QPainterPath mStopMask;
-  QPainterPath mSolderPaste;
   QRectF mBoundingRect;
   QFont mFont;
 

--- a/libs/librepcb/core/project/board/items/bi_footprintpad.h
+++ b/libs/librepcb/core/project/board/items/bi_footprintpad.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../../geometry/path.h"
+#include "../../../library/pkg/footprintpad.h"
 #include "../graphicsitems/bgi_footprintpad.h"
 #include "./bi_netline.h"
 #include "bi_base.h"
@@ -38,7 +39,6 @@ namespace librepcb {
 class BI_Device;
 class ComponentSignal;
 class ComponentSignalInstance;
-class FootprintPad;
 
 /*******************************************************************************
  *  Class BI_FootprintPad
@@ -83,6 +83,7 @@ public:
   const Uuid& getLibPadUuid() const noexcept;
   QString getDisplayText() const noexcept;
   BI_Device& getDevice() const noexcept { return mDevice; }
+  FootprintPad::ComponentSide getComponentSide() const noexcept;
   QString getLayerName() const noexcept;
   bool isOnLayer(const QString& layerName) const noexcept;
   const FootprintPad& getLibPad() const noexcept { return *mFootprintPad; }
@@ -93,8 +94,7 @@ public:
   NetSignal* getCompSigInstNetSignal() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
   bool isSelectable() const noexcept override;
-  Path getOutline(const Length& expansion = Length(0)) const noexcept;
-  Path getSceneOutline(const Length& expansion = Length(0)) const noexcept;
+  QList<PadGeometry> getGeometryOnLayer(const QString& layer) const noexcept;
   TraceAnchor toTraceAnchor() const noexcept override;
 
   // General Methods
@@ -126,6 +126,8 @@ private:  // Methods
   QString getComponentInstanceName() const noexcept;
   QString getPadNameOrUuid() const noexcept;
   QString getNetSignalName() const noexcept;
+  QList<PadGeometry> getGeometryOnCopperLayer(const QString& layer) const
+      noexcept;
 
 private:  // Data
   BI_Device& mDevice;

--- a/libs/librepcb/core/project/board/items/bi_footprintpad.h
+++ b/libs/librepcb/core/project/board/items/bi_footprintpad.h
@@ -128,6 +128,7 @@ private:  // Methods
   QString getNetSignalName() const noexcept;
   QList<PadGeometry> getGeometryOnCopperLayer(const QString& layer) const
       noexcept;
+  bool isConnectedOnLayer(const QString& layer) const noexcept;
 
 private:  // Data
   BI_Device& mDevice;

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -98,7 +98,11 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                QList<Message>& messages) {
   Q_UNUSED(root);
   Q_UNUSED(messages);
-  upgradeBoardDesignRules(root);
+  {
+    SExpression& child = root.getChild("design_rules/pad_annular_ring");
+    child.appendChild("outer", SExpression::createToken("full"));
+    child.appendChild("inner", SExpression::createToken("full"));
+  }
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -488,6 +488,11 @@ void FileFormatMigrationV01::upgradeBoardDesignRules(SExpression& root) {
       node.removeChild(oldChild);
     }
   }
+  {
+    SExpression& child = node.getChild("pad_annular_ring");
+    child.appendChild("outer", SExpression::createToken("full"));
+    child.appendChild("inner", SExpression::createToken("full"));
+  }
 }
 
 void FileFormatMigrationV01::upgradeGrid(SExpression& node) {

--- a/libs/librepcb/core/utils/clipperhelpers.h
+++ b/libs/librepcb/core/utils/clipperhelpers.h
@@ -52,9 +52,12 @@ public:
   ~ClipperHelpers() = delete;
 
   // General Methods
-  static void unite(ClipperLib::Paths& paths);
+  static void unite(ClipperLib::Paths& paths,
+                    ClipperLib::PolyFillType fillType);
   static void unite(ClipperLib::Paths& subject, const ClipperLib::Path& clip);
   static void unite(ClipperLib::Paths& subject, const ClipperLib::Paths& clip);
+  static std::unique_ptr<ClipperLib::PolyTree> uniteToTree(
+      const ClipperLib::Paths& paths, ClipperLib::PolyFillType fillType);
   static std::unique_ptr<ClipperLib::PolyTree> intersect(
       const ClipperLib::Paths& subject, const ClipperLib::Paths& clip);
   static std::unique_ptr<ClipperLib::PolyTree> intersect(

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -71,7 +71,7 @@ FootprintPadGraphicsItem::FootprintPadGraphicsItem(
   // pad properties
   setPosition(mPad->getPosition());
   setRotation(mPad->getRotation());
-  setShape(mPad->toQPainterPathPx());
+  setShape(mPad->getGeometry().toQPainterPathPx());
   setLayerName(mPad->getLayerName());
   updateText();
 
@@ -156,14 +156,14 @@ void FootprintPadGraphicsItem::padEdited(const FootprintPad& pad,
     case FootprintPad::Event::ShapeChanged:
     case FootprintPad::Event::WidthChanged:
     case FootprintPad::Event::HeightChanged:
-      setShape(pad.toQPainterPathPx());
+      setShape(pad.getGeometry().toQPainterPathPx());
       break;
     case FootprintPad::Event::ComponentSideChanged:
       setLayerName(pad.getLayerName());
       break;
     case FootprintPad::Event::HolesEdited:
       setLayerName(pad.getLayerName());
-      setShape(pad.toQPainterPathPx());
+      setShape(pad.getGeometry().toQPainterPathPx());
       break;
     default:
       qWarning()

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.cpp
@@ -109,6 +109,7 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
     mUi->cbxWarnNpthSlots->setChecked(checked);
     mUi->cbxWarnPthSlots->setChecked(checked);
     mUi->cbxCourtyardOffset->setChecked(checked);
+    mUi->cbxBrokenPadConnections->setChecked(checked);
     mUi->cbxMissingConnections->setChecked(checked);
   });
 
@@ -142,6 +143,7 @@ BoardDesignRuleCheckDialog::BoardDesignRuleCheckDialog(
           QVariant::fromValue(options.pthSlotsWarning)));
   mUi->cbxCourtyardOffset->setChecked(options.checkCourtyardClearance);
   mUi->edtCourtyardOffset->setValue(options.courtyardOffset);
+  mUi->cbxBrokenPadConnections->setChecked(options.checkBrokenPadConnections);
   mUi->cbxMissingConnections->setChecked(options.checkMissingConnections);
 
   // Load the window geometry.
@@ -193,6 +195,7 @@ BoardDesignRuleCheck::Options BoardDesignRuleCheckDialog::getOptions() const
           .value<BoardDesignRuleCheck::SlotsWarningLevel>();
   options.checkCourtyardClearance = mUi->cbxCourtyardOffset->isChecked();
   options.courtyardOffset = mUi->edtCourtyardOffset->getValue();
+  options.checkBrokenPadConnections = mUi->cbxBrokenPadConnections->isChecked();
   options.checkMissingConnections = mUi->cbxMissingConnections->isChecked();
   return options;
 }

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulecheckdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>778</width>
-    <height>594</height>
+    <height>643</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -177,7 +177,7 @@
         <item row="13" column="1">
          <widget class="librepcb::editor::LengthEdit" name="edtCourtyardOffset" native="true"/>
         </item>
-        <item row="14" column="0">
+        <item row="15" column="0">
          <widget class="QCheckBox" name="cbxMissingConnections">
           <property name="text">
            <string>Check for missing connections</string>
@@ -187,7 +187,7 @@
           </property>
          </widget>
         </item>
-        <item row="15" column="0">
+        <item row="16" column="0">
          <widget class="QPushButton" name="btnSelectAll">
           <property name="text">
            <string>Select All/None</string>
@@ -203,7 +203,7 @@
           </property>
          </widget>
         </item>
-        <item row="16" column="0">
+        <item row="17" column="0">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -216,7 +216,7 @@
           </property>
          </spacer>
         </item>
-        <item row="17" column="0" colspan="2">
+        <item row="18" column="0" colspan="2">
          <widget class="QProgressBar" name="prgProgress">
           <property name="value">
            <number>0</number>
@@ -233,6 +233,9 @@
          <widget class="QCheckBox" name="cbxMinNpthSlotWidth">
           <property name="text">
            <string>Minimum NPTH Slot Width:</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -266,6 +269,16 @@
          <widget class="QComboBox" name="cbxWarnPthSlotsConfig">
           <property name="insertPolicy">
            <enum>QComboBox::NoInsert</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="14" column="0">
+         <widget class="QCheckBox" name="cbxBrokenPadConnections">
+          <property name="text">
+           <string>Check for invalid pad connections</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.cpp
@@ -74,6 +74,30 @@ BoardDesignRulesDialog::BoardDesignRulesDialog(const BoardDesignRules& rules,
       lengthUnit, LengthEditBase::Steps::generic(),
       settingsPrefix % "/via_annular_ring_max");
 
+  // Add tooltips for annular rings.
+  for (auto rbtn : {mUi->rbtnCmpSidePadFullShape, mUi->rbtnInnerPadFullShape}) {
+    rbtn->setToolTip(
+        tr("<p>Always use the full pad shape as defined in the footprint from "
+           "the library.</p><p>This is the safer and thus preferred option, "
+           "but requires more space for the pads.</p>"));
+  }
+  for (auto rbtn :
+       {mUi->rbtnCmpSidePadAutoAnnular, mUi->rbtnInnerPadAutoAnnular}) {
+    rbtn->setToolTip(
+        tr("<p>Don't use the defined pad shape, but automatic annular rings "
+           "calculated by the parameters below. The annular ring of "
+           "unconnected pads is reduced to the specified mimimum value.</p>"
+           "<p>This option is more space-efficient, but works only reliable "
+           "if the entered parameters comply with the PCB manufacturers "
+           "capabilities.</p>"));
+  }
+
+  // Show warning only when relevant.
+  mUi->lblCmpSidePadWarning->setVisible(
+      mUi->rbtnCmpSidePadAutoAnnular->isChecked());
+  connect(mUi->rbtnCmpSidePadAutoAnnular, &QRadioButton::toggled,
+          mUi->lblCmpSidePadWarning, &QLabel::setVisible);
+
   updateWidgets();
 }
 
@@ -123,6 +147,16 @@ void BoardDesignRulesDialog::updateWidgets() noexcept {
   mUi->edtSolderPasteClrMax->setValue(
       mDesignRules.getSolderPasteClearanceMax());
   // pad annular ring
+  if (mDesignRules.getPadCmpSideAutoAnnularRing()) {
+    mUi->rbtnCmpSidePadAutoAnnular->setChecked(true);
+  } else {
+    mUi->rbtnCmpSidePadFullShape->setChecked(true);
+  }
+  if (mDesignRules.getPadInnerAutoAnnularRing()) {
+    mUi->rbtnInnerPadAutoAnnular->setChecked(true);
+  } else {
+    mUi->rbtnInnerPadFullShape->setChecked(true);
+  }
   mUi->edtPadAnnularRingRatio->setValue(mDesignRules.getPadAnnularRingRatio());
   mUi->edtPadAnnularRingMin->setValue(mDesignRules.getPadAnnularRingMin());
   mUi->edtPadAnnularRingMax->setValue(mDesignRules.getPadAnnularRingMax());
@@ -144,6 +178,10 @@ void BoardDesignRulesDialog::applyRules() noexcept {
         mUi->edtSolderPasteClrRatio->getValue(),
         mUi->edtSolderPasteClrMin->getValue(),
         mUi->edtSolderPasteClrMax->getValue());  // can throw
+    mDesignRules.setPadCmpSideAutoAnnularRing(
+        mUi->rbtnCmpSidePadAutoAnnular->isChecked());
+    mDesignRules.setPadInnerAutoAnnularRing(
+        mUi->rbtnInnerPadAutoAnnular->isChecked());
     mDesignRules.setPadAnnularRing(
         mUi->edtPadAnnularRingRatio->getValue(),
         mUi->edtPadAnnularRingMin->getValue(),

--- a/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boarddesignrulesdialog.ui
@@ -6,28 +6,50 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>579</width>
-    <height>188</height>
+    <width>613</width>
+    <height>252</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Board Design Rules</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtPadAnnularRingMax" native="true"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="0" column="2">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Stop Mask Clearance:</string>
+      <string>Ratio (% of diam.)</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_8">
+   <item row="6" column="2">
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtPadAnnularRingRatio" native="true"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Solder Paste Clearance:</string>
+      <string>Inner Layer Pads:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtSolderPasteClrMin" native="true"/>
+   </item>
+   <item row="2" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMax" native="true"/>
+   </item>
+   <item row="7" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtViaAnnularRingMax" native="true"/>
+   </item>
+   <item row="7" column="2">
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtViaAnnularRingRatio" native="true"/>
+   </item>
+   <item row="8" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
      </property>
     </widget>
    </item>
@@ -38,47 +60,31 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="label_5">
+   <item row="6" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtPadAnnularRingMax" native="true"/>
+   </item>
+   <item row="1" column="3">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskMaxViaDia" native="true"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtPadAnnularRingMin" native="true"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>Ratio (% of diam.)</string>
+      <string>Solder Paste Clearance:</string>
      </property>
     </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtStopMaskClrRatio" native="true"/>
-   </item>
-   <item row="5" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtViaAnnularRingRatio" native="true"/>
-   </item>
-   <item row="5" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtViaAnnularRingMin" native="true"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Pads Annular Ring:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMax" native="true"/>
    </item>
    <item row="3" column="3">
     <widget class="librepcb::editor::UnsignedLengthEdit" name="edtSolderPasteClrMax" native="true"/>
    </item>
-   <item row="6" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Vias Annular Ring:</string>
      </property>
     </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskMaxViaDia" native="true"/>
    </item>
    <item row="0" column="3">
     <widget class="QLabel" name="label_9">
@@ -87,15 +93,11 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Vias Annular Ring:</string>
-     </property>
-    </widget>
+   <item row="3" column="2">
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtSolderPasteClrRatio" native="true"/>
    </item>
-   <item row="5" column="3">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtViaAnnularRingMax" native="true"/>
+   <item row="2" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMin" native="true"/>
    </item>
    <item row="0" column="1">
     <widget class="QLabel" name="label_4">
@@ -104,20 +106,133 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtPadAnnularRingMin" native="true"/>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Stop Mask Clearance:</string>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtSolderPasteClrMin" native="true"/>
+   <item row="2" column="2">
+    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtStopMaskClrRatio" native="true"/>
    </item>
-   <item row="3" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtSolderPasteClrRatio" native="true"/>
+   <item row="7" column="1">
+    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtViaAnnularRingMin" native="true"/>
    </item>
-   <item row="2" column="1">
-    <widget class="librepcb::editor::UnsignedLengthEdit" name="edtStopMaskClrMin" native="true"/>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Autom. Pads Annular Ring:</string>
+     </property>
+    </widget>
    </item>
-   <item row="4" column="2">
-    <widget class="librepcb::editor::UnsignedRatioEdit" name="edtPadAnnularRingRatio" native="true"/>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Component Side Pads:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QRadioButton" name="rbtnCmpSidePadFullShape">
+       <property name="text">
+        <string>Full Shape</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">rbtnGroupCmpSidePadShape</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbtnCmpSidePadAutoAnnular">
+       <property name="text">
+        <string>Automatic Annular Ring</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">rbtnGroupCmpSidePadShape</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblCmpSidePadWarning">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>&lt;b&gt;Use with caution!&lt;/b&gt; If automatic annular rings are enabled for component-side pads, make sure all pads have set the 'component side' property to the correct value. With a wrong configuration, soldering may not be possible due to too small pad area.</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="pixmap">
+        <pixmap>:/img/status/dialog_warning.png</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="1" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1">
+     <item>
+      <widget class="QRadioButton" name="rbtnInnerPadFullShape">
+       <property name="text">
+        <string>Full Shape</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">rbtnGroupInnerPadShape</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbtnInnerPadAutoAnnular">
+       <property name="text">
+        <string>Automatic Annular Ring</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">rbtnGroupInnerPadShape</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -185,4 +300,8 @@
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="rbtnGroupCmpSidePadShape"/>
+  <buttongroup name="rbtnGroupInnerPadShape"/>
+ </buttongroups>
 </ui>

--- a/tests/unittests/core/export/gerberaperturelisttest.cpp
+++ b/tests/unittests/core/export/gerberaperturelisttest.cpp
@@ -1006,6 +1006,37 @@ TEST_F(GerberApertureListTest, testWideOctagon100deg) {
   }
 }
 
+// Test if outline apertures with rotations of -350° and 10° are exported as
+// the same aperture macro.
+TEST_F(GerberApertureListTest, testOutline10deg) {
+  GerberApertureList l;
+  StraightAreaPath p(Path({
+      Vertex(Point(-100000, 100000)),
+      Vertex(Point(500000, 700000)),
+      Vertex(Point(-500000, 700000)),
+      Vertex(Point(-100000, 100000)),
+  }));
+  QVector<Angle> rotations = {
+      Angle(-350000000),
+      Angle(10000000),
+  };
+
+  const char* expected =
+      "%AMOUTLINE10*"
+      "4,1,3,"
+      "-0.1,0.1,"
+      "0.5,0.7,"
+      "-0.5,0.7,"
+      "-0.1,0.1,"
+      "10.0*%\n"
+      "%ADD10OUTLINE10*%\n";
+
+  for (const Angle& rot : rotations) {
+    EXPECT_EQ(10, l.addOutline(p, rot, tl::nullopt));
+    EXPECT_EQ(expected, l.generateString().toStdString());
+  }
+}
+
 TEST_F(GerberApertureListTest, testComponentMain) {
   GerberApertureList l;
 

--- a/tests/unittests/core/export/gerbergeneratortest.cpp
+++ b/tests/unittests/core/export/gerbergeneratortest.cpp
@@ -158,6 +158,15 @@ protected:
                                    UnsignedLength(20000), rot, function, net,
                                    component, pin, signal);
 
+                  gen.flashOutline(Point(100, 200),
+                                   StraightAreaPath(Path({
+                                       Vertex(Point(-100, -100)),
+                                       Vertex(Point(100, -100)),
+                                       Vertex(Point(0, 100)),
+                                       Vertex(Point(-100, -100)),
+                                   })),
+                                   rot, function, net, component, pin, signal);
+
                   gen.flashComponent(Point(100, 200), rot, component, "",
                                      GerberGenerator::MountType::Tht, "", "",
                                      "");

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -151,6 +151,90 @@ TEST_F(PathTest, testReversed) {
   EXPECT_EQ(str(expected), str(actual));
 }
 
+TEST_F(PathTest, testFlattenArcsEmptyPath) {
+  Path input = Path();
+  const Path expected = Path();
+  const Path actual = input.flattenArcs(PositiveLength(1));
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_EQ(str(expected), str(input));
+}
+
+TEST_F(PathTest, testFlattenArcsOneVertex) {
+  Path input = Path({Vertex(Point(10, 20), Angle::deg180())});
+  const Path expected = Path({Vertex(Point(10, 20), Angle::deg0())});
+  const Path actual = input.flattenArcs(PositiveLength(1));
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_EQ(str(expected), str(input));
+}
+
+TEST_F(PathTest, testFlattenArcsTwoVerticesArc) {
+  Path input = Path({
+      Vertex(Point(1000, 2000), Angle::deg180()),
+      Vertex(Point(1000, 3000), Angle::deg180()),
+  });
+  const Path expected = Path({
+      Vertex(Point(1000, 2000), Angle::deg0()),
+      Vertex(Point(1433, 2250), Angle::deg0()),
+      Vertex(Point(1433, 2750), Angle::deg0()),
+      Vertex(Point(1000, 3000), Angle::deg0()),
+  });
+  const Path actual = input.flattenArcs(PositiveLength(600));
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_EQ(str(expected), str(input));
+}
+
+TEST_F(PathTest, testFlattenArcsMultipleVertices) {
+  Path input = Path({
+      Vertex(Point(1000, 1000), Angle::deg180()),
+      Vertex(Point(1000, 2000), Angle::deg0()),
+      Vertex(Point(1000, 3000), Angle::deg180()),
+      Vertex(Point(1000, 4000), Angle::deg0()),
+      Vertex(Point(1000, 5000), Angle::deg180()),
+      Vertex(Point(1000, 6000), Angle::deg180()),
+      Vertex(Point(1000, 7000), Angle::deg180()),
+      Vertex(Point(1000, 8000), Angle::deg180()),
+  });
+  const Path expected = Path({
+      Vertex(Point(1000, 1000), Angle::deg0()),
+      Vertex(Point(1433, 1250), Angle::deg0()),
+      Vertex(Point(1433, 1750), Angle::deg0()),
+      Vertex(Point(1000, 2000), Angle::deg0()),
+      Vertex(Point(1000, 3000), Angle::deg0()),
+      Vertex(Point(1433, 3250), Angle::deg0()),
+      Vertex(Point(1433, 3750), Angle::deg0()),
+      Vertex(Point(1000, 4000), Angle::deg0()),
+      Vertex(Point(1000, 5000), Angle::deg0()),
+      Vertex(Point(1433, 5250), Angle::deg0()),
+      Vertex(Point(1433, 5750), Angle::deg0()),
+      Vertex(Point(1000, 6000), Angle::deg0()),
+      Vertex(Point(1433, 6250), Angle::deg0()),
+      Vertex(Point(1433, 6750), Angle::deg0()),
+      Vertex(Point(1000, 7000), Angle::deg0()),
+      Vertex(Point(1433, 7250), Angle::deg0()),
+      Vertex(Point(1433, 7750), Angle::deg0()),
+      Vertex(Point(1000, 8000), Angle::deg0()),
+
+  });
+  const Path actual = input.flattenArcs(PositiveLength(600));
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_EQ(str(expected), str(input));
+}
+
+TEST_F(PathTest, testFlattenedArcs) {
+  const Path input = Path({
+      Vertex(Point(1000, 2000), Angle::deg180()),
+      Vertex(Point(1000, 3000), Angle::deg180()),
+  });
+  const Path expected = Path({
+      Vertex(Point(1000, 2000), Angle::deg0()),
+      Vertex(Point(1433, 2250), Angle::deg0()),
+      Vertex(Point(1433, 2750), Angle::deg0()),
+      Vertex(Point(1000, 3000), Angle::deg0()),
+  });
+  const Path actual = input.flattenedArcs(PositiveLength(600));
+  EXPECT_EQ(str(expected), str(actual));
+}
+
 TEST_F(PathTest, testOperatorCompareLess) {
   EXPECT_FALSE(Path() < Path());
   EXPECT_FALSE(Path({Vertex(Point(1, 2))}) < Path());

--- a/tests/unittests/core/project/board/boarddesignrulestest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulestest.cpp
@@ -46,7 +46,8 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
       " (stopmask_max_via_drill_diameter 0.2)\n"
       " (stopmask_clearance (ratio 0.1) (min 1.1) (max 2.1))\n"
       " (solderpaste_clearance (ratio 0.3) (min 1.3) (max 2.3))\n"
-      " (pad_annular_ring (ratio 0.4) (min 1.4) (max 2.4))\n"
+      " (pad_annular_ring (outer auto) (inner full)"
+      "  (ratio 0.4) (min 1.4) (max 2.4))\n"
       " (via_annular_ring (ratio 0.5) (min 1.5) (max 2.5))\n"
       ")",
       FilePath());
@@ -58,6 +59,8 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
   EXPECT_EQ(UnsignedRatio(Ratio(300000)), obj.getSolderPasteClearanceRatio());
   EXPECT_EQ(UnsignedLength(1300000), obj.getSolderPasteClearanceMin());
   EXPECT_EQ(UnsignedLength(2300000), obj.getSolderPasteClearanceMax());
+  EXPECT_EQ(true, obj.getPadCmpSideAutoAnnularRing());
+  EXPECT_EQ(false, obj.getPadInnerAutoAnnularRing());
   EXPECT_EQ(UnsignedRatio(Ratio(400000)), obj.getPadAnnularRingRatio());
   EXPECT_EQ(UnsignedLength(1400000), obj.getPadAnnularRingMin());
   EXPECT_EQ(UnsignedLength(2400000), obj.getPadAnnularRingMax());
@@ -73,6 +76,8 @@ TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
                             UnsignedLength(33));
   obj1.setSolderPasteClearance(UnsignedRatio(Ratio(55)), UnsignedLength(66),
                                UnsignedLength(77));
+  obj1.setPadCmpSideAutoAnnularRing(true);
+  obj1.setPadInnerAutoAnnularRing(false);
   obj1.setPadAnnularRing(UnsignedRatio(Ratio(88)), UnsignedLength(99),
                          UnsignedLength(111));
   obj1.setViaAnnularRing(UnsignedRatio(Ratio(222)), UnsignedLength(333),


### PR DESCRIPTION
## Summary

So far, THT pad shapes were the same on all copper layers. But this is wasting a lot of space on any layer where no soldering is done or not even a trace is connected. See for example #864. This PR allows to make THT pads much more space efficient.

## Design Parameters

In the board design rules dialog, two new options have been added. They are used in conjunction with the ratio/min/max values which were already there but actually didn't have any effect:

![image](https://user-images.githubusercontent.com/5374821/216990422-b7ca9495-14cc-4e69-a500-964349fab10d.png)

## Behavior

Basically you can enable/disable automatic pad annular rings separately for component side pads and for all inner layers. Disabling means the full pad shape is used (i.e. the v0.1 behavior). Automatic means the pad shape is completely ignored, but an automatic, circular annular ring is used instead. The width of the annular ring is calculated by the specified ratio/min/max values (i.e. it depends on the pad drill diameter). In addition, there's a special case: On layers where the pad has no trace connected to it, the ratio & max values are ignored and the annular ring is just set to its minimum value. This allows to safe even more space while still complying with the PCB manufacturers minimum annular width.

Generally this feature is most useful on inner layers. However, actually large pads are required just for soldering, i.e. on the *solder side* of pads. On the *component side*, usually no soldering is done so one might use automatic annular rings there as well to safe a lot of space. But since this is a bit "dangerous" (if the solder side is defined wrongly, or you placed a symmetric component on the wrong board side, you cannot simply mount it the other way around since pads are no longer symmetric), a warning is shown in the design rules dialog if this option is enabled.

## Appearance

The board editor now shows pads with the outlines on any copper layer. They are filled only on visible copper layers. In this example, automatic annular rings are enabled on both, component side and inner layers:

![librepcb-auto-pad-shapes](https://user-images.githubusercontent.com/5374821/216998637-f078811b-326a-4f4a-8ed7-41f9d400c4c2.gif)

## New Checks

Unfortunately this feature introduces a potential issue: Due to automatic annular rings, it's no longer guaranteed that at the pad's origin (center) there's copper on any layer. However, this is a requirement since traces will always be connected to the pad's origin. If there's no THT hole at this point, on layers with automatic annular rings there might be no copper and thus the connection doesn't work.

Therefore I implemented a new check in the library editor and in the DRC which warns if the pad's origin is not within a THT hole.

## Default Value / File Format Upgrade

By default, automatic annular rings are enabled only on inner layers since this is quite safe and still helpful (opinions welcome whether even this should be disabled by default). But when upgrading a v0.1 project, automatic annular rings will be disabled to avoid affecting the board.