### PR TITLE
DRC: Add checks for board outline validity

### DIFF
--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -93,6 +93,7 @@ private:  // Methods
   void checkAllowedPthSlots(int progressEnd);
   void checkInvalidPadConnections(int progressEnd);
   void checkCourtyardClearances(int progressEnd);
+  void checkBoardOutline(int progressEnd);
   void checkForUnplacedComponents(int progressEnd);
   void checkForMissingConnections(int progressEnd);
   void checkForStaleObjects(int progressEnd);

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
@@ -101,6 +101,85 @@ private:
 };
 
 /*******************************************************************************
+ *  Class DrcMsgMissingBoardOutline
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgMissingBoardOutline class
+ */
+class DrcMsgMissingBoardOutline final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgMissingBoardOutline)
+
+public:
+  // Constructors / Destructor
+  DrcMsgMissingBoardOutline() noexcept;
+  DrcMsgMissingBoardOutline(const DrcMsgMissingBoardOutline& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgMissingBoardOutline() noexcept {}
+};
+
+/*******************************************************************************
+ *  Class DrcMsgMultipleBoardOutlines
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgMultipleBoardOutlines class
+ */
+class DrcMsgMultipleBoardOutlines final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgMultipleBoardOutlines)
+
+public:
+  // Constructors / Destructor
+  explicit DrcMsgMultipleBoardOutlines(const QVector<Path>& locations) noexcept;
+  DrcMsgMultipleBoardOutlines(const DrcMsgMultipleBoardOutlines& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgMultipleBoardOutlines() noexcept {}
+};
+
+/*******************************************************************************
+ *  Class DrcMsgOpenBoardOutlinePolygon
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgOpenBoardOutlinePolygon class
+ */
+class DrcMsgOpenBoardOutlinePolygon final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgOpenBoardOutlinePolygon)
+
+public:
+  // Constructors / Destructor
+  DrcMsgOpenBoardOutlinePolygon() = delete;
+  DrcMsgOpenBoardOutlinePolygon(const BI_Device* device, const Polygon& polygon,
+                                const QVector<Path>& locations) noexcept;
+  DrcMsgOpenBoardOutlinePolygon(
+      const DrcMsgOpenBoardOutlinePolygon& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgOpenBoardOutlinePolygon() noexcept {}
+};
+
+/*******************************************************************************
+ *  Class DrcMsgMinimumBoardOutlineInnerRadiusViolation
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgMinimumBoardOutlineInnerRadiusViolation class
+ */
+class DrcMsgMinimumBoardOutlineInnerRadiusViolation final
+  : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgMinimumBoardOutlineInnerRadiusViolation)
+
+public:
+  // Constructors / Destructor
+  DrcMsgMinimumBoardOutlineInnerRadiusViolation() = delete;
+  DrcMsgMinimumBoardOutlineInnerRadiusViolation(
+      const UnsignedLength& minRadius, const QVector<Path>& locations) noexcept;
+  DrcMsgMinimumBoardOutlineInnerRadiusViolation(
+      const DrcMsgMinimumBoardOutlineInnerRadiusViolation& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgMinimumBoardOutlineInnerRadiusViolation() noexcept {}
+};
+
+/*******************************************************************************
  *  Class DrcMsgEmptyNetSegment
  ******************************************************************************/
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulechecksettings.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulechecksettings.cpp
@@ -85,6 +85,7 @@ BoardDesignRuleCheckSettings::BoardDesignRuleCheckSettings() noexcept
     mMinPthDrillDiameter(300000),  // 300um
     mMinNpthSlotWidth(1000000),  // 1mm
     mMinPthSlotWidth(700000),  // 0.7mm
+    mMinOutlineToolDiameter(2000000),  // 2mm
     mAllowedNpthSlots(AllowedSlots::SingleSegmentStraight),
     mAllowedPthSlots(AllowedSlots::SingleSegmentStraight) {
 }
@@ -120,6 +121,8 @@ BoardDesignRuleCheckSettings::BoardDesignRuleCheckSettings(
         deserialize<UnsignedLength>(node.getChild("min_npth_slot_width/@0"))),
     mMinPthSlotWidth(
         deserialize<UnsignedLength>(node.getChild("min_pth_slot_width/@0"))),
+    mMinOutlineToolDiameter(deserialize<UnsignedLength>(
+        node.getChild("min_outline_tool_diameter/@0"))),
     mAllowedNpthSlots(
         deserialize<AllowedSlots>(node.getChild("allowed_npth_slots/@0"))),
     mAllowedPthSlots(
@@ -157,6 +160,8 @@ void BoardDesignRuleCheckSettings::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("min_pth_slot_width", mMinPthSlotWidth);
   root.ensureLineBreak();
+  root.appendChild("min_outline_tool_diameter", mMinOutlineToolDiameter);
+  root.ensureLineBreak();
   root.appendChild("allowed_npth_slots", mAllowedNpthSlots);
   root.ensureLineBreak();
   root.appendChild("allowed_pth_slots", mAllowedPthSlots);
@@ -180,6 +185,7 @@ BoardDesignRuleCheckSettings& BoardDesignRuleCheckSettings::operator=(
   mMinPthDrillDiameter = rhs.mMinPthDrillDiameter;
   mMinNpthSlotWidth = rhs.mMinNpthSlotWidth;
   mMinPthSlotWidth = rhs.mMinPthSlotWidth;
+  mMinOutlineToolDiameter = rhs.mMinOutlineToolDiameter;
   mAllowedNpthSlots = rhs.mAllowedNpthSlots;
   mAllowedPthSlots = rhs.mAllowedPthSlots;
   return *this;
@@ -198,6 +204,7 @@ bool BoardDesignRuleCheckSettings::operator==(
   if (mMinPthDrillDiameter != rhs.mMinPthDrillDiameter) return false;
   if (mMinNpthSlotWidth != rhs.mMinNpthSlotWidth) return false;
   if (mMinPthSlotWidth != rhs.mMinPthSlotWidth) return false;
+  if (mMinOutlineToolDiameter != rhs.mMinOutlineToolDiameter) return false;
   if (mAllowedNpthSlots != rhs.mAllowedNpthSlots) return false;
   if (mAllowedPthSlots != rhs.mAllowedPthSlots) return false;
   return true;

--- a/libs/librepcb/core/project/board/drc/boarddesignrulechecksettings.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulechecksettings.h
@@ -92,6 +92,9 @@ public:
   const UnsignedLength& getMinPthSlotWidth() const noexcept {
     return mMinPthSlotWidth;
   }
+  const UnsignedLength& getMinOutlineToolDiameter() const noexcept {
+    return mMinOutlineToolDiameter;
+  }
   AllowedSlots getAllowedNpthSlots() const noexcept {
     return mAllowedNpthSlots;
   }
@@ -130,6 +133,9 @@ public:
   }
   void setMinPthSlotWidth(const UnsignedLength& value) noexcept {
     mMinPthSlotWidth = value;
+  }
+  void setMinOutlineToolDiameter(const UnsignedLength& value) noexcept {
+    mMinOutlineToolDiameter = value;
   }
   void setAllowedPthSlots(AllowedSlots value) noexcept {
     mAllowedNpthSlots = value;
@@ -170,6 +176,7 @@ private:  // Data
   UnsignedLength mMinPthDrillDiameter;
   UnsignedLength mMinNpthSlotWidth;
   UnsignedLength mMinPthSlotWidth;
+  UnsignedLength mMinOutlineToolDiameter;
 
   // Allowed features
   AllowedSlots mAllowedNpthSlots;

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -105,10 +105,8 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
   Q_UNUSED(root);
   Q_UNUSED(context);
   SExpression& node = root.getChild("design_rule_check");
-  node.appendChild("min_drill_drill_clearance",
-                   SExpression::createToken("0.35"));
-  node.appendChild("min_drill_board_clearance",
-                   SExpression::createToken("0.5"));
+  node.appendChild("min_outline_tool_diameter",
+                   SExpression::createToken("2.0"));
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -621,6 +621,8 @@ void FileFormatMigrationV01::upgradeBoardDrcSettings(SExpression& root) {
   node.appendChild("min_pth_drill_diameter", SExpression::createToken("0.3"));
   node.appendChild("min_npth_slot_width", SExpression::createToken("1.0"));
   node.appendChild("min_pth_slot_width", SExpression::createToken("0.7"));
+  node.appendChild("min_outline_tool_diameter",
+                   SExpression::createToken("2.0"));
   node.appendChild("allowed_npth_slots",
                    SExpression::createToken("single_segment_straight"));
   node.appendChild("allowed_pth_slots",

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
@@ -165,6 +165,9 @@ BoardSetupDialog::BoardSetupDialog(Board& board, UndoStack& undoStack,
   mUi->edtDrcMinPthSlotWidth->configure(
       mBoard.getGridUnit(), LengthEditBase::Steps::drillDiameter(),
       sSettingsPrefix % "/min_pth_slot_width");
+  mUi->edtDrcMinOutlineToolDiameter->configure(
+      mBoard.getGridUnit(), LengthEditBase::Steps::drillDiameter(),
+      sSettingsPrefix % "/min_outline_tool_diameter");
   for (QComboBox* cbx :
        {mUi->cbxDrcAllowedNpthSlots, mUi->cbxDrcAllowedPthSlots}) {
     cbx->addItem(
@@ -287,6 +290,8 @@ void BoardSetupDialog::load() noexcept {
       mBoard.getDrcSettings().getMinPthDrillDiameter());
   mUi->edtDrcMinPthSlotWidth->setValue(
       mBoard.getDrcSettings().getMinPthSlotWidth());
+  mUi->edtDrcMinOutlineToolDiameter->setValue(
+      mBoard.getDrcSettings().getMinOutlineToolDiameter());
   mUi->cbxDrcAllowedNpthSlots->setCurrentIndex(
       mUi->cbxDrcAllowedNpthSlots->findData(
           QVariant::fromValue(mBoard.getDrcSettings().getAllowedNpthSlots())));
@@ -342,6 +347,7 @@ bool BoardSetupDialog::apply() noexcept {
     s.setMinNpthSlotWidth(mUi->edtDrcMinNpthSlotWidth->getValue());
     s.setMinPthDrillDiameter(mUi->edtDrcMinPthDrillDiameter->getValue());
     s.setMinPthSlotWidth(mUi->edtDrcMinPthSlotWidth->getValue());
+    s.setMinOutlineToolDiameter(mUi->edtDrcMinOutlineToolDiameter->getValue());
     s.setAllowedNpthSlots(
         mUi->cbxDrcAllowedNpthSlots->currentData()
             .value<BoardDesignRuleCheckSettings::AllowedSlots>());

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
@@ -639,6 +639,19 @@ QAbstractScrollArea {
            <item row="3" column="3">
             <widget class="librepcb::editor::UnsignedLengthEdit" name="edtDrcClearanceDrillBoard" native="true"/>
            </item>
+           <item row="9" column="0">
+            <widget class="QLabel" name="label_30">
+             <property name="toolTip">
+              <string>Minimum board outline milling tool diameter. Restricts the radius of inner board edges.</string>
+             </property>
+             <property name="text">
+              <string>Outline Tool Diameter:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="1">
+            <widget class="librepcb::editor::UnsignedLengthEdit" name="edtDrcMinOutlineToolDiameter" native="true"/>
+           </item>
           </layout>
          </widget>
         </widget>


### PR DESCRIPTION
Adding several DRC checks to warn the user about common board outline problems:

- Report missing board outlines
- Report non-closed board outline polygons
- Report too small inner edge radii

![image](https://user-images.githubusercontent.com/5374821/223966164-bf1de713-55cd-4ede-b3ad-8859ecf6367b.png)

![image](https://user-images.githubusercontent.com/5374821/223965842-038e1e59-0942-4d25-9006-3236421d93c6.png)

Closes #992