### PR TITLE
Add unit test for FileUtils

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
   core/fileio/csvfiletest.cpp
   core/fileio/directorylocktest.cpp
   core/fileio/filepathtest.cpp
+  core/fileio/fileutilstest.cpp
   core/fileio/transactionaldirectorytest.cpp
   core/fileio/transactionalfilesystemtest.cpp
   core/fileio/versionfiletest.cpp

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -1,0 +1,313 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/core/exceptions.h>
+#include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/fileio/fileutils.h>
+#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)  // Windows
+#include <fileapi.h>
+#endif
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class FileUtilsTest : public ::testing::Test {
+protected:
+  FilePath root;
+  FilePath rootFile;  // source for all operations
+  FilePath rootFileHidden;
+
+  FilePath subdir;
+  FilePath subdirFile;
+  FilePath subdirSubdir;
+  FilePath subdirSubdirFile;
+  FilePath subdirSubdirFileHidden;
+
+  FilePath rootFileMissing;
+  FilePath rootFileCopy;
+  FilePath subdirCopy;
+  FilePath subdirCopyFile;
+  FilePath subdirCopySubdir;
+  FilePath subdirCopySubdirFile;
+  FilePath subdirCopySubdirFileHidden;
+
+  QStringList filter;
+
+  static void SetupFile(const FilePath& pth, const QByteArray& content) {
+    QFile f(pth.toNative());
+    if (f.open(QIODevice::ReadWrite | QIODevice::NewOnly)) f.write(content);
+    f.close();
+  }
+
+  void SetUp() override {
+    root = FilePath::getRandomTempPath();
+
+    // the sources of already existing files and directories
+    rootFile = FilePath::fromRelative(root, "file.txt");
+    rootFileHidden = FilePath::fromRelative(root, ".hidden.txt");
+    subdir = FilePath::fromRelative(root, "subdir");
+    subdirFile = FilePath::fromRelative(subdir, "file.txt");
+    subdirSubdir = FilePath::fromRelative(subdir, "subdir");
+    subdirSubdirFile = FilePath::fromRelative(subdirSubdir, "file.txt");
+    subdirSubdirFileHidden =
+        FilePath::fromRelative(subdirSubdir, ".hidden.txt");
+
+    // the destinations for copying files, nonexistent at start of test
+    rootFileCopy = FilePath::fromRelative(root, "fileCopy.txt");
+    rootFileCopy = FilePath::fromRelative(root, "missing.txt");
+    subdirCopy = FilePath::fromRelative(root, "subdirCopy");
+    subdirCopyFile = FilePath::fromRelative(subdirCopy, "file.txt");
+    subdirCopySubdir = FilePath::fromRelative(subdirCopy, "subdir");
+    subdirCopySubdirFile = FilePath::fromRelative(subdirCopySubdir, "file.txt");
+    subdirCopySubdirFileHidden =
+        FilePath::fromRelative(subdirCopySubdir, ".hidden.txt");
+
+    QDir().mkdir(root.toNative());
+    QDir().mkdir(subdir.toNative());
+    QDir().mkdir(subdirSubdir.toNative());
+
+    SetupFile(rootFile, "test\n");
+    SetupFile(rootFileHidden, "hiddenContent\n");
+    SetupFile(subdirFile, "test\n");
+    SetupFile(subdirSubdirFile, "test\n");
+    SetupFile(subdirSubdirFileHidden, "hiddenContent\n");
+
+    // TODO make hidden files already hidden under Windows !
+#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
+    SetFileAttributes(rootFileHidden.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
+    SetFileAttributes(subdirSubdirFileHidden.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
+#endif
+
+    filter << "*.txt";
+  }
+
+  void TearDown() override { QDir(root.toNative()).removeRecursively(); }
+
+  static void ExpectList(const QList<FilePath>& result,
+                         const QList<FilePath>& expected) {
+    std::string resultStr;
+    std::string expStr;
+    for (const auto& i : result)
+      resultStr += "  " + i.toStr().toStdString() + "\n";
+    for (const auto& i : expected)
+      expStr += "  " + i.toStr().toStdString() + "\n";
+
+    ASSERT_EQ(result.size(), expected.size())
+        << "\nActual:\n" << resultStr
+        << "\nExpected:\n" << expStr;
+    for (const auto& i : expected)
+      ASSERT_TRUE(result.contains(i))
+          << "\nActual:\n" << resultStr
+          << "\nExpected:\n" << expStr;
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(FileUtilsTest, testReadExistingFile) {
+  auto p = FileUtils::readFile(rootFile);
+
+  EXPECT_EQ("test\n", p.toStdString());
+}
+
+TEST_F(FileUtilsTest, testReadNonexistentFileShouldThrow) {
+  EXPECT_THROW(FileUtils::readFile(rootFileMissing), Exception);
+}
+
+TEST_F(FileUtilsTest, testWrittenDataShouldBeReadBack) {
+  FileUtils::writeFile(rootFile, "someData\n");
+  auto p = FileUtils::readFile(rootFile);
+
+  EXPECT_EQ("someData\n", p.toStdString());
+}
+
+TEST_F(FileUtilsTest, testCopyValidFile) {
+  FileUtils::copyFile(rootFile, rootFileCopy);
+  auto p1 = FileUtils::readFile(rootFile);
+  auto p2 = FileUtils::readFile(rootFileCopy);  // throws if file not found
+
+  EXPECT_EQ("test\n", p1.toStdString());
+  EXPECT_EQ("test\n", p2.toStdString());
+}
+
+TEST_F(FileUtilsTest, testCopyNonexistingFileShouldThrow) {
+  EXPECT_THROW(FileUtils::copyFile(rootFileMissing, rootFileCopy), Exception);
+}
+
+TEST_F(FileUtilsTest, testMoveValidFile) {
+  FileUtils::move(rootFile, rootFileCopy);
+  auto p = FileUtils::readFile(rootFileCopy);  // throws if file not found
+
+  EXPECT_THROW(FileUtils::readFile(rootFile), Exception);
+  EXPECT_EQ("test\n", p.toStdString());
+}
+
+TEST_F(FileUtilsTest, testMoveNonexistingFileShouldThrow) {
+  EXPECT_THROW(FileUtils::move(rootFileMissing, rootFileCopy), Exception);
+}
+
+TEST_F(FileUtilsTest, testRemoveValidFile) {
+  FileUtils::removeFile(rootFile);
+
+  EXPECT_THROW(FileUtils::readFile(rootFile), Exception);
+}
+
+TEST_F(FileUtilsTest, testRemoveNonexistingFileShouldThrow) {
+  EXPECT_THROW(FileUtils::removeFile(rootFileMissing), Exception);
+}
+
+TEST_F(FileUtilsTest, testCreateSubdir) {
+  FileUtils::makePath(subdirCopy);
+
+  EXPECT_TRUE(subdirCopy.isExistingDir());
+}
+
+TEST_F(FileUtilsTest, testRecursiveRemoveSubdir) {
+  FileUtils::removeDirRecursively(subdir);
+
+  EXPECT_FALSE(subdir.isExistingDir());
+  EXPECT_FALSE(subdirFile.isExistingFile());
+}
+
+TEST_F(FileUtilsTest, testRecursiveCopySubdir) {
+  FileUtils::copyDirRecursively(subdir, subdirCopy);
+
+  // ensure source remain unchanged
+  EXPECT_TRUE(subdir.isExistingDir());
+  EXPECT_TRUE(subdirFile.isExistingFile());
+  EXPECT_TRUE(subdirSubdirFile.isExistingFile());
+  EXPECT_TRUE(subdirSubdirFileHidden.isExistingFile());
+
+  // ensure destination is complete copy
+  EXPECT_TRUE(subdirCopy.isExistingDir());
+  EXPECT_TRUE(subdirCopyFile.isExistingFile());
+  EXPECT_TRUE(subdirCopySubdirFile.isExistingFile());
+  EXPECT_TRUE(subdirCopySubdirFileHidden.isExistingFile());
+}
+
+TEST_F(FileUtilsTest, testFindDirectories) {
+  auto p = FileUtils::findDirectories(root);
+
+  ExpectList(p, {subdir});
+}
+
+TEST_F(FileUtilsTest, testFindFileInDirectory) {
+  auto p = FileUtils::getFilesInDirectory(root);
+
+  ExpectList(p,
+             {
+                 rootFile, rootFileHidden,
+                 // subdirFile, skipped (not recursive)
+                 // subdirSubdirFile, skipped (not recursive)
+                 // subdirSubdirFileHidden (not recursive)
+             });
+}
+
+TEST_F(FileUtilsTest, testFindFileInDirectoryRecursive) {
+  auto p = FileUtils::getFilesInDirectory(root, {}, true);
+
+  ExpectList(p,
+             {
+                 rootFile,
+                 rootFileHidden,
+                 subdirFile,
+                 subdirSubdirFile,
+                 subdirSubdirFileHidden,
+             });
+}
+
+TEST_F(FileUtilsTest, testFindFileInDirectorySkipHidden) {
+  auto p = FileUtils::getFilesInDirectory(root, {}, false, true);
+
+  ExpectList(p,
+             {
+                 rootFile,
+                 // rootFileHidden, skipped (hidden)
+                 // subdirFile, skipped (not recursive)
+                 // subdirSubdirFile, skipped (not recursive)
+                 // subdirSubdirFileHidden (not recursive, hidden)
+             });
+}
+
+TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveSkipHidden) {
+  auto p = FileUtils::getFilesInDirectory(root, {}, true, true);
+
+  ExpectList(p,
+             {
+                 rootFile,
+                 // rootFileHidden, skipped (hidden)
+                 subdirFile, subdirSubdirFile,
+                 // subdirSubdirFileHidden (hidden)
+             });
+}
+
+TEST_F(FileUtilsTest, testFindFileInDirectoryFiltered) {
+  auto p = FileUtils::getFilesInDirectory(root, filter, false);
+
+  ExpectList(p,
+             {
+                 rootFile, rootFileHidden,
+                 // subdirFile skipped (not recursive)
+                 // subdirSubdirFile (not recursive)
+                 // subdirSubdirFileHidden (not recursive)
+             });
+}
+
+TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFiltered) {
+  auto p = FileUtils::getFilesInDirectory(root, filter, true);
+
+  ExpectList(p,
+             {rootFile, rootFileHidden, subdirFile, subdirSubdirFile,
+              subdirSubdirFileHidden});
+}
+
+TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFilteredSkipHidden) {
+  auto p = FileUtils::getFilesInDirectory(root, filter, true, true);
+
+  ExpectList(p,
+             {
+                 rootFile,
+                 // rootFileHidden skipped (hidden)
+                 subdirFile, subdirSubdirFile
+                 // subdirSubdirFileHidden skipped (hidden)
+             });
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -63,10 +63,19 @@ protected:
 
   QStringList filter;
 
-  static void setupFile(const FilePath& pth, const QByteArray& content) {
+  static void setupFile(const FilePath& pth, const QByteArray& content,
+                        bool hidden = false) {
     QFile f(pth.toNative());
-    if (f.open(QIODevice::ReadWrite | QIODevice::NewOnly)) f.write(content);
+    if (f.open(QIODevice::ReadWrite | QIODevice::NewOnly)) {
+      f.write(content);
+    }
     f.close();
+
+    if (hidden) {
+#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
+      SetFileAttributes(pth.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
+#endif
+    }
   }
 
   void SetUp() override {
@@ -95,15 +104,10 @@ protected:
     QDir().mkdir(subdirSubdir.toNative());
 
     setupFile(rootFile, "test\n");
-    setupFile(rootFileHidden, "hiddenContent\n");
+    setupFile(rootFileHidden, "hiddenContent\n", true);
     setupFile(subdirFile, "test\n");
     setupFile(subdirSubdirFile, "test\n");
-    setupFile(subdirSubdirFileHidden, "hiddenContent\n");
-
-#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
-    SetFileAttributes(rootFileHidden.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
-    SetFileAttributes(subdirSubdirFileHidden.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
-#endif
+    setupFile(subdirSubdirFileHidden, "hiddenContent\n", true);
 
     filter << "*.txt";
   }

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -212,7 +212,7 @@ TEST_F(FileUtilsTest, testFindDirectories) {
   expectList(p, {subdir});
 }
 
-TEST_F(FileUtilsTest, testFindFileInDirectory) {
+TEST_F(FileUtilsTest, testGetFilesInDirectory) {
   auto p = FileUtils::getFilesInDirectory(root);
 
   expectList(p,
@@ -224,7 +224,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectory) {
              });
 }
 
-TEST_F(FileUtilsTest, testFindFileInDirectoryRecursive) {
+TEST_F(FileUtilsTest, testGetFilesInDirectoryRecursive) {
   auto p = FileUtils::getFilesInDirectory(root, {}, true);
 
   expectList(p,
@@ -237,7 +237,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryRecursive) {
              });
 }
 
-TEST_F(FileUtilsTest, testFindFileInDirectorySkipHidden) {
+TEST_F(FileUtilsTest, testGetFilesInDirectorySkipHidden) {
   auto p = FileUtils::getFilesInDirectory(root, {}, false, true);
 
   expectList(p,
@@ -250,7 +250,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectorySkipHidden) {
              });
 }
 
-TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveSkipHidden) {
+TEST_F(FileUtilsTest, testGetFilesInDirectoryRecursiveSkipHidden) {
   auto p = FileUtils::getFilesInDirectory(root, {}, true, true);
 
   expectList(p,
@@ -262,7 +262,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveSkipHidden) {
              });
 }
 
-TEST_F(FileUtilsTest, testFindFileInDirectoryFiltered) {
+TEST_F(FileUtilsTest, testGetFilesInDirectoryFiltered) {
   auto p = FileUtils::getFilesInDirectory(root, filter, false);
 
   expectList(p,
@@ -274,7 +274,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryFiltered) {
              });
 }
 
-TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFiltered) {
+TEST_F(FileUtilsTest, testGetFilesInDirectoryRecursiveFiltered) {
   auto p = FileUtils::getFilesInDirectory(root, filter, true);
 
   expectList(p,
@@ -282,7 +282,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFiltered) {
               subdirSubdirFileHidden});
 }
 
-TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFilteredSkipHidden) {
+TEST_F(FileUtilsTest, testGetFilesInDirectoryRecursiveFilteredSkipHidden) {
   auto p = FileUtils::getFilesInDirectory(root, filter, true, true);
 
   expectList(p,

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -73,24 +73,22 @@ protected:
     root = FilePath::getRandomTempPath();
 
     // the sources of already existing files and directories
-    rootFile = FilePath::fromRelative(root, "file.txt");
-    rootFileHidden = FilePath::fromRelative(root, ".hidden.txt");
-    subdir = FilePath::fromRelative(root, "subdir");
-    subdirFile = FilePath::fromRelative(subdir, "file.txt");
-    subdirSubdir = FilePath::fromRelative(subdir, "subdir");
-    subdirSubdirFile = FilePath::fromRelative(subdirSubdir, "file.txt");
-    subdirSubdirFileHidden =
-        FilePath::fromRelative(subdirSubdir, ".hidden.txt");
+    rootFile = root.getPathTo("file.txt");
+    rootFileHidden = root.getPathTo(".hidden.txt");
+    subdir = root.getPathTo("subdir");
+    subdirFile = subdir.getPathTo("file.txt");
+    subdirSubdir = subdir.getPathTo("subdir");
+    subdirSubdirFile = subdirSubdir.getPathTo("file.txt");
+    subdirSubdirFileHidden = subdirSubdir.getPathTo(".hidden.txt");
 
     // the destinations for copying files, nonexistent at start of test
-    rootFileCopy = FilePath::fromRelative(root, "fileCopy.txt");
-    rootFileCopy = FilePath::fromRelative(root, "missing.txt");
-    subdirCopy = FilePath::fromRelative(root, "subdirCopy");
-    subdirCopyFile = FilePath::fromRelative(subdirCopy, "file.txt");
-    subdirCopySubdir = FilePath::fromRelative(subdirCopy, "subdir");
-    subdirCopySubdirFile = FilePath::fromRelative(subdirCopySubdir, "file.txt");
-    subdirCopySubdirFileHidden =
-        FilePath::fromRelative(subdirCopySubdir, ".hidden.txt");
+    rootFileCopy = root.getPathTo("fileCopy.txt");
+    rootFileCopy = root.getPathTo("missing.txt");
+    subdirCopy = root.getPathTo("subdirCopy");
+    subdirCopyFile = subdirCopy.getPathTo("file.txt");
+    subdirCopySubdir = subdirCopy.getPathTo("subdir");
+    subdirCopySubdirFile = subdirCopySubdir.getPathTo("file.txt");
+    subdirCopySubdirFileHidden = subdirCopySubdir.getPathTo(".hidden.txt");
 
     QDir().mkdir(root.toNative());
     QDir().mkdir(subdir.toNative());

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -63,7 +63,7 @@ protected:
 
   QStringList filter;
 
-  static void SetupFile(const FilePath& pth, const QByteArray& content) {
+  static void setupFile(const FilePath& pth, const QByteArray& content) {
     QFile f(pth.toNative());
     if (f.open(QIODevice::ReadWrite | QIODevice::NewOnly)) f.write(content);
     f.close();
@@ -94,13 +94,12 @@ protected:
     QDir().mkdir(subdir.toNative());
     QDir().mkdir(subdirSubdir.toNative());
 
-    SetupFile(rootFile, "test\n");
-    SetupFile(rootFileHidden, "hiddenContent\n");
-    SetupFile(subdirFile, "test\n");
-    SetupFile(subdirSubdirFile, "test\n");
-    SetupFile(subdirSubdirFileHidden, "hiddenContent\n");
+    setupFile(rootFile, "test\n");
+    setupFile(rootFileHidden, "hiddenContent\n");
+    setupFile(subdirFile, "test\n");
+    setupFile(subdirSubdirFile, "test\n");
+    setupFile(subdirSubdirFileHidden, "hiddenContent\n");
 
-    // TODO make hidden files already hidden under Windows !
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
     SetFileAttributes(rootFileHidden.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
     SetFileAttributes(subdirSubdirFileHidden.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
@@ -111,7 +110,7 @@ protected:
 
   void TearDown() override { QDir(root.toNative()).removeRecursively(); }
 
-  static void ExpectList(const QList<FilePath>& result,
+  static void expectList(const QList<FilePath>& result,
                          const QList<FilePath>& expected) {
     std::string resultStr;
     std::string expStr;
@@ -218,13 +217,13 @@ TEST_F(FileUtilsTest, testRecursiveCopySubdir) {
 TEST_F(FileUtilsTest, testFindDirectories) {
   auto p = FileUtils::findDirectories(root);
 
-  ExpectList(p, {subdir});
+  expectList(p, {subdir});
 }
 
 TEST_F(FileUtilsTest, testFindFileInDirectory) {
   auto p = FileUtils::getFilesInDirectory(root);
 
-  ExpectList(p,
+  expectList(p,
              {
                  rootFile, rootFileHidden,
                  // subdirFile, skipped (not recursive)
@@ -236,7 +235,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectory) {
 TEST_F(FileUtilsTest, testFindFileInDirectoryRecursive) {
   auto p = FileUtils::getFilesInDirectory(root, {}, true);
 
-  ExpectList(p,
+  expectList(p,
              {
                  rootFile,
                  rootFileHidden,
@@ -249,7 +248,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryRecursive) {
 TEST_F(FileUtilsTest, testFindFileInDirectorySkipHidden) {
   auto p = FileUtils::getFilesInDirectory(root, {}, false, true);
 
-  ExpectList(p,
+  expectList(p,
              {
                  rootFile,
                  // rootFileHidden, skipped (hidden)
@@ -262,7 +261,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectorySkipHidden) {
 TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveSkipHidden) {
   auto p = FileUtils::getFilesInDirectory(root, {}, true, true);
 
-  ExpectList(p,
+  expectList(p,
              {
                  rootFile,
                  // rootFileHidden, skipped (hidden)
@@ -274,7 +273,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveSkipHidden) {
 TEST_F(FileUtilsTest, testFindFileInDirectoryFiltered) {
   auto p = FileUtils::getFilesInDirectory(root, filter, false);
 
-  ExpectList(p,
+  expectList(p,
              {
                  rootFile, rootFileHidden,
                  // subdirFile skipped (not recursive)
@@ -286,7 +285,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryFiltered) {
 TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFiltered) {
   auto p = FileUtils::getFilesInDirectory(root, filter, true);
 
-  ExpectList(p,
+  expectList(p,
              {rootFile, rootFileHidden, subdirFile, subdirSubdirFile,
               subdirSubdirFileHidden});
 }
@@ -294,7 +293,7 @@ TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFiltered) {
 TEST_F(FileUtilsTest, testFindFileInDirectoryRecursiveFilteredSkipHidden) {
   auto p = FileUtils::getFilesInDirectory(root, filter, true, true);
 
-  ExpectList(p,
+  expectList(p,
              {
                  rootFile,
                  // rootFileHidden skipped (hidden)

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -42,10 +42,10 @@ namespace tests {
 static void setupFile(const FilePath& pth, const QByteArray& content,
                       bool hidden = false) {
   auto filename = pth.toNative().toStdString();
-  std::fstream file{filename, std::ios::out | std::ios::trunc};
-  EXPECT_TRUE(file.is_open());
-  file.write(content.data(), content.size());
-  file.close();
+  std::fstream fs{filename, std::ios::out | std::ios::trunc | std::ios::binary};
+  EXPECT_TRUE(fs.is_open());
+  fs.write(content.data(), content.size());
+  fs.close();
 
   if (hidden) {
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -49,7 +49,8 @@ static void setupFile(const FilePath& pth, const QByteArray& content,
 
   if (hidden) {
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
-    SetFileAttributes(pth.toNative().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
+    SetFileAttributes(pth.toNative().toStdWString().c_str(),
+                      FILE_ATTRIBUTE_HIDDEN);
 #endif
   }
 }
@@ -79,7 +80,8 @@ protected:
   FilePath subdirCopyFile{subdirCopy.getPathTo("file.txt")};
   FilePath subdirCopySubdir{subdirCopy.getPathTo("subdir")};
   FilePath subdirCopySubdirFile{subdirCopySubdir.getPathTo("file.txt")};
-  FilePath subdirCopySubdirFileHidden{subdirCopySubdir.getPathTo(".hidden.txt")};
+  FilePath subdirCopySubdirFileHidden{
+      subdirCopySubdir.getPathTo(".hidden.txt")};
 
   QStringList filter{"*.txt"};
 

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -60,47 +60,30 @@ static void setupFile(const FilePath& pth, const QByteArray& content,
 
 class FileUtilsTest : public ::testing::Test {
 protected:
-  FilePath root;
-  FilePath rootFile;  // source for all operations
-  FilePath rootFileHidden;
+  FilePath root{FilePath::getRandomTempPath()};
 
-  FilePath subdir;
-  FilePath subdirFile;
-  FilePath subdirSubdir;
-  FilePath subdirSubdirFile;
-  FilePath subdirSubdirFileHidden;
+  // the sources of already existing files and directories
+  FilePath rootFile{root.getPathTo("file.txt")};  // source for all operations
+  FilePath rootFileHidden{root.getPathTo(".hidden.txt")};
 
-  FilePath rootFileMissing;
-  FilePath rootFileCopy;
-  FilePath subdirCopy;
-  FilePath subdirCopyFile;
-  FilePath subdirCopySubdir;
-  FilePath subdirCopySubdirFile;
-  FilePath subdirCopySubdirFileHidden;
+  FilePath subdir{root.getPathTo("subdir")};
+  FilePath subdirFile{subdir.getPathTo("file.txt")};
+  FilePath subdirSubdir{subdir.getPathTo("subdir")};
+  FilePath subdirSubdirFile{subdirSubdir.getPathTo("file.txt")};
+  FilePath subdirSubdirFileHidden{subdirSubdir.getPathTo(".hidden.txt")};
+
+  // the destinations for copying files, nonexistent at start of test
+  FilePath rootFileMissing{root.getPathTo("missing.txt")};
+  FilePath rootFileCopy{root.getPathTo("fileCopy.txt")};
+  FilePath subdirCopy{root.getPathTo("subdirCopy")};
+  FilePath subdirCopyFile{subdirCopy.getPathTo("file.txt")};
+  FilePath subdirCopySubdir{subdirCopy.getPathTo("subdir")};
+  FilePath subdirCopySubdirFile{subdirCopySubdir.getPathTo("file.txt")};
+  FilePath subdirCopySubdirFileHidden{subdirCopySubdir.getPathTo(".hidden.txt")};
 
   QStringList filter{"*.txt"};
 
-  void SetUp() override {
-    root = FilePath::getRandomTempPath();
-
-    // the sources of already existing files and directories
-    rootFile = root.getPathTo("file.txt");
-    rootFileHidden = root.getPathTo(".hidden.txt");
-    subdir = root.getPathTo("subdir");
-    subdirFile = subdir.getPathTo("file.txt");
-    subdirSubdir = subdir.getPathTo("subdir");
-    subdirSubdirFile = subdirSubdir.getPathTo("file.txt");
-    subdirSubdirFileHidden = subdirSubdir.getPathTo(".hidden.txt");
-
-    // the destinations for copying files, nonexistent at start of test
-    rootFileCopy = root.getPathTo("fileCopy.txt");
-    rootFileCopy = root.getPathTo("missing.txt");
-    subdirCopy = root.getPathTo("subdirCopy");
-    subdirCopyFile = subdirCopy.getPathTo("file.txt");
-    subdirCopySubdir = subdirCopy.getPathTo("subdir");
-    subdirCopySubdirFile = subdirCopySubdir.getPathTo("file.txt");
-    subdirCopySubdirFileHidden = subdirCopySubdir.getPathTo(".hidden.txt");
-
+  FileUtilsTest() {
     QDir().mkdir(root.toNative());
     QDir().mkdir(subdir.toNative());
     QDir().mkdir(subdirSubdir.toNative());
@@ -112,7 +95,10 @@ protected:
     setupFile(subdirSubdirFileHidden, "hiddenContent\n", true);
   }
 
-  void TearDown() override { QDir(root.toNative()).removeRecursively(); }
+  ~FileUtilsTest() {
+    // each test should clean itself after run
+    QDir(root.toNative()).removeRecursively();
+  }
 
   static void expectList(const QList<FilePath>& result,
                          const QList<FilePath>& expected) {

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -30,8 +30,9 @@
 #include <fileapi.h>
 #endif
 
-#include <fstream>
 #include <QtCore>
+
+#include <fstream>
 
 /*******************************************************************************
  *  Namespace
@@ -302,8 +303,7 @@ TEST_F(FileUtilsTest, testGetFilesInDirectoryRecursiveFiltered) {
 
 TEST_F(FileUtilsTest, testGetFilesInDirectoryRecursiveFilteredSkipHidden) {
   auto actual = FileUtils::getFilesInDirectory(root, filter, true, true);
-  auto expected =
-      QList<FilePath>{rootFile, subdirFile, subdirSubdirFile};
+  auto expected = QList<FilePath>{rootFile, subdirFile, subdirSubdirFile};
 
   // Those should be skipped in output:
   // * rootFileHidden skipped (hidden)


### PR DESCRIPTION
This PR realizes issue #121 

During testing, I found two bugs inside `FileUtils::getFilesInDirectory` functions. 

I created issues #1234 and #1236 for them.

One of them is simple copy-paste mistake inside `FileUtils::getFilesInDirectory` and can be simply corrected in #1234. 

But the second needs deeper examination and testing under different OS or discussion on API used.