### PR TITLE
Support creating planes without a net

### DIFF
--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -674,8 +674,12 @@ void BoardGerberExport::drawLayer(GerberGenerator& gen,
     Q_ASSERT(plane);
     if (plane->getLayer() == layer) {
       foreach (const Path& fragment, plane->getFragments()) {
-        gen.drawPathArea(fragment, GerberAttribute::ApertureFunction::Conductor,
-                         *plane->getNetSignal().getName(), QString());
+        gen.drawPathArea(
+            fragment, GerberAttribute::ApertureFunction::Conductor,
+            plane->getNetSignal()
+                ? tl::make_optional(*plane->getNetSignal()->getName())
+                : tl::nullopt,
+            QString());
       }
     }
   }

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -120,7 +120,7 @@ private:  // Methods
   struct PlaneData {
     Uuid uuid;
     const Layer* layer;
-    Uuid netSignal;
+    tl::optional<Uuid> netSignal;
     Path outline;
     UnsignedLength minWidth;
     UnsignedLength minClearance;

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -93,7 +93,7 @@ void BoardClipperPathGenerator::addCopper(
     foreach (const BI_Plane* plane, mBoard.getPlanes()) {
       if ((plane->getLayer() == layer) &&
           (netsignals.isEmpty() ||
-           netsignals.contains(&plane->getNetSignal()))) {
+           netsignals.contains(plane->getNetSignal()))) {
         addPlane(*plane);
       }
     }

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -292,7 +292,7 @@ void BoardDesignRuleCheck::checkCopperCopperClearances(int progressEnd) {
                                     nullptr,
                                     &plane->getLayer(),
                                     &plane->getLayer(),
-                                    &plane->getNetSignal(),
+                                    plane->getNetSignal(),
                                     *clearance,
                                     {},
                                     {}});

--- a/libs/librepcb/core/project/board/items/bi_plane.h
+++ b/libs/librepcb/core/project/board/items/bi_plane.h
@@ -75,13 +75,13 @@ public:
   BI_Plane() = delete;
   BI_Plane(const BI_Plane& other) = delete;
   BI_Plane(Board& board, const Uuid& uuid, const Layer& layer,
-           NetSignal& netsignal, const Path& outline);
+           NetSignal* netsignal, const Path& outline);
   ~BI_Plane() noexcept;
 
   // Getters
   const Uuid& getUuid() const noexcept { return mUuid; }
   const Layer& getLayer() const noexcept { return *mLayer; }
-  NetSignal& getNetSignal() const noexcept { return *mNetSignal; }
+  NetSignal* getNetSignal() const noexcept { return mNetSignal; }
   const UnsignedLength& getMinWidth() const noexcept { return mMinWidth; }
   const UnsignedLength& getMinClearance() const noexcept {
     return mMinClearance;
@@ -101,7 +101,7 @@ public:
   // Setters
   void setOutline(const Path& outline) noexcept;
   void setLayer(const Layer& layer) noexcept;
-  void setNetSignal(NetSignal& netsignal);
+  void setNetSignal(NetSignal* netsignal);
   void setMinWidth(const UnsignedLength& minWidth) noexcept;
   void setMinClearance(const UnsignedLength& minClearance) noexcept;
   void setConnectStyle(ConnectStyle style) noexcept;
@@ -129,8 +129,8 @@ public:
 
 private:  // Data
   Uuid mUuid;
-  const Layer* mLayer;
-  NetSignal* mNetSignal;
+  const Layer* mLayer;  ///< Mandatory (never `nullptr`)
+  NetSignal* mNetSignal;  ///< Optional (`nullptr` = no net)
   Path mOutline;
   UnsignedLength mMinWidth;
   UnsignedLength mMinClearance;

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddata.h
@@ -182,7 +182,7 @@ public:
 
     Uuid uuid;
     const Layer* layer;
-    CircuitIdentifier netSignalName;
+    tl::optional<CircuitIdentifier> netSignalName;
     Path outline;
     UnsignedLength minWidth;
     UnsignedLength minClearance;
@@ -195,10 +195,10 @@ public:
     Signal<Plane> onEdited;  ///< Dummy event, not used
 
     Plane(const Uuid& uuid, const Layer& layer,
-          const CircuitIdentifier& netSignalName, const Path& outline,
-          const UnsignedLength& minWidth, const UnsignedLength& minClearance,
-          bool keepIslands, int priority, BI_Plane::ConnectStyle connectStyle,
-          const PositiveLength& thermalGap,
+          const tl::optional<CircuitIdentifier>& netSignalName,
+          const Path& outline, const UnsignedLength& minWidth,
+          const UnsignedLength& minClearance, bool keepIslands, int priority,
+          BI_Plane::ConnectStyle connectStyle, const PositiveLength& thermalGap,
           const PositiveLength& thermalSpokeWidth, bool locked)
       : uuid(uuid),
         layer(&layer),
@@ -217,7 +217,8 @@ public:
     explicit Plane(const SExpression& node)
       : uuid(deserialize<Uuid>(node.getChild("@0"))),
         layer(deserialize<const Layer*>(node.getChild("layer/@0"))),
-        netSignalName(deserialize<CircuitIdentifier>(node.getChild("net/@0"))),
+        netSignalName(deserialize<tl::optional<CircuitIdentifier>>(
+            node.getChild("net/@0"))),
         outline(node),
         minWidth(deserialize<UnsignedLength>(node.getChild("min_width/@0"))),
         minClearance(

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.cpp
@@ -165,8 +165,10 @@ std::unique_ptr<BoardClipboardData> BoardClipboardDataBuilder::generate(
     std::shared_ptr<BoardClipboardData::Plane> newPlane =
         std::make_shared<BoardClipboardData::Plane>(
             plane->getUuid(), plane->getLayer(),
-            plane->getNetSignal().getName(), plane->getOutline(),
-            plane->getMinWidth(), plane->getMinClearance(),
+            plane->getNetSignal()
+                ? tl::make_optional(plane->getNetSignal()->getName())
+                : tl::nullopt,
+            plane->getOutline(), plane->getMinWidth(), plane->getMinClearance(),
             plane->getKeepIslands(), plane->getPriority(),
             plane->getConnectStyle(), plane->getThermalGap(),
             plane->getThermalSpokeWidth(), plane->isLocked());

--- a/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/boardeditor/boardplanepropertiesdialog.ui
@@ -36,9 +36,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="cbxLayer"/>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_7">
        <property name="text">
@@ -133,6 +130,9 @@
      <item row="7" column="1">
       <widget class="librepcb::editor::PositiveLengthEdit" name="edtThermalSpokeWidth" native="true"/>
      </item>
+     <item row="1" column="1">
+      <widget class="librepcb::editor::LayerComboBox" name="cbxLayer" native="true"/>
+     </item>
     </layout>
    </item>
    <item>
@@ -159,6 +159,18 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>librepcb::editor::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::LayerComboBox</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/layercombobox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>librepcb::editor::UnsignedLengthEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
@@ -170,16 +182,9 @@
    <header location="global">librepcb/editor/widgets/patheditorwidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>librepcb::editor::PositiveLengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>cbxNetSignal</tabstop>
-  <tabstop>cbxLayer</tabstop>
   <tabstop>edtMinWidth</tabstop>
   <tabstop>edtMinClearance</tabstop>
   <tabstop>spbPriority</tabstop>

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
@@ -338,7 +338,7 @@ QList<std::shared_ptr<QGraphicsItem>> BoardEditorState::findItemsAtPos(
     for (auto it = scene->getPlanes().begin(); it != scene->getPlanes().end();
          it++) {
       if (netsignals.isEmpty() ||
-          netsignals.contains(&it.key()->getNetSignal())) {
+          netsignals.contains(it.key()->getNetSignal())) {
         if ((!cuLayer) || (*cuLayer == it.key()->getLayer())) {
           processItem(
               it.value(),

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_addvia.cpp
@@ -129,7 +129,7 @@ bool BoardEditorState_AddVia::entry() noexcept {
   mContext.commandToolBar.addWidget(std::move(drillEdit));
 
   // Add the netsignals combobox to the toolbar
-  mContext.commandToolBar.addLabel(tr("Signal:"), 10);
+  mContext.commandToolBar.addLabel(tr("Net:"), 10);
   mNetSignalComboBox = new QComboBox();
   mNetSignalComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   mNetSignalComboBox->setInsertPolicy(QComboBox::NoInsert);

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.cpp
@@ -86,7 +86,7 @@ bool BoardEditorState_DrawPlane::entry() noexcept {
   EditorCommandSet& cmd = EditorCommandSet::instance();
 
   // Add the netsignals combobox to the toolbar
-  mContext.commandToolBar.addLabel(tr("Signal:"), 10);
+  mContext.commandToolBar.addLabel(tr("Net:"), 10);
   std::unique_ptr<QComboBox> netSignalComboBox(new QComboBox());
   netSignalComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   netSignalComboBox->setInsertPolicy(QComboBox::NoInsert);
@@ -99,6 +99,7 @@ bool BoardEditorState_DrawPlane::entry() noexcept {
         return cmp(*lhs->getName(), *rhs->getName());
       },
       Qt::CaseInsensitive, false);
+  netSignalComboBox->addItem("[" % tr("None") % "]", QString());
   foreach (const NetSignal* netsignal, netSignals) {
     netSignalComboBox->addItem(*netsignal->getName(),
                                netsignal->getUuid().toStr());
@@ -206,7 +207,7 @@ bool BoardEditorState_DrawPlane::startAddPlane(const Point& pos) noexcept {
     // Add plane with two vertices
     Path path({Vertex(pos), Vertex(pos)});
     mCurrentPlane = new BI_Plane(*board, Uuid::createRandom(), *mLastLayer,
-                                 *mLastNetSignal, path);
+                                 mLastNetSignal, path);
     mCurrentPlane->setConnectStyle(BI_Plane::ConnectStyle::ThermalRelief);
     mContext.undoStack.appendToCmdGroup(new CmdBoardPlaneAdd(*mCurrentPlane));
 
@@ -274,14 +275,9 @@ bool BoardEditorState_DrawPlane::updateLastVertexPosition(
 }
 
 void BoardEditorState_DrawPlane::setNetSignal(NetSignal* netsignal) noexcept {
-  try {
-    if (!netsignal) throw LogicError(__FILE__, __LINE__);
-    mLastNetSignal = netsignal;
-    if (mCurrentPlaneEditCmd) {
-      mCurrentPlaneEditCmd->setNetSignal(*mLastNetSignal);
-    }
-  } catch (const Exception& e) {
-    QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
+  mLastNetSignal = netsignal;
+  if (mCurrentPlaneEditCmd) {
+    mCurrentPlaneEditCmd->setNetSignal(mLastNetSignal);
   }
 }
 

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_plane.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_plane.cpp
@@ -145,7 +145,7 @@ void BGI_Plane::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
 
   const bool selected = option->state.testFlag(QStyle::State_Selected);
   const bool highlight =
-      selected || mHighlightedNetSignals->contains(&mPlane.getNetSignal());
+      selected || mHighlightedNetSignals->contains(mPlane.getNetSignal());
   const qreal lod =
       option->levelOfDetailFromTransform(painter->worldTransform());
 

--- a/libs/librepcb/editor/project/cmd/cmdboardplaneedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardplaneedit.cpp
@@ -44,7 +44,7 @@ CmdBoardPlaneEdit::CmdBoardPlaneEdit(BI_Plane& plane) noexcept
     mNewOutline(mOldOutline),
     mOldLayer(&plane.getLayer()),
     mNewLayer(mOldLayer),
-    mOldNetSignal(&plane.getNetSignal()),
+    mOldNetSignal(plane.getNetSignal()),
     mNewNetSignal(mOldNetSignal),
     mOldMinWidth(plane.getMinWidth()),
     mNewMinWidth(mOldMinWidth),
@@ -113,9 +113,9 @@ void CmdBoardPlaneEdit::setLayer(const Layer& layer, bool immediate) noexcept {
   if (immediate) mPlane.setLayer(*mNewLayer);
 }
 
-void CmdBoardPlaneEdit::setNetSignal(NetSignal& netsignal) noexcept {
+void CmdBoardPlaneEdit::setNetSignal(NetSignal* netsignal) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewNetSignal = &netsignal;
+  mNewNetSignal = netsignal;
 }
 
 void CmdBoardPlaneEdit::setMinWidth(const UnsignedLength& minWidth) noexcept {
@@ -181,7 +181,7 @@ bool CmdBoardPlaneEdit::performExecute() {
 }
 
 void CmdBoardPlaneEdit::performUndo() {
-  mPlane.setNetSignal(*mOldNetSignal);  // can throw
+  mPlane.setNetSignal(mOldNetSignal);  // can throw
   mPlane.setOutline(mOldOutline);
   mPlane.setLayer(*mOldLayer);
   mPlane.setMinWidth(mOldMinWidth);
@@ -195,7 +195,7 @@ void CmdBoardPlaneEdit::performUndo() {
 }
 
 void CmdBoardPlaneEdit::performRedo() {
-  mPlane.setNetSignal(*mNewNetSignal);  // can throw
+  mPlane.setNetSignal(mNewNetSignal);  // can throw
   mPlane.setOutline(mNewOutline);
   mPlane.setLayer(*mNewLayer);
   mPlane.setMinWidth(mNewMinWidth);

--- a/libs/librepcb/editor/project/cmd/cmdboardplaneedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardplaneedit.h
@@ -61,7 +61,7 @@ public:
               int innerLayerCount, bool immediate) noexcept;
   void setOutline(const Path& outline, bool immediate) noexcept;
   void setLayer(const Layer& layer, bool immediate) noexcept;
-  void setNetSignal(NetSignal& netsignal) noexcept;
+  void setNetSignal(NetSignal* netsignal) noexcept;
   void setMinWidth(const UnsignedLength& minWidth) noexcept;
   void setMinClearance(const UnsignedLength& minClearance) noexcept;
   void setConnectStyle(BI_Plane::ConnectStyle style) noexcept;

--- a/libs/librepcb/editor/project/cmd/cmdcombinenetsignals.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdcombinenetsignals.cpp
@@ -113,7 +113,7 @@ bool CmdCombineNetSignals::performExecute() {
   // re-add all board planes
   foreach (BI_Plane* plane, boardPlanes) {
     CmdBoardPlaneEdit* cmd = new CmdBoardPlaneEdit(*plane);
-    cmd->setNetSignal(mResultingNetSignal);
+    cmd->setNetSignal(&mResultingNetSignal);
     execNewChildCmd(cmd);  // can throw
     execNewChildCmd(new CmdBoardPlaneAdd(*plane));  // can throw
   }

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -272,12 +272,14 @@ bool CmdPasteBoardItems::performExecute() {
 
   // Paste planes
   for (const BoardClipboardData::Plane& plane : mData->getPlanes()) {
-    BI_Plane* copy =
-        new BI_Plane(mBoard,
-                     Uuid::createRandom(),  // assign new UUID
-                     *plane.layer, *getOrCreateNetSignal(*plane.netSignalName),
-                     plane.outline.translated(mPosOffset)  // move
-        );
+    BI_Plane* copy = new BI_Plane(
+        mBoard,
+        Uuid::createRandom(),  // assign new UUID
+        *plane.layer,
+        plane.netSignalName ? getOrCreateNetSignal(**plane.netSignalName)
+                            : nullptr,
+        plane.outline.translated(mPosOffset)  // move
+    );
     copy->setMinWidth(plane.minWidth);
     copy->setMinClearance(plane.minClearance);
     copy->setKeepIslands(plane.keepIslands);


### PR DESCRIPTION
So far, it was mandatory to specify an existing net for each plane. But I think there are cases where one wants to keep as much copper on the PCB as possible, even without connecting those copper areas to any net. And since that's only a small change in the implementation, let's allow creating planes not connected to a net.