### PR TITLE
ShortcutsReferenceGenerator: Fix layout overflow

### DIFF
--- a/libs/librepcb/editor/utils/shortcutsreferencegenerator.h
+++ b/libs/librepcb/editor/utils/shortcutsreferencegenerator.h
@@ -70,7 +70,17 @@ public:
   ~ShortcutsReferenceGenerator() noexcept;
 
   // General Methods
-  void generatePdf(const FilePath& fp);
+  /**
+   * @brief Generate the PDF
+   *
+   * @param fp    Destination PDF file path.
+   *
+   * @retval true on success.
+   * @retval false If the PDF was generated, but the layout has overflown.
+   *
+   * @throw Exception in case of a fatal error.
+   */
+  bool generatePdf(const FilePath& fp);
 
   // Operator Overloadings
   ShortcutsReferenceGenerator& operator=(
@@ -97,7 +107,7 @@ private:  // Data
   static constexpr qreal sCategoryTextSize = 3;
   static constexpr qreal sRowTextSize = 2.5;
   static constexpr qreal sRowHeight = 3;
-  static constexpr qreal sCategorySpacing = 6;
+  static constexpr qreal sCategorySpacing = 5;
   static constexpr qreal sColumnSpacing = 3.5;
   static constexpr qreal sColumnWidth = (sPageWidth - 3 * sColumnSpacing) / 4;
   static constexpr qreal sShortcutsWidth = 28;

--- a/tests/unittests/editor/utils/shortcutsreferencegeneratortest.cpp
+++ b/tests/unittests/editor/utils/shortcutsreferencegeneratortest.cpp
@@ -37,8 +37,6 @@ namespace librepcb {
 namespace editor {
 namespace tests {
 
-using ::librepcb::tests::TestHelpers;
-
 /*******************************************************************************
  *  Test Class
  ******************************************************************************/
@@ -52,11 +50,11 @@ class ShortcutsReferenceGeneratorTest : public ::testing::Test {};
 TEST_F(ShortcutsReferenceGeneratorTest, testExportPdfMultipleTimes) {
   FilePath fp = FilePath::getRandomTempPath().getPathTo("test.pdf");
   ShortcutsReferenceGenerator gen(EditorCommandSet::instance());
-  gen.generatePdf(fp);
+  EXPECT_TRUE(gen.generatePdf(fp)) << "Page layout overflow!";
   EXPECT_TRUE(fp.isExistingFile());
 
   // Export again to see if it doesn't fail on already existing file.
-  gen.generatePdf(fp);
+  EXPECT_TRUE(gen.generatePdf(fp));
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Fixes the shortcuts reference PDF layout overflow (see #1120) and now makes the unit test fail if an overflow happens again in future when more shortcuts are added.

Fixes #1120.