### PR TITLE
Add support for custom footprint pad shapes

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -258,6 +258,8 @@ add_library(
   library/pkg/msg/msgpadannularringviolation.h
   library/pkg/msg/msgpadclearanceviolation.cpp
   library/pkg/msg/msgpadclearanceviolation.h
+  library/pkg/msg/msgpadholeoutsidecopper.cpp
+  library/pkg/msg/msgpadholeoutsidecopper.h
   library/pkg/msg/msgpadoriginoutsidecopper.cpp
   library/pkg/msg/msgpadoriginoutsidecopper.h
   library/pkg/msg/msgpadoverlapswithplacement.cpp

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -248,6 +248,8 @@ add_library(
   library/pkg/footprintpainter.h
   library/pkg/msg/msgduplicatepadname.cpp
   library/pkg/msg/msgduplicatepadname.h
+  library/pkg/msg/msginvalidcustompadoutline.cpp
+  library/pkg/msg/msginvalidcustompadoutline.h
   library/pkg/msg/msgmissingfootprint.cpp
   library/pkg/msg/msgmissingfootprint.h
   library/pkg/msg/msgmissingfootprintname.cpp
@@ -264,6 +266,8 @@ add_library(
   library/pkg/msg/msgpadoriginoutsidecopper.h
   library/pkg/msg/msgpadoverlapswithplacement.cpp
   library/pkg/msg/msgpadoverlapswithplacement.h
+  library/pkg/msg/msgunusedcustompadoutline.cpp
+  library/pkg/msg/msgunusedcustompadoutline.h
   library/pkg/msg/msgwrongfootprinttextlayer.cpp
   library/pkg/msg/msgwrongfootprinttextlayer.h
   library/pkg/package.cpp

--- a/libs/librepcb/core/geometry/padgeometry.h
+++ b/libs/librepcb/core/geometry/padgeometry.h
@@ -52,6 +52,7 @@ public:
     Rect,
     Octagon,
     Stroke,
+    Custom,
   };
 
   // Constructors / Destructor
@@ -90,6 +91,8 @@ public:
   static PadGeometry stroke(const PositiveLength& diameter,
                             const NonEmptyPath& path,
                             const HoleList& holes) noexcept;
+  static PadGeometry custom(const Path& outline, const HoleList& holes);
+  static bool isValidCustomOutline(const Path& path) noexcept;
 
   // Operator Overloadings
   bool operator==(const PadGeometry& rhs) const noexcept;

--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -100,9 +100,21 @@ Point Path::calcNearestPointBetweenVertices(const Point& p) const noexcept {
   }
 }
 
+Path Path::cleaned() const noexcept {
+  Path p(*this);
+  p.clean();
+  return p;
+}
+
 Path Path::toClosedPath() const noexcept {
   Path p(*this);
   p.close();
+  return p;
+}
+
+Path Path::toOpenPath() const noexcept {
+  Path p(*this);
+  p.open();
   return p;
 }
 
@@ -274,10 +286,32 @@ void Path::insertVertex(int index, const Point& pos,
   insertVertex(index, Vertex(pos, angle));
 }
 
+bool Path::clean() noexcept {
+  bool modified = false;
+  for (int i = mVertices.count() - 1; i > 0; --i) {
+    Vertex& v0 = mVertices[i - 1];
+    Vertex& v1 = mVertices[i];
+    if (v0.getPos() == v1.getPos()) {
+      mVertices.removeAt(i - 1);
+      modified = true;
+    }
+  }
+  return modified;
+}
+
 bool Path::close() noexcept {
   if (!isClosed() && (mVertices.count() > 1)) {
     addVertex(mVertices.first().getPos(), Angle::deg0());
     Q_ASSERT(isClosed());
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool Path::open() noexcept {
+  if ((mVertices.count() > 2) && isClosed()) {
+    mVertices.removeLast();
     return true;
   } else {
     return false;

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -76,7 +76,9 @@ public:
   const QVector<Vertex>& getVertices() const noexcept { return mVertices; }
   UnsignedLength getTotalStraightLength() const noexcept;
   Point calcNearestPointBetweenVertices(const Point& p) const noexcept;
+  Path cleaned() const noexcept;
   Path toClosedPath() const noexcept;
+  Path toOpenPath() const noexcept;
   QVector<Path> toOutlineStrokes(const PositiveLength& width) const noexcept;
   const QPainterPath& toQPainterPathPx() const noexcept;
 
@@ -103,7 +105,9 @@ public:
   void insertVertex(int index, const Vertex& vertex) noexcept;
   void insertVertex(int index, const Point& pos,
                     const Angle& angle = Angle::deg0()) noexcept;
+  bool clean() noexcept;
   bool close() noexcept;
+  bool open() noexcept;
 
   /**
    * @brief Serialize into ::librepcb::SExpression node

--- a/libs/librepcb/core/library/pkg/footprintpad.h
+++ b/libs/librepcb/core/library/pkg/footprintpad.h
@@ -53,7 +53,7 @@ class FootprintPad final {
 
 public:
   // Types
-  enum class Shape { ROUND, RECT, OCTAGON };
+  enum class Shape { Round, Rect, Octagon, Custom };
   enum class ComponentSide { Top, Bottom };
 
   // Signals
@@ -65,6 +65,7 @@ public:
     ShapeChanged,
     WidthChanged,
     HeightChanged,
+    CustomShapeOutlineChanged,
     ComponentSideChanged,
     HolesEdited,
   };
@@ -77,7 +78,8 @@ public:
   FootprintPad(const Uuid& uuid, const tl::optional<Uuid>& pkgPadUuid,
                const Point& pos, const Angle& rot, Shape shape,
                const PositiveLength& width, const PositiveLength& height,
-               ComponentSide side, const HoleList& holes) noexcept;
+               const Path& customShapeOutline, ComponentSide side,
+               const HoleList& holes) noexcept;
   explicit FootprintPad(const SExpression& node);
   ~FootprintPad() noexcept;
 
@@ -91,6 +93,9 @@ public:
   Shape getShape() const noexcept { return mShape; }
   const PositiveLength& getWidth() const noexcept { return mWidth; }
   const PositiveLength& getHeight() const noexcept { return mHeight; }
+  const Path& getCustomShapeOutline() const noexcept {
+    return mCustomShapeOutline;
+  }
   ComponentSide getComponentSide() const noexcept { return mComponentSide; }
   const HoleList& getHoles() const noexcept { return mHoles; }
   HoleList& getHoles() noexcept { return mHoles; }
@@ -106,6 +111,7 @@ public:
   bool setShape(Shape shape) noexcept;
   bool setWidth(const PositiveLength& width) noexcept;
   bool setHeight(const PositiveLength& height) noexcept;
+  bool setCustomShapeOutline(const Path& outline) noexcept;
   bool setComponentSide(ComponentSide side) noexcept;
 
   // General Methods
@@ -143,6 +149,7 @@ private:  // Data
   Shape mShape;
   PositiveLength mWidth;
   PositiveLength mHeight;
+  Path mCustomShapeOutline;  ///< Empty if not needed; Implicitly closed
   ComponentSide mComponentSide;
   HoleList mHoles;  ///< If not empty, it's a THT pad.
 

--- a/libs/librepcb/core/library/pkg/msg/msginvalidcustompadoutline.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msginvalidcustompadoutline.cpp
@@ -17,63 +17,41 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
-
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "msginvalidcustompadoutline.h"
 
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
-
 /*******************************************************************************
- *  Class PackageCheck
+ *  Constructors / Destructor
  ******************************************************************************/
 
-/**
- * @brief The PackageCheck class
- */
-class PackageCheck : public LibraryElementCheck {
-public:
-  // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+MsgInvalidCustomPadOutline::MsgInvalidCustomPadOutline(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        tr("Invalid custom outline of pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("The pad has set a custom outline which does not represent a valid "
+           "area. Either choose a different pad shape or specify a valid "
+           "custom outline.")),
+    mFootprint(footprint),
+    mPad(pad) {
+}
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
-
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsAnnularRing(MsgList& msgs) const;
-  void checkPadsConnectionPoint(MsgList& msgs) const;
-  void checkCustomPadOutline(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
-};
+MsgInvalidCustomPadOutline::~MsgInvalidCustomPadOutline() noexcept {
+}
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
 }  // namespace librepcb
-
-#endif

--- a/libs/librepcb/core/library/pkg/msg/msginvalidcustompadoutline.h
+++ b/libs/librepcb/core/library/pkg/msg/msginvalidcustompadoutline.h
@@ -17,13 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
+#ifndef LIBREPCB_CORE_MSGINVALIDCUSTOMPADOUTLINE_H
+#define LIBREPCB_CORE_MSGINVALIDCUSTOMPADOUTLINE_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "../../../types/length.h"
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
@@ -32,42 +33,40 @@
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
+class Footprint;
+class FootprintPad;
 
 /*******************************************************************************
- *  Class PackageCheck
+ *  Class MsgInvalidCustomPadOutline
  ******************************************************************************/
 
 /**
- * @brief The PackageCheck class
+ * @brief The MsgInvalidCustomPadOutline class
  */
-class PackageCheck : public LibraryElementCheck {
+class MsgInvalidCustomPadOutline final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgInvalidCustomPadOutline)
+
 public:
   // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+  MsgInvalidCustomPadOutline() = delete;
+  MsgInvalidCustomPadOutline(std::shared_ptr<const Footprint> footprint,
+                             std::shared_ptr<const FootprintPad> pad,
+                             const QString& pkgPadName) noexcept;
+  MsgInvalidCustomPadOutline(const MsgInvalidCustomPadOutline& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mPad(other.mPad) {}
+  virtual ~MsgInvalidCustomPadOutline() noexcept;
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
 
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsAnnularRing(MsgList& msgs) const;
-  void checkPadsConnectionPoint(MsgList& msgs) const;
-  void checkCustomPadOutline(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.cpp
@@ -39,7 +39,7 @@ MsgPadAnnularRingViolation::MsgPadAnnularRingViolation(
     const Length& annularRing) noexcept
   : LibraryElementCheckMessage(
         Severity::Warning,
-        tr("Annular ring of pad '%1' in '%3'")
+        tr("Annular ring of pad '%1' in '%2'")
             .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
         tr("Pads should have at least %1 annular ring (copper around each pad "
            "hole). Note that this value is just a general recommendation, the "

--- a/libs/librepcb/core/library/pkg/msg/msgpadholeoutsidecopper.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadholeoutsidecopper.cpp
@@ -17,63 +17,41 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_MSGPADANNULARRINGVIOLATION_H
-#define LIBREPCB_CORE_MSGPADANNULARRINGVIOLATION_H
-
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../../../types/length.h"
-#include "../../msg/libraryelementcheckmessage.h"
+#include "msgpadholeoutsidecopper.h"
 
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ******************************************************************************/
 namespace librepcb {
 
-class Footprint;
-class FootprintPad;
-
 /*******************************************************************************
- *  Class MsgPadAnnularRingViolation
+ *  Constructors / Destructor
  ******************************************************************************/
 
-/**
- * @brief The MsgPadAnnularRingViolation class
- */
-class MsgPadAnnularRingViolation final : public LibraryElementCheckMessage {
-  Q_DECLARE_TR_FUNCTIONS(MsgPadAnnularRingViolation)
+MsgPadHoleOutsideCopper::MsgPadHoleOutsideCopper(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        tr("Hole outside copper of pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("All THT pad holes must be fully surrounded by copper, otherwise "
+           "they could lead to serious issues during the design rule check or "
+           "manufacturing process.")),
+    mFootprint(footprint),
+    mPad(pad) {
+}
 
-public:
-  // Constructors / Destructor
-  MsgPadAnnularRingViolation() = delete;
-  MsgPadAnnularRingViolation(std::shared_ptr<const Footprint> footprint,
-                             std::shared_ptr<const FootprintPad> pad,
-                             const QString& pkgPadName,
-                             const Length& annularRing) noexcept;
-  MsgPadAnnularRingViolation(const MsgPadAnnularRingViolation& other) noexcept
-    : LibraryElementCheckMessage(other),
-      mFootprint(other.mFootprint),
-      mPad(other.mPad) {}
-  virtual ~MsgPadAnnularRingViolation() noexcept;
-
-  // Getters
-  std::shared_ptr<const Footprint> getFootprint() const noexcept {
-    return mFootprint;
-  }
-  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
-
-private:
-  std::shared_ptr<const Footprint> mFootprint;
-  std::shared_ptr<const FootprintPad> mPad;
-};
+MsgPadHoleOutsideCopper::~MsgPadHoleOutsideCopper() noexcept {
+}
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
 }  // namespace librepcb
-
-#endif

--- a/libs/librepcb/core/library/pkg/msg/msgpadholeoutsidecopper.h
+++ b/libs/librepcb/core/library/pkg/msg/msgpadholeoutsidecopper.h
@@ -17,13 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_MSGPADANNULARRINGVIOLATION_H
-#define LIBREPCB_CORE_MSGPADANNULARRINGVIOLATION_H
+#ifndef LIBREPCB_CORE_MSGPADHOLEOUTSIDECOPPER_H
+#define LIBREPCB_CORE_MSGPADHOLEOUTSIDECOPPER_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../../../types/length.h"
 #include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
@@ -37,27 +36,26 @@ class Footprint;
 class FootprintPad;
 
 /*******************************************************************************
- *  Class MsgPadAnnularRingViolation
+ *  Class MsgPadHoleOutsideCopper
  ******************************************************************************/
 
 /**
- * @brief The MsgPadAnnularRingViolation class
+ * @brief The MsgPadHoleOutsideCopper class
  */
-class MsgPadAnnularRingViolation final : public LibraryElementCheckMessage {
-  Q_DECLARE_TR_FUNCTIONS(MsgPadAnnularRingViolation)
+class MsgPadHoleOutsideCopper final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadHoleOutsideCopper)
 
 public:
   // Constructors / Destructor
-  MsgPadAnnularRingViolation() = delete;
-  MsgPadAnnularRingViolation(std::shared_ptr<const Footprint> footprint,
-                             std::shared_ptr<const FootprintPad> pad,
-                             const QString& pkgPadName,
-                             const Length& annularRing) noexcept;
-  MsgPadAnnularRingViolation(const MsgPadAnnularRingViolation& other) noexcept
+  MsgPadHoleOutsideCopper() = delete;
+  MsgPadHoleOutsideCopper(std::shared_ptr<const Footprint> footprint,
+                          std::shared_ptr<const FootprintPad> pad,
+                          const QString& pkgPadName) noexcept;
+  MsgPadHoleOutsideCopper(const MsgPadHoleOutsideCopper& other) noexcept
     : LibraryElementCheckMessage(other),
       mFootprint(other.mFootprint),
       mPad(other.mPad) {}
-  virtual ~MsgPadAnnularRingViolation() noexcept;
+  virtual ~MsgPadHoleOutsideCopper() noexcept;
 
   // Getters
   std::shared_ptr<const Footprint> getFootprint() const noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgunusedcustompadoutline.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgunusedcustompadoutline.cpp
@@ -17,63 +17,40 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
-
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "msgunusedcustompadoutline.h"
 
-#include <QtCore>
+#include "../footprint.h"
 
 /*******************************************************************************
- *  Namespace / Forward Declarations
+ *  Namespace
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
-
 /*******************************************************************************
- *  Class PackageCheck
+ *  Constructors / Destructor
  ******************************************************************************/
 
-/**
- * @brief The PackageCheck class
- */
-class PackageCheck : public LibraryElementCheck {
-public:
-  // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+MsgUnusedCustomPadOutline::MsgUnusedCustomPadOutline(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Warning,
+        tr("Unused custom outline of pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("The pad has set a custom outline but it isn't used as the shape. "
+           "So it has no effect and should be removed to avoid confusion.")),
+    mFootprint(footprint),
+    mPad(pad) {
+}
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
-
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsAnnularRing(MsgList& msgs) const;
-  void checkPadsConnectionPoint(MsgList& msgs) const;
-  void checkCustomPadOutline(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
-};
+MsgUnusedCustomPadOutline::~MsgUnusedCustomPadOutline() noexcept {
+}
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
 }  // namespace librepcb
-
-#endif

--- a/libs/librepcb/core/library/pkg/msg/msgunusedcustompadoutline.h
+++ b/libs/librepcb/core/library/pkg/msg/msgunusedcustompadoutline.h
@@ -17,13 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_CORE_PACKAGECHECK_H
-#define LIBREPCB_CORE_PACKAGECHECK_H
+#ifndef LIBREPCB_CORE_MSGUNUSEDCUSTOMPADOUTLINE_H
+#define LIBREPCB_CORE_MSGUNUSEDCUSTOMPADOUTLINE_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../libraryelementcheck.h"
+#include "../../../types/length.h"
+#include "../../msg/libraryelementcheckmessage.h"
 
 #include <QtCore>
 
@@ -32,42 +33,40 @@
  ******************************************************************************/
 namespace librepcb {
 
-class Package;
+class Footprint;
+class FootprintPad;
 
 /*******************************************************************************
- *  Class PackageCheck
+ *  Class MsgUnusedCustomPadOutline
  ******************************************************************************/
 
 /**
- * @brief The PackageCheck class
+ * @brief The MsgUnusedCustomPadOutline class
  */
-class PackageCheck : public LibraryElementCheck {
+class MsgUnusedCustomPadOutline final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgUnusedCustomPadOutline)
+
 public:
   // Constructors / Destructor
-  PackageCheck() = delete;
-  PackageCheck(const PackageCheck& other) = delete;
-  explicit PackageCheck(const Package& package) noexcept;
-  virtual ~PackageCheck() noexcept;
+  MsgUnusedCustomPadOutline() = delete;
+  MsgUnusedCustomPadOutline(std::shared_ptr<const Footprint> footprint,
+                            std::shared_ptr<const FootprintPad> pad,
+                            const QString& pkgPadName) noexcept;
+  MsgUnusedCustomPadOutline(const MsgUnusedCustomPadOutline& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mPad(other.mPad) {}
+  virtual ~MsgUnusedCustomPadOutline() noexcept;
 
-  // General Methods
-  virtual LibraryElementCheckMessageList runChecks() const override;
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
 
-  // Operator Overloadings
-  PackageCheck& operator=(const PackageCheck& rhs) = delete;
-
-protected:  // Methods
-  void checkDuplicatePadNames(MsgList& msgs) const;
-  void checkMissingFootprint(MsgList& msgs) const;
-  void checkMissingTexts(MsgList& msgs) const;
-  void checkWrongTextLayers(MsgList& msgs) const;
-  void checkPadsClearanceToPads(MsgList& msgs) const;
-  void checkPadsClearanceToPlacement(MsgList& msgs) const;
-  void checkPadsAnnularRing(MsgList& msgs) const;
-  void checkPadsConnectionPoint(MsgList& msgs) const;
-  void checkCustomPadOutline(MsgList& msgs) const;
-
-private:  // Data
-  const Package& mPackage;
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -805,6 +805,10 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator& gen,
         }
         break;
       }
+      case PadGeometry::Shape::Custom: {
+        flashPadOutline();  // can throw
+        break;
+      }
       default: { throw LogicError(__FILE__, __LINE__, "Unknown pad shape!"); }
     }
   }

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -274,6 +274,17 @@ ClipperLib::Paths BoardPlaneFragmentsBuilder::createPadCutOuts(
         result.push_back(ClipperHelpers::convert(
             deviceTransform.map(padTransform.map(outline)), maxArcTolerance()));
       }
+      // Also create cut-outs for each hole to ensure correct clearance even if
+      // the pad outline is too small or invalid.
+      for (const Hole& hole : geometry.getHoles()) {
+        const PositiveLength width(hole.getDiameter() +
+                                   (mPlane.getMinClearance() * 2));
+        foreach (const Path& outline, hole.getPath()->toOutlineStrokes(width)) {
+          result.push_back(ClipperHelpers::convert(
+              deviceTransform.map(padTransform.map(outline)),
+              maxArcTolerance()));
+        }
+      }
     }
   }
   return result;

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -280,6 +280,17 @@ void BoardClipperPathGenerator::addCopper(
               ClipperHelpers::convert(transform.map(padTransform.map(outline)),
                                       mMaxArcTolerance));
         }
+        // Also add each hole to ensure correct copper areas even if
+        // the pad outline is too small or invalid.
+        for (const Hole& hole : geometry.getHoles()) {
+          foreach (const Path& outline,
+                   hole.getPath()->toOutlineStrokes(hole.getDiameter())) {
+            ClipperHelpers::unite(mPaths,
+                                  ClipperHelpers::convert(
+                                      transform.map(padTransform.map(outline)),
+                                      mMaxArcTolerance));
+          }
+        }
       }
     }
   }

--- a/libs/librepcb/core/utils/clipperhelpers.cpp
+++ b/libs/librepcb/core/utils/clipperhelpers.cpp
@@ -184,6 +184,23 @@ void ClipperHelpers::offset(ClipperLib::Paths& paths, const Length& offset,
   }
 }
 
+std::unique_ptr<ClipperLib::PolyTree> ClipperHelpers::offsetToTree(
+    const ClipperLib::Paths& paths, const Length& offset,
+    const PositiveLength& maxArcTolerance) {
+  try {
+    // Wrap the PolyTree object in a smart pointer since PolyTree cannot
+    // safely be copied (i.e. returned by value), it would lead to a crash!!!
+    std::unique_ptr<ClipperLib::PolyTree> result(new ClipperLib::PolyTree());
+    ClipperLib::ClipperOffset o(2.0, maxArcTolerance->toNm());
+    o.AddPaths(paths, ClipperLib::jtRound, ClipperLib::etClosedPolygon);
+    o.Execute(*result, offset.toNm());
+    return result;
+  } catch (const std::exception& e) {
+    throw LogicError(__FILE__, __LINE__,
+                     QString("Failed to offset paths: %1").arg(e.what()));
+  }
+}
+
 ClipperLib::Paths ClipperHelpers::treeToPaths(
     const ClipperLib::PolyTree& tree) {
   try {

--- a/libs/librepcb/core/utils/clipperhelpers.h
+++ b/libs/librepcb/core/utils/clipperhelpers.h
@@ -68,6 +68,9 @@ public:
       const ClipperLib::Paths& subject, const ClipperLib::Paths& clip);
   static void offset(ClipperLib::Paths& paths, const Length& offset,
                      const PositiveLength& maxArcTolerance);
+  static std::unique_ptr<ClipperLib::PolyTree> offsetToTree(
+      const ClipperLib::Paths& paths, const Length& offset,
+      const PositiveLength& maxArcTolerance);
   static ClipperLib::Paths treeToPaths(const ClipperLib::PolyTree& tree);
   static ClipperLib::Paths flattenTree(const ClipperLib::PolyNode& node);
 

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -387,16 +387,16 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
   FootprintPad::Shape shape;
   switch (p.getShape()) {
     case parseagle::ThtPad::Shape::Square:
-      shape = FootprintPad::Shape::RECT;
+      shape = FootprintPad::Shape::Rect;
       break;
     case parseagle::ThtPad::Shape::Octagon:
-      shape = FootprintPad::Shape::OCTAGON;
+      shape = FootprintPad::Shape::Octagon;
       break;
     case parseagle::ThtPad::Shape::Round:
-      shape = FootprintPad::Shape::ROUND;
+      shape = FootprintPad::Shape::Round;
       break;
     case parseagle::ThtPad::Shape::Long:
-      shape = FootprintPad::Shape::ROUND;
+      shape = FootprintPad::Shape::Round;
       width = PositiveLength(size * 2);
       break;
     default:
@@ -416,6 +416,7 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           shape,  // Shape
           width,  // Width
           height,  // Height
+          Path(),  // Custom shape outline
           FootprintPad::ComponentSide::Top,  // Side
           HoleList{std::make_shared<Hole>(
               Uuid::createRandom(),
@@ -446,9 +447,10 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           uuid,  // Package pad UUID
           convertPoint(p.getPosition()),  // Position
           convertAngle(p.getRotation().getAngle()),  // Rotation
-          FootprintPad::Shape::RECT,  // Shape
+          FootprintPad::Shape::Rect,  // Shape
           PositiveLength(convertLength(p.getWidth())),  // Width
           PositiveLength(convertLength(p.getHeight())),  // Height
+          Path(),  // Custom shape outline
           side,  // Side
           HoleList{}  // Holes
           ));

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
@@ -47,6 +47,8 @@ CmdFootprintPadEdit::CmdFootprintPadEdit(FootprintPad& pad) noexcept
     mNewWidth(mOldWidth),
     mOldHeight(pad.getHeight()),
     mNewHeight(mOldHeight),
+    mOldCustomShapeOutline(pad.getCustomShapeOutline()),
+    mNewCustomShapeOutline(mOldCustomShapeOutline),
     mOldPos(pad.getPosition()),
     mNewPos(mOldPos),
     mOldRotation(pad.getRotation()),
@@ -104,6 +106,11 @@ void CmdFootprintPadEdit::setHeight(const PositiveLength& height,
   if (immediate) mPad.setHeight(mNewHeight);
 }
 
+void CmdFootprintPadEdit::setCustomShapeOutline(const Path& outline) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewCustomShapeOutline = outline;
+}
+
 void CmdFootprintPadEdit::setPosition(const Point& pos,
                                       bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
@@ -151,9 +158,11 @@ void CmdFootprintPadEdit::mirrorGeometry(Qt::Orientation orientation,
   } else {
     mNewRotation = -mNewRotation;
   }
+  mNewCustomShapeOutline.mirror(orientation);
   if (immediate) {
     mPad.setPosition(mNewPos);
     mPad.setRotation(mNewRotation);
+    mPad.setCustomShapeOutline(mNewCustomShapeOutline);
   }
 }
 
@@ -189,6 +198,7 @@ bool CmdFootprintPadEdit::performExecute() {
   if (mNewShape != mOldShape) return true;
   if (mNewWidth != mOldWidth) return true;
   if (mNewHeight != mOldHeight) return true;
+  if (mNewCustomShapeOutline != mOldCustomShapeOutline) return true;
   if (mNewPos != mOldPos) return true;
   if (mNewRotation != mOldRotation) return true;
   if (mNewHoles != mOldHoles) return true;
@@ -201,6 +211,7 @@ void CmdFootprintPadEdit::performUndo() {
   mPad.setShape(mOldShape);
   mPad.setWidth(mOldWidth);
   mPad.setHeight(mOldHeight);
+  mPad.setCustomShapeOutline(mOldCustomShapeOutline);
   mPad.setPosition(mOldPos);
   mPad.setRotation(mOldRotation);
   mPad.getHoles() = mOldHoles;
@@ -212,6 +223,7 @@ void CmdFootprintPadEdit::performRedo() {
   mPad.setShape(mNewShape);
   mPad.setWidth(mNewWidth);
   mPad.setHeight(mNewHeight);
+  mPad.setCustomShapeOutline(mNewCustomShapeOutline);
   mPad.setPosition(mNewPos);
   mPad.setRotation(mNewRotation);
   mPad.getHoles() = mNewHoles;

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
@@ -61,6 +61,7 @@ public:
   void setShape(FootprintPad::Shape shape, bool immediate) noexcept;
   void setWidth(const PositiveLength& width, bool immediate) noexcept;
   void setHeight(const PositiveLength& height, bool immediate) noexcept;
+  void setCustomShapeOutline(const Path& outline) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
@@ -102,6 +103,8 @@ private:
   PositiveLength mNewWidth;
   PositiveLength mOldHeight;
   PositiveLength mNewHeight;
+  Path mOldCustomShapeOutline;
+  Path mNewCustomShapeOutline;
   Point mOldPos;
   Point mNewPos;
   Angle mOldRotation;

--- a/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
@@ -101,8 +101,8 @@ bool CmdPasteFootprintItems::performExecute() {
         pkgPad ? pkgPad->getUuid() : tl::optional<Uuid>();
     std::shared_ptr<FootprintPad> copy = std::make_shared<FootprintPad>(
         uuid, pkgPadUuid, pad.getPosition() + mPosOffset, pad.getRotation(),
-        pad.getShape(), pad.getWidth(), pad.getHeight(), pad.getComponentSide(),
-        pad.getHoles());
+        pad.getShape(), pad.getWidth(), pad.getHeight(),
+        pad.getCustomShapeOutline(), pad.getComponentSide(), pad.getHoles());
     execNewChildCmd(new CmdFootprintPadInsert(mFootprint.getPads(), copy));
     if (auto graphicsItem = mGraphicsItem.getGraphicsItem(copy)) {
       graphicsItem->setSelected(true);

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -228,7 +228,8 @@ void NewElementWizardContext::copyElement(ElementType type,
           newFootprint->getPads().append(std::make_shared<FootprintPad>(
               Uuid::createRandom(), pkgPad, pad.getPosition(),
               pad.getRotation(), pad.getShape(), pad.getWidth(),
-              pad.getHeight(), pad.getComponentSide(), pad.getHoles()));
+              pad.getHeight(), pad.getCustomShapeOutline(),
+              pad.getComponentSide(), pad.getHoles()));
         }
         // copy polygons but generate new UUIDs
         for (const Polygon& polygon : footprint.getPolygons()) {

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -156,6 +156,7 @@ void FootprintPadGraphicsItem::padEdited(const FootprintPad& pad,
     case FootprintPad::Event::ShapeChanged:
     case FootprintPad::Event::WidthChanged:
     case FootprintPad::Event::HeightChanged:
+    case FootprintPad::Event::CustomShapeOutlineChanged:
       setShape(pad.getGeometry().toQPainterPathPx());
       break;
     case FootprintPad::Event::ComponentSideChanged:

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -23,6 +23,7 @@
 #include "footprintpadgraphicsitem.h"
 
 #include <librepcb/core/graphics/graphicslayer.h>
+#include <librepcb/core/graphics/origincrossgraphicsitem.h>
 #include <librepcb/core/graphics/primitivepathgraphicsitem.h>
 #include <librepcb/core/graphics/primitivetextgraphicsitem.h>
 #include <librepcb/core/types/angle.h>
@@ -49,6 +50,7 @@ FootprintPadGraphicsItem::FootprintPadGraphicsItem(
     mPad(pad),
     mLayerProvider(lp),
     mPackagePadList(packagePadList),
+    mOriginCrossGraphicsItem(new OriginCrossGraphicsItem(this)),
     mPathGraphicsItem(new PrimitivePathGraphicsItem(this)),
     mTextGraphicsItem(new PrimitiveTextGraphicsItem(this)),
     mOnPadEditedSlot(*this, &FootprintPadGraphicsItem::padEdited),
@@ -59,6 +61,11 @@ FootprintPadGraphicsItem::FootprintPadGraphicsItem(
   setFlag(QGraphicsItem::ItemHasNoContents, false);
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   setZValue(10);
+
+  // Origin cross properties
+  // Note: Should be smaller than the smallest pad, otherwise it would be
+  // annoying due to too large grab area.
+  mOriginCrossGraphicsItem->setSize(UnsignedLength(250000));
 
   // path properties
   mPathGraphicsItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
@@ -101,6 +108,7 @@ void FootprintPadGraphicsItem::setRotation(const Angle& rot) noexcept {
 }
 
 void FootprintPadGraphicsItem::setSelected(bool selected) noexcept {
+  mOriginCrossGraphicsItem->setSelected(selected);
   mPathGraphicsItem->setSelected(selected);
   mTextGraphicsItem->setSelected(selected);
   QGraphicsItem::setSelected(selected);
@@ -124,7 +132,7 @@ void FootprintPadGraphicsItem::updateText() noexcept {
  ******************************************************************************/
 
 QPainterPath FootprintPadGraphicsItem::shape() const noexcept {
-  return mPathGraphicsItem->shape();
+  return mPathGraphicsItem->shape() | mOriginCrossGraphicsItem->shape();
 }
 
 void FootprintPadGraphicsItem::paint(QPainter* painter,
@@ -191,6 +199,10 @@ void FootprintPadGraphicsItem::setShape(const QPainterPath& shape) noexcept {
 }
 
 void FootprintPadGraphicsItem::setLayerName(const QString& name) noexcept {
+  const QString originCrossLayer = GraphicsLayer::isBottomLayer(name)
+      ? GraphicsLayer::sBotReferences
+      : GraphicsLayer::sTopReferences;
+  mOriginCrossGraphicsItem->setLayer(mLayerProvider.getLayer(originCrossLayer));
   mPathGraphicsItem->setFillLayer(mLayerProvider.getLayer(name));
   mTextGraphicsItem->setLayer(mLayerProvider.getLayer(name));
 }

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.h
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.h
@@ -37,6 +37,7 @@
 namespace librepcb {
 
 class IF_GraphicsLayerProvider;
+class OriginCrossGraphicsItem;
 class PrimitivePathGraphicsItem;
 class PrimitiveTextGraphicsItem;
 
@@ -94,6 +95,7 @@ private:  // Data
   std::shared_ptr<FootprintPad> mPad;
   const IF_GraphicsLayerProvider& mLayerProvider;
   const PackagePadList* mPackagePadList;
+  QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
   QScopedPointer<PrimitivePathGraphicsItem> mPathGraphicsItem;
   QScopedPointer<PrimitiveTextGraphicsItem> mTextGraphicsItem;
 

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
@@ -90,6 +90,7 @@ private:  // Data
   HoleList mHoles;
   int mSelectedHoleIndex;
   QScopedPointer<Ui::FootprintPadPropertiesDialog> mUi;
+  Path mAutoCustomOutline;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>510</width>
+    <width>587</width>
     <height>325</height>
    </rect>
   </property>
@@ -116,6 +116,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QRadioButton" name="rbtnShapeCustom">
+            <property name="text">
+             <string>Custom</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -209,6 +216,31 @@
        </item>
        <item row="6" column="1">
         <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabCustomShape">
+      <attribute name="title">
+       <string>Custom Shape</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,0">
+       <item>
+        <widget class="librepcb::editor::PathEditorWidget" name="customShapePathEditor" native="true"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_8">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Coordinates are relative to the pad origin and before rotation.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -344,6 +376,12 @@
    <class>librepcb::editor::HoleEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/holeeditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::PathEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/patheditorwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
@@ -57,13 +57,14 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(Context& context,
     mPackagePadComboBox(nullptr),
     mLastPad(
         Uuid::createRandom(), tl::nullopt, Point(0, 0), Angle::deg0(),
-        FootprintPad::Shape::ROUND,  // Commonly used pad shape
+        FootprintPad::Shape::Round,  // Commonly used pad shape
         PositiveLength(2500000),  // There is no default/recommended pad size
         PositiveLength(1300000),  // -> choose reasonable multiple of 0.1mm
+        Path(),  // Custom shape outline
         FootprintPad::ComponentSide::Top,  // Default side
         HoleList{}) {
   if (mPadType == PadType::SMT) {
-    mLastPad.setShape(FootprintPad::Shape::RECT);  // Commonly used SMT shape
+    mLastPad.setShape(FootprintPad::Shape::Rect);  // Commonly used SMT shape
     mLastPad.setWidth(PositiveLength(1500000));  // Same as for THT pads ->
     mLastPad.setHeight(PositiveLength(700000));  // reasonable multiple of 0.1mm
   } else {
@@ -121,28 +122,28 @@ bool PackageEditorState_AddPads::entry() noexcept {
       new QActionGroup(&mContext.commandToolBar));
   QAction* aShapeRound =
       cmd.thtShapeRound.createAction(shapeActionGroup.get(), this, [this]() {
-        shapeSelectorCurrentShapeChanged(FootprintPad::Shape::ROUND);
+        shapeSelectorCurrentShapeChanged(FootprintPad::Shape::Round);
       });
   aShapeRound->setIcon(QIcon(":/img/command_toolbars/shape_round.png"));
   aShapeRound->setCheckable(true);
-  aShapeRound->setChecked(mLastPad.getShape() == FootprintPad::Shape::ROUND);
+  aShapeRound->setChecked(mLastPad.getShape() == FootprintPad::Shape::Round);
   aShapeRound->setActionGroup(shapeActionGroup.get());
   QAction* aShapeRect = cmd.thtShapeRectangular.createAction(
       shapeActionGroup.get(), this, [this]() {
-        shapeSelectorCurrentShapeChanged(FootprintPad::Shape::RECT);
+        shapeSelectorCurrentShapeChanged(FootprintPad::Shape::Rect);
       });
   aShapeRect->setIcon(QIcon(":/img/command_toolbars/shape_rect.png"));
   aShapeRect->setCheckable(true);
-  aShapeRect->setChecked(mLastPad.getShape() == FootprintPad::Shape::RECT);
+  aShapeRect->setChecked(mLastPad.getShape() == FootprintPad::Shape::Rect);
   aShapeRect->setActionGroup(shapeActionGroup.get());
   QAction* aShapeOctagon = cmd.thtShapeOctagonal.createAction(
       shapeActionGroup.get(), this, [this]() {
-        shapeSelectorCurrentShapeChanged(FootprintPad::Shape::OCTAGON);
+        shapeSelectorCurrentShapeChanged(FootprintPad::Shape::Octagon);
       });
   aShapeOctagon->setIcon(QIcon(":/img/command_toolbars/shape_octagon.png"));
   aShapeOctagon->setCheckable(true);
   aShapeOctagon->setChecked(mLastPad.getShape() ==
-                            FootprintPad::Shape::OCTAGON);
+                            FootprintPad::Shape::Octagon);
   aShapeOctagon->setActionGroup(shapeActionGroup.get());
   mContext.commandToolBar.addActionGroup(std::move(shapeActionGroup));
   mContext.commandToolBar.addSeparator();
@@ -309,7 +310,8 @@ bool PackageEditorState_AddPads::startAddPad(const Point& pos) noexcept {
     mCurrentPad = std::make_shared<FootprintPad>(
         Uuid::createRandom(), mLastPad.getPackagePadUuid(),
         mLastPad.getPosition(), mLastPad.getRotation(), mLastPad.getShape(),
-        mLastPad.getWidth(), mLastPad.getHeight(), mLastPad.getComponentSide(),
+        mLastPad.getWidth(), mLastPad.getHeight(),
+        mLastPad.getCustomShapeOutline(), mLastPad.getComponentSide(),
         HoleList{});
     for (const Hole& hole : mLastPad.getHoles()) {
       mCurrentPad->getHoles().append(std::make_shared<Hole>(

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -235,6 +235,97 @@ TEST_F(PathTest, testFlattenedArcs) {
   EXPECT_EQ(str(expected), str(actual));
 }
 
+TEST_F(PathTest, testCleanEmptyPath) {
+  Path actual = Path();
+  const Path expected = Path();
+  const bool modified = actual.clean();
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(PathTest, testCleanOneVertex) {
+  Path actual = Path({Vertex(Point(1, 2), Angle::deg90())});
+  const Path expected = Path({Vertex(Point(1, 2), Angle::deg90())});
+  const bool modified = actual.clean();
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(PathTest, testCleanMultipleVertices) {
+  Path actual = Path({
+      Vertex(Point(1, 2), Angle::deg45()),
+      Vertex(Point(1, 2), Angle::deg90()),  // duplicate
+      Vertex(Point(3, 4), Angle::deg0()), Vertex(Point(5, 6), Angle::deg0()),
+      Vertex(Point(5, 6), Angle::deg180()),  // duplicate
+      Vertex(Point(5, 6), Angle::deg270()),  // duplicate
+      Vertex(Point(7, 8), Angle::deg0()), Vertex(Point(9, 9), Angle::deg180()),
+      Vertex(Point(9, 9), Angle::deg270()),  // duplicate
+  });
+  const Path expected = Path({
+      Vertex(Point(1, 2), Angle::deg90()),
+      Vertex(Point(3, 4), Angle::deg0()),
+      Vertex(Point(5, 6), Angle::deg270()),
+      Vertex(Point(7, 8), Angle::deg0()),
+      Vertex(Point(9, 9), Angle::deg270()),
+  });
+  const bool modified = actual.clean();
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_TRUE(modified);
+}
+
+TEST_F(PathTest, testOpenEmptyPath) {
+  Path actual = Path();
+  const Path expected = Path();
+  const bool modified = actual.open();
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(PathTest, testOpenTwoVertices) {
+  Path actual = Path({
+      Vertex(Point(1, 2), Angle::deg180()),
+      Vertex(Point(1, 2), Angle::deg180()),
+  });
+  const Path expected = Path({
+      Vertex(Point(1, 2), Angle::deg180()),
+      Vertex(Point(1, 2), Angle::deg180()),
+  });
+  const bool modified = actual.open();
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(PathTest, testOpenMultipleVerticesClosed) {
+  Path actual = Path({
+      Vertex(Point(1, 2), Angle::deg45()),
+      Vertex(Point(3, 4), Angle::deg90()),
+      Vertex(Point(1, 2), Angle::deg180()),
+  });
+  const Path expected = Path({
+      Vertex(Point(1, 2), Angle::deg45()),
+      Vertex(Point(3, 4), Angle::deg90()),
+  });
+  const bool modified = actual.open();
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_TRUE(modified);
+}
+
+TEST_F(PathTest, testOpenMultipleVerticesOpen) {
+  Path actual = Path({
+      Vertex(Point(1, 2), Angle::deg45()),
+      Vertex(Point(3, 4), Angle::deg90()),
+      Vertex(Point(5, 6), Angle::deg180()),
+  });
+  const Path expected = Path({
+      Vertex(Point(1, 2), Angle::deg45()),
+      Vertex(Point(3, 4), Angle::deg90()),
+      Vertex(Point(5, 6), Angle::deg180()),
+  });
+  const bool modified = actual.open();
+  EXPECT_EQ(str(expected), str(actual));
+  EXPECT_FALSE(modified);
+}
+
 TEST_F(PathTest, testOperatorCompareLess) {
   EXPECT_FALSE(Path() < Path());
   EXPECT_FALSE(Path({Vertex(Point(1, 2))}) < Path());

--- a/tests/unittests/core/library/pkg/footprintpadtest.cpp
+++ b/tests/unittests/core/library/pkg/footprintpadtest.cpp
@@ -56,7 +56,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
             obj.getPackagePadUuid());
   EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
   EXPECT_EQ(Angle::deg45(), obj.getRotation());
-  EXPECT_EQ(FootprintPad::Shape::RECT, obj.getShape());
+  EXPECT_EQ(FootprintPad::Shape::Rect, obj.getShape());
   EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
   EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
   EXPECT_EQ(FootprintPad::ComponentSide::Top, obj.getComponentSide());
@@ -65,9 +65,12 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
 
 TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   SExpression sexpr = SExpression::parse(
-      "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side bottom) (shape rect)\n"
+      "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side bottom) (shape custom)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2)\n"
       " (package_pad none)\n"
+      " (vertex (position -1.1 -2.2) (angle 45.0))\n"
+      " (vertex (position 1.1 -2.2) (angle 90.0))\n"
+      " (vertex (position 0.0 2.2) (angle 0.0))\n"
       " (hole 7040952d-7016-49cd-8c3e-6078ecca98b9 (diameter 1.0)\n"
       "  (vertex (position 1.1 2.2) (angle 45.0))\n"
       " )\n"
@@ -82,17 +85,19 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   EXPECT_EQ(tl::nullopt, obj.getPackagePadUuid());
   EXPECT_EQ(Point(1234000, 2345000), obj.getPosition());
   EXPECT_EQ(Angle::deg45(), obj.getRotation());
-  EXPECT_EQ(FootprintPad::Shape::RECT, obj.getShape());
+  EXPECT_EQ(FootprintPad::Shape::Custom, obj.getShape());
   EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
   EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
   EXPECT_EQ(FootprintPad::ComponentSide::Bottom, obj.getComponentSide());
+  EXPECT_EQ(3, obj.getCustomShapeOutline().getVertices().count());
   EXPECT_EQ(2, obj.getHoles().count());
 }
 
 TEST_F(FootprintPadTest, testSerializeAndDeserialize) {
   FootprintPad obj1(
       Uuid::createRandom(), Uuid::createRandom(), Point(123, 567), Angle(789),
-      FootprintPad::Shape::OCTAGON, PositiveLength(123), PositiveLength(456),
+      FootprintPad::Shape::Octagon, PositiveLength(123), PositiveLength(456),
+      Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       FootprintPad::ComponentSide::Top,
       HoleList{
           std::make_shared<Hole>(Uuid::createRandom(), PositiveLength(100000),

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -315,7 +315,7 @@ TEST_F(EagleTypeConverterTest, testConvertThtPad) {
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
   EXPECT_EQ(Angle(0), out.second->getRotation());
-  EXPECT_EQ(FootprintPad::Shape::RECT, out.second->getShape());
+  EXPECT_EQ(FootprintPad::Shape::Rect, out.second->getShape());
   EXPECT_EQ(PositiveLength(2250000), out.second->getWidth());  // 1.5*drill
   EXPECT_EQ(PositiveLength(2250000), out.second->getHeight());  // 1.5*drill
   EXPECT_EQ(FootprintPad::ComponentSide::Top, out.second->getComponentSide());
@@ -333,7 +333,7 @@ TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
   EXPECT_EQ(Angle(90000000), out.second->getRotation());
-  EXPECT_EQ(FootprintPad::Shape::OCTAGON, out.second->getShape());
+  EXPECT_EQ(FootprintPad::Shape::Octagon, out.second->getShape());
   EXPECT_EQ(PositiveLength(2540000), out.second->getWidth());
   EXPECT_EQ(PositiveLength(2540000), out.second->getHeight());
   EXPECT_EQ(FootprintPad::ComponentSide::Top, out.second->getComponentSide());
@@ -350,7 +350,7 @@ TEST_F(EagleTypeConverterTest, testConvertSmtPad) {
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
   EXPECT_EQ(Angle(0), out.second->getRotation());
-  EXPECT_EQ(FootprintPad::Shape::RECT, out.second->getShape());
+  EXPECT_EQ(FootprintPad::Shape::Rect, out.second->getShape());
   EXPECT_EQ(PositiveLength(3000000), out.second->getWidth());
   EXPECT_EQ(PositiveLength(4000000), out.second->getHeight());
   EXPECT_EQ(FootprintPad::ComponentSide::Top, out.second->getComponentSide());
@@ -366,7 +366,7 @@ TEST_F(EagleTypeConverterTest, testConvertSmtPadRotated) {
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
   EXPECT_EQ(Angle(90000000), out.second->getRotation());
-  EXPECT_EQ(FootprintPad::Shape::RECT, out.second->getShape());
+  EXPECT_EQ(FootprintPad::Shape::Rect, out.second->getShape());
   EXPECT_EQ(PositiveLength(3000000), out.second->getWidth());
   EXPECT_EQ(PositiveLength(4000000), out.second->getHeight());
   EXPECT_EQ(FootprintPad::ComponentSide::Bottom,

--- a/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
@@ -83,12 +83,13 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
 
   std::shared_ptr<FootprintPad> footprintPad1 = std::make_shared<FootprintPad>(
       Uuid::createRandom(), packagePad1->getUuid(), Point(12, 34), Angle(56),
-      FootprintPad::Shape::OCTAGON, PositiveLength(11), PositiveLength(22),
-      FootprintPad::ComponentSide::Bottom, HoleList{});
+      FootprintPad::Shape::Octagon, PositiveLength(11), PositiveLength(22),
+      Path(), FootprintPad::ComponentSide::Bottom, HoleList{});
 
   std::shared_ptr<FootprintPad> footprintPad2 = std::make_shared<FootprintPad>(
       Uuid::createRandom(), tl::nullopt, Point(12, 34), Angle(56),
-      FootprintPad::Shape::RECT, PositiveLength(123), PositiveLength(456),
+      FootprintPad::Shape::Rect, PositiveLength(123), PositiveLength(456),
+      Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       FootprintPad::ComponentSide::Top,
       HoleList{std::make_shared<Hole>(Uuid::createRandom(), PositiveLength(789),
                                       makeNonEmptyPath(Point(0, 0)))});


### PR DESCRIPTION
### Summary

This feature allows to create arbitrary shaped pads in the footprint editor, for both SMT and THT pads. The shape is defined with a single polygon, consisting of straight lines and arc segments.

### File Format

There's a new shape called `custom` and the outline vertices are just added to the `pad` element:

```scheme
  (pad 0088e320-45c0-4580-a24f-bfa5697d7cd6 (side top) (shape custom)
   (position 0.0 4.7) (rotation 20.0) (size 3.2 3.2)
   (package_pad none)
   (vertex (position -4.0 0.0) (angle 0.0))
   (vertex (position 0.0 2.0) (angle -180.0))
   (vertex (position 0.0 -2.0) (angle 0.0))
  )
```

The `(size 3.2 3.2)` is actually unused/superfluous in that case. Also if `shape` is not set to `custom`, there could still exist superfluous outline vertices. Both is ugly, but somehow I also don't like to create a conditional file format, i.e. existence of nodes depending on the value of other nodes. Not sure yet which approach is better :thinking:

### User Interface

Currently there's no interactive tool yet to draw the pad outline. Instead, coordinates need to be entered manually. An interactive tool could be added in a later minor release as it won't affect the file format.

However, to still make creating custom shapes a bit easier, the coordinates will automatically be pre-filled with the same shape as the pad had before enabling custom shape. So for example if an octagon pad is changed to custom shape, the custom shape is initialized with the same octagon.

![librepcb-custom-pad-shape](https://user-images.githubusercontent.com/5374821/218717341-e1df0841-51fd-4d5d-b98a-bf5c6dfcc4ad.gif)

### Stop Mask / Solder Paste

As offsetting the pad shape for auto-generating the stop mask and solder paste is no longer trivial, the Clipper library is now used to offset custom pad shapes. This converts arcs to straight line segments, but that's good enough.

### Checks

As custom shapes introduce some additional potential errors, new library checks have been implemented in the package editor which warn about invalid shapes (too few vertices, shape area is zero, shape outline specified but not enabled, ...). However, the UI should generally disallow creating invalid pad shapes so usually these checks should not raise a warning.

Closes #540