### PR TITLE
Update/extend information shown in about dialog

### DIFF
--- a/ci/build_librepcb.sh
+++ b/ci/build_librepcb.sh
@@ -27,7 +27,8 @@ echo "Using CC=$CC"
 mkdir -p build && pushd build
 cmake .. \
   -DCMAKE_INSTALL_PREFIX=$(pwd)/install/opt \
-  -DBUILD_DISALLOW_WARNINGS=1
+  -DBUILD_DISALLOW_WARNINGS=1 \
+  -DLIBREPCB_BUILD_AUTHOR="LibrePCB CI"
 VERBOSE=1 $MAKE -j8
 $MAKE install
 popd

--- a/dev/doxygen/pages/building.md
+++ b/dev/doxygen/pages/building.md
@@ -89,6 +89,15 @@ pass the `BUILD_DISALLOW_WARNINGS` parameter to CMake:
 
   cmake .. -DBUILD_DISALLOW_WARNINGS=1
 
+## Author Information
+
+For investigating bug reports, it's useful to know where the application binary
+is coming from. Therefore this information can be compiled into the executable
+with the `LIBREPCB_BUILD_AUTHOR` parameter. Its value is then shown in the
+"About LibrePCB" dialog.
+
+  cmake .. -DLIBREPCB_BUILD_AUTHOR="Flathub Buildbot"
+
 ## Shared Resources Path
 
 The share directory contains icons, fonts, templates and more resources that

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -3,6 +3,12 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC OFF)
 set(CMAKE_AUTORCC OFF)
 
+# Allow specifying the author of the build to help investigating bug reports.
+set(LIBREPCB_BUILD_AUTHOR
+    ""
+    CACHE STRING "Author of this build."
+)
+
 # Allow overriding the share directory path
 set(LIBREPCB_SHARE
     "../share/librepcb"

--- a/libs/librepcb/core/application.cpp
+++ b/libs/librepcb/core/application.cpp
@@ -186,6 +186,30 @@ const StrokeFont& Application::getDefaultStrokeFont() const noexcept {
   }
 }
 
+QString Application::detectRuntime() const noexcept {
+  // Manually specified runtime has priority.
+  static QString envRuntime = qgetenv("LIBREPCB_RUNTIME").trimmed();
+  if (!envRuntime.isEmpty()) {
+    return envRuntime;
+  }
+
+  // Combine any other autodetected runtime, just in case multiple are set.
+  QStringList runtimes;
+  static QString envSnap = qgetenv("SNAP").trimmed();
+  if (!envSnap.isEmpty()) {
+    runtimes << "Snap";
+  }
+  static QString envFlatpak = qgetenv("FLATPAK_ID").trimmed();
+  if (!envFlatpak.isEmpty()) {
+    runtimes << "Flatpak";
+  }
+  static QString envAppimage = qgetenv("APPIMAGE").trimmed();
+  if (!envAppimage.isEmpty()) {
+    runtimes << "AppImage";
+  }
+  return runtimes.join(", ");
+}
+
 /*******************************************************************************
  *  Setters
  ******************************************************************************/

--- a/libs/librepcb/core/application.cpp
+++ b/libs/librepcb/core/application.cpp
@@ -46,6 +46,8 @@ Application::Application(int& argc, char** argv) noexcept
         Version::fromString(QString(LIBREPCB_APP_VERSION).section('-', 0, 0))),
     mAppVersionLabel(QString(LIBREPCB_APP_VERSION).section('-', 1, 1)),
     mGitRevision(GIT_COMMIT_SHA),
+    mBuildDate(),
+    mBuildAuthor(LIBREPCB_BUILD_AUTHOR),
     mFileFormatVersion(Version::fromString(LIBREPCB_FILE_FORMAT_VERSION)),
     mIsFileFormatStable(LIBREPCB_FILE_FORMAT_STABLE) {
   // register meta types

--- a/libs/librepcb/core/application.h
+++ b/libs/librepcb/core/application.h
@@ -92,6 +92,7 @@ public:
   }
   QString getDefaultStrokeFontName() const noexcept { return "newstroke.bene"; }
   const StrokeFont& getDefaultStrokeFont() const noexcept;
+  QString detectRuntime() const noexcept;
 
   // Setters
   void setTranslationLocale(const QLocale& locale) noexcept;

--- a/libs/librepcb/core/application.h
+++ b/libs/librepcb/core/application.h
@@ -73,6 +73,7 @@ public:
   }
   const QString& getGitRevision() const noexcept { return mGitRevision; }
   const QDateTime& getBuildDate() const noexcept { return mBuildDate; }
+  const QString& getBuildAuthor() const noexcept { return mBuildAuthor; }
   const Version& getFileFormatVersion() const noexcept {
     return mFileFormatVersion;
   }
@@ -115,6 +116,7 @@ private:  // Data
   QString mAppVersionLabel;
   QString mGitRevision;
   QDateTime mBuildDate;
+  QString mBuildAuthor;
   Version mFileFormatVersion;
   bool mIsFileFormatStable;
   FilePath mResourcesDir;

--- a/libs/librepcb/core/build_env.h.in
+++ b/libs/librepcb/core/build_env.h.in
@@ -32,6 +32,9 @@
 // Commit information
 #define GIT_COMMIT_SHA "@GIT_COMMIT_SHA@"
 
+// Build information
+#define LIBREPCB_BUILD_AUTHOR "@LIBREPCB_BUILD_AUTHOR@"
+
 // Directories
 #define LIBREPCB_SHARE "@LIBREPCB_SHARE@"
 #cmakedefine LIBREPCB_SHARE_SOURCE "@LIBREPCB_SHARE_SOURCE@"

--- a/libs/librepcb/editor/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/editor/dialogs/aboutdialog.cpp
@@ -108,6 +108,9 @@ AboutDialog::AboutDialog(QWidget* parent) noexcept
   details << "Operating System: " + QSysInfo::prettyProductName();
   details << "Platform Plugin:  " + qApp->platformName();
   details << "TLS Library:      " + QSslSocket::sslLibraryVersionString();
+  if (!qApp->detectRuntime().isEmpty()) {
+    details << "Runtime:          " + qApp->detectRuntime();
+  }
   mUi->txtDetails->setPlainText(details.join("\n"));
 }
 

--- a/libs/librepcb/editor/dialogs/aboutdialog.cpp
+++ b/libs/librepcb/editor/dialogs/aboutdialog.cpp
@@ -100,6 +100,9 @@ AboutDialog::AboutDialog(QWidget* parent) noexcept
   details << "LibrePCB Version: " + qApp->applicationVersion();
   details << "Git Revision:     " + qApp->getGitRevision();
   details << "Build Date:       " + qApp->getBuildDate().toString(Qt::ISODate);
+  if (!qApp->getBuildAuthor().isEmpty()) {
+    details << "Build Author:     " + qApp->getBuildAuthor();
+  }
   details << "Qt Version:       " + qt;
   details << "CPU Architecture: " + QSysInfo::currentCpuArchitecture();
   details << "Operating System: " + QSysInfo::prettyProductName();

--- a/libs/librepcb/editor/dialogs/aboutdialog.h
+++ b/libs/librepcb/editor/dialogs/aboutdialog.h
@@ -33,6 +33,9 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
+
+class WorkspaceSettings;
+
 namespace editor {
 
 namespace Ui {
@@ -53,18 +56,18 @@ public:
   // Constructors / Destructor
   AboutDialog() = delete;
   AboutDialog(const AboutDialog& other) = delete;
-  explicit AboutDialog(QWidget* parent = nullptr) noexcept;
+  explicit AboutDialog(const WorkspaceSettings& settings,
+                       QWidget* parent = nullptr) noexcept;
   ~AboutDialog() noexcept;
 
   // Operator Overloadings
   AboutDialog& operator=(const AboutDialog& rhs) = delete;
 
 private:  // Methods
-  void formatLabelHeading(QLabel* label) noexcept;
-  void formatLabelText(QLabel* label, bool selectable,
-                       bool containsLinks) noexcept;
+  void openExternalLink(const QString& url) noexcept;
 
 private:  // Data
+  const WorkspaceSettings& mSettings;
   QScopedPointer<Ui::AboutDialog> mUi;
 };
 

--- a/libs/librepcb/editor/dialogs/aboutdialog.ui
+++ b/libs/librepcb/editor/dialogs/aboutdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>460</width>
-    <height>438</height>
+    <width>539</width>
+    <height>456</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,11 +15,8 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="1" rowspan="2">
       <widget class="QLabel" name="logo">
        <property name="minimumSize">
         <size>
@@ -50,43 +47,35 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblRevision">
+       <property name="text">
+        <string notr="true">TEXT_REVISION</string>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblTitle">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>16</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string notr="true">TEXT_TITLE</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QLabel" name="heading">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>16</pointsize>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>About LibrePCB</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="textVersion">
-     <property name="text">
-      <string notr="true">TEXT_VERSION</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -107,90 +96,26 @@
        <property name="currentIndex">
         <number>0</number>
        </property>
-       <widget class="QWidget" name="tabGeneral">
+       <widget class="QWidget" name="tabAbout">
         <attribute name="title">
-         <string>General</string>
+         <string>About</string>
         </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <layout class="QVBoxLayout" name="verticalLayout_4">
          <item>
-          <layout class="QVBoxLayout" name="tabGeneralLayout">
-           <item>
-            <widget class="QLabel" name="textIntro">
-             <property name="text">
-              <string>LibrePCB is a free &amp;amp; open source schematic/layout-editor. It is mainly developed by Urban Bruhin, with &lt;a href=&quot;https://github.com/LibrePCB/LibrePCB/graphs/contributors&quot;&gt;over a dozen other contributors&lt;/a&gt;!</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="headerLinks">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string notr="true">Links</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="textLinks">
-             <property name="text">
-              <string notr="true">TEXT_LINKS</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="headerLicense">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string notr="true">License</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="textLicense">
-             <property name="text">
-              <string>LibrePCB is free software, released under the GNU General Public License (GPL) version 3 or later. You can find the full license text &lt;a href=&quot;https://github.com/LibrePCB/LibrePCB/blob/master/LICENSE.txt&quot;&gt;in our source code&lt;/a&gt;.</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="textIconLicense">
-             <property name="text">
-              <string>Some of the icons used in LibrePCB are provided by &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;, thank you!</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="spacerGeneral">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
+          <widget class="QLabel" name="lblIntro">
+           <property name="text">
+            <string notr="true">TEXT_INTRO</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -198,102 +123,22 @@
         <attribute name="title">
          <string>Contributing</string>
         </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
          <item>
-          <layout class="QVBoxLayout" name="tabContributingLayout">
-           <item>
-            <widget class="QLabel" name="textContributingIntro">
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibrePCB is a community project, and therefore it relies on contributions! There are different ways you can contribute:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="headerContributeFinancially">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Donate</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="textContributeFinancially">
-             <property name="text">
-              <string notr="true">TEXT_CONTRIBUTE_FINANCIALLY</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="headerContributeCode">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Contribute Code</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="textContributeCode">
-             <property name="text">
-              <string notr="true">TEXT_CONTRIBUTE_CODE</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="headerContributeShare">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Spread The Word</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="textContributeShare">
-             <property name="text">
-              <string>Speak about LibrePCB with your friends and colleagues, or write about it in the internet! Write a blogpost, or create a video tutorial. We're happy if more people can get to know LibrePCB.</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="spacerContributing">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
+          <widget class="QLabel" name="lblContributing">
+           <property name="text">
+            <string notr="true">TEXT_CONTRIBUTING</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -325,15 +170,21 @@
            <property name="textInteractionFlags">
             <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
            </property>
-           <property name="placeholderText" stdset="0">
+           <property name="placeholderText">
             <string notr="true"/>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="btnCopyDetailsToClipboard">
+          <widget class="QLabel" name="lblCopyDetailsToClipboard">
+           <property name="toolTip">
+            <string>Click on the link to copy the text into the clipboard.</string>
+           </property>
            <property name="text">
-            <string>Copy to clipboard</string>
+            <string>When reporting an issue, please &lt;a href='copy'&gt;copy this text&lt;/a&gt; into the report.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
+++ b/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
@@ -57,7 +57,7 @@ StandardEditorCommandHandler::~StandardEditorCommandHandler() noexcept {
  ******************************************************************************/
 
 void StandardEditorCommandHandler::aboutLibrePcb() const noexcept {
-  AboutDialog aboutDialog(mParent);
+  AboutDialog aboutDialog(mSettings, mParent);
   aboutDialog.exec();
 }
 


### PR DESCRIPTION
### Summary

It turned out that for many bug reports it's important to know how LibrePCB was installed (AppImage? Snap? Flatpak?) since various bugs are related to packaging. So I included this information in the "About LibrePCB" details page, together with some general UI improvements.

### Support compiling author information into the executable

Allow to pass `-DLIBREPCB_BUILD_AUTHOR="..."` to `cmake` to embed information about the **build**. Our CI now sets this variable to "LibrePCB CI" so whenever this is shown in the about dialog, we know it was a binary built by ourselves (in contrast to distribution packages). If the variable is not set, it won't be displayed in the about dialog.

### Detect and display runtime environment

In addition to the build environment, the **runtime environment** is also of interest. For example our official installer, AppImage and *.tar.gz binaries are all containing the same binaries (so `LIBREPCB_BUILD_AUTHOR` is identical for all of them), but the AppImage is run in a quite different, sandboxed environment.

The runtime environment is detected by the following environment variables and shown in the about dialog if not empty:

- `LIBREPCB_RUNTIME`: Allows to manually override the runtime detection with a custom value. Useful e.g. when LibrePCB is started by a wrapper shell script from some packaging/sandboxing system.
- `SNAP`: If set, runtime is detected as "Snap".
- `FLATPAK_ID`: If set, runtime is detected as "Flatpak".
- `APPIMAGE`: If set, runtime is detected as "AppImage".

### Major UI rework to fix issues and update content

- Open hyperlinks in the web browser configured in the workspace settings.
- Fix too large dialog window size by merging many wordwrapping QLabels into a single, large QLabel.
- Make layout of dialog header more compact (logo beside text).
- Generally update/improve information shown in the about dialog.

### Screenshots

| Old | New |
|---|---|
| ![image](https://user-images.githubusercontent.com/5374821/221579773-6fc4ddbf-cd10-4bf0-a85e-a425abdb0ef7.png) | ![image](https://user-images.githubusercontent.com/5374821/221579493-c6210a6b-313d-454f-82a0-bf35c3a3102b.png) |
| ![image](https://user-images.githubusercontent.com/5374821/221579880-67fe1ee0-0485-410f-9c17-b71d71064f96.png) | ![image](https://user-images.githubusercontent.com/5374821/221579571-abca998b-69e6-4e7d-bc26-2eb5b6bf86ea.png) |
| ![image](https://user-images.githubusercontent.com/5374821/221579944-643f90ff-6912-40b8-92b7-8f506800b77b.png) | ![image](https://user-images.githubusercontent.com/5374821/221580295-939ddbba-0c6c-4a3a-b3f5-bb3d01e96862.png) |
