### PR TITLE
Fix using legacy 'PARTNUMBER' attribute as default value

### DIFF
--- a/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
+++ b/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
@@ -64,8 +64,8 @@ MsgMissingComponentDefaultValue::MsgMissingComponentDefaultValue() noexcept
            "Generic parts (e.g. a diode): %1\n"
            "Specific parts (e.g. a microcontroller): %2\n"
            "Passive parts: Using an attribute, e.g. %3")
-            .arg("'{{PARTNUMBER or DEVICE}}'",
-                 "'{{PARTNUMBER or DEVICE or COMPONENT}}'", "'{{RESISTANCE}}'"),
+            .arg("'{{MPN or DEVICE}}'", "'{{MPN or DEVICE or COMPONENT}}'",
+                 "'{{RESISTANCE}}'"),
         "empty_default_value") {
 }
 

--- a/libs/librepcb/eagleimport/eaglelibraryimport.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryimport.cpp
@@ -535,7 +535,7 @@ void EagleLibraryImport::run() noexcept {
       component->setCategories(mComponentCategories);
       component->setPrefixes(NormDependentPrefixMap(
           ComponentPrefix(cmp.deviceSet->getPrefix().trimmed())));
-      component->setDefaultValue("{{ PARTNUMBER or DEVICE }}");
+      component->setDefaultValue("{{ MPN or DEVICE }}");
       auto symbolVariant = std::make_shared<ComponentSymbolVariant>(
           Uuid::createRandom(), "", ElementName("default"), "");
       component->getSymbolVariants().append(symbolVariant);

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
@@ -314,10 +314,10 @@ void ComponentEditorWidget::fixMsg(const MsgMissingComponentDefaultValue& msg) {
   int answer = QMessageBox::question(this, title, question, QMessageBox::Cancel,
                                      QMessageBox::Yes, QMessageBox::No);
   if (answer == QMessageBox::Yes) {
-    mUi->edtDefaultValue->setPlainText("{{PARTNUMBER or DEVICE or COMPONENT}}");
+    mUi->edtDefaultValue->setPlainText("{{MPN or DEVICE or COMPONENT}}");
     commitMetadata();
   } else if (answer == QMessageBox::No) {
-    mUi->edtDefaultValue->setPlainText("{{PARTNUMBER or DEVICE}}");
+    mUi->edtDefaultValue->setPlainText("{{MPN or DEVICE}}");
     commitMetadata();
   }
 }


### PR DESCRIPTION
The attribute `PARTNUMBER` has been renamed to `MPN` in v1.0, but the library editor still recommended it as the default component value. Replacing it by `MPN` now.