### PR TITLE
MacOS: Register *.lpp file extension

### DIFF
--- a/apps/librepcb-cli/CMakeLists.txt
+++ b/apps/librepcb-cli/CMakeLists.txt
@@ -46,17 +46,8 @@ if(APPLE)
   # Set bundle properties (used for Info.plist)
   set_target_properties(
     librepcb_cli
-    PROPERTIES BUNDLE True
-               MACOSX_BUNDLE_GUI_IDENTIFIER org.librepcb.LibrePCB-CLI
-               MACOSX_BUNDLE_BUNDLE_NAME "LibrePCB CLI"
-               MACOSX_BUNDLE_BUNDLE_VERSION ${LIBREPCB_APP_VERSION}
-               MACOSX_BUNDLE_SHORT_VERSION_STRING ${LIBREPCB_APP_VERSION}
-               MACOSX_BUNDLE_ICON_FILE librepcb.icns
-               MACOSX_BUNDLE_INFO_STRING "LibrePCB command-line utility."
-               MACOSX_BUNDLE_COPYRIGHT
-               "© LibrePCB contributors, released under the GPLv3 license"
-               MACOSX_BUNDLE_INFO_PLIST
-               "${CMAKE_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in"
+    PROPERTIES BUNDLE True MACOSX_BUNDLE_INFO_PLIST
+                           "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
   )
 endif()
 

--- a/apps/librepcb-cli/Info.plist.in
+++ b/apps/librepcb-cli/Info.plist.in
@@ -6,30 +6,28 @@
     <string>English</string>
     <key>CFBundleExecutable</key>
     <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
-    <key>CFBundleGetInfoString</key>
-    <string>${MACOSX_BUNDLE_INFO_STRING}</string>
     <key>CFBundleIconFile</key>
-    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
+    <string>librepcb.icns</string>
     <key>CFBundleIdentifier</key>
-    <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+    <string>org.librepcb.LibrePCB-CLI</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleLongVersionString</key>
-    <string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+    <string>${LIBREPCB_APP_VERSION}</string>
     <key>CFBundleName</key>
-    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <string>LibrePCB CLI</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <string>${LIBREPCB_APP_VERSION}</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleVersion</key>
-    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <string>${LIBREPCB_APP_VERSION}</string>
     <key>CSResourcesFileMapped</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
-    <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+    <string>© LibrePCB contributors, released under the GPLv3 license</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>

--- a/apps/librepcb/CMakeLists.txt
+++ b/apps/librepcb/CMakeLists.txt
@@ -49,19 +49,8 @@ if(APPLE)
 
   # Set bundle properties
   set_target_properties(
-    librepcb
-    PROPERTIES BUNDLE True
-               MACOSX_BUNDLE_GUI_IDENTIFIER org.librepcb.LibrePCB
-               MACOSX_BUNDLE_BUNDLE_NAME LibrePCB
-               MACOSX_BUNDLE_BUNDLE_VERSION ${LIBREPCB_APP_VERSION}
-               MACOSX_BUNDLE_SHORT_VERSION_STRING ${LIBREPCB_APP_VERSION}
-               MACOSX_BUNDLE_ICON_FILE librepcb.icns
-               MACOSX_BUNDLE_INFO_STRING
-               "A new, powerful and intuitive EDA tool for everyone."
-               MACOSX_BUNDLE_COPYRIGHT
-               "© LibrePCB contributors, released under the GPLv3 license"
-               MACOSX_BUNDLE_INFO_PLIST
-               "${CMAKE_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in"
+    librepcb PROPERTIES BUNDLE True MACOSX_BUNDLE_INFO_PLIST
+                                    "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
   )
 endif()
 

--- a/apps/librepcb/Info.plist.in
+++ b/apps/librepcb/Info.plist.in
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+    <key>CFBundleIconFile</key>
+    <string>librepcb.icns</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.librepcb.LibrePCB</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleLongVersionString</key>
+    <string>${LIBREPCB_APP_VERSION}</string>
+    <key>CFBundleName</key>
+    <string>LibrePCB</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${LIBREPCB_APP_VERSION}</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>${LIBREPCB_APP_VERSION}</string>
+    <key>CSResourcesFileMapped</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>© LibrePCB contributors, released under the GPLv3 license</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <string>True</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>lpp</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>LibrePCB Project</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>librepcb.icns</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -4,20 +4,22 @@
 set -euv -o pipefail
 
 # replace "bin" and "share" directories with the single *.app directory
-mv "./build/install/opt/bin/librepcb.app" "./build/install/opt/librepcb.app"
-cp -r "./build/install/opt/share" "./build/install/opt/librepcb.app/Contents/"
-mv "./build/install/opt/bin/librepcb-cli.app" "./build/install/opt/librepcb-cli.app"
-cp -r "./build/install/opt/share" "./build/install/opt/librepcb-cli.app/Contents/"
+mv "./build/install/opt/bin/librepcb.app" "./build/install/opt/LibrePCB.app"
+cp -r "./build/install/opt/share" "./build/install/opt/LibrePCB.app/Contents/"
+mv "./build/install/opt/bin/librepcb-cli.app" "./build/install/opt/LibrePCB-CLI.app"
+cp -r "./build/install/opt/share" "./build/install/opt/LibrePCB-CLI.app/Contents/"
 rm -r "./build/install/opt/bin" "./build/install/opt/share"
 
-# Build LibrePCB bundle
-macdeployqt "./build/install/opt/librepcb.app" -dmg
-mv ./build/install/opt/librepcb.dmg ./librepcb.dmg
+# Build bundles
+pushd "./build/install/opt/"  # Avoid having path in DMG name
+macdeployqt "LibrePCB.app" -dmg
+macdeployqt "LibrePCB-CLI.app" -dmg
+popd
 
-# Build LibrePCB CLI bundle
-macdeployqt "./build/install/opt/librepcb-cli.app" -dmg
-mv ./build/install/opt/librepcb-cli.dmg ./librepcb-cli.dmg
+# Restore lowercase app names for backwards compatibility with installers
+mv "./build/install/opt/LibrePCB.app" "./build/install/opt/librepcb.app"
+mv "./build/install/opt/LibrePCB-CLI.app" "./build/install/opt/librepcb-cli.app"
 
-# Copy bundles to artifacts directory
-cp ./librepcb.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
-cp ./librepcb-cli.dmg ./artifacts/nightly_builds/librepcb-cli-nightly-mac-x86_64.dmg
+# Move bundles to artifacts directory
+mv ./build/install/opt/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
+mv ./build/install/opt/LibrePCB-CLI.dmg ./artifacts/nightly_builds/librepcb-cli-nightly-mac-x86_64.dmg

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -63,36 +63,32 @@ class ControlPanel;
 class ControlPanel final : public QMainWindow {
   Q_OBJECT
 
-  friend
-
-      class ProjectLibraryUpdater;
-
-  // needs access to openProject() and
-  // getOpenProject()
+  // ProjectLibraryUpdater needs access to openProject() and getOpenProject()
+  friend class ProjectLibraryUpdater;
 
 public:
   // Constructors / Destructor
   ControlPanel() = delete;
   ControlPanel(const ControlPanel& other) = delete;
   explicit ControlPanel(Workspace& workspace, bool fileFormatIsOutdated);
-  ~ControlPanel();
+  virtual ~ControlPanel() noexcept;
 
   // Operator Overloadings
   ControlPanel& operator=(const ControlPanel& rhs) = delete;
 
 public slots:
-
   void showControlPanel() noexcept;
   void openProjectLibraryUpdater(const FilePath& project) noexcept;
 
 protected:
   // Inherited Methods
-  virtual void closeEvent(QCloseEvent* event);
+  virtual void closeEvent(QCloseEvent* event) override;
+  virtual bool eventFilter(QObject* watched, QEvent* event) override;
 
 private slots:
-
   // private slots
   void openProjectsPassedByCommandLine() noexcept;
+  void openProjectPassedByOs(const QString& file) noexcept;
   void projectEditorClosed() noexcept;
 
   // Actions


### PR DESCRIPTION
This associates the *.lpp file extension on macOS with LibrePCB, done by adding the corresponding entries to the `Info.plist` file. Since this is not needed for the CLI, there are now two different `Info.plist` files.

Also fixed the ugly names of the mounted DMG volume and the application shortcut, now they are displayed as "LibrePCB".

Tested on macOS 11.7, seems to work fine so far. Unfortunately I needed to use the deprecated key `CFBundleTypeExtensions` because I was not able to get it working with the newer key `LSItemContentTypes` :-/

See also the related issue #1058.