### PR TITLE
Support opening *.lppz projects with the editor

### DIFF
--- a/dist/installer/packages/librepcb.registerfileextensions/meta/installscript.qs
+++ b/dist/installer/packages/librepcb.registerfileextensions/meta/installscript.qs
@@ -33,6 +33,13 @@ Component.prototype.createOperations = function() {
                                    "text/plain",
                                    "\"@TargetDir@\\nightly\\bin\\librepcb.exe\"",
                                    "ProgId=LibrePCB.lpp");
+            component.addOperation("RegisterFileType",
+                                   "lppz",
+                                   "\"@TargetDir@\\nightly\\bin\\librepcb.exe\" \"%1\"",
+                                   "LibrePCB Project Archive",
+                                   "application/zip",
+                                   "\"@TargetDir@\\nightly\\bin\\librepcb.exe\"",
+                                   "ProgId=LibrePCB.lppz");
         }
 
         if (systemInfo.kernelType === "linux") {

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -206,6 +206,14 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
   createMenus();  // Depends on dock widgets!
   updateBoardActionGroup();  // Depends on menus!
 
+  // Disable actions which do not work nicely with *.lppz projects yet.
+  if (!mProject.getDirectory().isWritable()) {
+    mActionGenerateFabricationData->setEnabled(false);
+    mActionGenerateBom->setEnabled(false);
+    mActionGeneratePickPlace->setEnabled(false);
+    mActionOutputJobs->setEnabled(false);
+  }
+
   // Setup "project upgraded" message.
   {
     const QString msg = mProjectEditor.getUpgradeMessageLabelText();

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -152,6 +152,12 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
   createDockWidgets();
   createMenus();  // Depends on dock widgets!
 
+  // Disable actions which do not work nicely with *.lppz projects yet.
+  if (!mProject.getDirectory().isWritable()) {
+    mActionGenerateBom->setEnabled(false);
+    mActionOutputJobs->setEnabled(false);
+  }
+
   // Setup "project upgraded" message.
   {
     const QString msg = mProjectEditor.getUpgradeMessageLabelText();

--- a/libs/librepcb/editor/workspace/controlpanel/fileiconprovider.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/fileiconprovider.cpp
@@ -50,6 +50,8 @@ QIcon FileIconProvider::icon(const QFileInfo& info) const noexcept {
   if (info.isFile()) {
     if (info.suffix() == "lpp") {
       return QIcon(":/img/app/librepcb.png");
+    } else if (info.suffix() == "lppz") {
+      return QIcon(":/img/app/librepcb.png");  // TODO: Use zipped project icon.
     } else {
       return QIcon(":/img/places/file.png");
     }

--- a/share/icons/hicolor/scalable/mimetypes/org.librepcb.LibrePCB-archive.svg
+++ b/share/icons/hicolor/scalable/mimetypes/org.librepcb.LibrePCB-archive.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+   viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+  .st0{fill:#29D682;}
+  .st1{fill:#FFFFFF;}
+  .st2{fill:#4D4D4D;}
+  .st3{fill:none;}
+</style>
+<g id="New_Symbol-3">
+  <g id="_Group_2_2_">
+    <g>
+      <g id="_Group_3_2_">
+        <g id="_Group_4_2_">
+          <path class="st0" d="M0.8,255.9L0.8,255.9c0,140.8,114.2,255,255,255h0c140.8,0,255-114.2,255-255v0c0-140.8-114.2-255-255-255
+            h0C115,0.9,0.8,115.1,0.8,255.9z"/>
+        </g>
+      </g>
+    </g>
+  </g>
+  <rect x="291.5" y="340" class="st1" width="28.5" height="72.1"/>
+  <rect x="241.6" y="340" class="st1" width="28.5" height="72.1"/>
+  <rect x="191.7" y="340" class="st1" width="28.5" height="72.1"/>
+  <rect x="291.5" y="99.7" class="st1" width="28.5" height="72.1"/>
+  <rect x="241.6" y="99.7" class="st1" width="28.5" height="72.1"/>
+  <rect x="191.7" y="99.7" class="st1" width="28.5" height="72.1"/>
+  <rect x="99.6" y="291.5" class="st1" width="72" height="28.5"/>
+  <rect x="99.6" y="241.6" class="st1" width="72" height="28.5"/>
+  <rect x="99.6" y="191.7" class="st1" width="72" height="28.5"/>
+  <rect x="340" y="291.5" class="st1" width="72" height="28.5"/>
+  <rect x="340" y="241.6" class="st1" width="72" height="28.5"/>
+  <rect x="340" y="191.7" class="st1" width="72" height="28.5"/>
+  <path class="st2" d="M327.8,158.9c13.9,0,25.1,11.3,25,25.1v143.8c0,13.9-11.2,25.1-25.1,25.1H183.9c-13.9,0-25.1-11.2-25.1-25.1
+    V184c0,0,0,0,0-0.1c0-13.9,11.2-25.1,25.1-25.1L327.8,158.9C327.8,158.9,327.8,158.9,327.8,158.9z"/>
+  <path class="st1" d="M197.8,221.6c10.4,0,18.8-8.4,18.8-18.8c0-10.4-8.4-18.8-18.8-18.8c-10.4,0-18.8,8.4-18.8,18.8
+    C179,213.2,187.4,221.6,197.8,221.6C197.8,221.6,197.8,221.6,197.8,221.6z"/>
+  <rect class="st3" width="512" height="512"/>
+</g>
+</svg>

--- a/share/mime/packages/org.librepcb.LibrePCB.xml
+++ b/share/mime/packages/org.librepcb.LibrePCB.xml
@@ -18,4 +18,10 @@
     </magic>
     <icon name="org.librepcb.LibrePCB-project"/>
   </mime-type>
+  <mime-type type="application/x-librepcb-project-archive">
+    <sub-class-of type="application/zip"/>
+    <comment>LibrePCB Project Archive</comment>
+    <glob pattern="*.lppz"/>
+    <icon name="org.librepcb.LibrePCB-archive"/>
+  </mime-type>
 </mime-info>

--- a/tests/funq/commandline/test_open_project.py
+++ b/tests/funq/commandline/test_open_project.py
@@ -6,12 +6,27 @@ Test opening projects by command line arguments
 """
 
 
-def test_open_project(librepcb, helpers):
+def test_open_lpp(librepcb, helpers):
     """
-    Open project by command line argument
+    Open *.lpp project by command line argument
     """
     librepcb.add_project('Empty Project')
     librepcb.set_project('Empty Project/Empty Project.lpp')
+    with librepcb.open() as app:
+        # Check if both editors were opened
+        assert app.widget('schematicEditor').properties()['visible'] is True
+        assert app.widget('boardEditor').properties()['visible'] is True
+
+        # Check if the schematic editor is the active window
+        helpers.wait_for_active_window(app, app.widget('schematicEditor'))  # raises on timeout
+
+
+def test_open_lppz(librepcb, helpers):
+    """
+    Open *.lppz project by command line argument
+    """
+    librepcb.add_project('Empty Project', as_lppz=True)
+    librepcb.set_project('Empty Project.lppz')
     with librepcb.open() as app:
         # Check if both editors were opened
         assert app.widget('schematicEditor').properties()['visible'] is True


### PR DESCRIPTION
So far, the GUI only allowed to open *.lpp project files, but not zipped *.lppz projects. But since *.lppz projects can now very easily be generated for every PCB version with the output files generator, users may start creating *.lppz project snapshots to allow opening previous PCB versions without checking out a different Git tag or so.

But so far, *.lppz projects could only be opened with the CLI, not with the GUI. This PR changes that. *.lppz projects are now opened read-only and the *.lppz file extension is registered to the desktop environment the same way as *.lpp projects.