### PR TITLE
Make list_tests.py callable from within subfolder

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,7 @@ yourself by creating a pull request (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 - Raphael Nestler ([@rnestler](https://github.com/rnestler))
 - Danilo Bargen ([@dbrgn](https://github.com/dbrgn))
 - Florian Bruhin ([@The-Compiler](https://github.com/The-Compiler))
+- [@Luz](https://github.com/Luz)
 - [@NiFa18](https://github.com/NiFa18)
 - [@chrisgwerder](https://github.com/chrisgwerder)
 - [@0xB767B](https://github.com/0xB767B)

--- a/dev/list_tests.py
+++ b/dev/list_tests.py
@@ -16,7 +16,7 @@ import glob
 
 
 if __name__ == '__main__':
-    root = os.path.dirname(os.path.dirname(__file__))
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sources_dir = os.path.join(root, 'libs', 'librepcb')
     sources = [os.path.relpath(x, sources_dir)
                for x in glob.glob(sources_dir + '/**/*.h', recursive=True)]


### PR DESCRIPTION
It took me a while, until I noticed the script is not broken, but rather intended to be executed from the directory above.
`./dev/list_tests.py`
The changes intend to allow usage from within the subdirectory:

```
cd dev
python ./list_test.py
```
and/or
```
cd dev
python list_test.py
```
and/or
```
cd dev
./list_test.py
```