### PR TITLE
Move board related messages from ERC to DRC

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -493,7 +493,6 @@ bool CommandLineInterface::openProject(
           switch (msg->getMsgType()) {
             case ErcMsg::ErcMsgType_t::CircuitWarning:
             case ErcMsg::ErcMsgType_t::SchematicWarning:
-            case ErcMsg::ErcMsgType_t::BoardWarning:
               severity = tr("WARNING");
               break;
             default:

--- a/libs/librepcb/core/project/board/board.h
+++ b/libs/librepcb/core/project/board/board.h
@@ -30,7 +30,6 @@
 #include "../../types/length.h"
 #include "../../types/lengthunit.h"
 #include "../../types/uuid.h"
-#include "../erc/if_ercmsgprovider.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -72,11 +71,8 @@ class Project;
  * @brief The Board class represents a PCB of a project and is always part of a
  * circuit
  */
-class Board final : public QObject,
-                    public AttributeProvider,
-                    public IF_ErcMsgProvider {
+class Board final : public QObject, public AttributeProvider {
   Q_OBJECT
-  DECLARE_ERC_MSG_CLASS_NAME(Board)
 
 public:
   // Types
@@ -251,8 +247,6 @@ signals:
   void deviceRemoved(BI_Device& comp);
 
 private:
-  void updateErcMessages() noexcept;
-
   // General
   Project& mProject;  ///< A reference to the Project object (from the ctor)
   const QString mDirectoryName;
@@ -282,9 +276,6 @@ private:
   QMap<Uuid, BI_StrokeText*> mStrokeTexts;
   QMap<Uuid, BI_Hole*> mHoles;
   QMultiHash<NetSignal*, BI_AirWire*> mAirWires;
-
-  // ERC messages
-  QHash<Uuid, ErcMsg*> mErcMsgListUnplacedComponentInstances;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -92,7 +92,9 @@ private:  // Methods
   void checkAllowedPthSlots(int progressEnd);
   void checkInvalidPadConnections(int progressEnd);
   void checkCourtyardClearances(int progressEnd);
+  void checkForUnplacedComponents(int progressEnd);
   void checkForMissingConnections(int progressEnd);
+  void checkForStaleObjects(int progressEnd);
   template <typename THole>
   void processHoleSlotWarning(
       const THole& hole, BoardDesignRuleCheckSettings::AllowedSlots allowed,

--- a/libs/librepcb/core/project/board/items/bi_netpoint.cpp
+++ b/libs/librepcb/core/project/board/items/bi_netpoint.cpp
@@ -23,7 +23,6 @@
 #include "bi_netpoint.h"
 
 #include "../../circuit/netsignal.h"
-#include "../../erc/ercmsg.h"
 #include "bi_netsegment.h"
 
 #include <QtCore>
@@ -45,14 +44,6 @@ BI_NetPoint::BI_NetPoint(BI_NetSegment& segment, const Uuid& uuid,
   // create the graphics item
   mGraphicsItem.reset(new BGI_NetPoint(*this));
   mGraphicsItem->setPos(mJunction.getPosition().toPxQPointF());
-
-  // create ERC messages
-  mErcMsgDeadNetPoint.reset(new ErcMsg(mBoard.getProject(), *this,
-                                       mJunction.getUuid().toStr(), "Dead",
-                                       ErcMsg::ErcMsgType_t::BoardError,
-                                       tr("Dead net point in board \"%1\": %2")
-                                           .arg(*mBoard.getName())
-                                           .arg(mJunction.getUuid().toStr())));
 }
 
 BI_NetPoint::~BI_NetPoint() noexcept {
@@ -104,7 +95,6 @@ void BI_NetPoint::addToBoard() {
                 [this]() { mGraphicsItem->update(); });
     mBoard.scheduleAirWiresRebuild(netsignal);
   }
-  mErcMsgDeadNetPoint->setVisible(true);
   BI_Base::addToBoard(mGraphicsItem.data());
 }
 
@@ -119,7 +109,6 @@ void BI_NetPoint::removeFromBoard() {
     disconnect(mHighlightChangedConnection);
     mBoard.scheduleAirWiresRebuild(netsignal);
   }
-  mErcMsgDeadNetPoint->setVisible(false);
   BI_Base::removeFromBoard(mGraphicsItem.data());
 }
 
@@ -141,7 +130,6 @@ void BI_NetPoint::registerNetLine(BI_NetLine& netline) {
   mRegisteredNetLines.insert(&netline);
   netline.updateLine();
   mGraphicsItem->updateCacheAndRepaint();
-  mErcMsgDeadNetPoint->setVisible(mRegisteredNetLines.isEmpty());
 }
 
 void BI_NetPoint::unregisterNetLine(BI_NetLine& netline) {
@@ -153,7 +141,6 @@ void BI_NetPoint::unregisterNetLine(BI_NetLine& netline) {
   mRegisteredNetLines.remove(&netline);
   netline.updateLine();
   mGraphicsItem->updateCacheAndRepaint();
-  mErcMsgDeadNetPoint->setVisible(mRegisteredNetLines.isEmpty());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/items/bi_netpoint.h
+++ b/libs/librepcb/core/project/board/items/bi_netpoint.h
@@ -24,7 +24,6 @@
  *  Includes
  ******************************************************************************/
 #include "../../../geometry/junction.h"
-#include "../../erc/if_ercmsgprovider.h"
 #include "../graphicsitems/bgi_netpoint.h"
 #include "./bi_netline.h"
 #include "bi_base.h"
@@ -43,11 +42,8 @@ namespace librepcb {
 /**
  * @brief The BI_NetPoint class
  */
-class BI_NetPoint final : public BI_Base,
-                          public BI_NetLineAnchor,
-                          public IF_ErcMsgProvider {
+class BI_NetPoint final : public BI_Base, public BI_NetLineAnchor {
   Q_OBJECT
-  DECLARE_ERC_MSG_CLASS_NAME(BI_NetPoint)
 
 public:
   // Constructors / Destructor
@@ -103,10 +99,6 @@ private:
 
   // Registered Elements
   QSet<BI_NetLine*> mRegisteredNetLines;  ///< all registered netlines
-
-  // ERC Messages
-  /// @brief The ERC message for dead netpoints
-  QScopedPointer<ErcMsg> mErcMsgDeadNetPoint;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/erc/ercmsg.h
+++ b/libs/librepcb/core/project/erc/ercmsg.h
@@ -50,8 +50,6 @@ public:
     CircuitWarning,  ///< example: nets with only one pin
     SchematicError,  ///< example: unplaced required symbols
     SchematicWarning,  ///< example: unplaced optional symbols
-    BoardError,  ///< example: unplaced footprints
-    BoardWarning,  ///< example: ???
     _Count  ///< count of message types
   };
 

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -284,6 +284,14 @@ void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir,
     }
   }
 
+  // ERC.
+  {
+    const QString fp = "circuit/erc.lp";
+    SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    upgradeErc(root);
+    dir.write(fp, root.toByteArray());
+  }
+
   // Schematics.
   foreach (const QString& dirName, dir.getDirs("schematics")) {
     const QString fp = "schematics/" % dirName % "/schematic.lp";
@@ -373,6 +381,19 @@ void FileFormatMigrationV01::upgradeWorkspaceData(TransactionalDirectory& dir) {
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void FileFormatMigrationV01::upgradeErc(SExpression& root) {
+  for (SExpression* node : root.getChildren("approved")) {
+    if (node->getChild("class/@0").getValue() == "Board") {
+      root.removeChild(*node);  // Board error migrated to DRC.
+      continue;
+    }
+    if (node->getChild("class/@0").getValue() == "BI_NetPoint") {
+      root.removeChild(*node);  // Board error migrated to DRC.
+      continue;
+    }
+  }
+}
 
 void FileFormatMigrationV01::upgradeSchematic(SExpression& root,
                                               ProjectContext& context) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -118,6 +118,7 @@ public:
   FileFormatMigrationV01& operator=(const FileFormatMigrationV01& rhs) = delete;
 
 protected:  // Methods
+  virtual void upgradeErc(SExpression& root);
   virtual void upgradeSchematic(SExpression& root, ProjectContext& context);
   virtual void upgradeBoard(SExpression& root, ProjectContext& context);
   virtual void upgradeBoardUserSettings(SExpression& root);

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -1065,7 +1065,10 @@ void BoardEditor::runDrc(bool quick) noexcept {
 
 void BoardEditor::highlightDrcMessage(const BoardDesignRuleCheckMessage& msg,
                                       bool zoomTo) noexcept {
-  if (QGraphicsScene* scene = mUi->graphicsView->scene()) {
+  if (msg.getLocations().isEmpty()) {
+    // Position on board not known.
+    clearDrcMarker();
+  } else if (QGraphicsScene* scene = mUi->graphicsView->scene()) {
     const ThemeColor& color =
         mProjectEditor.getWorkspace().getSettings().themes.getActive().getColor(
             Theme::Color::sBoardOverlays);

--- a/libs/librepcb/editor/project/erc/ercmsgdock.cpp
+++ b/libs/librepcb/editor/project/erc/ercmsgdock.cpp
@@ -59,10 +59,6 @@ ErcMsgDock::ErcMsgDock(Project& project)
   mTopLevelItems.insert(
       static_cast<int>(ErcMsg::ErcMsgType_t::SchematicWarning),
       new QTreeWidgetItem(mUi->treeWidget));
-  mTopLevelItems.insert(static_cast<int>(ErcMsg::ErcMsgType_t::BoardError),
-                        new QTreeWidgetItem(mUi->treeWidget));
-  mTopLevelItems.insert(static_cast<int>(ErcMsg::ErcMsgType_t::BoardWarning),
-                        new QTreeWidgetItem(mUi->treeWidget));
   mTopLevelItems.insert(static_cast<int>(ErcMsg::ErcMsgType_t::_Count),
                         new QTreeWidgetItem(mUi->treeWidget));
 
@@ -80,10 +76,6 @@ ErcMsgDock::ErcMsgDock(Project& project)
       ->setIcon(0, QIcon(":/img/status/dialog_error.png"));
   mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::SchematicWarning)]
       ->setIcon(0, QIcon(":/img/status/dialog_warning.png"));
-  mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardError)]->setIcon(
-      0, QIcon(":/img/status/dialog_error.png"));
-  mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardWarning)]->setIcon(
-      0, QIcon(":/img/status/dialog_warning.png"));
   mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::_Count)]->setIcon(
       0, QIcon(":/img/actions/apply.png"));
 
@@ -95,10 +87,6 @@ ErcMsgDock::ErcMsgDock(Project& project)
   mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::SchematicError)]
       ->setExpanded(true);
   mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::SchematicWarning)]
-      ->setExpanded(true);
-  mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardError)]
-      ->setExpanded(true);
-  mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardWarning)]
       ->setExpanded(true);
 
   // add all already existing ERC messages
@@ -227,14 +215,6 @@ void ErcMsgDock::updateTopLevelItemTexts() noexcept {
   item =
       mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::SchematicWarning)];
   item->setText(0, tr("Schematic Warnings (%1)").arg(item->childCount()));
-  item->setHidden(item->childCount() == 0);
-  countOfNonIgnoredErcMessages += item->childCount();
-  item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardError)];
-  item->setText(0, tr("Board Errors (%1)").arg(item->childCount()));
-  item->setHidden(item->childCount() == 0);
-  countOfNonIgnoredErcMessages += item->childCount();
-  item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::BoardWarning)];
-  item->setText(0, tr("Board Warnings (%1)").arg(item->childCount()));
   item->setHidden(item->childCount() == 0);
   countOfNonIgnoredErcMessages += item->childCount();
   item = mTopLevelItems[static_cast<int>(ErcMsg::ErcMsgType_t::_Count)];


### PR DESCRIPTION
Although the ERC is nicer than the DRC because it is instantly updated, board related messages (e.g. unplaced component) are usually not of interest in the schematic editor. And in the board editor, probably nobody checks the ERC messages. So let's move these messages to the DRC to strictly distinguish between board issues (-> DRC) and schematic/circuit issues (-> ERC).