### PR TITLE
CI: Make build_mac_bundle.sh working on Apple Silicon

### DIFF
--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -19,9 +19,29 @@ dylibbundler -ns -od -b \
   -x LibrePCB-CLI.app/Contents/MacOS/librepcb-cli \
   -d LibrePCB-CLI.app/Contents/Frameworks/ \
   -p @executable_path/../Frameworks/
-macdeployqt "LibrePCB.app" -dmg -always-overwrite \
-  -qmldir=./LibrePCB.app/Contents/share/librepcb/qml
-macdeployqt "LibrePCB-CLI.app" -dmg -always-overwrite
+if [ "$ARCH" = "arm64" ]
+then
+  # Not run on CI (yet), but here to allow running it locally on a Apple
+  # Silicon Mac. Apple Silicon requires the binary to be signed, but
+  # somehow macdeployqt fails on that so we have to do it manually.
+  # Requirement: brew install create-dmg
+  macdeployqt "LibrePCB.app" -always-overwrite \
+    -qmldir=./LibrePCB.app/Contents/share/librepcb/qml
+  macdeployqt "LibrePCB-CLI.app" -always-overwrite
+  codesign --force --deep -s - ./LibrePCB.app/Contents/MacOS/librepcb
+  codesign --force --deep -s - ./LibrePCB-CLI.app/Contents/MacOS/librepcb-cli
+  create-dmg --skip-jenkins --volname "LibrePCB" \
+    --volicon ./LibrePCB.app/Contents/Resources/librepcb.icns \
+    ./LibrePCB.dmg ./LibrePCB.app
+  create-dmg --skip-jenkins --volname "LibrePCB-CLI" \
+    --volicon ./LibrePCB-CLI.app/Contents/Resources/librepcb.icns \
+    ./LibrePCB-CLI.dmg ./LibrePCB-CLI.app
+else
+  # On x86_64, directly create the *.dmg with macdeployqt.
+  macdeployqt "LibrePCB.app" -dmg -always-overwrite \
+    -qmldir=./LibrePCB.app/Contents/share/librepcb/qml
+  macdeployqt "LibrePCB-CLI.app" -dmg -always-overwrite
+fi
 popd
 
 # Restore lowercase app names for backwards compatibility with installers
@@ -33,5 +53,5 @@ mv "./build/install/opt/LibrePCB-CLI.app" "./build/install/opt/librepcb-cli.app"
 ./build/install/opt/librepcb.app/Contents/MacOS/librepcb --exit-after-startup
 
 # Move bundles to artifacts directory
-mv ./build/install/opt/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-x86_64.dmg
-mv ./build/install/opt/LibrePCB-CLI.dmg ./artifacts/nightly_builds/librepcb-cli-nightly-mac-x86_64.dmg
+mv ./build/install/opt/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-$ARCH.dmg
+mv ./build/install/opt/LibrePCB-CLI.dmg ./artifacts/nightly_builds/librepcb-cli-nightly-mac-$ARCH.dmg


### PR DESCRIPTION
It seems on Apple Silicon all binaries need to be signed, otherwise they won't run. Thus adjusted the bundle build script to create somehow signed binaries. Although that's not yet needed on CI (since we don't have an arm64 runner), it allows to run the script locally on Apple Silicon.