### PR TITLE
Support enter/delete shortcuts in table widgets

### DIFF
--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.cpp
@@ -111,8 +111,9 @@ void ComponentSymbolVariantListWidget::setReferences(
  ******************************************************************************/
 
 void ComponentSymbolVariantListWidget::btnEditClicked(
-    const QVariant& data) noexcept {
-  tl::optional<Uuid> uuid = Uuid::tryFromString(data.toString());
+    const QPersistentModelIndex& itemIndex) noexcept {
+  tl::optional<Uuid> uuid =
+      Uuid::tryFromString(itemIndex.data(Qt::EditRole).toString());
   if (uuid && mSymbolVariantList && mUndoStack && mEditorProvider) {
     editVariant(*uuid);
   }

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.h
@@ -68,7 +68,7 @@ public:
       const ComponentSymbolVariantListWidget& rhs) = delete;
 
 private:  // Methods
-  void btnEditClicked(const QVariant& data) noexcept;
+  void btnEditClicked(const QPersistentModelIndex& itemIndex) noexcept;
   void viewDoubleClicked(const QModelIndex& index) noexcept;
   void editVariant(const Uuid& uuid) noexcept;
 

--- a/libs/librepcb/editor/widgets/editabletablewidget.h
+++ b/libs/librepcb/editor/widgets/editabletablewidget.h
@@ -107,6 +107,8 @@ private:
   bool mCanRemove;
   bool mReadOnly;
 
+  QScopedPointer<QAction> mActionAddRow;
+  QScopedPointer<QAction> mActionRemoveRow;
   QMetaObject::Connection mRowsRemovedConnection;
 };
 


### PR DESCRIPTION
In most table widgets, the keyboard shortcut *Enter* now adds a new row (as requested in #848) and *Delete* now removes the selected row. However, *Enter* often needs to be pressed twice because while a cell is in edit mode, the first *Enter* exits the edit mode (so you could move the focus to another table cell then).

Usability is much better now especially because *Enter* first adds a new row instead of (accidentally) closing a modal dialog.

Closes #848.