### PR TITLE
DRC: Warn about devices which differ from schematic

### DIFF
--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -95,6 +95,7 @@ private:  // Methods
   void checkCourtyardClearances(int progressEnd);
   void checkBoardOutline(int progressEnd);
   void checkForUnplacedComponents(int progressEnd);
+  void checkCircuitDefaultDevices(int progressEnd);
   void checkForMissingConnections(int progressEnd);
   void checkForStaleObjects(int progressEnd);
   template <typename THole>
@@ -106,6 +107,7 @@ private:  // Methods
       const GraphicsLayer& layer, const QSet<const NetSignal*>& netsignals);
   ClipperLib::Paths getDeviceCourtyardPaths(const BI_Device& device,
                                             const GraphicsLayer* layer);
+  QVector<Path> getDeviceLocation(const BI_Device& device) const;
   template <typename THole>
   QVector<Path> getHoleLocation(const THole& hole,
                                 const Transform& transform1 = Transform(),

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
@@ -74,6 +74,29 @@ DrcMsgMissingDevice::DrcMsgMissingDevice(
 }
 
 /*******************************************************************************
+ *  DrcMsgDefaultDeviceMismatch
+ ******************************************************************************/
+
+DrcMsgDefaultDeviceMismatch::DrcMsgDefaultDeviceMismatch(
+    const ComponentInstance& component, const QVector<Path>& locations) noexcept
+  : RuleCheckMessage(
+        Severity::Warning,
+        tr("Device differs from schematic: '%1'", "Placeholders: Device name")
+            .arg(*component.getName()),
+        tr("The placed device is not the one specified in the schematics. The "
+           "component in the schematics has selected a different default "
+           "device.") %
+            "\n\n" %
+            tr("Check if the correct device was placed on the board or "
+               "optionally change the selected default device in the "
+               "schematics."),
+        "default_device_mismatch", locations) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("device", component.getUuid());
+  mApproval.ensureLineBreak();
+}
+
+/*******************************************************************************
  *  DrcMsgMissingConnection
  ******************************************************************************/
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
@@ -74,6 +74,26 @@ public:
 };
 
 /*******************************************************************************
+ *  Class DrcMsgDefaultDeviceMismatch
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgDefaultDeviceMismatch class
+ */
+class DrcMsgDefaultDeviceMismatch final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgDefaultDeviceMismatch)
+
+public:
+  // Constructors / Destructor
+  DrcMsgDefaultDeviceMismatch() = delete;
+  DrcMsgDefaultDeviceMismatch(const ComponentInstance& component,
+                              const QVector<Path>& locations) noexcept;
+  DrcMsgDefaultDeviceMismatch(const DrcMsgDefaultDeviceMismatch& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgDefaultDeviceMismatch() noexcept {}
+};
+
+/*******************************************************************************
  *  Class DrcMsgMissingConnection
  ******************************************************************************/
 


### PR DESCRIPTION
Warn about devices which are different to the device configured in the schematics. For example when adding a capacitor with 0603 package to the schematics but then using 0805 in the board, the warning appears.

Closes #584