### PR TITLE
Terminology: Rename plane "orphans" to "islands"

### DIFF
--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -605,7 +605,7 @@ void Board::copyFrom(const Board& other) {
                      plane->getNetSignal(), plane->getOutline());
     copy->setMinWidth(plane->getMinWidth());
     copy->setMinClearance(plane->getMinClearance());
-    copy->setKeepOrphans(plane->getKeepOrphans());
+    copy->setKeepIslands(plane->getKeepIslands());
     copy->setPriority(plane->getPriority());
     copy->setConnectStyle(plane->getConnectStyle());
     copy->setThermalGap(plane->getThermalGap());

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<BoardPlaneFragmentsBuilder::JobData>
       data->planes.append(PlaneData{
           plane->getUuid(), &plane->getLayer(), plane->getNetSignal().getUuid(),
           plane->getOutline(), plane->getMinWidth(), plane->getMinClearance(),
-          plane->getKeepOrphans(), plane->getPriority(),
+          plane->getKeepIslands(), plane->getPriority(),
           plane->getConnectStyle(), plane->getThermalGap(),
           plane->getThermalSpokeWidth()});
     }
@@ -600,9 +600,9 @@ std::shared_ptr<BoardPlaneFragmentsBuilder::JobData>
         break;
       }
 
-      // If requested, remove unconnected fragments (orphans).
-      if (!it->keepOrphans) {
-        auto isOrphan = [&](const ClipperLib::Path& p) {
+      // If requested, remove unconnected fragments (islands).
+      if (!it->keepIslands) {
+        auto isIsland = [&](const ClipperLib::Path& p) {
           ClipperLib::Paths intersections{p};
           ClipperHelpers::intersect(intersections, connectedNetSignalAreas,
                                     ClipperLib::pftNonZero,
@@ -610,7 +610,7 @@ std::shared_ptr<BoardPlaneFragmentsBuilder::JobData>
           return intersections.empty();
         };
         fragments.erase(
-            std::remove_if(fragments.begin(), fragments.end(), isOrphan),
+            std::remove_if(fragments.begin(), fragments.end(), isIsland),
             fragments.end());
       }
       if (mAbort) {

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -123,7 +123,7 @@ private:  // Methods
     Path outline;
     UnsignedLength minWidth;
     UnsignedLength minClearance;
-    bool keepOrphans;
+    bool keepIslands;
     int priority;
     BI_Plane::ConnectStyle connectStyle;
     PositiveLength thermalGap;

--- a/libs/librepcb/core/project/board/items/bi_plane.cpp
+++ b/libs/librepcb/core/project/board/items/bi_plane.cpp
@@ -50,7 +50,7 @@ BI_Plane::BI_Plane(Board& board, const Uuid& uuid, const Layer& layer,
     mOutline(outline),
     mMinWidth(200000),
     mMinClearance(300000),
-    mKeepOrphans(false),
+    mKeepIslands(false),
     mPriority(0),
     mConnectStyle(ConnectStyle::ThermalRelief),
     mThermalGap(300000),
@@ -142,9 +142,9 @@ void BI_Plane::setPriority(int priority) noexcept {
   }
 }
 
-void BI_Plane::setKeepOrphans(bool keepOrphans) noexcept {
-  if (keepOrphans != mKeepOrphans) {
-    mKeepOrphans = keepOrphans;
+void BI_Plane::setKeepIslands(bool keep) noexcept {
+  if (keep != mKeepIslands) {
+    mKeepIslands = keep;
     mBoard.invalidatePlanes(mLayer);
   }
 }
@@ -208,7 +208,7 @@ void BI_Plane::serialize(SExpression& root) const {
   root.appendChild("thermal_spoke", mThermalSpokeWidth);
   root.ensureLineBreak();
   root.appendChild("connect_style", mConnectStyle);
-  root.appendChild("keep_orphans", mKeepOrphans);
+  root.appendChild("keep_islands", mKeepIslands);
   root.appendChild("lock", mLocked);
   root.ensureLineBreak();
   mOutline.serialize(root);

--- a/libs/librepcb/core/project/board/items/bi_plane.h
+++ b/libs/librepcb/core/project/board/items/bi_plane.h
@@ -86,7 +86,7 @@ public:
   const UnsignedLength& getMinClearance() const noexcept {
     return mMinClearance;
   }
-  bool getKeepOrphans() const noexcept { return mKeepOrphans; }
+  bool getKeepIslands() const noexcept { return mKeepIslands; }
   int getPriority() const noexcept { return mPriority; }
   ConnectStyle getConnectStyle() const noexcept { return mConnectStyle; }
   const PositiveLength& getThermalGap() const noexcept { return mThermalGap; }
@@ -108,7 +108,7 @@ public:
   void setThermalGap(const PositiveLength& gap) noexcept;
   void setThermalSpokeWidth(const PositiveLength& width) noexcept;
   void setPriority(int priority) noexcept;
-  void setKeepOrphans(bool keepOrphans) noexcept;
+  void setKeepIslands(bool keep) noexcept;
   void setLocked(bool locked) noexcept;
   void setVisible(bool visible) noexcept;
   void setCalculatedFragments(const QVector<Path>& fragments) noexcept;
@@ -134,7 +134,7 @@ private:  // Data
   Path mOutline;
   UnsignedLength mMinWidth;
   UnsignedLength mMinClearance;
-  bool mKeepOrphans;
+  bool mKeepIslands;
   int mPriority;
   ConnectStyle mConnectStyle;
   PositiveLength mThermalGap;

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -737,7 +737,7 @@ void ProjectLoader::loadBoardPlane(Board& b, const SExpression& node) {
       deserialize<UnsignedLength>(node.getChild("min_width/@0")));
   plane->setMinClearance(
       deserialize<UnsignedLength>(node.getChild("min_clearance/@0")));
-  plane->setKeepOrphans(deserialize<bool>(node.getChild("keep_orphans/@0")));
+  plane->setKeepIslands(deserialize<bool>(node.getChild("keep_islands/@0")));
   plane->setPriority(deserialize<int>(node.getChild("priority/@0")));
   plane->setConnectStyle(
       deserialize<BI_Plane::ConnectStyle>(node.getChild("connect_style/@0")));

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -127,10 +127,7 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
   Q_UNUSED(root);
   Q_UNUSED(context);
   for (SExpression* planeNode : root.getChildren("plane")) {
-    planeNode->appendChild("thermal_gap",
-                           planeNode->getChild("min_clearance/@0"));
-    planeNode->appendChild("thermal_spoke",
-                           planeNode->getChild("min_width/@0"));
+    planeNode->getChild("keep_orphans").setName("keep_islands");
   }
 }
 

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -716,6 +716,7 @@ void FileFormatMigrationV01::upgradeBoard(SExpression& root,
     planeNode->appendChild("thermal_spoke",
                            planeNode->getChild("min_width/@0"));
     planeNode->appendChild("lock", SExpression::createToken("false"));
+    planeNode->getChild("keep_orphans").setName("keep_islands");
   }
 }
 

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
@@ -186,7 +186,7 @@ public:
     Path outline;
     UnsignedLength minWidth;
     UnsignedLength minClearance;
-    bool keepOrphans;
+    bool keepIslands;
     int priority;
     BI_Plane::ConnectStyle connectStyle;
     PositiveLength thermalGap;
@@ -197,7 +197,7 @@ public:
     Plane(const Uuid& uuid, const Layer& layer,
           const CircuitIdentifier& netSignalName, const Path& outline,
           const UnsignedLength& minWidth, const UnsignedLength& minClearance,
-          bool keepOrphans, int priority, BI_Plane::ConnectStyle connectStyle,
+          bool keepIslands, int priority, BI_Plane::ConnectStyle connectStyle,
           const PositiveLength& thermalGap,
           const PositiveLength& thermalSpokeWidth, bool locked)
       : uuid(uuid),
@@ -206,7 +206,7 @@ public:
         outline(outline),
         minWidth(minWidth),
         minClearance(minClearance),
-        keepOrphans(keepOrphans),
+        keepIslands(keepIslands),
         priority(priority),
         connectStyle(connectStyle),
         thermalGap(thermalGap),
@@ -222,7 +222,7 @@ public:
         minWidth(deserialize<UnsignedLength>(node.getChild("min_width/@0"))),
         minClearance(
             deserialize<UnsignedLength>(node.getChild("min_clearance/@0"))),
-        keepOrphans(deserialize<bool>(node.getChild("keep_orphans/@0"))),
+        keepIslands(deserialize<bool>(node.getChild("keep_islands/@0"))),
         priority(deserialize<int>(node.getChild("priority/@0"))),
         connectStyle(deserialize<BI_Plane::ConnectStyle>(
             node.getChild("connect_style/@0"))),
@@ -246,7 +246,7 @@ public:
       root.appendChild("thermal_spoke", thermalSpokeWidth);
       root.ensureLineBreak();
       root.appendChild("connect_style", connectStyle);
-      root.appendChild("keep_orphans", keepOrphans);
+      root.appendChild("keep_islands", keepIslands);
       root.appendChild("lock", locked);
       root.ensureLineBreak();
       outline.serialize(root);
@@ -257,7 +257,7 @@ public:
       return (uuid != rhs.uuid) || (layer != rhs.layer) ||
           (netSignalName != rhs.netSignalName) || (outline != rhs.outline) ||
           (minWidth != rhs.minWidth) || (minClearance != rhs.minClearance) ||
-          (keepOrphans != rhs.keepOrphans) || (priority != rhs.priority) ||
+          (keepIslands != rhs.keepIslands) || (priority != rhs.priority) ||
           (connectStyle != rhs.connectStyle) ||
           (thermalGap != rhs.thermalGap) ||
           (thermalSpokeWidth != rhs.thermalSpokeWidth) ||

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.cpp
@@ -167,7 +167,7 @@ std::unique_ptr<BoardClipboardData> BoardClipboardDataBuilder::generate(
             plane->getUuid(), plane->getLayer(),
             plane->getNetSignal().getName(), plane->getOutline(),
             plane->getMinWidth(), plane->getMinClearance(),
-            plane->getKeepOrphans(), plane->getPriority(),
+            plane->getKeepIslands(), plane->getPriority(),
             plane->getConnectStyle(), plane->getThermalGap(),
             plane->getThermalSpokeWidth(), plane->isLocked());
     data->getPlanes().append(newPlane);

--- a/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.cpp
@@ -114,7 +114,7 @@ BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(
   mUi->spbPriority->setValue(mPlane.getPriority());
 
   // checkboxes
-  mUi->cbKeepOrphans->setChecked(mPlane.getKeepOrphans());
+  mUi->cbKeepIslands->setChecked(mPlane.getKeepIslands());
   mUi->cbxLock->setChecked(mPlane.isLocked());
 
   // vertices
@@ -199,7 +199,7 @@ bool BoardPlanePropertiesDialog::applyChanges() noexcept {
     cmd->setPriority(mUi->spbPriority->value());
 
     // booleans
-    cmd->setKeepOrphans(mUi->cbKeepOrphans->isChecked());
+    cmd->setKeepIslands(mUi->cbKeepIslands->isChecked());
     cmd->setLocked(mUi->cbxLock->isChecked());
 
     // vertices

--- a/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.ui
@@ -89,9 +89,12 @@
      <item row="8" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QCheckBox" name="cbKeepOrphans">
+        <widget class="QCheckBox" name="cbKeepIslands">
+         <property name="toolTip">
+          <string>Do not delete unconnected copper areas (islands)</string>
+         </property>
          <property name="text">
-          <string>Keep Orphans</string>
+          <string>Keep Islands</string>
          </property>
         </widget>
        </item>

--- a/libs/librepcb/editor/project/cmd/cmdboardplaneedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardplaneedit.cpp
@@ -58,8 +58,8 @@ CmdBoardPlaneEdit::CmdBoardPlaneEdit(BI_Plane& plane) noexcept
     mNewThermalSpokeWidth(mOldThermalSpokeWidth),
     mOldPriority(plane.getPriority()),
     mNewPriority(mOldPriority),
-    mOldKeepOrphans(plane.getKeepOrphans()),
-    mNewKeepOrphans(mOldKeepOrphans),
+    mOldKeepIslands(plane.getKeepIslands()),
+    mNewKeepIslands(mOldKeepIslands),
     mOldLocked(plane.isLocked()),
     mNewLocked(mOldLocked) {
 }
@@ -149,9 +149,9 @@ void CmdBoardPlaneEdit::setPriority(int priority) noexcept {
   mNewPriority = priority;
 }
 
-void CmdBoardPlaneEdit::setKeepOrphans(bool keepOrphans) noexcept {
+void CmdBoardPlaneEdit::setKeepIslands(bool keep) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewKeepOrphans = keepOrphans;
+  mNewKeepIslands = keep;
 }
 
 void CmdBoardPlaneEdit::setLocked(bool locked) noexcept {
@@ -175,7 +175,7 @@ bool CmdBoardPlaneEdit::performExecute() {
   if (mNewThermalGap != mOldThermalGap) return true;
   if (mNewThermalSpokeWidth != mOldThermalSpokeWidth) return true;
   if (mNewPriority != mOldPriority) return true;
-  if (mNewKeepOrphans != mOldKeepOrphans) return true;
+  if (mNewKeepIslands != mOldKeepIslands) return true;
   if (mNewLocked != mOldLocked) return true;
   return false;
 }
@@ -190,7 +190,7 @@ void CmdBoardPlaneEdit::performUndo() {
   mPlane.setThermalGap(mOldThermalGap);
   mPlane.setThermalSpokeWidth(mOldThermalSpokeWidth);
   mPlane.setPriority(mOldPriority);
-  mPlane.setKeepOrphans(mOldKeepOrphans);
+  mPlane.setKeepIslands(mOldKeepIslands);
   mPlane.setLocked(mOldLocked);
 }
 
@@ -204,7 +204,7 @@ void CmdBoardPlaneEdit::performRedo() {
   mPlane.setThermalGap(mNewThermalGap);
   mPlane.setThermalSpokeWidth(mNewThermalSpokeWidth);
   mPlane.setPriority(mNewPriority);
-  mPlane.setKeepOrphans(mNewKeepOrphans);
+  mPlane.setKeepIslands(mNewKeepIslands);
   mPlane.setLocked(mNewLocked);
 }
 

--- a/libs/librepcb/editor/project/cmd/cmdboardplaneedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardplaneedit.h
@@ -68,7 +68,7 @@ public:
   void setThermalGap(const PositiveLength& gap) noexcept;
   void setThermalSpokeWidth(const PositiveLength& width) noexcept;
   void setPriority(int priority) noexcept;
-  void setKeepOrphans(bool keepOrphans) noexcept;
+  void setKeepIslands(bool keep) noexcept;
   void setLocked(bool locked) noexcept;
 
 private:
@@ -107,8 +107,8 @@ private:
   PositiveLength mNewThermalSpokeWidth;
   int mOldPriority;
   int mNewPriority;
-  bool mOldKeepOrphans;
-  bool mNewKeepOrphans;
+  bool mOldKeepIslands;
+  bool mNewKeepIslands;
   bool mOldLocked;
   bool mNewLocked;
 };

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -279,7 +279,7 @@ bool CmdPasteBoardItems::performExecute() {
         );
     copy->setMinWidth(plane.minWidth);
     copy->setMinClearance(plane.minClearance);
-    copy->setKeepOrphans(plane.keepOrphans);
+    copy->setKeepIslands(plane.keepIslands);
     copy->setPriority(plane.priority);
     copy->setConnectStyle(plane.connectStyle);
     copy->setThermalGap(plane.thermalGap);


### PR DESCRIPTION
I think the term "island" is more intuitive than "orphan" (unconnected plane areas), thus renaming it in the file format and in the UI.