### PR TITLE
3D view: Fix location and color of some STEP solids

### DIFF
--- a/tests/cli/open_step/test_tesselate.py
+++ b/tests/cli/open_step/test_tesselate.py
@@ -12,7 +12,7 @@ Test command "open-step --tesselate"
 PATTERN = "Open STEP file '{path}'...\\n" \
           "Load model...\\n" \
           "Tesselate model...\\n" \
-          " - Built \\d\\d+ vertices with 1 different colors\\n" \
+          " - Built \\d\\d+ vertices with [1-9]\\d* different colors\\n" \
           "SUCCESS\\n"
 
 


### PR DESCRIPTION
Fixes possibly missing colors and/or wrong location of shapes loaded from STEP files in the 3D viewer, mainly observed on STEP models which consist of multiple shapes which are not fused.