### PR TITLE
ERC: Warn about schematic wires with open end

### DIFF
--- a/libs/librepcb/core/project/erc/electricalrulecheck.h
+++ b/libs/librepcb/core/project/erc/electricalrulecheck.h
@@ -33,6 +33,7 @@
 namespace librepcb {
 
 class ComponentInstance;
+class NetSignal;
 class Project;
 class SI_NetSegment;
 class SI_Symbol;
@@ -72,6 +73,7 @@ private:  // Methods
 
 private:  // Data
   const Project& mProject;
+  mutable QSet<const NetSignal*> mOpenNetSignals;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
@@ -67,6 +67,23 @@ ErcMsgOpenNet::ErcMsgOpenNet(const NetSignal& net) noexcept
 }
 
 /*******************************************************************************
+ *  ErcMsgOpenWireInSegment
+ ******************************************************************************/
+
+ErcMsgOpenWireInSegment::ErcMsgOpenWireInSegment(
+    const SI_NetSegment& segment) noexcept
+  : RuleCheckMessage(
+        Severity::Warning,
+        tr("Open wire in net: '%1'").arg(*segment.getNetSignal().getName()),
+        tr("The wire has an open (unconnected) end with no net "
+           "label attached, thus is looks like a mistake. Check "
+           "if a connection to another wire or pin is missing (denoted by a "
+           "cross mark)."),
+        "open_wire") {
+  mApproval.appendChild("segment", segment.getUuid());
+}
+
+/*******************************************************************************
  *  ErcMsgUnconnectedRequiredSignal
  ******************************************************************************/
 

--- a/libs/librepcb/core/project/erc/electricalrulecheckmessages.h
+++ b/libs/librepcb/core/project/erc/electricalrulecheckmessages.h
@@ -38,6 +38,7 @@ class ComponentSymbolVariantItem;
 class NetClass;
 class NetSignal;
 class SI_NetPoint;
+class SI_NetSegment;
 class SI_SymbolPin;
 
 /*******************************************************************************
@@ -76,6 +77,25 @@ public:
   ErcMsgOpenNet(const ErcMsgOpenNet& other) noexcept
     : RuleCheckMessage(other) {}
   virtual ~ErcMsgOpenNet() noexcept {}
+};
+
+/*******************************************************************************
+ *  Class ErcMsgOpenWireInSegment
+ ******************************************************************************/
+
+/**
+ * @brief The ErcMsgOpenWireInSegment class
+ */
+class ErcMsgOpenWireInSegment final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(ErcMsgOpenWireInSegment)
+
+public:
+  // Constructors / Destructor
+  ErcMsgOpenWireInSegment() = delete;
+  explicit ErcMsgOpenWireInSegment(const SI_NetSegment& segment) noexcept;
+  ErcMsgOpenWireInSegment(const ErcMsgOpenWireInSegment& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~ErcMsgOpenWireInSegment() noexcept {}
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/items/si_netline.h
+++ b/libs/librepcb/core/project/schematic/items/si_netline.h
@@ -50,6 +50,7 @@ public:
   virtual void unregisterNetLine(SI_NetLine& netline) = 0;
   virtual const QSet<SI_NetLine*>& getNetLines() const noexcept = 0;
   virtual const Point& getPosition() const noexcept = 0;
+  virtual bool isOpen() const noexcept = 0;
 
   virtual NetLineAnchor toNetLineAnchor() const noexcept = 0;
 };

--- a/libs/librepcb/core/project/schematic/items/si_netpoint.h
+++ b/libs/librepcb/core/project/schematic/items/si_netpoint.h
@@ -71,6 +71,9 @@ public:
   SI_NetSegment& getNetSegment() const noexcept { return mNetSegment; }
   NetSignal& getNetSignalOfNetSegment() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
+  bool isOpen() const noexcept override {
+    return mRegisteredNetLines.count() < 2;
+  }
   NetLineAnchor toNetLineAnchor() const noexcept override;
 
   // Setters

--- a/libs/librepcb/core/project/schematic/items/si_symbolpin.h
+++ b/libs/librepcb/core/project/schematic/items/si_symbolpin.h
@@ -114,6 +114,9 @@ public:
   bool isRequired() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
   bool isVisibleJunction() const noexcept;
+  bool isOpen() const noexcept override {
+    return mRegisteredNetLines.isEmpty();
+  }
   NetLineAnchor toNetLineAnchor() const noexcept override;
 
   // General Methods


### PR DESCRIPTION
As requested in #1054, this adds an ERC check for open wires in the schematic, i.e. wires with an unconnected end and no net label:

![librepcb-erc-open-wire](https://github.com/LibrePCB/LibrePCB/assets/5374821/6bf979f5-7be6-437e-90ed-0ddd5d728ffa)

Note that this warning is suppressed if the "Less than two pins in net" warning is raised on the same net segment because these two warnings are very similar and thus annoying to get both of them in many cases. The new warning is only raised if the wire *does* connect multiple pins and has no net label attached.

Fixes #1054 