### PR TITLE
Support dismissing library check messages

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -68,11 +68,11 @@ private:  // Methods
                    const QStringList& boardNames,
                    const QStringList& boardIndices, bool removeOtherBoards,
                    bool save, bool strict) const noexcept;
-  bool openLibrary(const QString& libDir, bool all, bool save,
+  bool openLibrary(const QString& libDir, bool all, bool runCheck, bool save,
                    bool strict) const noexcept;
   void processLibraryElement(const QString& libDir, TransactionalFileSystem& fs,
-                             LibraryBaseElement& element, bool save,
-                             bool strict, bool& success) const;
+                             LibraryBaseElement& element, bool runCheck,
+                             bool save, bool strict, bool& success) const;
   static QString prettyPath(const FilePath& path,
                             const QString& style) noexcept;
   static bool failIfFileFormatUnstable() noexcept;

--- a/libs/librepcb/core/library/cat/librarycategory.cpp
+++ b/libs/librepcb/core/library/cat/librarycategory.cpp
@@ -64,6 +64,8 @@ void LibraryCategory::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("parent", mParentUuid);
   root.ensureLineBreak();
+  serializeMessageApprovals(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -162,6 +162,8 @@ void Component::serialize(SExpression& root) const {
   root.ensureLineBreak();
   mSymbolVariants.serialize(root);
   root.ensureLineBreak();
+  serializeMessageApprovals(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/cmp/msg/msgduplicatesignalname.cpp
+++ b/libs/librepcb/core/library/cmp/msg/msgduplicatesignalname.cpp
@@ -43,7 +43,9 @@ MsgDuplicateSignalName::MsgDuplicateSignalName(
            "has several pins which are electrically exactly equal (e.g. "
            "multiple GND pins), you should add only one of these pins as a "
            "component signal. The assignment to multiple pins should be done "
-           "in the device editor instead.")) {
+           "in the device editor instead."),
+        "DuplicateSignalName") {
+  mApproval.appendChild("name", *signal.getName());
 }
 
 MsgDuplicateSignalName::~MsgDuplicateSignalName() noexcept {

--- a/libs/librepcb/core/library/cmp/msg/msgmissingcomponentdefaultvalue.cpp
+++ b/libs/librepcb/core/library/cmp/msg/msgmissingcomponentdefaultvalue.cpp
@@ -43,8 +43,8 @@ MsgMissingComponentDefaultValue::MsgMissingComponentDefaultValue() noexcept
            "Specific parts (e.g. a microcontroller): %2\n"
            "Passive parts: Using an attribute, e.g. %3")
             .arg("'{{PARTNUMBER or DEVICE}}'",
-                 "'{{PARTNUMBER or DEVICE or COMPONENT}}'",
-                 "'{{RESISTANCE}}'")) {
+                 "'{{PARTNUMBER or DEVICE or COMPONENT}}'", "'{{RESISTANCE}}'"),
+        "EmptyDefaultValue") {
 }
 
 MsgMissingComponentDefaultValue::~MsgMissingComponentDefaultValue() noexcept {

--- a/libs/librepcb/core/library/cmp/msg/msgmissingcomponentprefix.cpp
+++ b/libs/librepcb/core/library/cmp/msg/msgmissingcomponentprefix.cpp
@@ -37,7 +37,8 @@ MsgMissingComponentPrefix::MsgMissingComponentPrefix() noexcept
         tr("Most components should have a prefix defined. The prefix is used "
            "to generate the component's name when adding it to a schematic. "
            "For example the prefix 'R' (resistor) leads to component names "
-           "'R1', 'R2', 'R3' etc.")) {
+           "'R1', 'R2', 'R3' etc."),
+        "EmptyPrefix") {
 }
 
 MsgMissingComponentPrefix::~MsgMissingComponentPrefix() noexcept {

--- a/libs/librepcb/core/library/cmp/msg/msgmissingsymbolvariant.cpp
+++ b/libs/librepcb/core/library/cmp/msg/msgmissingsymbolvariant.cpp
@@ -35,7 +35,8 @@ MsgMissingSymbolVariant::MsgMissingSymbolVariant() noexcept
   : LibraryElementCheckMessage(
         Severity::Error, tr("No symbol variant defined"),
         tr("Every component requires at least one symbol variant, otherwise it "
-           "can't be added to schematics.")) {
+           "can't be added to schematics."),
+        "MissingVariants") {
 }
 
 MsgMissingSymbolVariant::~MsgMissingSymbolVariant() noexcept {

--- a/libs/librepcb/core/library/cmp/msg/msgmissingsymbolvariantitem.cpp
+++ b/libs/librepcb/core/library/cmp/msg/msgmissingsymbolvariantitem.cpp
@@ -40,8 +40,12 @@ MsgMissingSymbolVariantItem::MsgMissingSymbolVariantItem(
         tr("Symbol variant '%1' has no items")
             .arg(*symbVar->getNames().getDefaultValue()),
         tr("Every symbol variant requires at least one symbol item, otherwise "
-           "it can't be added to schematics.")),
+           "it can't be added to schematics."),
+        "MissingGates"),
     mSymbVar(symbVar) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("variant", symbVar->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgMissingSymbolVariantItem::~MsgMissingSymbolVariantItem() noexcept {

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -119,6 +119,8 @@ void Device::serialize(SExpression& root) const {
   root.ensureLineBreak();
   mPadSignalMap.sortedByUuid().serialize(root);
   root.ensureLineBreak();
+  serializeMessageApprovals(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/dev/msg/msgnopadsindeviceconnected.cpp
+++ b/libs/librepcb/core/library/dev/msg/msgnopadsindeviceconnected.cpp
@@ -41,7 +41,8 @@ MsgNoPadsInDeviceConnected::MsgNoPadsInDeviceConnected() noexcept
            "them.\n\nTo fix this issue, connect the package pads to their "
            "corresponding component signals in the table widget.\n\nIf all "
            "pads have only a mechanical purpose and thus don't need to be "
-           "connected to component signals, this message can be ignored.")) {
+           "connected to component signals, this message can be ignored."),
+        "NoPadsConnected") {
 }
 
 MsgNoPadsInDeviceConnected::~MsgNoPadsInDeviceConnected() noexcept {

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -197,6 +197,8 @@ void Library::serialize(SExpression& root) const {
     root.appendChild("dependency", uuid);
   }
   root.ensureLineBreak();
+  serializeMessageApprovals(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/librarybaseelement.cpp
+++ b/libs/librepcb/core/library/librarybaseelement.cpp
@@ -25,6 +25,7 @@
 #include "../application.h"
 #include "../fileio/versionfile.h"
 #include "../serialization/sexpression.h"
+#include "../utils/toolbox.h"
 #include "librarybaseelementcheck.h"
 
 #include <QtCore>
@@ -56,7 +57,8 @@ LibraryBaseElement::LibraryBaseElement(const QString& shortElementName,
     mIsDeprecated(false),
     mNames(name_en_US),
     mDescriptions(description_en_US),
-    mKeywords(keywords_en_US) {
+    mKeywords(keywords_en_US),
+    mMessageApprovals() {
 }
 
 LibraryBaseElement::LibraryBaseElement(
@@ -74,7 +76,13 @@ LibraryBaseElement::LibraryBaseElement(
     mIsDeprecated(deserialize<bool>(root.getChild("deprecated/@0"))),
     mNames(root),
     mDescriptions(root),
-    mKeywords(root) {
+    mKeywords(root),
+    mMessageApprovals() {
+  // Load message approvals.
+  foreach (const SExpression* child, root.getChildren("approval")) {
+    mMessageApprovals.insert(*child);
+  }
+
   // Check directory name.
   const QString dirName = mDirectory->getAbsPath().getFilename();
   if (dirnameMustBeUuid && (dirName != mUuid.toStr())) {
@@ -158,6 +166,14 @@ void LibraryBaseElement::serialize(SExpression& root) const {
   root.appendChild("created", mCreated);
   root.ensureLineBreak();
   root.appendChild("deprecated", mIsDeprecated);
+  root.ensureLineBreak();
+}
+
+void LibraryBaseElement::serializeMessageApprovals(SExpression& root) const {
+  foreach (const SExpression& node, Toolbox::sortedQSet(mMessageApprovals)) {
+    root.ensureLineBreak();
+    root.appendChild(node);
+  }
   root.ensureLineBreak();
 }
 

--- a/libs/librepcb/core/library/librarybaseelement.h
+++ b/libs/librepcb/core/library/librarybaseelement.h
@@ -82,6 +82,9 @@ public:
   }
   const LocalizedKeywordsMap& getKeywords() const noexcept { return mKeywords; }
   QStringList getAllAvailableLocales() const noexcept;
+  const QSet<SExpression>& getMessageApprovals() const noexcept {
+    return mMessageApprovals;
+  }
 
   // Setters
   void setVersion(const Version& version) noexcept { mVersion = version; }
@@ -93,6 +96,9 @@ public:
   }
   void setKeywords(const LocalizedKeywordsMap& keywords) noexcept {
     mKeywords = keywords;
+  }
+  void setMessageApprovals(const QSet<SExpression>& approvals) noexcept {
+    mMessageApprovals = approvals;
   }
 
   // General Methods
@@ -127,6 +133,8 @@ protected:  // Methods
    */
   virtual void serialize(SExpression& root) const;
 
+  void serializeMessageApprovals(SExpression& root) const;
+
   static Version readFileFormat(const TransactionalDirectory& directory,
                                 const QString& fileName);
 
@@ -145,6 +153,9 @@ protected:  // Data
   LocalizedNameMap mNames;
   LocalizedDescriptionMap mDescriptions;
   LocalizedKeywordsMap mKeywords;
+
+  // Library element check
+  QSet<SExpression> mMessageApprovals;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/msg/libraryelementcheckmessage.cpp
+++ b/libs/librepcb/core/library/msg/libraryelementcheckmessage.cpp
@@ -34,7 +34,7 @@ namespace librepcb {
 LibraryElementCheckMessage::LibraryElementCheckMessage(
     const LibraryElementCheckMessage& other) noexcept
   : mSeverity(other.mSeverity),
-    mSeverityPixmap(other.mSeverityPixmap),
+    mSeverityIcon(other.mSeverityIcon),
     mMessage(other.mMessage),
     mDescription(other.mDescription),
     mApproval(other.mApproval) {
@@ -44,7 +44,7 @@ LibraryElementCheckMessage::LibraryElementCheckMessage(
     Severity severity, const QString& msg, const QString& description,
     const QString& approvalName) noexcept
   : mSeverity(severity),
-    mSeverityPixmap(getSeverityPixmap(severity)),
+    mSeverityIcon(getSeverityIcon(severity)),
     mMessage(msg),
     mDescription(description),
     mApproval(SExpression::createList("approval")) {
@@ -58,14 +58,13 @@ LibraryElementCheckMessage::~LibraryElementCheckMessage() noexcept {
  *  Static Methods
  ******************************************************************************/
 
-QPixmap LibraryElementCheckMessage::getSeverityPixmap(
-    Severity severity) noexcept {
-  static QMap<Severity, QPixmap> pixmap = {
-      {Severity::Hint, QPixmap(":/img/status/info.png")},
-      {Severity::Warning, QPixmap(":/img/status/dialog_warning.png")},
-      {Severity::Error, QPixmap(":/img/status/dialog_error.png")},
+QIcon LibraryElementCheckMessage::getSeverityIcon(Severity severity) noexcept {
+  static QMap<Severity, QIcon> icon = {
+      {Severity::Hint, QIcon(":/img/status/info.png")},
+      {Severity::Warning, QIcon(":/img/status/dialog_warning.png")},
+      {Severity::Error, QIcon(":/img/status/dialog_error.png")},
   };
-  return pixmap.value(severity);
+  return icon.value(severity);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/msg/libraryelementcheckmessage.cpp
+++ b/libs/librepcb/core/library/msg/libraryelementcheckmessage.cpp
@@ -36,15 +36,19 @@ LibraryElementCheckMessage::LibraryElementCheckMessage(
   : mSeverity(other.mSeverity),
     mSeverityPixmap(other.mSeverityPixmap),
     mMessage(other.mMessage),
-    mDescription(other.mDescription) {
+    mDescription(other.mDescription),
+    mApproval(other.mApproval) {
 }
 
 LibraryElementCheckMessage::LibraryElementCheckMessage(
-    Severity severity, const QString& msg, const QString& description) noexcept
+    Severity severity, const QString& msg, const QString& description,
+    const QString& approvalName) noexcept
   : mSeverity(severity),
     mSeverityPixmap(getSeverityPixmap(severity)),
     mMessage(msg),
-    mDescription(description) {
+    mDescription(description),
+    mApproval(SExpression::createList("approval")) {
+  mApproval.appendChild(approvalName);
 }
 
 LibraryElementCheckMessage::~LibraryElementCheckMessage() noexcept {

--- a/libs/librepcb/core/library/msg/libraryelementcheckmessage.h
+++ b/libs/librepcb/core/library/msg/libraryelementcheckmessage.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../serialization/sexpression.h"
+
 #include <QtCore>
 #include <QtWidgets>
 
@@ -59,6 +61,7 @@ public:
   const QPixmap& getSeverityPixmap() const noexcept { return mSeverityPixmap; }
   const QString& getMessage() const noexcept { return mMessage; }
   const QString& getDescription() const noexcept { return mDescription; }
+  const SExpression& getApproval() const noexcept { return mApproval; }
 
   // General Methods
   template <typename T>
@@ -80,7 +83,8 @@ public:
 protected:  // Methods
   LibraryElementCheckMessage(const LibraryElementCheckMessage& other) noexcept;
   LibraryElementCheckMessage(Severity severity, const QString& msg,
-                             const QString& description) noexcept;
+                             const QString& description,
+                             const QString& approvalName) noexcept;
   virtual ~LibraryElementCheckMessage() noexcept;
 
 protected:  // Data
@@ -88,6 +92,7 @@ protected:  // Data
   QPixmap mSeverityPixmap;
   QString mMessage;
   QString mDescription;
+  SExpression mApproval;
 };
 
 typedef QVector<std::shared_ptr<const LibraryElementCheckMessage>>

--- a/libs/librepcb/core/library/msg/libraryelementcheckmessage.h
+++ b/libs/librepcb/core/library/msg/libraryelementcheckmessage.h
@@ -58,7 +58,7 @@ public:
 
   // Getters
   Severity getSeverity() const noexcept { return mSeverity; }
-  const QPixmap& getSeverityPixmap() const noexcept { return mSeverityPixmap; }
+  const QIcon& getSeverityIcon() const noexcept { return mSeverityIcon; }
   const QString& getMessage() const noexcept { return mMessage; }
   const QString& getDescription() const noexcept { return mDescription; }
   const SExpression& getApproval() const noexcept { return mApproval; }
@@ -74,7 +74,7 @@ public:
   }
 
   // Static Methods
-  static QPixmap getSeverityPixmap(Severity severity) noexcept;
+  static QIcon getSeverityIcon(Severity severity) noexcept;
 
   // Operator Overloads
   bool operator==(const LibraryElementCheckMessage& rhs) const noexcept;
@@ -89,7 +89,7 @@ protected:  // Methods
 
 protected:  // Data
   Severity mSeverity;
-  QPixmap mSeverityPixmap;
+  QIcon mSeverityIcon;
   QString mMessage;
   QString mDescription;
   SExpression mApproval;

--- a/libs/librepcb/core/library/msg/msgmissingauthor.cpp
+++ b/libs/librepcb/core/library/msg/msgmissingauthor.cpp
@@ -35,7 +35,8 @@ MsgMissingAuthor::MsgMissingAuthor() noexcept
   : LibraryElementCheckMessage(
         Severity::Warning, tr("Author not set"),
         tr("It is recommended to set an author (e.g. full name or nickname), "
-           "although it's not required.")) {
+           "although it's not required."),
+        "EmptyAuthor") {
 }
 
 MsgMissingAuthor::~MsgMissingAuthor() noexcept {

--- a/libs/librepcb/core/library/msg/msgmissingcategories.cpp
+++ b/libs/librepcb/core/library/msg/msgmissingcategories.cpp
@@ -37,7 +37,8 @@ MsgMissingCategories::MsgMissingCategories() noexcept
         tr("It's very important to assign every library element to at least "
            "one category. Otherwise it will be very hard to find the element "
            "in the workspace library, so it's highly recommended to fix "
-           "this.")) {
+           "this."),
+        "MissingCategories") {
 }
 
 MsgMissingCategories::~MsgMissingCategories() noexcept {

--- a/libs/librepcb/core/library/msg/msgnamenottitlecase.cpp
+++ b/libs/librepcb/core/library/msg/msgnamenottitlecase.cpp
@@ -37,7 +37,8 @@ MsgNameNotTitleCase::MsgNameNotTitleCase(const ElementName& name) noexcept
         tr("Generally the library element name should be written in title case "
            "(for consistency). As the current name has words starting with a "
            "lowercase character, it seems that it is not title cases. If this "
-           "assumption is wrong, just ignore this message.")),
+           "assumption is wrong, just ignore this message."),
+        "NameNotTitleCase"),
     mName(name) {
 }
 

--- a/libs/librepcb/core/library/pkg/msg/msgduplicatepadname.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgduplicatepadname.cpp
@@ -42,7 +42,9 @@ MsgDuplicatePadName::MsgDuplicatePadName(const PackagePad& pad) noexcept
            "assign all these pads to the same component signal later in the "
            "device editor.\n\nFor neutral packages (e.g. SOT23), pads should "
            "be named only by numbers anyway, not by functionality (e.g. name "
-           "them '1', '2', '3' instead of 'D', 'G', 'S').")) {
+           "them '1', '2', '3' instead of 'D', 'G', 'S')."),
+        "DuplicatePadName") {
+  mApproval.appendChild("name", *pad.getName());
 }
 
 MsgDuplicatePadName::~MsgDuplicatePadName() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msginvalidcustompadoutline.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msginvalidcustompadoutline.cpp
@@ -42,9 +42,15 @@ MsgInvalidCustomPadOutline::MsgInvalidCustomPadOutline(
             .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
         tr("The pad has set a custom outline which does not represent a valid "
            "area. Either choose a different pad shape or specify a valid "
-           "custom outline.")),
+           "custom outline."),
+        "InvalidCustomPadOutline"),
     mFootprint(footprint),
     mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgInvalidCustomPadOutline::~MsgInvalidCustomPadOutline() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgmissingfootprint.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgmissingfootprint.cpp
@@ -35,7 +35,8 @@ MsgMissingFootprint::MsgMissingFootprint() noexcept
   : LibraryElementCheckMessage(
         Severity::Error, tr("No footprint defined"),
         tr("Every package must have at least one footprint, otherwise it can't "
-           "be added to a board.")) {
+           "be added to a board."),
+        "MissingFootprint") {
 }
 
 MsgMissingFootprint::~MsgMissingFootprint() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgmissingfootprintname.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgmissingfootprintname.cpp
@@ -43,7 +43,11 @@ MsgMissingFootprintName::MsgMissingFootprintName(
            "name, otherwise you won't see that name on the PCB (e.g. on "
            "silkscreen). There are only a few exceptions which don't need a "
            "name (e.g. if the footprint is only a drawing), for those you can "
-           "ignore this message.")) {
+           "ignore this message."),
+        "MissingNameText") {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgMissingFootprintName::~MsgMissingFootprintName() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgmissingfootprintvalue.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgmissingfootprintvalue.cpp
@@ -43,7 +43,11 @@ MsgMissingFootprintValue::MsgMissingFootprintValue(
            "value, otherwise you won't see that value on the PCB (e.g. on "
            "silkscreen). There are only a few exceptions which don't need a "
            "value (e.g. if the footprint is only a drawing), for those you can "
-           "ignore this message.")) {
+           "ignore this message."),
+        "MissingValueText") {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgMissingFootprintValue::~MsgMissingFootprintValue() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadannularringviolation.cpp
@@ -44,9 +44,15 @@ MsgPadAnnularRingViolation::MsgPadAnnularRingViolation(
         tr("Pads should have at least %1 annular ring (copper around each pad "
            "hole). Note that this value is just a general recommendation, the "
            "exact value depends on the capabilities of the PCB manufacturer.")
-            .arg(QString::number(annularRing.toMm() * 1000) % "μm")),
+            .arg(QString::number(annularRing.toMm() * 1000) % "μm"),
+        "SmallPadAnnularRing"),
     mFootprint(footprint),
     mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgPadAnnularRingViolation::~MsgPadAnnularRingViolation() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgpadclearanceviolation.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadclearanceviolation.cpp
@@ -47,10 +47,18 @@ MsgPadClearanceViolation::MsgPadClearanceViolation(
            "situations it might be needed to use smaller clearances but not "
            "all PCB manufacturers are able to reliably produce such small "
            "clearances, so usually this should be avoided.")
-            .arg(QString::number(clearance.toMm() * 1000) % "μm")),
+            .arg(QString::number(clearance.toMm() * 1000) % "μm"),
+        "SmallPadClearance"),
     mFootprint(footprint),
     mPad1(pad1),
     mPad2(pad2) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", std::min(pad1->getUuid(), pad2->getUuid()));
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", std::max(pad1->getUuid(), pad2->getUuid()));
+  mApproval.ensureLineBreak();
 }
 
 MsgPadClearanceViolation::~MsgPadClearanceViolation() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgpadholeoutsidecopper.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadholeoutsidecopper.cpp
@@ -42,9 +42,15 @@ MsgPadHoleOutsideCopper::MsgPadHoleOutsideCopper(
             .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
         tr("All THT pad holes must be fully surrounded by copper, otherwise "
            "they could lead to serious issues during the design rule check or "
-           "manufacturing process.")),
+           "manufacturing process."),
+        "PadHoleOutsideCopper"),
     mFootprint(footprint),
     mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgPadHoleOutsideCopper::~MsgPadHoleOutsideCopper() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgpadoriginoutsidecopper.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadoriginoutsidecopper.cpp
@@ -44,9 +44,15 @@ MsgPadOriginOutsideCopper::MsgPadOriginOutsideCopper(
            "otherwise traces won't be connected properly.\n\n"
            "For THT pads, the origin must be located within a drill "
            "hole since on some layers the pad might only have a small annular "
-           "ring instead of the full pad shape.")),
+           "ring instead of the full pad shape."),
+        "PadOriginOutsideCopper"),
     mFootprint(footprint),
     mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgPadOriginOutsideCopper::~MsgPadOriginOutsideCopper() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgpadoverlapswithplacement.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgpadoverlapswithplacement.cpp
@@ -44,9 +44,15 @@ MsgPadOverlapsWithPlacement::MsgPadOverlapsWithPlacement(
         tr("Pads should have at least %1 clearance to the outlines "
            "layer because outlines are drawn on silkscreen which will "
            "be cropped for Gerber export.")
-            .arg(QString::number(clearance.toMm() * 1000) % "μm")),
+            .arg(QString::number(clearance.toMm() * 1000) % "μm"),
+        "PadOverlapsPlacement"),
     mFootprint(footprint),
     mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgPadOverlapsWithPlacement::~MsgPadOverlapsWithPlacement() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgunusedcustompadoutline.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgunusedcustompadoutline.cpp
@@ -41,9 +41,15 @@ MsgUnusedCustomPadOutline::MsgUnusedCustomPadOutline(
         tr("Unused custom outline of pad '%1' in '%2'")
             .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
         tr("The pad has set a custom outline but it isn't used as the shape. "
-           "So it has no effect and should be removed to avoid confusion.")),
+           "So it has no effect and should be removed to avoid confusion."),
+        "UnusedCustomPadOutline"),
     mFootprint(footprint),
     mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgUnusedCustomPadOutline::~MsgUnusedCustomPadOutline() noexcept {

--- a/libs/librepcb/core/library/pkg/msg/msgwrongfootprinttextlayer.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgwrongfootprinttextlayer.cpp
@@ -46,10 +46,16 @@ MsgWrongFootprintTextLayer::MsgWrongFootprintTextLayer(
                  GraphicsLayer::getTranslation(expectedLayerName)),
         tr("The text element '%1' should normally be on layer '%2'.")
             .arg(text->getText(),
-                 GraphicsLayer::getTranslation(expectedLayerName))),
+                 GraphicsLayer::getTranslation(expectedLayerName)),
+        "UnusualTextLayer"),
     mFootprint(footprint),
     mText(text),
     mExpectedLayerName(expectedLayerName) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("text", text->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgWrongFootprintTextLayer::~MsgWrongFootprintTextLayer() noexcept {

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -93,6 +93,8 @@ void Package::serialize(SExpression& root) const {
   root.ensureLineBreak();
   mFootprints.serialize(root);
   root.ensureLineBreak();
+  serializeMessageApprovals(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/sym/msg/msgduplicatepinname.cpp
+++ b/libs/librepcb/core/library/sym/msg/msgduplicatepinname.cpp
@@ -40,7 +40,9 @@ MsgDuplicatePinName::MsgDuplicatePinName(const SymbolPin& pin) noexcept
            "distinguished later in the component editor. If your part has "
            "several pins with same functionality (e.g. multiple GND pins), you "
            "should add only one of these pins to the symbol. The assignment to "
-           "multiple leads should be done in the device editor instead.")) {
+           "multiple leads should be done in the device editor instead."),
+        "PinNameDuplicate") {
+  mApproval.appendChild("name", *pin.getName());
 }
 
 MsgDuplicatePinName::~MsgDuplicatePinName() noexcept {

--- a/libs/librepcb/core/library/sym/msg/msgmissingsymbolname.cpp
+++ b/libs/librepcb/core/library/sym/msg/msgmissingsymbolname.cpp
@@ -37,7 +37,8 @@ MsgMissingSymbolName::MsgMissingSymbolName() noexcept
         tr("Most symbols should have a text element for the component's name, "
            "otherwise you won't see that name in the schematics. There are "
            "only a few exceptions (e.g. a schematic frame) which don't need a "
-           "name, for those you can ignore this message.")) {
+           "name, for those you can ignore this message."),
+        "NameTextMissing") {
 }
 
 MsgMissingSymbolName::~MsgMissingSymbolName() noexcept {

--- a/libs/librepcb/core/library/sym/msg/msgmissingsymbolvalue.cpp
+++ b/libs/librepcb/core/library/sym/msg/msgmissingsymbolvalue.cpp
@@ -37,7 +37,8 @@ MsgMissingSymbolValue::MsgMissingSymbolValue() noexcept
         tr("Most symbols should have a text element for the component's value, "
            "otherwise you won't see that value in the schematics. There are "
            "only a few exceptions (e.g. a schematic frame) which don't need a "
-           "value, for those you can ignore this message.")) {
+           "value, for those you can ignore this message."),
+        "ValueTextMissing") {
 }
 
 MsgMissingSymbolValue::~MsgMissingSymbolValue() noexcept {

--- a/libs/librepcb/core/library/sym/msg/msgoverlappingsymbolpins.cpp
+++ b/libs/librepcb/core/library/sym/msg/msgoverlappingsymbolpins.cpp
@@ -40,8 +40,20 @@ MsgOverlappingSymbolPins::MsgOverlappingSymbolPins(
         Severity::Error, buildMessage(pins),
         tr("There are multiple pins at the same position. This is not allowed "
            "because you cannot connect wires to these pins in the schematic "
-           "editor.")),
+           "editor."),
+        "PinOverlap"),
     mPins(pins) {
+  QVector<std::shared_ptr<const SymbolPin>> sortedPins = pins;
+  std::sort(sortedPins.begin(), sortedPins.end(),
+            [](const std::shared_ptr<const SymbolPin>& a,
+               const std::shared_ptr<const SymbolPin>& b) {
+              return a->getUuid() < b->getUuid();
+            });
+  foreach (const auto& pin, pins) {
+    mApproval.ensureLineBreak();
+    mApproval.appendChild("pin", pin->getUuid());
+  }
+  mApproval.ensureLineBreak();
 }
 
 MsgOverlappingSymbolPins::~MsgOverlappingSymbolPins() noexcept {

--- a/libs/librepcb/core/library/sym/msg/msgsymbolpinnotongrid.cpp
+++ b/libs/librepcb/core/library/sym/msg/msgsymbolpinnotongrid.cpp
@@ -42,9 +42,13 @@ MsgSymbolPinNotOnGrid::MsgSymbolPinNotOnGrid(
             .arg(gridInterval->toMmString(), *pin->getName()),
         tr("Every pin must be placed exactly on the %1mm grid, "
            "otherwise it cannot be connected in the schematic editor.")
-            .arg(gridInterval->toMmString())),
+            .arg(gridInterval->toMmString()),
+        "PinPosition"),
     mPin(pin),
     mGridInterval(gridInterval) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pin", pin->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgSymbolPinNotOnGrid::~MsgSymbolPinNotOnGrid() noexcept {

--- a/libs/librepcb/core/library/sym/msg/msgwrongsymboltextlayer.cpp
+++ b/libs/librepcb/core/library/sym/msg/msgwrongsymboltextlayer.cpp
@@ -43,9 +43,13 @@ MsgWrongSymbolTextLayer::MsgWrongSymbolTextLayer(
                  GraphicsLayer::getTranslation(expectedLayerName)),
         tr("The text element '%1' should normally be on layer '%2'.")
             .arg(text->getText(),
-                 GraphicsLayer::getTranslation(expectedLayerName))),
+                 GraphicsLayer::getTranslation(expectedLayerName)),
+        "TextLayer"),
     mText(text),
     mExpectedLayerName(expectedLayerName) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("text", text->getUuid());
+  mApproval.ensureLineBreak();
 }
 
 MsgWrongSymbolTextLayer::~MsgWrongSymbolTextLayer() noexcept {

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -120,6 +120,8 @@ void Symbol::serialize(SExpression& root) const {
   root.ensureLineBreak();
   mTexts.serialize(root);
   root.ensureLineBreak();
+  serializeMessageApprovals(root);
+  root.ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/sexpression.cpp
+++ b/libs/librepcb/core/serialization/sexpression.cpp
@@ -26,6 +26,8 @@
 
 #include <QtCore>
 
+#include <algorithm>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -222,6 +224,22 @@ bool SExpression::operator==(const SExpression& rhs) const noexcept {
   // Note: Ignore the filepath since it's not part of the actual node.
   return (mType == rhs.mType) && (mValue == rhs.mValue) &&
       (mChildren == rhs.mChildren);
+}
+
+bool SExpression::operator<(const SExpression& rhs) const noexcept {
+  if (mType != rhs.mType) {
+    return static_cast<int>(mType) < static_cast<int>(rhs.mType);
+  } else if (mValue != rhs.mValue) {
+    return mValue < rhs.mValue;
+  } else {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    return mChildren < rhs.mChildren;
+#else
+    return std::lexicographical_compare(mChildren.begin(), mChildren.end(),
+                                        rhs.mChildren.begin(),
+                                        rhs.mChildren.end());
+#endif
+  }
 }
 
 SExpression& SExpression::operator=(const SExpression& rhs) noexcept {

--- a/libs/librepcb/core/serialization/sexpression.h
+++ b/libs/librepcb/core/serialization/sexpression.h
@@ -181,6 +181,7 @@ public:
   bool operator!=(const SExpression& rhs) const noexcept {
     return !(*this == rhs);
   }
+  bool operator<(const SExpression& rhs) const noexcept;
   SExpression& operator=(const SExpression& rhs) noexcept;
 
   // Static Methods
@@ -217,6 +218,28 @@ private:  // Data
   QList<SExpression> mChildren;
   FilePath mFilePath;
 };
+
+/*******************************************************************************
+ *  Non-Member Functions
+ ******************************************************************************/
+
+inline uint qHash(const SExpression& node, uint seed = 0) noexcept {
+  switch (node.getType()) {
+    case SExpression::Type::LineBreak:
+      return ::qHash(static_cast<int>(node.getType()), seed);
+    case SExpression::Type::String:
+    case SExpression::Type::Token:
+      return ::qHash(
+          qMakePair(static_cast<int>(node.getType()), node.getValue()), seed);
+    case SExpression::Type::List: {
+      const QList<SExpression>& children = node.getChildren();
+      return ::qHashRange(children.begin(), children.end(), seed);
+    }
+    default:
+      Q_ASSERT(false);
+      return 0;
+  }
+}
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.cpp
+++ b/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.cpp
@@ -110,6 +110,10 @@ QSet<EditorWidgetBase::Feature>
  ******************************************************************************/
 
 bool ComponentCategoryEditorWidget::save() noexcept {
+  // Remove obsolete message approvals (bypassing the undo stack).
+  mCategory->setMessageApprovals(mCategory->getMessageApprovals() -
+                                 mDisappearedApprovals);
+
   // Commit metadata.
   QString errorMsg = commitMetadata();
   if (!errorMsg.isEmpty()) {
@@ -141,6 +145,7 @@ void ComponentCategoryEditorWidget::updateMetadata() noexcept {
   mUi->edtAuthor->setText(mCategory->getAuthor());
   mUi->edtVersion->setText(mCategory->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mCategory->isDeprecated());
+  mUi->lstMessages->setApprovals(mCategory->getMessageApprovals());
   mParentUuid = mCategory->getParentUuid();
   updateCategoryLabel();
 }
@@ -213,6 +218,13 @@ bool ComponentCategoryEditorWidget::processCheckMessage(
   if (fixMsgHelper<MsgNameNotTitleCase>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingAuthor>(msg, applyFix)) return true;
   return false;
+}
+
+void ComponentCategoryEditorWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  setMessageApproved(*mCategory, msg, approve);
+  updateMetadata();
 }
 
 void ComponentCategoryEditorWidget::btnChooseParentCategoryClicked() noexcept {

--- a/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.h
+++ b/libs/librepcb/editor/library/cat/componentcategoryeditorwidget.h
@@ -88,6 +88,9 @@ private:  // Methods
   bool processCheckMessage(
       std::shared_ptr<const LibraryElementCheckMessage> msg,
       bool applyFix) override;
+  void libraryElementCheckApproveRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool approve) noexcept override;
   void btnChooseParentCategoryClicked() noexcept;
   void btnResetParentCategoryClicked() noexcept;
   void updateCategoryLabel() noexcept;

--- a/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.cpp
+++ b/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.cpp
@@ -110,6 +110,10 @@ QSet<EditorWidgetBase::Feature>
  ******************************************************************************/
 
 bool PackageCategoryEditorWidget::save() noexcept {
+  // Remove obsolete message approvals (bypassing the undo stack).
+  mCategory->setMessageApprovals(mCategory->getMessageApprovals() -
+                                 mDisappearedApprovals);
+
   // Commit metadata.
   QString errorMsg = commitMetadata();
   if (!errorMsg.isEmpty()) {
@@ -141,6 +145,7 @@ void PackageCategoryEditorWidget::updateMetadata() noexcept {
   mUi->edtAuthor->setText(mCategory->getAuthor());
   mUi->edtVersion->setText(mCategory->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mCategory->isDeprecated());
+  mUi->lstMessages->setApprovals(mCategory->getMessageApprovals());
   mParentUuid = mCategory->getParentUuid();
   updateCategoryLabel();
 }
@@ -213,6 +218,13 @@ bool PackageCategoryEditorWidget::processCheckMessage(
   if (fixMsgHelper<MsgNameNotTitleCase>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingAuthor>(msg, applyFix)) return true;
   return false;
+}
+
+void PackageCategoryEditorWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  setMessageApproved(*mCategory, msg, approve);
+  updateMetadata();
 }
 
 void PackageCategoryEditorWidget::btnChooseParentCategoryClicked() noexcept {

--- a/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.h
+++ b/libs/librepcb/editor/library/cat/packagecategoryeditorwidget.h
@@ -88,6 +88,9 @@ private:  // Methods
   bool processCheckMessage(
       std::shared_ptr<const LibraryElementCheckMessage> msg,
       bool applyFix) override;
+  void libraryElementCheckApproveRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool approve) noexcept override;
   void btnChooseParentCategoryClicked() noexcept;
   void btnResetParentCategoryClicked() noexcept;
   void updateCategoryLabel() noexcept;

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
@@ -151,6 +151,10 @@ QSet<EditorWidgetBase::Feature> ComponentEditorWidget::getAvailableFeatures()
  ******************************************************************************/
 
 bool ComponentEditorWidget::save() noexcept {
+  // Remove obsolete message approvals (bypassing the undo stack).
+  mComponent->setMessageApprovals(mComponent->getMessageApprovals() -
+                                  mDisappearedApprovals);
+
   // Commit metadata.
   QString errorMsg = commitMetadata();
   if (!errorMsg.isEmpty()) {
@@ -183,6 +187,7 @@ void ComponentEditorWidget::updateMetadata() noexcept {
   mUi->edtAuthor->setText(mComponent->getAuthor());
   mUi->edtVersion->setText(mComponent->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mComponent->isDeprecated());
+  mUi->lstMessages->setApprovals(mComponent->getMessageApprovals());
   mCategoriesEditorWidget->setUuids(mComponent->getCategories());
   mUi->cbxSchematicOnly->setChecked(mComponent->isSchematicOnly());
   mUi->edtPrefix->setText(*mComponent->getPrefixes().getDefaultValue());
@@ -349,6 +354,13 @@ bool ComponentEditorWidget::processCheckMessage(
   if (fixMsgHelper<MsgMissingComponentDefaultValue>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingSymbolVariant>(msg, applyFix)) return true;
   return false;
+}
+
+void ComponentEditorWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  setMessageApproved(*mComponent, msg, approve);
+  updateMetadata();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.h
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.h
@@ -94,6 +94,9 @@ private:  // Methods
   bool processCheckMessage(
       std::shared_ptr<const LibraryElementCheckMessage> msg,
       bool applyFix) override;
+  void libraryElementCheckApproveRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool approve) noexcept override;
 
 private:  // Data
   QScopedPointer<Ui::ComponentEditorWidget> mUi;

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
@@ -168,6 +168,10 @@ QSet<EditorWidgetBase::Feature> DeviceEditorWidget::getAvailableFeatures() const
  ******************************************************************************/
 
 bool DeviceEditorWidget::save() noexcept {
+  // Remove obsolete message approvals (bypassing the undo stack).
+  mDevice->setMessageApprovals(mDevice->getMessageApprovals() -
+                               mDisappearedApprovals);
+
   // Commit metadata.
   QString errorMsg = commitMetadata();
   if (!errorMsg.isEmpty()) {
@@ -218,6 +222,7 @@ void DeviceEditorWidget::updateMetadata() noexcept {
   mUi->edtAuthor->setText(mDevice->getAuthor());
   mUi->edtVersion->setText(mDevice->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mDevice->isDeprecated());
+  mUi->lstMessages->setApprovals(mDevice->getMessageApprovals());
   mCategoriesEditorWidget->setUuids(mDevice->getCategories());
 }
 
@@ -492,6 +497,13 @@ bool DeviceEditorWidget::processCheckMessage(
   if (fixMsgHelper<MsgMissingAuthor>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingCategories>(msg, applyFix)) return true;
   return false;
+}
+
+void DeviceEditorWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  setMessageApproved(*mDevice, msg, approve);
+  updateMetadata();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.h
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.h
@@ -104,6 +104,9 @@ private:  // Methods
   bool processCheckMessage(
       std::shared_ptr<const LibraryElementCheckMessage> msg,
       bool applyFix) override;
+  void libraryElementCheckApproveRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool approve) noexcept override;
 
 private:  // Data
   QScopedPointer<Ui::DeviceEditorWidget> mUi;

--- a/libs/librepcb/editor/library/editorwidgetbase.h
+++ b/libs/librepcb/editor/library/editorwidgetbase.h
@@ -122,7 +122,9 @@ public:
 
   // Getters
   const FilePath& getFilePath() const noexcept { return mFilePath; }
-  bool isDirty() const noexcept { return !mUndoStack->isClean(); }
+  bool isDirty() const noexcept {
+    return mManualModificationsMade || (!mUndoStack->isClean());
+  }
   virtual QSet<Feature> getAvailableFeatures() const noexcept = 0;
 
   // Setters
@@ -181,6 +183,9 @@ protected:  // Methods
     return false;
   }
   virtual bool runChecks(LibraryElementCheckMessageList& msgs) const = 0;
+  void setMessageApproved(LibraryBaseElement& element,
+                          std::shared_ptr<const LibraryElementCheckMessage> msg,
+                          bool approve) noexcept;
   virtual bool execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                         const QString& settingsKey) noexcept {
     Q_UNUSED(output);
@@ -236,8 +241,13 @@ protected:  // Data
   ExclusiveActionGroup* mToolsActionGroup;
   StatusBar* mStatusBar;
   QScopedPointer<ToolBarProxy> mCommandToolBarProxy;
+  bool mManualModificationsMade;  ///< Modifications bypassing the undo stack.
   bool mIsInterfaceBroken;
   QString mStatusBarMessage;
+
+  // Memorized message approvals
+  QSet<SExpression> mSupportedApprovals;
+  QSet<SExpression> mDisappearedApprovals;
 };
 
 inline uint qHash(const EditorWidgetBase::Feature& feature,

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
@@ -194,6 +194,10 @@ void LibraryOverviewWidget::setFilter(const QString& filter) noexcept {
  ******************************************************************************/
 
 bool LibraryOverviewWidget::save() noexcept {
+  // Remove obsolete message approvals (bypassing the undo stack).
+  mLibrary->setMessageApprovals(mLibrary->getMessageApprovals() -
+                                mDisappearedApprovals);
+
   // Commit metadata.
   QString errorMsg = commitMetadata();
   if (!errorMsg.isEmpty()) {
@@ -296,6 +300,7 @@ void LibraryOverviewWidget::updateMetadata() noexcept {
   mUi->edtVersion->setText(mLibrary->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mLibrary->isDeprecated());
   mUi->edtUrl->setText(mLibrary->getUrl().toString());
+  mUi->lstMessages->setApprovals(mLibrary->getMessageApprovals());
   mDependenciesEditorWidget->setUuids(mLibrary->getDependencies());
   mIcon = mLibrary->getIcon();
 }
@@ -369,6 +374,13 @@ bool LibraryOverviewWidget::processCheckMessage(
   if (fixMsgHelper<MsgNameNotTitleCase>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingAuthor>(msg, applyFix)) return true;
   return false;
+}
+
+void LibraryOverviewWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  setMessageApproved(*mLibrary, msg, approve);
+  updateMetadata();
 }
 
 void LibraryOverviewWidget::updateElementLists() noexcept {

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.h
@@ -118,6 +118,9 @@ private:  // Methods
   bool processCheckMessage(
       std::shared_ptr<const LibraryElementCheckMessage> msg,
       bool applyFix) override;
+  void libraryElementCheckApproveRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool approve) noexcept override;
   void updateElementLists() noexcept;
   template <typename ElementType>
   void updateElementList(QListWidget& listWidget, const QIcon& icon) noexcept;

--- a/libs/librepcb/editor/library/libraryelementchecklistwidget.cpp
+++ b/libs/librepcb/editor/library/libraryelementchecklistwidget.cpp
@@ -41,6 +41,7 @@ LibraryElementCheckListWidget::LibraryElementCheckListWidget(
   : QWidget(parent),
     mListWidget(new QListWidget(this)),
     mHandler(nullptr),
+    mApprovals(),
     mProvideFixes(true) {
   QVBoxLayout* layout = new QVBoxLayout(this);
   layout->setContentsMargins(0, 0, 0, 0);
@@ -109,17 +110,27 @@ void LibraryElementCheckListWidget::setMessages(
   }
 }
 
+void LibraryElementCheckListWidget::setApprovals(
+    const QSet<SExpression>& approvals) noexcept {
+  if (approvals != mApprovals) {
+    mApprovals = approvals;
+    updateList();
+  }
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 
 void LibraryElementCheckListWidget::updateList() noexcept {
+  mListWidget->setUpdatesEnabled(false);  // Avoid flicker.
   mListWidget->clear();
   foreach (const auto& msg, mMessages) {
     QListWidgetItem* item = new QListWidgetItem();
     mListWidget->addItem(item);
+    const bool approved = mApprovals.contains(msg->getApproval());
     LibraryElementCheckListItemWidget* widget =
-        new LibraryElementCheckListItemWidget(msg, *this);
+        new LibraryElementCheckListItemWidget(msg, *this, approved);
     mListWidget->setItemWidget(item, widget);
   }
   if (mListWidget->count() == 0) {
@@ -128,6 +139,7 @@ void LibraryElementCheckListWidget::updateList() noexcept {
   } else {
     mListWidget->setEnabled(true);
   }
+  mListWidget->setUpdatesEnabled(true);
 }
 
 void LibraryElementCheckListWidget::itemDoubleClicked(
@@ -163,6 +175,14 @@ void LibraryElementCheckListWidget::libraryElementCheckDescriptionRequested(
     std::shared_ptr<const LibraryElementCheckMessage> msg) noexcept {
   if (mHandler) {
     mHandler->libraryElementCheckDescriptionRequested(msg);
+  }
+}
+
+void LibraryElementCheckListWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  if (mHandler) {
+    mHandler->libraryElementCheckApproveRequested(msg, approve);
   }
 }
 

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -267,6 +267,10 @@ void PackageEditorWidget::disconnectEditor() noexcept {
  ******************************************************************************/
 
 bool PackageEditorWidget::save() noexcept {
+  // Remove obsolete message approvals (bypassing the undo stack).
+  mPackage->setMessageApprovals(mPackage->getMessageApprovals() -
+                                mDisappearedApprovals);
+
   // Commit metadata.
   QString errorMsg = commitMetadata();
   if (!errorMsg.isEmpty()) {
@@ -391,6 +395,7 @@ void PackageEditorWidget::updateMetadata() noexcept {
   mUi->edtAuthor->setText(mPackage->getAuthor());
   mUi->edtVersion->setText(mPackage->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mPackage->isDeprecated());
+  mUi->lstMessages->setApprovals(mPackage->getMessageApprovals());
   mCategoriesEditorWidget->setUuids(mPackage->getCategories());
 }
 
@@ -643,6 +648,13 @@ bool PackageEditorWidget::processCheckMessage(
   if (fixMsgHelper<MsgUnusedCustomPadOutline>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgInvalidCustomPadOutline>(msg, applyFix)) return true;
   return false;
+}
+
+void PackageEditorWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  setMessageApproved(*mPackage, msg, approve);
+  updateMetadata();
 }
 
 bool PackageEditorWidget::execGraphicsExportDialog(

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.h
@@ -125,6 +125,9 @@ private:  // Methods
   bool processCheckMessage(
       std::shared_ptr<const LibraryElementCheckMessage> msg,
       bool applyFix) override;
+  void libraryElementCheckApproveRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool approve) noexcept override;
   bool execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                 const QString& settingsKey) noexcept override;
   void setGridProperties(const PositiveLength& interval, const LengthUnit& unit,

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
@@ -252,6 +252,10 @@ void SymbolEditorWidget::disconnectEditor() noexcept {
  ******************************************************************************/
 
 bool SymbolEditorWidget::save() noexcept {
+  // Remove obsolete message approvals (bypassing the undo stack).
+  mSymbol->setMessageApprovals(mSymbol->getMessageApprovals() -
+                               mDisappearedApprovals);
+
   // Commit metadata.
   QString errorMsg = commitMetadata();
   if (!errorMsg.isEmpty()) {
@@ -372,6 +376,7 @@ void SymbolEditorWidget::updateMetadata() noexcept {
   mUi->edtAuthor->setText(mSymbol->getAuthor());
   mUi->edtVersion->setText(mSymbol->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mSymbol->isDeprecated());
+  mUi->lstMessages->setApprovals(mSymbol->getMessageApprovals());
   mCategoriesEditorWidget->setUuids(mSymbol->getCategories());
 }
 
@@ -576,6 +581,13 @@ bool SymbolEditorWidget::processCheckMessage(
   if (fixMsgHelper<MsgWrongSymbolTextLayer>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgSymbolPinNotOnGrid>(msg, applyFix)) return true;
   return false;
+}
+
+void SymbolEditorWidget::libraryElementCheckApproveRequested(
+    std::shared_ptr<const LibraryElementCheckMessage> msg,
+    bool approve) noexcept {
+  setMessageApproved(*mSymbol, msg, approve);
+  updateMetadata();
 }
 
 bool SymbolEditorWidget::execGraphicsExportDialog(

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.h
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.h
@@ -121,6 +121,9 @@ private:  // Methods
   bool processCheckMessage(
       std::shared_ptr<const LibraryElementCheckMessage> msg,
       bool applyFix) override;
+  void libraryElementCheckApproveRequested(
+      std::shared_ptr<const LibraryElementCheckMessage> msg,
+      bool approve) noexcept override;
   bool execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                 const QString& settingsKey) noexcept override;
   void setGridProperties(const PositiveLength& interval, const LengthUnit& unit,

--- a/tests/cli/open_library/test_parser.py
+++ b/tests/cli/open_library/test_parser.py
@@ -15,6 +15,9 @@ Options:
   -v, --verbose  Verbose output.
   --all          Perform the selected action(s) on all elements contained in
                  the opened library.
+  --check        Run the library element check, print all non-approved messages
+                 and report failure (exit code = 1) if there are non-approved
+                 messages.
   --save         Save library (and contained elements if '--all' is given)
                  before closing them (useful to upgrade file format).
   --strict       Fail if the opened files are not strictly canonical, i.e.


### PR DESCRIPTION
## Summary

Support dismissing library check messages, which is then stored in the corresponding files to make it persistent (see #1006). I called it "approvals". This feature is a requirement to allow running the library checks from the CLI (#1007).

## User Interface

![image](https://user-images.githubusercontent.com/5374821/220183324-9e323548-c824-4a93-846a-aaa6122d2d95.png)

Approved messages are currently not removed from the list to allow reviewing them easily and usually the list is not flooded by lots of messages anyway.

## File Format

Within each library elements S-Expression file, new nodes are added for each approved message:

```scheme
 (approval "PadOriginOutsideCopper"
  (footprint 36215090-ab6d-45fe-9ffd-693fe09d4aa2)
  (pad d4907411-cbd5-4ce2-838a-82de885d718c)
 )
```

The child nodes depend on the kind of message (to make them unique), some kinds do not have children at all.

## Open Questions

Not 100% sure about how to format approved messages in the file format. Currently I implemented the identifier as a PascalCase string:

```scheme
 (approval "PadOriginOutsideCopper")
```

But I wonder if one of the following formatting would look nicer:

```scheme
 (approval "pad origin outside copper")
 (approval "pad-origin-outside-copper")
 (approval pad_origin_outside_copper)
 (approval PadOriginOutsideCopper)
```

Any opinions welcome :slightly_smiling_face: 