### PR TITLE
Library: Support adding part numbers to devices

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -214,6 +214,8 @@ add_library(
   library/dev/devicecheckmessages.h
   library/dev/devicepadsignalmap.cpp
   library/dev/devicepadsignalmap.h
+  library/dev/part.cpp
+  library/dev/part.h
   library/library.cpp
   library/library.h
   library/librarybaseelement.cpp

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -411,6 +411,7 @@ add_library(
   types/ratio.h
   types/signalrole.cpp
   types/signalrole.h
+  types/simplestring.h
   types/stroketextspacing.cpp
   types/stroketextspacing.h
   types/uuid.cpp

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -44,8 +44,8 @@ Device::Device(const Uuid& uuid, const Version& version, const QString& author,
                    author, name_en_US, description_en_US, keywords_en_US),
     mComponentUuid(component),
     mPackageUuid(package),
-    mAttributes(),
-    mPadSignalMap() {
+    mPadSignalMap(),
+    mAttributes() {
 }
 
 Device::Device(std::unique_ptr<TransactionalDirectory> directory,
@@ -54,8 +54,8 @@ Device::Device(std::unique_ptr<TransactionalDirectory> directory,
                    std::move(directory), root),
     mComponentUuid(deserialize<Uuid>(root.getChild("component/@0"))),
     mPackageUuid(deserialize<Uuid>(root.getChild("package/@0"))),
-    mAttributes(root),
-    mPadSignalMap(root) {
+    mPadSignalMap(root),
+    mAttributes(root) {
 }
 
 Device::~Device() noexcept {
@@ -120,9 +120,9 @@ void Device::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("package", mPackageUuid);
   root.ensureLineBreak();
-  mAttributes.serialize(root);
-  root.ensureLineBreak();
   mPadSignalMap.sortedByUuid().serialize(root);
+  root.ensureLineBreak();
+  mAttributes.serialize(root);
   root.ensureLineBreak();
   serializeMessageApprovals(root);
   root.ensureLineBreak();

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -45,7 +45,8 @@ Device::Device(const Uuid& uuid, const Version& version, const QString& author,
     mComponentUuid(component),
     mPackageUuid(package),
     mPadSignalMap(),
-    mAttributes() {
+    mAttributes(),
+    mParts() {
 }
 
 Device::Device(std::unique_ptr<TransactionalDirectory> directory,
@@ -55,7 +56,8 @@ Device::Device(std::unique_ptr<TransactionalDirectory> directory,
     mComponentUuid(deserialize<Uuid>(root.getChild("component/@0"))),
     mPackageUuid(deserialize<Uuid>(root.getChild("package/@0"))),
     mPadSignalMap(root),
-    mAttributes(root) {
+    mAttributes(root),
+    mParts(root) {
 }
 
 Device::~Device() noexcept {
@@ -123,6 +125,8 @@ void Device::serialize(SExpression& root) const {
   mPadSignalMap.sortedByUuid().serialize(root);
   root.ensureLineBreak();
   mAttributes.serialize(root);
+  root.ensureLineBreak();
+  mParts.serialize(root);
   root.ensureLineBreak();
   serializeMessageApprovals(root);
   root.ensureLineBreak();

--- a/libs/librepcb/core/library/dev/device.h
+++ b/libs/librepcb/core/library/dev/device.h
@@ -26,6 +26,7 @@
 #include "../../attribute/attribute.h"
 #include "../libraryelement.h"
 #include "devicepadsignalmap.h"
+#include "part.h"
 
 #include <QtCore>
 
@@ -73,6 +74,8 @@ public:
   }
   AttributeList& getAttributes() noexcept { return mAttributes; }
   const AttributeList& getAttributes() const noexcept { return mAttributes; }
+  PartList& getParts() noexcept { return mParts; }
+  const PartList& getParts() const noexcept { return mParts; }
 
   // Setters
   void setComponentUuid(const Uuid& uuid) noexcept;
@@ -110,6 +113,7 @@ private:  // Data
   Uuid mPackageUuid;
   DevicePadSignalMap mPadSignalMap;
   AttributeList mAttributes;
+  PartList mParts;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/dev/device.h
+++ b/libs/librepcb/core/library/dev/device.h
@@ -67,11 +67,12 @@ public:
   // Getters
   const Uuid& getComponentUuid() const noexcept { return mComponentUuid; }
   const Uuid& getPackageUuid() const noexcept { return mPackageUuid; }
-  const AttributeList& getAttributes() const noexcept { return mAttributes; }
   DevicePadSignalMap& getPadSignalMap() noexcept { return mPadSignalMap; }
   const DevicePadSignalMap& getPadSignalMap() const noexcept {
     return mPadSignalMap;
   }
+  AttributeList& getAttributes() noexcept { return mAttributes; }
+  const AttributeList& getAttributes() const noexcept { return mAttributes; }
 
   // Setters
   void setComponentUuid(const Uuid& uuid) noexcept;
@@ -107,9 +108,8 @@ private:  // Methods
 private:  // Data
   Uuid mComponentUuid;
   Uuid mPackageUuid;
-  AttributeList
-      mAttributes;  ///< not yet used, but already specified in file format
   DevicePadSignalMap mPadSignalMap;
+  AttributeList mAttributes;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/dev/devicecheck.cpp
+++ b/libs/librepcb/core/library/dev/devicecheck.cpp
@@ -50,6 +50,7 @@ DeviceCheck::~DeviceCheck() noexcept {
 RuleCheckMessageList DeviceCheck::runChecks() const {
   RuleCheckMessageList msgs = LibraryElementCheck::runChecks();
   checkNoPadsConnected(msgs);
+  checkParts(msgs);
   return msgs;
 }
 
@@ -66,6 +67,12 @@ void DeviceCheck::checkNoPadsConnected(MsgList& msgs) const {
 
   if (!mDevice.getPadSignalMap().isEmpty()) {
     msgs.append(std::make_shared<MsgNoPadsInDeviceConnected>());
+  }
+}
+
+void DeviceCheck::checkParts(MsgList& msgs) const {
+  if (mDevice.getParts().isEmpty()) {
+    msgs.append(std::make_shared<MsgDeviceHasNoParts>());
   }
 }
 

--- a/libs/librepcb/core/library/dev/devicecheck.h
+++ b/libs/librepcb/core/library/dev/devicecheck.h
@@ -57,6 +57,7 @@ public:
 
 protected:  // Methods
   void checkNoPadsConnected(MsgList& msgs) const;
+  void checkParts(MsgList& msgs) const;
 
 private:  // Data
   const Device& mDevice;

--- a/libs/librepcb/core/library/dev/devicecheckmessages.cpp
+++ b/libs/librepcb/core/library/dev/devicecheckmessages.cpp
@@ -28,6 +28,22 @@
 namespace librepcb {
 
 /*******************************************************************************
+ *  MsgDeviceHasNoParts
+ ******************************************************************************/
+
+MsgDeviceHasNoParts::MsgDeviceHasNoParts() noexcept
+  : RuleCheckMessage(
+        Severity::Hint, tr("No part numbers added"),
+        tr("There are no orderable parts added to the device. It's recommended "
+           "(but not mandatory) to add the concrete manufacturer part numbers "
+           "this device is valid for. These MPNs are used by the BOM export to "
+           "make BOMs of projects much more complete and accurate.\n\n"
+           "If this device doesn't represent an orderable part, just ignore "
+           "this message."),
+        "no_parts") {
+}
+
+/*******************************************************************************
  *  MsgNoPadsInDeviceConnected
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/dev/devicecheckmessages.h
+++ b/libs/librepcb/core/library/dev/devicecheckmessages.h
@@ -33,6 +33,24 @@
 namespace librepcb {
 
 /*******************************************************************************
+ *  Class MsgDeviceHasNoParts
+ ******************************************************************************/
+
+/**
+ * @brief The MsgDeviceHasNoParts class
+ */
+class MsgDeviceHasNoParts final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgDeviceHasNoParts)
+
+public:
+  // Constructors / Destructor
+  MsgDeviceHasNoParts() noexcept;
+  MsgDeviceHasNoParts(const MsgDeviceHasNoParts& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~MsgDeviceHasNoParts() noexcept {}
+};
+
+/*******************************************************************************
  *  Class MsgNoPadsInDeviceConnected
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/dev/part.cpp
+++ b/libs/librepcb/core/library/dev/part.cpp
@@ -1,0 +1,168 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "part.h"
+
+#include "../../utils/qtmetatyperegistration.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+// Register meta type.
+static QtMetaTypeRegistration<std::shared_ptr<Part>> sSharedMetaType;
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+Part::Part(const Part& other) noexcept
+  : onEdited(*this),
+    mMpn(other.mMpn),
+    mManufacturer(other.mManufacturer),
+    mAttributes(other.mAttributes),
+    mOnAttributesEditedSlot(*this, &Part::attributeListEdited) {
+  mAttributes.onEdited.attach(mOnAttributesEditedSlot);
+}
+
+Part::Part(const SExpression& node)
+  : onEdited(*this),
+    mMpn(deserialize<ElementName>(node.getChild("@0"))),
+    mManufacturer(deserialize<SimpleString>(node.getChild("manufacturer/@0"))),
+    mAttributes(node),
+    mOnAttributesEditedSlot(*this, &Part::attributeListEdited) {
+  mAttributes.onEdited.attach(mOnAttributesEditedSlot);
+}
+
+Part::Part(const ElementName& mpn, const SimpleString& manufacturer,
+           const AttributeList& attributes) noexcept
+  : onEdited(*this),
+    mMpn(mpn),
+    mManufacturer(manufacturer),
+    mAttributes(attributes),
+    mOnAttributesEditedSlot(*this, &Part::attributeListEdited) {
+  mAttributes.onEdited.attach(mOnAttributesEditedSlot);
+}
+
+Part::~Part() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+QStringList Part::getAttributeValuesTr() const noexcept {
+  QStringList result;
+  for (const Attribute& attribute : mAttributes) {
+    const QString value = attribute.getValueTr(true).trimmed();
+    if (!value.isEmpty()) {
+      result.append(value);
+    }
+  }
+  return result;
+}
+
+QStringList Part::getAttributeKeyValuesTr() const noexcept {
+  QStringList result;
+  for (const Attribute& attribute : mAttributes) {
+    result.append(QString("%1=%2")
+                      .arg(*attribute.getKey())
+                      .arg(attribute.getValueTr(true)));
+  }
+  return result;
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void Part::setMpn(const ElementName& value) noexcept {
+  if (value == mMpn) {
+    return;
+  }
+
+  mMpn = value;
+  onEdited.notify(Event::MpnChanged);
+}
+
+void Part::setManufacturer(const SimpleString& value) noexcept {
+  if (value == mManufacturer) {
+    return;
+  }
+
+  mManufacturer = value;
+  onEdited.notify(Event::ManufacturerChanged);
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void Part::serialize(SExpression& root) const {
+  root.appendChild(mMpn);
+  root.appendChild("manufacturer", mManufacturer);
+  root.ensureLineBreak();
+  mAttributes.serialize(root);
+  root.ensureLineBreak();
+}
+
+/*******************************************************************************
+ *  Operator Overloadings
+ ******************************************************************************/
+
+bool Part::operator==(const Part& rhs) const noexcept {
+  if (mMpn != rhs.mMpn) return false;
+  if (mManufacturer != rhs.mManufacturer) return false;
+  if (mAttributes != rhs.mAttributes) return false;
+  return true;
+}
+
+Part& Part::operator=(const Part& rhs) noexcept {
+  setMpn(rhs.mMpn);
+  setManufacturer(rhs.mManufacturer);
+  mAttributes = rhs.mAttributes;
+  return *this;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void Part::attributeListEdited(
+    const AttributeList& list, int index,
+    const std::shared_ptr<const Attribute>& attribute,
+    AttributeList::Event event) noexcept {
+  Q_UNUSED(list);
+  Q_UNUSED(index);
+  Q_UNUSED(attribute);
+  Q_UNUSED(event);
+  onEdited.notify(Event::AttributesEdited);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/library/dev/part.h
+++ b/libs/librepcb/core/library/dev/part.h
@@ -1,0 +1,126 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_PART_H
+#define LIBREPCB_CORE_PART_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../attribute/attribute.h"
+#include "../../serialization/serializableobjectlist.h"
+#include "../../types/elementname.h"
+#include "../../types/simplestring.h"
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class Part
+ ******************************************************************************/
+
+/**
+ * @brief The Part class
+ */
+class Part final {
+  Q_DECLARE_TR_FUNCTIONS(Part)
+
+public:
+  // Signals
+  enum class Event {
+    MpnChanged,
+    ManufacturerChanged,
+    AttributesEdited,
+  };
+  Signal<Part, Event> onEdited;
+  typedef Slot<Part, Event> OnEditedSlot;
+
+  // Constructors / Destructor
+  Part() = delete;
+  Part(const Part& other) noexcept;
+  explicit Part(const SExpression& node);
+  Part(const ElementName& mpn, const SimpleString& manufacturer,
+       const AttributeList& attributes) noexcept;
+  ~Part() noexcept;
+
+  // Getters
+  const ElementName& getMpn() const noexcept { return mMpn; }
+  const SimpleString& getManufacturer() const noexcept { return mManufacturer; }
+  AttributeList& getAttributes() noexcept { return mAttributes; }
+  const AttributeList& getAttributes() const noexcept { return mAttributes; }
+  QStringList getAttributeValuesTr() const noexcept;
+  QStringList getAttributeKeyValuesTr() const noexcept;
+
+  // Setters
+  void setMpn(const ElementName& value) noexcept;
+  void setManufacturer(const SimpleString& value) noexcept;
+
+  // General Methods
+
+  /**
+   * @brief Serialize into ::librepcb::SExpression node
+   *
+   * @param root    Root node to serialize into.
+   */
+  void serialize(SExpression& root) const;
+
+  // Operator Overloadings
+  bool operator==(const Part& rhs) const noexcept;
+  bool operator!=(const Part& rhs) const noexcept { return !(*this == rhs); }
+  Part& operator=(const Part& rhs) noexcept;
+
+private:  // Methods
+  void attributeListEdited(const AttributeList& list, int index,
+                           const std::shared_ptr<const Attribute>& attribute,
+                           AttributeList::Event event) noexcept;
+
+private:  // Data
+  ElementName mMpn;
+  SimpleString mManufacturer;
+  AttributeList mAttributes;
+
+  // Slots
+  AttributeList::OnEditedSlot mOnAttributesEditedSlot;
+};
+
+/*******************************************************************************
+ *  Class PartList
+ ******************************************************************************/
+
+struct PartListNameProvider {
+  static constexpr const char* tagname = "part";
+};
+using PartList =
+    SerializableObjectList<Part, PartListNameProvider, Part::Event>;
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+Q_DECLARE_METATYPE(std::shared_ptr<librepcb::Part>)
+
+#endif

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -50,7 +50,8 @@ Library::Library(const Uuid& uuid, const Version& version,
                  const QString& keywords_en_US)
   : LibraryBaseElement(getShortElementName(), getLongElementName(), uuid,
                        version, author, name_en_US, description_en_US,
-                       keywords_en_US) {
+                       keywords_en_US),
+    mManufacturer("") {
 }
 
 Library::Library(std::unique_ptr<TransactionalDirectory> directory,
@@ -62,8 +63,8 @@ Library::Library(std::unique_ptr<TransactionalDirectory> directory,
     // case.
     mUrl(root.getChild("url/@0").getValue(), QUrl::StrictMode),
     mDependencies(),  // Initialized below.
-    mIcon()  // Initialized below.
-{
+    mIcon(),  // Initialized below.
+    mManufacturer(deserialize<SimpleString>(root.getChild("manufacturer/@0"))) {
   // Read dependency UUIDs.
   foreach (const SExpression* node, root.getChildren("dependency")) {
     mDependencies.insert(deserialize<Uuid>(node->getChild("@0")));
@@ -199,6 +200,7 @@ void Library::serialize(SExpression& root) const {
     root.appendChild("dependency", uuid);
   }
   root.ensureLineBreak();
+  root.appendChild("manufacturer", mManufacturer);
   serializeMessageApprovals(root);
   root.ensureLineBreak();
 }

--- a/libs/librepcb/core/library/library.h
+++ b/libs/librepcb/core/library/library.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../types/simplestring.h"
 #include "../types/uuid.h"
 #include "librarybaseelement.h"
 
@@ -61,6 +62,7 @@ public:
   const QSet<Uuid>& getDependencies() const noexcept { return mDependencies; }
   const QByteArray& getIcon() const noexcept { return mIcon; }
   QPixmap getIconAsPixmap() const noexcept;
+  const SimpleString& getManufacturer() const noexcept { return mManufacturer; }
 
   // Setters
   void setUrl(const QUrl& url) noexcept { mUrl = url; }
@@ -68,6 +70,9 @@ public:
     mDependencies = deps;
   }
   void setIcon(const QByteArray& png) noexcept { mIcon = png; }
+  void setManufacturer(const SimpleString& value) noexcept {
+    mManufacturer = value;
+  }
 
   // General Methods
   virtual void save() override;
@@ -99,6 +104,7 @@ private:  // Data
   QUrl mUrl;
   QSet<Uuid> mDependencies;
   QByteArray mIcon;
+  SimpleString mManufacturer;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -86,6 +86,11 @@ void FileFormatMigrationUnstable::upgradeDevice(TransactionalDirectory& dir) {
 
 void FileFormatMigrationUnstable::upgradeLibrary(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  const QString fp = "library.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  root.appendChild("manufacturer", QString());
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeWorkspaceData(

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -247,6 +247,14 @@ void FileFormatMigrationV01::upgradeDevice(TransactionalDirectory& dir) {
 void FileFormatMigrationV01::upgradeLibrary(TransactionalDirectory& dir) {
   // Version File.
   upgradeVersionFile(dir, ".librepcb-lib");
+
+  // Content File.
+  {
+    const QString fp = "library.lp";
+    SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root.appendChild("manufacturer", QString());
+    dir.write(fp, root.toByteArray());
+  }
 }
 
 void FileFormatMigrationV01::upgradeProject(TransactionalDirectory& dir,

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
@@ -35,6 +35,7 @@
  ******************************************************************************/
 namespace librepcb {
 
+class Attribute;
 class Component;
 class ComponentCategory;
 class Device;
@@ -85,10 +86,12 @@ public:
    * @param version       Version of the library.
    * @param deprecated    Whether the library is deprecated or not.
    * @param iconPng       Icon as a PNG.
+   * @param manufacturer  Name of the manufacturer of this library (optional).
    * @return ID of the added library.
    */
   int addLibrary(const FilePath& fp, const Uuid& uuid, const Version& version,
-                 bool deprecated, const QByteArray& iconPng);
+                 bool deprecated, const QByteArray& iconPng,
+                 const QString& manufacturer);
 
   /**
    * @brief Update library metadata
@@ -98,10 +101,11 @@ public:
    * @param version       New version of the library.
    * @param deprecated    Whether the library is deprecated or not.
    * @param iconPng       New icon as a PNG.
+   * @param manufacturer  Name of the manufacturer of this library (optional).
    */
   void updateLibrary(const FilePath& fp, const Uuid& uuid,
                      const Version& version, bool deprecated,
-                     const QByteArray& iconPng);
+                     const QByteArray& iconPng, const QString& manufacturer);
 
   /**
    * @brief Add a library element
@@ -163,6 +167,25 @@ public:
   int addDevice(int libId, const FilePath& fp, const Uuid& uuid,
                 const Version& version, bool deprecated, const Uuid& component,
                 const Uuid& package);
+
+  /**
+   * @brief Add a part to a previously added device
+   *
+   * @param devId         ID of the device containing this part.
+   * @param mpn           Manufacturer part number.
+   * @param manufacturer  Manufacturer name.
+   * @return ID of the added part.
+   */
+  int addPart(int devId, const ElementName& mpn, const QString& manufacturer);
+
+  /**
+   * @brief Add an attribute to a previously added part
+   *
+   * @param partId        ID of the part containing this attribute.
+   * @param attribute     Attribute to add.
+   * @return ID of the added attribute.
+   */
+  int addPartAttribute(int partId, const Attribute& attribute);
 
   /**
    * @brief Remove a library element
@@ -281,6 +304,7 @@ private:  // Methods
   int addToCategory(const QString& elementsTable, int elementId,
                     const Uuid& category);
   QString filePathToString(const FilePath& fp) const noexcept;
+  static QString nonNull(const QString& s) noexcept;
 
 private:  // Data
   FilePath mLibrariesRoot;

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -237,10 +237,12 @@ QHash<FilePath, int> WorkspaceLibraryScanner::updateLibraries(
     FilePath fp = lib->getDirectory().getAbsPath();
     if (dbLibIds.contains(fp)) {
       writer.updateLibrary(fp, lib->getUuid(), lib->getVersion(),
-                           lib->isDeprecated(), lib->getIcon());
+                           lib->isDeprecated(), lib->getIcon(),
+                           *lib->getManufacturer());
     } else {
       int id = writer.addLibrary(fp, lib->getUuid(), lib->getVersion(),
-                                 lib->isDeprecated(), lib->getIcon());
+                                 lib->isDeprecated(), lib->getIcon(),
+                                 *lib->getManufacturer());
       dbLibIds.insert(fp, id);
     }
   }
@@ -327,6 +329,13 @@ int WorkspaceLibraryScanner::addElementToDb<Device>(
       element.getVersion(), element.isDeprecated(), element.getComponentUuid(),
       element.getPackageUuid());
   addToCategories(writer, id, element);
+  for (const Part& part : element.getParts()) {
+    const int partId =
+        writer.addPart(id, part.getMpn(), *part.getManufacturer());
+    for (const Attribute& attribute : part.getAttributes()) {
+      writer.addPartAttribute(partId, attribute);
+    }
+  }
   return id;
 }
 

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -157,6 +157,8 @@ add_library(
   library/cmd/cmdpackagemodelremove.h
   library/cmd/cmdpackagepadedit.cpp
   library/cmd/cmdpackagepadedit.h
+  library/cmd/cmdpartedit.cpp
+  library/cmd/cmdpartedit.h
   library/cmd/cmdpastefootprintitems.cpp
   library/cmd/cmdpastefootprintitems.h
   library/cmd/cmdpastesymbolitems.cpp
@@ -202,6 +204,10 @@ add_library(
   library/dev/devicepadsignalmapmodel.h
   library/dev/padsignalmapeditorwidget.cpp
   library/dev/padsignalmapeditorwidget.h
+  library/dev/partlisteditorwidget.cpp
+  library/dev/partlisteditorwidget.h
+  library/dev/partlistmodel.cpp
+  library/dev/partlistmodel.h
   library/eaglelibraryimportwizard/eaglelibraryimportwizard.cpp
   library/eaglelibraryimportwizard/eaglelibraryimportwizard.h
   library/eaglelibraryimportwizard/eaglelibraryimportwizard.ui

--- a/libs/librepcb/editor/library/cmd/cmdlibraryedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdlibraryedit.cpp
@@ -42,7 +42,9 @@ CmdLibraryEdit::CmdLibraryEdit(Library& library) noexcept
     mOldDependencies(library.getDependencies()),
     mNewDependencies(mOldDependencies),
     mOldIcon(library.getIcon()),
-    mNewIcon(mOldIcon) {
+    mNewIcon(mOldIcon),
+    mOldManufacturer(library.getManufacturer()),
+    mNewManufacturer(mOldManufacturer) {
 }
 
 CmdLibraryEdit::~CmdLibraryEdit() noexcept {
@@ -67,6 +69,11 @@ void CmdLibraryEdit::setIcon(const QByteArray& png) noexcept {
   mNewIcon = png;
 }
 
+void CmdLibraryEdit::setManufacturer(const SimpleString& value) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewManufacturer = value;
+}
+
 /*******************************************************************************
  *  Inherited from UndoCommand
  ******************************************************************************/
@@ -76,6 +83,7 @@ bool CmdLibraryEdit::performExecute() {
   if (mNewUrl != mOldUrl) return true;
   if (mNewDependencies != mOldDependencies) return true;
   if (mNewIcon != mOldIcon) return true;
+  if (mNewManufacturer != mOldManufacturer) return true;
   return false;
 }
 
@@ -84,6 +92,7 @@ void CmdLibraryEdit::performUndo() {
   mLibrary.setUrl(mOldUrl);
   mLibrary.setDependencies(mOldDependencies);
   mLibrary.setIcon(mOldIcon);
+  mLibrary.setManufacturer(mOldManufacturer);
 }
 
 void CmdLibraryEdit::performRedo() {
@@ -91,6 +100,7 @@ void CmdLibraryEdit::performRedo() {
   mLibrary.setUrl(mNewUrl);
   mLibrary.setDependencies(mNewDependencies);
   mLibrary.setIcon(mNewIcon);
+  mLibrary.setManufacturer(mNewManufacturer);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdlibraryedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdlibraryedit.h
@@ -54,6 +54,7 @@ public:
   void setUrl(const QUrl& url) noexcept;
   void setDependencies(const QSet<Uuid>& deps) noexcept;
   void setIcon(const QByteArray& png) noexcept;
+  void setManufacturer(const SimpleString& value) noexcept;
 
   // Operator Overloadings
   CmdLibraryEdit& operator=(const CmdLibraryEdit& rhs) = delete;
@@ -77,6 +78,8 @@ private:  // Data
   QSet<Uuid> mNewDependencies;
   QByteArray mOldIcon;
   QByteArray mNewIcon;
+  SimpleString mOldManufacturer;
+  SimpleString mNewManufacturer;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdpartedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpartedit.cpp
@@ -1,0 +1,90 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdpartedit.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdPartEdit::CmdPartEdit(Part& part) noexcept
+  : UndoCommand(tr("Edit part")),
+    mPart(part),
+    mOldMpn(part.getMpn()),
+    mNewMpn(mOldMpn),
+    mOldManufacturer(part.getManufacturer()),
+    mNewManufacturer(mOldManufacturer) {
+}
+
+CmdPartEdit::~CmdPartEdit() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void CmdPartEdit::setMpn(const ElementName& value) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewMpn = value;
+}
+
+void CmdPartEdit::setManufacturer(const SimpleString& value) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewManufacturer = value;
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdPartEdit::performExecute() {
+  performRedo();
+
+  if (mNewMpn != mOldMpn) return true;
+  if (mNewManufacturer != mOldManufacturer) return true;
+  return false;
+}
+
+void CmdPartEdit::performUndo() {
+  mPart.setMpn(mOldMpn);
+  mPart.setManufacturer(mOldManufacturer);
+}
+
+void CmdPartEdit::performRedo() {
+  mPart.setMpn(mNewMpn);
+  mPart.setManufacturer(mNewManufacturer);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/library/cmd/cmdpartedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdpartedit.h
@@ -1,0 +1,100 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_CMDPARTEDIT_H
+#define LIBREPCB_EDITOR_CMDPARTEDIT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../cmd/cmdlistelementinsert.h"
+#include "../../cmd/cmdlistelementremove.h"
+#include "../../cmd/cmdlistelementsswap.h"
+#include "../../undocommand.h"
+
+#include <librepcb/core/library/dev/part.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Class CmdPartEdit
+ ******************************************************************************/
+
+/**
+ * @brief The CmdPartEdit class
+ */
+class CmdPartEdit final : public UndoCommand {
+public:
+  // Constructors / Destructor
+  CmdPartEdit() = delete;
+  CmdPartEdit(const CmdPartEdit& other) = delete;
+  explicit CmdPartEdit(Part& part) noexcept;
+  ~CmdPartEdit() noexcept;
+
+  // Setters
+  void setMpn(const ElementName& value) noexcept;
+  void setManufacturer(const SimpleString& value) noexcept;
+
+  // Operator Overloadings
+  CmdPartEdit& operator=(const CmdPartEdit& rhs) = delete;
+
+private:  // Methods
+  /// @copydoc ::librepcb::editor::UndoCommand::performExecute()
+  bool performExecute() override;
+
+  /// @copydoc ::librepcb::editor::UndoCommand::performUndo()
+  void performUndo() override;
+
+  /// @copydoc ::librepcb::editor::UndoCommand::performRedo()
+  void performRedo() override;
+
+private:  // Data
+  Part& mPart;
+
+  ElementName mOldMpn;
+  ElementName mNewMpn;
+  SimpleString mOldManufacturer;
+  SimpleString mNewManufacturer;
+};
+
+/*******************************************************************************
+ *  Undo Commands
+ ******************************************************************************/
+
+using CmdPartInsert =
+    CmdListElementInsert<Part, PartListNameProvider, Part::Event>;
+using CmdPartRemove =
+    CmdListElementRemove<Part, PartListNameProvider, Part::Event>;
+using CmdPartsSwap =
+    CmdListElementsSwap<Part, PartListNameProvider, Part::Event>;
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
@@ -37,6 +37,7 @@
 #include <librepcb/core/application.h>
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/library/dev/device.h>
+#include <librepcb/core/library/library.h>
 #include <librepcb/core/library/librarybaseelementcheckmessages.h>
 #include <librepcb/core/library/libraryelementcheckmessages.h>
 #include <librepcb/core/library/pkg/package.h>
@@ -74,6 +75,12 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
   mUi->btnChooseComponent->setHidden(mContext.readOnly);
   mUi->padSignalMapEditorWidget->setReadOnly(mContext.readOnly);
   mUi->padSignalMapEditorWidget->setFrameStyle(QFrame::NoFrame);
+  mUi->partsEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->partsEditorWidget->setFrameStyle(QFrame::NoFrame);
+  if (mContext.library) {
+    mUi->partsEditorWidget->setInitialManufacturer(
+        mContext.library->getManufacturer());
+  }
   mUi->attributesEditorWidget->setReadOnly(mContext.readOnly);
   mUi->attributesEditorWidget->setFrameStyle(QFrame::NoFrame);
   setupErrorNotificationWidget(*mUi->errorNotificationWidget);
@@ -114,9 +121,12 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
   updateDevicePackageUuid(mDevice->getPackageUuid());
   updateMetadata();
 
-  // Load attribute editor.
-  mUi->attributesEditorWidget->setReferences(mUndoStack.data(),
-                                             &mDevice->getAttributes());
+  // Load parts editor.
+  mUi->partsEditorWidget->setReferences(mUndoStack.data(),
+                                        &mDevice->getParts());
+  connect(mUi->partsEditorWidget, &PartListEditorWidget::currentItemChanged,
+          this, &DeviceEditorWidget::setSelectedPart);
+  setSelectedPart(-1);
 
   // Show "interface broken" warning when related properties are modified.
   memorizeDeviceInterface();
@@ -155,6 +165,7 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
 
 DeviceEditorWidget::~DeviceEditorWidget() noexcept {
   mUi->padSignalMapEditorWidget->setReferences(nullptr, nullptr);
+  mUi->partsEditorWidget->setReferences(nullptr, nullptr);
   mUi->attributesEditorWidget->setReferences(nullptr, nullptr);
 }
 
@@ -444,6 +455,18 @@ void DeviceEditorWidget::updatePackagePreview() noexcept {
         mComponent.get(), getLibLocaleOrder()));
     mPackageGraphicsScene->addItem(*mFootprintGraphicsItem);
     mUi->viewPackage->zoomAll();
+  }
+}
+
+void DeviceEditorWidget::setSelectedPart(int index) noexcept {
+  if (auto part = mDevice->getParts().value(index)) {
+    mUi->gbxAttributes->setTitle(tr("Attributes of Selected Part"));
+    mUi->attributesEditorWidget->setReferences(mUndoStack.data(),
+                                               &part->getAttributes());
+  } else {
+    mUi->gbxAttributes->setTitle(tr("Device Attributes"));
+    mUi->attributesEditorWidget->setReferences(mUndoStack.data(),
+                                               &mDevice->getAttributes());
   }
 }
 

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
@@ -73,6 +73,9 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
   mUi->btnChoosePackage->setHidden(mContext.readOnly);
   mUi->btnChooseComponent->setHidden(mContext.readOnly);
   mUi->padSignalMapEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->padSignalMapEditorWidget->setFrameStyle(QFrame::NoFrame);
+  mUi->attributesEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->attributesEditorWidget->setFrameStyle(QFrame::NoFrame);
   setupErrorNotificationWidget(*mUi->errorNotificationWidget);
   setWindowIcon(QIcon(":/img/library/device.png"));
 
@@ -111,6 +114,10 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
   updateDevicePackageUuid(mDevice->getPackageUuid());
   updateMetadata();
 
+  // Load attribute editor.
+  mUi->attributesEditorWidget->setReferences(mUndoStack.data(),
+                                             &mDevice->getAttributes());
+
   // Show "interface broken" warning when related properties are modified.
   memorizeDeviceInterface();
   setupInterfaceBrokenWarningWidget(*mUi->interfaceBrokenWarningWidget);
@@ -148,6 +155,7 @@ DeviceEditorWidget::DeviceEditorWidget(const Context& context,
 
 DeviceEditorWidget::~DeviceEditorWidget() noexcept {
   mUi->padSignalMapEditorWidget->setReferences(nullptr, nullptr);
+  mUi->attributesEditorWidget->setReferences(nullptr, nullptr);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.h
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.h
@@ -93,6 +93,7 @@ private:  // Methods
   void updateComponentPreview() noexcept;
   void updateDevicePackageUuid(const Uuid& uuid) noexcept;
   void updatePackagePreview() noexcept;
+  void setSelectedPart(int index) noexcept;
   void memorizeDeviceInterface() noexcept;
   bool isInterfaceBroken() const noexcept override;
   bool runChecks(RuleCheckMessageList& msgs) const override;

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>838</width>
-    <height>506</height>
+    <width>924</width>
+    <height>572</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -66,7 +66,7 @@
         <number>6</number>
        </property>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1,1">
          <property name="spacing">
           <number>3</number>
          </property>
@@ -75,12 +75,15 @@
            <property name="title">
             <string>Package</string>
            </property>
-           <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+           <layout class="QVBoxLayout" name="verticalLayout_6">
+            <property name="spacing">
+             <number>0</number>
+            </property>
             <property name="leftMargin">
              <number>0</number>
             </property>
             <property name="topMargin">
-             <number>6</number>
+             <number>0</number>
             </property>
             <property name="rightMargin">
              <number>0</number>
@@ -88,65 +91,90 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <property name="spacing">
-             <number>3</number>
-            </property>
-            <item row="2" column="0" colspan="2">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_5">
+              <property name="spacing">
+               <number>9</number>
+              </property>
+              <property name="leftMargin">
+               <number>3</number>
+              </property>
+              <property name="topMargin">
+               <number>3</number>
+              </property>
+              <property name="rightMargin">
+               <number>3</number>
+              </property>
+              <property name="bottomMargin">
+               <number>3</number>
+              </property>
+              <item>
+               <widget class="QToolButton" name="btnChoosePackage">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>28</width>
+                  <height>28</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>25</width>
+                  <height>25</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>25</width>
+                  <height>25</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="lblPackageName">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string notr="true">TextLabel</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
              <widget class="librepcb::editor::GraphicsView" name="viewPackage">
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
               <property name="verticalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
               </property>
               <property name="horizontalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0" rowspan="2">
-             <widget class="QToolButton" name="btnChoosePackage">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>28</width>
-                <height>28</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>25</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="icon">
-               <iconset>
-                <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>25</width>
-                <height>25</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1" rowspan="2">
-             <widget class="QLabel" name="lblPackageName">
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string notr="true">TextLabel</string>
               </property>
              </widget>
             </item>
@@ -158,12 +186,15 @@
            <property name="title">
             <string>Component</string>
            </property>
-           <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <property name="spacing">
+             <number>0</number>
+            </property>
             <property name="leftMargin">
              <number>0</number>
             </property>
             <property name="topMargin">
-             <number>6</number>
+             <number>0</number>
             </property>
             <property name="rightMargin">
              <number>0</number>
@@ -171,11 +202,85 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <property name="spacing">
-             <number>3</number>
-            </property>
-            <item row="2" column="0" colspan="2">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_4">
+              <property name="spacing">
+               <number>9</number>
+              </property>
+              <property name="leftMargin">
+               <number>3</number>
+              </property>
+              <property name="topMargin">
+               <number>3</number>
+              </property>
+              <property name="rightMargin">
+               <number>3</number>
+              </property>
+              <property name="bottomMargin">
+               <number>3</number>
+              </property>
+              <item>
+               <widget class="QToolButton" name="btnChooseComponent">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>28</width>
+                  <height>28</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>25</width>
+                  <height>25</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>25</width>
+                  <height>25</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="lblComponentName">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string notr="true">TextLabel</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
              <widget class="librepcb::editor::GraphicsView" name="viewComponent">
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
               <property name="verticalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
               </property>
@@ -184,54 +289,32 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0" rowspan="2">
-             <widget class="QToolButton" name="btnChooseComponent">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>28</width>
-                <height>28</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>25</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="icon">
-               <iconset>
-                <normaloff>:/img/actions/search.png</normaloff>:/img/actions/search.png</iconset>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>25</width>
-                <height>25</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1" rowspan="2">
-             <widget class="QLabel" name="lblComponentName">
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string notr="true">TextLabel</string>
-              </property>
-             </widget>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_3">
+           <property name="title">
+            <string>Pinout</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="librepcb::editor::PadSignalMapEditorWidget" name="padSignalMapEditorWidget" native="true"/>
             </item>
            </layout>
           </widget>
@@ -239,28 +322,28 @@
         </layout>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_3">
+        <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
-          <string>Pad-Signal-Map</string>
+          <string>Attributes</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <property name="spacing">
            <number>0</number>
           </property>
           <property name="leftMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="topMargin">
-           <number>6</number>
+           <number>0</number>
           </property>
           <property name="rightMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="bottomMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <item>
-           <widget class="librepcb::editor::PadSignalMapEditorWidget" name="padSignalMapEditorWidget" native="true"/>
+           <widget class="librepcb::editor::AttributeListEditorWidget" name="attributesEditorWidget" native="true"/>
           </item>
          </layout>
         </widget>
@@ -448,6 +531,12 @@
    <class>librepcb::editor::PadSignalMapEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/library/dev/padsignalmapeditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::AttributeListEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/attributelisteditorwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
@@ -322,31 +322,62 @@
         </layout>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="title">
-          <string>Attributes</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="librepcb::editor::AttributeListEditorWidget" name="attributesEditorWidget" native="true"/>
-          </item>
-         </layout>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QGroupBox" name="groupBox_5">
+           <property name="title">
+            <string>Part Numbers</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_7">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="librepcb::editor::PartListEditorWidget" name="partsEditorWidget" native="true"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="gbxAttributes">
+           <property name="title">
+            <string>Attributes</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="librepcb::editor::AttributeListEditorWidget" name="attributesEditorWidget" native="true"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </item>
@@ -537,6 +568,12 @@
    <class>librepcb::editor::AttributeListEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/attributelisteditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::PartListEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/library/dev/partlisteditorwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/librepcb/editor/library/dev/devicepadsignalmapmodel.cpp
+++ b/libs/librepcb/editor/library/dev/devicepadsignalmapmodel.cpp
@@ -166,9 +166,9 @@ QVariant DevicePadSignalMapModel::headerData(int section,
     if (role == Qt::DisplayRole) {
       switch (section) {
         case COLUMN_PAD:
-          return tr("Package Pad");
+          return tr("Pad");
         case COLUMN_SIGNAL:
-          return tr("Component Signal");
+          return tr("Signal");
       }
     }
   }

--- a/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.cpp
@@ -76,6 +76,10 @@ PadSignalMapEditorWidget::~PadSignalMapEditorWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void PadSignalMapEditorWidget::setFrameStyle(int style) noexcept {
+  mView->setFrameStyle(style);
+}
+
 void PadSignalMapEditorWidget::setReadOnly(bool readOnly) noexcept {
   mView->setEditTriggers(readOnly
                              ? QAbstractItemView::EditTrigger::NoEditTriggers

--- a/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.h
+++ b/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.h
@@ -60,6 +60,7 @@ public:
   ~PadSignalMapEditorWidget() noexcept;
 
   // General Methods
+  void setFrameStyle(int style) noexcept;
   void setReadOnly(bool readOnly) noexcept;
   void setReferences(UndoStack* undoStack, DevicePadSignalMap* map) noexcept;
   void setPadList(const PackagePadList& list) noexcept;

--- a/libs/librepcb/editor/library/dev/partlisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/partlisteditorwidget.cpp
@@ -20,11 +20,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "attributelisteditorwidget.h"
+#include "partlisteditorwidget.h"
 
-#include "../modelview/attributelistmodel.h"
-#include "../modelview/comboboxdelegate.h"
-#include "../widgets/editabletablewidget.h"
+#include "../../widgets/editabletablewidget.h"
+#include "partlistmodel.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -39,64 +38,63 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-AttributeListEditorWidget::AttributeListEditorWidget(QWidget* parent) noexcept
+PartListEditorWidget::PartListEditorWidget(QWidget* parent) noexcept
   : QWidget(parent),
-    mModel(new AttributeListModel(this)),
+    mModel(new PartListModel(this)),
     mView(new EditableTableWidget(this)) {
   mView->setShowMoveButtons(true);
+  mView->setShowCopyButton(true);
   mView->setModel(mModel.data());
-  // Start editing with a single click to immediately show the comboboxes - not
-  // very nice since edit triggers also apply to normal text cells, but better
-  // than needing one more click to drop down comboboxes...
-  mView->setEditTriggers(QAbstractItemView::AllEditTriggers);
+  mView->horizontalHeader()->setSectionResizeMode(PartListModel::COLUMN_MPN,
+                                                  QHeaderView::Stretch);
   mView->horizontalHeader()->setSectionResizeMode(
-      AttributeListModel::COLUMN_KEY, QHeaderView::Stretch);
+      PartListModel::COLUMN_MANUFACTURER, QHeaderView::Stretch);
   mView->horizontalHeader()->setSectionResizeMode(
-      AttributeListModel::COLUMN_TYPE, QHeaderView::Stretch);
+      PartListModel::COLUMN_ATTRIBUTES, QHeaderView::ResizeToContents);
   mView->horizontalHeader()->setSectionResizeMode(
-      AttributeListModel::COLUMN_VALUE, QHeaderView::Stretch);
-  mView->horizontalHeader()->setSectionResizeMode(
-      AttributeListModel::COLUMN_UNIT, QHeaderView::Stretch);
-  mView->horizontalHeader()->setSectionResizeMode(
-      AttributeListModel::COLUMN_ACTIONS, QHeaderView::ResizeToContents);
-  mView->setItemDelegateForColumn(AttributeListModel::COLUMN_TYPE,
-                                  new ComboBoxDelegate(false, this));
-  mView->setItemDelegateForColumn(AttributeListModel::COLUMN_UNIT,
-                                  new ComboBoxDelegate(false, this));
+      PartListModel::COLUMN_ACTIONS, QHeaderView::ResizeToContents);
   connect(mView.data(), &EditableTableWidget::btnAddClicked, mModel.data(),
-          &AttributeListModel::add);
+          &PartListModel::add);
+  connect(mView.data(), &EditableTableWidget::btnCopyClicked, mModel.data(),
+          &PartListModel::copy);
   connect(mView.data(), &EditableTableWidget::btnRemoveClicked, mModel.data(),
-          &AttributeListModel::remove);
+          &PartListModel::remove);
   connect(mView.data(), &EditableTableWidget::btnMoveUpClicked, mModel.data(),
-          &AttributeListModel::moveUp);
+          &PartListModel::moveUp);
   connect(mView.data(), &EditableTableWidget::btnMoveDownClicked, mModel.data(),
-          &AttributeListModel::moveDown);
+          &PartListModel::moveDown);
+  connect(mView.data(), &EditableTableWidget::currentRowChanged, this,
+          &PartListEditorWidget::currentItemChanged);
 
   QVBoxLayout* layout = new QVBoxLayout(this);
   layout->setContentsMargins(0, 0, 0, 0);
   layout->addWidget(mView.data());
 }
 
-AttributeListEditorWidget::~AttributeListEditorWidget() noexcept {
+PartListEditorWidget::~PartListEditorWidget() noexcept {
 }
 
 /*******************************************************************************
  *  Setters
  ******************************************************************************/
 
-void AttributeListEditorWidget::setFrameStyle(int style) noexcept {
+void PartListEditorWidget::setFrameStyle(int style) noexcept {
   mView->setFrameStyle(style);
 }
 
-void AttributeListEditorWidget::setReadOnly(bool readOnly) noexcept {
+void PartListEditorWidget::setReadOnly(bool readOnly) noexcept {
   mView->setReadOnly(readOnly);
 }
 
-void AttributeListEditorWidget::setReferences(UndoStack* undoStack,
-                                              AttributeList* list) noexcept {
-  mModel->setAttributeList(list);
+void PartListEditorWidget::setInitialManufacturer(
+    const SimpleString& value) noexcept {
+  mModel->setInitialManufacturer(value);
+}
+
+void PartListEditorWidget::setReferences(UndoStack* undoStack,
+                                         PartList* list) noexcept {
+  mModel->setPartList(list);
   mModel->setUndoStack(undoStack);
-  mView->horizontalHeader()->reset();  // Fix wrong column sizes.
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/dev/partlisteditorwidget.h
+++ b/libs/librepcb/editor/library/dev/partlisteditorwidget.h
@@ -1,0 +1,81 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_PARTLISTEDITORWIDGET_H
+#define LIBREPCB_EDITOR_PARTLISTEDITORWIDGET_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/library/dev/part.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+class EditableTableWidget;
+class PartListModel;
+class UndoStack;
+
+/*******************************************************************************
+ *  Class PartListEditorWidget
+ ******************************************************************************/
+
+/**
+ * @brief The PartListEditorWidget class
+ */
+class PartListEditorWidget final : public QWidget {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit PartListEditorWidget(QWidget* parent = nullptr) noexcept;
+  PartListEditorWidget(const PartListEditorWidget& other) = delete;
+  ~PartListEditorWidget() noexcept;
+
+  // Setters
+  void setFrameStyle(int style) noexcept;
+  void setReadOnly(bool readOnly) noexcept;
+  void setInitialManufacturer(const SimpleString& value) noexcept;
+  void setReferences(UndoStack* undoStack, PartList* list) noexcept;
+
+  // Operator Overloadings
+  PartListEditorWidget& operator=(const PartListEditorWidget& rhs) = delete;
+
+signals:
+  void currentItemChanged(int index);
+
+private:  // Data
+  QScopedPointer<PartListModel> mModel;
+  QScopedPointer<EditableTableWidget> mView;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/library/dev/partlistmodel.cpp
+++ b/libs/librepcb/editor/library/dev/partlistmodel.cpp
@@ -1,0 +1,375 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "partlistmodel.h"
+
+#include "../../undostack.h"
+#include "../cmd/cmdpartedit.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+#include <algorithm>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PartListModel::PartListModel(QObject* parent) noexcept
+  : QAbstractTableModel(parent),
+    mPartList(nullptr),
+    mUndoStack(nullptr),
+    mNewMpn(),
+    mNewManufacturer(),
+    mOnEditedSlot(*this, &PartListModel::partListEdited) {
+}
+
+PartListModel::~PartListModel() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void PartListModel::setInitialManufacturer(const SimpleString& value) noexcept {
+  mNewManufacturer = *value;
+}
+
+void PartListModel::setPartList(PartList* list) noexcept {
+  emit beginResetModel();
+
+  if (mPartList) {
+    mPartList->onEdited.detach(mOnEditedSlot);
+  }
+
+  mPartList = list;
+
+  if (mPartList) {
+    mPartList->onEdited.attach(mOnEditedSlot);
+  }
+
+  emit endResetModel();
+}
+
+void PartListModel::setUndoStack(UndoStack* stack) noexcept {
+  mUndoStack = stack;
+}
+
+/*******************************************************************************
+ *  Slots
+ ******************************************************************************/
+
+void PartListModel::add(const QPersistentModelIndex& itemIndex) noexcept {
+  Q_UNUSED(itemIndex);
+  if (!mPartList) {
+    return;
+  }
+
+  try {
+    std::shared_ptr<Part> obj = std::make_shared<Part>(
+        ElementName(mNewMpn), SimpleString(mNewManufacturer),
+        AttributeList());  // can throw
+    execCmd(new CmdPartInsert(*mPartList, obj));
+    mNewMpn.clear();
+  } catch (const Exception& e) {
+    QMessageBox::critical(0, tr("Error"), e.getMsg());
+  }
+}
+
+void PartListModel::copy(const QPersistentModelIndex& itemIndex) noexcept {
+  if (!mPartList) {
+    return;
+  }
+
+  try {
+    const int index = itemIndex.row();
+    if ((index >= 0) && (index < mPartList->count())) {
+      std::shared_ptr<const Part> original = mPartList->at(index);
+      std::shared_ptr<Part> copy = std::make_shared<Part>(*original);
+      execCmd(new CmdPartInsert(*mPartList, copy));
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(0, tr("Error"), e.getMsg());
+  }
+}
+
+void PartListModel::remove(const QPersistentModelIndex& itemIndex) noexcept {
+  if (!mPartList) {
+    return;
+  }
+
+  try {
+    const int index = itemIndex.row();
+    if ((index >= 0) && (index < mPartList->count())) {
+      execCmd(new CmdPartRemove(*mPartList, mPartList->at(index).get()));
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(0, tr("Error"), e.getMsg());
+  }
+}
+
+void PartListModel::moveUp(const QPersistentModelIndex& itemIndex) noexcept {
+  if (!mPartList) {
+    return;
+  }
+
+  try {
+    const int index = itemIndex.row();
+    if ((index >= 1) && (index < mPartList->count())) {
+      execCmd(new CmdPartsSwap(*mPartList, index, index - 1));
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(0, tr("Error"), e.getMsg());
+  }
+}
+
+void PartListModel::moveDown(const QPersistentModelIndex& itemIndex) noexcept {
+  if (!mPartList) {
+    return;
+  }
+
+  try {
+    const int index = itemIndex.row();
+    if ((index >= 0) && (index < mPartList->count() - 1)) {
+      execCmd(new CmdPartsSwap(*mPartList, index, index + 1));
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(0, tr("Error"), e.getMsg());
+  }
+}
+
+/*******************************************************************************
+ *  Inherited from QAbstractItemModel
+ ******************************************************************************/
+
+int PartListModel::rowCount(const QModelIndex& parent) const {
+  if (!parent.isValid() && mPartList) {
+    return mPartList->count() + 1;
+  }
+  return 0;
+}
+
+int PartListModel::columnCount(const QModelIndex& parent) const {
+  if (!parent.isValid()) {
+    return _COLUMN_COUNT;
+  }
+  return 0;
+}
+
+QVariant PartListModel::data(const QModelIndex& index, int role) const {
+  if (!index.isValid() || !mPartList) {
+    return QVariant();
+  }
+
+  std::shared_ptr<Part> item = mPartList->value(index.row());
+
+  if ((!item) && (mPartList->isEmpty()) && (role == Qt::BackgroundRole)) {
+    return QBrush(Qt::red);
+  }
+
+  switch (index.column()) {
+    case COLUMN_MPN: {
+      switch (role) {
+        case Qt::DisplayRole:
+        case Qt::EditRole:
+          return item ? *item->getMpn() : mNewMpn;
+        case Qt::ToolTipRole:
+          return item
+              ? QVariant()
+              : tr("Exact part number without placeholders (mandatory)");
+        default:
+          return QVariant();
+      }
+    }
+    case COLUMN_MANUFACTURER: {
+      switch (role) {
+        case Qt::DisplayRole:
+        case Qt::EditRole:
+          return item ? *item->getManufacturer() : mNewManufacturer;
+        case Qt::ToolTipRole:
+          return item ? QVariant()
+                      : tr("Name of the manufacturer (recommended)");
+        case Qt::BackgroundRole:
+          return (item && item->getManufacturer()->isEmpty())
+              ? QVariant(QBrush(Qt::yellow))
+              : QVariant();
+        default:
+          return QVariant();
+      }
+    }
+    case COLUMN_ATTRIBUTES: {
+      switch (role) {
+        case Qt::DisplayRole:
+          return item ? item->getAttributeValuesTr().join(", ") : QVariant();
+        case Qt::ToolTipRole:
+          return item ? item->getAttributeKeyValuesTr().join("\n") : QVariant();
+        default:
+          return QVariant();
+      }
+    }
+    default:
+      return QVariant();
+  }
+
+  return QVariant();
+}
+
+QVariant PartListModel::headerData(int section, Qt::Orientation orientation,
+                                   int role) const {
+  if (orientation == Qt::Horizontal) {
+    if (role == Qt::DisplayRole) {
+      switch (section) {
+        case COLUMN_MPN:
+          return tr("MPN");
+        case COLUMN_MANUFACTURER:
+          return tr("Manufacturer");
+        case COLUMN_ATTRIBUTES:
+          return tr("Attributes");
+        default:
+          return QVariant();
+      }
+    }
+  } else if (orientation == Qt::Vertical) {
+    if (mPartList && (role == Qt::DisplayRole)) {
+      std::shared_ptr<Part> item = mPartList->value(section);
+      return item ? QString::number(section + 1) : tr("New:");
+    } else if (mPartList && (role == Qt::ToolTipRole)) {
+      std::shared_ptr<Part> item = mPartList->value(section);
+      return item ? QVariant() : tr("Add a new part");
+    } else if (role == Qt::TextAlignmentRole) {
+      return QVariant(Qt::AlignRight | Qt::AlignVCenter);
+    }
+  }
+  return QVariant();
+}
+
+Qt::ItemFlags PartListModel::flags(const QModelIndex& index) const {
+  Qt::ItemFlags f = QAbstractTableModel::flags(index);
+  if (index.isValid() && (index.column() != COLUMN_ATTRIBUTES) &&
+      (index.column() != COLUMN_ACTIONS)) {
+    f |= Qt::ItemIsEditable;
+  }
+  return f;
+}
+
+bool PartListModel::setData(const QModelIndex& index, const QVariant& value,
+                            int role) {
+  if (!mPartList) {
+    return false;
+  }
+
+  try {
+    std::shared_ptr<Part> item = mPartList->value(index.row());
+    QScopedPointer<CmdPartEdit> cmd;
+    if (item) {
+      cmd.reset(new CmdPartEdit(*item));
+    }
+    if ((index.column() == COLUMN_MPN) && role == Qt::EditRole) {
+      const QString cleaned = cleanElementName(value.toString());
+      if (cmd) {
+        cmd->setMpn(ElementName(cleaned));  // can throw
+      } else {
+        mNewMpn = cleaned;
+      }
+    } else if ((index.column() == COLUMN_MANUFACTURER) &&
+               role == Qt::EditRole) {
+      const SimpleString cleaned = cleanSimpleString(value.toString());
+      if (cmd) {
+        cmd->setManufacturer(cleaned);  // can throw
+      } else {
+        mNewManufacturer = *cleaned;
+      }
+    } else {
+      return false;  // do not execute command!
+    }
+    if (cmd) {
+      execCmd(cmd.take());
+    } else if (!item) {
+      emit dataChanged(index, index);
+    }
+    return true;
+  } catch (const Exception& e) {
+    QMessageBox::critical(0, tr("Error"), e.getMsg());
+  }
+  return false;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void PartListModel::partListEdited(const PartList& list, int index,
+                                   const std::shared_ptr<const Part>& part,
+                                   PartList::Event event) noexcept {
+  Q_UNUSED(list);
+  Q_UNUSED(part);
+  switch (event) {
+    case PartList::Event::ElementAdded:
+      beginInsertRows(QModelIndex(), index, index);
+      endInsertRows();
+      if (list.count() == 1) {
+        // Update color of last row.
+        dataChanged(this->index(list.count() - 1, 0),
+                    this->index(list.count() - 1, _COLUMN_COUNT - 1));
+      }
+      break;
+    case PartList::Event::ElementRemoved:
+      beginRemoveRows(QModelIndex(), index, index);
+      endRemoveRows();
+      if (list.isEmpty()) {
+        // Update color of last row.
+        dataChanged(this->index(list.count() - 1, 0),
+                    this->index(list.count() - 1, _COLUMN_COUNT - 1));
+      }
+      break;
+    case PartList::Event::ElementEdited:
+      dataChanged(this->index(index, 0), this->index(index, _COLUMN_COUNT - 1));
+      break;
+    default:
+      qWarning() << "Unhandled switch-case in "
+                    "PartListModel::partListEdited():"
+                 << static_cast<int>(event);
+      break;
+  }
+}
+
+void PartListModel::execCmd(UndoCommand* cmd) {
+  if (mUndoStack) {
+    mUndoStack->execCmd(cmd);
+  } else {
+    QScopedPointer<UndoCommand> cmdGuard(cmd);
+    cmdGuard->execute();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/library/dev/partlistmodel.h
+++ b/libs/librepcb/editor/library/dev/partlistmodel.h
@@ -1,0 +1,113 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_PARTLISTMODEL_H
+#define LIBREPCB_EDITOR_PARTLISTMODEL_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/library/dev/part.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+class UndoCommand;
+class UndoStack;
+
+/*******************************************************************************
+ *  Class PartListModel
+ ******************************************************************************/
+
+/**
+ * @brief The PartListModel class
+ */
+class PartListModel final : public QAbstractTableModel {
+  Q_OBJECT
+
+public:
+  enum Column {
+    COLUMN_MPN,
+    COLUMN_MANUFACTURER,
+    COLUMN_ATTRIBUTES,
+    COLUMN_ACTIONS,
+    _COLUMN_COUNT
+  };
+
+  // Constructors / Destructor
+  PartListModel() = delete;
+  PartListModel(const PartListModel& other) noexcept;
+  explicit PartListModel(QObject* parent = nullptr) noexcept;
+  ~PartListModel() noexcept;
+
+  // Setters
+  void setInitialManufacturer(const SimpleString& value) noexcept;
+  void setPartList(PartList* list) noexcept;
+  void setUndoStack(UndoStack* stack) noexcept;
+
+  // Slots
+  void add(const QPersistentModelIndex& itemIndex) noexcept;
+  void copy(const QPersistentModelIndex& itemIndex) noexcept;
+  void remove(const QPersistentModelIndex& itemIndex) noexcept;
+  void moveUp(const QPersistentModelIndex& itemIndex) noexcept;
+  void moveDown(const QPersistentModelIndex& itemIndex) noexcept;
+
+  // Inherited from QAbstractItemModel
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+  QVariant data(const QModelIndex& index,
+                int role = Qt::DisplayRole) const override;
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role = Qt::DisplayRole) const override;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
+  bool setData(const QModelIndex& index, const QVariant& value,
+               int role = Qt::EditRole) override;
+
+  // Operator Overloadings
+  PartListModel& operator=(const PartListModel& rhs) noexcept;
+
+private:
+  void partListEdited(const PartList& list, int index,
+                      const std::shared_ptr<const Part>& part,
+                      PartList::Event event) noexcept;
+  void execCmd(UndoCommand* cmd);
+
+private:  // Data
+  PartList* mPartList;
+  UndoStack* mUndoStack;
+  QString mNewMpn;
+  QString mNewManufacturer;
+
+  // Slots
+  PartList::OnEditedSlot mOnEditedSlot;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/library/editorwidgetbase.h
+++ b/libs/librepcb/editor/library/editorwidgetbase.h
@@ -38,8 +38,8 @@
 namespace librepcb {
 
 class Angle;
+class Library;
 class LibraryBaseElement;
-class Point;
 class Point;
 class Workspace;
 
@@ -69,6 +69,7 @@ public:
     const IF_GraphicsLayerProvider& layerProvider;
     bool elementIsNewlyCreated;
     bool readOnly;
+    const Library* library;
   };
 
   enum Tool {

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
@@ -71,6 +71,7 @@ LibraryOverviewWidget::LibraryOverviewWidget(const Context& context,
   mUi->edtVersion->setReadOnly(mContext.readOnly);
   mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
   mUi->edtUrl->setReadOnly(mContext.readOnly);
+  mUi->edtManufacturer->setReadOnly(mContext.readOnly);
   connect(mUi->btnIcon, &QPushButton::clicked, this,
           &LibraryOverviewWidget::btnIconClicked);
   connect(mUi->lstCmpCat, &QListWidget::doubleClicked, this,
@@ -119,6 +120,8 @@ LibraryOverviewWidget::LibraryOverviewWidget(const Context& context,
   connect(mUi->cbxDeprecated, &QCheckBox::clicked, this,
           &LibraryOverviewWidget::commitMetadata);
   connect(mUi->edtUrl, &QLineEdit::editingFinished, this,
+          &LibraryOverviewWidget::commitMetadata);
+  connect(mUi->edtManufacturer, &QLineEdit::editingFinished, this,
           &LibraryOverviewWidget::commitMetadata);
   connect(mDependenciesEditorWidget.data(), &LibraryListEditorWidget::edited,
           this, &LibraryOverviewWidget::commitMetadata);
@@ -299,6 +302,7 @@ void LibraryOverviewWidget::updateMetadata() noexcept {
   mUi->edtVersion->setText(mLibrary->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mLibrary->isDeprecated());
   mUi->edtUrl->setText(mLibrary->getUrl().toString());
+  mUi->edtManufacturer->setText(*mLibrary->getManufacturer());
   mUi->lstMessages->setApprovals(mLibrary->getMessageApprovals());
   mDependenciesEditorWidget->setUuids(mLibrary->getDependencies());
   mIcon = mLibrary->getIcon();
@@ -322,6 +326,7 @@ QString LibraryOverviewWidget::commitMetadata() noexcept {
     cmd->setAuthor(mUi->edtAuthor->text().trimmed());
     cmd->setDeprecated(mUi->cbxDeprecated->isChecked());
     cmd->setUrl(QUrl::fromUserInput(mUi->edtUrl->text().trimmed()));
+    cmd->setManufacturer(cleanSimpleString(mUi->edtManufacturer->text()));
     cmd->setDependencies(mDependenciesEditorWidget->getUuids());
     cmd->setIcon(mIcon);
 

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.ui
@@ -463,14 +463,14 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0" colspan="2">
+       <item row="12" column="0" colspan="2">
         <widget class="Line" name="line_3">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Messages:</string>
@@ -480,13 +480,30 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="librepcb::editor::RuleCheckListWidget" name="lstMessages" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>1</verstretch>
           </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>Manufacturer:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QLineEdit" name="edtManufacturer">
+         <property name="toolTip">
+          <string>Manufacturer name, in case the library refers to a single manufacturer.</string>
+         </property>
+         <property name="maxLength">
+          <number>255</number>
          </property>
         </widget>
        </item>

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -928,10 +928,7 @@ void LibraryEditor::createMenus() noexcept {
 EditorWidgetBase::Context LibraryEditor::createContext(
     bool isNewElement) noexcept {
   return {
-      mWorkspace,
-      *this,
-      isNewElement,
-      mIsOpenedReadOnly,
+      mWorkspace, *this, isNewElement, mIsOpenedReadOnly, mLibrary,
   };
 }
 

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -106,6 +106,8 @@ void NewElementWizardContext::reset(ElementType newType) noexcept {
   // device
   mDeviceComponentUuid = tl::nullopt;
   mDevicePackageUuid = tl::nullopt;
+  mDevicePadSignalMap.clear();
+  mDeviceAttributes.clear();
 }
 
 void NewElementWizardContext::copyElement(ElementType type,
@@ -350,6 +352,7 @@ void NewElementWizardContext::copyElement(ElementType type,
       mDeviceComponentUuid = device->getComponentUuid();
       mDevicePackageUuid = device->getPackageUuid();
       mDevicePadSignalMap = device->getPadSignalMap();
+      mDeviceAttributes = device->getAttributes();
       break;
     }
 
@@ -459,6 +462,7 @@ void NewElementWizardContext::createLibraryElement() {
                      *mDeviceComponentUuid, *mDevicePackageUuid);
       element.setCategories(mElementCategoryUuids);
       element.getPadSignalMap() = mDevicePadSignalMap;
+      element.getAttributes() = mDeviceAttributes;
       TransactionalDirectory dir(mLibrary.getDirectory(),
                                  mLibrary.getElementsDirectoryName<Device>());
       element.moveIntoParentDirectory(dir);

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -108,6 +108,7 @@ void NewElementWizardContext::reset(ElementType newType) noexcept {
   mDevicePackageUuid = tl::nullopt;
   mDevicePadSignalMap.clear();
   mDeviceAttributes.clear();
+  mDeviceParts.clear();
 }
 
 void NewElementWizardContext::copyElement(ElementType type,
@@ -353,6 +354,7 @@ void NewElementWizardContext::copyElement(ElementType type,
       mDevicePackageUuid = device->getPackageUuid();
       mDevicePadSignalMap = device->getPadSignalMap();
       mDeviceAttributes = device->getAttributes();
+      mDeviceParts = device->getParts();
       break;
     }
 
@@ -463,6 +465,7 @@ void NewElementWizardContext::createLibraryElement() {
       element.setCategories(mElementCategoryUuids);
       element.getPadSignalMap() = mDevicePadSignalMap;
       element.getAttributes() = mDeviceAttributes;
+      element.getParts() = mDeviceParts;
       TransactionalDirectory dir(mLibrary.getDirectory(),
                                  mLibrary.getElementsDirectoryName<Device>());
       element.moveIntoParentDirectory(dir);

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.h
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.h
@@ -27,6 +27,7 @@
 #include <librepcb/core/fileio/filepath.h>
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/library/dev/device.h>
+#include <librepcb/core/library/dev/part.h>
 #include <librepcb/core/library/pkg/package.h>
 #include <librepcb/core/library/sym/symbol.h>
 #include <librepcb/core/types/uuid.h>
@@ -152,6 +153,7 @@ public:  // Data
   tl::optional<Uuid> mDevicePackageUuid;
   DevicePadSignalMap mDevicePadSignalMap;
   AttributeList mDeviceAttributes;
+  PartList mDeviceParts;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.h
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.h
@@ -151,6 +151,7 @@ public:  // Data
   tl::optional<Uuid> mDeviceComponentUuid;
   tl::optional<Uuid> mDevicePackageUuid;
   DevicePadSignalMap mDevicePadSignalMap;
+  AttributeList mDeviceAttributes;
 };
 
 /*******************************************************************************

--- a/tests/cli/open_library/test_check.py
+++ b/tests/cli/open_library/test_check.py
@@ -36,10 +36,24 @@ def test_messages(cli):
     code, stdout, stderr = cli.run('open-library', '--all', '--check',
                                    library.dir)
     assert stderr == \
+        "  - R-0805 (078650d3-483c-4b9e-a848-b14f1aad2edc):\n" \
+        "    - [HINT] No part numbers added\n" \
+        "  - R-0603 (483a71eb-318e-448e-82ff-f02efc4821aa):\n" \
+        "    - [HINT] No part numbers added\n" \
+        "  - Demo Device (4f5ee784-4b1b-407c-802b-44625163d90f):\n" \
+        "    - [HINT] No part numbers added\n" \
         "  - PSMN022-30PL (5738d8f9-4101-4409-bd46-d9c173b40d60):\n" \
         "    - [ERROR] No categories set\n" \
+        "    - [HINT] No part numbers added\n" \
+        "  - R-1206 (a6a6744d-7d3b-450a-b782-feca43939ca5):\n" \
+        "    - [HINT] No part numbers added\n" \
+        "  - C-0805 (c139e505-592b-46ba-bdf2-acb7383ea0cd):\n" \
+        "    - [HINT] No part numbers added\n" \
         "  - PSMN5R8 (f7fb22e8-0bbc-4f0f-aa89-596823b5bc3e):\n" \
-        "    - [ERROR] No categories set\n"
+        "    - [ERROR] No categories set\n" \
+        "    - [HINT] No part numbers added\n" \
+        "  - Crystal ABM3 (f83a5ae8-7f42-42be-9dd6-e762f4da2ec2):\n" \
+        "    - [HINT] No part numbers added\n"
     assert stdout == \
         "Open library 'Populated Library.lplib'...\n" \
         "Process {library.cmpcat} component categories...\n" \

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(
   core/types/pointtest.cpp
   core/types/ratiotest.cpp
   core/types/signalroletest.cpp
+  core/types/simplestringtest.cpp
   core/types/uuidtest.cpp
   core/types/versiontest.cpp
   core/utils/clipperhelperstest.cpp

--- a/tests/unittests/core/types/simplestringtest.cpp
+++ b/tests/unittests/core/types/simplestringtest.cpp
@@ -1,0 +1,119 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/serialization/sexpression.h>
+#include <librepcb/core/types/simplestring.h>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  QString input;
+  QString cleaned;
+  bool valid;
+} SimpleStringTestData;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class SimpleStringTest : public ::testing::TestWithParam<SimpleStringTestData> {
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_P(SimpleStringTest, testConstructor) {
+  const SimpleStringTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, *SimpleString(data.input));
+  } else {
+    EXPECT_THROW(SimpleString(data.input), RuntimeError);
+  }
+}
+
+TEST_P(SimpleStringTest, testClean) {
+  const SimpleStringTestData& data = GetParam();
+
+  EXPECT_EQ(data.cleaned, cleanSimpleString(data.input));
+}
+
+TEST_P(SimpleStringTest, testSerialize) {
+  const SimpleStringTestData& data = GetParam();
+
+  if (data.valid) {
+    SimpleString obj(data.input);
+    EXPECT_EQ("\"" % data.input % "\"\n", serialize(obj).toByteArray());
+  }
+}
+
+TEST_P(SimpleStringTest, testDeserialize) {
+  const SimpleStringTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(SimpleString(data.input),
+              deserialize<SimpleString>(SExpression::createString(data.input)));
+  } else {
+    EXPECT_THROW(
+        deserialize<SimpleString>(SExpression::createString(data.input)),
+        RuntimeError);
+  }
+}
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(SimpleStringTest, SimpleStringTest, ::testing::Values(
+    // Valid strings.
+    SimpleStringTestData({"", "", true}),
+    SimpleStringTestData({"1", "1", true}),
+    SimpleStringTestData({"foo:_-+*ç%&/()=", "foo:_-+*ç%&/()=", true}),
+    SimpleStringTestData({"_", "_", true}),
+    SimpleStringTestData({"_A B  C", "_A B C", true}),
+
+    // Invalid strings.
+    SimpleStringTestData({" ABC", "ABC", false}), // leading space
+    SimpleStringTestData({"ABC ", "ABC", false}), // trailing space
+    SimpleStringTestData({"AB\n\nCD", "AB CD", false}), // invalid character
+    SimpleStringTestData({"AB\r\rCD", "AB CD", false}), // invalid character
+    SimpleStringTestData({"AB\t\tCD", "AB CD", false}) // invalid character
+));
+// clang-format on
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
+++ b/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
@@ -160,7 +160,7 @@ TEST_F(WorkspaceLibraryDbTest, testGetAll) {
   for (int i = 0; i < 2; ++i) {
     QString number = QString::number(i + 1);
     mWriter->addLibrary(toAbs("lib" % number), uuid(), version("0.1." % number),
-                        false, QByteArray());
+                        false, QByteArray(), QString());
     mWriter->addCategory<ComponentCategory>(0, toAbs("cmpcat" % number), uuid(),
                                             version("0.2." % number), false,
                                             tl::nullopt);
@@ -206,9 +206,9 @@ TEST_F(WorkspaceLibraryDbTest, testGetAll) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetAllWithDuplicates) {
   int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
                               false);
   mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
@@ -227,9 +227,9 @@ TEST_F(WorkspaceLibraryDbTest, testGetAllWithDuplicates) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetAllWithUuid) {
   int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
                               false);
   mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
@@ -246,9 +246,9 @@ TEST_F(WorkspaceLibraryDbTest, testGetAllWithUuid) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetAllWithLibrary) {
   int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
                               false);
   mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
@@ -265,9 +265,9 @@ TEST_F(WorkspaceLibraryDbTest, testGetAllWithLibrary) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetAllWithUuidAndLibrary) {
   int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(1), version("0.1"),
                               false);
   mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(2), version("0.2"),
@@ -294,9 +294,9 @@ TEST_F(WorkspaceLibraryDbTest, testGetLatestEmptyDb) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetLatest) {
   int lib1 = mWriter->addLibrary(toAbs("lib1"), uuid(), version("1"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   int lib2 = mWriter->addLibrary(toAbs("lib2"), uuid(), version("2"), false,
-                                 QByteArray());
+                                 QByteArray(), QString());
   mWriter->addElement<Symbol>(lib1, toAbs("sym1"), uuid(0), version("0.1"),
                               false);
   mWriter->addElement<Symbol>(lib1, toAbs("sym2"), uuid(0), version("0.2"),
@@ -322,7 +322,7 @@ TEST_F(WorkspaceLibraryDbTest, testFindEmptyDb) {
 
 TEST_F(WorkspaceLibraryDbTest, testFindEmptyKeyword) {
   int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
-                                QByteArray());
+                                QByteArray(), QString());
   int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(),
                                         version("0.1"), false);
   mWriter->addTranslation<Symbol>(sym, "", ElementName("some name"),
@@ -333,7 +333,7 @@ TEST_F(WorkspaceLibraryDbTest, testFindEmptyKeyword) {
 
 TEST_F(WorkspaceLibraryDbTest, testFind) {
   int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
-                                QByteArray());
+                                QByteArray(), QString());
   int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(1),
                                         version("0.1"), false);
   mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym1 name"),
@@ -359,7 +359,7 @@ TEST_F(WorkspaceLibraryDbTest, testFind) {
 
 TEST_F(WorkspaceLibraryDbTest, testFindWithDuplicates) {
   int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
-                                QByteArray());
+                                QByteArray(), QString());
   int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(1),
                                         version("0.1"), false);
   mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym1 name"),
@@ -380,7 +380,7 @@ TEST_F(WorkspaceLibraryDbTest, testFindWithDuplicates) {
 
 TEST_F(WorkspaceLibraryDbTest, testFindWithMultipleTranslations) {
   int lib = mWriter->addLibrary(toAbs("lib"), uuid(), version("1"), false,
-                                QByteArray());
+                                QByteArray(), QString());
   int sym = mWriter->addElement<Symbol>(lib, toAbs("sym1"), uuid(1),
                                         version("0.1"), false);
   mWriter->addTranslation<Symbol>(sym, "", ElementName("the sym1 name"),
@@ -434,7 +434,7 @@ TEST_F(WorkspaceLibraryDbTest, testGetTranslationsInexistent) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetTranslationsEmpty) {
   int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("0.1"), false,
-                                  QByteArray());
+                                  QByteArray(), QString());
   mWriter->addCategory<ComponentCategory>(libId, toAbs("fp"), uuid(),
                                           version("0.1"), false, tl::nullopt);
   mWriter->addCategory<PackageCategory>(libId, toAbs("fp"), uuid(),
@@ -459,7 +459,7 @@ TEST_F(WorkspaceLibraryDbTest, testGetTranslationsEmpty) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetTranslationsDefaultLocale) {
   int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("0.1"), false,
-                                  QByteArray());
+                                  QByteArray(), QString());
   mWriter->addTranslation<Library>(libId, "", ElementName("lib_n"), "lib_d",
                                    "lib_k");
   int id = mWriter->addCategory<ComponentCategory>(
@@ -607,8 +607,8 @@ TEST_F(WorkspaceLibraryDbTest, testGetMetadataInexistent) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetMetadata) {
   FilePath fp = toAbs("fp");
-  int libId =
-      mWriter->addLibrary(fp, uuid(1), version("1.1"), false, QByteArray());
+  int libId = mWriter->addLibrary(fp, uuid(1), version("1.1"), false,
+                                  QByteArray(), QString());
   mWriter->addCategory<ComponentCategory>(libId, fp, uuid(2), version("2.2"),
                                           true, tl::nullopt);
   mWriter->addCategory<PackageCategory>(libId, fp, uuid(3), version("3.3"),
@@ -655,24 +655,34 @@ TEST_F(WorkspaceLibraryDbTest, testGetMetadataNullptr) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetLibraryMetadataInexistent) {
   QPixmap icon;
-  EXPECT_FALSE(mWsDb->getLibraryMetadata(toAbs("fp"), &icon));
+  QString manufacturer;
+  EXPECT_FALSE(mWsDb->getLibraryMetadata(toAbs("fp"), &icon, &manufacturer));
   EXPECT_TRUE(icon.isNull());
+  EXPECT_EQ("", manufacturer.toStdString());
 }
 
 TEST_F(WorkspaceLibraryDbTest, testGetLibraryMetadataNoIcon) {
   FilePath fp = toAbs("fp");
-  mWriter->addLibrary(fp, uuid(), version("1.1"), false, QByteArray());
+  mWriter->addLibrary(fp, uuid(), version("1.1"), false, QByteArray(),
+                      "Hello World!");
 
   QPixmap icon;
-  EXPECT_TRUE(mWsDb->getLibraryMetadata(fp, &icon));
+  QString manufacturer = "foo";
+  EXPECT_TRUE(mWsDb->getLibraryMetadata(fp, &icon, &manufacturer));
   EXPECT_TRUE(icon.isNull());
+  EXPECT_EQ("Hello World!", manufacturer.toStdString());
 }
 
 TEST_F(WorkspaceLibraryDbTest, testGetLibraryMetadataNullptr) {
   FilePath fp = toAbs("fp");
-  mWriter->addLibrary(fp, uuid(), version("1.1"), false, QByteArray());
+  mWriter->addLibrary(fp, uuid(), version("1.1"), false, QByteArray(),
+                      QString());
 
+  QPixmap icon;
+  QString manufacturer;
   EXPECT_TRUE(mWsDb->getLibraryMetadata(fp));
+  EXPECT_TRUE(mWsDb->getLibraryMetadata(fp, &icon));
+  EXPECT_TRUE(mWsDb->getLibraryMetadata(fp, nullptr, &manufacturer));
 }
 
 /*******************************************************************************
@@ -689,7 +699,7 @@ TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadataEmptyDb) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadataInexistent) {
   int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("1.1"), false,
-                                  QByteArray());
+                                  QByteArray(), QString());
   mWriter->addCategory<ComponentCategory>(libId, toAbs("fp"), uuid(),
                                           version("2.2"), false, tl::nullopt);
   mWriter->addCategory<PackageCategory>(libId, toAbs("fp"), uuid(),
@@ -704,7 +714,7 @@ TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadataInexistent) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadata) {
   int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("1.1"), false,
-                                  QByteArray());
+                                  QByteArray(), QString());
   mWriter->addCategory<ComponentCategory>(libId, toAbs("fp1"), uuid(1),
                                           version("2.2"), false, tl::nullopt);
   mWriter->addCategory<ComponentCategory>(libId, toAbs("fp2"), uuid(2),
@@ -735,7 +745,7 @@ TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadata) {
 
 TEST_F(WorkspaceLibraryDbTest, testGetCategoryMetadataNullptr) {
   int libId = mWriter->addLibrary(toAbs("fp"), uuid(), version("1.1"), false,
-                                  QByteArray());
+                                  QByteArray(), QString());
   mWriter->addCategory<ComponentCategory>(libId, toAbs("fp1"), uuid(1),
                                           version("2.2"), false, tl::nullopt);
   mWriter->addCategory<ComponentCategory>(libId, toAbs("fp2"), uuid(2),


### PR DESCRIPTION
## Summary

This is the first step to implement support for manufacturer part numbers (MPNs). In the end, MPNs are needed to make BOMs much more accurate (and thus more useful) than they are today. This PR extends the library structure with the following features:

- Support adding arbitrary attributes to devices (identical to how it is already possible for components).
- Support adding new objects called *parts* to devices. Parts represent the orderable variants of a device and are uniquely identified by an MPN (the part number) and optionally the name of the manufacturer. In addition, parts can contain arbitrary attributes as well, for example to specify the resistance of a resistor. This way it is possible to represent a whole resistor family with a single device - each resistance (with its MPN) is added as a separate part within the device.
- Add a new (optional) property *manufacturer* to libraries. This property is not critical at all, it is only used for convenience to initialize the *manufacturer* property of new parts with this value. For example within the library "Texas Instruments", you never need to specify the manufacturer for parts since it is automatically taken from the library.

Example structure of a device with parts:

- Device "R-0603":
  - Part "RC1608F102CS" from manufacturer "Samsung":
    - Attribute "RESISTANCE=1kΩ"
  - Part "RC1608F103CS" from manufacturer "Samsung":
    - Attribute "RESISTANCE=10kΩ"
  - Part "RC1608F104CS" from manufacturer "Samsung":
    - Attribute "RESISTANCE=100kΩ"

Note that the usage of parts in projects (for the BOM) will be implemented in a separate PR. This PR is only about the extension of the library structure.

## User Interface

The device editor UI has been rearranged a bit to get some space for the new attributes and part editors. The part editor is now at the bottom left, and the attribute editor at the bottom right. Due to limited space, the attribute editor is context dependent - if a part is selected, the part attributes are shown; if no part is selected, the (common) device attributes are shown. It's not very intuitive unfortunately, but to get v1.0.0 finished sooner I'd improve that in a later minor release.

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/202a1b99-b114-4add-a2cd-ee17f8d268de)

## File Format

Representation of the parts from the screenshot above:

```scheme
 (part "BAT54" (manufacturer "ON Semiconductor")
  (attribute "PACKING" (type string) (unit none) (value "3k T&R"))
 )
 (part "BAT54_D87Z" (manufacturer "ON Semiconductor")
  (attribute "PACKING" (type string) (unit none) (value "10k T&R"))
 )
```

## Concept Decisions

Unfortunately there are many different workflows and requirements imaginable regarding MPN management. So it is not easy at all to find a good concept how to implement this feature. For the record, here are some of my thoughts why I ended up with this concept.

#### Alternative 1: Parts as Separate Library Elements

First of all, a different way of implementation would be to make parts completely standalone library elements which reference a device by its UUID (like devices are standalone library elements referencing components & packages). This would have the advantage to easily extend devices from official libraries (which are installed read-only) because you could extend them with parts stored in your own local libraries. However, it would also have several disadvantages:

- Even more complex overall library structure
- More dependencies generally lead to more issues (e.g. deleting a device would break all parts referencing it)
- Much more overhead (number of files & file size) leading to much higher disk usage, longer library download times and longer library scanning time

#### Alternative 2: All Parts in a Single File

The overhead could be reduced by storing all parts of a library within a single file, but this would be quite inconsistent to the overall library concept and also isn't very practical for version control.

#### Alternative 3: Each Device is a Part

Another way would be to simply consider the device name as an MPN - basically this means we don't even need to change the library structure so this concept would not introduce any additional complexity at all. However, it means that a separate device needs to be created for every single MPN. Although this would be fine for most devices, devices like resistors would extremely bloat the library since there exist thousands of resistor MPNs.

#### Summary

So in the end I decided to store parts within their devices, as a compromise between flexibility, complexity and efficiency. But I'd appreciate any opinion/thoughts about this decision :slightly_smiling_face: 

#### SKU Handling

Another big question is whether we also need to store SKUs (stock keeping units), i.e. the corresponding order numbers of suppliers. For now I decided to *not* store this information at all because this would be an additional huge amount of data, which is even harder to maintain than MPNs. Maybe it makes more sense to allow the schematic editor to query this information from services like Octopart (with the drawback that this only works with Internet connection). As an alternative, users might also use attributes of parts to add this information to the library anyway (e.g. "SUPPLIER=DigiKey; SKU=1276-3484-1-ND"), although this wouldn't be possible for official LibrePCB libraries.

So for now I'd completely ignore SKUs (at least for the next major release of LibrePCB), but of course we could re-think about this topic at any time. And any ideas are welcome of course.

## Related Issues

- Closes #782
- Closes #653
- Required for #965