### PR TITLE
Suppress warning on stderr caused by argv[0]

### DIFF
--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -659,19 +659,23 @@ bool ControlPanel::closeAllLibraryEditors(bool askForSave) noexcept {
  ******************************************************************************/
 
 void ControlPanel::openProjectsPassedByCommandLine() noexcept {
-  // parse command line arguments and open all project files
-  foreach (const QString& arg, qApp->arguments()) {
-    openProjectPassedByOs(arg);
+  // Parse command line arguments and open all project files.
+  // Note: Do not print a warning if the first argument is not a valid project,
+  // since it might or might not be the application file path.
+  const QStringList args = qApp->arguments();
+  for (int i = 0; i < args.count(); ++i) {
+    openProjectPassedByOs(args.at(i), i == 0);  // Silent on first item.
   }
 }
 
-void ControlPanel::openProjectPassedByOs(const QString& file) noexcept {
+void ControlPanel::openProjectPassedByOs(const QString& file,
+                                         bool silent) noexcept {
   FilePath filepath(file);
   if ((filepath.isExistingFile()) &&
       ((filepath.getSuffix() == "lpp") || (filepath.getSuffix() == "lppz"))) {
     openProject(filepath);
-  } else {
-    qDebug() << "Ignore invalid request to open project:" << file;
+  } else if (!silent) {
+    qWarning() << "Ignore invalid request to open project:" << file;
   }
 }
 

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -88,7 +88,7 @@ protected:
 private slots:
   // private slots
   void openProjectsPassedByCommandLine() noexcept;
-  void openProjectPassedByOs(const QString& file) noexcept;
+  void openProjectPassedByOs(const QString& file, bool silent = false) noexcept;
   void projectEditorClosed() noexcept;
 
   // Actions


### PR DESCRIPTION
LibrePCB tries to open all project files passed as arguments to the process. Arguments with an extension other than `.lpp` or `.lppz` are ignored and a warning is printed on `stderr` (useful for debugging issues if opening projects does not work).

However, `argv[0]` usually (but not absolutely always) contains the path to the application executable, causing such a warning to be printed every time which is a bit ugly. Thus now suppressing the warning on `argv[0]`, but still printing it on any additional argument.