### PR TITLE
Render '!' in pin-, pad- and net names as overlines

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -421,6 +421,8 @@ add_library(
   utils/clipperhelpers.h
   utils/mathparser.cpp
   utils/mathparser.h
+  utils/overlinemarkupparser.cpp
+  utils/overlinemarkupparser.h
   utils/qtmetatyperegistration.h
   utils/scopeguard.h
   utils/scopeguardlist.h

--- a/libs/librepcb/core/export/graphicspainter.h
+++ b/libs/librepcb/core/export/graphicspainter.h
@@ -74,7 +74,7 @@ public:
   void drawText(const Point& position, const Angle& rotation,
                 const Length& height, const Alignment& alignment,
                 const QString& text, QFont font, const QColor& color,
-                bool autoRotate, bool mirrorInPlace,
+                bool autoRotate, bool mirrorInPlace, bool parseOverlines,
                 int fontPixelSize = 0) noexcept;
   void drawSymbolPin(const Point& position, const Angle& rotation,
                      const Length& length, const QColor& lineColor,

--- a/libs/librepcb/core/library/pkg/footprintpainter.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpainter.cpp
@@ -126,7 +126,7 @@ void FootprintPainter::paint(QPainter& painter,
     foreach (const Text& text, content.texts) {
       p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
                  text.getAlign(), text.getText(), mMonospaceFont,
-                 Qt::transparent, true, settings.getMirror());
+                 Qt::transparent, true, settings.getMirror(), false);
     }
   }
 }

--- a/libs/librepcb/core/library/sym/symbolpainter.cpp
+++ b/libs/librepcb/core/library/sym/symbolpainter.cpp
@@ -98,7 +98,7 @@ void SymbolPainter::paint(QPainter& painter,
     const QString color = text.getLayer().getThemeColor();
     p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
                text.getAlign(), text.getText(), mDefaultFont,
-               settings.getColor(color), true, false);
+               settings.getColor(color), true, false, false);
   }
 
   // Draw Pins.
@@ -110,14 +110,14 @@ void SymbolPainter::paint(QPainter& painter,
         pin.getPosition() + pin.getNamePosition().rotated(pin.getRotation()),
         pin.getRotation() + pin.getNameRotation(), *pin.getNameHeight(),
         pin.getNameAlignment(), *pin.getName(), mDefaultFont,
-        settings.getColor(Theme::Color::sSchematicPinNames), true, false);
+        settings.getColor(Theme::Color::sSchematicPinNames), true, false, true);
     const bool flipped = Toolbox::isTextUpsideDown(pin.getRotation());
     p.drawText(pin.getPosition() +
                    pin.getNumbersPosition(flipped).rotated(pin.getRotation()),
                pin.getRotation(), *SymbolPin::getNumbersHeight(),
                pin.getNumbersAlignment(flipped), "1…", mDefaultFont,
                settings.getColor(Theme::Color::sSchematicPinNumbers), true,
-               false);
+               false, false);
   }
 }
 

--- a/libs/librepcb/core/project/board/boardpainter.cpp
+++ b/libs/librepcb/core/project/board/boardpainter.cpp
@@ -223,7 +223,7 @@ void BoardPainter::paint(QPainter& painter,
     foreach (const TextData& text, content.texts) {
       p.drawText(text.position, text.rotation, *text.height, text.align,
                  text.text, mMonospaceFont, Qt::transparent, true,
-                 settings.getMirror());
+                 settings.getMirror(), false);
     }
   }
 }

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -179,14 +179,15 @@ void SchematicPainter::paint(QPainter& painter,
                                pin.namePosition.rotated(pin.rotation)),
           symbol.transform.mapNonMirrorable(pin.rotation + pin.nameRotation),
           *pin.nameHeight, nameAlignment, pin.name, mDefaultFont,
-          settings.getColor(Theme::Color::sSchematicPinNames), true, false);
+          settings.getColor(Theme::Color::sSchematicPinNames), true, false,
+          true);
       const Angle numberRot = symbol.transform.mapNonMirrorable(pin.rotation);
       p.drawText(symbol.transform.map(
                      pin.position + pin.numbersPosition.rotated(pin.rotation)),
                  numberRot, *SymbolPin::getNumbersHeight(),
                  pin.numbersAlignment, pin.numbers, mDefaultFont,
                  settings.getColor(Theme::Color::sSchematicPinNumbers), true,
-                 false);
+                 false, false);
     }
   }
 
@@ -203,7 +204,7 @@ void SchematicPainter::paint(QPainter& painter,
     const QString color = text.getLayer().getThemeColor();
     p.drawText(text.getPosition(), text.getRotation(), *text.getHeight(),
                text.getAlign(), text.getText(), mDefaultFont,
-               settings.getColor(color), true, false);
+               settings.getColor(color), true, false, false);
   }
 
   // Draw Net Lines.

--- a/libs/librepcb/core/utils/overlinemarkupparser.cpp
+++ b/libs/librepcb/core/utils/overlinemarkupparser.cpp
@@ -1,0 +1,126 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "overlinemarkupparser.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Static Methods
+ ******************************************************************************/
+
+QVector<std::pair<int, int>> OverlineMarkupParser::extract(
+    const QString& input, QString& output) noexcept {
+  output.clear();
+
+  // Determine length of string without trailing '!'.
+  int inputLength = input.length();
+  while ((inputLength > 0) && (input.at(inputLength - 1) == '!')) {
+    --inputLength;
+  }
+
+  // Convert remaining '!' to overlines and '!!' to '!'.
+  QVector<std::pair<int, int>> spans;
+  int spanStart = -1;
+  for (int i = 0; i < inputLength; ++i) {
+    if (input.midRef(i, 2) == "!!") {
+      // Substitutte '!!' by '!'.
+      output.append('!');
+      ++i;
+    } else if (input.midRef(i, 2) == "!/") {
+      // Do not end overline if '/' is prefixed with '!'.
+      if (spanStart < 0) {
+        spanStart = output.length();
+      }
+      output.append('/');
+      ++i;
+    } else if ((spanStart < 0) && (input.at(i) == '!')) {
+      // Start overline on single '!'.
+      spanStart = output.length();
+    } else if ((spanStart >= 0) && (input.at(i) == '!')) {
+      // End overline on single '!'.
+      spans.append(std::make_pair(spanStart, output.length() - spanStart));
+      spanStart = -1;
+    } else if ((spanStart >= 0) && (input.at(i) == '/')) {
+      // End overline implicitly on '/'.
+      spans.append(std::make_pair(spanStart, output.length() - spanStart));
+      spanStart = -1;
+      output.append(input.at(i));
+    } else {
+      output.append(input.at(i));
+    }
+  }
+
+  // Append trailing '!' as-is.
+  while (inputLength < input.length()) {
+    output.append('!');
+    ++inputLength;
+  }
+
+  // Finish current span.
+  if (spanStart >= 0) {
+    spans.append(std::make_pair(spanStart, output.length() - spanStart));
+  }
+
+  return spans;
+}
+
+QVector<QLineF> OverlineMarkupParser::calculate(
+    const QString& text, const QFontMetricsF& fm, int flags,
+    const QVector<std::pair<int, int>>& spans, QRectF& boundingRect) noexcept {
+  QVector<QLineF> overlines;
+  boundingRect = fm.boundingRect(QRectF(), flags | Qt::TextDontClip, text);
+  const qreal yBase = boundingRect.top() - fm.overlinePos();
+  foreach (const auto& span, spans) {
+    const QRectF prefixRect = fm.boundingRect(
+        QRectF(), Qt::TextDontClip | Qt::AlignBottom | Qt::AlignLeft,
+        text.left(span.first));
+    const QRectF suffixRect = fm.boundingRect(
+        QRectF(), Qt::TextDontClip | Qt::AlignBottom | Qt::AlignLeft,
+        text.mid(span.first + span.second));
+    overlines.append(QLineF(
+        boundingRect.left() + prefixRect.width(), yBase - prefixRect.top(),
+        boundingRect.right() - suffixRect.width(), yBase - prefixRect.top()));
+  }
+  return overlines;
+}
+
+void OverlineMarkupParser::process(const QString& input,
+                                   const QFontMetricsF& fm, int flags,
+                                   QString& output, QVector<QLineF>& overlines,
+                                   QRectF& boundingRect) noexcept {
+  const QVector<std::pair<int, int>> spans = extract(input, output);
+  overlines = calculate(output, fm, flags, spans, boundingRect);
+}
+
+qreal OverlineMarkupParser::getLineWidth(qreal heightPx) noexcept {
+  return heightPx / 15;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/utils/overlinemarkupparser.h
+++ b/libs/librepcb/core/utils/overlinemarkupparser.h
@@ -1,0 +1,85 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_OVERLINEMARKUPPARSER_H
+#define LIBREPCB_CORE_OVERLINEMARKUPPARSER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+#include <QtGui>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class OverlineMarkupParser
+ ******************************************************************************/
+
+/**
+ * @brief Extract overlines of text with markup
+ *
+ * Parses text like `RST/!SHDN`, removes the functional `!` and returns the
+ * coordinates where to draw overlines instead.
+ *
+ * Markup rules:
+ *   1. A single `!` toggles the overline on/off, depending on its previous
+ *      state (initial state is off).
+ *   2. The character `/` implicitly switches off the overline before rendering.
+ *      This can be prevented by prefixing it with `!`.
+ *   3. A double `!!` has no effect on overlines, they are rendered as a
+ *      single `!`. In case of an odd number of `!` (e.g. `!!!`), the **last**
+ *      one toggles overline on/off.
+ *   4. Any trailing `!` have no effect, they are rendered as-is (bypassing
+ *      rules 1 and 3).
+ */
+class OverlineMarkupParser final {
+  Q_DECLARE_TR_FUNCTIONS(OverlineMarkupParser)
+
+public:
+  // Constructors / Destructor
+  OverlineMarkupParser() = delete;
+  OverlineMarkupParser(const OverlineMarkupParser& other) = delete;
+
+  // General Methods
+  static QVector<std::pair<int, int>> extract(const QString& input,
+                                              QString& output) noexcept;
+  static QVector<QLineF> calculate(const QString& text, const QFontMetricsF& fm,
+                                   int flags,
+                                   const QVector<std::pair<int, int>>& spans,
+                                   QRectF& boundingRect) noexcept;
+  static void process(const QString& input, const QFontMetricsF& fm, int flags,
+                      QString& output, QVector<QLineF>& overlines,
+                      QRectF& boundingRect) noexcept;
+  static qreal getLineWidth(qreal heightPx) noexcept;
+
+  // Operator Overloadings
+  OverlineMarkupParser& operator=(const OverlineMarkupParser& rhs) = delete;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
@@ -106,7 +106,7 @@ void PrimitiveFootprintPadGraphicsItem::setMirrored(bool mirrored) noexcept {
 void PrimitiveFootprintPadGraphicsItem::setText(const QString& text) noexcept {
   setToolTip(text);
   mOriginCrossGraphicsItem->setToolTip(text);
-  mTextGraphicsItem->setText(text);
+  mTextGraphicsItem->setText(text, true);
   foreach (auto& item, mPathGraphicsItems) { item.item->setToolTip(text); }
   updateTextHeight();
 }

--- a/libs/librepcb/editor/graphics/primitivetextgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivetextgraphicsitem.h
@@ -63,7 +63,7 @@ public:
   // Setters
   void setPosition(const Point& pos) noexcept;
   void setRotation(const Angle& rot) noexcept;
-  void setText(const QString& text) noexcept;
+  void setText(const QString& text, bool parseOverlines = false) noexcept;
   void setHeight(const PositiveLength& height) noexcept;
   void setAlignment(const Alignment& align) noexcept;
   void setFont(Font font) noexcept;
@@ -88,6 +88,9 @@ private:  // Methods
 private:  // Data
   std::shared_ptr<GraphicsLayer> mLayer;
   QString mText;
+  QString mDisplayText;
+  bool mParseOverlines;
+  QVector<QLineF> mOverlines;
   PositiveLength mHeight;
   Alignment mAlignment;
   bool mRotate180;

--- a/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
@@ -30,6 +30,7 @@
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/types/angle.h>
 #include <librepcb/core/types/point.h>
+#include <librepcb/core/utils/overlinemarkupparser.h>
 #include <librepcb/core/workspace/theme.h>
 
 #include <QtCore>
@@ -152,7 +153,7 @@ void SymbolPinGraphicsItem::updateText() noexcept {
     text = *mPin->getName();
   }
   setToolTip(text);
-  mNameGraphicsItem->setText(text);
+  mNameGraphicsItem->setText(text, true);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_netlabel.h
+++ b/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_netlabel.h
@@ -87,6 +87,7 @@ private:  // Data
 
   // Cached Attributes
   QStaticText mStaticText;
+  QVector<QLineF> mOverlines;
   QFont mFont;
   bool mRotate180;
   QPointF mTextOrigin;

--- a/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbolpin.cpp
@@ -246,7 +246,7 @@ void SGI_SymbolPin::updateJunction() noexcept {
 
 void SGI_SymbolPin::updateName() noexcept {
   Q_ASSERT(mNameGraphicsItem);
-  mNameGraphicsItem->setText(mPin.getName());
+  mNameGraphicsItem->setText(mPin.getName(), true);
 }
 
 void SGI_SymbolPin::updateNumbers() noexcept {

--- a/libs/librepcb/editor/widgets/graphicsview.cpp
+++ b/libs/librepcb/editor/widgets/graphicsview.cpp
@@ -605,7 +605,7 @@ void GraphicsView::drawForeground(QPainter* painter, const QRectF& rect) {
                 Point(textOffset, tickPos), textRotation, textHeight,
                 (gauge.xScale != xScale) ? textAlign.mirroredH() : textAlign,
                 text, Application::getDefaultMonospaceFont(),
-                mOverlayContentColor, false, false, 10);
+                mOverlayContentColor, false, false, false, 10);
           }
         } else {
           // Draw short tick.

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(
   core/types/versiontest.cpp
   core/utils/clipperhelperstest.cpp
   core/utils/mathparsertest.cpp
+  core/utils/overlinemarkupparsertest.cpp
   core/utils/scopeguardtest.cpp
   core/utils/signalslottest.cpp
   core/utils/tangentpathjoinertest.cpp

--- a/tests/unittests/core/utils/overlinemarkupparsertest.cpp
+++ b/tests/unittests/core/utils/overlinemarkupparsertest.cpp
@@ -1,0 +1,99 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/utils/overlinemarkupparser.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Tests for extract()
+ ******************************************************************************/
+
+typedef struct {
+  QString input;
+  QString output;
+  QVector<std::pair<int, int>> spans;
+} ExtractTestData;
+
+class OverlineMarkupParserTest
+  : public ::testing::TestWithParam<ExtractTestData> {};
+
+TEST_P(OverlineMarkupParserTest, test) {
+  const ExtractTestData& data = GetParam();
+
+  QString output = "foo";
+  const QVector<std::pair<int, int>> result =
+      OverlineMarkupParser::extract(data.input, output);
+  EXPECT_EQ(data.output.toStdString(), output.toStdString());
+  EXPECT_EQ(data.spans, result);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(OverlineMarkupParserTest, OverlineMarkupParserTest, ::testing::Values(
+  // Without modification at all.
+  ExtractTestData{"", "", {}},
+  ExtractTestData{"!", "!", {}},
+  ExtractTestData{"!!", "!!", {}},
+  ExtractTestData{"!!!", "!!!", {}},
+  ExtractTestData{"A", "A", {}},
+  ExtractTestData{"A/B/C", "A/B/C", {}},
+  ExtractTestData{"AB_CD!", "AB_CD!", {}},
+  // With substitutions, but without overlines.
+  ExtractTestData{"!!A", "!A", {}},
+  ExtractTestData{"!!!!A", "!!A", {}},
+  ExtractTestData{"A!!B", "A!B", {}},
+  ExtractTestData{"A!!!!B", "A!!B", {}},
+  ExtractTestData{"!!/!!A", "!/!A", {}},
+  ExtractTestData{"!!!!/A", "!!/A", {}},
+  // Only with overlines.
+  ExtractTestData{"!ABCD", "ABCD", {std::make_pair(0, 4)}},
+  ExtractTestData{"AB!CD", "ABCD", {std::make_pair(2, 2)}},
+  ExtractTestData{"AB!CD!EF", "ABCDEF", {std::make_pair(2, 2)}},
+  ExtractTestData{"!AB/CD", "AB/CD", {std::make_pair(0, 2)}},
+  ExtractTestData{"!AB!/CD", "AB/CD", {std::make_pair(0, 5)}},
+  ExtractTestData{"AB!/CD", "AB/CD", {std::make_pair(2, 3)}},
+  ExtractTestData{"!AB/!CD", "AB/CD", {std::make_pair(0, 2), std::make_pair(3, 2)}},
+  ExtractTestData{"!AB/CD/!EF", "AB/CD/EF", {std::make_pair(0, 2), std::make_pair(6, 2)}},
+  ExtractTestData{"AB/!CD/EF", "AB/CD/EF", {std::make_pair(3, 2)}},
+  ExtractTestData{"!AB!/CD/EF", "AB/CD/EF", {std::make_pair(0, 5)}},
+  // Overlines mixed with substitutions.
+  ExtractTestData{"!!!AB!!CD", "!AB!CD", {std::make_pair(1, 5)}},
+  ExtractTestData{"AB!!!!!CD", "AB!!CD", {std::make_pair(4, 2)}},
+  ExtractTestData{"AB!CD!!EF!", "ABCD!EF!", {std::make_pair(2, 6)}},
+  ExtractTestData{"!AB!CD!!EF!", "ABCD!EF!", {std::make_pair(0, 2)}},
+  ExtractTestData{"!AB/CD!!EF!", "AB/CD!EF!", {std::make_pair(0, 2)}},
+  ExtractTestData{"!AB!!/CD", "AB!/CD", {std::make_pair(0, 3)}},
+  ExtractTestData{"!AB!!!/CD", "AB!/CD", {std::make_pair(0, 6)}}
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb


### PR DESCRIPTION
Support rendering overlines by adding `!` to pin-, pad-, or net names. The exact rules as described in https://github.com/LibrePCB/LibrePCB/issues/660#issuecomment-1590891734:

1. A single `!` toggles the overline on/off, depending on its previous state (initial state is off).
2. The character `/` implicitly switches off the overline before rendering. This can be prevented by prefixing it with `!`.
3. A double `!!` has no effect on overlines, they are rendered as a single `!`. In case of an odd number of `!` (e.g. `!!!`), the **last** one toggles overline on/off.
4. Any trailing `!` have no effect, they are rendered as-is (bypassing rules 1 and 3).

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/87d53ceb-11a2-45fe-8adb-6a9aee62b950)

Examples:

| Input | Rendering |
|---|---|
| `!RESET/SHDN` | `R̅E̅S̅E̅T̅/SHDN` |
| `RESET/!SHDN` | `RESET/S̅H̅D̅N̅` |
| `!D+` | `D̅+̅ ` |
| `!A!/B` | `A̅/̅B̅` |
| `!A/!B` | `A̅/B̅` |
| `!ABC!DEF` | `A̅B̅C̅DEF` |
| `DANGER!!RTFM` | `DANGER!RTFM` |
| `DANGER!` | `DANGER!` |
| `DANGER!!` | `DANGER!!` |

Closes #660