### PR TITLE
Library editor: Fix possible layout issue of banner

### DIFF
--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
    <property name="spacing">
     <number>0</number>
    </property>

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.ui
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,1">
    <property name="spacing">
     <number>0</number>
    </property>

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.ui
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
    <property name="spacing">
     <number>0</number>
    </property>


### PR DESCRIPTION
On some systems the yellow warning banner in the library editor was too large, caused by a wrong layout stretch factor.