### PR TITLE
Refactor format_code.sh and add QML formatter

### DIFF
--- a/share/librepcb/qml/testwindow.qml
+++ b/share/librepcb/qml/testwindow.qml
@@ -5,29 +5,37 @@ import QtQuick.Layouts 1.2
 
 ColumnLayout {
     anchors.fill: parent
+
     Rectangle {
         Layout.fillWidth: true
         Layout.fillHeight: true
+
         Text {
             anchors.centerIn: parent
             text: "Hello from QML!"
             font.pointSize: 24
             color: "green"
         }
+
     }
+
     Rectangle {
         Layout.fillWidth: true
         Layout.fillHeight: true
+
         Text {
             anchors.centerIn: parent
             text: "If you can read this text, it works!"
             color: "green"
         }
+
     }
+
     Button {
         Layout.fillWidth: true
         Layout.margins: 8
         text: "Close"
         onClicked: view.close()
     }
+
 }


### PR DESCRIPTION
In **first commit** of series, the QML formatter is added so programmer could autoformat modified QML files before submitting pull request

In **second commit** of series, there was plenty copy-pasted code inside that script. Adding new formatters and options can introduce new bugs. Proposed refactoring shortened all copied code to two bash function calls.

The `search_files` function searches for all intended files with specified extensions
they should be checked in the concrete linter.

The `update_file` checks, if the file content has been modified by linter tool and if
it's true, updates file and logs about the change on screen

**NOTE:** The `NEW_CONTENT` is transferred to the `update_file` via global variable, but it can be read from stdin until eof so the linter calls can be one-liners somewhere in the future, but for now the reason is to keep the trace of changes from previous version of script.

**Third commit** allows specification of branch to be compared against in the case of searching file modifications.

In current code, only master branch is hardcoded as reference to compare and track changes against them.
This modifies lot of files when working on branch that are modified by other people in history when not
rooted on master.

I propose adding option `--compare-against <branch_name>` where you can select different branch (or tag or sha)
to compare local modifications against it.

There could be discussion about the argument and variable name. I can rework both.

Probably there can be implementation detail where `ALL` and `COMPARE_AGAINST` have same meaning in the manner
of selecting which method to call, so in future the `ALL` variable can be left out and `COMPARE_AGAINST` will
be set to empty when `--all` argument is passed (KISS principle).