### PR TITLE
Fix FileUtils::getFilesInDirectory() reveal nested hidden files

### DIFF
--- a/libs/librepcb/core/fileio/fileutils.cpp
+++ b/libs/librepcb/core/fileio/fileutils.cpp
@@ -181,7 +181,7 @@ QList<FilePath> FileUtils::getFilesInDirectory(const FilePath& dir,
     if (info.isFile()) {
       files.append(fp);
     } else if (info.isDir() && recursive) {
-      files += getFilesInDirectory(fp, filters, recursive);
+      files += getFilesInDirectory(fp, filters, recursive, skipHiddenFiles);
     }
   }
   return files;


### PR DESCRIPTION
This PR fixes bug found in #1234 during creating tests in #121