### PR TITLE
Show deprecated library elements with red color

### DIFF
--- a/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
+++ b/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
@@ -159,7 +159,11 @@ void ComponentChooserDialog::searchComponents(const QString& input) {
       QString name;
       mWorkspace.getLibraryDb().getTranslations<Component>(fp, localeOrder(),
                                                            &name);  // can throw
+      bool deprecated = false;
+      mWorkspace.getLibraryDb().getMetadata<Component>(
+          fp, nullptr, nullptr, &deprecated);  // can throw
       QListWidgetItem* item = new QListWidgetItem(name);
+      item->setForeground(deprecated ? QBrush(Qt::red) : QBrush());
       item->setData(Qt::UserRole, uuid.toStr());
       mUi->listComponents->addItem(item);
     }
@@ -186,7 +190,11 @@ void ComponentChooserDialog::setSelectedCategory(
         mWorkspace.getLibraryDb().getTranslations<Component>(
             fp, localeOrder(),
             &name);  // can throw
+        bool deprecated = false;
+        mWorkspace.getLibraryDb().getMetadata<Component>(
+            fp, nullptr, nullptr, &deprecated);  // can throw
         QListWidgetItem* item = new QListWidgetItem(name);
+        item->setForeground(deprecated ? QBrush(Qt::red) : QBrush());
         item->setData(Qt::UserRole, cmpUuid.toStr());
         mUi->listComponents->addItem(item);
       } catch (const Exception& e) {

--- a/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/packagechooserdialog.cpp
@@ -157,7 +157,11 @@ void PackageChooserDialog::searchPackages(const QString& input) {
       QString name;
       mWorkspace.getLibraryDb().getTranslations<Package>(fp, localeOrder(),
                                                          &name);  // can throw
+      bool deprecated = false;
+      mWorkspace.getLibraryDb().getMetadata<Package>(fp, nullptr, nullptr,
+                                                     &deprecated);  // can throw
       QListWidgetItem* item = new QListWidgetItem(name);
+      item->setForeground(deprecated ? QBrush(Qt::red) : QBrush());
       item->setData(Qt::UserRole, uuid.toStr());
       mUi->listPackages->addItem(item);
     }
@@ -183,7 +187,11 @@ void PackageChooserDialog::setSelectedCategory(
         QString name;
         mWorkspace.getLibraryDb().getTranslations<Package>(fp, localeOrder(),
                                                            &name);  // can throw
+        bool deprecated = false;
+        mWorkspace.getLibraryDb().getMetadata<Package>(
+            fp, nullptr, nullptr, &deprecated);  // can throw
         QListWidgetItem* item = new QListWidgetItem(name);
+        item->setForeground(deprecated ? QBrush(Qt::red) : QBrush());
         item->setData(Qt::UserRole, pkgUuid.toStr());
         mUi->listPackages->addItem(item);
       } catch (const Exception& e) {

--- a/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
+++ b/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
@@ -175,7 +175,11 @@ void SymbolChooserDialog::searchSymbols(const QString& input) {
       QString name;
       mWorkspace.getLibraryDb().getTranslations<Symbol>(fp, localeOrder(),
                                                         &name);  // can throw
+      bool deprecated = false;
+      mWorkspace.getLibraryDb().getMetadata<Symbol>(fp, nullptr, nullptr,
+                                                    &deprecated);  // can throw
       QListWidgetItem* item = new QListWidgetItem(name);
+      item->setForeground(deprecated ? QBrush(Qt::red) : QBrush());
       item->setData(Qt::UserRole, fp.toStr());
       mUi->listSymbols->addItem(item);
     }
@@ -196,13 +200,18 @@ void SymbolChooserDialog::setSelectedCategory(
         mWorkspace.getLibraryDb().getByCategory<Symbol>(uuid);  // can throw
     foreach (const Uuid& symbolUuid, symbols) {
       try {
-        QString symName;
-        FilePath symFp = mWorkspace.getLibraryDb().getLatest<Symbol>(
+        FilePath fp = mWorkspace.getLibraryDb().getLatest<Symbol>(
             symbolUuid);  // can throw
-        mWorkspace.getLibraryDb().getTranslations<Symbol>(
-            symFp, localeOrder(), &symName);  // can throw
-        QListWidgetItem* item = new QListWidgetItem(symName);
-        item->setData(Qt::UserRole, symFp.toStr());
+        QString name;
+        mWorkspace.getLibraryDb().getTranslations<Symbol>(fp, localeOrder(),
+                                                          &name);  // can throw
+        bool deprecated = false;
+        mWorkspace.getLibraryDb().getMetadata<Symbol>(
+            fp, nullptr, nullptr,
+            &deprecated);  // can throw
+        QListWidgetItem* item = new QListWidgetItem(name);
+        item->setForeground(deprecated ? QBrush(Qt::red) : QBrush());
+        item->setData(Qt::UserRole, fp.toStr());
         mUi->listSymbols->addItem(item);
       } catch (const Exception& e) {
         continue;  // should we do something here?

--- a/libs/librepcb/editor/project/addcomponentdialog.h
+++ b/libs/librepcb/editor/project/addcomponentdialog.h
@@ -74,6 +74,7 @@ class AddComponentDialog final : public QDialog {
   struct SearchResultDevice {
     tl::optional<Uuid> uuid;
     QString name;
+    bool deprecated = false;
     FilePath pkgFp;
     QString pkgName;
     PartList parts;
@@ -82,6 +83,7 @@ class AddComponentDialog final : public QDialog {
 
   struct SearchResultComponent {
     QString name;
+    bool deprecated = false;
     QHash<FilePath, SearchResultDevice> devices;
     bool match = false;
   };


### PR DESCRIPTION
In most list views, draw deprecated library elements with red color. Otherwise the user has no chance to know these library elements should no longer be used. By far not perfect yet, but still much better than nothing...

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/6400c8fb-f513-46e6-be52-8e17fe345e40)