### PR TITLE
Linux: Support translating desktop entry comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,8 @@ endif()
 
 # Clang emits some warnings within the muParser library when compiling with
 # -Wpedantic, so let's suppress these warnings when compiling with Clang.
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-target_compile_options(common INTERFACE -Wno-nested-anon-types)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(common INTERFACE -Wno-nested-anon-types)
 endif()
 
 # Find required Qt packages
@@ -202,6 +202,10 @@ foreach(d ${SHARE_DIRS})
     )
   endif()
 endforeach()
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/i18n/share/
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR} OPTIONAL
+)
 install(
   DIRECTORY ${CMAKE_BINARY_DIR}/i18n
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/librepcb

--- a/share/applications/org.librepcb.LibrePCB.desktop
+++ b/share/applications/org.librepcb.LibrePCB.desktop
@@ -1,7 +1,6 @@
 [Desktop Entry]
 Name=LibrePCB
 Comment=Design Schematics and PCBs
-Comment[de]=Entwerfen eines Schaltplans oder einer Platine
 GenericName=PCB Designer
 Categories=Development;Engineering;Electronics;
 Type=Application


### PR DESCRIPTION
The `*.desktop` file to integrate LibrePCB into Linux desktop environments contains a comment string which is intended to be translated into multiple languages, but there was only a single translation hardcoded so far. I extended our i18n automation script to also push the string from the `*.desktop` file to Transifex to allow translating it by translators. The translated file will then show up within the `i18n` directory. This PR makes sure this file (if it exists) gets installed with `make install`.