### PR TITLE
Change backticks to POSIX style

### DIFF
--- a/dev/capture_overview_screenshot.sh
+++ b/dev/capture_overview_screenshot.sh
@@ -17,13 +17,13 @@ Y3=400
 
 # capture screenshots
 wmctrl -a "Control Panel" && wmctrl -r "Control Panel" -e 0,$X1,$Y1,$WIDTH,$HEIGHT
-shutter -w="Control Panel" -o `pwd`/control_panel_small.png -d 3 -c -e -n
+shutter -w="Control Panel" -o $(pwd)/control_panel_small.png -d 3 -c -e -n
 sleep 5
 wmctrl -a "Schematic Editor" && wmctrl -r "Schematic Editor" -e 0,$X3,$Y3,$WIDTH,$HEIGHT
-shutter -w="Schematic Editor" -o `pwd`/schematic_editor_small.png -d 3 -c -e -n
+shutter -w="Schematic Editor" -o $(pwd)/schematic_editor_small.png -d 3 -c -e -n
 sleep 5
 wmctrl -a "Board Editor" && wmctrl -r "Board Editor" -e 0,$X2,$Y2,$WIDTH,$HEIGHT
-shutter -w="Board Editor" -o `pwd`/board_editor_small.png -d 3 -c -e -n
+shutter -w="Board Editor" -o $(pwd)/board_editor_small.png -d 3 -c -e -n
 sleep 5
 
 # merge screenshots together

--- a/dev/capture_screenshots.sh
+++ b/dev/capture_screenshots.sh
@@ -10,7 +10,7 @@ function capture_screenshot {
   echo "----- NEXT WINDOW: $1 -----"
   sleep 5
   wmctrl -a "$1" && wmctrl -r "$1" -e 0,100,100,1100,650
-  shutter -w="$1" -o "`pwd`/$2" -d 3 -c -e -n
+  shutter -w="$1" -o "$(pwd)/$2" -d 3 -c -e -n
   sleep 5
   convert -thumbnail 770x455 "$2" "thumbs/$2"
 }

--- a/dev/diagrams/convert.sh
+++ b/dev/diagrams/convert.sh
@@ -6,7 +6,7 @@ mkdir svg
 # convert all *.dia files to *.svg files
 find . -type f -name "*.dia" | while read f
 do
-  mkdir -p "svg/"`dirname "$f"`
+  mkdir -p "svg/"$(dirname "$f")
   outfile="svg/${f%.dia}.svg"
   dia -e "$outfile" "$f"
 done

--- a/dev/graphics/convert.sh
+++ b/dev/graphics/convert.sh
@@ -6,6 +6,6 @@ mkdir -p png
 
 for f in *.pdf
 do
-  convert -density 600 -trim -border 100x100 -bordercolor White "$f" "png/`basename "$f" .pdf`.png"
+  convert -density 600 -trim -border 100x100 -bordercolor White "$f" "png/$(basename "$f" .pdf).png"
   # rm "$f"
 done


### PR DESCRIPTION
According [Stackoverflow](https://stackoverflow.com/questions/9449778/what-is-the-benefit-of-using-instead-of-backticks-in-shell-scripts) the backticks are legacy, so I think it would be stylish to have this new syntax.