### PR TITLE
Add mount type column to pick&place CSV files

### DIFF
--- a/libs/librepcb/core/export/pickplacedata.h
+++ b/libs/librepcb/core/export/pickplacedata.h
@@ -48,8 +48,15 @@ class PickPlaceDataItem final {
 
 public:
   enum class BoardSide {
-    TOP,
-    BOTTOM,
+    Top,
+    Bottom,
+  };
+
+  enum class Type {
+    Tht,
+    Smt,
+    Fiducial,
+    Other,
   };
 
   // Constructors / Destructor
@@ -57,14 +64,15 @@ public:
   PickPlaceDataItem(const QString& designator, const QString& value,
                     const QString& deviceName, const QString& packageName,
                     const Point& position, const Angle& rotation,
-                    BoardSide boardSide) noexcept
+                    BoardSide boardSide, Type type) noexcept
     : mDesignator(designator),
       mValue(value),
       mDeviceName(deviceName),
       mPackageName(packageName),
       mPosition(position),
       mRotation(rotation),
-      mBoardSide(boardSide) {}
+      mBoardSide(boardSide),
+      mType(type) {}
   PickPlaceDataItem(const PickPlaceDataItem& other) noexcept
     : mDesignator(other.mDesignator),
       mValue(other.mValue),
@@ -72,7 +80,8 @@ public:
       mPackageName(other.mPackageName),
       mPosition(other.mPosition),
       mRotation(other.mRotation),
-      mBoardSide(other.mBoardSide) {}
+      mBoardSide(other.mBoardSide),
+      mType(other.mType) {}
   ~PickPlaceDataItem() noexcept {}
 
   // Getters
@@ -83,6 +92,7 @@ public:
   const Point& getPosition() const noexcept { return mPosition; }
   const Angle& getRotation() const noexcept { return mRotation; }
   BoardSide getBoardSide() const noexcept { return mBoardSide; }
+  Type getType() const noexcept { return mType; }
 
   // Operator Overloadings
   PickPlaceDataItem& operator=(const PickPlaceDataItem& rhs) noexcept {
@@ -93,6 +103,7 @@ public:
     mPosition = rhs.mPosition;
     mRotation = rhs.mRotation;
     mBoardSide = rhs.mBoardSide;
+    mType = rhs.mType;
     return *this;
   }
 
@@ -104,6 +115,7 @@ private:
   Point mPosition;
   Angle mRotation;
   BoardSide mBoardSide;
+  Type mType;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/boardpickplacegenerator.cpp
+++ b/libs/librepcb/core/project/board/boardpickplacegenerator.cpp
@@ -54,6 +54,14 @@ BoardPickPlaceGenerator::~BoardPickPlaceGenerator() noexcept {
  ******************************************************************************/
 
 std::shared_ptr<PickPlaceData> BoardPickPlaceGenerator::generate() noexcept {
+  // Mount type map.
+  static QMap<BI_Device::MountType, PickPlaceDataItem::Type> types = {
+      {BI_Device::MountType::Tht, PickPlaceDataItem::Type::Tht},
+      {BI_Device::MountType::Smt, PickPlaceDataItem::Type::Smt},
+      {BI_Device::MountType::Fiducial, PickPlaceDataItem::Type::Fiducial},
+      {BI_Device::MountType::Other, PickPlaceDataItem::Type::Other},
+  };
+
   std::shared_ptr<PickPlaceData> data = std::make_shared<PickPlaceData>(
       *mBoard.getProject().getName(), mBoard.getProject().getVersion(),
       *mBoard.getName());
@@ -62,12 +70,9 @@ std::shared_ptr<PickPlaceData> BoardPickPlaceGenerator::generate() noexcept {
 
   foreach (const BI_Device* device, mBoard.getDeviceInstances()) {
     // Skip devices which are considered as no device to be mounted.
-    switch (device->determineMountType()) {
-      case BI_Device::MountType::None:
-      case BI_Device::MountType::Fiducial:
-        continue;
-      default:
-        break;
+    auto typeIt = types.find(device->determineMountType());
+    if (typeIt == types.end()) {
+      continue;
     }
 
     QString designator = *device->getComponentInstance().getName();
@@ -77,10 +82,10 @@ std::shared_ptr<PickPlaceData> BoardPickPlaceGenerator::generate() noexcept {
     Point position = device->getPosition();
     Angle rotation = device->getRotation();
     PickPlaceDataItem::BoardSide boardSide = device->getMirrored()
-        ? PickPlaceDataItem::BoardSide::BOTTOM
-        : PickPlaceDataItem::BoardSide::TOP;
+        ? PickPlaceDataItem::BoardSide::Bottom
+        : PickPlaceDataItem::BoardSide::Top;
     data->addItem(PickPlaceDataItem(designator, value, deviceName, packageName,
-                                    position, rotation, boardSide));
+                                    position, rotation, boardSide, *typeIt));
   }
 
   return data;

--- a/tests/unittests/core/export/pickplacecsvwritertest.cpp
+++ b/tests/unittests/core/export/pickplacecsvwritertest.cpp
@@ -45,14 +45,16 @@ protected:
         std::make_shared<PickPlaceData>("project", "version", "board");
     data->addItem(PickPlaceDataItem("R10", "", "device", "pack,\"age\"",
                                     Point(-1000000, -2000000), -Angle::deg45(),
-                                    PickPlaceDataItem::BoardSide::TOP));
+                                    PickPlaceDataItem::BoardSide::Top,
+                                    PickPlaceDataItem::Type::Tht));
     data->addItem(PickPlaceDataItem("U5", "1kΩ\r\n\r\n", "device", "package",
                                     Point(1000000, 2000000), Angle::deg45(),
-                                    PickPlaceDataItem::BoardSide::BOTTOM));
-    data->addItem(PickPlaceDataItem("R1", " 1kΩ\n1W\n100V ", "device \"foo\"",
-                                    "pack,age", Point(1000000, 2000000),
-                                    Angle::deg45(),
-                                    PickPlaceDataItem::BoardSide::TOP));
+                                    PickPlaceDataItem::BoardSide::Bottom,
+                                    PickPlaceDataItem::Type::Smt));
+    data->addItem(PickPlaceDataItem(
+        "R1", " 1kΩ\n1W\n100V ", "device \"foo\"", "pack,age",
+        Point(1000000, 2000000), Angle::deg45(),
+        PickPlaceDataItem::BoardSide::Top, PickPlaceDataItem::Type::Fiducial));
     return data;
   }
 };
@@ -67,7 +69,8 @@ TEST_F(PickPlaceCsvWriterTest, testEmptyData) {
   writer.setIncludeMetadataComment(false);
   std::shared_ptr<CsvFile> file = writer.generateCsv();
   EXPECT_EQ(
-      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side\n",
+      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side,"
+      "Type\n",
       file->toString().toStdString());
 }
 
@@ -84,19 +87,23 @@ TEST_F(PickPlaceCsvWriterTest, testBothSides) {
   EXPECT_EQ("# Unit:                mm", lines[7].toStdString());
   EXPECT_EQ("# Rotation:            Degrees CCW", lines[8].toStdString());
   EXPECT_EQ("# Board Side:          Top + Bottom", lines[9].toStdString());
-  EXPECT_EQ("", lines[10].toStdString());
+  EXPECT_EQ("# Supported Types:     THT, SMT, Fiducial, Other",
+            lines[10].toStdString());
+  EXPECT_EQ("", lines[11].toStdString());
   EXPECT_EQ(
-      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side",
-      lines[11].toStdString());
-  EXPECT_EQ(
-      "R1, 1kΩ 1W 100V ,\"device \"\"foo\"\"\",\"pack,age\",1.0,2.0,45.0,Top",
+      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side,"
+      "Type",
       lines[12].toStdString());
-  EXPECT_EQ("R10,,device,\"pack,\"\"age\"\"\",-1.0,-2.0,315.0,Top",
-            lines[13].toStdString());
-  EXPECT_EQ("U5,1kΩ  ,device,package,1.0,2.0,45.0,Bottom",
+  EXPECT_EQ(
+      "R1, 1kΩ 1W 100V ,\"device "
+      "\"\"foo\"\"\",\"pack,age\",1.0,2.0,45.0,Top,Fiducial",
+      lines[13].toStdString());
+  EXPECT_EQ("R10,,device,\"pack,\"\"age\"\"\",-1.0,-2.0,315.0,Top,THT",
             lines[14].toStdString());
-  EXPECT_EQ("", lines[15].toStdString());
-  EXPECT_EQ(16, lines.count());
+  EXPECT_EQ("U5,1kΩ  ,device,package,1.0,2.0,45.0,Bottom,SMT",
+            lines[15].toStdString());
+  EXPECT_EQ("", lines[16].toStdString());
+  EXPECT_EQ(17, lines.count());
 }
 
 TEST_F(PickPlaceCsvWriterTest, testTopSide) {
@@ -107,12 +114,14 @@ TEST_F(PickPlaceCsvWriterTest, testTopSide) {
   std::shared_ptr<CsvFile> file = writer.generateCsv();
   QStringList lines = file->toString().split("\n");
   EXPECT_EQ(
-      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side",
+      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side,"
+      "Type",
       lines[0].toStdString());
   EXPECT_EQ(
-      "R1, 1kΩ 1W 100V ,\"device \"\"foo\"\"\",\"pack,age\",1.0,2.0,45.0,Top",
+      "R1, 1kΩ 1W 100V ,\"device "
+      "\"\"foo\"\"\",\"pack,age\",1.0,2.0,45.0,Top,Fiducial",
       lines[1].toStdString());
-  EXPECT_EQ("R10,,device,\"pack,\"\"age\"\"\",-1.0,-2.0,315.0,Top",
+  EXPECT_EQ("R10,,device,\"pack,\"\"age\"\"\",-1.0,-2.0,315.0,Top,THT",
             lines[2].toStdString());
   EXPECT_EQ("", lines[3].toStdString());
   EXPECT_EQ(4, lines.count());
@@ -126,9 +135,10 @@ TEST_F(PickPlaceCsvWriterTest, testBottomSide) {
   std::shared_ptr<CsvFile> file = writer.generateCsv();
   QStringList lines = file->toString().split("\n");
   EXPECT_EQ(
-      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side",
+      "Designator,Value,Device,Package,Position X,Position Y,Rotation,Side,"
+      "Type",
       lines[0].toStdString());
-  EXPECT_EQ("U5,1kΩ  ,device,package,1.0,2.0,45.0,Bottom",
+  EXPECT_EQ("U5,1kΩ  ,device,package,1.0,2.0,45.0,Bottom,SMT",
             lines[1].toStdString());
   EXPECT_EQ("", lines[2].toStdString());
   EXPECT_EQ(3, lines.count());


### PR DESCRIPTION
Add a new column named "Type" to pick&place files to indicate whether a device is THT, SMT, Fiducial or something else. Required by assembly services to calculate the price.

```
# Pick&Place Position Data File
#
# Project Name:        Hydro Battery Charger
# Project Version:     v4
# Board Name:          default
# Generation Software: LibrePCB 0.2.0-unstable
# Generation Date:     2023-03-09T20:57:38
# Unit:                mm
# Rotation:            Degrees CCW
# Board Side:          Top
# Supported Types:     THT, SMT, Fiducial, Other

Designator,Value,Device,Package,Position X,Position Y,Rotation,Side,Type
LED1,LED 3mm Green,LED 3mm,LED 3mm,81.5,50.0,270.0,Top,THT
```