### PR TITLE
Add a QtQuick test window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(BUILD_TESTS "Build unit tests." ON)
 option(BUILD_DISALLOW_WARNINGS
        "Disallow compiler warnings during build (build with -Werror)." OFF
 )
+option(BUILD_QTQUICK_TEST "Build the QML test window." ON)
 option(UNBUNDLE_DXFLIB "Don't use vendored dxflib library." OFF)
 option(UNBUNDLE_FONTOBENE_QT5 "Don't use vendored FontoBeneQt5 library." OFF)
 option(UNBUNDLE_GTEST "Don't use vendored GoogleTest library." OFF)
@@ -125,6 +126,13 @@ find_package(
              Widgets
   REQUIRED
 )
+if(BUILD_QTQUICK_TEST)
+  find_package(
+    Qt5 5.5.0
+    COMPONENTS Quick
+    REQUIRED
+  )
+endif()
 if(BUILD_TESTS)
   find_package(
     Qt5 5.5.0

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -160,6 +160,15 @@ static void writeLogHeader() noexcept {
  ******************************************************************************/
 
 static int runApplication() noexcept {
+  // For deployment testing purposes, exit the application now if the flag
+  // '--exit-after-startup' is passed. This shall be done *before* any user
+  // interaction (e.g. message box) to make it working headless.
+  const char* exitFlagName = "--exit-after-startup";
+  if (qApp->arguments().contains(exitFlagName)) {
+    qInfo().nospace() << "Exit requested by flag '" << exitFlagName << "'.";
+    return 0;
+  }
+
   // If the file format is unstable (e.g. for nightly builds), ask to abort now.
   // This warning *must* come that early to be really sure that no files are
   // overwritten with unstable content!

--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -29,7 +29,9 @@ jobs:
     displayName: Run LibrePCB Unittests
   - bash: pytest -vvv --librepcb-executable="build/install/opt/librepcb-cli.app/Contents/MacOS/librepcb-cli" ./tests/cli
     displayName: Run LibrePCB-CLI Functional Tests
-  - bash: pytest -vvv --librepcb-executable="build/install/opt/librepcb.app/Contents/MacOS/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
+  # Note: Functional tests need to be run with the non-bundled app, otherwise
+  # we get the error "Cannot add multiple registrations for QtQml.Models 2".
+  - bash: pytest -vvv --librepcb-executable="build/install/opt/bin/librepcb.app/Contents/MacOS/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
     displayName: Run LibrePCB Functional Tests
   - bash: ./ci/upload_artifacts.sh
     displayName: Upload Artifacts

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -50,5 +50,10 @@ linuxdeployqt "./build/install/opt/bin/librepcb-cli" $LINUXDEPLOYQT_FLAGS -alway
 linuxdeployqt "./build/install/opt/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite \
   -qmldir="./build/install/opt/share/librepcb/qml"
 
+# Test if the bundles are working (hopefully catching deployment issues).
+# Doesn't work for AppImages unfortunately because of missing fuse on CI.
+xvfb-run -a ./build/install/opt/bin/librepcb-cli --version
+xvfb-run -a ./build/install/opt/bin/librepcb --exit-after-startup
+
 # Copy to artifacts.
 cp -r "./build/install/opt" "./artifacts/nightly_builds/librepcb-nightly-linux-x86_64"

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -40,13 +40,15 @@ cp -r "./build/install" "./build/appimage"
 cp "./build/appimage/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" \
   "./build/appimage/org.librepcb.LibrePCB.svg"
 linuxdeployqt "./build/appimage/opt/share/applications/org.librepcb.LibrePCB.desktop" \
+  -qmldir="./build/appimage/opt/share/librepcb/qml" \
   $LINUXDEPLOYQT_FLAGS -appimage
 patch_appimage
 mv ./LibrePCB-*-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-x86_64.AppImage
 
 # Run linuxdeployqt to bundle all libraries into the portable packages.
 linuxdeployqt "./build/install/opt/bin/librepcb-cli" $LINUXDEPLOYQT_FLAGS -always-overwrite
-linuxdeployqt "./build/install/opt/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite
+linuxdeployqt "./build/install/opt/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite \
+  -qmldir="./build/install/opt/share/librepcb/qml"
 
 # Copy to artifacts.
 cp -r "./build/install/opt" "./artifacts/nightly_builds/librepcb-nightly-linux-x86_64"

--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -28,6 +28,10 @@ popd
 mv "./build/install/opt/LibrePCB.app" "./build/install/opt/librepcb.app"
 mv "./build/install/opt/LibrePCB-CLI.app" "./build/install/opt/librepcb-cli.app"
 
+# Test if the bundles are working (hopefully catching deployment issues).
+./build/install/opt/librepcb-cli.app/Contents/MacOS/librepcb-cli --version
+./build/install/opt/librepcb.app/Contents/MacOS/librepcb --exit-after-startup
+
 # Move bundles to artifacts directory
 mv ./build/install/opt/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
 mv ./build/install/opt/LibrePCB-CLI.dmg ./artifacts/nightly_builds/librepcb-cli-nightly-mac-x86_64.dmg

--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -4,11 +4,10 @@
 set -euv -o pipefail
 
 # replace "bin" and "share" directories with the single *.app directory
-mv "./build/install/opt/bin/librepcb.app" "./build/install/opt/LibrePCB.app"
+cp -r "./build/install/opt/bin/librepcb.app" "./build/install/opt/LibrePCB.app"
 cp -r "./build/install/opt/share" "./build/install/opt/LibrePCB.app/Contents/"
-mv "./build/install/opt/bin/librepcb-cli.app" "./build/install/opt/LibrePCB-CLI.app"
+cp -r "./build/install/opt/bin/librepcb-cli.app" "./build/install/opt/LibrePCB-CLI.app"
 cp -r "./build/install/opt/share" "./build/install/opt/LibrePCB-CLI.app/Contents/"
-rm -r "./build/install/opt/bin" "./build/install/opt/share"
 
 # Build bundles
 pushd "./build/install/opt/"  # Avoid having path in DMG name
@@ -20,7 +19,8 @@ dylibbundler -ns -od -b \
   -x LibrePCB-CLI.app/Contents/MacOS/librepcb-cli \
   -d LibrePCB-CLI.app/Contents/Frameworks/ \
   -p @executable_path/../Frameworks/
-macdeployqt "LibrePCB.app" -dmg -always-overwrite
+macdeployqt "LibrePCB.app" -dmg -always-overwrite \
+  -qmldir=./LibrePCB.app/Contents/share/librepcb/qml
 macdeployqt "LibrePCB-CLI.app" -dmg -always-overwrite
 popd
 

--- a/ci/build_windows_archive.sh
+++ b/ci/build_windows_archive.sh
@@ -17,7 +17,9 @@ cp -v C:/OpenCascade/win32/gcc/bin/libTK*.dll ./build/install/opt/bin/
 cp -v "`qmake -query QT_INSTALL_PREFIX`"/bin/lib*.dll ./build/install/opt/bin/
 
 # Copy Qt DLLs
-windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb.exe
+windeployqt --compiler-runtime --force \
+    --qmldir=./build/install/opt/share/librepcb/qml \
+    ./build/install/opt/bin/librepcb.exe
 windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb-cli.exe
 
 # Copy everything to artifacts directory for deployment

--- a/ci/build_windows_archive.sh
+++ b/ci/build_windows_archive.sh
@@ -22,5 +22,9 @@ windeployqt --compiler-runtime --force \
     ./build/install/opt/bin/librepcb.exe
 windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb-cli.exe
 
+# Test if the bundles are working (hopefully catching deployment issues).
+./build/install/opt/bin/librepcb-cli.exe --version
+./build/install/opt/bin/librepcb.exe --exit-after-startup
+
 # Copy everything to artifacts directory for deployment
 cp -r ./build/install/opt/. ./artifacts/nightly_builds/librepcb-nightly-windows-x86/

--- a/dev/doxygen/pages/building.md
+++ b/dev/doxygen/pages/building.md
@@ -153,6 +153,23 @@ LibrePCB should also work with the Community Edition (OCE). CMake should
 automatically detect the availability of both variants.
 
 
+# QtQuick / Qt Declarative / QML Dependency
+
+Starting with version 1.0, LibrePCB depends on the QtQuick / Qt Declarative
+component for evaluation purposes. In future QML might be used for the GUI,
+but we first need to do some evaluation and testing. To catch potential issues
+as early as possible, the dependency has been added already but is not used
+yet for productive features. If this dependency causes any issues during
+packaging or during runtime, LibrePCB can currently be built without it:
+
+    cmake .. -DBUILD_QTQUICK_TEST=0
+
+**IMPORTANT**: Please report any problems in our
+[issue tracker](https://github.com/LibrePCB/LibrePCB/issues)! Otherwise,
+sooner or later the dependency might be mandatory without having a workaround
+anymore for your issue!
+
+
 # Dynamic Linking / Unbundling {#doc_building_unbundling}
 
 By default, all dependencies except Qt and OpenCascade will be linked

--- a/libs/librepcb/core/build_env.h.in
+++ b/libs/librepcb/core/build_env.h.in
@@ -41,6 +41,7 @@
 #cmakedefine LIBREPCB_BINARY_DIR "@LIBREPCB_BINARY_DIR@"
 
 // Features
+#cmakedefine01 BUILD_QTQUICK_TEST
 #cmakedefine01 LIBREPCB_ENABLE_DESKTOP_INTEGRATION
 #cmakedefine01 USE_GLU
 #cmakedefine01 USE_OPENCASCADE

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -935,6 +935,9 @@ target_link_libraries(
          Qt5::Network
          Qt5::Widgets
 )
+if(BUILD_QTQUICK_TEST)
+  target_link_libraries(librepcb_editor PUBLIC Qt5::Quick)
+endif()
 
 # Hoedown is only needed on Qt <5.14
 if(Qt5Core_VERSION_MAJOR EQUAL 5 AND Qt5Core_VERSION_MINOR LESS 14)

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -224,6 +224,7 @@ private:
   QScopedPointer<QAction> mActionOnlineDocumentation;
   QScopedPointer<QAction> mActionKeyboardShortcutsReference;
   QScopedPointer<QAction> mActionWebsite;
+  QScopedPointer<QAction> mActionQtQuickTest;
   QScopedPointer<QAction> mActionQuit;
 };
 

--- a/share/librepcb/qml/testwindow.qml
+++ b/share/librepcb/qml/testwindow.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.5
+import QtQuick.Controls 1.4
+import QtQuick.Layouts 1.2
+
+ColumnLayout {
+    anchors.fill: parent
+    Rectangle {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Text {
+            anchors.centerIn: parent
+            text: "Hello from QML!"
+            font.pointSize: 24
+            color: "green"
+        }
+    }
+    Rectangle {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Text {
+            anchors.centerIn: parent
+            text: "If you can read this text, it works!"
+            color: "green"
+        }
+    }
+    Button {
+        Layout.fillWidth: true
+        Layout.margins: 8
+        text: "Close"
+        onClicked: view.close()
+    }
+}


### PR DESCRIPTION
Due to many limitations of the QtWidgets GUI framework, I think we need to evaluate other options some day - of course QtQuick/QML would be the most obvious choice. I don't know whether we will ever use it or not, but we should at least do some serious evaluation. One of the potential problems might be the deployment and runtime issues since AFAIK it relies on OpenGL which we cannot bundle with LibrePCB. So my idea is to add QtQuick as an *optional* dependency to LibrePCB now to get some experience about it before the dependency may get mandatory some day.

For that, I just added a menu item *Help -> QtQuick Test Window* to the Control Panel which opens this window:

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/c4f833b8-2429-48d1-b06a-b7d1eca88387)

This allows us to easily check if it works properly on various platforms / operating systems and I think the menu item doesn't hurt for non-developers (it's only temporary anyway)...

In case the dependency causes troubles, I documented in the build instructions how to build without QtQuick: 

https://developers.librepcb.org/_branches/add-qml-test-window/d5/d96/doc_building.html#autotoc_md12