### PR TITLE
CI: Update Docker images & build matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,10 @@ if(BUILD_DISALLOW_WARNINGS)
   target_compile_options(common INTERFACE -Werror)
 endif()
 
+# The TypeSafe library causes some compiler warnings which are not of
+# interest, so let's suppress them.
+target_compile_options(common INTERFACE -Wno-noexcept-type)
+
 # Clang emits some warnings within the muParser library when compiling with
 # -Wpedantic, so let's suppress these warnings when compiling with Clang.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -8,18 +8,10 @@ jobs:
     ARCH: 'x86_64'
   strategy:
     matrix:
-      Ubuntu_1604_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-4
-      Ubuntu_1604_Qt_5_15_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-16.04-qt5.15.2-2
+      Ubuntu_1804_Qt_5_15_GCC:
+        IMAGE: librepcb/librepcb-dev:ubuntu-18.04-qt5.15.2-1
         DEPLOY: true
         NO_HOEDOWN: true
-      Ubuntu_1804_Clang:
-        IMAGE: librepcb/librepcb-dev:ubuntu-18.04-4
-        CC: clang
-        CXX: clang++
-      Ubuntu_2004_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-7
       Ubuntu_2004_Unbundled:
         IMAGE: librepcb/librepcb-dev:ubuntu-20.04-7
         UNBUNDLE_DXFLIB: true
@@ -28,6 +20,10 @@ jobs:
         #UNBUNDLE_QUAZIP: true  # Note: Does not ship quazip 1.x yet
         UNBUNDLE_POLYCLIPPING: true
         LD_LIBRARY_PATH: $(Build.Repository.LocalPath)/build/install/opt/lib
+      Ubuntu_2204_Clang:
+        IMAGE: librepcb/librepcb-dev:ubuntu-22.04-1
+        CC: clang
+        CXX: clang++
   container: $[ variables['IMAGE'] ]
   steps:
   - checkout: self

--- a/ci/azure-jobs-windows.yml
+++ b/ci/azure-jobs-windows.yml
@@ -6,14 +6,13 @@ jobs:
     variables:
       OS: 'windows'
       ARCH: 'x86'
-      CC: 'ccache gcc'
-      CXX: 'ccache g++'
       CCACHE_DIR: $(Pipeline.Workspace)/.ccache
-      CMAKE_GENERATOR: 'MinGW Makefiles'
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CMAKE_GENERATOR: 'Ninja'
     strategy:
       matrix:
         Qt_5_15_MinGW_32bit:
-          IMAGE: librepcb/librepcb-dev:windowsservercore-ltsc2019-qt5.15.2-32bit-2
+          IMAGE: librepcb/librepcb-dev:windowsservercore-ltsc2019-qt5.15.2-32bit-3
           DEPLOY: true
     container: $[ variables['IMAGE'] ]
     steps:

--- a/ci/build_librepcb.sh
+++ b/ci/build_librepcb.sh
@@ -3,12 +3,12 @@
 # set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
 set -euv -o pipefail
 
-# use mingw32 make on Windows
+# use Ninja on Windows
 if [ "$OS" = "windows" ]
 then
-  MAKE="mingw32-make"
+  MAKE="ninja"
 else
-  MAKE="make"
+  MAKE="make -j8"
 fi
 
 # default compiler
@@ -33,7 +33,7 @@ cmake .. \
   -DBUILD_DISALLOW_WARNINGS=1 \
   -DLIBREPCB_ENABLE_DESKTOP_INTEGRATION=1 \
   -DLIBREPCB_BUILD_AUTHOR="LibrePCB CI"
-VERBOSE=1 $MAKE -j8
+VERBOSE=1 $MAKE
 $MAKE install
 popd
 

--- a/ci/build_windows_archive.sh
+++ b/ci/build_windows_archive.sh
@@ -8,7 +8,7 @@ cp -v C:/Windows/SysWOW64/vc*140.dll ./build/install/opt/bin/
 cp -v C:/Windows/SysWOW64/msvcp140*.dll ./build/install/opt/bin/
 
 # Copy OpenSSL DLLs (required to get HTTPS working)
-cp -v C:/OpenSSL-Win32/bin/lib*.dll ./build/install/opt/bin/
+cp -v C:/Qt/Tools/OpenSSL/Win_x86/bin/lib*.dll ./build/install/opt/bin/
 
 # Copy MinGW DLLs
 cp -v "`qmake -query QT_INSTALL_PREFIX`"/bin/lib*.dll ./build/install/opt/bin/

--- a/tests/unittests/editor/workspace/categorytreemodeltest.cpp
+++ b/tests/unittests/editor/workspace/categorytreemodeltest.cpp
@@ -228,7 +228,9 @@ TEST_F(CategoryTreeModelTest, testSort) {
   // It seems that either Qt or ICU has a bug in some versions which leads to
   // wrong sort behavior. On our CI this only occurs with Qt 5.15 on Linux
   // so let's skipt the test in exactly that configuration.
-#if defined(Q_OS_LINUX) && (QT_VERSION == QT_VERSION_CHECK(5, 15, 2))
+#if defined(Q_OS_LINUX) && \
+    ((QT_VERSION == QT_VERSION_CHECK(5, 15, 2)) || \
+     (QT_VERSION == QT_VERSION_CHECK(5, 15, 3)))
   GTEST_SKIP();
 #endif
 


### PR DESCRIPTION
Update to our latest Docker images for Windows and Linux.

On Linux, also reduce the number of pipelines from 4 to 3 (one pipeline per Ubuntu version: 18.04, 20.04, 22.04). Ubuntu 16.04 is no longer used, the official binaries are now built on Ubuntu 18.04 as the contained glibc version should be compatible with any still supported Linux distribution.

Windows is now building with Ninja instead of Make from MinGW.