### PR TITLE
Gerber export: Omit zero-width outlines of filled polygons

### DIFF
--- a/libs/librepcb/core/project/board/boardgerberexport.h
+++ b/libs/librepcb/core/project/board/boardgerberexport.h
@@ -24,8 +24,11 @@
  *  Includes
  ******************************************************************************/
 #include "../../export/excellongenerator.h"
+#include "../../export/gerbergenerator.h"
 #include "../../fileio/filepath.h"
 #include "../../types/length.h"
+
+#include <optional/tl/optional.hpp>
 
 #include <QtCore>
 
@@ -120,6 +123,11 @@ private:
                   const Layer& layer) const;
   void drawFootprintPad(GerberGenerator& gen, const BI_FootprintPad& pad,
                         const Layer& layer) const;
+  void drawPolygon(GerberGenerator& gen, const Layer& layer,
+                   const Path& outline, const UnsignedLength& lineWidth,
+                   bool fill, GerberGenerator::Function function,
+                   const tl::optional<QString>& net,
+                   const QString& component) const;
 
   std::unique_ptr<ExcellonGenerator> createExcellonGenerator(
       const BoardFabricationOutputSettings& settings,


### PR DESCRIPTION
As kindly reported by Ucamco, zero-width outlines of filled polygons are currently exported to Gerber files even though Gerber states that zero-width apertures shall not be used. This PR omits such outlines in the Gerber output as they have no purpose anyway if the polygon is filled.