### PR TITLE
Schematic editor: Live update for schematic thumbnails

### DIFF
--- a/libs/librepcb/core/project/schematic/schematicpainter.h
+++ b/libs/librepcb/core/project/schematic/schematicpainter.h
@@ -86,7 +86,8 @@ class SchematicPainter final : public GraphicsPagePainter {
 public:
   // Constructors / Destructor
   SchematicPainter() = delete;
-  explicit SchematicPainter(const Schematic& schematic) noexcept;
+  explicit SchematicPainter(const Schematic& schematic,
+                            bool thumbnail = false) noexcept;
   SchematicPainter(const SchematicPainter& other) = delete;
   ~SchematicPainter() noexcept;
 

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -688,14 +688,9 @@ void SchematicEditor::createToolBars() noexcept {
 
 void SchematicEditor::createDockWidgets() noexcept {
   // Pages.
-  mDockPages.reset(
-      new SchematicPagesDock(mProject,
-                             mProjectEditor.getWorkspace()
-                                 .getSettings()
-                                 .themes.getActive()
-                                 .getColor(Theme::Color::sSchematicBackground)
-                                 .getPrimaryColor(),
-                             this));
+  mDockPages.reset(new SchematicPagesDock(
+      mProject, mProjectEditor.getUndoStack(),
+      mProjectEditor.getWorkspace().getSettings().themes.getActive(), this));
   connect(this, &SchematicEditor::activeSchematicChanged, mDockPages.data(),
           &SchematicPagesDock::setSelectedSchematic);
   connect(mDockPages.data(), &SchematicPagesDock::selectedSchematicChanged,

--- a/libs/librepcb/editor/project/schematiceditor/schematicpagesdock.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematicpagesdock.h
@@ -23,17 +23,27 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/core/types/uuid.h>
+
 #include <QtCore>
 #include <QtWidgets>
+
+#include <memory>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 
+class GraphicsExport;
+class GraphicsExportSettings;
 class Project;
+class SI_Symbol;
+class Theme;
 
 namespace editor {
+
+class UndoStack;
 
 namespace Ui {
 class SchematicPagesDock;
@@ -53,7 +63,7 @@ public:
   // Constructors / Destructor
   SchematicPagesDock() = delete;
   SchematicPagesDock(const SchematicPagesDock& other) = delete;
-  SchematicPagesDock(Project& project, const QColor& background,
+  SchematicPagesDock(Project& project, UndoStack& undoStack, const Theme& theme,
                      QWidget* parent = nullptr);
   ~SchematicPagesDock();
 
@@ -78,12 +88,25 @@ private:  // Methods
   void renameSelectedSchematic() noexcept;
   void schematicAdded(int newIndex) noexcept;
   void schematicRemoved(int oldIndex) noexcept;
+  void schematicModified(SI_Symbol& symbol) noexcept;
   void updateSchematicNames() noexcept;
+  void updateNextThumbnail() noexcept;
+  void thumbnailReady(int index, const QSize& pageSize, const QRectF margins,
+                      std::shared_ptr<QPicture> picture);
 
 private:  // Data
   Project& mProject;
+  UndoStack& mUndoStack;
   QScopedPointer<Ui::SchematicPagesDock> mUi;
   QColor mBackgroundColor;
+
+  // Thumbnail generator.
+  QSet<Uuid> mScheduledThumbnailSchematics;
+  tl::optional<Uuid> mCurrentThumbnailSchematic;
+  QScopedPointer<GraphicsExport> mThumbnailGenerator;
+  std::shared_ptr<GraphicsExportSettings> mThumbnailSettings;
+  QTimer mThumbnailTimer;
+  QVector<QVector<QMetaObject::Connection>> mSchematicConnections;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
The schematic thumbnails/previews of the "Pages" dock in the schematic editor were not updated after modifying schematics, mainly due to performance reasons since the update is a (more or less) heavy operation which would block the UI thread.

But thanks to #947 we have now the class `GraphicsExport` which allows to generate images of schematics in a worker thread, i.e. without blocking the UI. This PR now makes use of that class to generate the schematic thumbnails, which are now updated automatically after modifying schematics (for simplicity, only after adding or removing symbols).