### PR TITLE
Upgrade all libraries file format during background scan

### DIFF
--- a/libs/librepcb/core/fileio/fileutils.cpp
+++ b/libs/librepcb/core/fileio/fileutils.cpp
@@ -186,6 +186,16 @@ QList<FilePath> FileUtils::getFilesInDirectory(const FilePath& dir,
   return files;
 }
 
+QList<FilePath> FileUtils::findDirectories(const FilePath& rootDir) {
+  QList<FilePath> result;
+  QDir qDir(rootDir.toStr());
+  qDir.setFilter(QDir::Hidden | QDir::Dirs | QDir::NoDotAndDotDot);
+  foreach (const QFileInfo& info, qDir.entryInfoList()) {
+    result.append(FilePath(info.absoluteFilePath()));
+  }
+  return result;
+}
+
 /*******************************************************************************
  *  End of File
  ******************************************************************************/

--- a/libs/librepcb/core/fileio/fileutils.h
+++ b/libs/librepcb/core/fileio/fileutils.h
@@ -146,6 +146,16 @@ public:
       const FilePath& dir, const QStringList& filters = QStringList(),
       bool recursive = false);
 
+  /**
+   * @brief Get all directories within a given directory
+   *
+   * @param rootDir       Filepath to a directory (may or may not exist).
+   *
+   * @return  A list of filepaths to directories in the specified directory
+   *          (empty if the directory doesn't exist).
+   */
+  static QList<FilePath> findDirectories(const FilePath& rootDir);
+
   // Operator Overloadings
   FileUtils& operator=(const FileUtils& rhs) = delete;
 };

--- a/libs/librepcb/core/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/core/fileio/transactionalfilesystem.cpp
@@ -402,6 +402,11 @@ void TransactionalFileSystem::save() {
   discardChanges();
 }
 
+void TransactionalFileSystem::releaseLock() {
+  mIsWritable = false;
+  mLock.unlockIfLocked();  // can throw
+}
+
 /*******************************************************************************
  *  Static Methods
  ******************************************************************************/

--- a/libs/librepcb/core/fileio/transactionalfilesystem.h
+++ b/libs/librepcb/core/fileio/transactionalfilesystem.h
@@ -180,6 +180,7 @@ public:
   QStringList checkForModifications() const;
   void autosave();
   void save();
+  void releaseLock();
 
   // Static Methods
   static std::shared_ptr<TransactionalFileSystem> open(
@@ -215,7 +216,7 @@ private:  // Methods
 
 private:  // Data
   const FilePath mFilePath;
-  const bool mIsWritable;
+  bool mIsWritable;
   DirectoryLock mLock;
   bool mRestoredFromAutosave;
   mutable QMutex mMutex;

--- a/libs/librepcb/core/library/cat/componentcategory.cpp
+++ b/libs/librepcb/core/library/cat/componentcategory.cpp
@@ -58,13 +58,17 @@ ComponentCategory::~ComponentCategory() noexcept {
  ******************************************************************************/
 
 std::unique_ptr<ComponentCategory> ComponentCategory::open(
-    std::unique_ptr<TransactionalDirectory> directory) {
+    std::unique_ptr<TransactionalDirectory> directory,
+    bool abortBeforeMigration) {
   Q_ASSERT(directory);
 
   // Upgrade file format, if needed.
   const Version fileFormat =
       readFileFormat(*directory, ".librepcb-" % getShortElementName());
   const auto migrations = FileFormatMigration::getMigrations(fileFormat);
+  if (abortBeforeMigration && (!migrations.isEmpty())) {
+    return nullptr;
+  }
   for (auto migration : migrations) {
     migration->upgradeComponentCategory(*directory);
   }

--- a/libs/librepcb/core/library/cat/componentcategory.cpp
+++ b/libs/librepcb/core/library/cat/componentcategory.cpp
@@ -81,6 +81,7 @@ std::unique_ptr<ComponentCategory> ComponentCategory::open(
       new ComponentCategory(std::move(directory), root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
+    obj->save();  // Format all files correctly as the migration doesn't!
   }
   return obj;
 }

--- a/libs/librepcb/core/library/cat/componentcategory.h
+++ b/libs/librepcb/core/library/cat/componentcategory.h
@@ -59,7 +59,8 @@ public:
 
   // Static Methods
   static std::unique_ptr<ComponentCategory> open(
-      std::unique_ptr<TransactionalDirectory> directory);
+      std::unique_ptr<TransactionalDirectory> directory,
+      bool abortBeforeMigration = false);
   static QString getShortElementName() noexcept {
     return QStringLiteral("cmpcat");
   }

--- a/libs/librepcb/core/library/cat/packagecategory.cpp
+++ b/libs/librepcb/core/library/cat/packagecategory.cpp
@@ -81,6 +81,7 @@ std::unique_ptr<PackageCategory> PackageCategory::open(
       new PackageCategory(std::move(directory), root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
+    obj->save();  // Format all files correctly as the migration doesn't!
   }
   return obj;
 }

--- a/libs/librepcb/core/library/cat/packagecategory.cpp
+++ b/libs/librepcb/core/library/cat/packagecategory.cpp
@@ -58,13 +58,17 @@ PackageCategory::~PackageCategory() noexcept {
  ******************************************************************************/
 
 std::unique_ptr<PackageCategory> PackageCategory::open(
-    std::unique_ptr<TransactionalDirectory> directory) {
+    std::unique_ptr<TransactionalDirectory> directory,
+    bool abortBeforeMigration) {
   Q_ASSERT(directory);
 
   // Upgrade file format, if needed.
   const Version fileFormat =
       readFileFormat(*directory, ".librepcb-" % getShortElementName());
   const auto migrations = FileFormatMigration::getMigrations(fileFormat);
+  if (abortBeforeMigration && (!migrations.isEmpty())) {
+    return nullptr;
+  }
   for (auto migration : migrations) {
     migration->upgradePackageCategory(*directory);
   }

--- a/libs/librepcb/core/library/cat/packagecategory.h
+++ b/libs/librepcb/core/library/cat/packagecategory.h
@@ -59,7 +59,8 @@ public:
 
   // Static Methods
   static std::unique_ptr<PackageCategory> open(
-      std::unique_ptr<TransactionalDirectory> directory);
+      std::unique_ptr<TransactionalDirectory> directory,
+      bool abortBeforeMigration = false);
   static QString getShortElementName() noexcept {
     return QStringLiteral("pkgcat");
   }

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -148,6 +148,7 @@ std::unique_ptr<Component> Component::open(
   std::unique_ptr<Component> obj(new Component(std::move(directory), root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
+    obj->save();  // Format all files correctly as the migration doesn't!
   }
   return obj;
 }

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -126,13 +126,17 @@ RuleCheckMessageList Component::runChecks() const {
 }
 
 std::unique_ptr<Component> Component::open(
-    std::unique_ptr<TransactionalDirectory> directory) {
+    std::unique_ptr<TransactionalDirectory> directory,
+    bool abortBeforeMigration) {
   Q_ASSERT(directory);
 
   // Upgrade file format, if needed.
   const Version fileFormat =
       readFileFormat(*directory, ".librepcb-" % getShortElementName());
   const auto migrations = FileFormatMigration::getMigrations(fileFormat);
+  if (abortBeforeMigration && (!migrations.isEmpty())) {
+    return nullptr;
+  }
   for (auto migration : migrations) {
     migration->upgradeComponent(*directory);
   }

--- a/libs/librepcb/core/library/cmp/component.h
+++ b/libs/librepcb/core/library/cmp/component.h
@@ -137,7 +137,8 @@ public:
 
   // Static Methods
   static std::unique_ptr<Component> open(
-      std::unique_ptr<TransactionalDirectory> directory);
+      std::unique_ptr<TransactionalDirectory> directory,
+      bool abortBeforeMigration = false);
   static QString getShortElementName() noexcept {
     return QStringLiteral("cmp");
   }

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -89,13 +89,17 @@ RuleCheckMessageList Device::runChecks() const {
 }
 
 std::unique_ptr<Device> Device::open(
-    std::unique_ptr<TransactionalDirectory> directory) {
+    std::unique_ptr<TransactionalDirectory> directory,
+    bool abortBeforeMigration) {
   Q_ASSERT(directory);
 
   // Upgrade file format, if needed.
   const Version fileFormat =
       readFileFormat(*directory, ".librepcb-" % getShortElementName());
   const auto migrations = FileFormatMigration::getMigrations(fileFormat);
+  if (abortBeforeMigration && (!migrations.isEmpty())) {
+    return nullptr;
+  }
   for (auto migration : migrations) {
     migration->upgradeDevice(*directory);
   }

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -111,6 +111,7 @@ std::unique_ptr<Device> Device::open(
   std::unique_ptr<Device> obj(new Device(std::move(directory), root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
+    obj->save();  // Format all files correctly as the migration doesn't!
   }
   return obj;
 }

--- a/libs/librepcb/core/library/dev/device.h
+++ b/libs/librepcb/core/library/dev/device.h
@@ -89,7 +89,8 @@ public:
 
   // Static Methods
   static std::unique_ptr<Device> open(
-      std::unique_ptr<TransactionalDirectory> directory);
+      std::unique_ptr<TransactionalDirectory> directory,
+      bool abortBeforeMigration = false);
   static QString getShortElementName() noexcept {
     return QStringLiteral("dev");
   }

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -165,13 +165,17 @@ template QStringList Library::searchForElements<Component>() const noexcept;
 template QStringList Library::searchForElements<Device>() const noexcept;
 
 std::unique_ptr<Library> Library::open(
-    std::unique_ptr<TransactionalDirectory> directory) {
+    std::unique_ptr<TransactionalDirectory> directory,
+    bool abortBeforeMigration) {
   Q_ASSERT(directory);
 
   // Upgrade file format, if needed.
   const Version fileFormat =
       readFileFormat(*directory, ".librepcb-" % getShortElementName());
   const auto migrations = FileFormatMigration::getMigrations(fileFormat);
+  if (abortBeforeMigration && (!migrations.isEmpty())) {
+    return nullptr;
+  }
   for (auto migration : migrations) {
     migration->upgradeLibrary(*directory);
   }

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -187,6 +187,7 @@ std::unique_ptr<Library> Library::open(
   std::unique_ptr<Library> obj(new Library(std::move(directory), root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
+    obj->save();  // Format all files correctly as the migration doesn't!
   }
   return obj;
 }

--- a/libs/librepcb/core/library/library.h
+++ b/libs/librepcb/core/library/library.h
@@ -85,7 +85,8 @@ public:
 
   // Static Methods
   static std::unique_ptr<Library> open(
-      std::unique_ptr<TransactionalDirectory> directory);
+      std::unique_ptr<TransactionalDirectory> directory,
+      bool abortBeforeMigration = false);
   static QString getShortElementName() noexcept {
     return QStringLiteral("lib");
   }

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -195,6 +195,7 @@ std::unique_ptr<Package> Package::open(
   std::unique_ptr<Package> obj(new Package(std::move(directory), root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
+    obj->save();  // Format all files correctly as the migration doesn't!
   }
   return obj;
 }

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -173,13 +173,17 @@ RuleCheckMessageList Package::runChecks() const {
 }
 
 std::unique_ptr<Package> Package::open(
-    std::unique_ptr<TransactionalDirectory> directory) {
+    std::unique_ptr<TransactionalDirectory> directory,
+    bool abortBeforeMigration) {
   Q_ASSERT(directory);
 
   // Upgrade file format, if needed.
   const Version fileFormat =
       readFileFormat(*directory, ".librepcb-" % getShortElementName());
   const auto migrations = FileFormatMigration::getMigrations(fileFormat);
+  if (abortBeforeMigration && (!migrations.isEmpty())) {
+    return nullptr;
+  }
   for (auto migration : migrations) {
     migration->upgradePackage(*directory);
   }

--- a/libs/librepcb/core/library/pkg/package.h
+++ b/libs/librepcb/core/library/pkg/package.h
@@ -100,7 +100,8 @@ public:
 
   // Static Methods
   static std::unique_ptr<Package> open(
-      std::unique_ptr<TransactionalDirectory> directory);
+      std::unique_ptr<TransactionalDirectory> directory,
+      bool abortBeforeMigration = false);
   static QString getShortElementName() noexcept {
     return QStringLiteral("pkg");
   }

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -110,6 +110,7 @@ std::unique_ptr<Symbol> Symbol::open(
   std::unique_ptr<Symbol> obj(new Symbol(std::move(directory), root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
+    obj->save();  // Format all files correctly as the migration doesn't!
   }
   return obj;
 }

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -88,13 +88,17 @@ RuleCheckMessageList Symbol::runChecks() const {
 }
 
 std::unique_ptr<Symbol> Symbol::open(
-    std::unique_ptr<TransactionalDirectory> directory) {
+    std::unique_ptr<TransactionalDirectory> directory,
+    bool abortBeforeMigration) {
   Q_ASSERT(directory);
 
   // Upgrade file format, if needed.
   const Version fileFormat =
       readFileFormat(*directory, ".librepcb-" % getShortElementName());
   const auto migrations = FileFormatMigration::getMigrations(fileFormat);
+  if (abortBeforeMigration && (!migrations.isEmpty())) {
+    return nullptr;
+  }
   for (auto migration : migrations) {
     migration->upgradeSymbol(*directory);
   }

--- a/libs/librepcb/core/library/sym/symbol.h
+++ b/libs/librepcb/core/library/sym/symbol.h
@@ -92,7 +92,8 @@ public:
 
   // Static Methods
   static std::unique_ptr<Symbol> open(
-      std::unique_ptr<TransactionalDirectory> directory);
+      std::unique_ptr<TransactionalDirectory> directory,
+      bool abortBeforeMigration = false);
   static QString getShortElementName() noexcept {
     return QStringLiteral("sym");
   }

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -156,6 +156,12 @@ std::unique_ptr<Project> ProjectLoader::open(
     p->setErcMessageApprovals(p->getErcMessageApprovals() & approvals);
   }
 
+  // Make sure the files are formatted correctly. Also handle possible errors
+  // during serialization now instead of later.
+  if (mUpgradeMessages) {
+    p->save();
+  }
+
   // Done!
   qDebug() << "Successfully opened project in" << timer.elapsed() << "ms.";
   return p;

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.h
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.h
@@ -36,7 +36,6 @@ namespace librepcb {
 
 class Library;
 class SQLiteDatabase;
-class TransactionalFileSystem;
 class WorkspaceLibraryDbWriter;
 
 /*******************************************************************************
@@ -81,17 +80,15 @@ signals:
 private:  // Methods
   void run() noexcept override;
   void scan() noexcept;
-  void getLibrariesOfDirectory(std::shared_ptr<TransactionalFileSystem> fs,
-                               const QString& root,
+  void getLibrariesOfDirectory(const QString& root,
                                QList<std::shared_ptr<Library>>& libs) noexcept;
+
   QHash<FilePath, int> updateLibraries(
       SQLiteDatabase& db, WorkspaceLibraryDbWriter& writer,
       const QList<std::shared_ptr<Library>>& libs);
   template <typename ElementType>
-  int addElementsToDb(WorkspaceLibraryDbWriter& writer,
-                      std::shared_ptr<TransactionalFileSystem> fs,
-                      const FilePath& libPath, const QStringList& dirs,
-                      int libId);
+  int addElementsToDb(WorkspaceLibraryDbWriter& writer, const FilePath& libPath,
+                      const QStringList& dirs, int libId);
   template <typename ElementType>
   int addElementToDb(WorkspaceLibraryDbWriter& writer, int libId,
                      const ElementType& element);
@@ -101,6 +98,8 @@ private:  // Methods
   template <typename ElementType>
   void addToCategories(WorkspaceLibraryDbWriter& writer, int elementId,
                        const ElementType& element);
+  template <typename ElementType>
+  std::unique_ptr<ElementType> openAndMigrate(const FilePath& fp);
 
 private:  // Data
   const FilePath mLibrariesPath;  ///< Path to workspace libraries directory.

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_upgrade.ui
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_upgrade.ui
@@ -53,8 +53,8 @@
      </property>
      <property name="text">
       <string>&lt;p&gt;Your workspace was created with an older LibrePCB version and needs to be upgraded.&lt;/p&gt;
-&lt;p&gt;To still keep the workspace compatible with older versions of LibrePCB, a snapshot of the currently installed libraries and settings will be created.&lt;/p&gt;
-&lt;p&gt;No worries, this operation is not harmful at all, it may just take a few seconds ;-)&lt;/p&gt;</string>
+&lt;p&gt;To still keep the workspace compatible with older versions of LibrePCB, a snapshot of the currently installed libraries and settings will be created. This may take a moment.&lt;/p&gt;
+&lt;p&gt;Also the first background library scan after the upgrade takes longer than usual, but you can start working on projects without waiting for its completion.&lt;/p&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>

--- a/tests/unittests/core/fileio/transactionalfilesystemtest.cpp
+++ b/tests/unittests/core/fileio/transactionalfilesystemtest.cpp
@@ -751,6 +751,22 @@ TEST_F(TransactionalFileSystemTest, testCheckForModifications) {
   EXPECT_EQ(0, fs.checkForModifications().count());
 }
 
+TEST_F(TransactionalFileSystemTest, testReleaseLock) {
+  const FilePath lockFp = mPopulatedDir.getPathTo(".lock");
+
+  TransactionalFileSystem fs(mPopulatedDir, true);
+  EXPECT_TRUE(lockFp.isExistingFile());
+  fs.write("foo", "x");  // Create new file.
+  fs.save();
+  fs.write("bar", "x");  // Create new file.
+  fs.releaseLock();
+  EXPECT_FALSE(lockFp.isExistingFile());
+  fs.releaseLock();  // Second call should do nothing.
+  EXPECT_FALSE(lockFp.isExistingFile());
+  fs.write("foobar", "x");  // Create new file.
+  EXPECT_THROW(fs.save(), Exception);  // Failed because it's read-only.
+}
+
 /*******************************************************************************
  *  Parametrized getSubDirs() Tests
  ******************************************************************************/


### PR DESCRIPTION
So far, libraries and their contained elements were not upgraded to the latest file format unless the user opened and saved them manually. Basically this works fine, but for long term it means there are lots of outdated files in the workspace which requires us to keep backwards compatibility forever. In addition , the background scan takes *ages* longer because it temporarily upgrades each element in memory before it can be added to the cache database.

To avoid these two problems, the background library scan now automatically upgrades any outdated library element in the workspace to the latest file format. This takes long on the first scan, but any further scan in massively faster then. In addition, it ensures that all files in the workspace are stored in the latest file format.