### PR TITLE
Use lighter red/yellow background colors in parts table

### DIFF
--- a/libs/librepcb/editor/library/dev/partlistmodel.cpp
+++ b/libs/librepcb/editor/library/dev/partlistmodel.cpp
@@ -188,10 +188,12 @@ QVariant PartListModel::data(const QModelIndex& index, int role) const {
 
   std::shared_ptr<Part> item = mPartList->value(index.row());
 
+  const QBrush bgRed(QColor(255, 0, 0, 80));
+  const QBrush bgYellow(QColor(255, 255, 0, 120));
   if ((!item) && (mPartList->isEmpty()) && (role == Qt::BackgroundRole)) {
-    return QBrush(Qt::red);
+    return bgRed;
   } else if ((item) && (item->isEmpty()) && (role == Qt::BackgroundRole)) {
-    return QBrush(Qt::red);
+    return bgRed;
   }
 
   switch (index.column()) {
@@ -205,9 +207,8 @@ QVariant PartListModel::data(const QModelIndex& index, int role) const {
               ? QVariant()
               : tr("Exact manufacturer part number (without placeholders)");
         case Qt::BackgroundRole:
-          return (item && item->getMpn()->isEmpty())
-              ? QVariant(QBrush(Qt::yellow))
-              : QVariant();
+          return (item && item->getMpn()->isEmpty()) ? QVariant(bgYellow)
+                                                     : QVariant();
         default:
           return QVariant();
       }
@@ -221,7 +222,7 @@ QVariant PartListModel::data(const QModelIndex& index, int role) const {
           return item ? QVariant() : tr("Name of the manufacturer");
         case Qt::BackgroundRole:
           return (item && item->getManufacturer()->isEmpty())
-              ? QVariant(QBrush(Qt::yellow))
+              ? QVariant(bgYellow)
               : QVariant();
         default:
           return QVariant();

--- a/libs/librepcb/editor/project/componentassemblyoptionlisteditorwidget.cpp
+++ b/libs/librepcb/editor/project/componentassemblyoptionlisteditorwidget.cpp
@@ -454,8 +454,11 @@ void ComponentAssemblyOptionListEditorWidget::optionListEdited(
     return;
   }
 
-  auto fillOptionRow = [this](QTreeWidgetItem* item,
-                              const ComponentAssemblyOption& option) {
+  const QBrush bgRed(QColor(255, 0, 0, 80));
+  const QBrush bgYellow(QColor(255, 255, 0, 120));
+
+  auto fillOptionRow = [this, &bgRed](QTreeWidgetItem* item,
+                                      const ComponentAssemblyOption& option) {
     item->setIcon(COLUMN_DEVICE, QIcon(":/img/library/device.png"));
     QString devName = option.getDevice().toStr().left(8) % "...";
     QString toolTip;
@@ -500,12 +503,12 @@ void ComponentAssemblyOptionListEditorWidget::optionListEdited(
                       ? QVariant()
                       : QVariant(inAnyVariants ? Qt::Checked : Qt::Unchecked));
     item->setData(COLUMN_MOUNT, Qt::UserRole, QVariant::fromValue(avItems));
-    item->setBackground(COLUMN_MOUNT,
-                        inAnyVariants ? QBrush() : QBrush(Qt::red));
+    item->setBackground(COLUMN_MOUNT, inAnyVariants ? QBrush() : bgRed);
   };
 
-  auto fillPartRow = [](QTreeWidgetItem* item, std::shared_ptr<const Part> part,
-                        int index) {
+  auto fillPartRow = [&bgRed, &bgYellow](QTreeWidgetItem* item,
+                                         std::shared_ptr<const Part> part,
+                                         int index) {
     if (index > 0) {
       item->setText(COLUMN_DEVICE, "↳ " % tr("Alternative %1:").arg(index));
     }
@@ -513,19 +516,16 @@ void ComponentAssemblyOptionListEditorWidget::optionListEdited(
     item->setText(COLUMN_MPN, part ? *part->getMpn() : QString());
     item->setBackground(
         COLUMN_MPN,
-        (!part) ? QBrush(Qt::red)
-                : (part->getMpn()->isEmpty() ? QBrush(Qt::yellow) : QBrush()));
+        (!part) ? bgRed : (part->getMpn()->isEmpty() ? bgYellow : QBrush()));
     item->setText(COLUMN_MANUFACTURER,
                   part ? *part->getManufacturer() : QString());
     item->setBackground(
         COLUMN_MANUFACTURER,
-        (!part) ? QBrush(Qt::red)
-                : (part->getManufacturer()->isEmpty() ? QBrush(Qt::yellow)
-                                                      : QBrush()));
+        (!part) ? bgRed
+                : (part->getManufacturer()->isEmpty() ? bgYellow : QBrush()));
     item->setText(COLUMN_ATTRIBUTES,
                   part ? part->getAttributeValuesTr().join(" ") : QString());
-    item->setBackground(COLUMN_ATTRIBUTES,
-                        (!part) ? QBrush(Qt::red) : QBrush());
+    item->setBackground(COLUMN_ATTRIBUTES, (!part) ? bgRed : QBrush());
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsEditable |
                    Qt::ItemIsUserCheckable | Qt::ItemIsSelectable);
   };


### PR DESCRIPTION
Because @dbrgn was scared by the strong red color :grin:

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/a9f8feb1-9f98-42ad-baaa-99c4066510a7)