### PR TITLE
Add alternative names to packages file format

### DIFF
--- a/libs/librepcb/core/library/pkg/package.h
+++ b/libs/librepcb/core/library/pkg/package.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../../types/simplestring.h"
 #include "../libraryelement.h"
 #include "footprint.h"
 #include "packagemodel.h"
@@ -60,6 +61,20 @@ class Package final : public LibraryElement {
 
 public:
   // Types
+  struct AlternativeName {
+    ElementName name;
+    SimpleString reference;
+
+    AlternativeName(const ElementName& name, const SimpleString& reference)
+      : name(name), reference(reference) {}
+    AlternativeName(const SExpression& node)
+      : name(deserialize<ElementName>(node.getChild("@0"))),
+        reference(deserialize<SimpleString>(node.getChild("reference/@0"))) {}
+    void serialize(SExpression& root) const {
+      root.appendChild(name);
+      root.appendChild("reference", reference);
+    }
+  };
   enum class AssemblyType {
     None,  ///< Nothing to mount (i.e. not a package, just a footprint)
     Tht,  ///< Pure THT package
@@ -78,6 +93,9 @@ public:
   ~Package() noexcept;
 
   // Getters
+  const QList<AlternativeName>& getAlternativeNames() const noexcept {
+    return mAlternativeNames;
+  }
   AssemblyType getAssemblyType(bool resolveAuto) const noexcept;
   AssemblyType guessAssemblyType() const noexcept;
   PackagePadList& getPads() noexcept { return mPads; }
@@ -117,6 +135,7 @@ private:  // Methods
           const SExpression& root);
 
 private:  // Data
+  QList<AlternativeName> mAlternativeNames;  ///< Optional
   AssemblyType mAssemblyType;  ///< Package assembly type (metadata)
   PackagePadList mPads;  ///< empty list if the package has no pads
   PackageModelList mModels;  ///< 3D models (optional)

--- a/libs/librepcb/core/workspace/workspacelibrarydb.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.h
@@ -437,7 +437,7 @@ private:
   QScopedPointer<WorkspaceLibraryScanner> mLibraryScanner;
 
   // Constants
-  static const int sCurrentDbVersion = 4;
+  static const int sCurrentDbVersion = 5;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
@@ -202,6 +202,14 @@ void WorkspaceLibraryDbWriter::createAllTables() {
       "`category_uuid` TEXT NOT NULL, "
       "UNIQUE(element_id, category_uuid)"
       ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS packages_alt ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`package_id` INTEGER "
+      "REFERENCES packages(id) ON DELETE CASCADE NOT NULL, "
+      "`name` TEXT NOT NULL, "
+      "`reference` TEXT NOT NULL"
+      ")");
 
   // components
   queries << QString(
@@ -380,6 +388,18 @@ int WorkspaceLibraryDbWriter::addPartAttribute(int partId,
   query.bindValue(
       ":unit",
       attribute.getUnit() ? attribute.getUnit()->getName() : QVariant());
+  return mDb.insert(query);
+}
+
+int WorkspaceLibraryDbWriter::addAlternativeName(
+    int pkgId, const ElementName& name, const SimpleString& reference) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO packages_alt "
+      "(package_id, name, reference) VALUES "
+      "(:package_id, :name, :reference)");
+  query.bindValue(":package_id", pkgId);
+  query.bindValue(":name", *name);
+  query.bindValue(":reference", nonNull(*reference));
   return mDb.insert(query);
 }
 

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
@@ -25,6 +25,7 @@
  ******************************************************************************/
 #include "../fileio/filepath.h"
 #include "../types/elementname.h"
+#include "../types/simplestring.h"
 
 #include <optional/tl/optional.hpp>
 
@@ -261,6 +262,17 @@ public:
                   "Unsupported ElementType");
     return addToCategory(getElementTable<ElementType>(), elementId, category);
   }
+
+  /**
+   * @brief Add an alternative name to a previously added package
+   *
+   * @param pkgId         ID of the package for this alternative name.
+   * @param name          Alternative name (mandatory).
+   * @param reference     Origin of the alternative name (optional).
+   * @return ID of the added part.
+   */
+  int addAlternativeName(int pkgId, const ElementName& name,
+                         const SimpleString& reference);
 
   // Helper Functions
 

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -316,6 +316,20 @@ int WorkspaceLibraryScanner::addElementToDb<PackageCategory>(
 }
 
 template <>
+int WorkspaceLibraryScanner::addElementToDb<Package>(
+    WorkspaceLibraryDbWriter& writer, int libId, const Package& element) {
+  const int id = writer.addElement<Package>(
+      libId, element.getDirectory().getAbsPath(), element.getUuid(),
+      element.getVersion(), element.isDeprecated());
+  addToCategories(writer, id, element);
+  foreach (const Package::AlternativeName& name,
+           element.getAlternativeNames()) {
+    writer.addAlternativeName(id, name.name, name.reference);
+  }
+  return id;
+}
+
+template <>
 int WorkspaceLibraryScanner::addElementToDb<Device>(
     WorkspaceLibraryDbWriter& writer, int libId, const Device& element) {
   const int id = writer.addDevice(


### PR DESCRIPTION
The naming of packages already lead to several discussions (IPC naming vs. JEDEC/EIAJ vs. manufacturer names) and is probably confusing users since the IPC names are not (yet) as well known as names like "SOT-23". So far, our only solution is to add these well known names to the package description (for clarity) and keywords (for the search function).

However, maybe it makes sense to explicitly specify these alternative names in packages, so that the UI can somehow make them more visible than just a description. We might consider listing packages multiple times in list views, once for each name so the user will find it for sure, no matter which name he looks for. Or maybe just show the alternative names within the list views next to the main (IPC) names.

I didn't implement anything in the UI yet, but this PR adds the necessary file format extension to package files so we can extend the UI in a minor release. But I already extended the search function to respect these alternative names, so for example our generator can already start using this feature.

File format:

```lisp
(name "DIOM5226X240")
[...some other nodes, to keep the header identical for any library element type...]
(alternative_name "DO-214AC" (reference "JEDEC DO-214"))
(alternative_name "SMA" (reference ""))
```

The `reference` is optional and can for example be set to "TI" for a Texas Instruments specific name.

~~Still thinking about renaming the node to something like `aka` or `known_as` instead of `alternative_name`...~~

/cc @dbrgn 