### PR TITLE
WorkspaceLibraryScanner: Do not warn about empty directories

### DIFF
--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -146,7 +146,9 @@ QStringList Library::searchForElements() const noexcept {
     QString dirPath = subdir % "/" % dirname;
     if (isValidElementDirectory<ElementType>(*mDirectory, dirPath)) {
       list.append(dirPath);
-    } else {
+    } else if (!mDirectory->getFiles(dirPath).isEmpty()) {
+      // Note: Do not warn about empty directories since this happens often
+      // when switching branches, leading to annoying warnings.
       qWarning() << "Directory is not a valid library element, ignoring it:"
                  << mDirectory->getAbsPath(dirPath).toNative();
     }

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -199,7 +199,7 @@ void WorkspaceLibraryScanner::getLibrariesOfDirectory(
         qCritical() << "Library:" << fp.toNative();
         qCritical() << "Error:" << e.getMsg();
       }
-    } else {
+    } else if (!fp.isEmptyDir()) {
       qWarning() << "Directory is not a valid library, ignoring it:"
                  << fp.toNative();
     }


### PR DESCRIPTION
So far, the background library scanner emitted warnings to `stderr` for each directory within workspace libraries not containing a valid library element. This is useful to locate issues if a library element does not appear in the library editor for some reason.

However, especially when working with Git it happens often that empty directories are left over, leading to such warnings although there's nothing bad going on. Thus now only emitting these warnings on **non-empty** directories which do not contain valid library elements.

An alternative would be to automatically delete empty directories (tidying up the workspace), but this might be a little bit dangerous (e.g. causing race conditions with another operation just creating a new directory in a different thread or outside of LibrePCB) so I'm not sure if that's a good idea.