### PR TITLE
Fix possibly broken copy&paste in editors on some systems

### DIFF
--- a/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
@@ -98,9 +98,14 @@ std::unique_ptr<QMimeData> FootprintClipboardData::toMimeData(
   mHoles.serialize(root);
   root.ensureLineBreak();
 
+  const QByteArray sexpr = root.toByteArray();
   std::unique_ptr<QMimeData> data(new QMimeData());
   data->setImageData(generatePixmap(lp));
-  data->setData(getMimeType(), root.toByteArray());
+  data->setData(getMimeType(), sexpr);
+  // Note: At least on one system the clipboard didn't work if no text was
+  // set, so let's also copy the SExpression as text as a workaround. This
+  // might be useful anyway, e.g. for debugging purposes.
+  data->setText(QString::fromUtf8(sexpr));
   return data;
 }
 

--- a/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
+++ b/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
@@ -81,9 +81,14 @@ std::unique_ptr<QMimeData> SymbolClipboardData::toMimeData(
   mTexts.serialize(root);
   root.ensureLineBreak();
 
+  const QByteArray sexpr = root.toByteArray();
   std::unique_ptr<QMimeData> data(new QMimeData());
   data->setImageData(generatePixmap(lp));
-  data->setData(getMimeType(), root.toByteArray());
+  data->setData(getMimeType(), sexpr);
+  // Note: At least on one system the clipboard didn't work if no text was
+  // set, so let's also copy the SExpression as text as a workaround. This
+  // might be useful anyway, e.g. for debugging purposes.
+  data->setText(QString::fromUtf8(sexpr));
   return data;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddata.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddata.cpp
@@ -160,14 +160,18 @@ std::unique_ptr<QMimeData> BoardClipboardData::toMimeData() const {
     root.appendChild(child);
   }
   root.ensureLineBreak();
-  mFileSystem->write("board.lp", root.toByteArray());
 
-  QByteArray zip = mFileSystem->exportToZip();
+  const QByteArray sexpr = root.toByteArray();
+  mFileSystem->write("board.lp", sexpr);
+  const QByteArray zip = mFileSystem->exportToZip();
 
   std::unique_ptr<QMimeData> data(new QMimeData());
   data->setData(getMimeType(), zip);
   data->setData("application/zip", zip);
-  data->setText(root.toByteArray());  // TODO: Remove this
+  // Note: At least on one system the clipboard didn't work if no text was
+  // set, so let's also copy the SExpression as text as a workaround. This
+  // might be useful anyway, e.g. for debugging purposes.
+  data->setText(QString::fromUtf8(sexpr));
   return data;
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.cpp
@@ -111,13 +111,18 @@ std::unique_ptr<QMimeData> SchematicClipboardData::toMimeData() const {
   root.ensureLineBreak();
   mTexts.serialize(root);
   root.ensureLineBreak();
-  mFileSystem->write("schematic.lp", root.toByteArray());
 
-  QByteArray zip = mFileSystem->exportToZip();
+  const QByteArray sexpr = root.toByteArray();
+  mFileSystem->write("schematic.lp", sexpr);
+  const QByteArray zip = mFileSystem->exportToZip();
 
   std::unique_ptr<QMimeData> data(new QMimeData());
   data->setData(getMimeType(), zip);
   data->setData("application/zip", zip);
+  // Note: At least on one system the clipboard didn't work if no text was
+  // set, so let's also copy the SExpression as text as a workaround. This
+  // might be useful anyway, e.g. for debugging purposes.
+  data->setText(QString::fromUtf8(sexpr));
   return data;
 }
 


### PR DESCRIPTION
At least on one system the clipboard didn't work if no text was set, so let's also copy the `SExpression` as `text/plain` (beside the binary data) into the clipboard as a workaround. Might even be just a temporary bug in the clipboard manager of my system but it's hard to find the root cause and being able to paste the `SExpression` into a text editor might be useful anyway, e.g. for debugging purposes.