### PR TITLE
Board editor: Fix highlighting pads while drawing traces

### DIFF
--- a/libs/librepcb/editor/project/boardeditor/boardgraphicsscene.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardgraphicsscene.cpp
@@ -220,7 +220,7 @@ void BoardGraphicsScene::clearSelection() noexcept {
 }
 
 void BoardGraphicsScene::updateHighlightedNetSignals() noexcept {
-  foreach (auto item, mFootprintPads) { item->update(); }
+  foreach (auto item, mFootprintPads) { item->updateHighlightedNetSignals(); }
   foreach (auto item, mVias) { item->update(); }
   foreach (auto item, mNetLines) { item->update(); }
   foreach (auto item, mPlanes) { item->update(); }

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.cpp
@@ -76,6 +76,14 @@ BGI_FootprintPad::~BGI_FootprintPad() noexcept {
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_FootprintPad::updateHighlightedNetSignals() noexcept {
+  updateHightlighted(isSelected());
+}
+
+/*******************************************************************************
  *  Inherited from QGraphicsItem
  ******************************************************************************/
 
@@ -87,7 +95,7 @@ QPainterPath BGI_FootprintPad::shape() const noexcept {
 QVariant BGI_FootprintPad::itemChange(GraphicsItemChange change,
                                       const QVariant& value) noexcept {
   if ((change == ItemSelectedHasChanged) && mGraphicsItem) {
-    mGraphicsItem->setSelected(value.toBool());
+    updateHightlighted(value.toBool());
   }
   return QGraphicsItem::itemChange(change, value);
 }
@@ -142,6 +150,12 @@ void BGI_FootprintPad::updateLayer() noexcept {
     setZValue(BoardGraphicsScene::ZValue_FootprintPadsBottom);
     mGraphicsItem->setLayer(Theme::Color::sBoardCopperBot);
   }
+}
+
+void BGI_FootprintPad::updateHightlighted(bool selected) noexcept {
+  mGraphicsItem->setSelected(
+      selected ||
+      mHighlightedNetSignals->contains(mPad.getCompSigInstNetSignal()));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.h
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.h
@@ -67,6 +67,7 @@ public:
   const std::weak_ptr<BGI_Device>& getDeviceGraphicsItem() noexcept {
     return mDeviceGraphicsItem;
   }
+  void updateHighlightedNetSignals() noexcept;
 
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;
@@ -82,6 +83,7 @@ private:  // Methods
   virtual QVariant itemChange(GraphicsItemChange change,
                               const QVariant& value) noexcept override;
   void updateLayer() noexcept;
+  void updateHightlighted(bool selected) noexcept;
 
 private:  // Data
   BI_FootprintPad& mPad;


### PR DESCRIPTION
Pads of the same net were not highlighted while drawing traces in the board editor.