### PR TITLE
Board editor: Render pad & via texts with Fontobene

### DIFF
--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
@@ -45,7 +45,6 @@ namespace editor {
 
 class OriginCrossGraphicsItem;
 class PrimitivePathGraphicsItem;
-class PrimitiveTextGraphicsItem;
 
 /*******************************************************************************
  *  Class PrimitiveFootprintPadGraphicsItem
@@ -95,7 +94,7 @@ private:  // Data
   bool mMirror;
   std::shared_ptr<GraphicsLayer> mCopperLayer;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
-  QScopedPointer<PrimitiveTextGraphicsItem> mTextGraphicsItem;
+  QScopedPointer<PrimitivePathGraphicsItem> mTextGraphicsItem;
   struct PathItem {
     std::shared_ptr<GraphicsLayer> layer;
     bool isCopper;

--- a/libs/librepcb/editor/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivepathgraphicsitem.cpp
@@ -43,6 +43,7 @@ PrimitivePathGraphicsItem::PrimitivePathGraphicsItem(
     mMirror(false),
     mLineLayer(nullptr),
     mFillLayer(nullptr),
+    mLighterColors(false),
     mShapeMode(ShapeMode::StrokeAndAreaByLayer),
     mBoundingRectMarginPx(0),
     mOnLayerEditedSlot(*this, &PrimitivePathGraphicsItem::layerEdited) {
@@ -119,6 +120,11 @@ void PrimitivePathGraphicsItem::setFillLayer(
   updateBoundingRectAndShape();  // grab area may have changed
 }
 
+void PrimitivePathGraphicsItem::setLighterColors(bool lighter) noexcept {
+  mLighterColors = lighter;
+  updateColors();
+}
+
 void PrimitivePathGraphicsItem::setShapeMode(ShapeMode mode) noexcept {
   mShapeMode = mode;
   updateBoundingRectAndShape();
@@ -178,8 +184,8 @@ void PrimitivePathGraphicsItem::updateColors() noexcept {
   if (mLineLayer && mLineLayer->isVisible()) {
     mPen.setStyle(Qt::SolidLine);
     mPenHighlighted.setStyle(Qt::SolidLine);
-    mPen.setColor(mLineLayer->getColor(false));
-    mPenHighlighted.setColor(mLineLayer->getColor(true));
+    mPen.setColor(convertColor(mLineLayer->getColor(false)));
+    mPenHighlighted.setColor(convertColor(mLineLayer->getColor(true)));
   } else {
     mPen.setStyle(Qt::NoPen);
     mPenHighlighted.setStyle(Qt::NoPen);
@@ -188,8 +194,8 @@ void PrimitivePathGraphicsItem::updateColors() noexcept {
   if (mFillLayer && mFillLayer->isVisible()) {
     mBrush.setStyle(Qt::SolidPattern);
     mBrushHighlighted.setStyle(Qt::SolidPattern);
-    mBrush.setColor(mFillLayer->getColor(false));
-    mBrushHighlighted.setColor(mFillLayer->getColor(true));
+    mBrush.setColor(convertColor(mFillLayer->getColor(false)));
+    mBrushHighlighted.setColor(convertColor(mFillLayer->getColor(true)));
   } else {
     mBrush.setStyle(Qt::NoBrush);
     mBrushHighlighted.setStyle(Qt::NoBrush);
@@ -213,6 +219,11 @@ void PrimitivePathGraphicsItem::updateBoundingRectAndShape() noexcept {
 
 void PrimitivePathGraphicsItem::updateVisibility() noexcept {
   setVisible((mPen.style() != Qt::NoPen) || (mBrush.style() != Qt::NoBrush));
+}
+
+QColor PrimitivePathGraphicsItem::convertColor(const QColor& color) const
+    noexcept {
+  return mLighterColors ? color.lighter(200) : color;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/graphics/primitivepathgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivepathgraphicsitem.h
@@ -78,6 +78,7 @@ public:
   void setLineWidth(const UnsignedLength& width) noexcept;
   void setLineLayer(const std::shared_ptr<GraphicsLayer>& layer) noexcept;
   void setFillLayer(const std::shared_ptr<GraphicsLayer>& layer) noexcept;
+  void setLighterColors(bool lighter) noexcept;
   void setShapeMode(ShapeMode mode) noexcept;
 
   // Inherited from QGraphicsItem
@@ -100,11 +101,13 @@ private:  // Methods
   void updateColors() noexcept;
   void updateBoundingRectAndShape() noexcept;
   void updateVisibility() noexcept;
+  QColor convertColor(const QColor& color) const noexcept;
 
 protected:  // Data
   bool mMirror;
   std::shared_ptr<GraphicsLayer> mLineLayer;
   std::shared_ptr<GraphicsLayer> mFillLayer;
+  bool mLighterColors;
   ShapeMode mShapeMode;
   QPen mPen;
   QPen mPenHighlighted;

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_via.h
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_via.h
@@ -41,6 +41,8 @@ class NetSignal;
 
 namespace editor {
 
+class PrimitivePathGraphicsItem;
+
 /*******************************************************************************
  *  Class BGI_Via
  ******************************************************************************/
@@ -76,9 +78,13 @@ private:  // Methods
   void viaEdited(const BI_Via& obj, BI_Via::Event event) noexcept;
   void layerEdited(const GraphicsLayer& layer,
                    GraphicsLayer::Event event) noexcept;
+  virtual QVariant itemChange(GraphicsItemChange change,
+                              const QVariant& value) noexcept override;
   void updatePosition() noexcept;
   void updateShapes() noexcept;
   void updateToolTip() noexcept;
+  void updateText() noexcept;
+  void updateTextHeight() noexcept;
   void updateVisibility() noexcept;
   void attachToCopperLayers() noexcept;
 
@@ -90,6 +96,7 @@ private:  // Data
   std::shared_ptr<GraphicsLayer> mViaLayer;
   std::shared_ptr<GraphicsLayer> mTopStopMaskLayer;
   std::shared_ptr<GraphicsLayer> mBottomStopMaskLayer;
+  QScopedPointer<PrimitivePathGraphicsItem> mTextGraphicsItem;
 
   /// Copper layers for blind- and buried vias (empty for through-hole vias)
   QVector<std::shared_ptr<GraphicsLayer>> mBlindBuriedCopperLayers;
@@ -100,7 +107,7 @@ private:  // Data
   QPainterPath mStopMaskTop;
   QPainterPath mStopMaskBottom;
   QRectF mBoundingRect;
-  QFont mFont;
+  QString mText;
 
   // Slots
   BI_Via::OnEditedSlot mOnEditedSlot;


### PR DESCRIPTION
So far the texts within pads and vias (pad number resp. net name) were drawn with a TrueType font, but it turned out this rendering was a huge performance bottleneck, slowing down the whole board editor on large designs. Especially on Windows the board editor became basically unusable (depending on zoom level).

Now rendering these texts with a Fontobene stroke font which is much faster.