### PR TITLE
Support configuring automatic stop mask & solder paste on pads

### DIFF
--- a/libs/librepcb/core/library/pkg/footprintpad.h
+++ b/libs/librepcb/core/library/pkg/footprintpad.h
@@ -30,6 +30,7 @@
 #include "../../serialization/serializableobjectlist.h"
 #include "../../types/angle.h"
 #include "../../types/length.h"
+#include "../../types/maskconfig.h"
 #include "../../types/point.h"
 #include "../../types/ratio.h"
 #include "../../types/uuid.h"
@@ -78,6 +79,8 @@ public:
     HeightChanged,
     RadiusChanged,
     CustomShapeOutlineChanged,
+    StopMaskConfigChanged,
+    SolderPasteConfigChanged,
     ComponentSideChanged,
     HolesEdited,
   };
@@ -91,7 +94,8 @@ public:
                const Point& pos, const Angle& rot, Shape shape,
                const PositiveLength& width, const PositiveLength& height,
                const UnsignedLimitedRatio& radius,
-               const Path& customShapeOutline, ComponentSide side,
+               const Path& customShapeOutline, const MaskConfig& autoStopMask,
+               const MaskConfig& autoSolderPaste, ComponentSide side,
                const PadHoleList& holes) noexcept;
   explicit FootprintPad(const SExpression& node);
   ~FootprintPad() noexcept;
@@ -110,12 +114,24 @@ public:
   const Path& getCustomShapeOutline() const noexcept {
     return mCustomShapeOutline;
   }
+  const MaskConfig& getStopMaskConfig() const noexcept {
+    return mStopMaskConfig;
+  }
+  const MaskConfig& getSolderPasteConfig() const noexcept {
+    return mSolderPasteConfig;
+  }
   ComponentSide getComponentSide() const noexcept { return mComponentSide; }
   const PadHoleList& getHoles() const noexcept { return mHoles; }
   PadHoleList& getHoles() noexcept { return mHoles; }
   bool isTht() const noexcept;
   bool isOnLayer(const Layer& layer) const noexcept;
   const Layer& getSmtLayer() const noexcept;
+  bool hasTopCopper() const noexcept;
+  bool hasBottomCopper() const noexcept;
+  bool hasAutoTopStopMask() const noexcept;
+  bool hasAutoBottomStopMask() const noexcept;
+  bool hasAutoTopSolderPaste() const noexcept;
+  bool hasAutoBottomSolderPaste() const noexcept;
   PadGeometry getGeometry() const noexcept;
 
   // Setters
@@ -127,6 +143,8 @@ public:
   bool setHeight(const PositiveLength& height) noexcept;
   bool setRadius(const UnsignedLimitedRatio& radius) noexcept;
   bool setCustomShapeOutline(const Path& outline) noexcept;
+  bool setStopMaskConfig(const MaskConfig& config) noexcept;
+  bool setSolderPasteConfig(const MaskConfig& config) noexcept;
   bool setComponentSide(ComponentSide side) noexcept;
 
   // General Methods
@@ -170,6 +188,8 @@ private:  // Data
   PositiveLength mHeight;
   UnsignedLimitedRatio mRadius;
   Path mCustomShapeOutline;  ///< Empty if not needed; Implicitly closed
+  MaskConfig mStopMaskConfig;
+  MaskConfig mSolderPasteConfig;
   ComponentSide mComponentSide;
   PadHoleList mHoles;  ///< If not empty, it's a THT pad.
 

--- a/libs/librepcb/core/library/pkg/packagecheck.h
+++ b/libs/librepcb/core/library/pkg/packagecheck.h
@@ -66,6 +66,8 @@ protected:  // Methods
   void checkPadsAnnularRing(MsgList& msgs) const;
   void checkPadsConnectionPoint(MsgList& msgs) const;
   void checkCustomPadOutline(MsgList& msgs) const;
+  void checkStopMaskOnPads(MsgList& msgs) const;
+  void checkSolderPasteOnPads(MsgList& msgs) const;
   void checkHolesStopMask(MsgList& msgs) const;
 
 private:  // Data

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
@@ -337,6 +337,91 @@ MsgPadOverlapsWithPlacement::MsgPadOverlapsWithPlacement(
 }
 
 /*******************************************************************************
+ *  MsgPadWithoutStopMask
+ ******************************************************************************/
+
+MsgPadWithoutStopMask::MsgPadWithoutStopMask(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : RuleCheckMessage(
+        Severity::Error,
+        tr("No stop mask on pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("There's no stop mask opening enabled on the pad, so the copper "
+           "pad will be covered by solder resist and is thus not functional. "
+           "This is very unusual, you should double-check if this is really "
+           "what you want."),
+        "pad_without_stop_mask"),
+    mFootprint(footprint),
+    mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+MsgPadWithoutStopMask::~MsgPadWithoutStopMask() noexcept {
+}
+
+/*******************************************************************************
+ *  MsgSmtPadWithoutSolderPaste
+ ******************************************************************************/
+
+MsgSmtPadWithoutSolderPaste::MsgSmtPadWithoutSolderPaste(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : RuleCheckMessage(
+        Severity::Warning,
+        tr("No solder paste on SMT pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("The SMT pad has no solder paste enabled, which is unusual since "
+           "without solder paste the pad cannot be reflow soldered. Only use "
+           "this if there's no lead to be soldered on that pad, or if you have "
+           "drawn a manual solder paste area."),
+        "smt_pad_without_solder_paste"),
+    mFootprint(footprint),
+    mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+MsgSmtPadWithoutSolderPaste::~MsgSmtPadWithoutSolderPaste() noexcept {
+}
+
+/*******************************************************************************
+ *  MsgThtPadWithSolderPaste
+ ******************************************************************************/
+
+MsgThtPadWithSolderPaste::MsgThtPadWithSolderPaste(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : RuleCheckMessage(
+        Severity::Warning,
+        tr("Solder paste on THT pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("The THT pad has solder paste enabled, which is very unusual since "
+           "through-hole components are usually not reflow soldered. Also the "
+           "solder paste could flow into the pads hole, possibly causing "
+           "troubles during THT assembly. Double-check if this is really what "
+           "you want."),
+        "tht_pad_with_solder_paste"),
+    mFootprint(footprint),
+    mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+MsgThtPadWithSolderPaste::~MsgThtPadWithSolderPaste() noexcept {
+}
+
+/*******************************************************************************
  *  MsgUnusedCustomPadOutline
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.h
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.h
@@ -420,6 +420,99 @@ private:
 };
 
 /*******************************************************************************
+ *  Class MsgPadWithoutStopMask
+ ******************************************************************************/
+
+/**
+ * @brief The MsgPadWithoutStopMask class
+ */
+class MsgPadWithoutStopMask final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadWithoutStopMask)
+
+public:
+  // Constructors / Destructor
+  MsgPadWithoutStopMask() = delete;
+  MsgPadWithoutStopMask(std::shared_ptr<const Footprint> footprint,
+                        std::shared_ptr<const FootprintPad> pad,
+                        const QString& pkgPadName) noexcept;
+  MsgPadWithoutStopMask(const MsgPadWithoutStopMask& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgPadWithoutStopMask() noexcept;
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
+ *  Class MsgSmtPadWithoutSolderPaste
+ ******************************************************************************/
+
+/**
+ * @brief The MsgSmtPadWithoutSolderPaste class
+ */
+class MsgSmtPadWithoutSolderPaste final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgSmtPadWithoutSolderPaste)
+
+public:
+  // Constructors / Destructor
+  MsgSmtPadWithoutSolderPaste() = delete;
+  MsgSmtPadWithoutSolderPaste(std::shared_ptr<const Footprint> footprint,
+                              std::shared_ptr<const FootprintPad> pad,
+                              const QString& pkgPadName) noexcept;
+  MsgSmtPadWithoutSolderPaste(const MsgSmtPadWithoutSolderPaste& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgSmtPadWithoutSolderPaste() noexcept;
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
+ *  Class MsgThtPadWithSolderPaste
+ ******************************************************************************/
+
+/**
+ * @brief The MsgThtPadWithSolderPaste class
+ */
+class MsgThtPadWithSolderPaste final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgThtPadWithSolderPaste)
+
+public:
+  // Constructors / Destructor
+  MsgThtPadWithSolderPaste() = delete;
+  MsgThtPadWithSolderPaste(std::shared_ptr<const Footprint> footprint,
+                           std::shared_ptr<const FootprintPad> pad,
+                           const QString& pkgPadName) noexcept;
+  MsgThtPadWithSolderPaste(const MsgThtPadWithSolderPaste& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgThtPadWithSolderPaste() noexcept;
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
  *  Class MsgUnusedCustomPadOutline
  ******************************************************************************/
 

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -61,19 +61,19 @@ void FileFormatMigrationUnstable::upgradePackageCategory(
 
 void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-
-  const QString fp = "symbol.lp";
-  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  upgradeLayers(root);
-  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
-  Q_UNUSED(dir);
-
   const QString fp = "package.lp";
   SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  upgradeLayers(root);
+  for (SExpression* fptNode : root.getChildren("footprint")) {
+    for (SExpression* padNode : fptNode->getChildren("pad")) {
+      const bool isTht = !padNode->getChildren("hole").isEmpty();
+      padNode->appendChild("stop_mask", SExpression::createToken("auto"));
+      padNode->appendChild("solder_paste",
+                           SExpression::createToken(isTht ? "off" : "auto"));
+    }
+  }
   dir.write(fp, root.toByteArray());
 }
 
@@ -113,14 +113,12 @@ void FileFormatMigrationUnstable::upgradeSchematic(SExpression& root,
                                                    ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  upgradeLayers(root);
 }
 
 void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  upgradeLayers(root);
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -153,6 +153,12 @@ void FileFormatMigrationV01::upgradePackage(TransactionalDirectory& dir) {
           // from the top view, it should be safe to set it to "top" now.
           boardSideNode = SExpression::createToken("top");
         }
+
+        // Add mask configs.
+        padNode->appendChild("stop_mask", SExpression::createToken("auto"));
+        padNode->appendChild(
+            "solder_paste",
+            SExpression::createToken((drill > 0) ? "off" : "auto"));
       }
 
       // Holes.

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -425,6 +425,8 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           height,  // Height
           radius,  // Radius
           Path(),  // Custom shape outline
+          MaskConfig::automatic(),  // Stop mask
+          MaskConfig::off(),  // Solder paste
           FootprintPad::ComponentSide::Top,  // Side
           PadHoleList{std::make_shared<PadHole>(
               Uuid::createRandom(),
@@ -460,6 +462,8 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           PositiveLength(convertLength(p.getHeight())),  // Height
           UnsignedLimitedRatio(Ratio::percent0()),  // Radius
           Path(),  // Custom shape outline
+          MaskConfig::automatic(),  // Stop mask
+          MaskConfig::automatic(),  // Solder paste
           side,  // Side
           PadHoleList{}  // Holes
           ));

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
@@ -51,6 +51,10 @@ CmdFootprintPadEdit::CmdFootprintPadEdit(FootprintPad& pad) noexcept
     mNewRadius(mOldRadius),
     mOldCustomShapeOutline(pad.getCustomShapeOutline()),
     mNewCustomShapeOutline(mOldCustomShapeOutline),
+    mOldStopMaskConfig(pad.getStopMaskConfig()),
+    mNewStopMaskConfig(mOldStopMaskConfig),
+    mOldSolderPasteConfig(pad.getSolderPasteConfig()),
+    mNewSolderPasteConfig(mOldSolderPasteConfig),
     mOldPos(pad.getPosition()),
     mNewPos(mOldPos),
     mOldRotation(pad.getRotation()),
@@ -118,6 +122,17 @@ void CmdFootprintPadEdit::setRadius(const UnsignedLimitedRatio& radius,
 void CmdFootprintPadEdit::setCustomShapeOutline(const Path& outline) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewCustomShapeOutline = outline;
+}
+
+void CmdFootprintPadEdit::setStopMaskConfig(const MaskConfig& config) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewStopMaskConfig = config;
+}
+
+void CmdFootprintPadEdit::setSolderPasteConfig(
+    const MaskConfig& config) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewSolderPasteConfig = config;
 }
 
 void CmdFootprintPadEdit::setPosition(const Point& pos,
@@ -209,6 +224,8 @@ bool CmdFootprintPadEdit::performExecute() {
   if (mNewHeight != mOldHeight) return true;
   if (mNewRadius != mOldRadius) return true;
   if (mNewCustomShapeOutline != mOldCustomShapeOutline) return true;
+  if (mNewStopMaskConfig != mOldStopMaskConfig) return true;
+  if (mNewSolderPasteConfig != mOldSolderPasteConfig) return true;
   if (mNewPos != mOldPos) return true;
   if (mNewRotation != mOldRotation) return true;
   if (mNewHoles != mOldHoles) return true;
@@ -223,6 +240,8 @@ void CmdFootprintPadEdit::performUndo() {
   mPad.setHeight(mOldHeight);
   mPad.setRadius(mOldRadius);
   mPad.setCustomShapeOutline(mOldCustomShapeOutline);
+  mPad.setStopMaskConfig(mOldStopMaskConfig);
+  mPad.setSolderPasteConfig(mOldSolderPasteConfig);
   mPad.setPosition(mOldPos);
   mPad.setRotation(mOldRotation);
   mPad.getHoles() = mOldHoles;
@@ -236,6 +255,8 @@ void CmdFootprintPadEdit::performRedo() {
   mPad.setHeight(mNewHeight);
   mPad.setRadius(mNewRadius);
   mPad.setCustomShapeOutline(mNewCustomShapeOutline);
+  mPad.setStopMaskConfig(mNewStopMaskConfig);
+  mPad.setSolderPasteConfig(mNewSolderPasteConfig);
   mPad.setPosition(mNewPos);
   mPad.setRotation(mNewRotation);
   mPad.getHoles() = mNewHoles;

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
@@ -63,6 +63,8 @@ public:
   void setHeight(const PositiveLength& height, bool immediate) noexcept;
   void setRadius(const UnsignedLimitedRatio& radius, bool immediate) noexcept;
   void setCustomShapeOutline(const Path& outline) noexcept;
+  void setStopMaskConfig(const MaskConfig& config) noexcept;
+  void setSolderPasteConfig(const MaskConfig& config) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
@@ -108,6 +110,10 @@ private:
   UnsignedLimitedRatio mNewRadius;
   Path mOldCustomShapeOutline;
   Path mNewCustomShapeOutline;
+  MaskConfig mOldStopMaskConfig;
+  MaskConfig mNewStopMaskConfig;
+  MaskConfig mOldSolderPasteConfig;
+  MaskConfig mNewSolderPasteConfig;
   Point mOldPos;
   Point mNewPos;
   Angle mOldRotation;

--- a/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
@@ -102,7 +102,8 @@ bool CmdPasteFootprintItems::performExecute() {
     std::shared_ptr<FootprintPad> copy = std::make_shared<FootprintPad>(
         uuid, pkgPadUuid, pad.getPosition() + mPosOffset, pad.getRotation(),
         pad.getShape(), pad.getWidth(), pad.getHeight(), pad.getRadius(),
-        pad.getCustomShapeOutline(), pad.getComponentSide(), pad.getHoles());
+        pad.getCustomShapeOutline(), pad.getStopMaskConfig(),
+        pad.getSolderPasteConfig(), pad.getComponentSide(), pad.getHoles());
     execNewChildCmd(new CmdFootprintPadInsert(mFootprint.getPads(), copy));
     if (auto graphicsItem = mGraphicsItem.getGraphicsItem(copy)) {
       graphicsItem->setSelected(true);

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -231,6 +231,7 @@ void NewElementWizardContext::copyElement(ElementType type,
               Uuid::createRandom(), pkgPad, pad.getPosition(),
               pad.getRotation(), pad.getShape(), pad.getWidth(),
               pad.getHeight(), pad.getRadius(), pad.getCustomShapeOutline(),
+              pad.getStopMaskConfig(), pad.getSolderPasteConfig(),
               pad.getComponentSide(), pad.getHoles()));
         }
         // copy polygons but generate new UUIDs

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
@@ -85,6 +85,8 @@ private:  // Methods
   void removeAllHoles() noexcept;
   void updateGeneralTabHoleWidgets() noexcept;
   void setSelectedHole(int index) noexcept;
+  void applyTypicalThtProperties() noexcept;
+  void applyTypicalSmtProperties() noexcept;
   void on_buttonBox_clicked(QAbstractButton* button);
   bool applyChanges() noexcept;
 

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>587</width>
-    <height>325</height>
+    <height>335</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -348,31 +348,6 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabCustomShape">
-      <attribute name="title">
-       <string>Custom Shape</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,0">
-       <item>
-        <widget class="librepcb::editor::PathEditorWidget" name="customShapePathEditor" native="true"/>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_8">
-         <property name="font">
-          <font>
-           <italic>true</italic>
-          </font>
-         </property>
-         <property name="text">
-          <string>Coordinates are relative to the pad origin and before rotation.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
      <widget class="QWidget" name="tabHoles">
       <attribute name="title">
        <string>Plated Holes</string>
@@ -468,6 +443,188 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabMasks">
+      <attribute name="title">
+       <string>Automatic Masks</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>Stop Mask:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <widget class="QRadioButton" name="rbtnStopMaskOff">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Off</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">btnGroupStopMask</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="rbtnStopMaskAuto">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>From Design Rules</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">btnGroupStopMask</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="rbtnStopMaskManual">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Manual:</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">btnGroupStopMask</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtStopMaskOffset" native="true">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>Solder Paste:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <item>
+          <widget class="QRadioButton" name="rbtnSolderPasteOff">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Off</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">btnGroupSolderPaste</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="rbtnSolderPasteAuto">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>From Design Rules</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">btnGroupSolderPaste</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="rbtnSolderPasteManual">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Manual:</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">btnGroupSolderPaste</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="librepcb::editor::LengthEdit" name="edtSolderPasteOffset" native="true">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="label_13">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Note: For THT pads the solder paste should usually be set to 'Off'. But if enabled anyway, the solder paste is added only to the solder side of the pad.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabCustomShape">
+      <attribute name="title">
+       <string>Custom Shape</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,0">
+       <item>
+        <widget class="librepcb::editor::PathEditorWidget" name="customShapePathEditor" native="true"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_8">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Coordinates are relative to the pad origin and before rotation.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -549,6 +706,8 @@
  <resources/>
  <connections/>
  <buttongroups>
+  <buttongroup name="btnGroupSolderPaste"/>
+  <buttongroup name="btnGroupStopMask"/>
   <buttongroup name="btnGroupComponentSide"/>
   <buttongroup name="btnGroupShape"/>
  </buttongroups>

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
@@ -63,6 +63,8 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(Context& context,
         PositiveLength(1300000),  // -> choose reasonable multiple of 0.1mm
         UnsignedLimitedRatio(Ratio::percent100()),  // Rounded pad
         Path(),  // Custom shape outline
+        MaskConfig::automatic(),  // Stop mask
+        MaskConfig::off(),  // Solder paste
         FootprintPad::ComponentSide::Top,  // Default side
         PadHoleList{}) {
   if (mPadType == PadType::SMT) {
@@ -71,6 +73,7 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(Context& context,
     mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent50()));
     mLastPad.setWidth(PositiveLength(1500000));  // Same as for THT pads ->
     mLastPad.setHeight(PositiveLength(700000));  // reasonable multiple of 0.1mm
+    mLastPad.setSolderPasteConfig(MaskConfig::automatic());
     applyRecommendedRoundedRectRadius();
   } else {
     mLastPad.getHoles().append(std::make_shared<PadHole>(
@@ -351,7 +354,8 @@ bool PackageEditorState_AddPads::startAddPad(const Point& pos) noexcept {
         Uuid::createRandom(), mLastPad.getPackagePadUuid(),
         mLastPad.getPosition(), mLastPad.getRotation(), mLastPad.getShape(),
         mLastPad.getWidth(), mLastPad.getHeight(), mLastPad.getRadius(),
-        mLastPad.getCustomShapeOutline(), mLastPad.getComponentSide(),
+        mLastPad.getCustomShapeOutline(), mLastPad.getStopMaskConfig(),
+        mLastPad.getSolderPasteConfig(), mLastPad.getComponentSide(),
         PadHoleList{});
     for (const PadHole& hole : mLastPad.getHoles()) {
       mCurrentPad->getHoles().append(std::make_shared<PadHole>(

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -663,6 +663,28 @@ void PackageEditorWidget::fixMsg(const MsgInvalidCustomPadOutline& msg) {
 }
 
 template <>
+void PackageEditorWidget::fixMsg(const MsgPadWithoutStopMask& msg) {
+  std::shared_ptr<Footprint> footprint =
+      mPackage->getFootprints().get(msg.getFootprint().get());
+  std::shared_ptr<FootprintPad> pad =
+      footprint->getPads().get(msg.getPad().get());
+  QScopedPointer<CmdFootprintPadEdit> cmd(new CmdFootprintPadEdit(*pad));
+  cmd->setStopMaskConfig(MaskConfig::automatic());
+  mUndoStack->execCmd(cmd.take());
+}
+
+template <>
+void PackageEditorWidget::fixMsg(const MsgThtPadWithSolderPaste& msg) {
+  std::shared_ptr<Footprint> footprint =
+      mPackage->getFootprints().get(msg.getFootprint().get());
+  std::shared_ptr<FootprintPad> pad =
+      footprint->getPads().get(msg.getPad().get());
+  QScopedPointer<CmdFootprintPadEdit> cmd(new CmdFootprintPadEdit(*pad));
+  cmd->setSolderPasteConfig(MaskConfig::off());
+  mUndoStack->execCmd(cmd.take());
+}
+
+template <>
 void PackageEditorWidget::fixMsg(const MsgHoleWithoutStopMask& msg) {
   std::shared_ptr<Footprint> footprint =
       mPackage->getFootprints().get(msg.getFootprint().get());
@@ -697,6 +719,8 @@ bool PackageEditorWidget::processRuleCheckMessage(
   if (fixMsgHelper<MsgWrongFootprintTextLayer>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgUnusedCustomPadOutline>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgInvalidCustomPadOutline>(msg, applyFix)) return true;
+  if (fixMsgHelper<MsgPadWithoutStopMask>(msg, applyFix)) return true;
+  if (fixMsgHelper<MsgThtPadWithSolderPaste>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgHoleWithoutStopMask>(msg, applyFix)) return true;
   return false;
 }

--- a/tests/unittests/core/library/pkg/footprintpadtest.cpp
+++ b/tests/unittests/core/library/pkg/footprintpadtest.cpp
@@ -46,6 +46,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
   SExpression sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape roundrect)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
+      " (stop_mask auto) (solder_paste 0.25)\n"
       " (package_pad d48b8bd2-a46c-4495-87a5-662747034098)\n"
       ")",
       FilePath());
@@ -60,6 +61,8 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
   EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
   EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
   EXPECT_EQ(UnsignedLimitedRatio(Ratio::percent50()), obj.getRadius());
+  EXPECT_EQ(MaskConfig::automatic(), obj.getStopMaskConfig());
+  EXPECT_EQ(MaskConfig::manual(Length(250000)), obj.getSolderPasteConfig());
   EXPECT_EQ(FootprintPad::ComponentSide::Top, obj.getComponentSide());
   EXPECT_EQ(0, obj.getHoles().count());
 }
@@ -68,6 +71,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   SExpression sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side bottom) (shape custom)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
+      " (stop_mask off) (solder_paste auto)\n"
       " (package_pad none)\n"
       " (vertex (position -1.1 -2.2) (angle 45.0))\n"
       " (vertex (position 1.1 -2.2) (angle 90.0))\n"
@@ -90,6 +94,8 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
   EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
   EXPECT_EQ(UnsignedLimitedRatio(Ratio::percent50()), obj.getRadius());
+  EXPECT_EQ(MaskConfig::off(), obj.getStopMaskConfig());
+  EXPECT_EQ(MaskConfig::automatic(), obj.getSolderPasteConfig());
   EXPECT_EQ(FootprintPad::ComponentSide::Bottom, obj.getComponentSide());
   EXPECT_EQ(3, obj.getCustomShapeOutline().getVertices().count());
   EXPECT_EQ(2, obj.getHoles().count());
@@ -101,6 +107,7 @@ TEST_F(FootprintPadTest, testSerializeAndDeserialize) {
       FootprintPad::Shape::RoundedOctagon, PositiveLength(123),
       PositiveLength(456), UnsignedLimitedRatio(Ratio::percent50()),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
+      MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
       FootprintPad::ComponentSide::Top,
       PadHoleList{
           std::make_shared<PadHole>(Uuid::createRandom(),

--- a/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
@@ -88,6 +88,7 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       Uuid::createRandom(), packagePad1->getUuid(), Point(12, 34), Angle(56),
       FootprintPad::Shape::RoundedOctagon, PositiveLength(11),
       PositiveLength(22), UnsignedLimitedRatio(Ratio::percent50()), Path(),
+      MaskConfig::off(), MaskConfig::automatic(),
       FootprintPad::ComponentSide::Bottom, PadHoleList{});
 
   std::shared_ptr<FootprintPad> footprintPad2 = std::make_shared<FootprintPad>(
@@ -95,6 +96,7 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       FootprintPad::Shape::RoundedRect, PositiveLength(123),
       PositiveLength(456), UnsignedLimitedRatio(Ratio::percent100()),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
+      MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
       FootprintPad::ComponentSide::Top,
       PadHoleList{std::make_shared<PadHole>(Uuid::createRandom(),
                                             PositiveLength(789),


### PR DESCRIPTION
### Summary

Instead of automatically applying stop mask & solder paste on each footprint pad, these masks can now be controlled manually in the library editor:

![image](https://user-images.githubusercontent.com/5374821/227529629-6f84477b-363c-4ec4-a607-d8f68d2f9eb1.png)

### Library checks

The library check warns about any unusual configuration (e.g. disabled stop mask, solder paste on THT pad, ...).

### File format

During the file format upgrade, the new nodes `stop_mask` and `solder_paste` are added with values corresponding to the previous behavior, so this change doesn't affect existing footprints/boards:

```
  (pad 0ac27dbe-de00-433d-b872-185028ad8311 (side top) (shape roundrect)
   (position -4.975 0.0) (rotation 0.0) (size 3.85 5.5) (radius 0.0)
   (stop_mask auto) (solder_paste auto)
   (package_pad 0ac27dbe-de00-433d-b872-185028ad8311)
  )
```

### Various

For manual stop mask areas (not just an offset of the copper area) as described in #845, this PR doesn't provide a complete solution yet. However, at least it now allows to disable the automatic stop mask and add custom stop masks with polygons. For long term it might make sense to allow grouping these polygons to the pads (e.g. to drag them together). However, since I'm not sure if this is really needed so I consider #845 as closed for now.

Closes #845