### PR TITLE
BOM export: Store custom BOM attributes in project files

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -601,9 +601,14 @@ bool CommandLineInterface::openProject(
         jobs.append(qMakePair(fp, true));
       }
       QStringList attributes;
-      foreach (const QString str,
-               bomAttributes.simplified().split(',', QString::SkipEmptyParts)) {
-        attributes.append(str.trimmed());
+      if (bomAttributes.isEmpty()) {
+        attributes = project->getCustomBomAttributes();
+      } else {
+        foreach (const QString str, bomAttributes.simplified().split(',')) {
+          if (!str.trimmed().isEmpty()) {
+            attributes.append(str.trimmed());
+          }
+        }
       }
       foreach (const auto& job, jobs) {
         QList<Board*> boardsToExport;

--- a/libs/librepcb/core/project/project.cpp
+++ b/libs/librepcb/core/project/project.cpp
@@ -61,7 +61,8 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
     mCreated(QDateTime::currentDateTime()),
     mLastModified(QDateTime::currentDateTime()),
     mLocaleOrder(),
-    mNormOrder() {
+    mNormOrder(),
+    mCustomBomAttributes() {
   // Check if the file extension is correct
   if (!mFilename.endsWith(".lpp")) {
     throw RuntimeError(__FILE__, __LINE__,
@@ -171,6 +172,12 @@ void Project::setNormOrder(const QStringList& newNorms) noexcept {
     mNormOrder = newNorms;
     emit attributesChanged();
     emit normOrderChanged();
+  }
+}
+
+void Project::setCustomBomAttributes(const QStringList& newKeys) noexcept {
+  if (newKeys != mCustomBomAttributes) {
+    mCustomBomAttributes = newKeys;
   }
 }
 
@@ -404,6 +411,15 @@ void Project::save() {
       foreach (const QString& norm, mNormOrder) {
         node.ensureLineBreak();
         node.appendChild("norm", norm);
+      }
+      node.ensureLineBreak();
+    }
+    root.ensureLineBreak();
+    {
+      SExpression& node = root.appendList("custom_bom_attributes");
+      foreach (const QString& key, mCustomBomAttributes) {
+        node.ensureLineBreak();
+        node.appendChild("attribute", key);
       }
       node.ensureLineBreak();
     }

--- a/libs/librepcb/core/project/project.h
+++ b/libs/librepcb/core/project/project.h
@@ -191,6 +191,15 @@ public:
   const QStringList& getNormOrder() const noexcept { return mNormOrder; }
 
   /**
+   * @brief Get the configured custom BOM attributes
+   *
+   * @return Attribute keys in a specific order
+   */
+  const QStringList& getCustomBomAttributes() const noexcept {
+    return mCustomBomAttributes;
+  }
+
+  /**
    * @brief Get the ProjectLibrary object which contains all library elements
    * used in this project
    *
@@ -279,6 +288,13 @@ public:
    * @param newNorms          The new norm order.
    */
   void setNormOrder(const QStringList& newNorms) noexcept;
+
+  /**
+   * @brief Set the custom BOM attributes
+   *
+   * @param newKeys           The new attribute keys.
+   */
+  void setCustomBomAttributes(const QStringList& newKeys) noexcept;
 
   /**
    * @brief Set all ERC message approvals
@@ -546,6 +562,9 @@ private:
 
   /// Configured norms in a particular order.
   QStringList mNormOrder;
+
+  /// Custom attributes to be included in BOM export.
+  QStringList mCustomBomAttributes;
 
   /// Ehe library which contains all elements needed in this project.
   QScopedPointer<ProjectLibrary> mProjectLibrary;

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -201,6 +201,15 @@ void ProjectLoader::loadSettings(Project& p) {
     p.setNormOrder(l);
   }
 
+  {
+    QStringList l;
+    foreach (const SExpression* node,
+             root.getChild("custom_bom_attributes").getChildren("attribute")) {
+      l.append(node->getChild("@0").getValue());
+    }
+    p.setCustomBomAttributes(l);
+  }
+
   qDebug() << "Successfully loaded project settings.";
 }
 

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -195,7 +195,7 @@ void ProjectLoader::loadSettings(Project& p) {
   {
     QStringList l;
     foreach (const SExpression* node,
-             root.getChild("library_norm_order").getChildren("locale")) {
+             root.getChild("library_norm_order").getChildren("norm")) {
       l.append(node->getChild("@0").getValue());
     }
     p.setNormOrder(l);

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -65,11 +65,6 @@ void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-
-  const QString fp = "package.lp";
-  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  root.appendChild("assembly_type", SExpression::createToken("auto"));
-  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(
@@ -94,9 +89,14 @@ void FileFormatMigrationUnstable::upgradeWorkspaceData(
  *  Private Methods
  ******************************************************************************/
 
+void FileFormatMigrationUnstable::upgradeSettings(SExpression& root) {
+  FileFormatMigrationV01::upgradeSettings(root);
+}
+
 void FileFormatMigrationUnstable::upgradeErc(SExpression& root,
                                              ProjectContext& context) {
-  FileFormatMigrationV01::upgradeErc(root, context);
+  Q_UNUSED(root);
+  Q_UNUSED(context);
 }
 
 void FileFormatMigrationUnstable::upgradeSchematic(SExpression& root,

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.h
@@ -72,6 +72,7 @@ public:
       const FileFormatMigrationUnstable& rhs) = delete;
 
 private:  // Methods
+  virtual void upgradeSettings(SExpression& root) override;
   virtual void upgradeErc(SExpression& root, ProjectContext& context) override;
   virtual void upgradeSchematic(SExpression& root,
                                 ProjectContext& context) override;

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -271,6 +271,14 @@ void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir,
     }
   }
 
+  // Settings.
+  {
+    const QString fp = "project/settings.lp";
+    SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    upgradeSettings(root);
+    dir.write(fp, root.toByteArray());
+  }
+
   // Circuit.
   {
     const QString fp = "circuit/circuit.lp";
@@ -392,6 +400,10 @@ void FileFormatMigrationV01::upgradeWorkspaceData(TransactionalDirectory& dir) {
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
+
+void FileFormatMigrationV01::upgradeSettings(SExpression& root) {
+  root.appendList("custom_bom_attributes");
+}
 
 void FileFormatMigrationV01::upgradeErc(SExpression& root,
                                         ProjectContext& context) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -119,6 +119,7 @@ public:
   FileFormatMigrationV01& operator=(const FileFormatMigrationV01& rhs) = delete;
 
 protected:  // Methods
+  virtual void upgradeSettings(SExpression& root);
   virtual void upgradeErc(SExpression& root, ProjectContext& context);
   virtual void upgradeSchematic(SExpression& root, ProjectContext& context);
   virtual void upgradeBoard(SExpression& root, ProjectContext& context);

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -397,6 +397,8 @@ void BoardEditor::createActions() noexcept {
   mActionGenerateBom.reset(cmd.generateBom.createAction(this, this, [this]() {
     BomGeneratorDialog dialog(mProjectEditor.getWorkspace().getSettings(),
                               mProject, getActiveBoard(), this);
+    connect(&dialog, &BomGeneratorDialog::projectSettingsModified,
+            &mProjectEditor, &ProjectEditor::setManualModificationsMade);
     dialog.exec();
   }));
   mActionGenerateFabricationData.reset(

--- a/libs/librepcb/editor/project/bomgeneratordialog.h
+++ b/libs/librepcb/editor/project/bomgeneratordialog.h
@@ -61,13 +61,16 @@ public:
   // Constructors / Destructor
   BomGeneratorDialog() = delete;
   BomGeneratorDialog(const BomGeneratorDialog& other) = delete;
-  BomGeneratorDialog(const WorkspaceSettings& settings, const Project& project,
+  BomGeneratorDialog(const WorkspaceSettings& settings, Project& project,
                      const Board* board = nullptr,
                      QWidget* parent = nullptr) noexcept;
   ~BomGeneratorDialog() noexcept;
 
   // Operator Overloads
   BomGeneratorDialog& operator=(const BomGeneratorDialog& rhs) = delete;
+
+signals:
+  void projectSettingsModified();
 
 private:  // GUI Event Handlers
   void cbxBoardCurrentIndexChanged(int index) noexcept;
@@ -76,13 +79,14 @@ private:  // GUI Event Handlers
   void btnGenerateClicked() noexcept;
 
 private:  // Methods
+  void updateAttributes() noexcept;
   void updateBom() noexcept;
   void updateTable() noexcept;
   FilePath getOutputFilePath() const noexcept;
 
 private:  // Data
   const WorkspaceSettings& mSettings;
-  const Project& mProject;
+  Project& mProject;
   std::shared_ptr<Bom> mBom;
   QScopedPointer<Ui::BomGeneratorDialog> mUi;
   QPointer<QPushButton> mBtnGenerate;

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -378,6 +378,8 @@ void SchematicEditor::createActions() noexcept {
         : nullptr;
     BomGeneratorDialog dialog(mProjectEditor.getWorkspace().getSettings(),
                               mProject, board, this);
+    connect(&dialog, &BomGeneratorDialog::projectSettingsModified,
+            &mProjectEditor, &ProjectEditor::setManualModificationsMade);
     dialog.exec();
   }));
   mActionOrderPcb.reset(cmd.orderPcb.createAction(


### PR DESCRIPTION
Persistently store the configured custom BOM attributes in the project file `project/settings.lp`. Not sure if this will still be needed once #1000 is implemented, but it was easy and allows to close #624 now :see_no_evil: 

Closes #624