### PR TITLE
CLI: Support "--check" flag to run library element checks

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -68,11 +68,11 @@ private:  // Methods
                    const QStringList& boardNames,
                    const QStringList& boardIndices, bool removeOtherBoards,
                    bool save, bool strict) const noexcept;
-  bool openLibrary(const QString& libDir, bool all, bool save,
+  bool openLibrary(const QString& libDir, bool all, bool runCheck, bool save,
                    bool strict) const noexcept;
   void processLibraryElement(const QString& libDir, TransactionalFileSystem& fs,
-                             LibraryBaseElement& element, bool save,
-                             bool strict, bool& success) const;
+                             LibraryBaseElement& element, bool runCheck,
+                             bool save, bool strict, bool& success) const;
   static QString prettyPath(const FilePath& path,
                             const QString& style) noexcept;
   static bool failIfFileFormatUnstable() noexcept;

--- a/tests/cli/open_library/test_parser.py
+++ b/tests/cli/open_library/test_parser.py
@@ -15,6 +15,9 @@ Options:
   -v, --verbose  Verbose output.
   --all          Perform the selected action(s) on all elements contained in
                  the opened library.
+  --check        Run the library element check, print all non-approved messages
+                 and report failure (exit code = 1) if there are non-approved
+                 messages.
   --save         Save library (and contained elements if '--all' is given)
                  before closing them (useful to upgrade file format).
   --strict       Fail if the opened files are not strictly canonical, i.e.


### PR DESCRIPTION
Adding a new CLI flag `--check` to run the library element checks. If there are any non-approved messages, the CLI prints them to stderr and returns with exit code 1.

Closes #1007