### PR TITLE
Change transformation order of mirror and rotate

### DIFF
--- a/libs/librepcb/core/export/graphicspainter.cpp
+++ b/libs/librepcb/core/export/graphicspainter.cpp
@@ -123,8 +123,7 @@ void GraphicsPainter::drawText(const Point& position, const Angle& rotation,
     return;  // Nothing to draw.
   }
 
-  const bool rotate180 =
-      autoRotate && Toolbox::isTextUpsideDown(rotation, false);
+  const bool rotate180 = autoRotate && Toolbox::isTextUpsideDown(rotation);
   Alignment align = rotate180 ? alignment.mirrored() : alignment;
   if (mirrorInPlace) {
     align.mirrorH();
@@ -204,7 +203,7 @@ void GraphicsPainter::drawNetLabel(const Point& position, const Angle& rotation,
 
   const Alignment align(mirror ? HAlign::right() : HAlign::left(),
                         VAlign::bottom());
-  const bool rotate180 = Toolbox::isTextUpsideDown(rotation, false);
+  const bool rotate180 = Toolbox::isTextUpsideDown(rotation);
   const int flags =
       rotate180 ? align.mirrored().toQtAlign() : align.toQtAlign();
   const QFontMetricsF metrics(font);

--- a/libs/librepcb/core/font/stroketextpathbuilder.cpp
+++ b/libs/librepcb/core/font/stroketextpathbuilder.cpp
@@ -41,14 +41,13 @@ QVector<Path> StrokeTextPathBuilder::build(
     const StrokeFont& font, const StrokeTextSpacing& letterSpacing,
     const StrokeTextSpacing& lineSpacing, const PositiveLength& height,
     const UnsignedLength& strokeWidth, const Alignment& align,
-    const Angle& rotation, bool autoRotate, bool mirror,
-    const QString& text) noexcept {
+    const Angle& rotation, bool autoRotate, const QString& text) noexcept {
   Point bottomLeft, topRight;
   QVector<Path> paths = font.stroke(
       text, height, calcLetterSpacing(font, letterSpacing, height, strokeWidth),
       calcLineSpacing(font, lineSpacing, height, strokeWidth), align,
       bottomLeft, topRight);
-  if (autoRotate && Toolbox::isTextUpsideDown(rotation, mirror)) {
+  if (autoRotate && Toolbox::isTextUpsideDown(rotation)) {
     const Point center = (bottomLeft + topRight) / 2;
     for (Path& p : paths) {
       p.rotate(Angle::deg180(), center);

--- a/libs/librepcb/core/font/stroketextpathbuilder.h
+++ b/libs/librepcb/core/font/stroketextpathbuilder.h
@@ -60,8 +60,7 @@ public:
                              const PositiveLength& height,
                              const UnsignedLength& strokeWidth,
                              const Alignment& align, const Angle& rotation,
-                             bool autoRotate, bool mirror,
-                             const QString& text) noexcept;
+                             bool autoRotate, const QString& text) noexcept;
   static Length calcLetterSpacing(const StrokeFont& font,
                                   const StrokeTextSpacing& spacing,
                                   const PositiveLength& height,

--- a/libs/librepcb/core/geometry/stroketext.cpp
+++ b/libs/librepcb/core/geometry/stroketext.cpp
@@ -112,7 +112,7 @@ QVector<Path> StrokeText::generatePaths(const StrokeFont& font,
                                         const QString& text) const noexcept {
   return StrokeTextPathBuilder::build(font, mLetterSpacing, mLineSpacing,
                                       mHeight, mStrokeWidth, mAlign, mRotation,
-                                      mAutoRotate, mMirrored, text);
+                                      mAutoRotate, text);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/pkg/footprintpainter.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpainter.cpp
@@ -182,7 +182,7 @@ void FootprintPainter::initContentByColor() const noexcept {
                     false, false, path));
       }
 
-      Angle rotation = transform.map(Angle::deg0());
+      Angle rotation = transform.mapNonMirrorable(Angle::deg0());
       Alignment align =
           text.getMirrored() ? text.getAlign().mirroredV() : text.getAlign();
       Length totalHeight = *text.getHeight() + *text.getStrokeWidth();

--- a/libs/librepcb/core/library/sym/symbolpainter.cpp
+++ b/libs/librepcb/core/library/sym/symbolpainter.cpp
@@ -111,7 +111,7 @@ void SymbolPainter::paint(QPainter& painter,
         pin.getRotation() + pin.getNameRotation(), *pin.getNameHeight(),
         pin.getNameAlignment(), *pin.getName(), mDefaultFont,
         settings.getColor(Theme::Color::sSchematicPinNames), true, false);
-    const bool flipped = Toolbox::isTextUpsideDown(pin.getRotation(), false);
+    const bool flipped = Toolbox::isTextUpsideDown(pin.getRotation());
     p.drawText(pin.getPosition() +
                    pin.getNumbersPosition(flipped).rotated(pin.getRotation()),
                pin.getRotation(), *SymbolPin::getNumbersHeight(),

--- a/libs/librepcb/core/project/board/boardd356netlistexport.cpp
+++ b/libs/librepcb/core/project/board/boardd356netlistexport.cpp
@@ -86,13 +86,16 @@ QByteArray BoardD356NetlistExport::generate() const {
       if (const PackagePad* pkgPad = pad->getLibPackagePad()) {
         padName = *pkgPad->getName();
       }
+      const Angle rotation = pad->getMirrored()
+          ? (pad->getRotation() + Angle::deg180())
+          : pad->getRotation();
       if (pad->getLibPad().isTht()) {
         // THT pad. Not sure if we really need to export all holes, if there
         // are multiple. Also slots are probably not supported by IPC-D-356A.
         // I suspect it's good enough to export only a single, circular hole?
         gen.thtPad(netName, cmpName, padName, pad->getPosition(),
                    pad->getLibPad().getWidth(), pad->getLibPad().getHeight(),
-                   pad->getRotation(),
+                   rotation,
                    pad->getLibPad().getHoles().first()->getDiameter());
       } else {
         // SMT pad.
@@ -102,17 +105,13 @@ QByteArray BoardD356NetlistExport::generate() const {
             : (mBoard.getInnerLayerCount() + 2);
         gen.smtPad(netName, cmpName, padName, pad->getPosition(),
                    pad->getLibPad().getWidth(), pad->getLibPad().getHeight(),
-                   pad->getRotation(), layerNumber);
+                   rotation, layerNumber);
       }
     }
   }
 
   return gen.generate();
 }
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/core/project/board/boardpickplacegenerator.cpp
+++ b/libs/librepcb/core/project/board/boardpickplacegenerator.cpp
@@ -84,10 +84,12 @@ std::shared_ptr<PickPlaceData> BoardPickPlaceGenerator::generate() noexcept {
         if (pad->isOnLayer(Layer::botCopper())) {
           sides.append(PickPlaceDataItem::BoardSide::Bottom);
         }
+        const Angle rotation =
+            pad->getMirrored() ? -pad->getRotation() : pad->getRotation();
         foreach (const auto side, sides) {
-          items.append(PickPlaceDataItem(
-              designator, val, devName, pkgName, pad->getPosition(),
-              pad->getRotation(), side, PickPlaceDataItem::Type::Fiducial));
+          items.append(PickPlaceDataItem(designator, val, devName, pkgName,
+                                         pad->getPosition(), rotation, side,
+                                         PickPlaceDataItem::Type::Fiducial));
         }
       }
     }
@@ -104,7 +106,8 @@ std::shared_ptr<PickPlaceData> BoardPickPlaceGenerator::generate() noexcept {
     auto typeIt = types.find(device->getLibPackage().getAssemblyType(true));
     if (typeIt != types.end()) {
       const Point position = device->getPosition();
-      const Angle rotation = device->getRotation();
+      const Angle rotation = device->getMirrored() ? -device->getRotation()
+                                                   : device->getRotation();
       const PickPlaceDataItem::BoardSide boardSide = device->getMirrored()
           ? PickPlaceDataItem::BoardSide::Bottom
           : PickPlaceDataItem::BoardSide::Top;

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -70,8 +70,7 @@ private:  // Methods
   void removeOrphans();
 
   // Helper Methods
-  ClipperLib::Paths createPadCutOuts(const Transform& deviceTransform,
-                                     const Transform& padTransform,
+  ClipperLib::Paths createPadCutOuts(const Transform& transform,
                                      const BI_FootprintPad& pad) const;
   ClipperLib::Path createViaCutOut(const BI_Via& via) const noexcept;
 

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -136,7 +136,7 @@ void BoardClipperPathGenerator::addCopper(
       if (pad->isOnLayer(layer) &&
           (netsignals.isEmpty() ||
            netsignals.contains(pad->getCompSigInstNetSignal()))) {
-        addPad(*pad, transform, layer);
+        addPad(*pad, layer);
       }
     }
   }
@@ -254,11 +254,9 @@ void BoardClipperPathGenerator::addHole(const PositiveLength& diameter,
 }
 
 void BoardClipperPathGenerator::addPad(const BI_FootprintPad& pad,
-                                       const Transform& transform,
                                        const Layer& layer,
                                        const Length& offset) {
-  const Transform padTransform(pad.getLibPad().getPosition(),
-                               pad.getLibPad().getRotation());
+  const Transform transform(pad);
   foreach (PadGeometry geometry, pad.getGeometries().value(&layer)) {
     if (offset != 0) {
       geometry = geometry.withOffset(offset);
@@ -266,8 +264,7 @@ void BoardClipperPathGenerator::addPad(const BI_FootprintPad& pad,
     foreach (const Path& outline, geometry.toOutlines()) {
       ClipperHelpers::unite(
           mPaths,
-          ClipperHelpers::convert(transform.map(padTransform.map(outline)),
-                                  mMaxArcTolerance));
+          ClipperHelpers::convert(transform.map(outline), mMaxArcTolerance));
     }
 
     // Also add each hole to ensure correct copper areas even if
@@ -277,8 +274,7 @@ void BoardClipperPathGenerator::addPad(const BI_FootprintPad& pad,
                hole.getPath()->toOutlineStrokes(hole.getDiameter())) {
         ClipperHelpers::unite(
             mPaths,
-            ClipperHelpers::convert(transform.map(padTransform.map(outline)),
-                                    mMaxArcTolerance));
+            ClipperHelpers::convert(transform.map(outline), mMaxArcTolerance));
       }
     }
   }

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
@@ -81,8 +81,8 @@ public:
   void addHole(const PositiveLength& diameter, const NonEmptyPath& path,
                const Transform& transform = Transform(),
                const Length& offset = Length(0));
-  void addPad(const BI_FootprintPad& pad, const Transform& transform,
-              const Layer& layer, const Length& offset = Length(0));
+  void addPad(const BI_FootprintPad& pad, const Layer& layer,
+              const Length& offset = Length(0));
 
 private:  // Data
   Board& mBoard;

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -109,8 +109,7 @@ private:  // Methods
   QVector<Path> getDeviceLocation(const BI_Device& device) const;
   template <typename THole>
   QVector<Path> getHoleLocation(const THole& hole,
-                                const Transform& transform1 = Transform(),
-                                const Transform& transform2 = Transform()) const
+                                const Transform& transform = Transform()) const
       noexcept;
   void emitProgress(int percent) noexcept;
   void emitStatus(const QString& status) noexcept;

--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -196,13 +196,7 @@ StrokeTextList BI_Device::getDefaultStrokeTexts() const noexcept {
   Transform transform(*this);
   for (StrokeText& text : texts) {
     text.setPosition(transform.map(text.getPosition()));
-    if (getMirrored()) {
-      text.setRotation(text.getRotation() +
-                       (text.getMirrored() ? -getRotation() : getRotation()));
-    } else {
-      text.setRotation(text.getRotation() +
-                       (text.getMirrored() ? -getRotation() : getRotation()));
-    }
+    text.setRotation(transform.mapMirrorable(text.getRotation()));
     text.setMirrored(transform.map(text.getMirrored()));
     text.setLayer(transform.map(text.getLayer()));
   }

--- a/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
+++ b/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
@@ -255,7 +255,7 @@ void BI_FootprintPad::netSignalChanged(NetSignal* from, NetSignal* to) {
 void BI_FootprintPad::updateTransform() noexcept {
   Transform transform(mDevice);
   const Point position = transform.map(mFootprintPad->getPosition());
-  const Angle rotation = transform.map(mFootprintPad->getRotation());
+  const Angle rotation = transform.mapMirrorable(mFootprintPad->getRotation());
   const bool mirrored = mDevice.getMirrored();
   if (position != mPosition) {
     mPosition = position;

--- a/libs/librepcb/core/project/board/items/bi_stroketext.cpp
+++ b/libs/librepcb/core/project/board/items/bi_stroketext.cpp
@@ -235,8 +235,7 @@ void BI_StrokeText::updatePaths() noexcept {
   const QVector<Path> paths = StrokeTextPathBuilder::build(
       mFont, mData.getLetterSpacing(), mData.getLineSpacing(),
       mData.getHeight(), mData.getStrokeWidth(), mData.getAlign(),
-      mData.getRotation(), mData.getAutoRotate(), mData.getMirrored(),
-      mSubstitutedText);
+      mData.getRotation(), mData.getAutoRotate(), mSubstitutedText);
   if (paths != mPaths) {
     mPaths = paths;
     onEdited.notify(Event::PathsChanged);

--- a/libs/librepcb/core/project/schematic/items/si_symbol.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_symbol.cpp
@@ -159,11 +159,9 @@ TextList SI_Symbol::getDefaultTexts() const noexcept {
   Transform transform(*this);
   for (Text& text : texts) {
     text.setPosition(transform.map(text.getPosition()));
+    text.setRotation(transform.mapNonMirrorable(text.getRotation()));
     if (transform.getMirrored()) {
-      text.setRotation(Angle::deg180() - text.getRotation() - getRotation());
       text.setAlign(text.getAlign().mirroredV());
-    } else {
-      text.setRotation(text.getRotation() + getRotation());
     }
   }
   return texts;

--- a/libs/librepcb/core/project/schematic/items/si_symbolpin.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_symbolpin.cpp
@@ -238,7 +238,7 @@ void SI_SymbolPin::netSignalNameChanged() noexcept {
 void SI_SymbolPin::updateTransform() noexcept {
   Transform transform(mSymbol);
   const Point position = transform.map(mSymbolPin->getPosition());
-  const Angle rotation = transform.map(mSymbolPin->getRotation());
+  const Angle rotation = transform.mapNonMirrorable(mSymbolPin->getRotation());
   if (position != mPosition) {
     mPosition = position;
     onEdited.notify(Event::PositionChanged);
@@ -300,7 +300,7 @@ void SI_SymbolPin::updateNumbers() noexcept {
 }
 
 void SI_SymbolPin::updateNumbersTransform() noexcept {
-  const bool flip = Toolbox::isTextUpsideDown(mRotation, false);
+  const bool flip = Toolbox::isTextUpsideDown(mRotation);
   const Point position = mSymbolPin->getNumbersPosition(flip);
   const Alignment alignment = SymbolPin::getNumbersAlignment(flip);
   if (position != mNumbersPosition) {

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -166,21 +166,21 @@ void SchematicPainter::paint(QPainter& painter,
 
     // Draw Symbol Pins.
     foreach (const Pin& pin, symbol.pins) {
-      p.drawSymbolPin(symbol.transform.map(pin.position),
-                      symbol.transform.map(pin.rotation), *pin.length,
-                      settings.getColor(Theme::Color::sSchematicPinLines),
-                      QColor());
+      p.drawSymbolPin(
+          symbol.transform.map(pin.position),
+          symbol.transform.mapNonMirrorable(pin.rotation), *pin.length,
+          settings.getColor(Theme::Color::sSchematicPinLines), QColor());
       Alignment nameAlignment = pin.nameAlignment;
       if (symbol.transform.getMirrored()) {
         nameAlignment.mirrorV();
       }
-      p.drawText(symbol.transform.map(pin.position +
-                                      pin.namePosition.rotated(pin.rotation)),
-                 symbol.transform.map(pin.rotation + pin.nameRotation),
-                 *pin.nameHeight, nameAlignment, pin.name, mDefaultFont,
-                 settings.getColor(Theme::Color::sSchematicPinNames), true,
-                 false);
-      const Angle numberRot = symbol.transform.map(pin.rotation);
+      p.drawText(
+          symbol.transform.map(pin.position +
+                               pin.namePosition.rotated(pin.rotation)),
+          symbol.transform.mapNonMirrorable(pin.rotation + pin.nameRotation),
+          *pin.nameHeight, nameAlignment, pin.name, mDefaultFont,
+          settings.getColor(Theme::Color::sSchematicPinNames), true, false);
+      const Angle numberRot = symbol.transform.mapNonMirrorable(pin.rotation);
       p.drawText(symbol.transform.map(
                      pin.position + pin.numbersPosition.rotated(pin.rotation)),
                  numberRot, *SymbolPin::getNumbersHeight(),

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -61,35 +61,30 @@ void FileFormatMigrationUnstable::upgradePackageCategory(
 
 void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-  const QString fp = "symbol.lp";
-  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  upgradeStrings(root);
-  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
   const QString fp = "package.lp";
   SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  upgradeStrings(root);
+  for (SExpression* fptNode : root.getChildren("footprint")) {
+    for (SExpression* txtNode : fptNode->getChildren("stroke_text")) {
+      if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
+        SExpression& rotNode = txtNode->getChild("rotation/@0");
+        rotNode = serialize(-deserialize<Angle>(rotNode));
+      }
+    }
+  }
   dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(
     TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-  const QString fp = "component.lp";
-  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  upgradeStrings(root);
-  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeDevice(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-  const QString fp = "device.lp";
-  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  upgradeStrings(root);
-  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeLibrary(TransactionalDirectory& dir) {
@@ -107,12 +102,10 @@ void FileFormatMigrationUnstable::upgradeWorkspaceData(
 
 void FileFormatMigrationUnstable::upgradeSettings(SExpression& root) {
   Q_UNUSED(root);
-  upgradeStrings(root);
 }
 
 void FileFormatMigrationUnstable::upgradeCircuit(SExpression& root) {
   Q_UNUSED(root);
-  upgradeStrings(root);
 }
 
 void FileFormatMigrationUnstable::upgradeErc(SExpression& root,
@@ -125,14 +118,36 @@ void FileFormatMigrationUnstable::upgradeSchematic(SExpression& root,
                                                    ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  upgradeStrings(root);
+  for (SExpression* symNode : root.getChildren("symbol")) {
+    if (deserialize<bool>(symNode->getChild("mirror/@0"))) {
+      SExpression& rotNode = symNode->getChild("rotation/@0");
+      rotNode = serialize(-deserialize<Angle>(rotNode));
+    }
+  }
 }
 
 void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  upgradeStrings(root);
+  for (SExpression* devNode : root.getChildren("device")) {
+    if (deserialize<bool>(devNode->getChild("mirror/@0"))) {
+      SExpression& rotNode = devNode->getChild("rotation/@0");
+      rotNode = serialize(-deserialize<Angle>(rotNode));
+    }
+    for (SExpression* txtNode : devNode->getChildren("stroke_text")) {
+      if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
+        SExpression& rotNode = txtNode->getChild("rotation/@0");
+        rotNode = serialize(-deserialize<Angle>(rotNode));
+      }
+    }
+  }
+  for (SExpression* txtNode : root.getChildren("stroke_text")) {
+    if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
+      SExpression& rotNode = txtNode->getChild("rotation/@0");
+      rotNode = serialize(-deserialize<Angle>(rotNode));
+    }
+  }
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -174,6 +174,14 @@ void FileFormatMigrationV01::upgradePackage(TransactionalDirectory& dir) {
         padNode->appendChild("clearance", SExpression::createToken("0.0"));
       }
 
+      // Stroke texts.
+      for (SExpression* txtNode : fptNode->getChildren("stroke_text")) {
+        if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
+          SExpression& rotNode = txtNode->getChild("rotation/@0");
+          rotNode = serialize(-deserialize<Angle>(rotNode));
+        }
+      }
+
       // Holes.
       upgradeHoles(*fptNode, false);
     }
@@ -586,6 +594,12 @@ void FileFormatMigrationV01::upgradeSchematic(SExpression& root,
       position.serialize(textNode.appendList("position"));
       textNode.appendChild("rotation", rotation);
     }
+
+    // Swap transformation order of mirror/rotate.
+    if (symMirror) {
+      SExpression& rotNode = symNode->getChild("rotation/@0");
+      rotNode = serialize(-deserialize<Angle>(rotNode));
+    }
   }
 
   // Net segments.
@@ -614,8 +628,16 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
 
   // Devices.
   for (SExpression* devNode : root.getChildren("device")) {
+    if (deserialize<bool>(devNode->getChild("mirror/@0"))) {
+      SExpression& rotNode = devNode->getChild("rotation/@0");
+      rotNode = serialize(-deserialize<Angle>(rotNode));
+    }
     devNode->appendChild("lock", SExpression::createToken("false"));
     for (SExpression* txtNode : devNode->getChildren("stroke_text")) {
+      if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
+        SExpression& rotNode = txtNode->getChild("rotation/@0");
+        rotNode = serialize(-deserialize<Angle>(rotNode));
+      }
       txtNode->appendChild("lock", SExpression::createToken("false"));
     }
   }
@@ -639,6 +661,10 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
 
   // Stroke texts.
   for (SExpression* txtNode : root.getChildren("stroke_text")) {
+    if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
+      SExpression& rotNode = txtNode->getChild("rotation/@0");
+      rotNode = serialize(-deserialize<Angle>(rotNode));
+    }
     txtNode->appendChild("lock", SExpression::createToken("false"));
   }
 

--- a/libs/librepcb/core/utils/toolbox.cpp
+++ b/libs/librepcb/core/utils/toolbox.cpp
@@ -33,13 +33,9 @@ namespace librepcb {
  *  Static Methods
  ******************************************************************************/
 
-bool Toolbox::isTextUpsideDown(const Angle& rotation, bool mirrored) noexcept {
+bool Toolbox::isTextUpsideDown(const Angle& rotation) noexcept {
   const Angle mapped180 = rotation.mappedTo180deg();
-  if (mirrored) {
-    return ((mapped180 < -Angle::deg90()) || (mapped180 >= Angle::deg90()));
-  } else {
-    return ((mapped180 <= -Angle::deg90()) || (mapped180 > Angle::deg90()));
-  }
+  return ((mapped180 <= -Angle::deg90()) || (mapped180 > Angle::deg90()));
 }
 
 QPainterPath Toolbox::shapeFromPath(const QPainterPath& path, const QPen& pen,

--- a/libs/librepcb/core/utils/toolbox.h
+++ b/libs/librepcb/core/utils/toolbox.h
@@ -145,15 +145,14 @@ public:
    *
    * A text is considered as upside down if it is rotated counterclockwise by
    * [-90..90°[, i.e. -90° is considered as upside down, but 90° is *not*
-   * considered as upside down. For mirrored texts (rotated clockwise), it
-   * is the other way around. Used to determine whether a text needs to be
-   * auto-rotated or not.
+   * considered as upside down.
+   *
+   * Used to determine whether a text needs to be auto-rotated or not.
    *
    * @param rotation  The global (scene coordinates) rotation of the text.
-   * @param mirrored  If the text is mirrored (inverted rotation!).
    * @return Whether the text is upside down or not.
    */
-  static bool isTextUpsideDown(const Angle& rotation, bool mirrored) noexcept;
+  static bool isTextUpsideDown(const Angle& rotation) noexcept;
 
   static QRectF boundingRectFromRadius(qreal radius) noexcept {
     return QRectF(-radius, -radius, 2 * radius, 2 * radius);

--- a/libs/librepcb/core/utils/transform.cpp
+++ b/libs/librepcb/core/utils/transform.cpp
@@ -37,29 +37,32 @@ bool Transform::map(bool mirror) const noexcept {
   return mMirrored ? !mirror : mirror;
 }
 
-Angle Transform::map(const Angle& angle) const noexcept {
-  Angle a = mRotation + angle;
-  return mMirrored ? (Angle::deg180() - a) : a;
+Angle Transform::mapMirrorable(const Angle& angle) const noexcept {
+  return mMirrored ? (mRotation - angle) : (mRotation + angle);
+}
+
+Angle Transform::mapNonMirrorable(const Angle& angle) const noexcept {
+  return mRotation + (mMirrored ? (Angle::deg180() - angle) : angle);
 }
 
 Point Transform::map(const Point& point) const noexcept {
   Point p = point;
-  if (mRotation) {
-    p.rotate(mRotation);
-  }
   if (mMirrored) {
     p.mirror(Qt::Horizontal);
+  }
+  if (mRotation) {
+    p.rotate(mRotation);
   }
   return p + mPosition;
 }
 
 Path Transform::map(const Path& path) const noexcept {
   Path p = path;
-  if (mRotation) {
-    p.rotate(mRotation);
-  }
   if (mMirrored) {
     p.mirror(Qt::Horizontal);
+  }
+  if (mRotation) {
+    p.rotate(mRotation);
   }
   if (!mPosition.isOrigin()) {
     p.translate(mPosition);

--- a/libs/librepcb/core/utils/transform.h
+++ b/libs/librepcb/core/utils/transform.h
@@ -51,7 +51,7 @@ class Layer;
  *     and translate. The order of the transformation is not configurable, it
  *     is hardcoded to the order of transformations applied to symbols within
  *     a schematic, and to footprints within a board. This order is:
- *     rotate CCW -> mirror horizontally (negating X-coordinate) -> translate.
+ *     mirror horizontally (negating X-coordinate) -> rotate CCW -> translate.
  *
  * Long story short, this class converts symbol- or footprint coordinates
  * into schematic- resp. board coordinates.
@@ -124,19 +124,34 @@ public:
   /**
    * @brief Map a given angle to the transformed coordinate system
    *
+   * @note Intended for mirrorable objects (e.g. footprint pads), which expects
+   *       the mapped object to mirror its geometry.
+   *
    * @param angle The angle to map.
-   * @return The passed angle, rotated by the transformations rotation, and
-   *         mirrored horizontally if the transformation is mirroring.
+   * @return The passed angle, mirrored horizontally if the transformation is
+   *         mirroring and rotated by the transformations rotation.
    */
-  Angle map(const Angle& angle) const noexcept;
+  Angle mapMirrorable(const Angle& angle) const noexcept;
+
+  /**
+   * @brief Map a given angle to the transformed coordinate system
+   *
+   * @note Intended for non-mirrorable objects (e.g. symbol pins), which will
+   *       cause the mirroring to be "emulated" by a 180° rotation.
+   *
+   * @param angle The angle to map.
+   * @return The passed angle, mirrored horizontally if the transformation is
+   *         mirroring and rotated by the transformations rotation.
+   */
+  Angle mapNonMirrorable(const Angle& angle) const noexcept;
 
   /**
    * @brief Map a given point to the transformed coordinate system
    *
    * @param point The point to map.
-   * @return The passed point, rotated by the transformations rotation,
-   *         mirrored horizontally if the transformation is mirroring, and
-   *         translated by the transformation offset.
+   * @return The passed point, mirrored horizontally if the transformation is
+   *         mirroring, rotated by the transformations rotation, and translated
+   *         by the transformation offset.
    */
   Point map(const Point& point) const noexcept;
 
@@ -144,9 +159,9 @@ public:
    * @brief Map a given path to the transformed coordinate system
    *
    * @param path  The path to map.
-   * @return The passed path, rotated by the transformations rotation,
-   *         mirrored horizontally if the transformation is mirroring, and
-   *         translated by the transformation offset.
+   * @return The passed path, mirrored horizontally if the transformation is
+   *         mirroring, rotated by the transformations rotation, and translated
+   *         by the transformation offset.
    */
   Path map(const Path& path) const noexcept;
 
@@ -154,9 +169,9 @@ public:
    * @brief Map a given path to the transformed coordinate system
    *
    * @param path  The path to map.
-   * @return The passed path, rotated by the transformations rotation,
-   *         mirrored horizontally if the transformation is mirroring, and
-   *         translated by the transformation offset.
+   * @return The passed path, mirrored horizontally if the transformation is
+   *         mirroring, rotated by the transformations rotation, and translated
+   *         by the transformation offset.
    */
   NonEmptyPath map(const NonEmptyPath& path) const noexcept;
 
@@ -174,9 +189,9 @@ public:
    *
    * @tparam Container type.
    * @param container The items to map.
-   * @return The passed items, rotated by the transformations rotation,
-   *         mirrored horizontally if the transformation is mirroring, and
-   *         translated by the transformation offset.
+   * @return The passed items, mirrored horizontally if the transformation is
+   *         mirroring, rotated by the transformations rotation, and translated
+   *         by the transformation offset.
    */
   template <typename T>
   T map(const T& container) const noexcept {
@@ -192,18 +207,18 @@ public:
    *
    * @param obj The Qt object (in pixel coordinates) to map, e.g. QPoint,
    *            QPainterPath, ...).
-   * @return The passed object, rotated by the transformations rotation,
-   *         mirrored horizontally if the transformation is mirroring, and
-   *         translated by the transformation offset.
+   * @return The passed object, mirrored horizontally if the transformation is
+   *         mirroring, rotated by the transformations rotation, and translated
+   *         by the transformation offset.
    */
   template <typename T>
   T mapPx(const T& obj) const noexcept {
     QTransform t;
     t.translate(mPosition.toPxQPointF().x(), mPosition.toPxQPointF().y());
+    t.rotate(-mRotation.toDeg());
     if (mMirrored) {
       t.scale(-1, 1);
     }
-    t.rotate(-mRotation.toDeg());
     return t.map(obj);
   }
 

--- a/libs/librepcb/editor/cmd/cmdstroketextedit.cpp
+++ b/libs/librepcb/editor/cmd/cmdstroketextedit.cpp
@@ -146,15 +146,8 @@ void CmdStrokeTextEdit::setRotation(const Angle& angle,
 
 void CmdStrokeTextEdit::rotate(const Angle& angle, const Point& center,
                                bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewPosition.rotate(angle, center);
-  mNewRotation += mNewMirrored
-      ? -angle
-      : angle;  // mirror --> rotation direction is inverted!
-  if (immediate) {
-    mText.setPosition(mNewPosition);
-    mText.setRotation(mNewRotation);
-  }
+  setPosition(mNewPosition.rotated(angle, center), immediate);
+  setRotation(mNewRotation + angle, immediate);
 }
 
 void CmdStrokeTextEdit::setMirrored(bool mirrored, bool immediate) noexcept {
@@ -166,33 +159,19 @@ void CmdStrokeTextEdit::setMirrored(bool mirrored, bool immediate) noexcept {
 void CmdStrokeTextEdit::mirrorGeometry(Qt::Orientation orientation,
                                        const Point& center,
                                        bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewPosition.mirror(orientation, center);
-  if (orientation == Qt::Horizontal) {
-    mNewRotation = Angle::deg180() - mNewRotation;
+  setPosition(mNewPosition.mirrored(orientation, center), immediate);
+  if (orientation == Qt::Vertical) {
+    setRotation(Angle::deg180() - mNewRotation, immediate);
   } else {
-    mNewRotation = -mNewRotation;
+    setRotation(-mNewRotation, immediate);
   }
-  mNewAlign.mirrorV();
-  if (immediate) {
-    mText.setPosition(mNewPosition);
-    mText.setRotation(mNewRotation);
-    mText.setAlign(mNewAlign);
-  }
+  setAlignment(mNewAlign.mirroredH(), immediate);
 }
 
 void CmdStrokeTextEdit::mirrorLayer(bool immediate) noexcept {
   setLayer(mNewLayer->mirrored(), immediate);
   setMirrored(!mNewMirrored, immediate);
-
-  // Changing the mirror property inverts the rotation and alignment. To keep
-  // rotation and alignment, invert them manually too.
-  mNewRotation = Angle::deg180() - mNewRotation;
-  mNewAlign.mirrorV();
-  if (immediate) {
-    mText.setRotation(mNewRotation);
-    mText.setAlign(mNewAlign);
-  }
+  setAlignment(mNewAlign.mirroredH(), immediate);
 }
 
 void CmdStrokeTextEdit::setAutoRotate(bool autoRotate,

--- a/libs/librepcb/editor/cmd/cmdtextedit.cpp
+++ b/libs/librepcb/editor/cmd/cmdtextedit.cpp
@@ -112,30 +112,26 @@ void CmdTextEdit::setRotation(const Angle& angle, bool immediate) noexcept {
 
 void CmdTextEdit::rotate(const Angle& angle, const Point& center,
                          bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewPosition.rotate(angle, center);
-  mNewRotation += angle;
-  if (immediate) {
-    mText.setPosition(mNewPosition);
-    mText.setRotation(mNewRotation);
-  }
+  setPosition(mNewPosition.rotated(angle, center), immediate);
+  setRotation(mNewRotation + angle, immediate);
 }
 
 void CmdTextEdit::mirror(Qt::Orientation orientation, const Point& center,
                          bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewPosition.mirror(orientation, center);
-  if (orientation == Qt::Horizontal) {
-    mNewRotation = Angle::deg180() - mNewRotation;
-  } else {
-    mNewRotation = -mNewRotation;
-  }
-  mNewAlign.mirrorV();
-  if (immediate) {
-    mText.setPosition(mNewPosition);
-    mText.setRotation(mNewRotation);
-    mText.setAlign(mNewAlign);
-  }
+  setPosition(mNewPosition.mirrored(orientation, center), immediate);
+  setRotation((orientation == Qt::Horizontal) ? (Angle::deg180() - mNewRotation)
+                                              : (-mNewRotation),
+              immediate);
+  setAlignment(mNewAlign.mirroredV(), immediate);
+}
+
+void CmdTextEdit::mirror(const Angle& rotation, const Point& center,
+                         bool immediate) noexcept {
+  setPosition(mNewPosition.rotated(-rotation, center)
+                  .mirrored(Qt::Horizontal, center)
+                  .rotated(rotation, center),
+              immediate);
+  setAlignment(mNewAlign.mirroredH(), immediate);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/cmd/cmdtextedit.h
+++ b/libs/librepcb/editor/cmd/cmdtextedit.h
@@ -68,6 +68,8 @@ public:
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirror(Qt::Orientation orientation, const Point& center,
               bool immediate) noexcept;
+  void mirror(const Angle& rotation, const Point& center,
+              bool immediate) noexcept;
 
   // Operator Overloadings
   CmdTextEdit& operator=(const CmdTextEdit& rhs) = delete;

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
@@ -68,6 +68,7 @@ public:
   // Setters
   void setPosition(const Point& position) noexcept;
   void setRotation(const Angle& rotation) noexcept;
+  void setMirrored(bool mirrored) noexcept;
   void setText(const QString& text) noexcept;
   void setLayer(const QString& layerName) noexcept;
   void setGeometries(const QHash<const Layer*, QList<PadGeometry>>& geometries,
@@ -91,6 +92,7 @@ private:  // Methods
 
 private:  // Data
   const IF_GraphicsLayerProvider& mLayerProvider;
+  bool mMirror;
   std::shared_ptr<GraphicsLayer> mCopperLayer;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
   QScopedPointer<PrimitiveTextGraphicsItem> mTextGraphicsItem;

--- a/libs/librepcb/editor/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivepathgraphicsitem.cpp
@@ -40,6 +40,7 @@ namespace editor {
 PrimitivePathGraphicsItem::PrimitivePathGraphicsItem(
     QGraphicsItem* parent) noexcept
   : QGraphicsItem(parent),
+    mMirror(false),
     mLineLayer(nullptr),
     mFillLayer(nullptr),
     mShapeMode(ShapeMode::StrokeAndAreaByLayer),
@@ -71,6 +72,11 @@ void PrimitivePathGraphicsItem::setPosition(const Point& pos) noexcept {
 
 void PrimitivePathGraphicsItem::setRotation(const Angle& rot) noexcept {
   QGraphicsItem::setRotation(-rot.toDeg());
+}
+
+void PrimitivePathGraphicsItem::setMirrored(bool mirrored) noexcept {
+  mMirror = mirrored;
+  update();
 }
 
 void PrimitivePathGraphicsItem::setPath(const QPainterPath& path) noexcept {
@@ -135,6 +141,10 @@ void PrimitivePathGraphicsItem::paint(QPainter* painter,
   Q_UNUSED(widget);
 
   const bool isSelected = option->state.testFlag(QStyle::State_Selected);
+
+  if (mMirror) {
+    painter->scale(-1, 1);
+  }
 
   painter->setPen(isSelected ? mPenHighlighted : mPen);
   painter->setBrush(isSelected ? mBrushHighlighted : mBrush);

--- a/libs/librepcb/editor/graphics/primitivepathgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivepathgraphicsitem.h
@@ -73,6 +73,7 @@ public:
   // Setters
   void setPosition(const Point& pos) noexcept;
   void setRotation(const Angle& rot) noexcept;
+  void setMirrored(bool mirrored) noexcept;
   void setPath(const QPainterPath& path) noexcept;
   void setLineWidth(const UnsignedLength& width) noexcept;
   void setLineLayer(const std::shared_ptr<GraphicsLayer>& layer) noexcept;
@@ -101,6 +102,7 @@ private:  // Methods
   void updateVisibility() noexcept;
 
 protected:  // Data
+  bool mMirror;
   std::shared_ptr<GraphicsLayer> mLineLayer;
   std::shared_ptr<GraphicsLayer> mFillLayer;
   ShapeMode mShapeMode;

--- a/libs/librepcb/editor/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivetextgraphicsitem.cpp
@@ -70,7 +70,7 @@ void PrimitiveTextGraphicsItem::setPosition(const Point& pos) noexcept {
 }
 
 void PrimitiveTextGraphicsItem::setRotation(const Angle& rot) noexcept {
-  const bool rotate180 = Toolbox::isTextUpsideDown(rot, false);
+  const bool rotate180 = Toolbox::isTextUpsideDown(rot);
   if (rotate180 != mRotate180) {
     mRotate180 = rotate180;
     updateBoundingRectAndShape();

--- a/libs/librepcb/editor/graphics/stroketextgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/stroketextgraphicsitem.cpp
@@ -152,8 +152,8 @@ void StrokeTextGraphicsItem::updateText() noexcept {
 
 void StrokeTextGraphicsItem::updateTransform() noexcept {
   QTransform t;
-  if (mText.getMirrored()) t.scale(qreal(-1), qreal(1));
   t.rotate(-mText.getRotation().toDeg());
+  if (mText.getMirrored()) t.scale(qreal(-1), qreal(1));
   setTransform(t);
 }
 

--- a/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
@@ -232,7 +232,7 @@ void SymbolPinGraphicsItem::updateNamePosition() noexcept {
 }
 
 void SymbolPinGraphicsItem::updateNumbersTransform() noexcept {
-  const bool flipped = Toolbox::isTextUpsideDown(mPin->getRotation(), false);
+  const bool flipped = Toolbox::isTextUpsideDown(mPin->getRotation());
   mNumbersGraphicsItem->setPosition(
       mPin->getNumbersPosition(flipped).rotated(mPin->getRotation()));
   mNumbersGraphicsItem->setAlignment(SymbolPin::getNumbersAlignment(flipped));

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_device.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_device.cpp
@@ -194,8 +194,8 @@ void BGI_Device::updatePosition() noexcept {
 
 void BGI_Device::updateRotationAndMirrored() noexcept {
   QTransform t;
-  if (mDevice.getMirrored()) t.scale(qreal(-1), qreal(1));
   t.rotate(-mDevice.getRotation().toDeg());
+  if (mDevice.getMirrored()) t.scale(qreal(-1), qreal(1));
   setTransform(t);
 }
 

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.cpp
@@ -60,6 +60,7 @@ BGI_FootprintPad::BGI_FootprintPad(BI_FootprintPad& pad,
 
   setPos(mPad.getPosition().toPxQPointF());
   mGraphicsItem->setRotation(mPad.getRotation());
+  mGraphicsItem->setMirrored(mPad.getMirrored());
   mGraphicsItem->setText(mPad.getText());
   mGraphicsItem->setGeometries(mPad.getGeometries(),
                                *mPad.getLibPad().getCopperClearance());
@@ -106,6 +107,7 @@ void BGI_FootprintPad::padEdited(const BI_FootprintPad& obj,
       mGraphicsItem->setRotation(obj.getRotation());
       break;
     case BI_FootprintPad::Event::MirroredChanged:
+      mGraphicsItem->setMirrored(obj.getMirrored());
       updateLayer();
       break;
     case BI_FootprintPad::Event::TextChanged:

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_stroketext.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_stroketext.cpp
@@ -161,8 +161,8 @@ void BGI_StrokeText::updatePosition() noexcept {
 
 void BGI_StrokeText::updateTransform() noexcept {
   QTransform t;
-  if (mText.getData().getMirrored()) t.scale(qreal(-1), qreal(1));
   t.rotate(-mText.getData().getRotation().toDeg());
+  if (mText.getData().getMirrored()) t.scale(qreal(-1), qreal(1));
   setTransform(t);
 }
 

--- a/libs/librepcb/editor/project/cmd/cmdboardstroketextedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardstroketextedit.cpp
@@ -143,9 +143,7 @@ void CmdBoardStrokeTextEdit::rotate(const Angle& angle, const Point& center,
                                     bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   setPosition(mNewData.getPosition().rotated(angle, center), immediate);
-  setRotation(
-      mNewData.getRotation() + (mNewData.getMirrored() ? -angle : angle),
-      immediate);
+  setRotation(mNewData.getRotation() + angle, immediate);
 }
 
 void CmdBoardStrokeTextEdit::setMirrored(bool mirrored,
@@ -159,11 +157,24 @@ void CmdBoardStrokeTextEdit::setMirrored(bool mirrored,
 void CmdBoardStrokeTextEdit::mirrorGeometry(Qt::Orientation orientation,
                                             const Point& center,
                                             bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
   setPosition(mNewData.getPosition().mirrored(orientation, center), immediate);
-  setRotation((orientation == Qt::Horizontal)
-                  ? (Angle::deg180() - mNewData.getRotation())
-                  : (-mNewData.getRotation()),
+  if (orientation == Qt::Vertical) {
+    setRotation(Angle::deg180() - mNewData.getRotation(), immediate);
+  } else {
+    setRotation(-mNewData.getRotation(), immediate);
+  }
+  setAlignment(mNewData.getAlign().mirroredH(), immediate);
+}
+
+void CmdBoardStrokeTextEdit::mirrorGeometry(const Angle& rotation,
+                                            const Point& center,
+                                            bool immediate) noexcept {
+  setPosition(mNewData.getPosition()
+                  .rotated(-rotation, center)
+                  .mirrored(Qt::Horizontal, center)
+                  .rotated(rotation, center),
+              immediate);
+  setRotation(rotation + Angle::deg180() - mNewData.getRotation() + rotation,
               immediate);
   setAlignment(mNewData.getAlign().mirroredV(), immediate);
 }
@@ -171,11 +182,7 @@ void CmdBoardStrokeTextEdit::mirrorGeometry(Qt::Orientation orientation,
 void CmdBoardStrokeTextEdit::mirrorLayer(bool immediate) noexcept {
   setLayer(mNewData.getLayer().mirrored(), immediate);
   setMirrored(!mNewData.getMirrored(), immediate);
-
-  // Changing the mirror property inverts the rotation and alignment. To keep
-  // rotation and alignment, invert them manually too.
-  setRotation(Angle::deg180() - mNewData.getRotation(), immediate);
-  setAlignment(mNewData.getAlign().mirroredV(), immediate);
+  setAlignment(mNewData.getAlign().mirroredH(), immediate);
 }
 
 void CmdBoardStrokeTextEdit::setAutoRotate(bool autoRotate,

--- a/libs/librepcb/editor/project/cmd/cmdboardstroketextedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardstroketextedit.h
@@ -70,6 +70,8 @@ public:
   void setMirrored(bool mirrored, bool immediate) noexcept;
   void mirrorGeometry(Qt::Orientation orientation, const Point& center,
                       bool immediate) noexcept;
+  void mirrorGeometry(const Angle& rotation, const Point& center,
+                      bool immediate) noexcept;
   void mirrorLayer(bool immediate) noexcept;
   void setAutoRotate(bool autoRotate, bool immediate) noexcept;
   void setLocked(bool locked) noexcept;

--- a/libs/librepcb/editor/project/cmd/cmddeviceinstanceedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddeviceinstanceedit.cpp
@@ -93,15 +93,8 @@ void CmdDeviceInstanceEdit::setRotation(const Angle& angle,
 
 void CmdDeviceInstanceEdit::rotate(const Angle& angle, const Point& center,
                                    bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewPos.rotate(angle, center);
-  mNewRotation += mNewMirrored
-      ? -angle
-      : angle;  // mirror --> rotation direction is inverted!
-  if (immediate) {
-    mDevice.setPosition(mNewPos);
-    mDevice.setRotation(mNewRotation);
-  }
+  setPosition(mNewPos.rotated(angle, center), immediate);
+  setRotation(mNewRotation + angle, immediate);
 }
 
 void CmdDeviceInstanceEdit::setMirrored(bool mirrored, bool immediate) {
@@ -115,36 +108,12 @@ void CmdDeviceInstanceEdit::setMirrored(bool mirrored, bool immediate) {
 void CmdDeviceInstanceEdit::mirror(const Point& center,
                                    Qt::Orientation orientation,
                                    bool immediate) {
-  Q_ASSERT(!wasEverExecuted());
-  bool mirror = !mNewMirrored;
-  Point position = mNewPos;
-  Angle rotation = mNewRotation;
-  switch (orientation) {
-    case Qt::Vertical: {
-      position.setY(position.getY() +
-                    Length(2) * (center.getY() - position.getY()));
-      rotation += Angle::deg180();
-      break;
-    }
-    case Qt::Horizontal: {
-      position.setX(position.getX() +
-                    Length(2) * (center.getX() - position.getX()));
-      break;
-    }
-    default: {
-      qCritical() << "Unhandled switch-case in CmdDeviceInstanceEdit::mirror():"
-                  << orientation;
-      break;
-    }
-  }
-  if (immediate) {
-    mDevice.setMirrored(mirror);  // can throw
-    mDevice.setPosition(position);
-    mDevice.setRotation(rotation);
-  }
-  mNewMirrored = mirror;
-  mNewPos = position;
-  mNewRotation = rotation;
+  setMirrored(!mNewMirrored, immediate);  // can throw
+  setPosition(mNewPos.mirrored(orientation, center), immediate);
+  setRotation((orientation == Qt::Horizontal)
+                  ? -mNewRotation
+                  : (Angle::deg180() - mNewRotation),
+              immediate);
 }
 
 void CmdDeviceInstanceEdit::setLocked(bool locked) {

--- a/libs/librepcb/editor/project/cmd/cmddeviceinstanceeditall.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddeviceinstanceeditall.cpp
@@ -77,9 +77,7 @@ void CmdDeviceInstanceEditAll::translate(const Point& deltaPos,
 void CmdDeviceInstanceEditAll::setRotation(const Angle& angle,
                                            bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  const Angle delta = mDevEditCmd->mNewMirrored
-      ? (mDevEditCmd->mNewRotation - angle)  // Mirrored -> inverted rotation!
-      : (angle - mDevEditCmd->mNewRotation);
+  const Angle delta = angle - mDevEditCmd->mNewRotation;
   mDevEditCmd->setRotation(angle, immediate);
   foreach (CmdBoardStrokeTextEdit* cmd, mTextEditCmds) {
     cmd->rotate(delta, mDevEditCmd->mNewPos, immediate);
@@ -98,7 +96,12 @@ void CmdDeviceInstanceEditAll::rotate(const Angle& angle, const Point& center,
 void CmdDeviceInstanceEditAll::setMirrored(bool mirrored, bool immediate) {
   Q_ASSERT(!wasEverExecuted());
   if (mirrored != mDevEditCmd->mNewMirrored) {
-    mirror(mDevEditCmd->mNewPos, Qt::Horizontal, immediate);  // can throw
+    mDevEditCmd->setMirrored(mirrored, immediate);
+    foreach (CmdBoardStrokeTextEdit* cmd, mTextEditCmds) {
+      cmd->mirrorGeometry(mDevEditCmd->mNewRotation, mDevEditCmd->mNewPos,
+                          immediate);
+      cmd->mirrorLayer(immediate);
+    }
   }
 }
 

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.cpp
@@ -93,12 +93,6 @@ void CmdSchematicNetLabelEdit::rotate(const Angle& angle, const Point& center,
   }
 }
 
-void CmdSchematicNetLabelEdit::mirror(bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewMirrored = !mNewMirrored;
-  if (immediate) mNetLabel.setMirrored(mNewMirrored);
-}
-
 void CmdSchematicNetLabelEdit::mirror(Qt::Orientation orientation,
                                       const Point& center,
                                       bool immediate) noexcept {

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.h
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.h
@@ -58,7 +58,6 @@ public:
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
-  void mirror(bool immediate) noexcept;
   void mirror(Qt::Orientation orientation, const Point& center,
               bool immediate) noexcept;
 

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
@@ -82,15 +82,8 @@ void CmdSymbolInstanceEdit::setRotation(const Angle& angle,
 
 void CmdSymbolInstanceEdit::rotate(const Angle& angle, const Point& center,
                                    bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  mNewPos.rotate(angle, center);
-  mNewRotation += mNewMirrored
-      ? -angle
-      : angle;  // mirror --> rotation direction is inverted!
-  if (immediate) {
-    mSymbol.setPosition(mNewPos);
-    mSymbol.setRotation(mNewRotation);
-  }
+  setPosition(mNewPos.rotated(angle, center), immediate);
+  setRotation(mNewRotation + angle, immediate);
 }
 
 void CmdSymbolInstanceEdit::setMirrored(bool mirrored,
@@ -103,36 +96,12 @@ void CmdSymbolInstanceEdit::setMirrored(bool mirrored,
 void CmdSymbolInstanceEdit::mirror(const Point& center,
                                    Qt::Orientation orientation,
                                    bool immediate) noexcept {
-  Q_ASSERT(!wasEverExecuted());
-  bool mirror = !mNewMirrored;
-  Point position = mNewPos;
-  Angle rotation = mNewRotation;
-  switch (orientation) {
-    case Qt::Vertical: {
-      position.setY(position.getY() +
-                    Length(2) * (center.getY() - position.getY()));
-      rotation += Angle::deg180();
-      break;
-    }
-    case Qt::Horizontal: {
-      position.setX(position.getX() +
-                    Length(2) * (center.getX() - position.getX()));
-      break;
-    }
-    default: {
-      qCritical() << "Unhandled switch-case in CmdSymbolInstanceEdit::mirror():"
-                  << orientation;
-      break;
-    }
-  }
-  if (immediate) {
-    mSymbol.setPosition(position);
-    mSymbol.setRotation(rotation);
-    mSymbol.setMirrored(mirror);
-  }
-  mNewMirrored = mirror;
-  mNewPos = position;
-  mNewRotation = rotation;
+  setPosition(mNewPos.mirrored(orientation, center), immediate);
+  setRotation((orientation == Qt::Horizontal)
+                  ? -mNewRotation
+                  : (Angle::deg180() - mNewRotation),
+              immediate);
+  setMirrored(!mNewMirrored, immediate);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.cpp
@@ -77,9 +77,7 @@ void CmdSymbolInstanceEditAll::translate(const Point& deltaPos,
 void CmdSymbolInstanceEditAll::setRotation(const Angle& angle,
                                            bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  const Angle delta = mSymEditCmd->mNewMirrored
-      ? (mSymEditCmd->mNewRotation - angle)  // Mirrored -> inverted rotation!
-      : (angle - mSymEditCmd->mNewRotation);
+  const Angle delta = angle - mSymEditCmd->mNewRotation;
   mSymEditCmd->setRotation(angle, immediate);
   foreach (CmdTextEdit* cmd, mTextEditCmds) {
     cmd->rotate(delta, mSymEditCmd->mNewPos, immediate);
@@ -95,18 +93,22 @@ void CmdSymbolInstanceEditAll::rotate(const Angle& angle, const Point& center,
   }
 }
 
-void CmdSymbolInstanceEditAll::setMirrored(bool mirrored, bool immediate) {
+void CmdSymbolInstanceEditAll::setMirrored(bool mirrored,
+                                           bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   if (mirrored != mSymEditCmd->mNewMirrored) {
-    mirror(mSymEditCmd->mNewPos, Qt::Horizontal, immediate);  // can throw
+    mSymEditCmd->setMirrored(mirrored, immediate);
+    foreach (CmdTextEdit* cmd, mTextEditCmds) {
+      cmd->mirror(mSymEditCmd->mNewRotation, mSymEditCmd->mNewPos, immediate);
+    }
   }
 }
 
 void CmdSymbolInstanceEditAll::mirror(const Point& center,
                                       Qt::Orientation orientation,
-                                      bool immediate) {
+                                      bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mSymEditCmd->mirror(center, orientation, immediate);  // can throw
+  mSymEditCmd->mirror(center, orientation, immediate);
   foreach (CmdTextEdit* cmd, mTextEditCmds) {
     cmd->mirror(orientation, center, immediate);
   }

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.h
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceeditall.h
@@ -59,8 +59,9 @@ public:
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
-  void setMirrored(bool mirrored, bool immediate);
-  void mirror(const Point& center, Qt::Orientation orientation, bool immediate);
+  void setMirrored(bool mirrored, bool immediate) noexcept;
+  void mirror(const Point& center, Qt::Orientation orientation,
+              bool immediate) noexcept;
 
 private:
   CmdSymbolInstanceEdit* mSymEditCmd;

--- a/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_netlabel.cpp
@@ -184,7 +184,7 @@ void SGI_NetLabel::updateRotation() noexcept {
 void SGI_NetLabel::updateText() noexcept {
   prepareGeometryChange();
 
-  mRotate180 = Toolbox::isTextUpsideDown(mNetLabel.getRotation(), false);
+  mRotate180 = Toolbox::isTextUpsideDown(mNetLabel.getRotation());
 
   mStaticText.setText(*mNetLabel.getNetSignalOfNetSegment().getName());
   mStaticText.prepare(QTransform(), mFont);

--- a/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbol.cpp
@@ -133,8 +133,8 @@ void SGI_Symbol::updatePosition() noexcept {
 
 void SGI_Symbol::updateRotationAndMirrored() noexcept {
   QTransform t;
-  if (mSymbol.getMirrored()) t.scale(qreal(-1), qreal(1));
   t.rotate(-mSymbol.getRotation().toDeg());
+  if (mSymbol.getMirrored()) t.scale(qreal(-1), qreal(1));
   setTransform(t);
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbolpin.cpp
@@ -211,8 +211,8 @@ void SGI_SymbolPin::updateRotation() noexcept {
       transform.map(mPin.getLibPin().getNamePosition().rotated(
           mPin.getLibPin().getRotation())) -
       transform.getPosition();
-  Angle nameRotation = transform.map(mPin.getLibPin().getRotation() +
-                                     mPin.getLibPin().getNameRotation());
+  Angle nameRotation = transform.mapNonMirrorable(
+      mPin.getLibPin().getRotation() + mPin.getLibPin().getNameRotation());
   Alignment nameAlignment = mPin.getLibPin().getNameAlignment();
   if (transform.getMirrored()) {
     nameAlignment.mirrorV();

--- a/libs/librepcb/editor/widgets/graphicsview.cpp
+++ b/libs/librepcb/editor/widgets/graphicsview.cpp
@@ -503,7 +503,7 @@ void GraphicsView::drawForeground(QPainter* painter, const QRectF& rect) {
     Angle textRotation = Angle::deg0();
     Alignment textAlign(HAlign::left(), VAlign::center());
     qreal xScale = 1;
-    if (Toolbox::isTextUpsideDown(angle - Angle::deg90(), false)) {
+    if (Toolbox::isTextUpsideDown(angle - Angle::deg90())) {
       textRotation = Angle::deg180();
       textAlign.mirrorH();
       xScale = -1;

--- a/tests/unittests/core/utils/toolboxtest.cpp
+++ b/tests/unittests/core/utils/toolboxtest.cpp
@@ -42,43 +42,23 @@ class ToolboxTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(ToolboxTest, testIsTextUpsideDown) {
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-360000000), false));  // 0°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-315000000), false));  // 45°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-270000000), false));  // 90°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-225000000), false));  // 135°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-180000000), false));  // 180°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-135000000), false));  // 225°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-90000000), false));  // 270°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-45000000), false));  // 315°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(0), false));  // 0°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(45000000), false));  // 45°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(90000000), false));  // 90°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(135000000), false));  // 135°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(180000000), false));  // 180°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(225000000), false));  // 225°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(270000000), false));  // 270°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(315000000), false));  // 315°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(360000000), false));  // 0°
-}
-
-TEST_F(ToolboxTest, testIsTextUpsideDownMirrored) {
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-360000000), true));  // 0°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-315000000), true));  // 45°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-270000000), true));  // 90°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-225000000), true));  // 135°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-180000000), true));  // 180°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-135000000), true));  // 225°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-90000000), true));  // 270°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-45000000), true));  // 315°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(0), true));  // 0°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(45000000), true));  // 45°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(90000000), true));  // 90°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(135000000), true));  // 135°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(180000000), true));  // 180°
-  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(225000000), true));  // 225°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(270000000), true));  // 270°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(315000000), true));  // 315°
-  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(360000000), true));  // 0°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-360000000)));  // 0°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-315000000)));  // 45°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-270000000)));  // 90°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-225000000)));  // 135°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-180000000)));  // 180°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-135000000)));  // 225°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(-90000000)));  // 270°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(-45000000)));  // 315°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(0)));  // 0°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(45000000)));  // 45°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(90000000)));  // 90°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(135000000)));  // 135°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(180000000)));  // 180°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(225000000)));  // 225°
+  EXPECT_TRUE(Toolbox::isTextUpsideDown(Angle(270000000)));  // 270°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(315000000)));  // 315°
+  EXPECT_FALSE(Toolbox::isTextUpsideDown(Angle(360000000)));  // 0°
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/utils/transformtest.cpp
+++ b/tests/unittests/core/utils/transformtest.cpp
@@ -73,20 +73,36 @@ TEST_F(TransformTest, testCopyConstructor) {
   EXPECT_EQ(t1.getMirrored(), t2.getMirrored());
 }
 
-TEST_F(TransformTest, testMapAngleNonMirrored) {
+TEST_F(TransformTest, testMapMirrorableAngleNonMirrored) {
   Transform t(Point(1000, 2000), Angle(3000), false);
-  EXPECT_EQ(str(Angle(3000)), str(t.map(Angle(0))));
-  EXPECT_EQ(str(Angle(0)), str(t.map(Angle(-3000))));
-  EXPECT_EQ(str(Angle(180003000)), str(t.map(Angle(180000000))));
-  EXPECT_EQ(str(Angle(-179997000)), str(t.map(Angle(-180000000))));
+  EXPECT_EQ(str(Angle(3000)), str(t.mapMirrorable(Angle(0))));
+  EXPECT_EQ(str(Angle(0)), str(t.mapMirrorable(Angle(-3000))));
+  EXPECT_EQ(str(Angle(180003000)), str(t.mapMirrorable(Angle(180000000))));
+  EXPECT_EQ(str(Angle(-179997000)), str(t.mapMirrorable(Angle(-180000000))));
 }
 
-TEST_F(TransformTest, testMapAngleMirrored) {
+TEST_F(TransformTest, testMapMirrorableAngleMirrored) {
   Transform t(Point(1000, 2000), Angle(3000), true);
-  EXPECT_EQ(str(Angle(179997000)), str(t.map(Angle(0))));
-  EXPECT_EQ(str(Angle(180000000)), str(t.map(Angle(-3000))));
-  EXPECT_EQ(str(Angle(-3000)), str(t.map(Angle(180000000))));
-  EXPECT_EQ(str(Angle(359997000)), str(t.map(Angle(-180000000))));
+  EXPECT_EQ(str(Angle(3000)), str(t.mapMirrorable(Angle(0))));
+  EXPECT_EQ(str(Angle(6000)), str(t.mapMirrorable(Angle(-3000))));
+  EXPECT_EQ(str(Angle(-179997000)), str(t.mapMirrorable(Angle(180000000))));
+  EXPECT_EQ(str(Angle(180003000)), str(t.mapMirrorable(Angle(-180000000))));
+}
+
+TEST_F(TransformTest, testMapNonMirrorableAngleNonMirrored) {
+  Transform t(Point(1000, 2000), Angle(3000), false);
+  EXPECT_EQ(str(Angle(3000)), str(t.mapNonMirrorable(Angle(0))));
+  EXPECT_EQ(str(Angle(0)), str(t.mapNonMirrorable(Angle(-3000))));
+  EXPECT_EQ(str(Angle(180003000)), str(t.mapNonMirrorable(Angle(180000000))));
+  EXPECT_EQ(str(Angle(-179997000)), str(t.mapNonMirrorable(Angle(-180000000))));
+}
+
+TEST_F(TransformTest, testMapNonMirrorableAngleMirrored) {
+  Transform t(Point(1000, 2000), Angle(3000), true);
+  EXPECT_EQ(str(Angle(180003000)), str(t.mapNonMirrorable(Angle(0))));
+  EXPECT_EQ(str(Angle(180006000)), str(t.mapNonMirrorable(Angle(-3000))));
+  EXPECT_EQ(str(Angle(3000)), str(t.mapNonMirrorable(Angle(180000000))));
+  EXPECT_EQ(str(Angle(3000)), str(t.mapNonMirrorable(Angle(-180000000))));
 }
 
 TEST_F(TransformTest, testMapPointNonMirrored) {
@@ -98,7 +114,7 @@ TEST_F(TransformTest, testMapPointNonMirrored) {
 TEST_F(TransformTest, testMapPointMirrored) {
   Transform t(Point(1000, 2000), Angle(30000000), true);
   EXPECT_EQ(str(Point(1000, 2000)), str(t.map(Point(0, 0))));
-  EXPECT_EQ(str(Point(1983, 12836)), str(t.map(Point(4567, 9876))));
+  EXPECT_EQ(str(Point(-7893, 8269)), str(t.map(Point(4567, 9876))));
 }
 
 TEST_F(TransformTest, testMapPathNonMirrored) {
@@ -122,7 +138,7 @@ TEST_F(TransformTest, testMapPathMirrored) {
   });
   Path expected({
       Vertex(Point(1000, 2000), -Angle::deg90()),
-      Vertex(Point(1983, 12836), Angle::deg0()),
+      Vertex(Point(-7893, 8269), Angle::deg0()),
   });
   EXPECT_EQ(str(expected), str(t.map(input)));
 }


### PR DESCRIPTION
Changing the transformation order from *rotate -> mirror -> translate* to *mirror -> rotate -> translate*. See #956 for details. I think this way the transformations are indeed more intuitive and at least slightly simpler to implement.

The `rotation` parameter of affected objects are automatically converted to the new transformation order during the file format upgrade to keep the positioning of all board/schematic items.

Closes #956