### PR TITLE
Add "generated by" property to library elements

### DIFF
--- a/libs/librepcb/core/library/libraryelement.cpp
+++ b/libs/librepcb/core/library/libraryelement.cpp
@@ -43,7 +43,8 @@ LibraryElement::LibraryElement(const QString& shortElementName,
                                const QString& description_en_US,
                                const QString& keywords_en_US)
   : LibraryBaseElement(shortElementName, longElementName, uuid, version, author,
-                       name_en_US, description_en_US, keywords_en_US) {
+                       name_en_US, description_en_US, keywords_en_US),
+    mGeneratedBy() {
 }
 
 LibraryElement::LibraryElement(
@@ -52,6 +53,7 @@ LibraryElement::LibraryElement(
     const SExpression& root)
   : LibraryBaseElement(shortElementName, longElementName, dirnameMustBeUuid,
                        std::move(directory), root),
+    mGeneratedBy(root.getChild("generated_by/@0").getValue()),
     mCategories(),
     mResources(root) {
   // read category UUIDs
@@ -78,6 +80,8 @@ RuleCheckMessageList LibraryElement::runChecks() const {
 
 void LibraryElement::serialize(SExpression& root) const {
   LibraryBaseElement::serialize(root);
+  root.ensureLineBreak();
+  root.appendChild("generated_by", mGeneratedBy);
   foreach (const Uuid& uuid, Toolbox::sortedQSet(mCategories)) {
     root.ensureLineBreak();
     root.appendChild("category", uuid);

--- a/libs/librepcb/core/library/libraryelement.h
+++ b/libs/librepcb/core/library/libraryelement.h
@@ -62,10 +62,12 @@ public:
   virtual ~LibraryElement() noexcept;
 
   // Getters
+  const QString& getGeneratedBy() const noexcept { return mGeneratedBy; }
   const QSet<Uuid>& getCategories() const noexcept { return mCategories; }
   const ResourceList& getResources() const noexcept { return mResources; }
 
   // Setters
+  void setGeneratedBy(const QString& gen) noexcept { mGeneratedBy = gen; }
   void setCategories(const QSet<Uuid>& uuids) noexcept { mCategories = uuids; }
   void setResources(const ResourceList& resources) noexcept {
     mResources = resources;
@@ -80,6 +82,7 @@ public:
 protected:
   virtual void serialize(SExpression& root) const override;
 
+  QString mGeneratedBy;  ///< If not empty, the element is generated.
   QSet<Uuid> mCategories;
   ResourceList mResources;
 };

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -63,19 +63,39 @@ void FileFormatMigrationUnstable::upgradePackageCategory(
 
 void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  const QString fp = "symbol.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  root.appendChild("generated_by", QString());
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  const QString fp = "package.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  root.appendChild("generated_by", QString());
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(
     TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  const QString fp = "component.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  root.appendChild("generated_by", QString());
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeDevice(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  const QString fp = "device.lp";
+  SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+  root.appendChild("generated_by", QString());
+  dir.write(fp, root.toByteArray());
 }
 
 void FileFormatMigrationUnstable::upgradeLibrary(TransactionalDirectory& dir) {
@@ -125,12 +145,7 @@ void FileFormatMigrationUnstable::upgradeBoardUserSettings(SExpression& root) {
 }
 
 void FileFormatMigrationUnstable::upgradeBoardDrcSettings(SExpression& root) {
-  SExpression& node = root.getChild("design_rule_check");
-  node.appendChild("min_silkscreen_stopmask_clearance",
-                   SExpression::createToken("0.127"));
-  node.appendChild("min_silkscreen_width", SExpression::createToken("0.15"));
-  node.appendChild("min_silkscreen_text_height",
-                   SExpression::createToken("0.8"));
+  Q_UNUSED(root);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv01.cpp
@@ -78,6 +78,7 @@ void FileFormatMigrationV01::upgradeSymbol(TransactionalDirectory& dir) {
   {
     const QString fp = "symbol.lp";
     SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root.appendChild("generated_by", QString());
 
     // Various strings.
     upgradeStrings(root);
@@ -110,6 +111,7 @@ void FileFormatMigrationV01::upgradePackage(TransactionalDirectory& dir) {
   {
     const QString fp = "package.lp";
     SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root.appendChild("generated_by", QString());
 
     // Various strings.
     upgradeStrings(root);
@@ -218,6 +220,7 @@ void FileFormatMigrationV01::upgradeComponent(TransactionalDirectory& dir) {
   {
     const QString fp = "component.lp";
     SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root.appendChild("generated_by", QString());
 
     // Signals.
     upgradeInversionCharacters(root, "signal", "name/@0");
@@ -237,6 +240,7 @@ void FileFormatMigrationV01::upgradeDevice(TransactionalDirectory& dir) {
   {
     const QString fp = "device.lp";
     SExpression root = SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root.appendChild("generated_by", QString());
 
     // Various strings.
     upgradeStrings(root);


### PR DESCRIPTION
Just adding the node `(generated_by "")` to symbol/package/component/device files to allow marking library elements which were generated by a script like `librepcb-parts-generator`. The property is not used yet by LibrePCB, but in future we could show a note in the UI to make it clear when a library element is generated.

I think this helps to avoid modifying or duplicating such elements manually although adjusting the generator makes more sense. A custom UI warning can be made much more visible than the current "Generated by ..." sentence in the description of library elements (which is then no longer needed).