### PR TITLE
Rename board device property "mirror" to "flip"

### DIFF
--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -323,7 +323,7 @@ void BI_Device::serialize(SExpression& root) const {
   root.ensureLineBreak();
   mPosition.serialize(root.appendList("position"));
   root.appendChild("rotation", mRotation);
-  root.appendChild("mirror", mMirrored);
+  root.appendChild("flip", mMirrored);
   root.appendChild("lock", mLocked);
   root.ensureLineBreak();
   mAttributes.serialize(root);

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -617,7 +617,7 @@ void ProjectLoader::loadBoardDeviceInstance(Board& b, const SExpression& node) {
                     deserialize<Uuid>(node.getChild("lib_footprint/@0")),
                     Point(node.getChild("position")),
                     deserialize<Angle>(node.getChild("rotation/@0")),
-                    deserialize<bool>(node.getChild("mirror/@0")),
+                    deserialize<bool>(node.getChild("flip/@0")),
                     deserialize<bool>(node.getChild("lock/@0")), false);
   device->setAttributes(AttributeList(node));
   foreach (const SExpression* child, node.getChildren("stroke_text")) {

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -113,21 +113,9 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  root.appendChild("thickness", SExpression::createToken("1.6"));
-  root.appendChild("solder_resist", SExpression::createToken("green"));
-  root.appendChild("silkscreen", SExpression::createToken("white"));
-
-  SExpression& fabNode = root.getChild("fabrication_output_settings");
-
-  SExpression& silkTop = fabNode.getChild("silkscreen_top");
-  SExpression& silkLayersTop = silkTop.getChild("layers");
-  root.appendChild(SExpression(silkLayersTop)).setName("silkscreen_layers_top");
-  silkTop.removeChild(silkLayersTop);
-
-  SExpression& silkBot = fabNode.getChild("silkscreen_bot");
-  SExpression& silkLayersBot = silkBot.getChild("layers");
-  root.appendChild(SExpression(silkLayersBot)).setName("silkscreen_layers_bot");
-  silkBot.removeChild(silkLayersBot);
+  for (SExpression* devNode : root.getChildren("device")) {
+    devNode->getChild("mirror").setName("flip");
+  }
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -657,6 +657,7 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
       }
       txtNode->appendChild("lock", SExpression::createToken("false"));
     }
+    devNode->getChild("mirror").setName("flip");
   }
 
   // Net segments.

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
@@ -99,7 +99,7 @@ public:
         libFootprintUuid(deserialize<Uuid>(node.getChild("lib_footprint/@0"))),
         position(node.getChild("position")),
         rotation(deserialize<Angle>(node.getChild("rotation/@0"))),
-        mirrored(deserialize<bool>(node.getChild("mirror/@0"))),
+        mirrored(deserialize<bool>(node.getChild("flip/@0"))),
         locked(deserialize<bool>(node.getChild("lock/@0"))),
         attributes(node),
         strokeTexts(),
@@ -118,7 +118,7 @@ public:
       root.ensureLineBreak();
       position.serialize(root.appendList("position"));
       root.appendChild("rotation", rotation);
-      root.appendChild("mirror", mirrored);
+      root.appendChild("flip", mirrored);
       root.appendChild("lock", locked);
       root.ensureLineBreak();
       attributes.serialize(root);

--- a/libs/librepcb/editor/project/boardeditor/deviceinstancepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/deviceinstancepropertiesdialog.ui
@@ -66,7 +66,7 @@
           <item>
            <widget class="QCheckBox" name="cbxMirror">
             <property name="text">
-             <string notr="true">Mirror</string>
+             <string notr="true">Flip</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
For consistent terminology with the "Flip" action (Ctrl+F) in the board editor, rename the property "mirror" of devices to "flip". This is more intuitive because flip is not the same as mirror (in contrast to schematics, where mirror is indeed just a graphical operation).

However, in the source code it's still called "mirror" for compatibility with the `Transform` template constructor.
