### PR TITLE
Allow characters .&() in identifiers

### DIFF
--- a/libs/librepcb/core/types/circuitidentifier.h
+++ b/libs/librepcb/core/types/circuitidentifier.h
@@ -45,7 +45,7 @@ namespace librepcb {
 inline static QString cleanCircuitIdentifier(
     const QString& userInput) noexcept {
   return Toolbox::cleanUserInputString(
-      userInput, QRegularExpression("[^-a-zA-Z0-9_+/!?@#$]"), true, false,
+      userInput, QRegularExpression("[^-a-zA-Z0-9._+/!?&@#$()]"), true, false,
       false, "_", 32);
 }
 
@@ -66,7 +66,7 @@ struct CircuitIdentifierVerifier {
 
 struct CircuitIdentifierConstraint {
   bool operator()(const QString& value) const noexcept {
-    return QRegularExpression("\\A[-a-zA-Z0-9_+/!?@#$]{1,32}\\z")
+    return QRegularExpression("\\A[-a-zA-Z0-9._+/!?&@#$()]{1,32}\\z")
         .match(value, 0, QRegularExpression::PartialPreferCompleteMatch)
         .hasMatch();
   }

--- a/tests/unittests/core/types/circuitidentifiertest.cpp
+++ b/tests/unittests/core/types/circuitidentifiertest.cpp
@@ -124,7 +124,7 @@ INSTANTIATE_TEST_SUITE_P(CircuitIdentifierTest, CircuitIdentifierTest, ::testing
     CircuitIdentifierTestData({"+", true}),
     CircuitIdentifierTestData({"-", true}),
     CircuitIdentifierTestData({"01234567890123456789012345678901", true}),
-    CircuitIdentifierTestData({"_+-/!?@#$asDF1234", true}),
+    CircuitIdentifierTestData({"._+-/!?&@#$asDF1234()", true}),
 
     // invalid identifiers
     CircuitIdentifierTestData({"", false}), // empty


### PR DESCRIPTION
Allow the characters `.`, `&`, `(` and `)` in symbol pin names, package pad names, component signal names, net names and component names (designators). They should not cause any issues within production output files (IPC-D356, Gerber, ...).

There might be more characters useful in some cases, e.g. `:`, `;`, `*`, `%`, `~`, `[` and `]` which are still rejected because some of them could cause problems in production data and others I want to keep reserved for future extensions (e.g. `[]` might be useful for buses, and `~` for overline).

Closes #1074
Closes #642