### PR TITLE
Extend board setup with more PCB properties

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -389,6 +389,8 @@ add_library(
   types/lengthunit.h
   types/maskconfig.cpp
   types/maskconfig.h
+  types/pcbcolor.cpp
+  types/pcbcolor.h
   types/point.cpp
   types/point.h
   types/ratio.cpp

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -30,6 +30,7 @@
 #include "../../library/pkg/footprint.h"
 #include "../../serialization/sexpression.h"
 #include "../../types/lengthunit.h"
+#include "../../types/pcbcolor.h"
 #include "../../utils/scopeguardlist.h"
 #include "../../utils/toolbox.h"
 #include "../circuit/circuit.h"
@@ -86,6 +87,8 @@ Board::Board(Project& project,
     mInnerLayerCount(-1),  // Force update of setter.
     mCopperLayers(),
     mPcbThickness(1600000),  // 1.6mm
+    mSolderResist(&PcbColor::green()),
+    mSilkscreenColor(&PcbColor::white()),
     mDrcMessageApprovalsVersion(Application::getFileFormatVersion()),
     mDrcMessageApprovals(),
     mSupportedDrcMessageApprovals() {
@@ -515,6 +518,8 @@ void Board::copyFrom(const Board& other) {
   mInnerLayerCount = other.getInnerLayerCount();
   mCopperLayers = other.getCopperLayers();
   mPcbThickness = other.mPcbThickness;
+  mSolderResist = other.mSolderResist;
+  mSilkscreenColor = other.mSilkscreenColor;
   *mDesignRules = other.getDesignRules();
   *mFabricationOutputSettings = other.getFabricationOutputSettings();
 
@@ -688,6 +693,10 @@ void Board::save() {
     }
     root.ensureLineBreak();
     root.appendChild("thickness", mPcbThickness);
+    root.ensureLineBreak();
+    root.appendChild("solder_resist", mSolderResist);
+    root.ensureLineBreak();
+    root.appendChild("silkscreen", mSilkscreenColor);
     root.ensureLineBreak();
     mDesignRules->serialize(root.appendList("design_rules"));
     root.ensureLineBreak();

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -85,6 +85,7 @@ Board::Board(Project& project,
     mGridUnit(LengthUnit::millimeters()),
     mInnerLayerCount(-1),  // Force update of setter.
     mCopperLayers(),
+    mPcbThickness(1600000),  // 1.6mm
     mDrcMessageApprovalsVersion(Application::getFileFormatVersion()),
     mDrcMessageApprovals(),
     mSupportedDrcMessageApprovals() {
@@ -513,6 +514,7 @@ void Board::copyFrom(const Board& other) {
   mGridUnit = other.getGridUnit();
   mInnerLayerCount = other.getInnerLayerCount();
   mCopperLayers = other.getCopperLayers();
+  mPcbThickness = other.mPcbThickness;
   *mDesignRules = other.getDesignRules();
   *mFabricationOutputSettings = other.getFabricationOutputSettings();
 
@@ -684,6 +686,8 @@ void Board::save() {
       SExpression& node = root.appendList("layers");
       node.appendChild("inner", mInnerLayerCount);
     }
+    root.ensureLineBreak();
+    root.appendChild("thickness", mPcbThickness);
     root.ensureLineBreak();
     mDesignRules->serialize(root.appendList("design_rules"));
     root.ensureLineBreak();

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -89,6 +89,8 @@ Board::Board(Project& project,
     mPcbThickness(1600000),  // 1.6mm
     mSolderResist(&PcbColor::green()),
     mSilkscreenColor(&PcbColor::white()),
+    mSilkscreenLayersTop({&Layer::topPlacement(), &Layer::topNames()}),
+    mSilkscreenLayersBot({&Layer::botPlacement(), &Layer::botNames()}),
     mDrcMessageApprovalsVersion(Application::getFileFormatVersion()),
     mDrcMessageApprovals(),
     mSupportedDrcMessageApprovals() {
@@ -520,6 +522,8 @@ void Board::copyFrom(const Board& other) {
   mPcbThickness = other.mPcbThickness;
   mSolderResist = other.mSolderResist;
   mSilkscreenColor = other.mSilkscreenColor;
+  mSilkscreenLayersTop = other.mSilkscreenLayersTop;
+  mSilkscreenLayersBot = other.mSilkscreenLayersBot;
   *mDesignRules = other.getDesignRules();
   *mFabricationOutputSettings = other.getFabricationOutputSettings();
 
@@ -697,6 +701,20 @@ void Board::save() {
     root.appendChild("solder_resist", mSolderResist);
     root.ensureLineBreak();
     root.appendChild("silkscreen", mSilkscreenColor);
+    root.ensureLineBreak();
+    {
+      SExpression& node = root.appendList("silkscreen_layers_top");
+      foreach (const Layer* layer, mSilkscreenLayersTop) {
+        node.appendChild(*layer);
+      }
+    }
+    root.ensureLineBreak();
+    {
+      SExpression& node = root.appendList("silkscreen_layers_bot");
+      foreach (const Layer* layer, mSilkscreenLayersBot) {
+        node.appendChild(*layer);
+      }
+    }
     root.ensureLineBreak();
     mDesignRules->serialize(root.appendList("design_rules"));
     root.ensureLineBreak();

--- a/libs/librepcb/core/project/board/board.h
+++ b/libs/librepcb/core/project/board/board.h
@@ -58,6 +58,7 @@ class BoardDesignRules;
 class BoardFabricationOutputSettings;
 class Layer;
 class NetSignal;
+class PcbColor;
 class Project;
 
 /*******************************************************************************
@@ -117,6 +118,10 @@ public:
   const PositiveLength& getPcbThickness() const noexcept {
     return mPcbThickness;
   }
+  const PcbColor* getSolderResist() const noexcept { return mSolderResist; }
+  const PcbColor& getSilkscreenColor() const noexcept {
+    return *mSilkscreenColor;
+  }
   const QMap<QString, bool>& getLayersVisibility() const noexcept {
     return mLayersVisibility;
   }
@@ -132,6 +137,8 @@ public:
   void setGridUnit(const LengthUnit& unit) noexcept { mGridUnit = unit; }
   void setInnerLayerCount(int count) noexcept;
   void setPcbThickness(const PositiveLength& t) noexcept { mPcbThickness = t; }
+  void setSolderResist(const PcbColor* c) noexcept { mSolderResist = c; }
+  void setSilkscreenColor(const PcbColor& c) noexcept { mSilkscreenColor = &c; }
   void setLayersVisibility(const QMap<QString, bool>& visibility) noexcept {
     mLayersVisibility = visibility;
   }
@@ -262,6 +269,8 @@ private:
   int mInnerLayerCount;
   QSet<const Layer*> mCopperLayers;  ///< Derived from #mInnerLayerCount
   PositiveLength mPcbThickness;  ///< Total PCB thickness (all layers)
+  const PcbColor* mSolderResist;  ///< `nullptr` means no solder resist!
+  const PcbColor* mSilkscreenColor;  ///< Must never be `nullptr`!
 
   // User settings
   QMap<QString, bool> mLayersVisibility;

--- a/libs/librepcb/core/project/board/board.h
+++ b/libs/librepcb/core/project/board/board.h
@@ -114,6 +114,9 @@ public:
   const QSet<const Layer*> getCopperLayers() const noexcept {
     return mCopperLayers;
   }
+  const PositiveLength& getPcbThickness() const noexcept {
+    return mPcbThickness;
+  }
   const QMap<QString, bool>& getLayersVisibility() const noexcept {
     return mLayersVisibility;
   }
@@ -128,6 +131,7 @@ public:
   }
   void setGridUnit(const LengthUnit& unit) noexcept { mGridUnit = unit; }
   void setInnerLayerCount(int count) noexcept;
+  void setPcbThickness(const PositiveLength& t) noexcept { mPcbThickness = t; }
   void setLayersVisibility(const QMap<QString, bool>& visibility) noexcept {
     mLayersVisibility = visibility;
   }
@@ -253,8 +257,13 @@ private:
   QString mDefaultFontFileName;
   PositiveLength mGridInterval;
   LengthUnit mGridUnit;
+
+  // Board setup
   int mInnerLayerCount;
-  QSet<const Layer*> mCopperLayers;
+  QSet<const Layer*> mCopperLayers;  ///< Derived from #mInnerLayerCount
+  PositiveLength mPcbThickness;  ///< Total PCB thickness (all layers)
+
+  // User settings
   QMap<QString, bool> mLayersVisibility;
 
   // DRC

--- a/libs/librepcb/core/project/board/board.h
+++ b/libs/librepcb/core/project/board/board.h
@@ -122,6 +122,12 @@ public:
   const PcbColor& getSilkscreenColor() const noexcept {
     return *mSilkscreenColor;
   }
+  const QVector<const Layer*>& getSilkscreenLayersTop() const noexcept {
+    return mSilkscreenLayersTop;
+  }
+  const QVector<const Layer*>& getSilkscreenLayersBot() const noexcept {
+    return mSilkscreenLayersBot;
+  }
   const QMap<QString, bool>& getLayersVisibility() const noexcept {
     return mLayersVisibility;
   }
@@ -139,6 +145,12 @@ public:
   void setPcbThickness(const PositiveLength& t) noexcept { mPcbThickness = t; }
   void setSolderResist(const PcbColor* c) noexcept { mSolderResist = c; }
   void setSilkscreenColor(const PcbColor& c) noexcept { mSilkscreenColor = &c; }
+  void setSilkscreenLayersTop(const QVector<const Layer*>& l) noexcept {
+    mSilkscreenLayersTop = l;
+  }
+  void setSilkscreenLayersBot(const QVector<const Layer*>& l) noexcept {
+    mSilkscreenLayersBot = l;
+  }
   void setLayersVisibility(const QMap<QString, bool>& visibility) noexcept {
     mLayersVisibility = visibility;
   }
@@ -271,6 +283,8 @@ private:
   PositiveLength mPcbThickness;  ///< Total PCB thickness (all layers)
   const PcbColor* mSolderResist;  ///< `nullptr` means no solder resist!
   const PcbColor* mSilkscreenColor;  ///< Must never be `nullptr`!
+  QVector<const Layer*> mSilkscreenLayersTop;
+  QVector<const Layer*> mSilkscreenLayersBot;
 
   // User settings
   QMap<QString, bool> mLayersVisibility;

--- a/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
+++ b/libs/librepcb/core/project/board/boardfabricationoutputsettings.cpp
@@ -51,8 +51,6 @@ BoardFabricationOutputSettings::BoardFabricationOutputSettings() noexcept
     mSuffixSilkscreenBot("_SILKSCREEN-BOTTOM.gbr"),
     mSuffixSolderPasteTop("_SOLDERPASTE-TOP.gbr"),
     mSuffixSolderPasteBot("_SOLDERPASTE-BOTTOM.gbr"),
-    mSilkscreenLayersTop({&Layer::topPlacement(), &Layer::topNames()}),
-    mSilkscreenLayersBot({&Layer::botPlacement(), &Layer::botNames()}),
     mMergeDrillFiles(false),
     mUseG85SlotCommand(false),
     mEnableSolderPasteTop(true),
@@ -84,24 +82,12 @@ BoardFabricationOutputSettings::BoardFabricationOutputSettings(
         node.getChild("solderpaste_top/suffix/@0").getValue()),
     mSuffixSolderPasteBot(
         node.getChild("solderpaste_bot/suffix/@0").getValue()),
-    mSilkscreenLayersTop(),  // Initialized below.
-    mSilkscreenLayersBot(),  // Initialized below.
     mMergeDrillFiles(deserialize<bool>(node.getChild("drills/merge/@0"))),
     mUseG85SlotCommand(deserialize<bool>(node.getChild("drills/g85_slots/@0"))),
     mEnableSolderPasteTop(
         deserialize<bool>(node.getChild("solderpaste_top/create/@0"))),
     mEnableSolderPasteBot(
         deserialize<bool>(node.getChild("solderpaste_bot/create/@0"))) {
-  foreach (const SExpression* child,
-           node.getChild("silkscreen_top/layers")
-               .getChildren(SExpression::Type::Token)) {
-    mSilkscreenLayersTop.append(deserialize<const Layer*>(*child));
-  }
-  foreach (const SExpression* child,
-           node.getChild("silkscreen_bot/layers")
-               .getChildren(SExpression::Type::Token)) {
-    mSilkscreenLayersBot.append(deserialize<const Layer*>(*child));
-  }
 }
 
 BoardFabricationOutputSettings::~BoardFabricationOutputSettings() noexcept {
@@ -127,25 +113,9 @@ void BoardFabricationOutputSettings::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendList("soldermask_bot").appendChild("suffix", mSuffixSolderMaskBot);
   root.ensureLineBreak();
-
-  SExpression& silkscreenTop = root.appendList("silkscreen_top");
-  silkscreenTop.appendChild("suffix", mSuffixSilkscreenTop);
-  silkscreenTop.ensureLineBreak();
-  SExpression& silkscreenTopLayers = silkscreenTop.appendList("layers");
-  foreach (const Layer* layer, mSilkscreenLayersTop) {
-    silkscreenTopLayers.appendChild(*layer);
-  }
-  silkscreenTop.ensureLineBreak();
+  root.appendList("silkscreen_top").appendChild("suffix", mSuffixSilkscreenTop);
   root.ensureLineBreak();
-
-  SExpression& silkscreenBot = root.appendList("silkscreen_bot");
-  silkscreenBot.appendChild("suffix", mSuffixSilkscreenBot);
-  silkscreenBot.ensureLineBreak();
-  SExpression& silkscreenBotLayers = silkscreenBot.appendList("layers");
-  foreach (const Layer* layer, mSilkscreenLayersBot) {
-    silkscreenBotLayers.appendChild(*layer);
-  }
-  silkscreenBot.ensureLineBreak();
+  root.appendList("silkscreen_bot").appendChild("suffix", mSuffixSilkscreenBot);
   root.ensureLineBreak();
 
   SExpression& drills = root.appendList("drills");
@@ -192,8 +162,6 @@ BoardFabricationOutputSettings& BoardFabricationOutputSettings::operator=(
   mSuffixSilkscreenBot = rhs.mSuffixSilkscreenBot;
   mSuffixSolderPasteTop = rhs.mSuffixSolderPasteTop;
   mSuffixSolderPasteBot = rhs.mSuffixSolderPasteBot;
-  mSilkscreenLayersTop = rhs.mSilkscreenLayersTop;
-  mSilkscreenLayersBot = rhs.mSilkscreenLayersBot;
   mMergeDrillFiles = rhs.mMergeDrillFiles;
   mUseG85SlotCommand = rhs.mUseG85SlotCommand;
   mEnableSolderPasteTop = rhs.mEnableSolderPasteTop;
@@ -217,8 +185,6 @@ bool BoardFabricationOutputSettings::operator==(
   if (mSuffixSilkscreenBot != rhs.mSuffixSilkscreenBot) return false;
   if (mSuffixSolderPasteTop != rhs.mSuffixSolderPasteTop) return false;
   if (mSuffixSolderPasteBot != rhs.mSuffixSolderPasteBot) return false;
-  if (mSilkscreenLayersTop != rhs.mSilkscreenLayersTop) return false;
-  if (mSilkscreenLayersBot != rhs.mSilkscreenLayersBot) return false;
   if (mMergeDrillFiles != rhs.mMergeDrillFiles) return false;
   if (mUseG85SlotCommand != rhs.mUseG85SlotCommand) return false;
   if (mEnableSolderPasteTop != rhs.mEnableSolderPasteTop) return false;

--- a/libs/librepcb/core/project/board/boardfabricationoutputsettings.h
+++ b/libs/librepcb/core/project/board/boardfabricationoutputsettings.h
@@ -86,12 +86,6 @@ public:
   const QString& getSuffixSolderPasteBot() const noexcept {
     return mSuffixSolderPasteBot;
   }
-  const QVector<const Layer*>& getSilkscreenLayersTop() const noexcept {
-    return mSilkscreenLayersTop;
-  }
-  const QVector<const Layer*>& getSilkscreenLayersBot() const noexcept {
-    return mSilkscreenLayersBot;
-  }
   bool getMergeDrillFiles() const noexcept { return mMergeDrillFiles; }
   bool getUseG85SlotCommand() const noexcept { return mUseG85SlotCommand; }
   bool getEnableSolderPasteTop() const noexcept {
@@ -130,12 +124,6 @@ public:
   void setSuffixSolderPasteBot(const QString& s) noexcept {
     mSuffixSolderPasteBot = s;
   }
-  void setSilkscreenLayersTop(const QVector<const Layer*>& l) noexcept {
-    mSilkscreenLayersTop = l;
-  }
-  void setSilkscreenLayersBot(const QVector<const Layer*>& l) noexcept {
-    mSilkscreenLayersBot = l;
-  }
   void setMergeDrillFiles(bool m) noexcept { mMergeDrillFiles = m; }
   void setUseG85SlotCommand(bool u) noexcept { mUseG85SlotCommand = u; }
   void setEnableSolderPasteTop(bool e) noexcept { mEnableSolderPasteTop = e; }
@@ -173,8 +161,6 @@ private:  // Data
   QString mSuffixSilkscreenBot;
   QString mSuffixSolderPasteTop;
   QString mSuffixSolderPasteBot;
-  QVector<const Layer*> mSilkscreenLayersTop;
-  QVector<const Layer*> mSilkscreenLayersBot;
   bool mMergeDrillFiles;
   bool mUseG85SlotCommand;
   bool mEnableSolderPasteTop;

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -399,30 +399,34 @@ void BoardGerberExport::exportLayerInnerCopper(
 
 void BoardGerberExport::exportLayerTopSolderMask(
     const BoardFabricationOutputSettings& settings) const {
-  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
-                                  settings.getSuffixSolderMaskTop());
-  GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
-                      mProject.getVersion());
-  gen.setFileFunctionSolderMask(GerberGenerator::BoardSide::Top,
-                                GerberGenerator::Polarity::Negative);
-  drawLayer(gen, Layer::topStopMask());
-  gen.generate();
-  gen.saveToFile(fp);
-  mWrittenFiles.append(fp);
+  if (mBoard.getSolderResist()) {
+    FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                    settings.getSuffixSolderMaskTop());
+    GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
+                        mProject.getVersion());
+    gen.setFileFunctionSolderMask(GerberGenerator::BoardSide::Top,
+                                  GerberGenerator::Polarity::Negative);
+    drawLayer(gen, Layer::topStopMask());
+    gen.generate();
+    gen.saveToFile(fp);
+    mWrittenFiles.append(fp);
+  }
 }
 
 void BoardGerberExport::exportLayerBottomSolderMask(
     const BoardFabricationOutputSettings& settings) const {
-  FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
-                                  settings.getSuffixSolderMaskBot());
-  GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
-                      mProject.getVersion());
-  gen.setFileFunctionSolderMask(GerberGenerator::BoardSide::Bottom,
-                                GerberGenerator::Polarity::Negative);
-  drawLayer(gen, Layer::botStopMask());
-  gen.generate();
-  gen.saveToFile(fp);
-  mWrittenFiles.append(fp);
+  if (mBoard.getSolderResist()) {
+    FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
+                                    settings.getSuffixSolderMaskBot());
+    GerberGenerator gen(mCreationDateTime, mProjectName, mBoard.getUuid(),
+                        mProject.getVersion());
+    gen.setFileFunctionSolderMask(GerberGenerator::BoardSide::Bottom,
+                                  GerberGenerator::Polarity::Negative);
+    drawLayer(gen, Layer::botStopMask());
+    gen.generate();
+    gen.saveToFile(fp);
+    mWrittenFiles.append(fp);
+  }
 }
 
 void BoardGerberExport::exportLayerTopSilkscreen(

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -431,7 +431,7 @@ void BoardGerberExport::exportLayerBottomSolderMask(
 
 void BoardGerberExport::exportLayerTopSilkscreen(
     const BoardFabricationOutputSettings& settings) const {
-  const QVector<const Layer*>& layers = settings.getSilkscreenLayersTop();
+  const QVector<const Layer*>& layers = mBoard.getSilkscreenLayersTop();
   if (layers.count() > 0) {  // don't export silkscreen if no layers selected
     FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
                                     settings.getSuffixSilkscreenTop());
@@ -450,7 +450,7 @@ void BoardGerberExport::exportLayerTopSilkscreen(
 
 void BoardGerberExport::exportLayerBottomSilkscreen(
     const BoardFabricationOutputSettings& settings) const {
-  const QVector<const Layer*>& layers = settings.getSilkscreenLayersBot();
+  const QVector<const Layer*>& layers = mBoard.getSilkscreenLayersBot();
   if (layers.count() > 0) {  // don't export silkscreen if no layers selected
     FilePath fp = getOutputFilePath(settings.getOutputBasePath() %
                                     settings.getSuffixSilkscreenBot());

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -532,6 +532,8 @@ void ProjectLoader::loadBoard(Project& p, const QString& relativeFilePath) {
   board->setDefaultFontName(root.getChild("default_font/@0").getValue());
   board->setInnerLayerCount(
       deserialize<uint>(root.getChild("layers/inner/@0")));
+  board->setPcbThickness(
+      deserialize<PositiveLength>(root.getChild("thickness/@0")));
   board->setDesignRules(BoardDesignRules(root.getChild("design_rules")));
   {
     const SExpression& node = root.getChild("design_rule_check");

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -539,6 +539,24 @@ void ProjectLoader::loadBoard(Project& p, const QString& relativeFilePath) {
       deserialize<const PcbColor*>(root.getChild("solder_resist/@0")));
   board->setSilkscreenColor(
       deserialize<const PcbColor&>(root.getChild("silkscreen/@0")));
+  {
+    QVector<const Layer*> layers;
+    foreach (const SExpression* child,
+             root.getChild("silkscreen_layers_top")
+                 .getChildren(SExpression::Type::Token)) {
+      layers.append(deserialize<const Layer*>(*child));
+    }
+    board->setSilkscreenLayersTop(layers);
+  }
+  {
+    QVector<const Layer*> layers;
+    foreach (const SExpression* child,
+             root.getChild("silkscreen_layers_bot")
+                 .getChildren(SExpression::Type::Token)) {
+      layers.append(deserialize<const Layer*>(*child));
+    }
+    board->setSilkscreenLayersBot(layers);
+  }
   board->setDesignRules(BoardDesignRules(root.getChild("design_rules")));
   {
     const SExpression& node = root.getChild("design_rule_check");

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -29,6 +29,7 @@
 #include "../library/pkg/package.h"
 #include "../library/sym/symbol.h"
 #include "../serialization/fileformatmigration.h"
+#include "../types/pcbcolor.h"
 #include "board/board.h"
 #include "board/boarddesignrules.h"
 #include "board/boardfabricationoutputsettings.h"
@@ -534,6 +535,10 @@ void ProjectLoader::loadBoard(Project& p, const QString& relativeFilePath) {
       deserialize<uint>(root.getChild("layers/inner/@0")));
   board->setPcbThickness(
       deserialize<PositiveLength>(root.getChild("thickness/@0")));
+  board->setSolderResist(
+      deserialize<const PcbColor*>(root.getChild("solder_resist/@0")));
+  board->setSilkscreenColor(
+      deserialize<const PcbColor&>(root.getChild("silkscreen/@0")));
   board->setDesignRules(BoardDesignRules(root.getChild("design_rules")));
   {
     const SExpression& node = root.getChild("design_rule_check");

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -65,17 +65,6 @@ void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-  const QString fp = "package.lp";
-  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  for (SExpression* fptNode : root.getChildren("footprint")) {
-    for (SExpression* txtNode : fptNode->getChildren("stroke_text")) {
-      if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
-        SExpression& rotNode = txtNode->getChild("rotation/@0");
-        rotNode = serialize(-deserialize<Angle>(rotNode));
-      }
-    }
-  }
-  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(
@@ -118,36 +107,13 @@ void FileFormatMigrationUnstable::upgradeSchematic(SExpression& root,
                                                    ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  for (SExpression* symNode : root.getChildren("symbol")) {
-    if (deserialize<bool>(symNode->getChild("mirror/@0"))) {
-      SExpression& rotNode = symNode->getChild("rotation/@0");
-      rotNode = serialize(-deserialize<Angle>(rotNode));
-    }
-  }
 }
 
 void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  for (SExpression* devNode : root.getChildren("device")) {
-    if (deserialize<bool>(devNode->getChild("mirror/@0"))) {
-      SExpression& rotNode = devNode->getChild("rotation/@0");
-      rotNode = serialize(-deserialize<Angle>(rotNode));
-    }
-    for (SExpression* txtNode : devNode->getChildren("stroke_text")) {
-      if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
-        SExpression& rotNode = txtNode->getChild("rotation/@0");
-        rotNode = serialize(-deserialize<Angle>(rotNode));
-      }
-    }
-  }
-  for (SExpression* txtNode : root.getChildren("stroke_text")) {
-    if (deserialize<bool>(txtNode->getChild("mirror/@0"))) {
-      SExpression& rotNode = txtNode->getChild("rotation/@0");
-      rotNode = serialize(-deserialize<Angle>(rotNode));
-    }
-  }
+  root.appendChild("thickness", SExpression::createToken("1.6"));
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -114,6 +114,8 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
   Q_UNUSED(root);
   Q_UNUSED(context);
   root.appendChild("thickness", SExpression::createToken("1.6"));
+  root.appendChild("solder_resist", SExpression::createToken("green"));
+  root.appendChild("silkscreen", SExpression::createToken("white"));
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -116,6 +116,18 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
   root.appendChild("thickness", SExpression::createToken("1.6"));
   root.appendChild("solder_resist", SExpression::createToken("green"));
   root.appendChild("silkscreen", SExpression::createToken("white"));
+
+  SExpression& fabNode = root.getChild("fabrication_output_settings");
+
+  SExpression& silkTop = fabNode.getChild("silkscreen_top");
+  SExpression& silkLayersTop = silkTop.getChild("layers");
+  root.appendChild(SExpression(silkLayersTop)).setName("silkscreen_layers_top");
+  silkTop.removeChild(silkLayersTop);
+
+  SExpression& silkBot = fabNode.getChild("silkscreen_bot");
+  SExpression& silkLayersBot = silkBot.getChild("layers");
+  root.appendChild(SExpression(silkLayersBot)).setName("silkscreen_layers_bot");
+  silkBot.removeChild(silkLayersBot);
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -629,6 +629,18 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
     SExpression& node = root.getChild("fabrication_output_settings");
     SExpression& drillNode = node.getChild("drills");
     drillNode.appendChild("g85_slots", false);
+
+    SExpression& silkTop = node.getChild("silkscreen_top");
+    SExpression& silkLayersTop = silkTop.getChild("layers");
+    root.appendChild(SExpression(silkLayersTop))
+        .setName("silkscreen_layers_top");
+    silkTop.removeChild(silkLayersTop);
+
+    SExpression& silkBot = node.getChild("silkscreen_bot");
+    SExpression& silkLayersBot = silkBot.getChild("layers");
+    root.appendChild(SExpression(silkLayersBot))
+        .setName("silkscreen_layers_bot");
+    silkBot.removeChild(silkLayersBot);
   }
 
   // Devices.

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -619,6 +619,9 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
   upgradeBoardDrcSettings(root);
   upgradeLayers(root);
 
+  // Board setup.
+  root.appendChild("thickness", SExpression::createToken("1.6"));
+
   // Fabrication output settings.
   {
     SExpression& node = root.getChild("fabrication_output_settings");

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -621,6 +621,8 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
 
   // Board setup.
   root.appendChild("thickness", SExpression::createToken("1.6"));
+  root.appendChild("solder_resist", SExpression::createToken("green"));
+  root.appendChild("silkscreen", SExpression::createToken("white"));
 
   // Fabrication output settings.
   {

--- a/libs/librepcb/core/types/pcbcolor.cpp
+++ b/libs/librepcb/core/types/pcbcolor.cpp
@@ -1,0 +1,223 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "pcbcolor.h"
+
+#include "../exceptions.h"
+#include "../serialization/sexpression.h"
+
+#include <QtCore>
+#include <QtGui>
+
+#include <algorithm>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PcbColor::PcbColor(const QString& id, const QString& nameTr, Flags flags,
+                   const QColor& solderResistColor,
+                   const QColor& silkscreenColor) noexcept
+  : mId(id),
+    mNameTr(nameTr),
+    mFlags(flags),
+    mSolderResistColor(solderResistColor),
+    mSilkscreenColor(silkscreenColor) {
+}
+
+PcbColor::PcbColor(const PcbColor& other) noexcept
+  : mId(other.mId),
+    mNameTr(other.mNameTr),
+    mFlags(other.mFlags),
+    mSolderResistColor(other.mSolderResistColor),
+    mSilkscreenColor(other.mSilkscreenColor) {
+}
+
+PcbColor::~PcbColor() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+const QColor& PcbColor::toSolderResistColor() const noexcept {
+  return mSolderResistColor.isValid() ? mSolderResistColor
+                                      : green().toSolderResistColor();
+}
+
+const QColor& PcbColor::toSilkscreenColor() const noexcept {
+  return mSilkscreenColor.isValid() ? mSilkscreenColor
+                                    : white().toSilkscreenColor();
+}
+
+/*******************************************************************************
+ *  Static Methods
+ ******************************************************************************/
+
+const PcbColor& PcbColor::black() noexcept {
+  static PcbColor obj("black", tr("Black"),
+                      Flag::SolderResist | Flag::Silkscreen,
+                      QColor(0, 0, 0, 210), QColor(40, 40, 40));
+  return obj;
+}
+
+const PcbColor& PcbColor::blackMatte() noexcept {
+  static PcbColor obj("black_matte", tr("Black Matte"), Flag::SolderResist,
+                      QColor(0, 0, 0, 210), Qt::black);
+  return obj;
+}
+
+const PcbColor& PcbColor::blue() noexcept {
+  static PcbColor obj("blue", tr("Blue"), Flag::SolderResist | Flag::Silkscreen,
+                      QColor(0, 20, 100, 220), QColor(0, 0, 110));
+  return obj;
+}
+
+const PcbColor& PcbColor::clear() noexcept {
+  static PcbColor obj("clear", tr("Clear"), Flags(/* not available (yet) */),
+                      QColor(50, 50, 50, 50), Qt::white);
+  return obj;
+}
+
+const PcbColor& PcbColor::green() noexcept {
+  static PcbColor obj("green", tr("Green"), Flag::SolderResist,
+                      QColor(0, 50, 0, 180), Qt::green);
+  return obj;
+}
+
+const PcbColor& PcbColor::greenMatte() noexcept {
+  static PcbColor obj("green_matte", tr("Green Matte"), Flag::SolderResist,
+                      QColor(0, 50, 0, 180), Qt::green);
+  return obj;
+}
+
+const PcbColor& PcbColor::purple() noexcept {
+  static PcbColor obj("purple", tr("Purple"), Flag::SolderResist,
+                      QColor(80, 0, 130, 180), QColor(100, 0, 160));
+  return obj;
+}
+
+const PcbColor& PcbColor::red() noexcept {
+  static PcbColor obj("red", tr("Red"), Flag::SolderResist | Flag::Silkscreen,
+                      QColor(160, 0, 0, 180), QColor(140, 0, 0));
+  return obj;
+}
+
+const PcbColor& PcbColor::white() noexcept {
+  static PcbColor obj("white", tr("White"),
+                      Flag::SolderResist | Flag::Silkscreen,
+                      QColor(220, 220, 220, 210), Qt::white);
+  return obj;
+}
+
+const PcbColor& PcbColor::yellow() noexcept {
+  static PcbColor obj("yellow", tr("Yellow"),
+                      Flag::SolderResist | Flag::Silkscreen,
+                      QColor(220, 220, 0, 160), QColor(210, 210, 0));
+  return obj;
+}
+
+const PcbColor& PcbColor::other() noexcept {
+  static PcbColor obj("other", tr("Other"),
+                      Flag::SolderResist | Flag::Silkscreen, QColor(),
+                      QColor());
+  return obj;
+}
+
+const QVector<const PcbColor*>& PcbColor::all() noexcept {
+  auto init = []() {
+    // Sort the list by function and name.
+    QVector<const PcbColor*> l{
+        &black(),  //
+        &blackMatte(),  //
+        &blue(),  //
+        &clear(),  //
+        &green(),  //
+        &greenMatte(),  //
+        &purple(),  //
+        &red(),  //
+        &white(),  //
+        &yellow(),  //
+    };
+    std::sort(l.begin(), l.end(), [](const PcbColor* a, const PcbColor* b) {
+      return a->mNameTr < b->mNameTr;
+    });
+    l.append(&other());
+    return l;
+  };
+  static QVector<const PcbColor*> list = init();  // Thread-safe initialization.
+  return list;
+}
+
+const PcbColor& PcbColor::get(const QString& id) {
+  foreach (const PcbColor* PcbColor, all()) {
+    if (PcbColor->getId() == id) {
+      return *PcbColor;
+    }
+  }
+  throw RuntimeError(__FILE__, __LINE__,
+                     QString("Unknown color: '%1'").arg(id));
+}
+
+/*******************************************************************************
+ *  Non-Member Functions
+ ******************************************************************************/
+
+template <>
+SExpression serialize(const PcbColor& obj) {
+  return SExpression::createToken(obj.getId());
+}
+
+template <>
+SExpression serialize(const PcbColor* const& obj) {
+  if (obj) {
+    return SExpression::createToken(obj->getId());
+  } else {
+    return SExpression::createToken("none");
+  }
+}
+
+template <>
+const PcbColor& deserialize(const SExpression& node) {
+  return PcbColor::get(node.getValue());
+}
+
+template <>
+const PcbColor* deserialize(const SExpression& node) {
+  const QString value = node.getValue();
+  if (value == "none") {
+    return nullptr;
+  } else {
+    return &PcbColor::get(node.getValue());
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/types/pcbcolor.h
+++ b/libs/librepcb/core/types/pcbcolor.h
@@ -1,0 +1,165 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_PCBCOLOR_H
+#define LIBREPCB_CORE_PCBCOLOR_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtGui>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class PcbColor
+ ******************************************************************************/
+
+/**
+ * @brief Predefined colors relevant for PCB fabrication
+ */
+class PcbColor final {
+  Q_DECLARE_TR_FUNCTIONS(PcbColor)
+
+public:
+  // Types
+  enum class Flag : quint32 {
+    SolderResist = (1 << 0),  ///< Color available for solder resist
+    Silkscreen = (1 << 1),  ///< Color available for silkscreen
+  };
+  Q_DECLARE_FLAGS(Flags, Flag)
+
+  // Constructors / Destructor
+  PcbColor() = delete;
+  PcbColor(const PcbColor& other) noexcept;
+  ~PcbColor() noexcept;
+
+  // Getters
+
+  /**
+   * @brief Get the identifier used for serialization
+   *
+   * @return Identifier string (lower_snake_case)
+   */
+  const QString& getId() const noexcept { return mId; }
+
+  /**
+   * @brief Get the name of the color (human readable and translated)
+   *
+   * @return The name of the color
+   */
+  const QString& getNameTr() const noexcept { return mNameTr; }
+
+  /**
+   * @brief Get the actual color for solder resist rendering
+   *
+   * @return A QColor object representing this color, or a default color
+   *         if this color does not represent a valid solder resist color
+   */
+  const QColor& toSolderResistColor() const noexcept;
+
+  /**
+   * @brief Get the actual color for silkscreen rendering
+   *
+   * @return A QColor object representing this color, or a default color
+   *         if this color does not represent a valid silkscreen color
+   */
+  const QColor& toSilkscreenColor() const noexcept;
+
+  /**
+   * @brief Check if this color is available for solder resist
+   *
+   * @return Whether this color is available or not
+   */
+  bool isAvailableForSolderResist() const noexcept {
+    return mFlags.testFlag(Flag::SolderResist);
+  }
+
+  /**
+   * @brief Check if this color is available for silkscreen
+   *
+   * @return Whether this color is available or not
+   */
+  bool isAvailableForSilkscreen() const noexcept {
+    return mFlags.testFlag(Flag::Silkscreen);
+  }
+
+  // Operator Overloadings
+  PcbColor& operator=(const PcbColor& rhs) noexcept = delete;
+  bool operator==(const PcbColor& rhs) const noexcept { return this == &rhs; }
+  bool operator!=(const PcbColor& rhs) const noexcept { return this != &rhs; }
+
+  // Static Methods
+  static const PcbColor& black() noexcept;
+  static const PcbColor& blackMatte() noexcept;
+  static const PcbColor& blue() noexcept;
+  static const PcbColor& clear() noexcept;
+  static const PcbColor& green() noexcept;
+  static const PcbColor& greenMatte() noexcept;
+  static const PcbColor& purple() noexcept;
+  static const PcbColor& red() noexcept;
+  static const PcbColor& white() noexcept;
+  static const PcbColor& yellow() noexcept;
+  static const PcbColor& other() noexcept;
+
+  /**
+   * @brief Get a list of all available colors
+   *
+   * @return A list of all colors
+   */
+  static const QVector<const PcbColor*>& all() noexcept;
+
+  /**
+   * @brief Get a color by its identifier
+   *
+   * @param id  Color identifier.
+   *
+   * @return PcbColor object.
+   *
+   * @throw Exception if the color was not found.
+   */
+  static const PcbColor& get(const QString& id);
+
+private:  // Methods
+  PcbColor(const QString& id, const QString& nameTr, Flags flags,
+           const QColor& solderResistColor,
+           const QColor& silkscreenColor) noexcept;
+
+private:  // Data
+  const QString mId;
+  const QString mNameTr;
+  const Flags mFlags;
+  const QColor mSolderResistColor;
+  const QColor mSilkscreenColor;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(librepcb::PcbColor::Flags)
+Q_DECLARE_METATYPE(const librepcb::PcbColor*)
+
+#endif

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
@@ -90,6 +90,12 @@ BoardSetupDialog::BoardSetupDialog(Board& board, UndoStack& undoStack,
   }
   mUi->lblNoteAboutSettingsHandover->setText(
       "*) " % mUi->lblNoteAboutSettingsHandover->text());
+  mUi->cbxSilkTopPlacement->setText(Layer::topPlacement().getNameTr());
+  mUi->cbxSilkTopNames->setText(Layer::topNames().getNameTr());
+  mUi->cbxSilkTopValues->setText(Layer::topValues().getNameTr());
+  mUi->cbxSilkBotPlacement->setText(Layer::botPlacement().getNameTr());
+  mUi->cbxSilkBotNames->setText(Layer::botNames().getNameTr());
+  mUi->cbxSilkBotValues->setText(Layer::botValues().getNameTr());
 
   // Tab: Design Rules
   mUi->edtRulesStopMaskClrRatio->setSingleStep(5.0);  // [%]
@@ -274,6 +280,18 @@ void BoardSetupDialog::load() noexcept {
       QVariant::fromValue(mBoard.getSolderResist())));
   mUi->cbxSilkscreenColor->setCurrentIndex(mUi->cbxSilkscreenColor->findData(
       QVariant::fromValue(&mBoard.getSilkscreenColor())));
+  const QVector<const Layer*>& topSilkscreen = mBoard.getSilkscreenLayersTop();
+  mUi->cbxSilkTopPlacement->setChecked(
+      topSilkscreen.contains(&Layer::topPlacement()));
+  mUi->cbxSilkTopNames->setChecked(topSilkscreen.contains(&Layer::topNames()));
+  mUi->cbxSilkTopValues->setChecked(
+      topSilkscreen.contains(&Layer::topValues()));
+  const QVector<const Layer*>& botSilkscreen = mBoard.getSilkscreenLayersBot();
+  mUi->cbxSilkBotPlacement->setChecked(
+      botSilkscreen.contains(&Layer::botPlacement()));
+  mUi->cbxSilkBotNames->setChecked(botSilkscreen.contains(&Layer::botNames()));
+  mUi->cbxSilkBotValues->setChecked(
+      botSilkscreen.contains(&Layer::botValues()));
 
   // Tab: Design Rules
   const BoardDesignRules& r = mBoard.getDesignRules();
@@ -354,6 +372,8 @@ bool BoardSetupDialog::apply() noexcept {
             mUi->cbxSilkscreenColor->currentData().value<const PcbColor*>()) {
       cmd->setSilkscreenColor(*color);
     }
+    cmd->setSilkscreenLayersTop(getTopSilkscreenLayers());
+    cmd->setSilkscreenLayersBot(getBotSilkscreenLayers());
 
     // Tab: Design Rules
     BoardDesignRules r = mBoard.getDesignRules();
@@ -408,6 +428,36 @@ bool BoardSetupDialog::apply() noexcept {
     QMessageBox::warning(this, tr("Could not apply settings"), e.getMsg());
     return false;
   }
+}
+
+QVector<const Layer*> BoardSetupDialog::getTopSilkscreenLayers() const
+    noexcept {
+  QVector<const Layer*> layers;
+  if (mUi->cbxSilkTopPlacement->isChecked()) {
+    layers << &Layer::topPlacement();
+  }
+  if (mUi->cbxSilkTopNames->isChecked()) {
+    layers << &Layer::topNames();
+  }
+  if (mUi->cbxSilkTopValues->isChecked()) {
+    layers << &Layer::topValues();
+  }
+  return layers;
+}
+
+QVector<const Layer*> BoardSetupDialog::getBotSilkscreenLayers() const
+    noexcept {
+  QVector<const Layer*> layers;
+  if (mUi->cbxSilkBotPlacement->isChecked()) {
+    layers << &Layer::botPlacement();
+  }
+  if (mUi->cbxSilkBotNames->isChecked()) {
+    layers << &Layer::botNames();
+  }
+  if (mUi->cbxSilkBotValues->isChecked()) {
+    layers << &Layer::botValues();
+  }
+  return layers;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
@@ -59,6 +59,10 @@ BoardSetupDialog::BoardSetupDialog(Board& board, UndoStack& undoStack,
   // Tab: General
   mUi->spbxInnerCopperLayerCount->setMinimum(0);
   mUi->spbxInnerCopperLayerCount->setMaximum(Layer::innerCopperCount());
+  mUi->edtPcbThickness->setToolTip(tr("Default:") % " 1.6 mm");
+  mUi->edtPcbThickness->configure(mBoard.getGridUnit(),
+                                  LengthEditBase::Steps::generic(),
+                                  sSettingsPrefix % "/pcb_thickness");
 
   // Tab: Design Rules
   mUi->edtRulesStopMaskClrRatio->setSingleStep(5.0);  // [%]
@@ -238,6 +242,7 @@ void BoardSetupDialog::load() noexcept {
   // Tab: General
   mUi->edtBoardName->setText(*mBoard.getName());
   mUi->spbxInnerCopperLayerCount->setValue(mBoard.getInnerLayerCount());
+  mUi->edtPcbThickness->setValue(mBoard.getPcbThickness());
 
   // Tab: Design Rules
   const BoardDesignRules& r = mBoard.getDesignRules();
@@ -309,6 +314,7 @@ bool BoardSetupDialog::apply() noexcept {
     cmd->setName(
         ElementName(mUi->edtBoardName->text().trimmed()));  // can throw
     cmd->setInnerLayerCount(mUi->spbxInnerCopperLayerCount->value());
+    cmd->setPcbThickness(mUi->edtPcbThickness->getValue());
 
     // Tab: Design Rules
     BoardDesignRules r = mBoard.getDesignRules();

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.h
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.h
@@ -32,6 +32,7 @@
 namespace librepcb {
 
 class Board;
+class Layer;
 
 namespace editor {
 
@@ -69,6 +70,8 @@ private:  // Methods
   void buttonBoxClicked(QAbstractButton* button);
   void load() noexcept;
   bool apply() noexcept;
+  QVector<const Layer*> getTopSilkscreenLayers() const noexcept;
+  QVector<const Layer*> getBotSilkscreenLayers() const noexcept;
 
 private:  // Date
   Board& mBoard;

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
@@ -58,6 +58,29 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_31">
+         <property name="text">
+          <string>Total PCB Thickness:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="librepcb::editor::PositiveLengthEdit" name="edtPcbThickness" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabDesignRules">
@@ -682,11 +705,18 @@ QAbstractScrollArea {
    <header location="global">librepcb/editor/widgets/unsignedratioedit.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>librepcb::editor::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>edtBoardName</tabstop>
   <tabstop>spbxInnerCopperLayerCount</tabstop>
+  <tabstop>edtPcbThickness</tabstop>
   <tabstop>edtRulesStopMaskClrMin</tabstop>
   <tabstop>edtRulesStopMaskClrRatio</tabstop>
   <tabstop>edtRulesStopMaskClrMax</tabstop>
@@ -708,7 +738,7 @@ QAbstractScrollArea {
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="btnGroupRulesCmpSidePadShape"/>
   <buttongroup name="btnGroupRulesInnerPadShape"/>
+  <buttongroup name="btnGroupRulesCmpSidePadShape"/>
  </buttongroups>
 </ui>

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
@@ -39,7 +39,7 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="lblInnerLayers">
          <property name="text">
           <string>Inner Copper Layers:</string>
          </property>
@@ -59,7 +59,7 @@
         </widget>
        </item>
        <item row="2" column="0">
-        <widget class="QLabel" name="label_31">
+        <widget class="QLabel" name="lblPcbThickness">
          <property name="text">
           <string>Total PCB Thickness:</string>
          </property>
@@ -78,6 +78,64 @@
            <width>100</width>
            <height>0</height>
           </size>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="lblSolderResist">
+         <property name="text">
+          <string>Solder Resist:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="lblSilkscreenColor">
+         <property name="text">
+          <string>Silkscreen:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="cbxSolderResist">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="cbxSilkscreenColor">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QLabel" name="lblNoteAboutSettingsHandover">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>These settings might not be supported and/or automatically taken into account by the PCB manufacturer. Always check/specify these manufacturing properties manually when ordering the PCB.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -717,6 +775,8 @@ QAbstractScrollArea {
   <tabstop>edtBoardName</tabstop>
   <tabstop>spbxInnerCopperLayerCount</tabstop>
   <tabstop>edtPcbThickness</tabstop>
+  <tabstop>cbxSolderResist</tabstop>
+  <tabstop>cbxSilkscreenColor</tabstop>
   <tabstop>edtRulesStopMaskClrMin</tabstop>
   <tabstop>edtRulesStopMaskClrRatio</tabstop>
   <tabstop>edtRulesStopMaskClrMax</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>624</width>
-    <height>383</height>
+    <height>405</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -115,7 +115,83 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0" colspan="2">
+       <item row="5" column="1">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QCheckBox" name="cbxSilkTopPlacement">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cbxSilkTopNames">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cbxSilkTopValues">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <widget class="QCheckBox" name="cbxSilkBotPlacement">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cbxSilkBotNames">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cbxSilkBotValues">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_31">
+         <property name="text">
+          <string>Silkscreen Content:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
         <widget class="QLabel" name="lblNoteAboutSettingsHandover">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -451,7 +527,7 @@ QAbstractScrollArea {
             <x>0</x>
             <y>0</y>
             <width>602</width>
-            <height>301</height>
+            <height>323</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -777,6 +853,12 @@ QAbstractScrollArea {
   <tabstop>edtPcbThickness</tabstop>
   <tabstop>cbxSolderResist</tabstop>
   <tabstop>cbxSilkscreenColor</tabstop>
+  <tabstop>cbxSilkTopPlacement</tabstop>
+  <tabstop>cbxSilkTopNames</tabstop>
+  <tabstop>cbxSilkTopValues</tabstop>
+  <tabstop>cbxSilkBotPlacement</tabstop>
+  <tabstop>cbxSilkBotNames</tabstop>
+  <tabstop>cbxSilkBotValues</tabstop>
   <tabstop>edtRulesStopMaskClrMin</tabstop>
   <tabstop>edtRulesStopMaskClrRatio</tabstop>
   <tabstop>edtRulesStopMaskClrMax</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -29,7 +29,6 @@
 #include <librepcb/core/project/board/boardfabricationoutputsettings.h>
 #include <librepcb/core/project/board/boardgerberexport.h>
 #include <librepcb/core/project/project.h>
-#include <librepcb/core/types/layer.h>
 #include <librepcb/core/utils/scopeguard.h>
 
 #include <QtCore>
@@ -127,20 +126,6 @@ FabricationOutputDialog::FabricationOutputDialog(
   mUi->cbxSolderPasteTop->setChecked(s.getEnableSolderPasteTop());
   mUi->cbxSolderPasteBot->setChecked(s.getEnableSolderPasteBot());
 
-  const QVector<const Layer*>& topSilkscreen = s.getSilkscreenLayersTop();
-  mUi->cbxSilkTopPlacement->setChecked(
-      topSilkscreen.contains(&Layer::topPlacement()));
-  mUi->cbxSilkTopNames->setChecked(topSilkscreen.contains(&Layer::topNames()));
-  mUi->cbxSilkTopValues->setChecked(
-      topSilkscreen.contains(&Layer::topValues()));
-
-  const QVector<const Layer*>& botSilkscreen = s.getSilkscreenLayersBot();
-  mUi->cbxSilkBotPlacement->setChecked(
-      botSilkscreen.contains(&Layer::botPlacement()));
-  mUi->cbxSilkBotNames->setChecked(botSilkscreen.contains(&Layer::botNames()));
-  mUi->cbxSilkBotValues->setChecked(
-      botSilkscreen.contains(&Layer::botValues()));
-
   // Load window geometry.
   QSettings clientSettings;
   restoreGeometry(
@@ -218,8 +203,6 @@ void FabricationOutputDialog::btnGenerateClicked() {
     s.setSuffixSilkscreenBot(mUi->edtSuffixSilkscreenBot->text().trimmed());
     s.setSuffixSolderPasteTop(mUi->edtSuffixSolderPasteTop->text().trimmed());
     s.setSuffixSolderPasteBot(mUi->edtSuffixSolderPasteBot->text().trimmed());
-    s.setSilkscreenLayersTop(getTopSilkscreenLayers());
-    s.setSilkscreenLayersBot(getBotSilkscreenLayers());
     s.setMergeDrillFiles(mUi->cbxDrillsMerge->isChecked());
     s.setUseG85SlotCommand(mUi->cbxUseG85Slots->isChecked());
     s.setEnableSolderPasteTop(mUi->cbxSolderPasteTop->isChecked());
@@ -258,40 +241,6 @@ void FabricationOutputDialog::btnBrowseOutputDirClicked() {
   } else {
     QMessageBox::warning(this, tr("Warning"), tr("Directory does not exist."));
   }
-}
-
-/*******************************************************************************
- *  Private Methods
- ******************************************************************************/
-
-QVector<const Layer*> FabricationOutputDialog::getTopSilkscreenLayers() const
-    noexcept {
-  QVector<const Layer*> layers;
-  if (mUi->cbxSilkTopPlacement->isChecked()) {
-    layers << &Layer::topPlacement();
-  }
-  if (mUi->cbxSilkTopNames->isChecked()) {
-    layers << &Layer::topNames();
-  }
-  if (mUi->cbxSilkTopValues->isChecked()) {
-    layers << &Layer::topValues();
-  }
-  return layers;
-}
-
-QVector<const Layer*> FabricationOutputDialog::getBotSilkscreenLayers() const
-    noexcept {
-  QVector<const Layer*> layers;
-  if (mUi->cbxSilkBotPlacement->isChecked()) {
-    layers << &Layer::botPlacement();
-  }
-  if (mUi->cbxSilkBotNames->isChecked()) {
-    layers << &Layer::botNames();
-  }
-  if (mUi->cbxSilkBotValues->isChecked()) {
-    layers << &Layer::botValues();
-  }
-  return layers;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.h
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.h
@@ -32,7 +32,6 @@
 namespace librepcb {
 
 class Board;
-class Layer;
 class Project;
 class WorkspaceSettings;
 
@@ -68,8 +67,6 @@ private:
   void btnProtelSuffixesClicked();
   void btnGenerateClicked();
   void btnBrowseOutputDirClicked();
-  QVector<const Layer*> getTopSilkscreenLayers() const noexcept;
-  QVector<const Layer*> getBotSilkscreenLayers() const noexcept;
 
   const WorkspaceSettings& mSettings;
   Project& mProject;

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>691</width>
-    <height>597</height>
+    <width>699</width>
+    <height>472</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -307,88 +307,6 @@ Attention: Curved slots are not supported in G85 mode (will raise an error).</st
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Top Silkscreen Layers</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QCheckBox" name="cbxSilkTopPlacement">
-          <property name="text">
-           <string>Placement</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="cbxSilkTopNames">
-          <property name="text">
-           <string>Names</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="cbxSilkTopValues">
-          <property name="text">
-           <string>Values</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="title">
-        <string>Bottom Silkscreen Layers</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QCheckBox" name="cbxSilkBotPlacement">
-          <property name="text">
-           <string>Placement</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="cbxSilkBotNames">
-          <property name="text">
-           <string>Names</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="cbxSilkBotValues">
-          <property name="text">
-           <string>Values</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -448,12 +366,6 @@ Attention: Curved slots are not supported in G85 mode (will raise an error).</st
   <tabstop>edtSuffixSolderPasteTop</tabstop>
   <tabstop>cbxSolderPasteBot</tabstop>
   <tabstop>edtSuffixSolderPasteBot</tabstop>
-  <tabstop>cbxSilkTopPlacement</tabstop>
-  <tabstop>cbxSilkTopNames</tabstop>
-  <tabstop>cbxSilkTopValues</tabstop>
-  <tabstop>cbxSilkBotPlacement</tabstop>
-  <tabstop>cbxSilkBotNames</tabstop>
-  <tabstop>cbxSilkBotValues</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/libs/librepcb/editor/project/cmd/cmdboardedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardedit.cpp
@@ -45,6 +45,10 @@ CmdBoardEdit::CmdBoardEdit(Board& board) noexcept
     mNewInnerLayerCount(mOldInnerLayerCount),
     mOldPcbThickness(mBoard.getPcbThickness()),
     mNewPcbThickness(mOldPcbThickness),
+    mOldSolderResist(mBoard.getSolderResist()),
+    mNewSolderResist(mOldSolderResist),
+    mOldSilkscreenColor(&mBoard.getSilkscreenColor()),
+    mNewSilkscreenColor(mOldSilkscreenColor),
     mOldDesignRules(mBoard.getDesignRules()),
     mNewDesignRules(mOldDesignRules),
     mOldDrcSettings(mBoard.getDrcSettings()),
@@ -73,6 +77,15 @@ void CmdBoardEdit::setPcbThickness(const PositiveLength& thickness) noexcept {
   mNewPcbThickness = thickness;
 }
 
+void CmdBoardEdit::setSolderResist(const PcbColor* c) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewSolderResist = c;
+}
+void CmdBoardEdit::setSilkscreenColor(const PcbColor& c) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewSilkscreenColor = &c;
+}
+
 void CmdBoardEdit::setDesignRules(const BoardDesignRules& rules) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewDesignRules = rules;
@@ -94,6 +107,8 @@ bool CmdBoardEdit::performExecute() {
   if (mNewName != mOldName) return true;
   if (mNewInnerLayerCount != mOldInnerLayerCount) return true;
   if (mNewPcbThickness != mOldPcbThickness) return true;
+  if (mNewSolderResist != mOldSolderResist) return true;
+  if (mNewSilkscreenColor != mOldSilkscreenColor) return true;
   if (mNewDesignRules != mOldDesignRules) return true;
   if (mNewDrcSettings != mOldDrcSettings) return true;
   return false;
@@ -103,6 +118,8 @@ void CmdBoardEdit::performUndo() {
   mBoard.setName(mOldName);
   mBoard.setInnerLayerCount(mOldInnerLayerCount);
   mBoard.setPcbThickness(mOldPcbThickness);
+  mBoard.setSolderResist(mOldSolderResist);
+  mBoard.setSilkscreenColor(*mOldSilkscreenColor);
   mBoard.setDesignRules(mOldDesignRules);
   mBoard.setDrcSettings(mOldDrcSettings);
 }
@@ -111,6 +128,8 @@ void CmdBoardEdit::performRedo() {
   mBoard.setName(mNewName);
   mBoard.setInnerLayerCount(mNewInnerLayerCount);
   mBoard.setPcbThickness(mNewPcbThickness);
+  mBoard.setSolderResist(mNewSolderResist);
+  mBoard.setSilkscreenColor(*mNewSilkscreenColor);
   mBoard.setDesignRules(mNewDesignRules);
   mBoard.setDrcSettings(mNewDrcSettings);
 }

--- a/libs/librepcb/editor/project/cmd/cmdboardedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardedit.cpp
@@ -43,6 +43,8 @@ CmdBoardEdit::CmdBoardEdit(Board& board) noexcept
     mNewName(mOldName),
     mOldInnerLayerCount(mBoard.getInnerLayerCount()),
     mNewInnerLayerCount(mOldInnerLayerCount),
+    mOldPcbThickness(mBoard.getPcbThickness()),
+    mNewPcbThickness(mOldPcbThickness),
     mOldDesignRules(mBoard.getDesignRules()),
     mNewDesignRules(mOldDesignRules),
     mOldDrcSettings(mBoard.getDrcSettings()),
@@ -66,6 +68,11 @@ void CmdBoardEdit::setInnerLayerCount(int count) noexcept {
   mNewInnerLayerCount = count;
 }
 
+void CmdBoardEdit::setPcbThickness(const PositiveLength& thickness) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewPcbThickness = thickness;
+}
+
 void CmdBoardEdit::setDesignRules(const BoardDesignRules& rules) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewDesignRules = rules;
@@ -86,6 +93,7 @@ bool CmdBoardEdit::performExecute() {
 
   if (mNewName != mOldName) return true;
   if (mNewInnerLayerCount != mOldInnerLayerCount) return true;
+  if (mNewPcbThickness != mOldPcbThickness) return true;
   if (mNewDesignRules != mOldDesignRules) return true;
   if (mNewDrcSettings != mOldDrcSettings) return true;
   return false;
@@ -94,6 +102,7 @@ bool CmdBoardEdit::performExecute() {
 void CmdBoardEdit::performUndo() {
   mBoard.setName(mOldName);
   mBoard.setInnerLayerCount(mOldInnerLayerCount);
+  mBoard.setPcbThickness(mOldPcbThickness);
   mBoard.setDesignRules(mOldDesignRules);
   mBoard.setDrcSettings(mOldDrcSettings);
 }
@@ -101,6 +110,7 @@ void CmdBoardEdit::performUndo() {
 void CmdBoardEdit::performRedo() {
   mBoard.setName(mNewName);
   mBoard.setInnerLayerCount(mNewInnerLayerCount);
+  mBoard.setPcbThickness(mNewPcbThickness);
   mBoard.setDesignRules(mNewDesignRules);
   mBoard.setDrcSettings(mNewDrcSettings);
 }

--- a/libs/librepcb/editor/project/cmd/cmdboardedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardedit.cpp
@@ -49,6 +49,10 @@ CmdBoardEdit::CmdBoardEdit(Board& board) noexcept
     mNewSolderResist(mOldSolderResist),
     mOldSilkscreenColor(&mBoard.getSilkscreenColor()),
     mNewSilkscreenColor(mOldSilkscreenColor),
+    mOldSilkscreenLayersTop(mBoard.getSilkscreenLayersTop()),
+    mNewSilkscreenLayersTop(mOldSilkscreenLayersTop),
+    mOldSilkscreenLayersBot(mBoard.getSilkscreenLayersBot()),
+    mNewSilkscreenLayersBot(mOldSilkscreenLayersBot),
     mOldDesignRules(mBoard.getDesignRules()),
     mNewDesignRules(mOldDesignRules),
     mOldDrcSettings(mBoard.getDrcSettings()),
@@ -86,6 +90,18 @@ void CmdBoardEdit::setSilkscreenColor(const PcbColor& c) noexcept {
   mNewSilkscreenColor = &c;
 }
 
+void CmdBoardEdit::setSilkscreenLayersTop(
+    const QVector<const Layer*>& l) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewSilkscreenLayersTop = l;
+}
+
+void CmdBoardEdit::setSilkscreenLayersBot(
+    const QVector<const Layer*>& l) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewSilkscreenLayersBot = l;
+}
+
 void CmdBoardEdit::setDesignRules(const BoardDesignRules& rules) noexcept {
   Q_ASSERT(!wasEverExecuted());
   mNewDesignRules = rules;
@@ -109,6 +125,8 @@ bool CmdBoardEdit::performExecute() {
   if (mNewPcbThickness != mOldPcbThickness) return true;
   if (mNewSolderResist != mOldSolderResist) return true;
   if (mNewSilkscreenColor != mOldSilkscreenColor) return true;
+  if (mNewSilkscreenLayersTop != mOldSilkscreenLayersTop) return true;
+  if (mNewSilkscreenLayersBot != mOldSilkscreenLayersBot) return true;
   if (mNewDesignRules != mOldDesignRules) return true;
   if (mNewDrcSettings != mOldDrcSettings) return true;
   return false;
@@ -120,6 +138,8 @@ void CmdBoardEdit::performUndo() {
   mBoard.setPcbThickness(mOldPcbThickness);
   mBoard.setSolderResist(mOldSolderResist);
   mBoard.setSilkscreenColor(*mOldSilkscreenColor);
+  mBoard.setSilkscreenLayersTop(mOldSilkscreenLayersTop);
+  mBoard.setSilkscreenLayersBot(mOldSilkscreenLayersBot);
   mBoard.setDesignRules(mOldDesignRules);
   mBoard.setDrcSettings(mOldDrcSettings);
 }
@@ -130,6 +150,8 @@ void CmdBoardEdit::performRedo() {
   mBoard.setPcbThickness(mNewPcbThickness);
   mBoard.setSolderResist(mNewSolderResist);
   mBoard.setSilkscreenColor(*mNewSilkscreenColor);
+  mBoard.setSilkscreenLayersTop(mNewSilkscreenLayersTop);
+  mBoard.setSilkscreenLayersBot(mNewSilkscreenLayersBot);
   mBoard.setDesignRules(mNewDesignRules);
   mBoard.setDrcSettings(mNewDrcSettings);
 }

--- a/libs/librepcb/editor/project/cmd/cmdboardedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardedit.h
@@ -58,6 +58,7 @@ public:
   // Setters
   void setName(const ElementName& name) noexcept;
   void setInnerLayerCount(int count) noexcept;
+  void setPcbThickness(const PositiveLength& thickness) noexcept;
   void setDesignRules(const BoardDesignRules& rules) noexcept;
   void setDrcSettings(const BoardDesignRuleCheckSettings& settings) noexcept;
 
@@ -78,6 +79,8 @@ private:  // Data
   ElementName mNewName;
   int mOldInnerLayerCount;
   int mNewInnerLayerCount;
+  PositiveLength mOldPcbThickness;
+  PositiveLength mNewPcbThickness;
   BoardDesignRules mOldDesignRules;
   BoardDesignRules mNewDesignRules;
   BoardDesignRuleCheckSettings mOldDrcSettings;

--- a/libs/librepcb/editor/project/cmd/cmdboardedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardedit.h
@@ -37,6 +37,7 @@
 namespace librepcb {
 
 class Board;
+class Layer;
 class PcbColor;
 
 namespace editor {
@@ -62,6 +63,8 @@ public:
   void setPcbThickness(const PositiveLength& thickness) noexcept;
   void setSolderResist(const PcbColor* c) noexcept;
   void setSilkscreenColor(const PcbColor& c) noexcept;
+  void setSilkscreenLayersTop(const QVector<const Layer*>& l) noexcept;
+  void setSilkscreenLayersBot(const QVector<const Layer*>& l) noexcept;
   void setDesignRules(const BoardDesignRules& rules) noexcept;
   void setDrcSettings(const BoardDesignRuleCheckSettings& settings) noexcept;
 
@@ -88,6 +91,10 @@ private:  // Data
   const PcbColor* mNewSolderResist;
   const PcbColor* mOldSilkscreenColor;
   const PcbColor* mNewSilkscreenColor;
+  QVector<const Layer*> mOldSilkscreenLayersTop;
+  QVector<const Layer*> mNewSilkscreenLayersTop;
+  QVector<const Layer*> mOldSilkscreenLayersBot;
+  QVector<const Layer*> mNewSilkscreenLayersBot;
   BoardDesignRules mOldDesignRules;
   BoardDesignRules mNewDesignRules;
   BoardDesignRuleCheckSettings mOldDrcSettings;

--- a/libs/librepcb/editor/project/cmd/cmdboardedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardedit.h
@@ -37,6 +37,7 @@
 namespace librepcb {
 
 class Board;
+class PcbColor;
 
 namespace editor {
 
@@ -59,6 +60,8 @@ public:
   void setName(const ElementName& name) noexcept;
   void setInnerLayerCount(int count) noexcept;
   void setPcbThickness(const PositiveLength& thickness) noexcept;
+  void setSolderResist(const PcbColor* c) noexcept;
+  void setSilkscreenColor(const PcbColor& c) noexcept;
   void setDesignRules(const BoardDesignRules& rules) noexcept;
   void setDrcSettings(const BoardDesignRuleCheckSettings& settings) noexcept;
 
@@ -81,6 +84,10 @@ private:  // Data
   int mNewInnerLayerCount;
   PositiveLength mOldPcbThickness;
   PositiveLength mNewPcbThickness;
+  const PcbColor* mOldSolderResist;
+  const PcbColor* mNewSolderResist;
+  const PcbColor* mOldSilkscreenColor;
+  const PcbColor* mNewSilkscreenColor;
   BoardDesignRules mOldDesignRules;
   BoardDesignRules mNewDesignRules;
   BoardDesignRuleCheckSettings mOldDrcSettings;

--- a/tests/unittests/core/project/board/boardfabricationoutputsettingstest.cpp
+++ b/tests/unittests/core/project/board/boardfabricationoutputsettingstest.cpp
@@ -23,7 +23,6 @@
 #include <gtest/gtest.h>
 #include <librepcb/core/project/board/boardfabricationoutputsettings.h>
 #include <librepcb/core/serialization/sexpression.h>
-#include <librepcb/core/types/layer.h>
 
 #include <QtCore>
 
@@ -59,8 +58,6 @@ TEST_F(BoardFabricationOutputSettingsTest, testSerializeAndDeserialize) {
   obj1.setSuffixSilkscreenBot("l");
   obj1.setSuffixSolderPasteTop("m");
   obj1.setSuffixSolderPasteBot("n");
-  obj1.setSilkscreenLayersTop({&Layer::topCopper(), &Layer::topStopMask()});
-  obj1.setSilkscreenLayersBot({&Layer::botCopper(), &Layer::botStopMask()});
   obj1.setMergeDrillFiles(!obj1.getMergeDrillFiles());
   obj1.setUseG85SlotCommand(!obj1.getUseG85SlotCommand());
   obj1.setEnableSolderPasteTop(!obj1.getEnableSolderPasteTop());


### PR DESCRIPTION
## Summary

- Support specifying PCB thickness
- Support specifying solder resist as one of:
  ```
  None (bare copper) --> stop mask Gerber files will not be generated
  Black
  Black Matte
  Blue
  Green
  Green Matte
  Purple
  Red
  White
  Yellow
  Other
  ```
- Support specifying silkscreen color as one of:
  ```
  Black
  Blue
  Red
  White
  Yellow
  Other
  ```
- Move silkscreen layer selection from fabrication settings to board setup, i.e. making them a property of the board instead of an export configuration.

This allows us to make the upcoming 3D board viewer taking these properties into account for rendering, to get the same colors as the ordered PCB will have. In addition, in future we might be able to include these properties in the exported production data to avoid manual specification of these values (e.g. our fab service could automatically select the corresponding settings when placing the order at PCBWay).

Note: The list of colors is taken from various PCB manufacturer websites so I hope this list represents the current state of the art technology. For the case the market supports more colors, I added the option "Other", intended to *not* take the color configuration into account during production data export.

## Screenshot

![image](https://user-images.githubusercontent.com/5374821/234244352-72237ffa-a381-4bca-a1bc-3694c0fe5cbc.png)

## File Format

These properties are stored in the `board.lp` file, initialized with the default values of 1.6mm, green solder resist and white silkscreen.

```
 (thickness 1.6)
 (solder_resist green)
 (silkscreen white)
 (silkscreen_layers_top top_placement top_names)
 (silkscreen_layers_bot bot_placement bot_names)
```