### PR TITLE
Always connect vias to planes, regardless of connect style

### DIFF
--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -281,10 +281,11 @@ ClipperLib::Paths BoardPlaneFragmentsBuilder::createPadCutOuts(
 
 ClipperLib::Path BoardPlaneFragmentsBuilder::createViaCutOut(
     const BI_Via& via) const noexcept {
-  bool differentNetSignal =
-      (via.getNetSegment().getNetSignal() != &mPlane.getNetSignal());
-  if ((mPlane.getConnectStyle() == BI_Plane::ConnectStyle::None) ||
-      differentNetSignal) {
+  // Note: Do not respect the plane connect style for vias, but always connect
+  // them with solid style. Since vias are not soldered, heat dissipation is
+  // not an issue or often even desired. See discussion in
+  // https://github.com/LibrePCB/LibrePCB/issues/454#issuecomment-1373402172
+  if (via.getNetSegment().getNetSignal() != &mPlane.getNetSignal()) {
     return ClipperHelpers::convert(
         via.getVia().getSceneOutline(*mPlane.getMinClearance()),
         maxArcTolerance());

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -444,9 +444,13 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
 
   // Planes.
   int planeCount = 0;
+  int planeConnectNoneCount = 0;
   for (SExpression* planeNode : root.getChildren("plane")) {
     Q_UNUSED(planeNode);
     ++planeCount;
+    if (planeNode->getChild("connect_style/@0").getValue() == "none") {
+      ++planeConnectNoneCount;
+    }
   }
   if (planeCount > 0) {
     messages.append(buildMessage(
@@ -454,6 +458,15 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
         tr("Plane area calculations have been adjusted, manual review and "
            "running the DRC is recommended."),
         planeCount));
+  }
+  if (planeConnectNoneCount > 0) {
+    messages.append(buildMessage(
+        Message::Severity::Warning,
+        tr("Vias within planes with connect style 'None' are now fully "
+           "connected to the planes since the connect style is no longer "
+           "respected for vias. You might want to remove traces now which are "
+           "no longer needed to connect these vias."),
+        planeConnectNoneCount));
   }
 }
 


### PR DESCRIPTION
The 'connect style' property of planes is no longer respected for vias since isolating vias from the planes makes no sense. Isolating only makes sense for pads due to heat dissipation. See discussion in https://github.com/LibrePCB/LibrePCB/issues/454#issuecomment-1373402172.

Since this change affects projects during the v0.1 -> v0.2 migration, an upgrade message is shown to the user if there are any planes with connect style set to 'none'.