### PR TITLE
Rename attributes 'MODIFIED_DATE/TIME' to 'DATE/TIME'

### DIFF
--- a/libs/librepcb/core/project/project.cpp
+++ b/libs/librepcb/core/project/project.cpp
@@ -58,7 +58,7 @@ Project::Project(std::unique_ptr<TransactionalDirectory> directory,
     mAuthor(),
     mVersion(),
     mCreated(QDateTime::currentDateTime()),
-    mLastModified(QDateTime::currentDateTime()),
+    mDateTime(QDateTime::currentDateTime()),
     mLocaleOrder(),
     mNormOrder(),
     mCustomBomAttributes(),
@@ -145,8 +145,8 @@ void Project::setCreated(const QDateTime& newCreated) noexcept {
   }
 }
 
-void Project::updateLastModified() noexcept {
-  mLastModified = QDateTime::currentDateTime();
+void Project::updateDateTime() noexcept {
+  mDateTime = QDateTime::currentDateTime();
   emit attributesChanged();
 }
 
@@ -473,8 +473,8 @@ void Project::save() {
     mDirectory->write("boards/boards.lp", root.toByteArray());
   }
 
-  // Update the "last modified datetime" attribute of the project.
-  updateLastModified();
+  // Update the datetime attribute of the project.
+  updateDateTime();
 }
 
 /*******************************************************************************
@@ -505,10 +505,10 @@ QString Project::getBuiltInAttributeValue(const QString& key) const noexcept {
     return mCreated.date().toString(Qt::ISODate);
   } else if (key == QLatin1String("CREATED_TIME")) {
     return mCreated.time().toString(Qt::ISODate);
-  } else if (key == QLatin1String("MODIFIED_DATE")) {
-    return mLastModified.date().toString(Qt::ISODate);
-  } else if (key == QLatin1String("MODIFIED_TIME")) {
-    return mLastModified.time().toString(Qt::ISODate);
+  } else if (key == QLatin1String("DATE")) {
+    return mDateTime.date().toString(Qt::ISODate);
+  } else if (key == QLatin1String("TIME")) {
+    return mDateTime.time().toString(Qt::ISODate);
   } else if (key == QLatin1String("AUTHOR")) {
     return mAuthor;
   } else if (key == QLatin1String("VERSION")) {

--- a/libs/librepcb/core/project/project.h
+++ b/libs/librepcb/core/project/project.h
@@ -159,14 +159,11 @@ public:
   const QDateTime& getCreated() const noexcept { return mCreated; }
 
   /**
-   * @brief Get the date and time when the project was last modified
+   * @brief Get the date and time when the project was opened or saved
    *
-   * @return The local date and time of last modification
-   *
-   * @todo    Dynamically determine the datetime of the last modification from
-   *          version control system, file attributes or something like that.
+   * @return The local date and time
    */
-  const QDateTime& getLastModified() const noexcept { return mLastModified; }
+  const QDateTime& getDateTime() const noexcept { return mDateTime; }
 
   /**
    * @brief Get the list of attributes
@@ -272,7 +269,7 @@ public:
   /**
    * @brief Update the last modified date/time
    */
-  void updateLastModified() noexcept;
+  void updateDateTime() noexcept;
 
   /**
    * @brief Set all project attributes
@@ -560,8 +557,8 @@ private:  // Data
   /// Date/time of project creation.
   QDateTime mCreated;
 
-  /// Date/time of last modification.
-  QDateTime mLastModified;
+  /// Date/time of opening or saving the project.
+  QDateTime mDateTime;
 
   /// User-defined attributes in the specified order.
   AttributeList mAttributes;

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -61,19 +61,35 @@ void FileFormatMigrationUnstable::upgradePackageCategory(
 
 void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+  const QString fp = "symbol.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  upgradeStrings(root);
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+  const QString fp = "package.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  upgradeStrings(root);
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(
     TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+  const QString fp = "component.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  upgradeStrings(root);
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeDevice(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+  const QString fp = "device.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  upgradeStrings(root);
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeLibrary(TransactionalDirectory& dir) {
@@ -91,6 +107,12 @@ void FileFormatMigrationUnstable::upgradeWorkspaceData(
 
 void FileFormatMigrationUnstable::upgradeSettings(SExpression& root) {
   Q_UNUSED(root);
+  upgradeStrings(root);
+}
+
+void FileFormatMigrationUnstable::upgradeCircuit(SExpression& root) {
+  Q_UNUSED(root);
+  upgradeStrings(root);
 }
 
 void FileFormatMigrationUnstable::upgradeErc(SExpression& root,
@@ -103,41 +125,18 @@ void FileFormatMigrationUnstable::upgradeSchematic(SExpression& root,
                                                    ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
+  upgradeStrings(root);
 }
 
 void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  for (SExpression* devNode : root.getChildren("device")) {
-    devNode->appendChild("lock", SExpression::createToken("false"));
-    for (SExpression* txtNode : devNode->getChildren("stroke_text")) {
-      txtNode->appendChild("lock", SExpression::createToken("false"));
-    }
-  }
-  for (SExpression* polyNode : root.getChildren("polygon")) {
-    polyNode->appendChild("lock", SExpression::createToken("false"));
-  }
-  for (SExpression* txtNode : root.getChildren("stroke_text")) {
-    txtNode->appendChild("lock", SExpression::createToken("false"));
-  }
-  for (SExpression* planeNode : root.getChildren("plane")) {
-    planeNode->appendChild("lock", SExpression::createToken("false"));
-  }
-  upgradeHoles(root, true);
+  upgradeStrings(root);
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {
   Q_UNUSED(root);
-}
-
-void FileFormatMigrationUnstable::upgradeHoles(SExpression& node,
-                                               bool isBoardHole) {
-  for (SExpression* holeNode : node.getChildren("hole")) {
-    if (isBoardHole) {
-      holeNode->appendChild("lock", SExpression::createToken("false"));
-    }
-  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.h
@@ -73,13 +73,13 @@ public:
 
 private:  // Methods
   virtual void upgradeSettings(SExpression& root) override;
+  virtual void upgradeCircuit(SExpression& root) override;
   virtual void upgradeErc(SExpression& root, ProjectContext& context) override;
   virtual void upgradeSchematic(SExpression& root,
                                 ProjectContext& context) override;
   virtual void upgradeBoard(SExpression& root,
                             ProjectContext& context) override;
   virtual void upgradeBoardUserSettings(SExpression& root) override;
-  virtual void upgradeHoles(SExpression& node, bool isBoardHole) override;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -119,6 +119,7 @@ public:
 
 protected:  // Methods
   virtual void upgradeSettings(SExpression& root);
+  virtual void upgradeCircuit(SExpression& root);
   virtual void upgradeErc(SExpression& root, ProjectContext& context);
   virtual void upgradeSchematic(SExpression& root, ProjectContext& context);
   virtual void upgradeBoard(SExpression& root, ProjectContext& context);
@@ -128,6 +129,9 @@ protected:  // Methods
   virtual void upgradeGrid(SExpression& node);
   virtual void upgradeHoles(SExpression& node, bool isBoardHole);
   virtual void upgradeLayers(SExpression& node);
+  virtual void upgradeStrings(SExpression& root);
+  virtual void replaceStrings(SExpression& root,
+                              const QMap<QString, QString>& replacements);
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/sexpression.cpp
+++ b/libs/librepcb/core/serialization/sexpression.cpp
@@ -176,6 +176,14 @@ void SExpression::setName(const QString& name) {
   }
 }
 
+void SExpression::setValue(const QString& value) {
+  if ((mType == Type::String) || (mType == Type::Token)) {
+    mValue = value;
+  } else {
+    throw LogicError(__FILE__, __LINE__);
+  }
+}
+
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/

--- a/libs/librepcb/core/serialization/sexpression.h
+++ b/libs/librepcb/core/serialization/sexpression.h
@@ -158,6 +158,7 @@ public:
 
   // Setters
   void setName(const QString& name);
+  void setValue(const QString& value);
 
   // General Methods
   void ensureLineBreak();

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.cpp
@@ -102,7 +102,8 @@ bool PackageEditorState_DrawTextBase::entry() noexcept {
     textComboBox->addItem("{{PROJECT}}");
     textComboBox->addItem("{{AUTHOR}}");
     textComboBox->addItem("{{VERSION}}");
-    textComboBox->addItem("{{MODIFIED_DATE}}");
+    textComboBox->addItem("{{DATE}}");
+    textComboBox->addItem("{{TIME}}");
     int currentTextIndex = textComboBox->findText(mLastText);
     if (currentTextIndex >= 0) {
       textComboBox->setCurrentIndex(currentTextIndex);

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.cpp
@@ -97,7 +97,8 @@ bool SymbolEditorState_DrawTextBase::entry() noexcept {
     textComboBox->addItem("{{VALUE}}");
     textComboBox->addItem("{{SHEET}}");
     textComboBox->addItem("{{PROJECT}}");
-    textComboBox->addItem("{{MODIFIED_DATE}}");
+    textComboBox->addItem("{{DATE}}");
+    textComboBox->addItem("{{TIME}}");
     textComboBox->addItem("{{AUTHOR}}");
     textComboBox->addItem("{{VERSION}}");
     textComboBox->addItem("{{PAGE_X_OF_Y}}");

--- a/libs/librepcb/editor/project/projectsetupdialog.cpp
+++ b/libs/librepcb/editor/project/projectsetupdialog.cpp
@@ -212,8 +212,6 @@ void ProjectSetupDialog::load() noexcept {
   mUi->edtProjectVersion->setText(mProject.getVersion());
   mUi->lblProjectCreated->setText(
       mProject.getCreated().toString(Qt::DefaultLocaleLongDate));
-  mUi->lblProjectLastModified->setText(
-      mProject.getLastModified().toString(Qt::DefaultLocaleLongDate));
 
   // Tab: Locales & Norms
   mUi->lstLocaleOrder->clear();

--- a/libs/librepcb/editor/project/projectsetupdialog.ui
+++ b/libs/librepcb/editor/project/projectsetupdialog.ui
@@ -72,20 +72,6 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_32">
-         <property name="text">
-          <string>Last Modified:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="lblProjectLastModified">
-         <property name="text">
-          <string notr="true">TextLabel</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabAttributes">

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addtext.cpp
@@ -108,7 +108,8 @@ bool SchematicEditorState_AddText::entry() noexcept {
   textComboBox->addItem("{{PROJECT}}");
   textComboBox->addItem("{{AUTHOR}}");
   textComboBox->addItem("{{VERSION}}");
-  textComboBox->addItem("{{MODIFIED_DATE}}");
+  textComboBox->addItem("{{DATE}}");
+  textComboBox->addItem("{{TIME}}");
   textComboBox->setCurrentIndex(
       textComboBox->findText(mLastTextProperties.getText()));
   textComboBox->setCurrentText(mLastTextProperties.getText());

--- a/tests/unittests/core/project/projecttest.cpp
+++ b/tests/unittests/core/project/projecttest.cpp
@@ -77,7 +77,7 @@ TEST_F(ProjectTest, testCreateCloseOpen) {
   EXPECT_NEAR(datetime.toMSecsSinceEpoch(),
               project->getCreated().toMSecsSinceEpoch(), 5000);
   EXPECT_NEAR(datetime.toMSecsSinceEpoch(),
-              project->getLastModified().toMSecsSinceEpoch(), 5000);
+              project->getDateTime().toMSecsSinceEpoch(), 5000);
   EXPECT_EQ(0, project->getSchematics().count());
   EXPECT_EQ(0, project->getBoards().count());
 
@@ -107,7 +107,7 @@ TEST_F(ProjectTest, testCreateCloseOpen) {
   EXPECT_NEAR(datetime.toMSecsSinceEpoch(),
               project->getCreated().toMSecsSinceEpoch(), 5000);
   EXPECT_NEAR(datetime.toMSecsSinceEpoch(),
-              project->getLastModified().toMSecsSinceEpoch(), 5000);
+              project->getDateTime().toMSecsSinceEpoch(), 5000);
   EXPECT_EQ(0, project->getSchematics().count());
   EXPECT_EQ(0, project->getBoards().count());
 }
@@ -140,21 +140,20 @@ TEST_F(ProjectTest, testSave) {
   }
 }
 
-TEST_F(ProjectTest, testIfLastModifiedDateTimeIsUpdatedOnSave) {
+TEST_F(ProjectTest, testIfDateTimeIsUpdatedOnSave) {
   // create new project
   std::unique_ptr<Project> project =
       Project::create(createDir(), mProjectFile.getFilename());
-  qint64 datetimeAfterCreating = project->getLastModified().toMSecsSinceEpoch();
+  qint64 datetimeAfterCreating = project->getDateTime().toMSecsSinceEpoch();
 
   // check if datetime has not changed
   QThread::msleep(1000);
-  EXPECT_EQ(datetimeAfterCreating,
-            project->getLastModified().toMSecsSinceEpoch());
+  EXPECT_EQ(datetimeAfterCreating, project->getDateTime().toMSecsSinceEpoch());
 
   // save project and verify that datetime has changed
   QThread::msleep(1000);
   project->save();
-  qint64 datetimeAfterSaving = project->getLastModified().toMSecsSinceEpoch();
+  qint64 datetimeAfterSaving = project->getDateTime().toMSecsSinceEpoch();
   EXPECT_NEAR(QDateTime::currentMSecsSinceEpoch(), datetimeAfterSaving,
               1000);  // +/- 1s
   EXPECT_NE(datetimeAfterCreating, datetimeAfterSaving);


### PR DESCRIPTION
Renaming attribute `MODIFIED_DATE` to `DATE` and `MODIFIED_TIME` to `TIME` to fix the misleading name. See details in #1130.

Any of these strings within symbol/schematic texts or component attributes will be replaced accordingly during the file format upgrade procedure, thus no user interaction is needed.

Closes #1130.