### PR TITLE
Library editor: Replace UUIDs in tables by row number

### DIFF
--- a/libs/librepcb/editor/library/cmp/componentpinsignalmapmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentpinsignalmapmodel.cpp
@@ -264,17 +264,6 @@ QVariant ComponentPinSignalMapModel::headerData(int section,
           return tr("Designator in Schematics");
       }
     }
-  } else if (orientation == Qt::Vertical) {
-    if (role == Qt::FontRole) {
-      // Actually we don't show UUIDs in the vertical header, thus monospace
-      // font is not needed. However, it seems that the table rows are less
-      // high if the font is set to monospace, so the tables are more compact.
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);
-      f.setFamily("Monospace");
-      return f;
-    }
   }
   return QVariant();
 }

--- a/libs/librepcb/editor/library/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsignallisteditorwidget.cpp
@@ -45,6 +45,7 @@ ComponentSignalListEditorWidget::ComponentSignalListEditorWidget(
     mModel(new ComponentSignalListModel(this)),
     mProxy(new SortFilterProxyModel(this)),
     mView(new EditableTableWidget(this)) {
+  mProxy->setKeepHeaderColumnUnsorted(true);
   mProxy->setKeepLastRowAtBottom(true);
   mProxy->setSourceModel(mModel.data());
   mView->setModel(mProxy.data());

--- a/libs/librepcb/editor/library/cmp/componentsignallistmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsignallistmodel.cpp
@@ -232,18 +232,12 @@ QVariant ComponentSignalListModel::headerData(int section,
   } else if (orientation == Qt::Vertical) {
     if (mSignalList && (role == Qt::DisplayRole)) {
       std::shared_ptr<ComponentSignal> item = mSignalList->value(section);
-      return item ? item->getUuid().toStr().left(8) : tr("New:");
+      return item ? QString::number(section + 1) : tr("New:");
     } else if (mSignalList && (role == Qt::ToolTipRole)) {
       std::shared_ptr<ComponentSignal> item = mSignalList->value(section);
       return item ? item->getUuid().toStr() : tr("Add a new signal");
     } else if (role == Qt::TextAlignmentRole) {
       return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);  // ensure fixed column width
-      f.setFamily("Monospace");
-      return f;
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlisteditorwidget.cpp
@@ -55,9 +55,6 @@ ComponentSymbolVariantItemListEditorWidget::
       ComponentSymbolVariantItemListModel::COLUMN_SYMBOL);
   mView->setModel(mModel.data());
   mView->horizontalHeader()->setSectionResizeMode(
-      ComponentSymbolVariantItemListModel::COLUMN_NUMBER,
-      QHeaderView::ResizeToContents);
-  mView->horizontalHeader()->setSectionResizeMode(
       ComponentSymbolVariantItemListModel::COLUMN_SYMBOL, QHeaderView::Stretch);
   mView->horizontalHeader()->setSectionResizeMode(
       ComponentSymbolVariantItemListModel::COLUMN_SUFFIX,

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.cpp
@@ -236,14 +236,6 @@ QVariant ComponentSymbolVariantItemListModel::data(const QModelIndex& index,
   std::shared_ptr<ComponentSymbolVariantItem> item =
       mItemList->value(index.row());
   switch (index.column()) {
-    case COLUMN_NUMBER: {
-      switch (role) {
-        case Qt::DisplayRole:
-          return index.row() + 1;
-        default:
-          return QVariant();
-      }
-    }
     case COLUMN_SYMBOL: {
       std::shared_ptr<const Symbol> symbol;
       tl::optional<Uuid> uuid = item ? item->getSymbolUuid() : mNewSymbolUuid;
@@ -353,8 +345,6 @@ QVariant ComponentSymbolVariantItemListModel::headerData(
   if (orientation == Qt::Horizontal) {
     if (role == Qt::DisplayRole) {
       switch (section) {
-        case COLUMN_NUMBER:
-          return "#";
         case COLUMN_SYMBOL:
           return tr("Symbol");
         case COLUMN_SUFFIX:
@@ -375,19 +365,13 @@ QVariant ComponentSymbolVariantItemListModel::headerData(
     if (mItemList && (role == Qt::DisplayRole)) {
       std::shared_ptr<ComponentSymbolVariantItem> item =
           mItemList->value(section);
-      return item ? item->getUuid().toStr().left(8) : tr("New:");
+      return item ? QString::number(section + 1) : tr("New:");
     } else if (mItemList && (role == Qt::ToolTipRole)) {
       std::shared_ptr<ComponentSymbolVariantItem> item =
           mItemList->value(section);
       return item ? item->getUuid().toStr() : tr("Add a new symbol");
     } else if (role == Qt::TextAlignmentRole) {
       return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);  // ensure fixed column width
-      f.setFamily("Monospace");
-      return f;
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.h
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.h
@@ -49,7 +49,6 @@ class ComponentSymbolVariantItemListModel final : public QAbstractTableModel {
 
 public:
   enum Column {
-    COLUMN_NUMBER,
     COLUMN_SYMBOL,
     COLUMN_SUFFIX,
     COLUMN_ISREQUIRED,

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistmodel.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistmodel.cpp
@@ -273,19 +273,13 @@ QVariant ComponentSymbolVariantListModel::headerData(
     if (mSymbolVariantList && (role == Qt::DisplayRole)) {
       std::shared_ptr<ComponentSymbolVariant> item =
           mSymbolVariantList->value(section);
-      return item ? item->getUuid().toStr().left(8) : tr("New:");
+      return item ? QString::number(section + 1) : tr("New:");
     } else if (mSymbolVariantList && (role == Qt::ToolTipRole)) {
       std::shared_ptr<ComponentSymbolVariant> item =
           mSymbolVariantList->value(section);
       return item ? item->getUuid().toStr() : tr("Add a new symbol variant");
     } else if (role == Qt::TextAlignmentRole) {
       return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);  // ensure fixed column width
-      f.setFamily("Monospace");
-      return f;
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/library/dev/devicepadsignalmapmodel.cpp
+++ b/libs/librepcb/editor/library/dev/devicepadsignalmapmodel.cpp
@@ -171,24 +171,6 @@ QVariant DevicePadSignalMapModel::headerData(int section,
           return tr("Component Signal");
       }
     }
-  } else if (orientation == Qt::Vertical) {
-    if (mPadSignalMap && (role == Qt::DisplayRole)) {
-      std::shared_ptr<DevicePadSignalMapItem> item =
-          mPadSignalMap->value(section);
-      return item ? item->getPadUuid().toStr().left(8) : QVariant();
-    } else if (mPadSignalMap && (role == Qt::ToolTipRole)) {
-      std::shared_ptr<DevicePadSignalMapItem> item =
-          mPadSignalMap->value(section);
-      return item ? item->getPadUuid().toStr() : QVariant();
-    } else if (role == Qt::TextAlignmentRole) {
-      return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);  // ensure fixed column width
-      f.setFamily("Monospace");
-      return f;
-    }
   }
   return QVariant();
 }

--- a/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.cpp
@@ -53,6 +53,7 @@ PadSignalMapEditorWidget::PadSignalMapEditorWidget(QWidget* parent) noexcept
   mView->setEditTriggers(QAbstractItemView::AllEditTriggers);
   mView->setSortingEnabled(true);
   mView->setWordWrap(false);  // avoid too high cells due to word wrap
+  mView->verticalHeader()->setVisible(false);  // no content
   mView->verticalHeader()->setMinimumSectionSize(10);  // more compact rows
   mView->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
   mView->horizontalHeader()->setSectionResizeMode(

--- a/libs/librepcb/editor/library/pkg/footprintlistmodel.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintlistmodel.cpp
@@ -240,18 +240,12 @@ QVariant FootprintListModel::headerData(int section,
   } else if (orientation == Qt::Vertical) {
     if (mFootprintList && (role == Qt::DisplayRole)) {
       std::shared_ptr<Footprint> item = mFootprintList->value(section);
-      return item ? item->getUuid().toStr().left(8) : tr("New:");
+      return item ? QString::number(section + 1) : tr("New:");
     } else if (mFootprintList && (role == Qt::ToolTipRole)) {
       std::shared_ptr<Footprint> item = mFootprintList->value(section);
       return item ? item->getUuid().toStr() : tr("Add a new footprint");
     } else if (role == Qt::TextAlignmentRole) {
       return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);  // ensure fixed column width
-      f.setFamily("Monospace");
-      return f;
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/library/pkg/packagepadlisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packagepadlisteditorwidget.cpp
@@ -44,6 +44,7 @@ PackagePadListEditorWidget::PackagePadListEditorWidget(QWidget* parent) noexcept
     mModel(new PackagePadListModel(this)),
     mProxy(new SortFilterProxyModel(this)),
     mView(new EditableTableWidget(this)) {
+  mProxy->setKeepHeaderColumnUnsorted(true);
   mProxy->setKeepLastRowAtBottom(true);
   mProxy->setSourceModel(mModel.data());
   mView->setModel(mProxy.data());

--- a/libs/librepcb/editor/library/pkg/packagepadlistmodel.cpp
+++ b/libs/librepcb/editor/library/pkg/packagepadlistmodel.cpp
@@ -197,18 +197,12 @@ QVariant PackagePadListModel::headerData(int section,
   } else if (orientation == Qt::Vertical) {
     if (mPadList && (role == Qt::DisplayRole)) {
       std::shared_ptr<PackagePad> item = mPadList->value(section);
-      return item ? item->getUuid().toStr().left(8) : tr("New:");
+      return item ? QString::number(section + 1) : tr("New:");
     } else if (mPadList && (role == Qt::ToolTipRole)) {
       std::shared_ptr<PackagePad> item = mPadList->value(section);
       return item ? item->getUuid().toStr() : tr("Add a new pad");
     } else if (role == Qt::TextAlignmentRole) {
       return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);  // ensure fixed column width
-      f.setFamily("Monospace");
-      return f;
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/modelview/attributelistmodel.cpp
+++ b/libs/librepcb/editor/modelview/attributelistmodel.cpp
@@ -286,15 +286,6 @@ QVariant AttributeListModel::headerData(int section,
       return item ? QVariant() : tr("Add a new attribute");
     } else if (role == Qt::TextAlignmentRole) {
       return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      // Actually we don't show UUIDs in the vertical header, thus monospace
-      // font is not needed. However, it seems that the table rows are less
-      // high if the font is set to monospace, so the tables are more compact.
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);
-      f.setFamily("Monospace");
-      return f;
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/modelview/pathmodel.cpp
+++ b/libs/librepcb/editor/modelview/pathmodel.cpp
@@ -213,15 +213,6 @@ QVariant PathModel::headerData(int section, Qt::Orientation orientation,
       return tr("Add a new vertex");
     } else if (role == Qt::TextAlignmentRole) {
       return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    } else if (role == Qt::FontRole) {
-      // Actually we don't show UUIDs in the vertical header, thus monospace
-      // font is not needed. However, it seems that the table rows are less
-      // high if the font is set to monospace, so the tables are more compact.
-      QFont f = QAbstractTableModel::headerData(section, orientation, role)
-                    .value<QFont>();
-      f.setStyleHint(QFont::Monospace);
-      f.setFamily("Monospace");
-      return f;
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/modelview/sortfilterproxymodel.h
+++ b/libs/librepcb/editor/modelview/sortfilterproxymodel.h
@@ -54,9 +54,16 @@ public:
   virtual ~SortFilterProxyModel() noexcept;
 
   // Setters
+  void setKeepHeaderColumnUnsorted(bool keep) noexcept {
+    mKeepHeaderColumnUnsorted = keep;
+  }
   void setKeepLastRowAtBottom(bool keep) noexcept {
     mKeepLastRowAtBottom = keep;
   }
+
+  // Inherited from QAbstractItemModel
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role = Qt::DisplayRole) const override;
 
   // Operator Overloadings
   SortFilterProxyModel& operator=(const SortFilterProxyModel& rhs) noexcept;
@@ -67,6 +74,7 @@ protected:
 
 private:
   QCollator mCollator;
+  bool mKeepHeaderColumnUnsorted;
   bool mKeepLastRowAtBottom;
 };
 


### PR DESCRIPTION
Instead of displaying shortened UUIDs in various table widgets, just display the row number. Advantages:

- Cleaner UI by hiding unimportant, "cryptic" data (UUIDs are normally not of interest and may even be confusing for new users). However, if needed anyway they are still shown as tooltip when hovering over the corresponding table cell.
- Now you can easily see the total number of rows, e.g. how many pads a package has in total. Useful to quickly cross-check if you added all required entries.

![image](https://user-images.githubusercontent.com/5374821/228190409-ec9a712f-3c58-4fdb-a21b-994527f33091.png)

Unfortunately there's a small vertical offset between the header text and the cell text which looks a bit ugly, but I couldn't find a solution for that...