### PR TITLE
Automatically migrate obsolete inversion sign '/' to '!'

### DIFF
--- a/libs/librepcb/core/library/cmp/componentcheck.cpp
+++ b/libs/librepcb/core/library/cmp/componentcheck.cpp
@@ -52,6 +52,7 @@ RuleCheckMessageList ComponentCheck::runChecks() const {
   checkMissingPrefix(msgs);
   checkMissingDefaultValue(msgs);
   checkDuplicateSignalNames(msgs);
+  checkSignalNamesInversionSign(msgs);
   checkMissingSymbolVariants(msgs);
   checkMissingSymbolVariantItems(msgs);
   return msgs;
@@ -80,6 +81,19 @@ void ComponentCheck::checkDuplicateSignalNames(MsgList& msgs) const {
       msgs.append(std::make_shared<MsgDuplicateSignalName>(signal));
     } else {
       names.insert(signal.getName());
+    }
+  }
+}
+
+void ComponentCheck::checkSignalNamesInversionSign(MsgList& msgs) const {
+  for (auto it = mComponent.getSignals().begin();
+       it != mComponent.getSignals().end(); ++it) {
+    const QString name = *it->getName();
+    if (name.startsWith("/") ||
+        ((name.count() >= 2) && name.startsWith("n") && name.at(1).isUpper())) {
+      msgs.append(
+          std::make_shared<MsgNonFunctionalComponentSignalInversionSign>(
+              it.ptr()));
     }
   }
 }

--- a/libs/librepcb/core/library/cmp/componentcheck.h
+++ b/libs/librepcb/core/library/cmp/componentcheck.h
@@ -59,6 +59,7 @@ protected:  // Methods
   void checkMissingPrefix(MsgList& msgs) const;
   void checkMissingDefaultValue(MsgList& msgs) const;
   void checkDuplicateSignalNames(MsgList& msgs) const;
+  void checkSignalNamesInversionSign(MsgList& msgs) const;
   void checkMissingSymbolVariants(MsgList& msgs) const;
   void checkMissingSymbolVariantItems(MsgList& msgs) const;
 

--- a/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
+++ b/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
@@ -115,6 +115,28 @@ MsgMissingSymbolVariantItem::MsgMissingSymbolVariantItem(
 }
 
 /*******************************************************************************
+ *  MsgNonFunctionalComponentSignalInversionSign
+ ******************************************************************************/
+
+MsgNonFunctionalComponentSignalInversionSign::
+    MsgNonFunctionalComponentSignalInversionSign(
+        std::shared_ptr<const ComponentSignal> signal) noexcept
+  : RuleCheckMessage(
+        Severity::Hint,
+        tr("Non-functional inversion sign: '%1'").arg(*signal->getName()),
+        tr("The signal name seems to start with an inversion sign, but "
+           "LibrePCB uses a different sign to indicate inversion.\n\nIt's "
+           "recommended to prefix inverted signal names with '%1', regardless "
+           "of the inversion sign used in the parts datasheet.")
+            .arg("!"),
+        "nonfunctional_inversion_sign"),
+    mSignal(signal) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("signal", signal->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/cmp/componentcheckmessages.h
+++ b/libs/librepcb/core/library/cmp/componentcheckmessages.h
@@ -138,6 +138,36 @@ private:
 };
 
 /*******************************************************************************
+ *  Class MsgNonFunctionalComponentSignalInversionSign
+ ******************************************************************************/
+
+/**
+ * @brief The MsgNonFunctionalComponentSignalInversionSign class
+ */
+class MsgNonFunctionalComponentSignalInversionSign final
+  : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgNonFunctionalComponentSignalInversionSign)
+
+public:
+  // Constructors / Destructor
+  MsgNonFunctionalComponentSignalInversionSign() = delete;
+  explicit MsgNonFunctionalComponentSignalInversionSign(
+      std::shared_ptr<const ComponentSignal> signal) noexcept;
+  MsgNonFunctionalComponentSignalInversionSign(
+      const MsgNonFunctionalComponentSignalInversionSign& other) noexcept
+    : RuleCheckMessage(other), mSignal(other.mSignal) {}
+  virtual ~MsgNonFunctionalComponentSignalInversionSign() noexcept {}
+
+  // Getters
+  const std::shared_ptr<const ComponentSignal>& getSignal() const noexcept {
+    return mSignal;
+  }
+
+private:
+  std::shared_ptr<const ComponentSignal> mSignal;
+};
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/sym/symbolcheck.cpp
+++ b/libs/librepcb/core/library/sym/symbolcheck.cpp
@@ -50,6 +50,7 @@ SymbolCheck::~SymbolCheck() noexcept {
 RuleCheckMessageList SymbolCheck::runChecks() const {
   RuleCheckMessageList msgs = LibraryElementCheck::runChecks();
   checkDuplicatePinNames(msgs);
+  checkPinNamesInversionSign(msgs);
   checkOffTheGridPins(msgs);
   checkOverlappingPins(msgs);
   checkMissingTexts(msgs);
@@ -68,6 +69,18 @@ void SymbolCheck::checkDuplicatePinNames(MsgList& msgs) const {
       msgs.append(std::make_shared<MsgDuplicatePinName>(pin));
     } else {
       pinNames.insert(pin.getName());
+    }
+  }
+}
+
+void SymbolCheck::checkPinNamesInversionSign(MsgList& msgs) const {
+  for (auto it = mSymbol.getPins().begin(); it != mSymbol.getPins().end();
+       ++it) {
+    const QString name = *it->getName();
+    if (name.startsWith("/") ||
+        ((name.count() >= 2) && name.startsWith("n") && name.at(1).isUpper())) {
+      msgs.append(
+          std::make_shared<MsgNonFunctionalSymbolPinInversionSign>(it.ptr()));
     }
   }
 }

--- a/libs/librepcb/core/library/sym/symbolcheck.h
+++ b/libs/librepcb/core/library/sym/symbolcheck.h
@@ -57,6 +57,7 @@ public:
 
 protected:  // Methods
   void checkDuplicatePinNames(MsgList& msgs) const;
+  void checkPinNamesInversionSign(MsgList& msgs) const;
   void checkOffTheGridPins(MsgList& msgs) const;
   void checkOverlappingPins(MsgList& msgs) const;
   void checkMissingTexts(MsgList& msgs) const;

--- a/libs/librepcb/core/library/sym/symbolcheckmessages.cpp
+++ b/libs/librepcb/core/library/sym/symbolcheckmessages.cpp
@@ -77,6 +77,27 @@ MsgMissingSymbolValue::MsgMissingSymbolValue() noexcept
 }
 
 /*******************************************************************************
+ *  MsgNonFunctionalSymbolPinInversionSign
+ ******************************************************************************/
+
+MsgNonFunctionalSymbolPinInversionSign::MsgNonFunctionalSymbolPinInversionSign(
+    std::shared_ptr<const SymbolPin> pin) noexcept
+  : RuleCheckMessage(
+        Severity::Hint,
+        tr("Non-functional inversion sign: '%1'").arg(*pin->getName()),
+        tr("The pin name seems to start with an inversion sign, but LibrePCB "
+           "uses a different sign to indicate inversion.\n\nIt's recommended "
+           "to prefix inverted pin names with '%1', regardless of the "
+           "inversion sign used in the parts datasheet.")
+            .arg("!"),
+        "nonfunctional_inversion_sign"),
+    mPin(pin) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pin", pin->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+/*******************************************************************************
  *  MsgOverlappingSymbolPins
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/sym/symbolcheckmessages.h
+++ b/libs/librepcb/core/library/sym/symbolcheckmessages.h
@@ -93,6 +93,35 @@ public:
 };
 
 /*******************************************************************************
+ *  Class MsgNonFunctionalSymbolPinInversionSign
+ ******************************************************************************/
+
+/**
+ * @brief The MsgNonFunctionalSymbolPinInversionSign class
+ */
+class MsgNonFunctionalSymbolPinInversionSign final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgNonFunctionalSymbolPinInversionSign)
+
+public:
+  // Constructors / Destructor
+  MsgNonFunctionalSymbolPinInversionSign() = delete;
+  explicit MsgNonFunctionalSymbolPinInversionSign(
+      std::shared_ptr<const SymbolPin> pin) noexcept;
+  MsgNonFunctionalSymbolPinInversionSign(
+      const MsgNonFunctionalSymbolPinInversionSign& other) noexcept
+    : RuleCheckMessage(other), mPin(other.mPin) {}
+  virtual ~MsgNonFunctionalSymbolPinInversionSign() noexcept {}
+
+  // Getters
+  const std::shared_ptr<const SymbolPin>& getPin() const noexcept {
+    return mPin;
+  }
+
+private:
+  std::shared_ptr<const SymbolPin> mPin;
+};
+
+/*******************************************************************************
  *  Class MsgOverlappingSymbolPins
  ******************************************************************************/
 

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -61,22 +61,23 @@ void FileFormatMigrationUnstable::upgradePackageCategory(
 
 void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+  const QString fp = "symbol.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  upgradeInversionCharacters(root, "pin", "name/@0");
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-  const QString fp = "package.lp";
-  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
-  upgradeLayers(root);
-  for (SExpression* fptNode : root.getChildren("footprint")) {
-    upgradeCutouts(*fptNode, nullptr);
-  }
-  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(
     TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+  const QString fp = "component.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  upgradeInversionCharacters(root, "signal", "name/@0");
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeDevice(TransactionalDirectory& dir) {
@@ -90,16 +91,6 @@ void FileFormatMigrationUnstable::upgradeLibrary(TransactionalDirectory& dir) {
 void FileFormatMigrationUnstable::upgradeWorkspaceData(
     TransactionalDirectory& dir) {
   Q_UNUSED(dir);
-  const QString settingsFp = "settings.lp";
-  if (dir.fileExists(settingsFp)) {
-    SExpression root =
-        SExpression::parse(dir.read(settingsFp), dir.getAbsPath(settingsFp));
-    root.replaceRecursive(SExpression::createToken("board_placement_top"),
-                          SExpression::createToken("board_legend_top"));
-    root.replaceRecursive(SExpression::createToken("board_placement_bottom"),
-                          SExpression::createToken("board_legend_bottom"));
-    dir.write(settingsFp, root.toByteArray());
-  }
 }
 
 /*******************************************************************************
@@ -130,13 +121,10 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root,
                                                ProjectContext& context) {
   Q_UNUSED(root);
   Q_UNUSED(context);
-  upgradeLayers(root);
-  upgradeCutouts(root, &context);
 }
 
 void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {
   Q_UNUSED(root);
-  upgradeLayers(root);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.h
@@ -132,6 +132,9 @@ protected:  // Methods
   virtual void upgradeCutouts(SExpression& node, ProjectContext* context);
   virtual void upgradeHoles(SExpression& node, bool isBoardHole);
   virtual void upgradeLayers(SExpression& node);
+  virtual void upgradeInversionCharacters(SExpression& root,
+                                          const QString& childName,
+                                          const QString& valuePath);
   virtual void upgradeStrings(SExpression& root);
   virtual void replaceStrings(SExpression& root,
                               const QMap<QString, QString>& replacements);

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
@@ -24,6 +24,7 @@
 
 #include "../../widgets/signalrolecombobox.h"
 #include "../cmd/cmdcomponentedit.h"
+#include "../cmd/cmdcomponentsignaledit.h"
 #include "../cmd/cmdcomponentsymbolvariantedit.h"
 #include "componentsymbolvarianteditdialog.h"
 #include "ui_componenteditorwidget.h"
@@ -331,6 +332,17 @@ void ComponentEditorWidget::fixMsg(const MsgMissingSymbolVariant& msg) {
       mComponent->getSymbolVariants(), symbVar));
 }
 
+template <>
+void ComponentEditorWidget::fixMsg(
+    const MsgNonFunctionalComponentSignalInversionSign& msg) {
+  std::shared_ptr<ComponentSignal> signal =
+      mComponent->getSignals().get(msg.getSignal().get());
+  QScopedPointer<CmdComponentSignalEdit> cmd(
+      new CmdComponentSignalEdit(*signal));
+  cmd->setName(CircuitIdentifier("!" % signal->getName()->mid(1)));
+  mUndoStack->execCmd(cmd.take());
+}
+
 template <typename MessageType>
 bool ComponentEditorWidget::fixMsgHelper(
     std::shared_ptr<const RuleCheckMessage> msg, bool applyFix) {
@@ -350,6 +362,8 @@ bool ComponentEditorWidget::processRuleCheckMessage(
   if (fixMsgHelper<MsgMissingCategories>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingComponentDefaultValue>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingSymbolVariant>(msg, applyFix)) return true;
+  if (fixMsgHelper<MsgNonFunctionalComponentSignalInversionSign>(msg, applyFix))
+    return true;
   return false;
 }
 

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
@@ -556,6 +556,15 @@ void SymbolEditorWidget::fixMsg(const MsgSymbolPinNotOnGrid& msg) {
   mUndoStack->execCmd(cmd.take());
 }
 
+template <>
+void SymbolEditorWidget::fixMsg(
+    const MsgNonFunctionalSymbolPinInversionSign& msg) {
+  std::shared_ptr<SymbolPin> pin = mSymbol->getPins().get(msg.getPin().get());
+  QScopedPointer<CmdSymbolPinEdit> cmd(new CmdSymbolPinEdit(pin));
+  cmd->setName(CircuitIdentifier("!" % pin->getName()->mid(1)), false);
+  mUndoStack->execCmd(cmd.take());
+}
+
 template <typename MessageType>
 bool SymbolEditorWidget::fixMsgHelper(
     std::shared_ptr<const RuleCheckMessage> msg, bool applyFix) {
@@ -577,6 +586,8 @@ bool SymbolEditorWidget::processRuleCheckMessage(
   if (fixMsgHelper<MsgMissingSymbolValue>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgWrongSymbolTextLayer>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgSymbolPinNotOnGrid>(msg, applyFix)) return true;
+  if (fixMsgHelper<MsgNonFunctionalSymbolPinInversionSign>(msg, applyFix))
+    return true;
   return false;
 }
 


### PR DESCRIPTION
Addendum to #1172: For convenience, the widely used inversion character `/` at the beginning of pin names and component signal names is automatically converted to `!` to make it appearing as an overline. So this migration in libraries does not need to be applied by hand.

However, net names in projects are not automatically migrated since I don't like to make possibly unintended changes in existing projects. It's no harm to stay with `/` so it's probably the safer option.

EDIT: In addition, also added library checks to show a hint if non-functional inversion signs are used.