### PR TITLE
Select-all functionality in library (fixing #1179)

### DIFF
--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -373,8 +373,9 @@ bool PackageEditorState_Select::processSelectAll() noexcept {
       if (auto item = mContext.currentGraphicsItem) {
         // Set a selection rect slightly larger than the total items bounding
         // rect to get all items selected.
-        item->setSelectionRect(
-            item->boundingRect().adjusted(-100, -100, 100, 100));
+        auto bounds = mContext.graphicsScene.itemsBoundingRect();
+        bounds.adjust(-100, -100, 100, 100);
+        item->setSelectionRect(bounds);
         emit availableFeaturesChanged();  // Selection might have changed.
         return true;
       }

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -325,9 +325,9 @@ bool SymbolEditorState_Select::processSelectAll() noexcept {
     case SubState::IDLE: {
       // Set a selection rect slightly larger than the total items bounding
       // rect to get all items selected.
-      mContext.symbolGraphicsItem.setSelectionRect(
-          mContext.symbolGraphicsItem.boundingRect().adjusted(-100, -100, 100,
-                                                              100));
+      auto bounds = mContext.graphicsScene.itemsBoundingRect();
+      bounds.adjust(-100, -100, 100, 100);
+      mContext.symbolGraphicsItem.setSelectionRect(bounds);
       emit availableFeaturesChanged();  // Selection might have changed.
       return true;
     }


### PR DESCRIPTION
The `currentGraphicsItem` is always empty (there is no insert anywhere) so it returned always empty rect.

After this PR, for `selectAll` functionality, the entire `graphicsScene` for retrieving entire content rect is used.

Maybe the solution is wrong, probably I missed intent of `currentGraphicsItem`. The board and schematic does this differently.

One architecture misconception is that on symbol it is **reference**, on package it is **shared pointer** so probably there is really unfinished rework.

There should be no style bugs because I tried to run `dev/format_code.sh` :smiley: 