### PR TITLE
CMake: Compile with '-Wpedantic' flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,15 @@ endif()
 # Create "common" interface library which is used for DRY configuration of
 # build flags.
 add_library(common INTERFACE)
-target_compile_options(common INTERFACE -Wall -Wextra)
+target_compile_options(common INTERFACE -Wall -Wextra -Wpedantic)
 if(BUILD_DISALLOW_WARNINGS)
   target_compile_options(common INTERFACE -Werror)
+endif()
+
+# Clang emits some warnings within the muParser library when compiling with
+# -Wpedantic, so let's suppress these warnings when compiling with Clang.
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+target_compile_options(common INTERFACE -Wno-nested-anon-types)
 endif()
 
 # Find required Qt packages

--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -45,7 +45,7 @@ namespace cli {
  * @brief The CommandLineInterface class
  */
 class CommandLineInterface final {
-  Q_DECLARE_TR_FUNCTIONS(CommandLineInterface);
+  Q_DECLARE_TR_FUNCTIONS(CommandLineInterface)
 
 public:
   // Constructors / Destructor

--- a/libs/librepcb/core/export/graphicsexport.cpp
+++ b/libs/librepcb/core/export/graphicsexport.cpp
@@ -31,8 +31,8 @@
 #include <QtPrintSupport>
 #include <QtSvg>
 
-Q_DECLARE_METATYPE(QImage);
-Q_DECLARE_METATYPE(std::shared_ptr<QPicture>);
+Q_DECLARE_METATYPE(QImage)
+Q_DECLARE_METATYPE(std::shared_ptr<QPicture>)
 
 /*******************************************************************************
  *  Namespace

--- a/libs/librepcb/core/fileio/filepath.h
+++ b/libs/librepcb/core/fileio/filepath.h
@@ -137,7 +137,7 @@ public:  // Types
     // default
     Default = KeepSpaces | KeepCase,
   };
-  Q_DECLARE_FLAGS(CleanFileNameOptions, CleanFileNameOption);
+  Q_DECLARE_FLAGS(CleanFileNameOptions, CleanFileNameOption)
 
 public:  // Methods
   // Constructors / Destructor

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -76,7 +76,6 @@ protected:
 
   struct Component {
     QList<ComponentSymbolVariant> symbolVariants;
-    ;
   };
 
   struct ComponentInstance {

--- a/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
@@ -178,7 +178,7 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
   };
   auto processItem = [this, &items, &pos, &posAreaSmall, &posAreaLarge, flags](
                          const std::shared_ptr<QGraphicsItem>& item,
-                         int priority, bool large = false) {
+                         int priority, bool large) {
     Q_ASSERT(item);
     const QPainterPath grabArea = mapFromItem(item.get(), item->shape());
     const QPointF center = grabArea.controlPointRect().center();
@@ -194,21 +194,22 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
 
   if (flags.testFlag(FindFlag::Holes)) {
     foreach (auto ptr, mHoleGraphicsItems) {
-      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 0);
+      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 0, false);
     }
   }
 
   if (flags.testFlag(FindFlag::Pads)) {
     foreach (auto ptr, mPadGraphicsItems) {
       processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr),
-                  10 + priorityFromLayer(ptr->getPad()->getLayerName()));
+                  10 + priorityFromLayer(ptr->getPad()->getLayerName()), false);
     }
   }
 
   if (flags.testFlag(FindFlag::StrokeTexts)) {
     foreach (auto ptr, mStrokeTextGraphicsItems) {
       processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr),
-                  20 + priorityFromLayer(*ptr->getText().getLayerName()));
+                  20 + priorityFromLayer(*ptr->getText().getLayerName()),
+                  false);
     }
   }
 

--- a/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
@@ -135,7 +135,7 @@ QList<std::shared_ptr<QGraphicsItem>> SymbolGraphicsItem::findItemsAtPos(
   QMultiMap<std::pair<int, qreal>, std::shared_ptr<QGraphicsItem>> items;
   auto processItem = [this, &items, &pos, &posAreaSmall, &posAreaLarge, flags](
                          const std::shared_ptr<QGraphicsItem>& item,
-                         int priority, bool large = false) {
+                         int priority, bool large) {
     Q_ASSERT(item);
     const QPainterPath grabArea = mapFromItem(item.get(), item->shape());
     const QPointF center = grabArea.controlPointRect().center();
@@ -151,13 +151,13 @@ QList<std::shared_ptr<QGraphicsItem>> SymbolGraphicsItem::findItemsAtPos(
 
   if (flags.testFlag(FindFlag::Pins)) {
     foreach (auto ptr, mPinGraphicsItems) {
-      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 0);
+      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 0, false);
     }
   }
 
   if (flags.testFlag(FindFlag::Texts)) {
     foreach (auto ptr, mTextGraphicsItems) {
-      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 10);
+      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 10, false);
     }
   }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
@@ -213,7 +213,7 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
   auto processItem = [&pos, &posExact, &posOnGrid, &posArea, &posAreaLarge,
                       flags, &except, &addItem,
                       &canSkip](BI_Base* item, const Point& nearestPos,
-                                int priority, bool large = false) {
+                                int priority, bool large) {
     if (except.contains(item) || (!item->isSelectable())) {
       return;
     }
@@ -254,7 +254,8 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
   if (flags.testFlag(FindFlag::Holes)) {
     foreach (BI_Hole* hole, board->getHoles()) {
       processItem(hole,
-                  hole->getHole().getPath()->getVertices().first().getPos(), 5);
+                  hole->getHole().getPath()->getVertices().first().getPos(), 5,
+                  false);
     }
   }
 
@@ -266,7 +267,7 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
       }
       if (flags.testFlag(FindFlag::Vias)) {
         foreach (BI_Via* via, segment->getVias()) {
-          processItem(via, via->getPosition(), 0);
+          processItem(via, via->getPosition(), 0, false);
         }
       }
       if (flags.testFlag(FindFlag::NetPoints)) {
@@ -276,7 +277,8 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
             continue;
           }
           processItem(netpoint, netpoint->getPosition(),
-                      10 + (layer ? priorityFromLayer(layer->getName()) : 0));
+                      10 + (layer ? priorityFromLayer(layer->getName()) : 0),
+                      false);
         }
       }
       if (flags.testFlag(FindFlag::NetLines)) {
@@ -290,7 +292,7 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
                           pos.mappedToGrid(getGridInterval()),
                           netline->getStartPoint().getPosition(),
                           netline->getEndPoint().getPosition()),
-                      20 + priorityFromLayer(layer.getName()));
+                      20 + priorityFromLayer(layer.getName()), false);
         }
       }
     }
@@ -318,7 +320,7 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
     foreach (BI_Device* device, board->getDeviceInstances()) {
       if (flags.testFlag(FindFlag::Footprints)) {
         processItem(device, device->getPosition(),
-                    40 + (device->getMirrored() ? 300 : 100));
+                    40 + (device->getMirrored() ? 300 : 100), false);
       }
       if (flags.testFlag(FindFlag::FootprintPads)) {
         foreach (BI_FootprintPad* pad, device->getPads()) {
@@ -330,13 +332,14 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
             continue;
           }
           processItem(pad, pad->getPosition(),
-                      50 + (pad->getMirrored() ? 300 : 100));
+                      50 + (pad->getMirrored() ? 300 : 100), false);
         }
       }
       if (flags.testFlag(FindFlag::StrokeTexts)) {
         foreach (BI_StrokeText* text, device->getStrokeTexts()) {
           processItem(text, text->getPosition(),
-                      60 + priorityFromLayer(*text->getText().getLayerName()));
+                      60 + priorityFromLayer(*text->getText().getLayerName()),
+                      false);
         }
       }
     }
@@ -355,7 +358,8 @@ QList<BI_Base*> BoardEditorState::findItemsAtPos(
   if (flags.testFlag(FindFlag::StrokeTexts)) {
     foreach (BI_StrokeText* text, board->getStrokeTexts()) {
       processItem(text, text->getPosition(),
-                  60 + priorityFromLayer(*text->getText().getLayerName()));
+                  60 + priorityFromLayer(*text->getText().getLayerName()),
+                  false);
     }
   }
 

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.cpp
@@ -162,7 +162,7 @@ QList<SI_Base*> SchematicEditorState::findItemsAtPos(
   auto processItem = [&pos, &posExact, &posArea, &posAreaLarge, &posAreaInGrid,
                       flags, &except, &addItem,
                       &canSkip](SI_Base* item, const Point& nearestPos,
-                                int priority, bool large = false) {
+                                int priority, bool large) {
     if (except.contains(item)) {
       return;
     }
@@ -207,7 +207,7 @@ QList<SI_Base*> SchematicEditorState::findItemsAtPos(
       if (flags.testFlag(FindFlag::NetPoints)) {
         foreach (SI_NetPoint* netpoint, segment->getNetPoints()) {
           processItem(netpoint, netpoint->getPosition(),
-                      netpoint->isVisibleJunction() ? 0 : 10);
+                      netpoint->isVisibleJunction() ? 0 : 10, false);
         }
       }
       if (flags.testFlag(FindFlag::NetLines)) {
@@ -222,7 +222,7 @@ QList<SI_Base*> SchematicEditorState::findItemsAtPos(
       }
       if (flags.testFlag(FindFlag::NetLabels)) {
         foreach (SI_NetLabel* netlabel, segment->getNetLabels()) {
-          processItem(netlabel, netlabel->getPosition(), 30);
+          processItem(netlabel, netlabel->getPosition(), 30, false);
         }
       }
     }
@@ -233,20 +233,20 @@ QList<SI_Base*> SchematicEditorState::findItemsAtPos(
        FindFlag::SymbolPinsWithComponentSignal | FindFlag::Texts)) {
     foreach (SI_Symbol* symbol, schematic->getSymbols()) {
       if (flags.testFlag(FindFlag::Symbols)) {
-        processItem(symbol, symbol->getPosition(), 40);
+        processItem(symbol, symbol->getPosition(), 40, false);
       }
       if (flags &
           (FindFlag::SymbolPins | FindFlag::SymbolPinsWithComponentSignal)) {
         foreach (SI_SymbolPin* pin, symbol->getPins()) {
           if (flags.testFlag(FindFlag::SymbolPins) ||
               (pin->getComponentSignalInstance())) {
-            processItem(pin, pin->getPosition(), 50);
+            processItem(pin, pin->getPosition(), 50, false);
           }
         }
       }
       if (flags.testFlag(FindFlag::Texts)) {
         foreach (SI_Text* text, symbol->getTexts()) {
-          processItem(text, text->getPosition(), 70);
+          processItem(text, text->getPosition(), 70, false);
         }
       }
     }
@@ -263,7 +263,7 @@ QList<SI_Base*> SchematicEditorState::findItemsAtPos(
 
   if (flags.testFlag(FindFlag::Texts)) {
     foreach (SI_Text* text, schematic->getTexts()) {
-      processItem(text, text->getPosition(), 70);
+      processItem(text, text->getPosition(), 70, false);
     }
   }
 

--- a/libs/librepcb/editor/widgets/statusbar.h
+++ b/libs/librepcb/editor/widgets/statusbar.h
@@ -51,7 +51,7 @@ public:
     AbsolutePosition = 1 << 0,
     ProgressBar = 1 << 1,
   };
-  Q_DECLARE_FLAGS(Fields, Field);
+  Q_DECLARE_FLAGS(Fields, Field)
 
   // Constructors / Destructor
   explicit StatusBar(QWidget* parent = nullptr) noexcept;

--- a/libs/librepcb/editor/workspace/categorytreemodel.h
+++ b/libs/librepcb/editor/workspace/categorytreemodel.h
@@ -123,7 +123,7 @@ private:  // Data
 }  // namespace editor
 }  // namespace librepcb
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(librepcb::editor::CategoryTreeModel::Filters);
+Q_DECLARE_OPERATORS_FOR_FLAGS(librepcb::editor::CategoryTreeModel::Filters)
 
 /*******************************************************************************
  *  End of File

--- a/tests/unittests/core/fileio/filepathtest.cpp
+++ b/tests/unittests/core/fileio/filepathtest.cpp
@@ -172,8 +172,7 @@ TEST(FilePathTest, testCleanFileName) {
  ******************************************************************************/
 
 // clang-format off
-INSTANTIATE_TEST_SUITE_P(FilePathTest, FilePathTest, ::testing::Values(
-
+static auto sFilePathTestData = ::testing::Values(
     // valid paths   {valid, "inputFilePath"         , "inputBasePath"  , "toStr"           , "toWindowsStyle"      , "toRelative"      , "isRoot" }
 #ifdef Q_OS_WIN
     FilePathTestData({true , "C:\\foo\\bar"          , "C:/foo"         , "C:/foo/bar"      , "C:\\foo\\bar"        , "bar"             , false}), // Win path to a dir
@@ -199,8 +198,10 @@ INSTANTIATE_TEST_SUITE_P(FilePathTest, FilePathTest, ::testing::Values(
     FilePathTestData({false, "foo/bar"               , ""               , ""                , ""                    , ""                , false}), // rel. UNIX path to a dir
     FilePathTestData({false, "foo/bar.txt"           , ""               , ""                , ""                    , ""                , false}), // rel. UNIX path to a file
     FilePathTestData({false, ""                      , ""               , ""                , ""                    , ""                , false})  // empty path
-));
+);
 // clang-format on
+
+INSTANTIATE_TEST_SUITE_P(FilePathTest, FilePathTest, sFilePathTestData);
 
 /*******************************************************************************
  *  End of File


### PR DESCRIPTION
Just because it shouldn't hurt to enforce writing more portable code...

Fixed all the warnings caused by `-Wpedantic`.