### PR TITLE
Gerber export: Enable solder paste export by default

### DIFF
--- a/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
+++ b/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
@@ -56,8 +56,8 @@ BoardFabricationOutputSettings::BoardFabricationOutputSettings() noexcept
         {GraphicsLayer::sBotPlacement, GraphicsLayer::sBotNames}),
     mMergeDrillFiles(false),
     mUseG85SlotCommand(false),
-    mEnableSolderPasteTop(false),
-    mEnableSolderPasteBot(false) {
+    mEnableSolderPasteTop(true),
+    mEnableSolderPasteBot(true) {
 }
 
 BoardFabricationOutputSettings::BoardFabricationOutputSettings(

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
@@ -56,7 +56,7 @@
       <item row="9" column="0">
        <widget class="QCheckBox" name="cbxSolderPasteTop">
         <property name="text">
-         <string>Top Paste Mask
+         <string>Top Solder Paste
 (Top Stencil):</string>
         </property>
        </widget>
@@ -64,7 +64,7 @@
       <item row="9" column="2">
        <widget class="QCheckBox" name="cbxSolderPasteBot">
         <property name="text">
-         <string>Bottom Paste Mask
+         <string>Bottom Solder Paste
 (Bottom Stencil):</string>
         </property>
        </widget>
@@ -238,7 +238,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
-         <string>Top Soldermask:</string>
+         <string>Top Stopmask:</string>
         </property>
        </widget>
       </item>
@@ -252,7 +252,7 @@
       <item row="4" column="2">
        <widget class="QLabel" name="label_11">
         <property name="text">
-         <string>Bottom Soldermask:</string>
+         <string>Bottom Stopmask:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
If you forget to enable the top/bottom solder paste export in the Gerber export settings but still want to order a stencil, there's a risk that the PCB manufacturer auto-generates the stencil from the stop mask layer (or from the copper layer?). But the other way around, if you don't need a stencil but forget to disable exporting these layers, I think there's no risk at all (just two unnecessary files generated). So changing from opt-in to opt-out is probably the safer option.

Also fixed some inconsistent layer naming in the UI.