### PR TITLE
Prepare file format for adding resources to library elements

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -244,6 +244,8 @@ add_library(
   library/pkg/packagemodel.h
   library/pkg/packagepad.cpp
   library/pkg/packagepad.h
+  library/resource.cpp
+  library/resource.h
   library/sym/symbol.cpp
   library/sym/symbol.h
   library/sym/symbolcheck.cpp

--- a/libs/librepcb/core/library/libraryelement.h
+++ b/libs/librepcb/core/library/libraryelement.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "librarybaseelement.h"
+#include "resource.h"
 
 #include <QtCore>
 
@@ -60,11 +61,15 @@ public:
                  const SExpression& root);
   virtual ~LibraryElement() noexcept;
 
-  // Getters: Attributes
+  // Getters
   const QSet<Uuid>& getCategories() const noexcept { return mCategories; }
+  const ResourceList& getResources() const noexcept { return mResources; }
 
-  // Setters: Attributes
+  // Setters
   void setCategories(const QSet<Uuid>& uuids) noexcept { mCategories = uuids; }
+  void setResources(const ResourceList& resources) noexcept {
+    mResources = resources;
+  }
 
   // General Methods
   virtual RuleCheckMessageList runChecks() const override;
@@ -76,6 +81,7 @@ protected:
   virtual void serialize(SExpression& root) const override;
 
   QSet<Uuid> mCategories;
+  ResourceList mResources;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/resource.h
+++ b/libs/librepcb/core/library/resource.h
@@ -1,0 +1,114 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_RESOURCE_H
+#define LIBREPCB_CORE_RESOURCE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../serialization/serializableobjectlist.h"
+#include "../types/elementname.h"
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class Resource
+ ******************************************************************************/
+
+/**
+ * @brief The Resource class
+ */
+class Resource final {
+  Q_DECLARE_TR_FUNCTIONS(Resource)
+
+public:
+  // Signals
+  enum class Event {
+    NameChanged,
+    MediaTypeChanged,
+    UrlChanged,
+  };
+  Signal<Resource, Event> onEdited;
+  typedef Slot<Resource, Event> OnEditedSlot;
+
+  // Constructors / Destructor
+  Resource() = delete;
+  Resource(const Resource& other) noexcept;
+  explicit Resource(const SExpression& node);
+  Resource(const ElementName& name, const QString& mimeType,
+           const QUrl& url) noexcept;
+  ~Resource() noexcept;
+
+  // Getters
+  const ElementName& getName() const noexcept { return mName; }
+  const QString& getMediaType() const noexcept { return mMediaType; }
+  const QUrl& getUrl() const noexcept { return mUrl; }
+
+  // Setters
+  void setName(const ElementName& name) noexcept;
+  void setMediaType(const QString& type) noexcept;
+  void setUrl(const QUrl& url) noexcept;
+
+  // General Methods
+
+  /**
+   * @brief Serialize into ::librepcb::SExpression node
+   *
+   * @param root    Root node to serialize into.
+   */
+  void serialize(SExpression& root) const;
+
+  // Operator Overloadings
+  bool operator==(const Resource& rhs) const noexcept;
+  bool operator!=(const Resource& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+  Resource& operator=(const Resource& rhs) noexcept;
+
+private:  // Data
+  ElementName mName;
+  QString mMediaType;
+  QUrl mUrl;
+};
+
+/*******************************************************************************
+ *  Class ResourceList
+ ******************************************************************************/
+
+struct ResourceListNameProvider {
+  static constexpr const char* tagname = "resource";
+};
+using ResourceList =
+    SerializableObjectList<Resource, ResourceListNameProvider, Resource::Event>;
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif


### PR DESCRIPTION
As suggested in #706, it would be useful to have links to datasheets etc. available right in the schematic editor (e.g. in the context menu of symbols). One option might be to "abuse" the attributes system (e.g. by adding a `DATASHEET` attribute). However, I think it makes sense to implement this as a dedicated feature - especially because many ICs require links to several documents, not just a single datasheet.

This PR does not yet implement this feature, but extends the file format to allow implementing it in a later minor release. I called the documents "resources", but I'm open for suggestions of another naming. In the file format they look like this:

```scheme
(resource "Datasheet" (mediatype "application/pdf")
 (url "https://example.com/datasheet.pdf")
)
```

The `mediatype` key is intended to allow the UI to display a corresponding icon (e.g. a PDF symbol) where useful. In addition, the application might download PDFs directly and open them with the local PDF reader instead of just opening the URL in the webbrowser.

Resources will be supported for the library elements symbols, components, packages and devices.

Once we implement this feature in the UI, we should consider to extend the CLI to validate the URLs used in a library against a domain whitelist since contributing arbitrary URLs could be dangerous. In addition, URLs used in libraries should probably periodically be tested to automatically remove broken URLs since they are very annoying. After all, I don't know if datasheet URLs are usually stable enough for adding them to libraries - if not, we need to reconsider this feature in general.