### PR TITLE
Gerber export: Delete files left over from previous run

### DIFF
--- a/libs/librepcb/core/project/board/boardgerberexport.h
+++ b/libs/librepcb/core/project/board/boardgerberexport.h
@@ -93,7 +93,7 @@ signals:
 
 private:
   // Private Methods
-  void exportDrills(const BoardFabricationOutputSettings& settings) const;
+  void exportDrillsMerged(const BoardFabricationOutputSettings& settings) const;
   void exportDrillsNpth(const BoardFabricationOutputSettings& settings) const;
   void exportDrillsPth(const BoardFabricationOutputSettings& settings) const;
   void exportLayerBoardOutlines(


### PR DESCRIPTION
For example when generating Gerber files with solder paste (stencil) enabled first, and then with solder paste disabled, the old files are left over in the output directory and thus might be sent to the manufacturer by accident.

Thus any non-generated file is now explicitly deleted if it exists. It's not perfect since it only works if the output file names have not changed, but at least it's much safer than before.

Some day #1000 might improve this situation further.