### PR TITLE
Workpace upgrade wizard: Allow switching workspace

### DIFF
--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard.cpp
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard.cpp
@@ -49,6 +49,14 @@ InitializeWorkspaceWizard::InitializeWorkspaceWizard(bool forceChoosePath,
   setPixmap(WizardPixmap::LogoPixmap, QPixmap(":/img/logo/48x48.png"));
   setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));
 
+  // Setup "switch workspace" button.
+  setButtonText(CustomButton1, tr("Switch Workspace"));
+  connect(button(CustomButton1), &QAbstractButton::clicked, this, [this]() {
+    setStartId(InitializeWorkspaceWizardContext::ID_ChooseWorkspace);
+    setOption(QWizard::HaveCustomButton1, false);
+    restart();
+  });
+
   // Add pages.
   setPage(InitializeWorkspaceWizardContext::ID_Welcome,
           new InitializeWorkspaceWizard_Welcome(mContext));
@@ -110,6 +118,12 @@ void InitializeWorkspaceWizard::updateStartPage() noexcept {
     setStartId(InitializeWorkspaceWizardContext::ID_None);
     mNeedsToBeShown = false;
   }
+
+  // If a workspace upgrade or initialization is needed, provide the option to
+  // choose a different workspace instead, otherwise it would be very bad user
+  // experience. See https://github.com/LibrePCB/LibrePCB/issues/1044.
+  setOption(QWizard::HaveCustomButton1,
+            startId() > InitializeWorkspaceWizardContext::ID_ChooseWorkspace);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_upgrade.cpp
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_upgrade.cpp
@@ -105,16 +105,14 @@ bool InitializeWorkspaceWizard_Upgrade::validatePage() noexcept {
     return true;
   }
 
-  if (QAbstractButton* btn = wizard()->button(QWizard::BackButton)) {
-    btn->setEnabled(false);
-  } else {
-    qWarning() << "Could not disable back button in workspace upgrade wizard.";
-  }
-  if (QAbstractButton* btn = wizard()->button(QWizard::FinishButton)) {
-    btn->setEnabled(false);
-  } else {
-    qWarning()
-        << "Could not disable finish button in workspace upgrade wizard.";
+  for (auto btnId :
+       {QWizard::CustomButton1, QWizard::BackButton, QWizard::FinishButton}) {
+    if (QAbstractButton* btn = wizard()->button(btnId)) {
+      btn->setEnabled(false);
+    } else {
+      qWarning() << "Could not disable button in workspace upgrade wizard:"
+                 << btnId;
+    }
   }
   mUi->progressBar->show();
   mCopyOperation->start();


### PR DESCRIPTION
Adding a button to allow choosing a different workspace if an upgrade is required on the default workspace:

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/b7d84925-83ea-4ac7-97e0-15c8f8e28ba3)

Fixes #1044
