### PR TITLE
Add 'function' property to footprint pads

### DIFF
--- a/libs/librepcb/core/export/gerberattribute.cpp
+++ b/libs/librepcb/core/export/gerberattribute.cpp
@@ -330,6 +330,10 @@ GerberAttribute GerberAttribute::apertureFunction(
       return GerberAttribute(Type::Aperture, ".AperFunction",
                              {"ComponentDrill"});
     }
+    case ApertureFunction::ComponentDrillPressFit: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"ComponentDrill", "PressFit"});
+    }
     case ApertureFunction::MechanicalDrill: {
       return GerberAttribute(Type::Aperture, ".AperFunction",
                              {"MechanicalDrill"});
@@ -351,8 +355,33 @@ GerberAttribute GerberAttribute::apertureFunction(
       return GerberAttribute(Type::Aperture, ".AperFunction",
                              {"SMDPad", "SMDef"});
     }
+    case ApertureFunction::BgaPadCopperDefined: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"BGAPad", "CuDef"});
+    }
+    case ApertureFunction::BgaPadSolderMaskDefined: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"BGAPad", "SMDef"});
+    }
+    case ApertureFunction::ConnectorPad: {
+      return GerberAttribute(Type::Aperture, ".AperFunction", {"ConnectorPad"});
+    }
+    case ApertureFunction::HeatsinkPad: {
+      return GerberAttribute(Type::Aperture, ".AperFunction", {"HeatsinkPad"});
+    }
     case ApertureFunction::ViaPad: {
       return GerberAttribute(Type::Aperture, ".AperFunction", {"ViaPad"});
+    }
+    case ApertureFunction::TestPad: {
+      return GerberAttribute(Type::Aperture, ".AperFunction", {"TestPad"});
+    }
+    case ApertureFunction::FiducialPadLocal: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"FiducialPad", "Local"});
+    }
+    case ApertureFunction::FiducialPadGlobal: {
+      return GerberAttribute(Type::Aperture, ".AperFunction",
+                             {"FiducialPad", "Global"});
     }
     case ApertureFunction::ComponentMain: {
       return GerberAttribute(Type::Aperture, ".AperFunction",

--- a/libs/librepcb/core/export/gerberattribute.h
+++ b/libs/librepcb/core/export/gerberattribute.h
@@ -57,6 +57,7 @@ public:
     // Available only on drill/rout layers:
     ViaDrill,  ///< Drill of a via (usually plated)
     ComponentDrill,  ///< Drill for component pads (usually plated)
+    ComponentDrillPressFit,  ///< Drill for press-fit component pads (plated)
     MechanicalDrill,  ///< Drill for mechanical purpose (usually not plated)
 
     // Available only on copper layers:
@@ -65,7 +66,14 @@ public:
     ComponentPad,  ///< THT pad
     SmdPadCopperDefined,  ///< SMT pad, copper-defined
     SmdPadSolderMaskDefined,  ///< SMT pad, stopmask-defined
+    BgaPadCopperDefined,  ///< BGA pad, copper-defined
+    BgaPadSolderMaskDefined,  ///< BGA pad, stopmask-defined
+    ConnectorPad,  ///< Edge connector pad
+    HeatsinkPad,  ///< Heat sink or thermal pad
     ViaPad,  ///< Via
+    TestPad,  ///< Test pad
+    FiducialPadLocal,  ///< Local fiducial pad
+    FiducialPadGlobal,  ///< Global fiducial pad
 
     // Available only on component layers:
     ComponentMain,  ///< Center of component

--- a/libs/librepcb/core/export/pickplacedata.h
+++ b/libs/librepcb/core/export/pickplacedata.h
@@ -95,6 +95,9 @@ public:
   BoardSide getBoardSide() const noexcept { return mBoardSide; }
   Type getType() const noexcept { return mType; }
 
+  // Setters
+  void setDesignator(const QString& value) noexcept { mDesignator = value; }
+
   // Operator Overloadings
   PickPlaceDataItem& operator=(const PickPlaceDataItem& rhs) noexcept {
     mDesignator = rhs.mDesignator;

--- a/libs/librepcb/core/library/pkg/footprintpad.h
+++ b/libs/librepcb/core/library/pkg/footprintpad.h
@@ -67,6 +67,19 @@ public:
     Bottom,
   };
 
+  enum class Function {
+    Unspecified = 0,
+    StandardPad,
+    PressFitPad,
+    ThermalPad,
+    BgaPad,
+    EdgeConnectorPad,
+    TestPad,
+    LocalFiducial,
+    GlobalFiducial,
+    _COUNT,
+  };
+
   // Signals
   enum class Event {
     UuidChanged,
@@ -81,6 +94,7 @@ public:
     StopMaskConfigChanged,
     SolderPasteConfigChanged,
     ComponentSideChanged,
+    FunctionChanged,
     HolesEdited,
   };
   Signal<FootprintPad, Event> onEdited;
@@ -95,7 +109,7 @@ public:
                const UnsignedLimitedRatio& radius,
                const Path& customShapeOutline, const MaskConfig& autoStopMask,
                const MaskConfig& autoSolderPaste, ComponentSide side,
-               const PadHoleList& holes) noexcept;
+               Function function, const PadHoleList& holes) noexcept;
   explicit FootprintPad(const SExpression& node);
   ~FootprintPad() noexcept;
 
@@ -120,6 +134,9 @@ public:
     return mSolderPasteConfig;
   }
   ComponentSide getComponentSide() const noexcept { return mComponentSide; }
+  Function getFunction() const noexcept { return mFunction; }
+  bool getFunctionIsFiducial() const noexcept;
+  bool getFunctionNeedsSoldering() const noexcept;
   const PadHoleList& getHoles() const noexcept { return mHoles; }
   PadHoleList& getHoles() noexcept { return mHoles; }
   bool isTht() const noexcept;
@@ -145,6 +162,7 @@ public:
   bool setStopMaskConfig(const MaskConfig& config) noexcept;
   bool setSolderPasteConfig(const MaskConfig& config) noexcept;
   bool setComponentSide(ComponentSide side) noexcept;
+  bool setFunction(Function function) noexcept;
 
   // General Methods
 
@@ -165,6 +183,7 @@ public:
   // Static Methods
   static UnsignedLimitedRatio getRecommendedRadius(
       const PositiveLength& width, const PositiveLength& height) noexcept;
+  static QString getFunctionDescriptionTr(Function function) noexcept;
 
 private:  // Methods
   void holesEdited(const PadHoleList& list, int index,
@@ -190,11 +209,20 @@ private:  // Data
   MaskConfig mStopMaskConfig;
   MaskConfig mSolderPasteConfig;
   ComponentSide mComponentSide;
+  Function mFunction;
   PadHoleList mHoles;  ///< If not empty, it's a THT pad.
 
   // Slots
   PadHoleList::OnEditedSlot mHolesEditedSlot;
 };
+
+/*******************************************************************************
+ *  Non-Member Functions
+ ******************************************************************************/
+
+inline uint qHash(const FootprintPad::Function& key, uint seed = 0) noexcept {
+  return ::qHash(static_cast<int>(key), seed);
+}
 
 /*******************************************************************************
  *  Class FootprintPadList
@@ -212,5 +240,7 @@ using FootprintPadList =
  ******************************************************************************/
 
 }  // namespace librepcb
+
+Q_DECLARE_METATYPE(librepcb::FootprintPad::Function)
 
 #endif

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -118,15 +118,22 @@ Package::AssemblyType Package::getAssemblyType(bool resolveAuto) const
 }
 
 Package::AssemblyType Package::guessAssemblyType() const noexcept {
+  // If there are no package pads, probably there's nothing to mount.
+  if (mPads.isEmpty()) {
+    return AssemblyType::None;
+  }
+
   // Auto-detect based on default footprint pads.
   bool hasThtPads = false;
   bool hasSmtPads = false;
   if (!mFootprints.isEmpty()) {
     for (const FootprintPad& pad : mFootprints.first()->getPads()) {
-      if (pad.isTht()) {
-        hasThtPads = true;
-      } else {
-        hasSmtPads = true;
+      if (pad.getFunctionNeedsSoldering()) {
+        if (pad.isTht()) {
+          hasThtPads = true;
+        } else {
+          hasSmtPads = true;
+        }
       }
     }
   }

--- a/libs/librepcb/core/library/pkg/packagecheck.h
+++ b/libs/librepcb/core/library/pkg/packagecheck.h
@@ -68,6 +68,7 @@ protected:  // Methods
   void checkCustomPadOutline(MsgList& msgs) const;
   void checkStopMaskOnPads(MsgList& msgs) const;
   void checkSolderPasteOnPads(MsgList& msgs) const;
+  void checkPadFunctions(MsgList& msgs) const;
   void checkHolesStopMask(MsgList& msgs) const;
 
 private:  // Data

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.h
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.h
@@ -96,6 +96,36 @@ public:
 };
 
 /*******************************************************************************
+ *  Class MsgFiducialStopMaskNotSet
+ ******************************************************************************/
+
+/**
+ * @brief The MsgFiducialStopMaskNotSet class
+ */
+class MsgFiducialStopMaskNotSet final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgFiducialStopMaskNotSet)
+
+public:
+  // Constructors / Destructor
+  MsgFiducialStopMaskNotSet() = delete;
+  MsgFiducialStopMaskNotSet(std::shared_ptr<const Footprint> footprint,
+                            std::shared_ptr<const FootprintPad> pad) noexcept;
+  MsgFiducialStopMaskNotSet(const MsgFiducialStopMaskNotSet& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgFiducialStopMaskNotSet() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
  *  Class MsgHoleWithoutStopMask
  ******************************************************************************/
 
@@ -420,24 +450,55 @@ private:
 };
 
 /*******************************************************************************
- *  Class MsgPadWithoutStopMask
+ *  Class MsgPadStopMaskOff
  ******************************************************************************/
 
 /**
- * @brief The MsgPadWithoutStopMask class
+ * @brief The MsgPadStopMaskOff class
  */
-class MsgPadWithoutStopMask final : public RuleCheckMessage {
-  Q_DECLARE_TR_FUNCTIONS(MsgPadWithoutStopMask)
+class MsgPadStopMaskOff final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadStopMaskOff)
 
 public:
   // Constructors / Destructor
-  MsgPadWithoutStopMask() = delete;
-  MsgPadWithoutStopMask(std::shared_ptr<const Footprint> footprint,
-                        std::shared_ptr<const FootprintPad> pad,
-                        const QString& pkgPadName) noexcept;
-  MsgPadWithoutStopMask(const MsgPadWithoutStopMask& other) noexcept
+  MsgPadStopMaskOff() = delete;
+  MsgPadStopMaskOff(std::shared_ptr<const Footprint> footprint,
+                    std::shared_ptr<const FootprintPad> pad,
+                    const QString& pkgPadName) noexcept;
+  MsgPadStopMaskOff(const MsgPadStopMaskOff& other) noexcept
     : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
-  virtual ~MsgPadWithoutStopMask() noexcept;
+  virtual ~MsgPadStopMaskOff() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
+ *  Class MsgSmtPadWithSolderPaste
+ ******************************************************************************/
+
+/**
+ * @brief The MsgSmtPadWithSolderPaste class
+ */
+class MsgSmtPadWithSolderPaste final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgSmtPadWithSolderPaste)
+
+public:
+  // Constructors / Destructor
+  MsgSmtPadWithSolderPaste() = delete;
+  MsgSmtPadWithSolderPaste(std::shared_ptr<const Footprint> footprint,
+                           std::shared_ptr<const FootprintPad> pad,
+                           const QString& pkgPadName) noexcept;
+  MsgSmtPadWithSolderPaste(const MsgSmtPadWithSolderPaste& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgSmtPadWithSolderPaste() noexcept {}
 
   // Getters
   std::shared_ptr<const Footprint> getFootprint() const noexcept {
@@ -468,7 +529,37 @@ public:
                               const QString& pkgPadName) noexcept;
   MsgSmtPadWithoutSolderPaste(const MsgSmtPadWithoutSolderPaste& other) noexcept
     : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
-  virtual ~MsgSmtPadWithoutSolderPaste() noexcept;
+  virtual ~MsgSmtPadWithoutSolderPaste() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
+ *  Class MsgSuspiciousPadFunction
+ ******************************************************************************/
+
+/**
+ * @brief The MsgSuspiciousPadFunction class
+ */
+class MsgSuspiciousPadFunction final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgSuspiciousPadFunction)
+
+public:
+  // Constructors / Destructor
+  MsgSuspiciousPadFunction(std::shared_ptr<const Footprint> footprint,
+                           std::shared_ptr<const FootprintPad> pad,
+                           const QString& pkgPadName) noexcept;
+  MsgSuspiciousPadFunction(const MsgSuspiciousPadFunction& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgSuspiciousPadFunction() noexcept {}
 
   // Getters
   std::shared_ptr<const Footprint> getFootprint() const noexcept {
@@ -499,7 +590,37 @@ public:
                            const QString& pkgPadName) noexcept;
   MsgThtPadWithSolderPaste(const MsgThtPadWithSolderPaste& other) noexcept
     : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
-  virtual ~MsgThtPadWithSolderPaste() noexcept;
+  virtual ~MsgThtPadWithSolderPaste() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
+ *  Class MsgUnspecifiedPadFunction
+ ******************************************************************************/
+
+/**
+ * @brief The MsgUnspecifiedPadFunction class
+ */
+class MsgUnspecifiedPadFunction final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgUnspecifiedPadFunction)
+
+public:
+  // Constructors / Destructor
+  MsgUnspecifiedPadFunction(std::shared_ptr<const Footprint> footprint,
+                            std::shared_ptr<const FootprintPad> pad,
+                            const QString& pkgPadName) noexcept;
+  MsgUnspecifiedPadFunction(const MsgUnspecifiedPadFunction& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgUnspecifiedPadFunction() noexcept {}
 
   // Getters
   std::shared_ptr<const Footprint> getFootprint() const noexcept {

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -68,10 +68,7 @@ void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
   for (SExpression* fptNode : root.getChildren("footprint")) {
     for (SExpression* padNode : fptNode->getChildren("pad")) {
-      const bool isTht = !padNode->getChildren("hole").isEmpty();
-      padNode->appendChild("stop_mask", SExpression::createToken("auto"));
-      padNode->appendChild("solder_paste",
-                           SExpression::createToken(isTht ? "off" : "auto"));
+      padNode->appendChild("function", SExpression::createToken("unspecified"));
     }
   }
   dir.write(fp, root.toByteArray());

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -159,6 +159,10 @@ void FileFormatMigrationV01::upgradePackage(TransactionalDirectory& dir) {
         padNode->appendChild(
             "solder_paste",
             SExpression::createToken((drill > 0) ? "off" : "auto"));
+
+        // Add function.
+        padNode->appendChild("function",
+                             SExpression::createToken("unspecified"));
       }
 
       // Holes.

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -428,6 +428,7 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           MaskConfig::automatic(),  // Stop mask
           MaskConfig::off(),  // Solder paste
           FootprintPad::ComponentSide::Top,  // Side
+          FootprintPad::Function::Unspecified,  // Function
           PadHoleList{std::make_shared<PadHole>(
               Uuid::createRandom(),
               PositiveLength(convertLength(p.getDrillDiameter())),
@@ -465,6 +466,7 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           MaskConfig::automatic(),  // Stop mask
           MaskConfig::automatic(),  // Solder paste
           side,  // Side
+          FootprintPad::Function::Unspecified,  // Function
           PadHoleList{}  // Holes
           ));
 }

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -874,6 +874,15 @@ public:
       {QKeySequence(Qt::Key_I)},
       &categoryTools,
   };
+  EditorCommand toolPadTht{
+      "tool_pad_tht",  // clang-format break
+      QT_TR_NOOP("Add THT Pad"),
+      QT_TR_NOOP("Add plated through-hole copper pads"),
+      QIcon(":/img/actions/add_tht_pad.png"),
+      EditorCommand::Flags(),
+      {QKeySequence(Qt::Key_H)},
+      &categoryTools,
+  };
   EditorCommand toolPadSmt{
       "tool_pad_smt",  // clang-format break
       QT_TR_NOOP("Add SMT Pad"),
@@ -883,13 +892,58 @@ public:
       {QKeySequence(Qt::Key_D)},
       &categoryTools,
   };
-  EditorCommand toolPadTht{
-      "tool_pad_tht",  // clang-format break
-      QT_TR_NOOP("Add THT Pad"),
-      QT_TR_NOOP("Add plated through-hole copper pads"),
-      QIcon(":/img/actions/add_tht_pad.png"),
+  EditorCommand toolPadThermal{
+      "tool_pad_thermal",  // clang-format break
+      QT_TR_NOOP("Add Thermal Pad"),
+      QT_TR_NOOP("Add special SMT pads used as heat sink"),
+      QIcon(),
       EditorCommand::Flags(),
-      {QKeySequence(Qt::Key_H)},
+      {},
+      &categoryTools,
+  };
+  EditorCommand toolPadBga{
+      "tool_pad_bga",  // clang-format break
+      QT_TR_NOOP("Add BGA Pad"),
+      QT_TR_NOOP("Add special SMT pads used for ball grid arrays"),
+      QIcon(),
+      EditorCommand::Flags(),
+      {},
+      &categoryTools,
+  };
+  EditorCommand toolPadEdgeConnector{
+      "tool_pad_edge_connector",  // clang-format break
+      QT_TR_NOOP("Add Edge Connector Pad"),
+      QT_TR_NOOP("Add special SMT pads used as edge connector"),
+      QIcon(),
+      EditorCommand::Flags(),
+      {},
+      &categoryTools,
+  };
+  EditorCommand toolPadTest{
+      "tool_pad_test_point",  // clang-format break
+      QT_TR_NOOP("Add Test Pad"),
+      QT_TR_NOOP("Add special SMT pads used as test points"),
+      QIcon(),
+      EditorCommand::Flags(),
+      {},
+      &categoryTools,
+  };
+  EditorCommand toolPadLocalFiducial{
+      "tool_pad_local_fiducial",  // clang-format break
+      QT_TR_NOOP("Add Local Fiducial Pad"),
+      QT_TR_NOOP("Add special SMT pads used as local fiducials"),
+      QIcon(),
+      EditorCommand::Flags(),
+      {},
+      &categoryTools,
+  };
+  EditorCommand toolPadGlobalFiducial{
+      "tool_pad_global_fiducial",  // clang-format break
+      QT_TR_NOOP("Add Global Fiducial Pad"),
+      QT_TR_NOOP("Add special SMT pads used as global fiducials"),
+      QIcon(),
+      EditorCommand::Flags(),
+      {},
       &categoryTools,
   };
   EditorCommand toolHole{

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
@@ -41,6 +41,8 @@ CmdFootprintPadEdit::CmdFootprintPadEdit(FootprintPad& pad) noexcept
     mNewPackagePadUuid(mOldPackagePadUuid),
     mOldComponentSide(pad.getComponentSide()),
     mNewComponentSide(mOldComponentSide),
+    mOldFunction(pad.getFunction()),
+    mNewFunction(mOldFunction),
     mOldShape(pad.getShape()),
     mNewShape(mOldShape),
     mOldWidth(pad.getWidth()),
@@ -89,6 +91,13 @@ void CmdFootprintPadEdit::setComponentSide(FootprintPad::ComponentSide side,
   Q_ASSERT(!wasEverExecuted());
   mNewComponentSide = side;
   if (immediate) mPad.setComponentSide(mNewComponentSide);
+}
+
+void CmdFootprintPadEdit::setFunction(FootprintPad::Function function,
+                                      bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewFunction = function;
+  if (immediate) mPad.setFunction(mNewFunction);
 }
 
 void CmdFootprintPadEdit::setShape(FootprintPad::Shape shape,
@@ -219,6 +228,7 @@ bool CmdFootprintPadEdit::performExecute() {
 
   if (mNewPackagePadUuid != mOldPackagePadUuid) return true;
   if (mNewComponentSide != mOldComponentSide) return true;
+  if (mNewFunction != mOldFunction) return true;
   if (mNewShape != mOldShape) return true;
   if (mNewWidth != mOldWidth) return true;
   if (mNewHeight != mOldHeight) return true;
@@ -235,6 +245,7 @@ bool CmdFootprintPadEdit::performExecute() {
 void CmdFootprintPadEdit::performUndo() {
   mPad.setPackagePadUuid(mOldPackagePadUuid);
   mPad.setComponentSide(mOldComponentSide);
+  mPad.setFunction(mOldFunction);
   mPad.setShape(mOldShape);
   mPad.setWidth(mOldWidth);
   mPad.setHeight(mOldHeight);
@@ -250,6 +261,7 @@ void CmdFootprintPadEdit::performUndo() {
 void CmdFootprintPadEdit::performRedo() {
   mPad.setPackagePadUuid(mNewPackagePadUuid);
   mPad.setComponentSide(mNewComponentSide);
+  mPad.setFunction(mNewFunction);
   mPad.setShape(mNewShape);
   mPad.setWidth(mNewWidth);
   mPad.setHeight(mNewHeight);

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
@@ -133,9 +133,11 @@ void CmdFootprintPadEdit::setCustomShapeOutline(const Path& outline) noexcept {
   mNewCustomShapeOutline = outline;
 }
 
-void CmdFootprintPadEdit::setStopMaskConfig(const MaskConfig& config) noexcept {
+void CmdFootprintPadEdit::setStopMaskConfig(const MaskConfig& config,
+                                            bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewStopMaskConfig = config;
+  if (immediate) mPad.setStopMaskConfig(mNewStopMaskConfig);
 }
 
 void CmdFootprintPadEdit::setSolderPasteConfig(

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
@@ -64,7 +64,7 @@ public:
   void setHeight(const PositiveLength& height, bool immediate) noexcept;
   void setRadius(const UnsignedLimitedRatio& radius, bool immediate) noexcept;
   void setCustomShapeOutline(const Path& outline) noexcept;
-  void setStopMaskConfig(const MaskConfig& config) noexcept;
+  void setStopMaskConfig(const MaskConfig& config, bool immediate) noexcept;
   void setSolderPasteConfig(const MaskConfig& config) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
@@ -58,6 +58,7 @@ public:
                          bool immediate) noexcept;
   void setComponentSide(FootprintPad::ComponentSide side,
                         bool immediate) noexcept;
+  void setFunction(FootprintPad::Function function, bool immediate) noexcept;
   void setShape(FootprintPad::Shape shape, bool immediate) noexcept;
   void setWidth(const PositiveLength& width, bool immediate) noexcept;
   void setHeight(const PositiveLength& height, bool immediate) noexcept;
@@ -100,6 +101,8 @@ private:
   tl::optional<Uuid> mNewPackagePadUuid;
   FootprintPad::ComponentSide mOldComponentSide;
   FootprintPad::ComponentSide mNewComponentSide;
+  FootprintPad::Function mOldFunction;
+  FootprintPad::Function mNewFunction;
   FootprintPad::Shape mOldShape;
   FootprintPad::Shape mNewShape;
   PositiveLength mOldWidth;

--- a/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
@@ -103,7 +103,8 @@ bool CmdPasteFootprintItems::performExecute() {
         uuid, pkgPadUuid, pad.getPosition() + mPosOffset, pad.getRotation(),
         pad.getShape(), pad.getWidth(), pad.getHeight(), pad.getRadius(),
         pad.getCustomShapeOutline(), pad.getStopMaskConfig(),
-        pad.getSolderPasteConfig(), pad.getComponentSide(), pad.getHoles());
+        pad.getSolderPasteConfig(), pad.getComponentSide(), pad.getFunction(),
+        pad.getHoles());
     execNewChildCmd(new CmdFootprintPadInsert(mFootprint.getPads(), copy));
     if (auto graphicsItem = mGraphicsItem.getGraphicsItem(copy)) {
       graphicsItem->setSelected(true);

--- a/libs/librepcb/editor/library/editorwidgetbase.cpp
+++ b/libs/librepcb/editor/library/editorwidgetbase.cpp
@@ -91,8 +91,8 @@ void EditorWidgetBase::connectEditor(UndoStackActionGroup& undoStackActionGroup,
 
   mToolsActionGroup = &toolsActionGroup;
   mToolsActionGroup->reset();
-  connect(mToolsActionGroup, &ExclusiveActionGroup::changeRequestTriggered,
-          this, &EditorWidgetBase::toolActionGroupChangeTriggered);
+  connect(mToolsActionGroup, &ExclusiveActionGroup::actionTriggered, this,
+          &EditorWidgetBase::toolRequested);
 
   mCommandToolBarProxy->setToolBar(&commandToolBar);
 
@@ -104,8 +104,8 @@ void EditorWidgetBase::disconnectEditor() noexcept {
   mUndoStackActionGroup->setUndoStack(nullptr);
   mUndoStackActionGroup = nullptr;
 
-  disconnect(mToolsActionGroup, &ExclusiveActionGroup::changeRequestTriggered,
-             this, &EditorWidgetBase::toolActionGroupChangeTriggered);
+  disconnect(mToolsActionGroup, &ExclusiveActionGroup::actionTriggered, this,
+             &EditorWidgetBase::toolRequested);
   mToolsActionGroup->reset();
 
   mCommandToolBarProxy->setToolBar(nullptr);
@@ -265,9 +265,8 @@ bool EditorWidgetBase::askForRestoringBackup(const FilePath& dir) {
   }
 }
 
-void EditorWidgetBase::toolActionGroupChangeTriggered(
-    const QVariant& newTool) noexcept {
-  toolChangeRequested(static_cast<Tool>(newTool.toInt()));
+void EditorWidgetBase::toolRequested(int tool, const QVariant& mode) noexcept {
+  toolChangeRequested(static_cast<Tool>(tool), mode);
 }
 
 void EditorWidgetBase::undoStackCleanChanged(bool clean) noexcept {

--- a/libs/librepcb/editor/library/editorwidgetbase.h
+++ b/libs/librepcb/editor/library/editorwidgetbase.h
@@ -177,8 +177,10 @@ protected:  // Methods
   void setupInterfaceBrokenWarningWidget(QWidget& widget) noexcept;
   void setupErrorNotificationWidget(QWidget& widget) noexcept;
   virtual bool isInterfaceBroken() const noexcept = 0;
-  virtual bool toolChangeRequested(Tool newTool) noexcept {
+  virtual bool toolChangeRequested(Tool newTool,
+                                   const QVariant& mode) noexcept {
     Q_UNUSED(newTool);
+    Q_UNUSED(mode);
     return false;
   }
   virtual bool runChecks(RuleCheckMessageList& msgs) const = 0;
@@ -211,7 +213,7 @@ private:  // Methods
    * @throw Exception to abort opening the library element.
    */
   static bool askForRestoringBackup(const FilePath& dir);
-  void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void toolRequested(int tool, const QVariant& mode) noexcept;
   void undoStackCleanChanged(bool clean) noexcept;
   void scheduleLibraryElementChecks() noexcept;
   virtual bool processRuleCheckMessage(

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -657,34 +657,34 @@ void LibraryEditor::createActions() noexcept {
 
   // Tools action group.
   mToolsActionGroup.reset(new ExclusiveActionGroup());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::SELECT,
-                               mActionToolSelect.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::DRAW_LINE,
-                               mActionToolLine.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::DRAW_RECT,
-                               mActionToolRect.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::DRAW_POLYGON,
-                               mActionToolPolygon.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::DRAW_CIRCLE,
-                               mActionToolCircle.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::DRAW_ARC,
-                               mActionToolArc.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::ADD_NAMES,
-                               mActionToolName.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::ADD_VALUES,
-                               mActionToolValue.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::DRAW_TEXT,
-                               mActionToolText.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::ADD_PINS,
-                               mActionToolPin.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::ADD_THT_PADS,
-                               mActionToolThtPad.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::ADD_SMT_PADS,
-                               mActionToolSmtPad.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::ADD_HOLES,
-                               mActionToolHole.data());
-  mToolsActionGroup->addAction(EditorWidgetBase::Tool::MEASURE,
-                               mActionToolMeasure.data());
+  mToolsActionGroup->addAction(mActionToolSelect.data(),
+                               EditorWidgetBase::Tool::SELECT);
+  mToolsActionGroup->addAction(mActionToolLine.data(),
+                               EditorWidgetBase::Tool::DRAW_LINE);
+  mToolsActionGroup->addAction(mActionToolRect.data(),
+                               EditorWidgetBase::Tool::DRAW_RECT);
+  mToolsActionGroup->addAction(mActionToolPolygon.data(),
+                               EditorWidgetBase::Tool::DRAW_POLYGON);
+  mToolsActionGroup->addAction(mActionToolCircle.data(),
+                               EditorWidgetBase::Tool::DRAW_CIRCLE);
+  mToolsActionGroup->addAction(mActionToolArc.data(),
+                               EditorWidgetBase::Tool::DRAW_ARC);
+  mToolsActionGroup->addAction(mActionToolName.data(),
+                               EditorWidgetBase::Tool::ADD_NAMES);
+  mToolsActionGroup->addAction(mActionToolValue.data(),
+                               EditorWidgetBase::Tool::ADD_VALUES);
+  mToolsActionGroup->addAction(mActionToolText.data(),
+                               EditorWidgetBase::Tool::DRAW_TEXT);
+  mToolsActionGroup->addAction(mActionToolPin.data(),
+                               EditorWidgetBase::Tool::ADD_PINS);
+  mToolsActionGroup->addAction(mActionToolThtPad.data(),
+                               EditorWidgetBase::Tool::ADD_THT_PADS);
+  mToolsActionGroup->addAction(mActionToolSmtPad.data(),
+                               EditorWidgetBase::Tool::ADD_SMT_PADS);
+  mToolsActionGroup->addAction(mActionToolHole.data(),
+                               EditorWidgetBase::Tool::ADD_HOLES);
+  mToolsActionGroup->addAction(mActionToolMeasure.data(),
+                               EditorWidgetBase::Tool::MEASURE);
   mToolsActionGroup->setEnabled(false);
 }
 

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -646,8 +646,17 @@ void LibraryEditor::createActions() noexcept {
   mActionToolName.reset(cmd.toolName.createAction(this));
   mActionToolValue.reset(cmd.toolValue.createAction(this));
   mActionToolPin.reset(cmd.toolPin.createAction(this));
-  mActionToolSmtPad.reset(cmd.toolPadSmt.createAction(this));
+  mActionToolSmtPadStandard.reset(cmd.toolPadSmt.createAction(this));
   mActionToolThtPad.reset(cmd.toolPadTht.createAction(this));
+  mActionToolSpecialPadThermal.reset(cmd.toolPadThermal.createAction(this));
+  mActionToolSpecialPadBga.reset(cmd.toolPadBga.createAction(this));
+  mActionToolSpecialPadEdgeConnector.reset(
+      cmd.toolPadEdgeConnector.createAction(this));
+  mActionToolSpecialPadTest.reset(cmd.toolPadTest.createAction(this));
+  mActionToolSpecialPadLocalFiducial.reset(
+      cmd.toolPadLocalFiducial.createAction(this));
+  mActionToolSpecialPadGlobalFiducial.reset(
+      cmd.toolPadGlobalFiducial.createAction(this));
   mActionToolHole.reset(cmd.toolHole.createAction(this));
   mActionToolMeasure.reset(cmd.toolMeasure.createAction(this));
 
@@ -679,8 +688,30 @@ void LibraryEditor::createActions() noexcept {
                                EditorWidgetBase::Tool::ADD_PINS);
   mToolsActionGroup->addAction(mActionToolThtPad.data(),
                                EditorWidgetBase::Tool::ADD_THT_PADS);
-  mToolsActionGroup->addAction(mActionToolSmtPad.data(),
-                               EditorWidgetBase::Tool::ADD_SMT_PADS);
+  mToolsActionGroup->addAction(
+      mActionToolSmtPadStandard.data(), EditorWidgetBase::Tool::ADD_SMT_PADS,
+      QVariant::fromValue(FootprintPad::Function::StandardPad));
+  mToolsActionGroup->addAction(
+      mActionToolSpecialPadThermal.data(), EditorWidgetBase::Tool::ADD_SMT_PADS,
+      QVariant::fromValue(FootprintPad::Function::ThermalPad));
+  mToolsActionGroup->addAction(
+      mActionToolSpecialPadBga.data(), EditorWidgetBase::Tool::ADD_SMT_PADS,
+      QVariant::fromValue(FootprintPad::Function::BgaPad));
+  mToolsActionGroup->addAction(
+      mActionToolSpecialPadEdgeConnector.data(),
+      EditorWidgetBase::Tool::ADD_SMT_PADS,
+      QVariant::fromValue(FootprintPad::Function::EdgeConnectorPad));
+  mToolsActionGroup->addAction(
+      mActionToolSpecialPadTest.data(), EditorWidgetBase::Tool::ADD_SMT_PADS,
+      QVariant::fromValue(FootprintPad::Function::TestPad));
+  mToolsActionGroup->addAction(
+      mActionToolSpecialPadLocalFiducial.data(),
+      EditorWidgetBase::Tool::ADD_SMT_PADS,
+      QVariant::fromValue(FootprintPad::Function::LocalFiducial));
+  mToolsActionGroup->addAction(
+      mActionToolSpecialPadGlobalFiducial.data(),
+      EditorWidgetBase::Tool::ADD_SMT_PADS,
+      QVariant::fromValue(FootprintPad::Function::GlobalFiducial));
   mToolsActionGroup->addAction(mActionToolHole.data(),
                                EditorWidgetBase::Tool::ADD_HOLES);
   mToolsActionGroup->addAction(mActionToolMeasure.data(),
@@ -764,7 +795,19 @@ void LibraryEditor::createToolBars() noexcept {
   mToolBarTools->addAction(mActionToolPin.data());
   mToolBarTools->addSeparator();
   mToolBarTools->addAction(mActionToolThtPad.data());
-  mToolBarTools->addAction(mActionToolSmtPad.data());
+  mToolBarTools->addAction(mActionToolSmtPadStandard.data());
+  if (auto btn = qobject_cast<QToolButton*>(
+          mToolBarTools->widgetForAction(mActionToolSmtPadStandard.data()))) {
+    QMenu* menu = new QMenu(mToolBarTools.data());
+    menu->addAction(mActionToolSpecialPadThermal.data());
+    menu->addAction(mActionToolSpecialPadBga.data());
+    menu->addAction(mActionToolSpecialPadEdgeConnector.data());
+    menu->addAction(mActionToolSpecialPadTest.data());
+    menu->addAction(mActionToolSpecialPadLocalFiducial.data());
+    menu->addAction(mActionToolSpecialPadGlobalFiducial.data());
+    btn->setMenu(menu);
+    btn->setPopupMode(QToolButton::DelayedPopup);
+  }
   mToolBarTools->addAction(mActionToolHole.data());
   mToolBarTools->addSeparator();
   mToolBarTools->addAction(mActionToolMeasure.data());
@@ -850,7 +893,13 @@ void LibraryEditor::createMenus() noexcept {
   mb.addAction(mActionToolPin);
   mb.addSeparator();
   mb.addAction(mActionToolThtPad);
-  mb.addAction(mActionToolSmtPad);
+  mb.addAction(mActionToolSmtPadStandard);
+  mb.addAction(mActionToolSpecialPadThermal);
+  mb.addAction(mActionToolSpecialPadBga);
+  mb.addAction(mActionToolSpecialPadEdgeConnector);
+  mb.addAction(mActionToolSpecialPadTest);
+  mb.addAction(mActionToolSpecialPadLocalFiducial);
+  mb.addAction(mActionToolSpecialPadGlobalFiducial);
   mb.addAction(mActionToolHole);
   mb.addSeparator();
   mb.addAction(mActionToolMeasure);

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -236,8 +236,14 @@ private:  // Data
   QScopedPointer<QAction> mActionToolName;
   QScopedPointer<QAction> mActionToolValue;
   QScopedPointer<QAction> mActionToolPin;
-  QScopedPointer<QAction> mActionToolSmtPad;
+  QScopedPointer<QAction> mActionToolSmtPadStandard;
   QScopedPointer<QAction> mActionToolThtPad;
+  QScopedPointer<QAction> mActionToolSpecialPadThermal;
+  QScopedPointer<QAction> mActionToolSpecialPadBga;
+  QScopedPointer<QAction> mActionToolSpecialPadEdgeConnector;
+  QScopedPointer<QAction> mActionToolSpecialPadTest;
+  QScopedPointer<QAction> mActionToolSpecialPadLocalFiducial;
+  QScopedPointer<QAction> mActionToolSpecialPadGlobalFiducial;
   QScopedPointer<QAction> mActionToolHole;
   QScopedPointer<QAction> mActionToolMeasure;
 

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -232,7 +232,7 @@ void NewElementWizardContext::copyElement(ElementType type,
               pad.getRotation(), pad.getShape(), pad.getWidth(),
               pad.getHeight(), pad.getRadius(), pad.getCustomShapeOutline(),
               pad.getStopMaskConfig(), pad.getSolderPasteConfig(),
-              pad.getComponentSide(), pad.getHoles()));
+              pad.getComponentSide(), pad.getFunction(), pad.getHoles()));
         }
         // copy polygons but generate new UUIDs
         for (const Polygon& polygon : footprint.getPolygons()) {

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -112,6 +112,7 @@ void FootprintPadGraphicsItem::padEdited(const FootprintPad& pad,
                                          FootprintPad::Event event) noexcept {
   switch (event) {
     case FootprintPad::Event::UuidChanged:
+    case FootprintPad::Event::FunctionChanged:
       break;
     case FootprintPad::Event::PackagePadUuidChanged:
       updateText();

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
@@ -168,6 +168,13 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   connect(mUi->rbtnSolderPasteManual, &QRadioButton::toggled,
           mUi->edtSolderPasteOffset, &LengthEdit::setEnabled);
 
+  // Populate functions.
+  for (int i = 0; i < static_cast<int>(FootprintPad::Function::_COUNT); ++i) {
+    const FootprintPad::Function value = static_cast<FootprintPad::Function>(i);
+    mUi->cbxFunction->addItem(FootprintPad::getFunctionDescriptionTr(value),
+                              QVariant::fromValue(value));
+  }
+
   // load pad attributes
   int currentPadIndex = 0;
   mUi->cbxPackagePad->addItem(tr("(not connected)"), "");
@@ -178,6 +185,8 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
     }
   }
   mUi->cbxPackagePad->setCurrentIndex(currentPadIndex);
+  mUi->cbxFunction->setCurrentIndex(
+      mUi->cbxFunction->findData(QVariant::fromValue(mPad.getFunction())));
   if (mPad.getComponentSide() == FootprintPad::ComponentSide::Bottom) {
     mUi->btnComponentSideBottom->setChecked(true);
   } else {
@@ -248,6 +257,7 @@ FootprintPadPropertiesDialog::~FootprintPadPropertiesDialog() noexcept {
 
 void FootprintPadPropertiesDialog::setReadOnly(bool readOnly) noexcept {
   mUi->cbxPackagePad->setDisabled(readOnly);
+  mUi->cbxFunction->setDisabled(readOnly);
   mUi->btnComponentSideTop->setDisabled(readOnly);
   mUi->btnComponentSideBottom->setDisabled(readOnly);
   mUi->btnShapeRound->setDisabled(readOnly);
@@ -448,6 +458,10 @@ bool FootprintPadPropertiesDialog::applyChanges() noexcept {
     tl::optional<Uuid> pkgPad =
         Uuid::tryFromString(mUi->cbxPackagePad->currentData().toString());
     cmd->setPackagePadUuid(pkgPad, false);
+    QVariant function = mUi->cbxFunction->currentData();
+    if (function.isValid() && function.canConvert<FootprintPad::Function>()) {
+      cmd->setFunction(function.value<FootprintPad::Function>(), false);
+    }
     if (mUi->btnComponentSideTop->isChecked()) {
       cmd->setComponentSide(FootprintPad::ComponentSide::Top, false);
     } else if (mUi->btnComponentSideBottom->isChecked()) {

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
@@ -482,11 +482,11 @@ bool FootprintPadPropertiesDialog::applyChanges() noexcept {
     cmd->setCustomShapeOutline(customOutlinePath);
     if (mUi->rbtnStopMaskManual->isChecked()) {
       cmd->setStopMaskConfig(
-          MaskConfig::manual(mUi->edtStopMaskOffset->getValue()));
+          MaskConfig::manual(mUi->edtStopMaskOffset->getValue()), false);
     } else if (mUi->rbtnStopMaskAuto->isChecked()) {
-      cmd->setStopMaskConfig(MaskConfig::automatic());
+      cmd->setStopMaskConfig(MaskConfig::automatic(), false);
     } else {
-      cmd->setStopMaskConfig(MaskConfig::off());
+      cmd->setStopMaskConfig(MaskConfig::off(), false);
     }
     if (mUi->rbtnSolderPasteManual->isChecked()) {
       cmd->setSolderPasteConfig(

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>587</width>
-    <height>335</height>
+    <height>367</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,28 +34,28 @@
        <item row="0" column="1">
         <widget class="QComboBox" name="cbxPackagePad"/>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Component Side:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Shape:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Hole Diameter:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="librepcb::editor::PositiveLengthEdit" name="edtHoleDiameter" native="true"/>
@@ -95,14 +95,14 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Position:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="librepcb::editor::LengthEdit" name="edtPosX" native="true"/>
@@ -112,24 +112,24 @@
          </item>
         </layout>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Rotation:</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="librepcb::editor::AngleEdit" name="edtRotation" native="true"/>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Corner Radius:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
           <widget class="librepcb::editor::UnsignedLimitedRatioEdit" name="edtRadiusRatio" native="true"/>
@@ -139,7 +139,7 @@
          </item>
         </layout>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <widget class="QToolButton" name="btnComponentSideTop">
@@ -193,7 +193,7 @@
          </item>
         </layout>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QToolButton" name="btnShapeRound">
@@ -329,14 +329,14 @@
          </item>
         </layout>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Size:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="librepcb::editor::PositiveLengthEdit" name="edtWidth" native="true"/>
@@ -345,6 +345,16 @@
           <widget class="librepcb::editor::PositiveLengthEdit" name="edtHeight" native="true"/>
          </item>
         </layout>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>Function:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="cbxFunction"/>
        </item>
       </layout>
      </widget>
@@ -685,6 +695,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>cbxPackagePad</tabstop>
+  <tabstop>cbxFunction</tabstop>
   <tabstop>btnComponentSideTop</tabstop>
   <tabstop>btnComponentSideBottom</tabstop>
   <tabstop>btnShapeRound</tabstop>
@@ -706,9 +717,9 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="btnGroupSolderPaste"/>
+  <buttongroup name="btnGroupShape"/>
   <buttongroup name="btnGroupStopMask"/>
   <buttongroup name="btnGroupComponentSide"/>
-  <buttongroup name="btnGroupShape"/>
+  <buttongroup name="btnGroupSolderPaste"/>
  </buttongroups>
 </ui>

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
@@ -62,9 +62,37 @@ PackageEditorFsm::PackageEditorFsm(const Context& context) noexcept
     mPreviousState(State::IDLE) {
   mStates.insert(State::SELECT, new PackageEditorState_Select(mContext));
   mStates.insert(State::ADD_THT_PADS,
-                 new PackageEditorState_AddPadsTht(mContext));
-  mStates.insert(State::ADD_SMT_PADS,
-                 new PackageEditorState_AddPadsSmt(mContext));
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::THT,
+                     FootprintPad::Function::StandardPad));
+  mStates.insert(State::ADD_SMT_PADS_STANDARD,
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::SMT,
+                     FootprintPad::Function::StandardPad));
+  mStates.insert(State::ADD_SMT_PADS_THERMAL,
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::SMT,
+                     FootprintPad::Function::ThermalPad));
+  mStates.insert(State::ADD_SMT_PADS_BGA,
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::SMT,
+                     FootprintPad::Function::BgaPad));
+  mStates.insert(State::ADD_SMT_PADS_EDGE_CONNECTOR,
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::SMT,
+                     FootprintPad::Function::EdgeConnectorPad));
+  mStates.insert(State::ADD_SMT_PADS_TEST,
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::SMT,
+                     FootprintPad::Function::TestPad));
+  mStates.insert(State::ADD_SMT_PADS_LOCAL_FIDUCIAL,
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::SMT,
+                     FootprintPad::Function::LocalFiducial));
+  mStates.insert(State::ADD_SMT_PADS_GLOBAL_FIDUCIAL,
+                 new PackageEditorState_AddPads(
+                     mContext, PackageEditorState_AddPads::PadType::SMT,
+                     FootprintPad::Function::GlobalFiducial));
   mStates.insert(State::ADD_NAMES, new PackageEditorState_AddNames(mContext));
   mStates.insert(State::ADD_VALUES, new PackageEditorState_AddValues(mContext));
   mStates.insert(State::DRAW_LINE, new PackageEditorState_DrawLine(mContext));
@@ -104,7 +132,13 @@ EditorWidgetBase::Tool PackageEditorFsm::getCurrentTool() const noexcept {
       return EditorWidgetBase::Tool::SELECT;
     case State::ADD_THT_PADS:
       return EditorWidgetBase::Tool::ADD_THT_PADS;
-    case State::ADD_SMT_PADS:
+    case State::ADD_SMT_PADS_STANDARD:
+    case State::ADD_SMT_PADS_THERMAL:
+    case State::ADD_SMT_PADS_BGA:
+    case State::ADD_SMT_PADS_EDGE_CONNECTOR:
+    case State::ADD_SMT_PADS_TEST:
+    case State::ADD_SMT_PADS_LOCAL_FIDUCIAL:
+    case State::ADD_SMT_PADS_GLOBAL_FIDUCIAL:
       return EditorWidgetBase::Tool::ADD_SMT_PADS;
     case State::ADD_NAMES:
       return EditorWidgetBase::Tool::ADD_NAMES;
@@ -382,8 +416,24 @@ bool PackageEditorFsm::processStartAddingFootprintThtPads() noexcept {
   return setNextState(State::ADD_THT_PADS);
 }
 
-bool PackageEditorFsm::processStartAddingFootprintSmtPads() noexcept {
-  return setNextState(State::ADD_SMT_PADS);
+bool PackageEditorFsm::processStartAddingFootprintSmtPads(
+    FootprintPad::Function function) noexcept {
+  switch (function) {
+    case FootprintPad::Function::ThermalPad:
+      return setNextState(State::ADD_SMT_PADS_THERMAL);
+    case FootprintPad::Function::BgaPad:
+      return setNextState(State::ADD_SMT_PADS_BGA);
+    case FootprintPad::Function::EdgeConnectorPad:
+      return setNextState(State::ADD_SMT_PADS_EDGE_CONNECTOR);
+    case FootprintPad::Function::TestPad:
+      return setNextState(State::ADD_SMT_PADS_TEST);
+    case FootprintPad::Function::LocalFiducial:
+      return setNextState(State::ADD_SMT_PADS_LOCAL_FIDUCIAL);
+    case FootprintPad::Function::GlobalFiducial:
+      return setNextState(State::ADD_SMT_PADS_GLOBAL_FIDUCIAL);
+    default:
+      return setNextState(State::ADD_SMT_PADS_STANDARD);
+  }
 }
 
 bool PackageEditorFsm::processStartAddingNames() noexcept {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -25,6 +25,8 @@
  ******************************************************************************/
 #include "../../editorwidgetbase.h"
 
+#include <librepcb/core/library/pkg/footprintpad.h>
+
 #include <QtCore>
 
 #include <memory>
@@ -63,7 +65,13 @@ private:  // Types
     IDLE,
     SELECT,
     ADD_THT_PADS,
-    ADD_SMT_PADS,
+    ADD_SMT_PADS_STANDARD,
+    ADD_SMT_PADS_THERMAL,
+    ADD_SMT_PADS_BGA,
+    ADD_SMT_PADS_EDGE_CONNECTOR,
+    ADD_SMT_PADS_TEST,
+    ADD_SMT_PADS_LOCAL_FIDUCIAL,
+    ADD_SMT_PADS_GLOBAL_FIDUCIAL,
     ADD_NAMES,
     ADD_VALUES,
     DRAW_LINE,
@@ -135,7 +143,8 @@ public:
   bool processAbortCommand() noexcept;
   bool processStartSelecting() noexcept;
   bool processStartAddingFootprintThtPads() noexcept;
-  bool processStartAddingFootprintSmtPads() noexcept;
+  bool processStartAddingFootprintSmtPads(
+      FootprintPad::Function function) noexcept;
   bool processStartAddingNames() noexcept;
   bool processStartAddingValues() noexcept;
   bool processStartDrawLines() noexcept;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
@@ -66,6 +66,7 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(Context& context,
         MaskConfig::automatic(),  // Stop mask
         MaskConfig::off(),  // Solder paste
         FootprintPad::ComponentSide::Top,  // Default side
+        FootprintPad::Function::StandardPad,  // Most common function
         PadHoleList{}) {
   if (mPadType == PadType::SMT) {
     mLastPad.setShape(
@@ -356,7 +357,7 @@ bool PackageEditorState_AddPads::startAddPad(const Point& pos) noexcept {
         mLastPad.getWidth(), mLastPad.getHeight(), mLastPad.getRadius(),
         mLastPad.getCustomShapeOutline(), mLastPad.getStopMaskConfig(),
         mLastPad.getSolderPasteConfig(), mLastPad.getComponentSide(),
-        PadHoleList{});
+        mLastPad.getFunction(), PadHoleList{});
     for (const PadHole& hole : mLastPad.getHoles()) {
       mCurrentPad->getHoles().append(std::make_shared<PadHole>(
           Uuid::createRandom(), hole.getDiameter(), hole.getPath()));

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.h
@@ -62,7 +62,8 @@ public:
   // Constructors / Destructor
   PackageEditorState_AddPads() = delete;
   PackageEditorState_AddPads(const PackageEditorState_AddPads& other) = delete;
-  explicit PackageEditorState_AddPads(Context& context, PadType type) noexcept;
+  explicit PackageEditorState_AddPads(Context& context, PadType type,
+                                      FootprintPad::Function function) noexcept;
   virtual ~PackageEditorState_AddPads() noexcept;
 
   // General Methods
@@ -98,7 +99,9 @@ private:  // Methods
   void widthEditValueChanged(const PositiveLength& value) noexcept;
   void heightEditValueChanged(const PositiveLength& value) noexcept;
   void drillDiameterEditValueChanged(const PositiveLength& value) noexcept;
+  void fiducialClearanceEditValueChanged(const UnsignedLength& value) noexcept;
   void radiusEditValueChanged(const UnsignedLimitedRatio& value) noexcept;
+  void pressFitCheckedChanged(bool value) noexcept;
   void applyRecommendedRoundedRectRadius() noexcept;
 
 signals:
@@ -114,54 +117,6 @@ private:  // Types / Data
 
   // parameter memory
   FootprintPad mLastPad;
-};
-
-/*******************************************************************************
- *  Class PackageEditorState_AddPadsTht
- ******************************************************************************/
-
-/**
- * @brief The PackageEditorState_AddPadsTht class
- */
-class PackageEditorState_AddPadsTht final : public PackageEditorState_AddPads {
-  Q_OBJECT
-
-public:
-  // Constructors / Destructor
-  PackageEditorState_AddPadsTht() = delete;
-  PackageEditorState_AddPadsTht(const PackageEditorState_AddPadsTht& other) =
-      delete;
-  explicit PackageEditorState_AddPadsTht(Context& context) noexcept
-    : PackageEditorState_AddPads(context, PadType::THT) {}
-  ~PackageEditorState_AddPadsTht() noexcept {}
-
-  // Operator Overloadings
-  PackageEditorState_AddPadsTht& operator=(
-      const PackageEditorState_AddPadsTht& rhs) = delete;
-};
-
-/*******************************************************************************
- *  Class PackageEditorState_AddPadsSmt
- ******************************************************************************/
-
-/**
- * @brief The PackageEditorState_AddPadsSmt class
- */
-class PackageEditorState_AddPadsSmt final : public PackageEditorState_AddPads {
-  Q_OBJECT
-
-public:
-  // Constructors / Destructor
-  PackageEditorState_AddPadsSmt() = delete;
-  PackageEditorState_AddPadsSmt(const PackageEditorState_AddPadsSmt& other) =
-      delete;
-  explicit PackageEditorState_AddPadsSmt(Context& context) noexcept
-    : PackageEditorState_AddPads(context, PadType::SMT) {}
-  ~PackageEditorState_AddPadsSmt() noexcept {}
-
-  // Operator Overloadings
-  PackageEditorState_AddPadsSmt& operator=(
-      const PackageEditorState_AddPadsSmt& rhs) = delete;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -507,7 +507,9 @@ bool PackageEditorWidget::graphicsViewEventHandler(QEvent* event) noexcept {
   }
 }
 
-bool PackageEditorWidget::toolChangeRequested(Tool newTool) noexcept {
+bool PackageEditorWidget::toolChangeRequested(Tool newTool,
+                                              const QVariant& mode) noexcept {
+  Q_UNUSED(mode);
   switch (newTool) {
     case Tool::SELECT:
       return mFsm->processStartSelecting();

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -509,14 +509,18 @@ bool PackageEditorWidget::graphicsViewEventHandler(QEvent* event) noexcept {
 
 bool PackageEditorWidget::toolChangeRequested(Tool newTool,
                                               const QVariant& mode) noexcept {
-  Q_UNUSED(mode);
   switch (newTool) {
     case Tool::SELECT:
       return mFsm->processStartSelecting();
     case Tool::ADD_THT_PADS:
       return mFsm->processStartAddingFootprintThtPads();
-    case Tool::ADD_SMT_PADS:
-      return mFsm->processStartAddingFootprintSmtPads();
+    case Tool::ADD_SMT_PADS: {
+      FootprintPad::Function function = FootprintPad::Function::StandardPad;
+      if (mode.isValid() && mode.canConvert<FootprintPad::Function>()) {
+        function = mode.value<FootprintPad::Function>();
+      }
+      return mFsm->processStartAddingFootprintSmtPads(function);
+    }
     case Tool::ADD_NAMES:
       return mFsm->processStartAddingNames();
     case Tool::ADD_VALUES:
@@ -671,7 +675,7 @@ void PackageEditorWidget::fixMsg(const MsgPadStopMaskOff& msg) {
   std::shared_ptr<FootprintPad> pad =
       footprint->getPads().get(msg.getPad().get());
   QScopedPointer<CmdFootprintPadEdit> cmd(new CmdFootprintPadEdit(*pad));
-  cmd->setStopMaskConfig(MaskConfig::automatic());
+  cmd->setStopMaskConfig(MaskConfig::automatic(), false);
   mUndoStack->execCmd(cmd.take());
 }
 

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.h
@@ -111,7 +111,8 @@ private:  // Methods
   QString commitMetadata() noexcept;
   /// @see ::librepcb::editor::IF_GraphicsViewEventHandler
   bool graphicsViewEventHandler(QEvent* event) noexcept override;
-  bool toolChangeRequested(Tool newTool) noexcept override;
+  bool toolChangeRequested(Tool newTool,
+                           const QVariant& mode) noexcept override;
   void currentFootprintChanged(int index) noexcept;
   void memorizePackageInterface() noexcept;
   bool isInterfaceBroken() const noexcept override;

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.h
@@ -119,6 +119,8 @@ private:  // Methods
   template <typename MessageType>
   void fixMsg(const MessageType& msg);
   template <typename MessageType>
+  void fixPadFunction(const MessageType& msg);
+  template <typename MessageType>
   bool fixMsgHelper(std::shared_ptr<const RuleCheckMessage> msg, bool applyFix);
   bool processRuleCheckMessage(std::shared_ptr<const RuleCheckMessage> msg,
                                bool applyFix) override;

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
@@ -460,7 +460,9 @@ bool SymbolEditorWidget::graphicsViewEventHandler(QEvent* event) noexcept {
   }
 }
 
-bool SymbolEditorWidget::toolChangeRequested(Tool newTool) noexcept {
+bool SymbolEditorWidget::toolChangeRequested(Tool newTool,
+                                             const QVariant& mode) noexcept {
+  Q_UNUSED(mode);
   switch (newTool) {
     case Tool::SELECT:
       return mFsm->processStartSelecting();

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.h
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.h
@@ -110,7 +110,8 @@ private:  // Methods
   QString commitMetadata() noexcept;
   /// @see ::librepcb::editor::IF_GraphicsViewEventHandler
   bool graphicsViewEventHandler(QEvent* event) noexcept override;
-  bool toolChangeRequested(Tool newTool) noexcept override;
+  bool toolChangeRequested(Tool newTool,
+                           const QVariant& mode) noexcept override;
   bool isInterfaceBroken() const noexcept override;
   bool runChecks(RuleCheckMessageList& msgs) const override;
   template <typename MessageType>

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -721,28 +721,27 @@ void BoardEditor::createActions() noexcept {
 
   // Tools action group.
   mToolsActionGroup.reset(new ExclusiveActionGroup());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::SELECT,
-                               mActionToolSelect.data());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::DRAW_TRACE,
-                               mActionToolTrace.data());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::ADD_VIA,
-                               mActionToolVia.data());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::DRAW_POLYGON,
-                               mActionToolPolygon.data());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::DRAW_PLANE,
-                               mActionToolPlane.data());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::ADD_STROKE_TEXT,
-                               mActionToolText.data());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::ADD_HOLE,
-                               mActionToolHole.data());
-  mToolsActionGroup->addAction(BoardEditorFsm::State::MEASURE,
-                               mActionToolMeasure.data());
+  mToolsActionGroup->addAction(mActionToolSelect.data(),
+                               BoardEditorFsm::State::SELECT);
+  mToolsActionGroup->addAction(mActionToolTrace.data(),
+                               BoardEditorFsm::State::DRAW_TRACE);
+  mToolsActionGroup->addAction(mActionToolVia.data(),
+                               BoardEditorFsm::State::ADD_VIA);
+  mToolsActionGroup->addAction(mActionToolPolygon.data(),
+                               BoardEditorFsm::State::DRAW_POLYGON);
+  mToolsActionGroup->addAction(mActionToolPlane.data(),
+                               BoardEditorFsm::State::DRAW_PLANE);
+  mToolsActionGroup->addAction(mActionToolText.data(),
+                               BoardEditorFsm::State::ADD_STROKE_TEXT);
+  mToolsActionGroup->addAction(mActionToolHole.data(),
+                               BoardEditorFsm::State::ADD_HOLE);
+  mToolsActionGroup->addAction(mActionToolMeasure.data(),
+                               BoardEditorFsm::State::MEASURE);
   mToolsActionGroup->setCurrentAction(mFsm->getCurrentState());
   connect(mFsm.data(), &BoardEditorFsm::stateChanged, mToolsActionGroup.data(),
           &ExclusiveActionGroup::setCurrentAction);
-  connect(mToolsActionGroup.data(),
-          &ExclusiveActionGroup::changeRequestTriggered, this,
-          &BoardEditor::toolActionGroupChangeTriggered);
+  connect(mToolsActionGroup.data(), &ExclusiveActionGroup::actionTriggered,
+          this, &BoardEditor::toolRequested);
 }
 
 void BoardEditor::createToolBars() noexcept {
@@ -1121,8 +1120,7 @@ bool BoardEditor::graphicsViewEventHandler(QEvent* event) {
   return (event->type() != QEvent::GraphicsSceneWheel);
 }
 
-void BoardEditor::toolActionGroupChangeTriggered(
-    const QVariant& newTool) noexcept {
+void BoardEditor::toolRequested(const QVariant& newTool) noexcept {
   switch (newTool.toInt()) {
     case BoardEditorFsm::State::SELECT:
       mFsm->processSelect();

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.h
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.h
@@ -141,7 +141,7 @@ private:
   void createMenus() noexcept;
   void updateBoardActionGroup() noexcept;
   virtual bool graphicsViewEventHandler(QEvent* event) override;
-  void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void toolRequested(const QVariant& newTool) noexcept;
   void unplacedComponentsCountChanged(int count) noexcept;
   void runDrc(bool quick) noexcept;
   void highlightDrcMessage(const RuleCheckMessage& msg, bool zoomTo) noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -620,26 +620,25 @@ void SchematicEditor::createActions() noexcept {
 
   // Tools action group.
   mToolsActionGroup.reset(new ExclusiveActionGroup());
-  mToolsActionGroup->addAction(SchematicEditorFsm::State::SELECT,
-                               mActionToolSelect.data());
-  mToolsActionGroup->addAction(SchematicEditorFsm::State::DRAW_WIRE,
-                               mActionToolWire.data());
-  mToolsActionGroup->addAction(SchematicEditorFsm::State::ADD_NETLABEL,
-                               mActionToolNetLabel.data());
-  mToolsActionGroup->addAction(SchematicEditorFsm::State::DRAW_POLYGON,
-                               mActionToolPolygon.data());
-  mToolsActionGroup->addAction(SchematicEditorFsm::State::ADD_TEXT,
-                               mActionToolText.data());
-  mToolsActionGroup->addAction(SchematicEditorFsm::State::ADD_COMPONENT,
-                               mActionToolComponent.data());
-  mToolsActionGroup->addAction(SchematicEditorFsm::State::MEASURE,
-                               mActionToolMeasure.data());
+  mToolsActionGroup->addAction(mActionToolSelect.data(),
+                               SchematicEditorFsm::State::SELECT);
+  mToolsActionGroup->addAction(mActionToolWire.data(),
+                               SchematicEditorFsm::State::DRAW_WIRE);
+  mToolsActionGroup->addAction(mActionToolNetLabel.data(),
+                               SchematicEditorFsm::State::ADD_NETLABEL);
+  mToolsActionGroup->addAction(mActionToolPolygon.data(),
+                               SchematicEditorFsm::State::DRAW_POLYGON);
+  mToolsActionGroup->addAction(mActionToolText.data(),
+                               SchematicEditorFsm::State::ADD_TEXT);
+  mToolsActionGroup->addAction(mActionToolComponent.data(),
+                               SchematicEditorFsm::State::ADD_COMPONENT);
+  mToolsActionGroup->addAction(mActionToolMeasure.data(),
+                               SchematicEditorFsm::State::MEASURE);
   mToolsActionGroup->setCurrentAction(mFsm->getCurrentState());
   connect(mFsm.data(), &SchematicEditorFsm::stateChanged,
           mToolsActionGroup.data(), &ExclusiveActionGroup::setCurrentAction);
-  connect(mToolsActionGroup.data(),
-          &ExclusiveActionGroup::changeRequestTriggered, this,
-          &SchematicEditor::toolActionGroupChangeTriggered);
+  connect(mToolsActionGroup.data(), &ExclusiveActionGroup::actionTriggered,
+          this, &SchematicEditor::toolRequested);
 }
 
 void SchematicEditor::createToolBars() noexcept {
@@ -977,8 +976,7 @@ bool SchematicEditor::graphicsViewEventHandler(QEvent* event) {
   return (event->type() != QEvent::GraphicsSceneWheel);
 }
 
-void SchematicEditor::toolActionGroupChangeTriggered(
-    const QVariant& newTool) noexcept {
+void SchematicEditor::toolRequested(const QVariant& newTool) noexcept {
   // Note: Converting the QVariant to SchematicEditorFsm::State doesn't work
   // with some Qt versions, thus we convert to int instead. Fixed in:
   // https://codereview.qt-project.org/c/qt/qtbase/+/159277/

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -131,7 +131,7 @@ private:
   void createDockWidgets() noexcept;
   void createMenus() noexcept;
   virtual bool graphicsViewEventHandler(QEvent* event) override;
-  void toolActionGroupChangeTriggered(const QVariant& newTool) noexcept;
+  void toolRequested(const QVariant& newTool) noexcept;
   void addSchematic() noexcept;
   void removeSchematic(int index) noexcept;
   void renameSchematic(int index) noexcept;

--- a/libs/librepcb/editor/utils/exclusiveactiongroup.cpp
+++ b/libs/librepcb/editor/utils/exclusiveactiongroup.cpp
@@ -35,8 +35,7 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-ExclusiveActionGroup::ExclusiveActionGroup() noexcept
-  : QObject(nullptr), mCurrentAction() {
+ExclusiveActionGroup::ExclusiveActionGroup() noexcept : QObject(nullptr) {
 }
 
 ExclusiveActionGroup::~ExclusiveActionGroup() noexcept {
@@ -47,42 +46,14 @@ ExclusiveActionGroup::~ExclusiveActionGroup() noexcept {
  ******************************************************************************/
 
 void ExclusiveActionGroup::reset() noexcept {
-  setCurrentAction(QVariant());
+  setCurrentAction(-1);
   setEnabled(false);
 }
 
 void ExclusiveActionGroup::setEnabled(bool enabled) noexcept {
-  foreach (QAction* action, mActions) {
-    if (action) action->setEnabled(enabled);
-  }
-}
-
-void ExclusiveActionGroup::addAction(const QVariant& key,
-                                     QAction* action) noexcept {
-  Q_ASSERT(!key.isNull());
-  Q_ASSERT(!mActions.contains(key));
-  mActions.insert(key, action);
-  if (action) {
-    connect(action, &QAction::triggered, this,
-            &ExclusiveActionGroup::actionTriggered);
-    action->setCheckable(key == mCurrentAction);
-    action->setChecked(key == mCurrentAction);
-  }
-}
-
-void ExclusiveActionGroup::setActionEnabled(const QVariant& key,
-                                            bool enabled) noexcept {
-  QAction* action = mActions.value(key);
-  if (action) action->setEnabled(enabled);
-}
-
-void ExclusiveActionGroup::setCurrentAction(const QVariant& key) noexcept {
-  mCurrentAction = key;
-  foreach (const QVariant& val, mActions.keys()) {
-    QAction* action = mActions.value(val);
-    if (action) {
-      action->setCheckable(val == mCurrentAction);
-      action->setChecked(val == mCurrentAction);
+  for (auto it = mActions.begin(); it != mActions.end(); it++) {
+    foreach (auto& pair, it.value()) {
+      if (pair.first) pair.first->setEnabled(enabled);
     }
   }
 }
@@ -91,13 +62,47 @@ void ExclusiveActionGroup::setCurrentAction(const QVariant& key) noexcept {
  *  Private Methods
  ******************************************************************************/
 
-void ExclusiveActionGroup::actionTriggered() noexcept {
+void ExclusiveActionGroup::addAction(QPointer<QAction> action, int id,
+                                     const QVariant& mode) noexcept {
+  Q_ASSERT(id != -1);
+  Q_ASSERT(action);
+  mActions[id].append(std::make_pair(action, mode));
+  connect(action, &QAction::triggered, this,
+          &ExclusiveActionGroup::actionTriggeredSlot);
+}
+
+void ExclusiveActionGroup::setActionEnabled(int id, bool enabled) noexcept {
+  foreach (auto& pair, mActions.value(id)) {
+    if (pair.first) pair.first->setEnabled(enabled);
+  }
+}
+
+void ExclusiveActionGroup::setCurrentAction(int id) noexcept {
+  for (auto it = mActions.begin(); it != mActions.end(); it++) {
+    Q_ASSERT(!it.value().isEmpty());
+    if (QAction* action = it.value().first().first) {
+      QSignalBlocker blocker(action);
+      action->setCheckable(it.key() == id);
+      action->setChecked(it.key() == id);
+    }
+  }
+}
+
+void ExclusiveActionGroup::actionTriggeredSlot() noexcept {
   QAction* action = dynamic_cast<QAction*>(sender());
   Q_ASSERT(action);
-  QVariant key = mActions.key(action);
-  Q_ASSERT(!key.isNull());
-  if (key != mCurrentAction) {
-    emit changeRequestTriggered(key);
+  if (action->isCheckable()) {
+    QSignalBlocker blocker(action);
+    action->setChecked(true);
+  } else {
+    for (auto it = mActions.begin(); it != mActions.end(); it++) {
+      foreach (auto& pair, it.value()) {
+        if (pair.first == action) {
+          emit actionTriggered(it.key(), pair.second);
+          return;
+        }
+      }
+    }
   }
 }
 

--- a/libs/librepcb/editor/utils/exclusiveactiongroup.h
+++ b/libs/librepcb/editor/utils/exclusiveactiongroup.h
@@ -43,10 +43,13 @@ namespace editor {
  * (http://doc.qt.io/qt-5/qactiongroup.html). But there is one important
  * difference: When the user clicks on a QAction, that action won't be checked
  * instantly. Instead, this class only emits the signal
- * #changeRequestTriggered(). Whether the triggered action actually gets checked
+ * #actionTriggered(). Whether the triggered action actually gets checked
  * or the request is rejected can be decided from outside this class (typically
  * by the state machine of an editor window). To change the selected action,
  * #setCurrentAction() needs to be called.
+ *
+ * In addition, this class provides support for "nested" actions, used to
+ * create tools which can be entered in different modes.
  */
 class ExclusiveActionGroup final : public QObject {
   Q_OBJECT
@@ -60,23 +63,22 @@ public:
   // General Methods
   void reset() noexcept;
   void setEnabled(bool enabled) noexcept;
-  void addAction(const QVariant& key, QAction* action) noexcept;
-  void setActionEnabled(const QVariant& key, bool enabled) noexcept;
-  void setCurrentAction(const QVariant& key) noexcept;
-  const QVariant& getCurrentAction() const noexcept { return mCurrentAction; }
+  void addAction(QPointer<QAction> action, int id,
+                 const QVariant& mode = QVariant()) noexcept;
+  void setActionEnabled(int id, bool enabled) noexcept;
+  void setCurrentAction(int id) noexcept;
 
   // Operator Overloadings
   ExclusiveActionGroup& operator=(const ExclusiveActionGroup& rhs) = delete;
 
 signals:
-  void changeRequestTriggered(const QVariant& key);
+  void actionTriggered(int id, const QVariant& mode);
 
 private:  // Methods
-  void actionTriggered() noexcept;
+  void actionTriggeredSlot() noexcept;
 
 private:  // Data
-  QVariant mCurrentAction;
-  QMap<QVariant, QAction*> mActions;
+  QHash<int, QVector<std::pair<QPointer<QAction>, QVariant>>> mActions;
 };
 
 /*******************************************************************************

--- a/tests/unittests/core/export/gerberattributetest.cpp
+++ b/tests/unittests/core/export/gerberattributetest.cpp
@@ -229,9 +229,44 @@ TEST_F(GerberAttributeTest, testApertureFunction) {
                 GerberAttribute::ApertureFunction::SmdPadSolderMaskDefined)
                 .toGerberString()
                 .toStdString());
+  EXPECT_EQ("G04 #@! TA.AperFunction,BGAPad,CuDef*\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::BgaPadCopperDefined)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TA.AperFunction,BGAPad,SMDef*\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::BgaPadSolderMaskDefined)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TA.AperFunction,ConnectorPad*\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::ConnectorPad)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TA.AperFunction,HeatsinkPad*\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::HeatsinkPad)
+                .toGerberString()
+                .toStdString());
   EXPECT_EQ("G04 #@! TA.AperFunction,ViaPad*\n",
             GerberAttribute::apertureFunction(
                 GerberAttribute::ApertureFunction::ViaPad)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TA.AperFunction,TestPad*\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::TestPad)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TA.AperFunction,FiducialPad,Local*\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::FiducialPadLocal)
+                .toGerberString()
+                .toStdString());
+  EXPECT_EQ("G04 #@! TA.AperFunction,FiducialPad,Global*\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::FiducialPadGlobal)
                 .toGerberString()
                 .toStdString());
 }
@@ -245,6 +280,11 @@ TEST_F(GerberAttributeTest, testApertureFunctionExcellon) {
   EXPECT_EQ("; #@! TA.AperFunction,ComponentDrill\n",
             GerberAttribute::apertureFunction(
                 GerberAttribute::ApertureFunction::ComponentDrill)
+                .toExcellonString()
+                .toStdString());
+  EXPECT_EQ("; #@! TA.AperFunction,ComponentDrill,PressFit\n",
+            GerberAttribute::apertureFunction(
+                GerberAttribute::ApertureFunction::ComponentDrillPressFit)
                 .toExcellonString()
                 .toStdString());
   EXPECT_EQ("; #@! TA.AperFunction,MechanicalDrill\n",
@@ -265,6 +305,12 @@ TEST_F(GerberAttributeTest, testApertureFunctionMixedPlatingDrillExcellon) {
                 false, GerberAttribute::ApertureFunction::ComponentDrill)
                 .toExcellonString()
                 .toStdString());
+  EXPECT_EQ(
+      "; #@! TA.AperFunction,NonPlated,NPTH,ComponentDrill,PressFit\n",
+      GerberAttribute::apertureFunctionMixedPlatingDrill(
+          false, GerberAttribute::ApertureFunction::ComponentDrillPressFit)
+          .toExcellonString()
+          .toStdString());
   EXPECT_EQ("; #@! TA.AperFunction,NonPlated,NPTH,MechanicalDrill\n",
             GerberAttribute::apertureFunctionMixedPlatingDrill(
                 false, GerberAttribute::ApertureFunction::MechanicalDrill)
@@ -278,6 +324,11 @@ TEST_F(GerberAttributeTest, testApertureFunctionMixedPlatingDrillExcellon) {
   EXPECT_EQ("; #@! TA.AperFunction,Plated,PTH,ComponentDrill\n",
             GerberAttribute::apertureFunctionMixedPlatingDrill(
                 true, GerberAttribute::ApertureFunction::ComponentDrill)
+                .toExcellonString()
+                .toStdString());
+  EXPECT_EQ("; #@! TA.AperFunction,Plated,PTH,ComponentDrill,PressFit\n",
+            GerberAttribute::apertureFunctionMixedPlatingDrill(
+                true, GerberAttribute::ApertureFunction::ComponentDrillPressFit)
                 .toExcellonString()
                 .toStdString());
   EXPECT_EQ("; #@! TA.AperFunction,Plated,PTH,MechanicalDrill\n",

--- a/tests/unittests/core/library/pkg/footprintpadtest.cpp
+++ b/tests/unittests/core/library/pkg/footprintpadtest.cpp
@@ -46,7 +46,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
   SExpression sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape roundrect)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
-      " (stop_mask auto) (solder_paste 0.25)\n"
+      " (stop_mask auto) (solder_paste 0.25) (function unspecified)\n"
       " (package_pad d48b8bd2-a46c-4495-87a5-662747034098)\n"
       ")",
       FilePath());
@@ -64,6 +64,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
   EXPECT_EQ(MaskConfig::automatic(), obj.getStopMaskConfig());
   EXPECT_EQ(MaskConfig::manual(Length(250000)), obj.getSolderPasteConfig());
   EXPECT_EQ(FootprintPad::ComponentSide::Top, obj.getComponentSide());
+  EXPECT_EQ(FootprintPad::Function::Unspecified, obj.getFunction());
   EXPECT_EQ(0, obj.getHoles().count());
 }
 
@@ -71,7 +72,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   SExpression sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side bottom) (shape custom)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
-      " (stop_mask off) (solder_paste auto)\n"
+      " (stop_mask off) (solder_paste auto) (function standard)\n"
       " (package_pad none)\n"
       " (vertex (position -1.1 -2.2) (angle 45.0))\n"
       " (vertex (position 1.1 -2.2) (angle 90.0))\n"
@@ -97,6 +98,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   EXPECT_EQ(MaskConfig::off(), obj.getStopMaskConfig());
   EXPECT_EQ(MaskConfig::automatic(), obj.getSolderPasteConfig());
   EXPECT_EQ(FootprintPad::ComponentSide::Bottom, obj.getComponentSide());
+  EXPECT_EQ(FootprintPad::Function::StandardPad, obj.getFunction());
   EXPECT_EQ(3, obj.getCustomShapeOutline().getVertices().count());
   EXPECT_EQ(2, obj.getHoles().count());
 }
@@ -108,7 +110,7 @@ TEST_F(FootprintPadTest, testSerializeAndDeserialize) {
       PositiveLength(456), UnsignedLimitedRatio(Ratio::percent50()),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
-      FootprintPad::ComponentSide::Top,
+      FootprintPad::ComponentSide::Top, FootprintPad::Function::Unspecified,
       PadHoleList{
           std::make_shared<PadHole>(Uuid::createRandom(),
                                     PositiveLength(100000),

--- a/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
@@ -89,7 +89,8 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       FootprintPad::Shape::RoundedOctagon, PositiveLength(11),
       PositiveLength(22), UnsignedLimitedRatio(Ratio::percent50()), Path(),
       MaskConfig::off(), MaskConfig::automatic(),
-      FootprintPad::ComponentSide::Bottom, PadHoleList{});
+      FootprintPad::ComponentSide::Bottom, FootprintPad::Function::Unspecified,
+      PadHoleList{});
 
   std::shared_ptr<FootprintPad> footprintPad2 = std::make_shared<FootprintPad>(
       Uuid::createRandom(), tl::nullopt, Point(12, 34), Angle(56),
@@ -97,7 +98,7 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       PositiveLength(456), UnsignedLimitedRatio(Ratio::percent100()),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
-      FootprintPad::ComponentSide::Top,
+      FootprintPad::ComponentSide::Top, FootprintPad::Function::TestPad,
       PadHoleList{std::make_shared<PadHole>(Uuid::createRandom(),
                                             PositiveLength(789),
                                             makeNonEmptyPath(Point(0, 0)))});


### PR DESCRIPTION
### Summary

Adds a metadata property called "function" to each footprint pad, to allow more accurate production data exports. The supported functions are:

- Not Specified
- Standard Pad (soldered)
- Press-Fit Pad (THT, soldered)
- Thermal Pad (SMT, soldered)
- BGA Pad (SMT, soldered)
- Edge Connector Pad (SMT, no soldering)
- Test Pad (SMT, no soldering)
- Local Footprint Fiducial (SMT, no soldering)
- Global Board Fiducial (SMT, no soldering)

The "Not Specified" is handled identically to "Standard Pad", but allows the UI to inform the user that the function is not explicitly set (which is the case e.g. after a file format upgrade).

The function property has an impact on the following things:

- Pick&place CSV files now include fiducials
- Gerber files set the corresponding X2/X3 attributes for pads & drills
- The package check in the library editor now respects this property to provide more accurate warnings about potential footprint issues. In addition, several new warnings have been implemented to help avoiding issues (e.g. if solder paste is enabled on a fiducial).

### User Interface

The pad function is now configurable in the pad properties dialog:

![image](https://user-images.githubusercontent.com/5374821/229348820-74cd2690-2ca8-48eb-bb26-c8f42aab0346.png)

In addition, the "Add SMT Pads" tool now provides presets for the special pad functions, to simplify adding special pads (accessible by a long click on the tool button):

![image](https://user-images.githubusercontent.com/5374821/229348929-f585c86c-85e2-4225-b28f-290d2a0494c1.png)

### File Format

The property `function` is set to `unspecified` during file format upgrade:

```
  (pad 19d59886-4023-49c0-acbb-350b25cbe189 (side top) (shape roundrect)
   (position 1.422 0.0) (rotation 0.0) (size 1.6 1.803) (radius 0.0)
   (stop_mask auto) (solder_paste auto) (function unspecified)
   (package_pad 19d59886-4023-49c0-acbb-350b25cbe189)
  )
```

### Related Issues

Required for #1127, but is not yet fully functional for fiducials since they also need a custom copper clearance which I'll implement in a separate PR.