### PR TITLE
CLI: Implement new command 'open-step'

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -345,6 +345,7 @@ int CommandLineInterface::execute(const QStringList& args) noexcept {
   // --verbose
   if (parser.isSet(verboseOption)) {
     Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::All);
+    OccModel::setVerboseOutput(true);
   }
 
   // --help (also shown if no arguments supplied)

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -84,10 +84,14 @@ int CommandLineInterface::execute(const QStringList& args) noexcept {
   QMap<QString, QPair<QString, QString>> commands = {
       {"open-project",
        {tr("Open a project to execute project-related tasks."),
-        tr("open-project [command_options]")}},
+        "open-project [command_options]"}},  // no tr()!
       {"open-library",
        {tr("Open a library to execute library-related tasks."),
-        tr("open-library [command_options]")}},
+        "open-library [command_options]"}},  // no tr()!
+      {"open-step",
+       {tr("Open a STEP model to execute STEP-related tasks outside of a "
+           "library."),
+        "open-step [command_options]"}},  // no tr()!
   };
 
   // Add global options
@@ -259,6 +263,24 @@ int CommandLineInterface::execute(const QStringList& args) noexcept {
       tr("Fail if the opened files are not strictly canonical, i.e. "
          "there would be changes when saving the library elements."));
 
+  // Define options for "open-step"
+  QCommandLineOption stepMinifyOption(
+      "minify",
+      tr("Minify the STEP model before validating it. Use in conjunction with "
+         "'%1' to save the output of the operation.")
+          .arg("--save-to"));
+  QCommandLineOption stepTesselateOption(
+      "tesselate",
+      tr("Tesselate the loaded STEP model to check if LibrePCB is able to "
+         "render it. Reports failure (exit code = 1) if no content is "
+         "detected."));
+  QCommandLineOption stepSaveToOption(
+      "save-to",
+      tr("Write the (modified) STEP file to this output location (may be equal "
+         "to the opened file path). Only makes sense in conjunction with '%1'.")
+          .arg("--minify"),
+      tr("file"));
+
   // Build help text.
   const QString executable = args.value(0);
   QString helpText = parser.helpText() % "\n" % tr("Commands:") % "\n";
@@ -319,6 +341,15 @@ int CommandLineInterface::execute(const QStringList& args) noexcept {
     parser.addOption(libMinifyStepOption);
     parser.addOption(libSaveOption);
     parser.addOption(libStrictOption);
+  } else if (command == "open-step") {
+    parser.addPositionalArgument(command, commands[command].first,
+                                 commands[command].second);
+    parser.addPositionalArgument(
+        "file", tr("Path to the STEP file (%1).").arg("*.step"));
+    positionalArgNames.append("file");
+    parser.addOption(stepMinifyOption);
+    parser.addOption(stepTesselateOption);
+    parser.addOption(stepSaveToOption);
   } else if (!command.isEmpty()) {
     printErr(tr("Unknown command '%1'.").arg(command));
     printErr(usageHelpText);
@@ -425,6 +456,12 @@ int CommandLineInterface::execute(const QStringList& args) noexcept {
                              parser.isSet(libMinifyStepOption),  // minify STEP
                              parser.isSet(libSaveOption),  // save
                              parser.isSet(libStrictOption)  // strict mode
+    );
+  } else if (command == "open-step") {
+    cmdSuccess = openStep(positionalArgs.value(1),  // STEP file path
+                          parser.isSet(stepMinifyOption),  // minify
+                          parser.isSet(stepTesselateOption),  // tesselate
+                          parser.value(stepSaveToOption)  // save to
     );
   } else {
     printErr("Internal failure.");  // No tr() because this cannot occur.
@@ -1249,6 +1286,80 @@ void CommandLineInterface::processLibraryElement(
   // Do not propagate changes in the transactional file system to the
   // following checks
   fs.discardChanges();
+}
+
+bool CommandLineInterface::openStep(const QString& filePath, bool minify,
+                                    bool tesselate, const QString& saveTo) const
+    noexcept {
+  try {
+    // Note: Not using tr() for this command as it is basically intended for
+    // developers, not end users.
+
+    bool success = true;
+
+    // Open file.
+    const FilePath stepFp(QFileInfo(filePath).absoluteFilePath());
+    print(QString("Open STEP file '%1'...").arg(prettyPath(stepFp, filePath)));
+    QByteArray stepContent = FileUtils::readFile(stepFp);  // can throw
+
+    // Minify before validation.
+    if (minify) {
+      print("Perform minify...");
+      const QByteArray minified =
+          OccModel::minifyStep(stepContent);  // can throw
+      if (minified != stepContent) {
+        const qreal percent = 100 * (minified.size() - stepContent.size()) /
+            qreal(stepContent.size());
+        QLocale locale = QLocale::c();
+        locale.setNumberOptions(QLocale::DefaultNumberOptions);
+        print(QString(" - Minified from %1 bytes to %2 bytes (%3%)")
+                  .arg(locale.toString(stepContent.size()))
+                  .arg(locale.toString(minified.size()))
+                  .arg(percent, 0, 'f', 0));
+        if (minified.size() > stepContent.size()) {
+          printErr(" - ERROR: The output is larger than the input!");
+          success = false;
+        }
+        stepContent = minified;
+      } else {
+        print(" - File is already minified");
+      }
+    }
+
+    // Write to output *before* validating it, otherwise it won't be possible
+    // to inspect the invalid result of the minify operation.
+    if (!saveTo.isEmpty()) {
+      const FilePath outFp(QFileInfo(saveTo).absoluteFilePath());
+      print(QString("Save to '%1'...").arg(prettyPath(outFp, saveTo)));
+      FileUtils::writeFile(outFp, stepContent);  // can throw
+    }
+
+    // Validate.
+    print("Load model...");
+    std::unique_ptr<OccModel> model =
+        OccModel::loadStep(stepContent);  // throws if STEP is invalid
+
+    // Tesselate.
+    if (tesselate) {
+      print("Tesselate model...");
+      const QMap<OccModel::Color, QVector<QVector3D>> vertices =
+          model->tesselate();  // can throw
+      int vertexCount = 0;
+      foreach (const auto& v, vertices) { vertexCount += v.count(); }
+      print(QString(" - Built %1 vertices with %2 different colors")
+                .arg(vertexCount)
+                .arg(vertices.count()));
+      if (vertexCount == 0) {
+        printErr(" - ERROR: No content found in model!");
+        success = false;
+      }
+    }
+
+    return success;
+  } catch (const Exception& e) {
+    printErr(tr("ERROR: %1").arg(e.getMsg()));
+    return false;
+  }
 }
 
 QStringList CommandLineInterface::prepareRuleCheckMessages(

--- a/apps/librepcb-cli/commandlineinterface.h
+++ b/apps/librepcb-cli/commandlineinterface.h
@@ -78,6 +78,8 @@ private:  // Methods
                              LibraryBaseElement& element, bool runCheck,
                              bool minifyStepFiles, bool save, bool strict,
                              bool& success) const;
+  bool openStep(const QString& filePath, bool minify, bool tesselate,
+                const QString& saveTo) const noexcept;
   static QStringList prepareRuleCheckMessages(
       RuleCheckMessageList messages, const QSet<SExpression>& approvals,
       int& approvedMsgCount) noexcept;

--- a/libs/librepcb/core/3d/occmodel.h
+++ b/libs/librepcb/core/3d/occmodel.h
@@ -72,6 +72,7 @@ public:
   // Static Methods
   static bool isAvailable() noexcept;
   static QString getOccVersionString() noexcept;
+  static void setVerboseOutput(bool verbose) noexcept;
   static std::unique_ptr<OccModel> createAssembly(const QString& name);
   static std::unique_ptr<OccModel> createBoard(const Path& outline,
                                                const QVector<Path>& holes,
@@ -90,6 +91,8 @@ private:  // Methods
   static void throwNotAvailable();
 
 private:  // Data
+  static bool sOutputVerbosityConfigured;
+
   std::unique_ptr<Data> mImpl;
 };
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -52,6 +52,12 @@ class CliExecutor(object):
         else:
             shutil.copytree(src, dst)
 
+    def add_file(self, relpath):
+        src = os.path.join(DATA_DIR, relpath)
+        dst = os.path.join(self.tmpdir, os.path.basename(relpath))
+        shutil.copyfile(src, dst)
+        return dst
+
     def run(self, *args):
         p = subprocess.Popen([self.executable] + list(args), cwd=self.tmpdir,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/tests/cli/open_step/test_minify.py
+++ b/tests/cli/open_step/test_minify.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+"""
+Test command "open-step --minify"
+"""
+
+
+def test_valid_file(cli):
+    fp = cli.add_file('unittests/librepcbcommon/OccModelTest/model.step')
+    code, stdout, stderr = cli.run('open-step', '--minify', fp)
+    if 'LibrePCB was compiled without OpenCascade' in stderr:
+        pytest.skip("Feature not available.")
+    assert stderr == ''
+    assert stdout == \
+        "Open STEP file '{path}'...\n" \
+        "Perform minify...\n" \
+        " - Minified from 28,521 bytes to 11,716 bytes (-59%)\n" \
+        "Load model...\n" \
+        "SUCCESS\n".format(path=fp)
+    assert code == 0
+
+
+def test_invalid_file(cli):
+    fp = cli.add_file('LICENSE.txt')
+    code, stdout, stderr = cli.run('open-step', '--minify', fp)
+    if 'LibrePCB was compiled without OpenCascade' in stderr:
+        pytest.skip("Feature not available.")
+    assert stderr == 'ERROR: STEP data section not found.\n'
+    assert stdout == \
+        "Open STEP file '{path}'...\n" \
+        "Perform minify...\n" \
+        "Finished with errors!\n".format(path=fp)
+    assert code == 1
+
+
+def test_on_save_to_output(cli):
+    fp = cli.add_file('unittests/librepcbcommon/OccModelTest/model.step')
+    fp_out = cli.abspath('out.step')
+    code, stdout, stderr = cli.run('open-step', '--minify',
+                                   '--save-to', fp_out, fp)
+    if 'LibrePCB was compiled without OpenCascade' in stderr:
+        pytest.skip("Feature not available.")
+    assert stderr == ''
+    assert stdout == \
+        "Open STEP file '{path}'...\n" \
+        "Perform minify...\n" \
+        " - Minified from 28,521 bytes to 11,716 bytes (-59%)\n" \
+        "Save to '{outpath}'...\n" \
+        "Load model...\n" \
+        "SUCCESS\n".format(path=fp, outpath=fp_out)
+    assert code == 0
+
+    code, stdout, stderr = cli.run('open-step', '--minify', fp_out)
+    assert stderr == ''
+    assert stdout == \
+        "Open STEP file '{path}'...\n" \
+        "Perform minify...\n" \
+        " - File is already minified\n" \
+        "Load model...\n" \
+        "SUCCESS\n".format(path=fp_out)
+    assert code == 0

--- a/tests/cli/open_step/test_open.py
+++ b/tests/cli/open_step/test_open.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+"""
+Test command "open-step"
+"""
+
+
+def test_valid_file(cli):
+    fp = cli.add_file('unittests/librepcbcommon/OccModelTest/model.step')
+    code, stdout, stderr = cli.run('open-step', fp)
+    if 'LibrePCB was compiled without OpenCascade' in stderr:
+        pytest.skip("Feature not available.")
+    assert stderr == ''
+    assert stdout == \
+        "Open STEP file '{path}'...\n" \
+        "Load model...\n" \
+        "SUCCESS\n".format(path=fp)
+    assert code == 0
+
+
+def test_invalid_file(cli):
+    fp = cli.add_file('LICENSE.txt')
+    code, stdout, stderr = cli.run('open-step', fp)
+    if 'LibrePCB was compiled without OpenCascade' in stderr:
+        pytest.skip("Feature not available.")
+    assert len(stderr) > 10
+    assert "Open STEP file '{path}'...\n".format(path=fp) in stdout
+    assert "Finished with errors!\n" in stdout
+    assert code == 1

--- a/tests/cli/open_step/test_parser.py
+++ b/tests/cli/open_step/test_parser.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test command "open-step" (basic parser tests)
+"""
+
+HELP_TEXT = """\
+Usage: {executable} [options] open-step [command_options] file
+LibrePCB Command Line Interface
+
+Options:
+  -h, --help        Print this message.
+  -V, --version     Displays version information.
+  -v, --verbose     Verbose output.
+  --minify          Minify the STEP model before validating it. Use in
+                    conjunction with '--save-to' to save the output of the
+                    operation.
+  --tesselate       Tesselate the loaded STEP model to check if LibrePCB is
+                    able to render it. Reports failure (exit code = 1) if no
+                    content is detected.
+  --save-to <file>  Write the (modified) STEP file to this output location (may
+                    be equal to the opened file path). Only makes sense in
+                    conjunction with '--minify'.
+
+Arguments:
+  open-step         Open a STEP model to execute STEP-related tasks outside of
+                    a library.
+  file              Path to the STEP file (*.step).
+"""
+
+ERROR_TEXT = """\
+{error}
+Usage: {executable} [options] open-step [command_options] file
+Help: {executable} open-step --help
+"""
+
+
+def test_help(cli):
+    code, stdout, stderr = cli.run('open-step', '--help')
+    assert stderr == ''
+    assert stdout == HELP_TEXT.format(executable=cli.executable)
+    assert code == 0
+
+
+def test_no_arguments(cli):
+    code, stdout, stderr = cli.run('open-step')
+    assert stderr == ERROR_TEXT.format(
+        executable=cli.executable,
+        error="Missing arguments: file",
+    )
+    assert stdout == ''
+    assert code == 1
+
+
+def test_invalid_argument(cli):
+    code, stdout, stderr = cli.run('open-step', '--invalid-argument')
+    assert stderr == ERROR_TEXT.format(
+        executable=cli.executable,
+        error="Unknown option 'invalid-argument'.",
+    )
+    assert stdout == ''
+    assert code == 1

--- a/tests/cli/open_step/test_tesselate.py
+++ b/tests/cli/open_step/test_tesselate.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+import re
+
+"""
+Test command "open-step --tesselate"
+"""
+
+
+PATTERN = "Open STEP file '{path}'...\\n" \
+          "Load model...\\n" \
+          "Tesselate model...\\n" \
+          " - Built \\d\\d+ vertices with 1 different colors\\n" \
+          "SUCCESS\\n"
+
+
+def test_valid_file(cli):
+    fp = cli.add_file('unittests/librepcbcommon/OccModelTest/model.step')
+    code, stdout, stderr = cli.run('open-step', '--tesselate', fp)
+    if 'LibrePCB was compiled without OpenCascade' in stderr:
+        pytest.skip("Feature not available.")
+    assert stderr == ''
+    assert re.fullmatch(PATTERN.format(path=re.escape(fp)), stdout)
+    assert code == 0

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -24,6 +24,7 @@ Arguments:
 Commands:
   open-library   Open a library to execute library-related tasks.
   open-project   Open a project to execute project-related tasks.
+  open-step      Open a STEP model to execute STEP-related tasks outside of a library.
 
 List command-specific options:
   {executable} <command> --help


### PR DESCRIPTION
Add a new CLI command to minify and validate individual STEP files without requiring to open a whole LibrePCB library. This is intended mainly for `librepcb-parts-generator` to post-process generated STEP files.

### Usage

```
Usage: ./librepcb-cli [options] open-step [command_options] file
LibrePCB Command Line Interface

Options:
  -h, --help        Print this message.
  -V, --version     Displays version information.
  -v, --verbose     Verbose output.
  --minify          Minify the STEP model before validating it. Use in
                    conjunction with '--save-to' to save the output of the
                    operation.
  --tesselate       Tesselate the loaded STEP model to check if LibrePCB is
                    able to render it. Reports failure (exit code = 1) if no
                    content is detected.
  --save-to <file>  Write the (modified) STEP file to this output location (may
                    be equal to the opened file path). Only makes sense in
                    conjunction with '--minify'.

Arguments:
  open-step         Open a STEP model to execute STEP-related tasks outside of
                    a library.
  file              Path to the STEP file (*.step).
```

### Example

```
$ librepcb-cli open-step --minify --tesselate --save-to=minified.step model.step
Open STEP file 'model.step'...
Perform minify...
 - Minified from 138,951 bytes to 54,462 bytes (-61%)
Save to 'minified.step'...
Load model...
Tesselate model...
 - Built 6360 vertices with 1 different colors
SUCCESS
```

@dbrgn Maybe you like to take a look at this API before it gets released(?)