### PR TITLE
Use bash from env for better portability

### DIFF
--- a/dev/capture_overview_screenshot.sh
+++ b/dev/capture_overview_screenshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Helper script to capture screenshots of LibrePCB windows.
 # Requirements: sudo apt-get install wmctrl shutter imagemagick

--- a/dev/capture_screenshots.sh
+++ b/dev/capture_screenshots.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Helper script to capture screenshots of LibrePCB windows.
 # Requirements: sudo apt-get install wmctrl shutter imagemagick

--- a/dev/diagrams/convert.sh
+++ b/dev/diagrams/convert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -r svg
 mkdir svg

--- a/dev/doxygen/make.sh
+++ b/dev/doxygen/make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
 set -eu -o pipefail

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -55,7 +55,7 @@ if [ "$DOCKER" == "--docker" ]; then
   $DOCKER_CMD run --rm -t --user "$(id -u):$(id -g)" \
     -v "$REPO_ROOT:/code" \
     $DOCKER_IMAGE \
-    /bin/bash -c "cd /code && dev/format_code.sh $ALL"
+    /usr/bin/env bash -c "cd /code && dev/format_code.sh $ALL"
 
   echo "[Docker done.]"
   exit 0

--- a/dev/generate_db_schema_diagram.sh
+++ b/dev/generate_db_schema_diagram.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Configuration

--- a/dev/graphics/convert.sh
+++ b/dev/graphics/convert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Note: the PDF files must be created "by hand" (e.g. with the print-to-pdf feature of LibreCAD)
 


### PR DESCRIPTION
Hi
According to [Stackoverflow](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang#10383546) it looks like the portability of the development scripts could be improved by having this new style for the bash shebang.
What do you think?
If possible, verify the line 58 of "dev/format_code.sh" as I did not test this inside docker yet. :(