### PR TITLE
Add copper clearance property to footprint pads

### DIFF
--- a/libs/librepcb/core/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpad.cpp
@@ -161,6 +161,7 @@ FootprintPad::FootprintPad(const FootprintPad& other) noexcept
     mCustomShapeOutline(other.mCustomShapeOutline),
     mStopMaskConfig(other.mStopMaskConfig),
     mSolderPasteConfig(other.mSolderPasteConfig),
+    mCopperClearance(other.mCopperClearance),
     mComponentSide(other.mComponentSide),
     mFunction(other.mFunction),
     mHoles(other.mHoles),
@@ -173,8 +174,8 @@ FootprintPad::FootprintPad(
     const Angle& rot, Shape shape, const PositiveLength& width,
     const PositiveLength& height, const UnsignedLimitedRatio& radius,
     const Path& customShapeOutline, const MaskConfig& autoStopMask,
-    const MaskConfig& autoSolderPaste, ComponentSide side, Function function,
-    const PadHoleList& holes) noexcept
+    const MaskConfig& autoSolderPaste, const UnsignedLength& copperClearance,
+    ComponentSide side, Function function, const PadHoleList& holes) noexcept
   : onEdited(*this),
     mUuid(uuid),
     mPackagePadUuid(pkgPadUuid),
@@ -187,6 +188,7 @@ FootprintPad::FootprintPad(
     mCustomShapeOutline(customShapeOutline),
     mStopMaskConfig(autoStopMask),
     mSolderPasteConfig(autoSolderPaste),
+    mCopperClearance(copperClearance),
     mComponentSide(side),
     mFunction(function),
     mHoles(holes),
@@ -209,6 +211,8 @@ FootprintPad::FootprintPad(const SExpression& node)
     mStopMaskConfig(deserialize<MaskConfig>(node.getChild("stop_mask/@0"))),
     mSolderPasteConfig(
         deserialize<MaskConfig>(node.getChild("solder_paste/@0"))),
+    mCopperClearance(
+        deserialize<UnsignedLength>(node.getChild("clearance/@0"))),
     mComponentSide(deserialize<ComponentSide>(node.getChild("side/@0"))),
     mFunction(deserialize<Function>(node.getChild("function/@0"))),
     mHoles(node),
@@ -408,6 +412,17 @@ bool FootprintPad::setSolderPasteConfig(const MaskConfig& config) noexcept {
   return true;
 }
 
+bool FootprintPad::setCopperClearance(
+    const UnsignedLength& clearance) noexcept {
+  if (clearance == mCopperClearance) {
+    return false;
+  }
+
+  mCopperClearance = clearance;
+  onEdited.notify(Event::CopperClearanceChanged);
+  return true;
+}
+
 bool FootprintPad::setComponentSide(ComponentSide side) noexcept {
   if (side == mComponentSide) {
     return false;
@@ -444,6 +459,7 @@ void FootprintPad::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("stop_mask", mStopMaskConfig);
   root.appendChild("solder_paste", mSolderPasteConfig);
+  root.appendChild("clearance", mCopperClearance);
   root.appendChild("function", mFunction);
   root.ensureLineBreak();
   root.appendChild("package_pad", mPackagePadUuid);
@@ -470,6 +486,7 @@ bool FootprintPad::operator==(const FootprintPad& rhs) const noexcept {
   if (mCustomShapeOutline != rhs.mCustomShapeOutline) return false;
   if (mStopMaskConfig != rhs.mStopMaskConfig) return false;
   if (mSolderPasteConfig != rhs.mSolderPasteConfig) return false;
+  if (mCopperClearance != rhs.mCopperClearance) return false;
   if (mComponentSide != rhs.mComponentSide) return false;
   if (mFunction != rhs.mFunction) return false;
   if (mHoles != rhs.mHoles) return false;
@@ -491,6 +508,7 @@ FootprintPad& FootprintPad::operator=(const FootprintPad& rhs) noexcept {
   setCustomShapeOutline(rhs.mCustomShapeOutline);
   setStopMaskConfig(rhs.mStopMaskConfig);
   setSolderPasteConfig(rhs.mSolderPasteConfig);
+  setCopperClearance(rhs.mCopperClearance);
   setComponentSide(rhs.mComponentSide);
   setFunction(rhs.mFunction);
   mHoles = rhs.mHoles;

--- a/libs/librepcb/core/library/pkg/footprintpad.h
+++ b/libs/librepcb/core/library/pkg/footprintpad.h
@@ -93,6 +93,7 @@ public:
     CustomShapeOutlineChanged,
     StopMaskConfigChanged,
     SolderPasteConfigChanged,
+    CopperClearanceChanged,
     ComponentSideChanged,
     FunctionChanged,
     HolesEdited,
@@ -108,7 +109,8 @@ public:
                const PositiveLength& width, const PositiveLength& height,
                const UnsignedLimitedRatio& radius,
                const Path& customShapeOutline, const MaskConfig& autoStopMask,
-               const MaskConfig& autoSolderPaste, ComponentSide side,
+               const MaskConfig& autoSolderPaste,
+               const UnsignedLength& copperClearance, ComponentSide side,
                Function function, const PadHoleList& holes) noexcept;
   explicit FootprintPad(const SExpression& node);
   ~FootprintPad() noexcept;
@@ -132,6 +134,9 @@ public:
   }
   const MaskConfig& getSolderPasteConfig() const noexcept {
     return mSolderPasteConfig;
+  }
+  const UnsignedLength& getCopperClearance() const noexcept {
+    return mCopperClearance;
   }
   ComponentSide getComponentSide() const noexcept { return mComponentSide; }
   Function getFunction() const noexcept { return mFunction; }
@@ -161,6 +166,7 @@ public:
   bool setCustomShapeOutline(const Path& outline) noexcept;
   bool setStopMaskConfig(const MaskConfig& config) noexcept;
   bool setSolderPasteConfig(const MaskConfig& config) noexcept;
+  bool setCopperClearance(const UnsignedLength& clearance) noexcept;
   bool setComponentSide(ComponentSide side) noexcept;
   bool setFunction(Function function) noexcept;
 
@@ -208,6 +214,7 @@ private:  // Data
   Path mCustomShapeOutline;  ///< Empty if not needed; Implicitly closed
   MaskConfig mStopMaskConfig;
   MaskConfig mSolderPasteConfig;
+  UnsignedLength mCopperClearance;
   ComponentSide mComponentSide;
   Function mFunction;
   PadHoleList mHoles;  ///< If not empty, it's a THT pad.

--- a/libs/librepcb/core/library/pkg/packagecheck.h
+++ b/libs/librepcb/core/library/pkg/packagecheck.h
@@ -68,6 +68,7 @@ protected:  // Methods
   void checkCustomPadOutline(MsgList& msgs) const;
   void checkStopMaskOnPads(MsgList& msgs) const;
   void checkSolderPasteOnPads(MsgList& msgs) const;
+  void checkCopperClearanceOnPads(MsgList& msgs) const;
   void checkPadFunctions(MsgList& msgs) const;
   void checkHolesStopMask(MsgList& msgs) const;
 

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
@@ -76,6 +76,31 @@ MsgDuplicatePadName::MsgDuplicatePadName(const PackagePad& pad) noexcept
 }
 
 /*******************************************************************************
+ *  Class MsgFiducialClearanceLessThanStopMask
+ ******************************************************************************/
+
+MsgFiducialClearanceLessThanStopMask::MsgFiducialClearanceLessThanStopMask(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad) noexcept
+  : RuleCheckMessage(
+        Severity::Warning,
+        tr("Small copper clearance on fiducial in '%1'")
+            .arg(*footprint->getNames().getDefaultValue()),
+        tr("The copper clearance of the fiducial pad is less than its stop "
+           "mask expansion, which is unusual. Typically the copper clearance "
+           "should be equal to or greater than the stop mask expansion to "
+           "avoid copper located within the stop mask opening."),
+        "fiducial_copper_clearance_less_than_stop_mask"),
+    mFootprint(footprint),
+    mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+/*******************************************************************************
  *  Class MsgFiducialStopMaskNotSet
  ******************************************************************************/
 
@@ -376,6 +401,33 @@ MsgPadStopMaskOff::MsgPadStopMaskOff(std::shared_ptr<const Footprint> footprint,
            "This is very unusual, you should double-check if this is really "
            "what you want."),
         "pad_stop_mask_off"),
+    mFootprint(footprint),
+    mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+/*******************************************************************************
+ *  Class MsgPadWithCopperClearance
+ ******************************************************************************/
+
+MsgPadWithCopperClearance::MsgPadWithCopperClearance(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad, const QString& pkgPadName) noexcept
+  : RuleCheckMessage(
+        Severity::Hint,
+        tr("Copper clearance >0 on pad '%1' in '%2'")
+            .arg(pkgPadName, *footprint->getNames().getDefaultValue()),
+        tr("There is a custom copper clearance enabled on the pad, which is "
+           "unusual for pads which do not represent a fiducial. Note that the "
+           "clearance value from the board design rules is applied to all pads "
+           "anyway, thus manual clearance values are usually not needed. If "
+           "this pad is a fiducial, make sure to set its function to the "
+           "corresponding value."),
+        "pad_with_copper_clearance"),
     mFootprint(footprint),
     mPad(pad) {
   mApproval.ensureLineBreak();

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.h
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.h
@@ -96,6 +96,38 @@ public:
 };
 
 /*******************************************************************************
+ *  Class MsgFiducialClearanceLessThanStopMask
+ ******************************************************************************/
+
+/**
+ * @brief The MsgFiducialClearanceLessThanStopMask class
+ */
+class MsgFiducialClearanceLessThanStopMask final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgFiducialClearanceLessThanStopMask)
+
+public:
+  // Constructors / Destructor
+  MsgFiducialClearanceLessThanStopMask() = delete;
+  MsgFiducialClearanceLessThanStopMask(
+      std::shared_ptr<const Footprint> footprint,
+      std::shared_ptr<const FootprintPad> pad) noexcept;
+  MsgFiducialClearanceLessThanStopMask(
+      const MsgFiducialClearanceLessThanStopMask& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgFiducialClearanceLessThanStopMask() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
  *  Class MsgFiducialStopMaskNotSet
  ******************************************************************************/
 
@@ -468,6 +500,37 @@ public:
   MsgPadStopMaskOff(const MsgPadStopMaskOff& other) noexcept
     : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
   virtual ~MsgPadStopMaskOff() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
+ *  Class MsgPadWithCopperClearance
+ ******************************************************************************/
+
+/**
+ * @brief The MsgPadWithCopperClearance class
+ */
+class MsgPadWithCopperClearance final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgPadWithCopperClearance)
+
+public:
+  // Constructors / Destructor
+  MsgPadWithCopperClearance() = delete;
+  MsgPadWithCopperClearance(std::shared_ptr<const Footprint> footprint,
+                            std::shared_ptr<const FootprintPad> pad,
+                            const QString& pkgPadName) noexcept;
+  MsgPadWithCopperClearance(const MsgPadWithCopperClearance& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgPadWithCopperClearance() noexcept {}
 
   // Getters
   std::shared_ptr<const Footprint> getFootprint() const noexcept {

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -56,6 +56,15 @@ BoardClipperPathGenerator::~BoardClipperPathGenerator() noexcept {
 }
 
 /*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+void BoardClipperPathGenerator::takePathsTo(ClipperLib::Paths& out) noexcept {
+  out = mPaths;
+  mPaths.clear();
+}
+
+/*******************************************************************************
  *  General Methods
  ******************************************************************************/
 

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
@@ -65,6 +65,7 @@ public:
 
   // Getters
   const ClipperLib::Paths& getPaths() const noexcept { return mPaths; }
+  void takePathsTo(ClipperLib::Paths& out) noexcept;
 
   // General Methods
   void addCopper(const Layer& layer, const QSet<const NetSignal*>& netsignals,

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -344,6 +344,8 @@ void BoardDesignRuleCheck::checkCopperCopperClearances(int progressEnd) {
 
     // Pads.
     foreach (const BI_FootprintPad* pad, device->getPads()) {
+      const UnsignedLength padClearance =
+          std::max(clearance, pad->getLibPad().getCopperClearance());
       foreach (const Layer* layer, mBoard.getCopperLayers()) {
         if (pad->isOnLayer(*layer)) {
           auto it = items.insert(items.end(),
@@ -352,12 +354,12 @@ void BoardDesignRuleCheck::checkCopperCopperClearances(int progressEnd) {
                                       nullptr,
                                       layer,
                                       pad->getCompSigInstNetSignal(),
-                                      *clearance,
+                                      *padClearance,
                                       {},
                                       {}});
           gen.addPad(*pad, transform, *layer);
           gen.takePathsTo(it->copperArea);
-          gen.addPad(*pad, transform, *layer, clearance - tolerance);
+          gen.addPad(*pad, transform, *layer, padClearance - tolerance);
           gen.takePathsTo(it->clearanceArea);
         }
       }

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
@@ -374,7 +374,7 @@ DrcMsgCopperCopperClearanceViolation::DrcMsgCopperCopperClearanceViolation(
     const Layer* layer1, const NetSignal* net1, const BI_Base& item1,
     const Polygon* polygon1, const Circle* circle1, const Layer* layer2,
     const NetSignal* net2, const BI_Base& item2, const Polygon* polygon2,
-    const Circle* circle2, const UnsignedLength& minClearance,
+    const Circle* circle2, const Length& minClearance,
     const QVector<Path>& locations)
   : RuleCheckMessage(
         Severity::Error,
@@ -384,7 +384,7 @@ DrcMsgCopperCopperClearanceViolation::DrcMsgCopperCopperClearanceViolation(
             .arg(getLayerName(layer1, layer2),
                  getObjectName(net1, item1, polygon1, circle1),
                  getObjectName(net2, item2, polygon2, circle2),
-                 minClearance->toMmString(), "mm"),
+                 minClearance.toMmString(), "mm"),
         tr("The clearance between two copper objects of different nets is "
            "smaller than the minimum copper clearance configured in the DRC "
            "settings.") %
@@ -426,9 +426,11 @@ QString DrcMsgCopperCopperClearanceViolation::getObjectName(
   }
   if (const BI_FootprintPad* pad =
           dynamic_cast<const BI_FootprintPad*>(&item)) {
-    name = QString("'%1:%2'").arg(
-        *pad->getDevice().getComponentInstance().getName(),
-        *pad->getLibPackagePad()->getName());
+    name = "'" % (*pad->getDevice().getComponentInstance().getName());
+    if (const PackagePad* pkgPad = pad->getLibPackagePad()) {
+      name += ":" % *pkgPad->getName();
+    }
+    name += "'";
   } else if (dynamic_cast<const BI_Via*>(&item)) {
     name += tr("via");
   } else if (dynamic_cast<const BI_NetLine*>(&item)) {

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
@@ -282,7 +282,7 @@ public:
       const Layer* layer1, const NetSignal* net1, const BI_Base& item1,
       const Polygon* polygon1, const Circle* circle1, const Layer* layer2,
       const NetSignal* net2, const BI_Base& item2, const Polygon* polygon2,
-      const Circle* circle2, const UnsignedLength& minClearance,
+      const Circle* circle2, const Length& minClearance,
       const QVector<Path>& locations);
   DrcMsgCopperCopperClearanceViolation(
       const DrcMsgCopperCopperClearanceViolation& other) noexcept

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -69,6 +69,7 @@ void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   for (SExpression* fptNode : root.getChildren("footprint")) {
     for (SExpression* padNode : fptNode->getChildren("pad")) {
       padNode->appendChild("function", SExpression::createToken("unspecified"));
+      padNode->appendChild("clearance", SExpression::createToken("0.0"));
     }
   }
   dir.write(fp, root.toByteArray());

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -163,6 +163,9 @@ void FileFormatMigrationV01::upgradePackage(TransactionalDirectory& dir) {
         // Add function.
         padNode->appendChild("function",
                              SExpression::createToken("unspecified"));
+
+        // Add copper clearance.
+        padNode->appendChild("clearance", SExpression::createToken("0.0"));
       }
 
       // Holes.

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -427,6 +427,7 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           Path(),  // Custom shape outline
           MaskConfig::automatic(),  // Stop mask
           MaskConfig::off(),  // Solder paste
+          UnsignedLength(0),  // Copper clearance
           FootprintPad::ComponentSide::Top,  // Side
           FootprintPad::Function::Unspecified,  // Function
           PadHoleList{std::make_shared<PadHole>(
@@ -465,6 +466,7 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad> >
           Path(),  // Custom shape outline
           MaskConfig::automatic(),  // Stop mask
           MaskConfig::automatic(),  // Solder paste
+          UnsignedLength(0),  // Copper clearance
           side,  // Side
           FootprintPad::Function::Unspecified,  // Function
           PadHoleList{}  // Holes

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
@@ -37,6 +37,7 @@ namespace librepcb {
 
 class Angle;
 class Layer;
+class Length;
 class PadGeometry;
 class Point;
 
@@ -69,8 +70,8 @@ public:
   void setRotation(const Angle& rotation) noexcept;
   void setText(const QString& text) noexcept;
   void setLayer(const QString& layerName) noexcept;
-  void setGeometries(
-      const QHash<const Layer*, QList<PadGeometry>>& geometries) noexcept;
+  void setGeometries(const QHash<const Layer*, QList<PadGeometry>>& geometries,
+                     const Length& clearance) noexcept;
 
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;
@@ -93,9 +94,13 @@ private:  // Data
   std::shared_ptr<GraphicsLayer> mCopperLayer;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
   QScopedPointer<PrimitiveTextGraphicsItem> mTextGraphicsItem;
-  QVector<std::tuple<std::shared_ptr<GraphicsLayer>, bool,
-                     std::shared_ptr<PrimitivePathGraphicsItem>>>
-      mPathGraphicsItems;
+  struct PathItem {
+    std::shared_ptr<GraphicsLayer> layer;
+    bool isCopper;
+    bool isClearance;
+    std::shared_ptr<PrimitivePathGraphicsItem> item;
+  };
+  QVector<PathItem> mPathGraphicsItems;
   QMap<std::shared_ptr<GraphicsLayer>, QPainterPath> mShapes;
   QRectF mShapesBoundingRect;
 

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.cpp
@@ -37,32 +37,8 @@ namespace editor {
 CmdFootprintPadEdit::CmdFootprintPadEdit(FootprintPad& pad) noexcept
   : UndoCommand(tr("Edit footprint pad")),
     mPad(pad),
-    mOldPackagePadUuid(pad.getPackagePadUuid()),
-    mNewPackagePadUuid(mOldPackagePadUuid),
-    mOldComponentSide(pad.getComponentSide()),
-    mNewComponentSide(mOldComponentSide),
-    mOldFunction(pad.getFunction()),
-    mNewFunction(mOldFunction),
-    mOldShape(pad.getShape()),
-    mNewShape(mOldShape),
-    mOldWidth(pad.getWidth()),
-    mNewWidth(mOldWidth),
-    mOldHeight(pad.getHeight()),
-    mNewHeight(mOldHeight),
-    mOldRadius(pad.getRadius()),
-    mNewRadius(mOldRadius),
-    mOldCustomShapeOutline(pad.getCustomShapeOutline()),
-    mNewCustomShapeOutline(mOldCustomShapeOutline),
-    mOldStopMaskConfig(pad.getStopMaskConfig()),
-    mNewStopMaskConfig(mOldStopMaskConfig),
-    mOldSolderPasteConfig(pad.getSolderPasteConfig()),
-    mNewSolderPasteConfig(mOldSolderPasteConfig),
-    mOldPos(pad.getPosition()),
-    mNewPos(mOldPos),
-    mOldRotation(pad.getRotation()),
-    mNewRotation(mOldRotation),
-    mOldHoles(pad.getHoles()),
-    mNewHoles(mOldHoles) {
+    mOldProperties(mPad),
+    mNewProperties(mOldProperties) {
 }
 
 CmdFootprintPadEdit::~CmdFootprintPadEdit() noexcept {
@@ -82,104 +58,112 @@ CmdFootprintPadEdit::~CmdFootprintPadEdit() noexcept {
 void CmdFootprintPadEdit::setPackagePadUuid(const tl::optional<Uuid>& pad,
                                             bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewPackagePadUuid = pad;
-  if (immediate) mPad.setPackagePadUuid(mNewPackagePadUuid);
+  mNewProperties.setPackagePadUuid(pad);
+  if (immediate) mPad.setPackagePadUuid(pad);
 }
 
 void CmdFootprintPadEdit::setComponentSide(FootprintPad::ComponentSide side,
                                            bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewComponentSide = side;
-  if (immediate) mPad.setComponentSide(mNewComponentSide);
+  mNewProperties.setComponentSide(side);
+  if (immediate) mPad.setComponentSide(side);
 }
 
 void CmdFootprintPadEdit::setFunction(FootprintPad::Function function,
                                       bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewFunction = function;
-  if (immediate) mPad.setFunction(mNewFunction);
+  mNewProperties.setFunction(function);
+  if (immediate) mPad.setFunction(function);
 }
 
 void CmdFootprintPadEdit::setShape(FootprintPad::Shape shape,
                                    bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewShape = shape;
-  if (immediate) mPad.setShape(mNewShape);
+  mNewProperties.setShape(shape);
+  if (immediate) mPad.setShape(shape);
 }
 
 void CmdFootprintPadEdit::setWidth(const PositiveLength& width,
                                    bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewWidth = width;
-  if (immediate) mPad.setWidth(mNewWidth);
+  mNewProperties.setWidth(width);
+  if (immediate) mPad.setWidth(width);
 }
 
 void CmdFootprintPadEdit::setHeight(const PositiveLength& height,
                                     bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewHeight = height;
-  if (immediate) mPad.setHeight(mNewHeight);
+  mNewProperties.setHeight(height);
+  if (immediate) mPad.setHeight(height);
 }
 
 void CmdFootprintPadEdit::setRadius(const UnsignedLimitedRatio& radius,
                                     bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewRadius = radius;
-  if (immediate) mPad.setRadius(mNewRadius);
+  mNewProperties.setRadius(radius);
+  if (immediate) mPad.setRadius(radius);
 }
 
 void CmdFootprintPadEdit::setCustomShapeOutline(const Path& outline) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewCustomShapeOutline = outline;
+  mNewProperties.setCustomShapeOutline(outline);
 }
 
 void CmdFootprintPadEdit::setStopMaskConfig(const MaskConfig& config,
                                             bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewStopMaskConfig = config;
-  if (immediate) mPad.setStopMaskConfig(mNewStopMaskConfig);
+  mNewProperties.setStopMaskConfig(config);
+  if (immediate) mPad.setStopMaskConfig(config);
 }
 
 void CmdFootprintPadEdit::setSolderPasteConfig(
     const MaskConfig& config) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewSolderPasteConfig = config;
+  mNewProperties.setSolderPasteConfig(config);
+}
+
+void CmdFootprintPadEdit::setCopperClearance(
+    const UnsignedLength& clearance) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewProperties.setCopperClearance(clearance);
 }
 
 void CmdFootprintPadEdit::setPosition(const Point& pos,
                                       bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewPos = pos;
-  if (immediate) mPad.setPosition(mNewPos);
+  mNewProperties.setPosition(pos);
+  if (immediate) mPad.setPosition(pos);
 }
 
 void CmdFootprintPadEdit::translate(const Point& deltaPos,
                                     bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewPos += deltaPos;
-  if (immediate) mPad.setPosition(mNewPos);
+  mNewProperties.setPosition(mNewProperties.getPosition() + deltaPos);
+  if (immediate) mPad.setPosition(mNewProperties.getPosition());
 }
 
 void CmdFootprintPadEdit::snapToGrid(const PositiveLength& gridInterval,
                                      bool immediate) noexcept {
-  setPosition(mNewPos.mappedToGrid(gridInterval), immediate);
+  setPosition(mNewProperties.getPosition().mappedToGrid(gridInterval),
+              immediate);
 }
 
 void CmdFootprintPadEdit::setRotation(const Angle& angle,
                                       bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewRotation = angle;
-  if (immediate) mPad.setRotation(mNewRotation);
+  mNewProperties.setRotation(angle);
+  if (immediate) mPad.setRotation(angle);
 }
 
 void CmdFootprintPadEdit::rotate(const Angle& angle, const Point& center,
                                  bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewPos.rotate(angle, center);
-  mNewRotation += angle;
+  mNewProperties.setPosition(
+      mNewProperties.getPosition().rotated(angle, center));
+  mNewProperties.setRotation(mNewProperties.getRotation() + angle);
   if (immediate) {
-    mPad.setPosition(mNewPos);
-    mPad.setRotation(mNewRotation);
+    mPad.setPosition(mNewProperties.getPosition());
+    mPad.setRotation(mNewProperties.getRotation());
   }
 }
 
@@ -187,35 +171,37 @@ void CmdFootprintPadEdit::mirrorGeometry(Qt::Orientation orientation,
                                          const Point& center,
                                          bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewPos.mirror(orientation, center);
+  mNewProperties.setPosition(
+      mNewProperties.getPosition().mirrored(orientation, center));
   if (orientation == Qt::Horizontal) {
-    mNewRotation = Angle::deg180() - mNewRotation;
+    mNewProperties.setRotation(Angle::deg180() - mNewProperties.getRotation());
   } else {
-    mNewRotation = -mNewRotation;
+    mNewProperties.setRotation(-mNewProperties.getRotation());
   }
-  mNewCustomShapeOutline.mirror(orientation);
+  mNewProperties.setCustomShapeOutline(
+      mNewProperties.getCustomShapeOutline().mirrored(orientation));
   if (immediate) {
-    mPad.setPosition(mNewPos);
-    mPad.setRotation(mNewRotation);
-    mPad.setCustomShapeOutline(mNewCustomShapeOutline);
+    mPad.setPosition(mNewProperties.getPosition());
+    mPad.setRotation(mNewProperties.getRotation());
+    mPad.setCustomShapeOutline(mNewProperties.getCustomShapeOutline());
   }
 }
 
 void CmdFootprintPadEdit::mirrorLayer(bool immediate) noexcept {
-  if (mNewComponentSide == FootprintPad::ComponentSide::Top) {
-    mNewComponentSide = FootprintPad::ComponentSide::Bottom;
+  if (mNewProperties.getComponentSide() == FootprintPad::ComponentSide::Top) {
+    mNewProperties.setComponentSide(FootprintPad::ComponentSide::Bottom);
   } else {
-    mNewComponentSide = FootprintPad::ComponentSide::Top;
+    mNewProperties.setComponentSide(FootprintPad::ComponentSide::Top);
   }
   if (immediate) {
-    mPad.setComponentSide(mNewComponentSide);
+    mPad.setComponentSide(mNewProperties.getComponentSide());
   }
 }
 
 void CmdFootprintPadEdit::setHoles(const PadHoleList& holes,
                                    bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewHoles = holes;
+  mNewProperties.getHoles() = holes;
   if (immediate) {
     mPad.getHoles() = holes;
   }
@@ -228,52 +214,16 @@ void CmdFootprintPadEdit::setHoles(const PadHoleList& holes,
 bool CmdFootprintPadEdit::performExecute() {
   performRedo();  // can throw
 
-  if (mNewPackagePadUuid != mOldPackagePadUuid) return true;
-  if (mNewComponentSide != mOldComponentSide) return true;
-  if (mNewFunction != mOldFunction) return true;
-  if (mNewShape != mOldShape) return true;
-  if (mNewWidth != mOldWidth) return true;
-  if (mNewHeight != mOldHeight) return true;
-  if (mNewRadius != mOldRadius) return true;
-  if (mNewCustomShapeOutline != mOldCustomShapeOutline) return true;
-  if (mNewStopMaskConfig != mOldStopMaskConfig) return true;
-  if (mNewSolderPasteConfig != mOldSolderPasteConfig) return true;
-  if (mNewPos != mOldPos) return true;
-  if (mNewRotation != mOldRotation) return true;
-  if (mNewHoles != mOldHoles) return true;
+  if (mNewProperties != mOldProperties) return true;
   return false;
 }
 
 void CmdFootprintPadEdit::performUndo() {
-  mPad.setPackagePadUuid(mOldPackagePadUuid);
-  mPad.setComponentSide(mOldComponentSide);
-  mPad.setFunction(mOldFunction);
-  mPad.setShape(mOldShape);
-  mPad.setWidth(mOldWidth);
-  mPad.setHeight(mOldHeight);
-  mPad.setRadius(mOldRadius);
-  mPad.setCustomShapeOutline(mOldCustomShapeOutline);
-  mPad.setStopMaskConfig(mOldStopMaskConfig);
-  mPad.setSolderPasteConfig(mOldSolderPasteConfig);
-  mPad.setPosition(mOldPos);
-  mPad.setRotation(mOldRotation);
-  mPad.getHoles() = mOldHoles;
+  mPad = mOldProperties;
 }
 
 void CmdFootprintPadEdit::performRedo() {
-  mPad.setPackagePadUuid(mNewPackagePadUuid);
-  mPad.setComponentSide(mNewComponentSide);
-  mPad.setFunction(mNewFunction);
-  mPad.setShape(mNewShape);
-  mPad.setWidth(mNewWidth);
-  mPad.setHeight(mNewHeight);
-  mPad.setRadius(mNewRadius);
-  mPad.setCustomShapeOutline(mNewCustomShapeOutline);
-  mPad.setStopMaskConfig(mNewStopMaskConfig);
-  mPad.setSolderPasteConfig(mNewSolderPasteConfig);
-  mPad.setPosition(mNewPos);
-  mPad.setRotation(mNewRotation);
-  mPad.getHoles() = mNewHoles;
+  mPad = mNewProperties;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdfootprintpadedit.h
@@ -66,6 +66,7 @@ public:
   void setCustomShapeOutline(const Path& outline) noexcept;
   void setStopMaskConfig(const MaskConfig& config, bool immediate) noexcept;
   void setSolderPasteConfig(const MaskConfig& config) noexcept;
+  void setCopperClearance(const UnsignedLength& clearance) noexcept;
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
@@ -97,32 +98,8 @@ private:
   FootprintPad& mPad;
 
   // General Attributes
-  tl::optional<Uuid> mOldPackagePadUuid;
-  tl::optional<Uuid> mNewPackagePadUuid;
-  FootprintPad::ComponentSide mOldComponentSide;
-  FootprintPad::ComponentSide mNewComponentSide;
-  FootprintPad::Function mOldFunction;
-  FootprintPad::Function mNewFunction;
-  FootprintPad::Shape mOldShape;
-  FootprintPad::Shape mNewShape;
-  PositiveLength mOldWidth;
-  PositiveLength mNewWidth;
-  PositiveLength mOldHeight;
-  PositiveLength mNewHeight;
-  UnsignedLimitedRatio mOldRadius;
-  UnsignedLimitedRatio mNewRadius;
-  Path mOldCustomShapeOutline;
-  Path mNewCustomShapeOutline;
-  MaskConfig mOldStopMaskConfig;
-  MaskConfig mNewStopMaskConfig;
-  MaskConfig mOldSolderPasteConfig;
-  MaskConfig mNewSolderPasteConfig;
-  Point mOldPos;
-  Point mNewPos;
-  Angle mOldRotation;
-  Angle mNewRotation;
-  PadHoleList mOldHoles;
-  PadHoleList mNewHoles;
+  FootprintPad mOldProperties;
+  FootprintPad mNewProperties;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastefootprintitems.cpp
@@ -103,8 +103,8 @@ bool CmdPasteFootprintItems::performExecute() {
         uuid, pkgPadUuid, pad.getPosition() + mPosOffset, pad.getRotation(),
         pad.getShape(), pad.getWidth(), pad.getHeight(), pad.getRadius(),
         pad.getCustomShapeOutline(), pad.getStopMaskConfig(),
-        pad.getSolderPasteConfig(), pad.getComponentSide(), pad.getFunction(),
-        pad.getHoles());
+        pad.getSolderPasteConfig(), pad.getCopperClearance(),
+        pad.getComponentSide(), pad.getFunction(), pad.getHoles());
     execNewChildCmd(new CmdFootprintPadInsert(mFootprint.getPads(), copy));
     if (auto graphicsItem = mGraphicsItem.getGraphicsItem(copy)) {
       graphicsItem->setSelected(true);

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -232,7 +232,8 @@ void NewElementWizardContext::copyElement(ElementType type,
               pad.getRotation(), pad.getShape(), pad.getWidth(),
               pad.getHeight(), pad.getRadius(), pad.getCustomShapeOutline(),
               pad.getStopMaskConfig(), pad.getSolderPasteConfig(),
-              pad.getComponentSide(), pad.getFunction(), pad.getHoles()));
+              pad.getCopperClearance(), pad.getComponentSide(),
+              pad.getFunction(), pad.getHoles()));
         }
         // copy polygons but generate new UUIDs
         for (const Polygon& polygon : footprint.getPolygons()) {

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -128,10 +128,9 @@ void FootprintPadGraphicsItem::padEdited(const FootprintPad& pad,
     case FootprintPad::Event::HeightChanged:
     case FootprintPad::Event::RadiusChanged:
     case FootprintPad::Event::CustomShapeOutlineChanged:
-      updateGeometries();
-      break;
     case FootprintPad::Event::StopMaskConfigChanged:
     case FootprintPad::Event::SolderPasteConfigChanged:
+    case FootprintPad::Event::CopperClearanceChanged:
       updateGeometries();
       break;
     case FootprintPad::Event::ComponentSideChanged:
@@ -195,7 +194,7 @@ void FootprintPadGraphicsItem::updateGeometries() noexcept {
     geometries.insert(&Layer::botSolderPaste(),
                       {geometry.withOffset(-solderPasteOffset)});
   }
-  mGraphicsItem->setGeometries(geometries);
+  mGraphicsItem->setGeometries(geometries, *mPad->getCopperClearance());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
@@ -64,6 +64,15 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   mUi->edtPosY->configure(lengthUnit, LengthEditBase::Steps::generic(),
                           settingsPrefix % "/pos_y");
   mUi->edtRotation->setSingleStep(90.0);  // [°]
+  mUi->edtStopMaskOffset->configure(lengthUnit,
+                                    LengthEditBase::Steps::generic(),
+                                    settingsPrefix % "/stop_mask_offset");
+  mUi->edtSolderPasteOffset->configure(lengthUnit,
+                                       LengthEditBase::Steps::generic(),
+                                       settingsPrefix % "/solder_paste_offset");
+  mUi->edtCopperClearance->configure(lengthUnit,
+                                     LengthEditBase::Steps::generic(),
+                                     settingsPrefix % "/copper_clearance");
   mUi->customShapePathEditor->setLengthUnit(lengthUnit);
   mUi->holeEditorWidget->configureClientSettings(
       lengthUnit, settingsPrefix % "/hole_editor");
@@ -235,6 +244,7 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   } else {
     mUi->rbtnSolderPasteAuto->setChecked(true);
   }
+  mUi->edtCopperClearance->setValue(mPad.getCopperClearance());
   updateGeneralTabHoleWidgets();
   setSelectedHole(0);
 
@@ -287,6 +297,7 @@ void FootprintPadPropertiesDialog::setReadOnly(bool readOnly) noexcept {
   mUi->rbtnSolderPasteAuto->setEnabled(!readOnly);
   mUi->rbtnSolderPasteManual->setEnabled(!readOnly);
   mUi->edtSolderPasteOffset->setReadOnly(readOnly);
+  mUi->edtCopperClearance->setReadOnly(readOnly);
   if (readOnly) {
     mUi->buttonBox->setStandardButtons(QDialogButtonBox::StandardButton::Close);
   } else {
@@ -496,6 +507,7 @@ bool FootprintPadPropertiesDialog::applyChanges() noexcept {
     } else {
       cmd->setSolderPasteConfig(MaskConfig::off());
     }
+    cmd->setCopperClearance(mUi->edtCopperClearance->getValue());
     cmd->setHoles(mHoles, false);
     cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),
                      false);

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.ui
@@ -453,9 +453,9 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabMasks">
+     <widget class="QWidget" name="tabClearances">
       <attribute name="title">
-       <string>Automatic Masks</string>
+       <string>Clearances</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_2">
        <item row="0" column="0">
@@ -608,6 +608,34 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_15">
+         <property name="text">
+          <string>Copper Keepout:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="librepcb::editor::UnsignedLengthEdit" name="edtCopperClearance" native="true"/>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="label_14">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Note: Intended to keep copper away from fiducials.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabCustomShape">
@@ -717,9 +745,9 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="btnGroupShape"/>
   <buttongroup name="btnGroupStopMask"/>
-  <buttongroup name="btnGroupComponentSide"/>
+  <buttongroup name="btnGroupShape"/>
   <buttongroup name="btnGroupSolderPaste"/>
+  <buttongroup name="btnGroupComponentSide"/>
  </buttongroups>
 </ui>

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
@@ -65,6 +65,7 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(
         Path(),  // Custom shape outline
         MaskConfig::automatic(),  // Stop mask
         MaskConfig::off(),  // Solder paste
+        UnsignedLength(0),  // Copper clearance
         FootprintPad::ComponentSide::Top,  // Default side
         function,  // Supplied by library editor
         PadHoleList{}) {
@@ -99,7 +100,9 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(
         mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent100()));
         mLastPad.setWidth(PositiveLength(1000000));
         mLastPad.setHeight(PositiveLength(1000000));
-        mLastPad.setStopMaskConfig(MaskConfig::manual(500000));
+        mLastPad.setCopperClearance(UnsignedLength(500000));
+        mLastPad.setStopMaskConfig(
+            MaskConfig::manual(*mLastPad.getCopperClearance()));
         mLastPad.setSolderPasteConfig(MaskConfig::off());
         break;
       default:
@@ -430,8 +433,8 @@ bool PackageEditorState_AddPads::startAddPad(const Point& pos) noexcept {
         mLastPad.getPosition(), mLastPad.getRotation(), mLastPad.getShape(),
         mLastPad.getWidth(), mLastPad.getHeight(), mLastPad.getRadius(),
         mLastPad.getCustomShapeOutline(), mLastPad.getStopMaskConfig(),
-        mLastPad.getSolderPasteConfig(), mLastPad.getComponentSide(),
-        mLastPad.getFunction(), PadHoleList{});
+        mLastPad.getSolderPasteConfig(), mLastPad.getCopperClearance(),
+        mLastPad.getComponentSide(), mLastPad.getFunction(), PadHoleList{});
     for (const PadHole& hole : mLastPad.getHoles()) {
       mCurrentPad->getHoles().append(std::make_shared<PadHole>(
           Uuid::createRandom(), hole.getDiameter(), hole.getPath()));

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.cpp
@@ -61,7 +61,8 @@ BGI_FootprintPad::BGI_FootprintPad(BI_FootprintPad& pad,
   setPos(mPad.getPosition().toPxQPointF());
   mGraphicsItem->setRotation(mPad.getRotation());
   mGraphicsItem->setText(mPad.getText());
-  mGraphicsItem->setGeometries(mPad.getGeometries());
+  mGraphicsItem->setGeometries(mPad.getGeometries(),
+                               *mPad.getLibPad().getCopperClearance());
   updateLayer();
 
   mPad.onEdited.attach(mOnPadEditedSlot);
@@ -111,7 +112,8 @@ void BGI_FootprintPad::padEdited(const BI_FootprintPad& obj,
       mGraphicsItem->setText(obj.getText());
       break;
     case BI_FootprintPad::Event::GeometriesChanged:
-      mGraphicsItem->setGeometries(obj.getGeometries());
+      mGraphicsItem->setGeometries(obj.getGeometries(),
+                                   *obj.getLibPad().getCopperClearance());
       break;
     default:
       qWarning() << "Unhandled switch-case in BGI_FootprintPad::padEdited():"

--- a/tests/unittests/core/library/pkg/footprintpadtest.cpp
+++ b/tests/unittests/core/library/pkg/footprintpadtest.cpp
@@ -46,7 +46,8 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
   SExpression sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape roundrect)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
-      " (stop_mask auto) (solder_paste 0.25) (function unspecified)\n"
+      " (stop_mask auto) (solder_paste 0.25) (clearance 0.33)"
+      " (function unspecified)\n"
       " (package_pad d48b8bd2-a46c-4495-87a5-662747034098)\n"
       ")",
       FilePath());
@@ -63,6 +64,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
   EXPECT_EQ(UnsignedLimitedRatio(Ratio::percent50()), obj.getRadius());
   EXPECT_EQ(MaskConfig::automatic(), obj.getStopMaskConfig());
   EXPECT_EQ(MaskConfig::manual(Length(250000)), obj.getSolderPasteConfig());
+  EXPECT_EQ(UnsignedLength(330000), obj.getCopperClearance());
   EXPECT_EQ(FootprintPad::ComponentSide::Top, obj.getComponentSide());
   EXPECT_EQ(FootprintPad::Function::Unspecified, obj.getFunction());
   EXPECT_EQ(0, obj.getHoles().count());
@@ -72,7 +74,8 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   SExpression sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side bottom) (shape custom)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
-      " (stop_mask off) (solder_paste auto) (function standard)\n"
+      " (stop_mask off) (solder_paste auto) (clearance 0.33)"
+      " (function standard)\n"
       " (package_pad none)\n"
       " (vertex (position -1.1 -2.2) (angle 45.0))\n"
       " (vertex (position 1.1 -2.2) (angle 90.0))\n"
@@ -97,6 +100,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   EXPECT_EQ(UnsignedLimitedRatio(Ratio::percent50()), obj.getRadius());
   EXPECT_EQ(MaskConfig::off(), obj.getStopMaskConfig());
   EXPECT_EQ(MaskConfig::automatic(), obj.getSolderPasteConfig());
+  EXPECT_EQ(UnsignedLength(330000), obj.getCopperClearance());
   EXPECT_EQ(FootprintPad::ComponentSide::Bottom, obj.getComponentSide());
   EXPECT_EQ(FootprintPad::Function::StandardPad, obj.getFunction());
   EXPECT_EQ(3, obj.getCustomShapeOutline().getVertices().count());
@@ -110,7 +114,8 @@ TEST_F(FootprintPadTest, testSerializeAndDeserialize) {
       PositiveLength(456), UnsignedLimitedRatio(Ratio::percent50()),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
-      FootprintPad::ComponentSide::Top, FootprintPad::Function::Unspecified,
+      UnsignedLength(98765), FootprintPad::ComponentSide::Top,
+      FootprintPad::Function::Unspecified,
       PadHoleList{
           std::make_shared<PadHole>(Uuid::createRandom(),
                                     PositiveLength(100000),

--- a/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
@@ -88,7 +88,7 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       Uuid::createRandom(), packagePad1->getUuid(), Point(12, 34), Angle(56),
       FootprintPad::Shape::RoundedOctagon, PositiveLength(11),
       PositiveLength(22), UnsignedLimitedRatio(Ratio::percent50()), Path(),
-      MaskConfig::off(), MaskConfig::automatic(),
+      MaskConfig::off(), MaskConfig::automatic(), UnsignedLength(0),
       FootprintPad::ComponentSide::Bottom, FootprintPad::Function::Unspecified,
       PadHoleList{});
 
@@ -98,7 +98,8 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
       PositiveLength(456), UnsignedLimitedRatio(Ratio::percent100()),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
-      FootprintPad::ComponentSide::Top, FootprintPad::Function::TestPad,
+      UnsignedLength(123456), FootprintPad::ComponentSide::Top,
+      FootprintPad::Function::TestPad,
       PadHoleList{std::make_shared<PadHole>(Uuid::createRandom(),
                                             PositiveLength(789),
                                             makeNonEmptyPath(Point(0, 0)))});


### PR DESCRIPTION
### Summary

Adding a property 'copper clearance' to footprint pads to allow specifying a custom clearance value for particular pads. Intended mainly for fiducials to keep the area around their copper circle clear of copper. In particular, planes will keep this area clear and the DRC will warn if there are copper objects within it.

### User Interface

The clearance is visualized with a thin line around the copper area, and the value is configurable in the pad properties dialog:

![image](https://user-images.githubusercontent.com/5374821/229474027-49e3c019-cafd-4147-8165-2fd25cfacd59.png)

### File Format

New node `clearance`:

```
  (pad 474059df-640b-4b17-98b2-148e340a7152 (side top) (shape roundrect)
   (position 2.54 0.0) (rotation 90.0) (size 4.064 2.032) (radius 1.0)
   (stop_mask auto) (solder_paste off) (clearance 0.0) (function unspecified)
   (package_pad 474059df-640b-4b17-98b2-148e340a7152)
   (hole 474059df-640b-4b17-98b2-148e340a7152 (diameter 1.016)
    (vertex (position 0.0 0.0) (angle 0.0))
   )
  )
```

### Related Issues

Closes #1127

Based on #1142 (needs rebase)