### PR TITLE
Support panning with right mouse button in all editors

### DIFF
--- a/libs/librepcb/editor/widgets/graphicsview.h
+++ b/libs/librepcb/editor/widgets/graphicsview.h
@@ -182,6 +182,7 @@ private:
 
   // State
   volatile bool mPanningActive;
+  Qt::MouseButton mPanningButton;
   Qt::MouseButtons mPressedMouseButtons;
   QCursor mCursorBeforePanning;
   qint64 mIdleTimeMs;

--- a/libs/librepcb/editor/widgets/openglview.cpp
+++ b/libs/librepcb/editor/widgets/openglview.cpp
@@ -178,7 +178,8 @@ void OpenGlView::mousePressEvent(QMouseEvent* e) {
 
 void OpenGlView::mouseMoveEvent(QMouseEvent* e) {
   const QVector2D diff = QVector2D(e->pos()) - mMousePressPosition;
-  if (e->buttons() & Qt::MiddleButton) {
+  if (e->buttons().testFlag(Qt::MiddleButton) ||
+      e->buttons().testFlag(Qt::RightButton)) {
     mTransform = mMousePressTransform;
     mTransform.translate(
         mMousePressTransform.inverted().map(QVector3D(diff.x(), -diff.y(), 0)) /


### PR DESCRIPTION
In addition to the middle mouse button, panning now also works with the right mouse button. This is especially useful on notebooks which don't have a dedicated middle mouse button. Also it should not have any negative impact (context menu still works if the cursor was more-or-less steady while pressing the right mouse button).