### PR TITLE
Package check: Turn overlapping pads into an error

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -256,6 +256,8 @@ add_library(
   library/pkg/msg/msgmissingfootprintname.h
   library/pkg/msg/msgmissingfootprintvalue.cpp
   library/pkg/msg/msgmissingfootprintvalue.h
+  library/pkg/msg/msgoverlappingpads.cpp
+  library/pkg/msg/msgoverlappingpads.h
   library/pkg/msg/msgpadannularringviolation.cpp
   library/pkg/msg/msgpadannularringviolation.h
   library/pkg/msg/msgpadclearanceviolation.cpp

--- a/libs/librepcb/core/library/pkg/msg/msgoverlappingpads.cpp
+++ b/libs/librepcb/core/library/pkg/msg/msgoverlappingpads.cpp
@@ -1,0 +1,61 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "msgoverlappingpads.h"
+
+#include "../footprint.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+MsgOverlappingPads::MsgOverlappingPads(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad1, const QString& pkgPad1Name,
+    std::shared_ptr<const FootprintPad> pad2,
+    const QString& pkgPad2Name) noexcept
+  : LibraryElementCheckMessage(
+        Severity::Error,
+        tr("Overlapping pads '%1' and '%2' in '%3'")
+            .arg(pkgPad1Name, pkgPad2Name,
+                 *footprint->getNames().getDefaultValue()),
+        tr("The copper area of two pads overlap. This can lead to serious "
+           "issues with the design rule check and probably leads to a short "
+           "circuit in the board so this really needs to be fixed.")),
+    mFootprint(footprint),
+    mPad1(pad1),
+    mPad2(pad2) {
+}
+
+MsgOverlappingPads::~MsgOverlappingPads() noexcept {
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/library/pkg/msg/msgoverlappingpads.h
+++ b/libs/librepcb/core/library/pkg/msg/msgoverlappingpads.h
@@ -1,0 +1,82 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_MSGOVERLAPPINGPADS_H
+#define LIBREPCB_CORE_MSGOVERLAPPINGPADS_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../msg/libraryelementcheckmessage.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class Footprint;
+class FootprintPad;
+
+/*******************************************************************************
+ *  Class MsgOverlappingPads
+ ******************************************************************************/
+
+/**
+ * @brief The MsgOverlappingPads class
+ */
+class MsgOverlappingPads final : public LibraryElementCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgOverlappingPads)
+
+public:
+  // Constructors / Destructor
+  MsgOverlappingPads() = delete;
+  MsgOverlappingPads(std::shared_ptr<const Footprint> footprint,
+                     std::shared_ptr<const FootprintPad> pad1,
+                     const QString& pkgPad1Name,
+                     std::shared_ptr<const FootprintPad> pad2,
+                     const QString& pkgPad2Name) noexcept;
+  MsgOverlappingPads(const MsgOverlappingPads& other) noexcept
+    : LibraryElementCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mPad1(other.mPad1),
+      mPad2(other.mPad2) {}
+  virtual ~MsgOverlappingPads() noexcept;
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad1() const noexcept { return mPad1; }
+  std::shared_ptr<const FootprintPad> getPad2() const noexcept { return mPad2; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad1;
+  std::shared_ptr<const FootprintPad> mPad2;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif


### PR DESCRIPTION
So far there was only a clearance warning if the clearance between two footprint pads was too small - even if they actually overlapped. Now an overlap is handled separately and turned into an error (instead of warning) since this can cause serious trouble.