### PR TITLE
Use std::hypot() for Point::getLength() calculation

### DIFF
--- a/libs/librepcb/core/types/point.h
+++ b/libs/librepcb/core/types/point.h
@@ -210,7 +210,7 @@ public:
    */
   UnsignedLength getLength() const noexcept {
     LengthBase_t length = static_cast<LengthBase_t>(
-        qSqrt(mX.toNm() * mX.toNm() + mY.toNm() * mY.toNm()));
+        std::hypot(mX.toNm(), mY.toNm()));
     Q_ASSERT(length >= 0);
     return UnsignedLength(length);
   }

--- a/libs/librepcb/core/types/point.h
+++ b/libs/librepcb/core/types/point.h
@@ -209,8 +209,8 @@ public:
    * @return The length of this vector (as a Length object)
    */
   UnsignedLength getLength() const noexcept {
-    LengthBase_t length = static_cast<LengthBase_t>(
-        std::hypot(mX.toNm(), mY.toNm()));
+    LengthBase_t length =
+        static_cast<LengthBase_t>(std::hypot(mX.toNm(), mY.toNm()));
     Q_ASSERT(length >= 0);
     return UnsignedLength(length);
   }

--- a/tests/unittests/core/types/pointtest.cpp
+++ b/tests/unittests/core/types/pointtest.cpp
@@ -166,7 +166,8 @@ struct PointLengthPrecisionTestData {
   UnsignedLength squaredLength;
 };
 
-class PointLengthPrecisionTest : public ::testing::TestWithParam<PointLengthPrecisionTestData> {};
+class PointLengthPrecisionTest
+  : public ::testing::TestWithParam<PointLengthPrecisionTestData> {};
 
 TEST_P(PointLengthPrecisionTest, testPrecision) {
   const PointLengthPrecisionTestData& data = GetParam();
@@ -180,14 +181,18 @@ TEST_P(PointLengthPrecisionTest, testPrecision) {
   ASSERT_NO_THROW(pxy.getLength());
 
   EXPECT_EQ(data.axisLength, px.getLength())
-    << "Computed: " << px.getLength()->toNm() << " Expected: " << data.axisLength->toNm();
+      << "Computed: " << px.getLength()->toNm()
+      << " Expected: " << data.axisLength->toNm();
   EXPECT_EQ(data.axisLength, py.getLength())
-    << "Computed: " << px.getLength()->toNm() << " Expected: " << data.axisLength->toNm();
+      << "Computed: " << px.getLength()->toNm()
+      << " Expected: " << data.axisLength->toNm();
   EXPECT_EQ(data.squaredLength, pxy.getLength())
-    << "Computed: " << pxy.getLength()->toNm() << " Expected: " << data.squaredLength->toNm();
+      << "Computed: " << pxy.getLength()->toNm()
+      << " Expected: " << data.squaredLength->toNm();
 }
 
-// sqrt2 according wikipedia 1.41421356237309504880168872420969807856967187537694807317667973799
+// sqrt2 according wikipedia
+// 1.41421356237309504880168872420969807856967187537694807317667973799
 
 static const LengthBase_t MM = 1000000LL;
 static const LengthBase_t M = 1000000000LL;

--- a/tests/unittests/core/types/pointtest.cpp
+++ b/tests/unittests/core/types/pointtest.cpp
@@ -157,6 +157,73 @@ INSTANTIATE_TEST_SUITE_P(PointRotateTest, PointRotateTest, ::testing::Values(
 // clang-format on
 
 /*******************************************************************************
+ *  Tests for precision of getLength()
+ ******************************************************************************/
+
+struct PointLengthPrecisionTestData {
+  Length range;
+  UnsignedLength axisLength;
+  UnsignedLength squaredLength;
+};
+
+class PointLengthPrecisionTest : public ::testing::TestWithParam<PointLengthPrecisionTestData> {};
+
+TEST_P(PointLengthPrecisionTest, testPrecision) {
+  const PointLengthPrecisionTestData& data = GetParam();
+
+  Point px(data.range, 0);
+  Point py(0, data.range);
+  Point pxy(data.range, data.range);
+
+  ASSERT_NO_THROW(px.getLength());
+  ASSERT_NO_THROW(py.getLength());
+  ASSERT_NO_THROW(pxy.getLength());
+
+  EXPECT_EQ(data.axisLength, px.getLength())
+    << "Computed: " << px.getLength()->toNm() << " Expected: " << data.axisLength->toNm();
+  EXPECT_EQ(data.axisLength, py.getLength())
+    << "Computed: " << px.getLength()->toNm() << " Expected: " << data.axisLength->toNm();
+  EXPECT_EQ(data.squaredLength, pxy.getLength())
+    << "Computed: " << pxy.getLength()->toNm() << " Expected: " << data.squaredLength->toNm();
+}
+
+// sqrt2 according wikipedia 1.41421356237309504880168872420969807856967187537694807317667973799
+
+#define MM 1000000LL
+#define M  1000000000LL
+#define KM 1000000000000LL
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(PointLengthPrecisionTest, PointLengthPrecisionTest, ::testing::Values(
+    //                           {range,            axisLength,               squaredLength}
+    PointLengthPrecisionTestData({Length(0),        UnsignedLength(0),        UnsignedLength(0)}),
+
+    // keep precision on nanometer scale
+    PointLengthPrecisionTestData({Length(10),       UnsignedLength(10),       UnsignedLength(14)}),
+
+    // keep precision on millimeter scale
+    PointLengthPrecisionTestData({Length(MM),       UnsignedLength(MM),       UnsignedLength(1414213)}),
+
+    // keep precision on meter scale
+    PointLengthPrecisionTestData({Length(M),        UnsignedLength(M),        UnsignedLength(1414213562)}),
+    PointLengthPrecisionTestData({Length(2*M),      UnsignedLength(2*M),      UnsignedLength(2828427124)}),
+    PointLengthPrecisionTestData({Length(3*M),      UnsignedLength(3*M),      UnsignedLength(4242640687)}),
+
+    // keep precision on kilometer scale
+    PointLengthPrecisionTestData({Length(KM),       UnsignedLength(KM),       UnsignedLength(1414213562373)}),
+    PointLengthPrecisionTestData({Length(10*KM),    UnsignedLength(10*KM),    UnsignedLength(14142135623730)}),
+    PointLengthPrecisionTestData({Length(100*KM),   UnsignedLength(100*KM),   UnsignedLength(141421356237309)}),
+
+    // keep precision on small planet's scale
+    PointLengthPrecisionTestData({Length(1000*KM),  UnsignedLength(1000*KM),  UnsignedLength(1414213562373095)})
+));
+// clang-format on
+
+#undef MM
+#undef M
+#undef KM
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 

--- a/tests/unittests/core/types/pointtest.cpp
+++ b/tests/unittests/core/types/pointtest.cpp
@@ -189,9 +189,9 @@ TEST_P(PointLengthPrecisionTest, testPrecision) {
 
 // sqrt2 according wikipedia 1.41421356237309504880168872420969807856967187537694807317667973799
 
-#define MM 1000000LL
-#define M  1000000000LL
-#define KM 1000000000000LL
+static const LengthBase_t MM = 1000000LL;
+static const LengthBase_t M = 1000000000LL;
+static const LengthBase_t KM = 1000000000000LL;
 
 // clang-format off
 INSTANTIATE_TEST_SUITE_P(PointLengthPrecisionTest, PointLengthPrecisionTest, ::testing::Values(
@@ -218,10 +218,6 @@ INSTANTIATE_TEST_SUITE_P(PointLengthPrecisionTest, PointLengthPrecisionTest, ::t
     PointLengthPrecisionTestData({Length(1000*KM),  UnsignedLength(1000*KM),  UnsignedLength(1414213562373095)})
 ));
 // clang-format on
-
-#undef MM
-#undef M
-#undef KM
 
 /*******************************************************************************
  *  End of File


### PR DESCRIPTION
The Testsuite for #1204 revealed maximum value of Point +/- 2m without losing precision

When the qt function `qSqrt` get out and using `std::hypot` instead, The point can be 1e15nm (100km) large in size without loss of precision and any overflow (test on that succeeded)

Amazing that there is no `qHypot` function on my PC (compiler says undefined external, but I can see it in header of some version of Qt found on internet). Standard c++ function `std::hypot` exists so I used that.

by the way, is there reason to stick on c++11 standard in this app ?