### PR TITLE
Visually separate colors in board layers

### DIFF
--- a/libs/librepcb/core/workspace/theme.cpp
+++ b/libs/librepcb/core/workspace/theme.cpp
@@ -116,7 +116,7 @@ Theme::Theme(const Uuid& uuid, const QString& name) noexcept
   addColor(Color::sBoardAirWires,              brd, tr("Air Wires"),                Qt::yellow,                 Qt::yellow        );
   addColor(Color::sBoardMeasures,              brd, tr("Measures"),                 QColor("#FF808000"),        QColor("#FFA3B200"));
   addColor(Color::sBoardAlignment,             brd, tr("Alignment"),                QColor("#B4E59500"),        QColor("#DCFFBF00"));
-  addColor(Color::sBoardDocumentation,         brd, tr("Documentation"),            QColor("#76fbc697"),        QColor("#b6fbc697"));
+  addColor(Color::sBoardDocumentation,         brd, tr("Documentation"),            QColor("#76FBC697"),        QColor("#B6FBC697"));
   addColor(Color::sBoardComments,              brd, tr("Comments"),                 QColor("#B4E59500"),        QColor("#DCFFBF00"));
   addColor(Color::sBoardGuide,                 brd, tr("Guide"),                    QColor("#FF808000"),        QColor("#FFA3B200"));
   addColor(Color::sBoardNamesTop,              brd, tr("Names Top"),                QColor("#96EDFFD8"),        QColor("#DCE0E0E0")  );
@@ -125,8 +125,8 @@ Theme::Theme(const Uuid& uuid, const QString& name) noexcept
   addColor(Color::sBoardValuesBot,             brd, tr("Values Bottom"),            QColor("#96D8F2FF"),        QColor("#DCE0E0E0")  );
   addColor(Color::sBoardLegendTop,             brd, tr("Legend Top"),               QColor("#BBFFFFFF"),        QColor("#FFFFFFFF")  );
   addColor(Color::sBoardLegendBot,             brd, tr("Legend Bottom"),            QColor("#BBFFFFFF"),        QColor("#FFFFFFFF")  );
-  addColor(Color::sBoardDocumentationTop,      brd, tr("Documentation Top"),        QColor("#96E0E0E0"),        QColor("#DCE0E0E0")  );
-  addColor(Color::sBoardDocumentationBot,      brd, tr("Documentation Bottom"),     QColor("#96E0E0E0"),        QColor("#DCE0E0E0")  );
+  addColor(Color::sBoardDocumentationTop,      brd, tr("Documentation Top"),        QColor("#76FBC697"),        QColor("#B6FBC697")  );
+  addColor(Color::sBoardDocumentationBot,      brd, tr("Documentation Bottom"),     QColor("#76FBC697"),        QColor("#B6FBC697")  );
   addColor(Color::sBoardPackageOutlinesTop,    brd, tr("Package Outlines Top"),     QColor("#C000FFFF"),        QColor("#FF00FFFF")  );
   addColor(Color::sBoardPackageOutlinesBot,    brd, tr("Package Outlines Bottom"),  QColor("#C000FFFF"),        QColor("#FF00FFFF")  );
   addColor(Color::sBoardCourtyardTop,          brd, tr("Courtyard Top"),            QColor("#C0FF00FF"),        QColor("#FFFF00FF")  );

--- a/libs/librepcb/core/workspace/theme.cpp
+++ b/libs/librepcb/core/workspace/theme.cpp
@@ -116,7 +116,7 @@ Theme::Theme(const Uuid& uuid, const QString& name) noexcept
   addColor(Color::sBoardAirWires,              brd, tr("Air Wires"),                Qt::yellow,                 Qt::yellow        );
   addColor(Color::sBoardMeasures,              brd, tr("Measures"),                 QColor("#FF808000"),        QColor("#FFA3B200"));
   addColor(Color::sBoardAlignment,             brd, tr("Alignment"),                QColor("#B4E59500"),        QColor("#DCFFBF00"));
-  addColor(Color::sBoardDocumentation,         brd, tr("Documentation"),            QColor("#96E0E0E0"),        QColor("#DCE0E0E0"));
+  addColor(Color::sBoardDocumentation,         brd, tr("Documentation"),            QColor("#76fbc697"),        QColor("#b6fbc697"));
   addColor(Color::sBoardComments,              brd, tr("Comments"),                 QColor("#B4E59500"),        QColor("#DCFFBF00"));
   addColor(Color::sBoardGuide,                 brd, tr("Guide"),                    QColor("#FF808000"),        QColor("#FFA3B200"));
   addColor(Color::sBoardNamesTop,              brd, tr("Names Top"),                QColor("#96EDFFD8"),        QColor("#DCE0E0E0")  );

--- a/libs/librepcb/core/workspace/theme.cpp
+++ b/libs/librepcb/core/workspace/theme.cpp
@@ -156,16 +156,16 @@ Theme::Theme(const Uuid& uuid, const QString& name) noexcept
         secondary = QColor("#C0DA84FF");
         break;
       case 1:
-        primary = QColor("#96E2A1FF");
-        secondary = QColor("#C0E9BAFF");
+        primary = QColor("#96E50063");
+        secondary = QColor("#C0E50063");
         break;
       case 2:
         primary = QColor("#96EE5C9B");
         secondary = QColor("#C0FF4C99");
         break;
       case 3:
-        primary = QColor("#96E50063");
-        secondary = QColor("#C0E50063");
+        primary = QColor("#96E2A1FF");
+        secondary = QColor("#C0E9BAFF");
         break;
       case 4:
         primary = QColor("#96A70049");


### PR DESCRIPTION
The colors of Documentation layer and inner layers has not been visually differentiated.

This PR uses recommended colors by doom-fr in LibrePCB#707 and LibrePCB#608
therefore fully resolves both issues.

Resolves LibrePCB#707 
Resolves LibrePCB#608