### PR TITLE
devtools: Update to clang-format 15.0.7

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,30 +1,59 @@
 ---
-# NOTE: Created and tested with clang-format version 6.0.0!
+# NOTE: Created and tested with clang-format version 15.0.7!
 #       Other versions may throw errors because of unknown or deprecated keys.
 Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
 AlignEscapedNewlines: DontAlign
-AlignOperands:   false
+AlignOperands:   DontAlign
 AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: InlineOnly
-AllowShortIfStatementsOnASingleLine: true
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
+  AfterCaseLabel:  false
   AfterClass:      false
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   false
   AfterNamespace:  false
@@ -34,13 +63,17 @@ BraceWrapping:
   AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
@@ -48,74 +81,175 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '".*"'
     Priority:        2
+    SortPriority:    2
+    CaseSensitive:   true
   - Regex:           '<Q.*>'
     Priority:        4
+    SortPriority:    4
+    CaseSensitive:   true
   - Regex:           '<[[:alnum:].]+>'
     Priority:        5
+    SortPriority:    5
+    CaseSensitive:   true
   - Regex:           '<.*>'
     Priority:        3
+    SortPriority:    3
+    CaseSensitive:   true
   - Regex:           '.*'
     Priority:        1
+    SortPriority:    1
+    CaseSensitive:   true
 IncludeIsMainRegex: ''
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
 IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
 IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: true
+InsertBraces:    false
+InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: false
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
+PPIndentWidth:   -1
 RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
     BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
 ReflowComments:  true
-SortIncludes:    true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
 Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
 TabWidth:        8
+UseCRLF:         false
 UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 ...
-

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,6 @@ d6d93815095230db700ab1377b18a426b3bfef53
 
 # 2020-09-17: Reformat with clang-format
 7078a0fff181d167a1b45776dbbd2e9c27eccd2b
+
+# 2023-11-27: Reformat with clang-format
+617541447ddc242083675b0e18d1b6578477d737

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -1289,8 +1289,8 @@ void CommandLineInterface::processLibraryElement(
 }
 
 bool CommandLineInterface::openStep(const QString& filePath, bool minify,
-                                    bool tesselate, const QString& saveTo) const
-    noexcept {
+                                    bool tesselate,
+                                    const QString& saveTo) const noexcept {
   try {
     // Note: Not using tr() for this command as it is basically intended for
     // developers, not end users.
@@ -1345,7 +1345,9 @@ bool CommandLineInterface::openStep(const QString& filePath, bool minify,
       const QMap<OccModel::Color, QVector<QVector3D>> vertices =
           model->tesselate();  // can throw
       int vertexCount = 0;
-      foreach (const auto& v, vertices) { vertexCount += v.count(); }
+      foreach (const auto& v, vertices) {
+        vertexCount += v.count();
+      }
       print(QString(" - Built %1 vertices with %2 different colors")
                 .arg(vertexCount)
                 .arg(vertices.count()));
@@ -1366,17 +1368,18 @@ QStringList CommandLineInterface::prepareRuleCheckMessages(
     RuleCheckMessageList messages, const QSet<SExpression>& approvals,
     int& approvedMsgCount) noexcept {
   // Sort messages to increases readability of console output.
-  Toolbox::sortNumeric(messages,
-                       [](const QCollator& cmp,
-                          const std::shared_ptr<const RuleCheckMessage>& lhs,
-                          const std::shared_ptr<const RuleCheckMessage>& rhs) {
-                         if (lhs->getSeverity() != rhs->getSeverity()) {
-                           return lhs->getSeverity() > rhs->getSeverity();
-                         } else {
-                           return cmp(lhs->getMessage(), rhs->getMessage());
-                         }
-                       },
-                       Qt::CaseInsensitive, false);
+  Toolbox::sortNumeric(
+      messages,
+      [](const QCollator& cmp,
+         const std::shared_ptr<const RuleCheckMessage>& lhs,
+         const std::shared_ptr<const RuleCheckMessage>& rhs) {
+        if (lhs->getSeverity() != rhs->getSeverity()) {
+          return lhs->getSeverity() > rhs->getSeverity();
+        } else {
+          return cmp(lhs->getMessage(), rhs->getMessage());
+        }
+      },
+      Qt::CaseInsensitive, false);
   approvedMsgCount = 0;
   QStringList printedMessages;
   foreach (const auto& msg, messages) {

--- a/dev/devtools/Dockerfile
+++ b/dev/devtools/Dockerfile
@@ -1,16 +1,16 @@
-# Container with clang-format 6. Used in the `dev/format_code.sh` script.
+# Container with clang-format 15. Used in the `dev/format_code.sh` script.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get -q update \
  && apt-get -qy install \
-  clang-format-6.0 \
+  clang-format-15 \
   git \
   python3 \
   python3-pip \
   libxml-filter-sort-perl \
  && apt-get clean
 
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 50
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 50
 
 RUN pip3 install cmakelang==0.6.13

--- a/dev/doxygen/pages/code_style_guide.md
+++ b/dev/doxygen/pages/code_style_guide.md
@@ -15,7 +15,7 @@ This page describes the code style guide for LibrePCB developers.
   `dev/CodingStyle_QtCreator.xml` which you can import.
 - In the repository root there is a `.clang-format` file with the exact rules.
   You can use [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
-  (version 6.0.0) to automatically format files according these rules. Use the
+  (version 15.0.7) to automatically format files according these rules. Use the
   command `clang-format -style=file -i <FILE>` to format a single source file.
 - To automatically format all modified source, CMake, *.ui and *.qrc files,
   please run the script `./dev/format_code.sh`. It will format all files which

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -44,11 +44,11 @@ done
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 if [ "$DOCKER" == "--docker" ]; then
-  DOCKER_IMAGE=librepcb/devtools:1.0.0
+  DOCKER_IMAGE=librepcb/devtools:2.0.0
 
   if [ "$($DOCKER_CMD images -q $DOCKER_IMAGE | wc -l)" == "0" ]; then
     echo "Building devtools container..."
-    $DOCKER_CMD build "$REPO_ROOT/dev/devtools" -t librepcb/devtools:1.0.0
+    $DOCKER_CMD build "$REPO_ROOT/dev/devtools" -t $DOCKER_IMAGE
   fi
 
   echo "[Re-running format_code.sh inside Docker container]"

--- a/libs/librepcb/core/attribute/attributetype.h
+++ b/libs/librepcb/core/attribute/attributetype.h
@@ -76,9 +76,9 @@ public:
   const AttributeUnit* tryExtractUnitFromValue(QString& value) const noexcept;
   virtual bool isValueValid(const QString& value) const noexcept = 0;
   virtual QString valueFromTr(const QString& value) const noexcept = 0;
-  virtual QString printableValueTr(const QString& value,
-                                   const AttributeUnit* unit = nullptr) const
-      noexcept = 0;
+  virtual QString printableValueTr(
+      const QString& value,
+      const AttributeUnit* unit = nullptr) const noexcept = 0;
 
   // Static Methods
   static QList<const AttributeType*> getAllTypes() noexcept;

--- a/libs/librepcb/core/attribute/attrtypecapacitance.cpp
+++ b/libs/librepcb/core/attribute/attrtypecapacitance.cpp
@@ -71,9 +71,8 @@ QString AttrTypeCapacitance::valueFromTr(const QString& value) const noexcept {
     return QString();
 }
 
-QString AttrTypeCapacitance::printableValueTr(const QString& value,
-                                              const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypeCapacitance::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   bool ok = false;
   float v = value.toFloat(&ok);
   if (ok && unit)

--- a/libs/librepcb/core/attribute/attrtypecurrent.cpp
+++ b/libs/librepcb/core/attribute/attrtypecurrent.cpp
@@ -76,9 +76,8 @@ QString AttrTypeCurrent::valueFromTr(const QString& value) const noexcept {
     return QString();
 }
 
-QString AttrTypeCurrent::printableValueTr(const QString& value,
-                                          const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypeCurrent::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   bool ok = false;
   float v = value.toFloat(&ok);
   if (ok && unit)

--- a/libs/librepcb/core/attribute/attrtypefrequency.cpp
+++ b/libs/librepcb/core/attribute/attrtypefrequency.cpp
@@ -74,9 +74,8 @@ QString AttrTypeFrequency::valueFromTr(const QString& value) const noexcept {
     return QString();
 }
 
-QString AttrTypeFrequency::printableValueTr(const QString& value,
-                                            const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypeFrequency::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   bool ok = false;
   float v = value.toFloat(&ok);
   if (ok && unit)

--- a/libs/librepcb/core/attribute/attrtypeinductance.cpp
+++ b/libs/librepcb/core/attribute/attrtypeinductance.cpp
@@ -69,9 +69,8 @@ QString AttrTypeInductance::valueFromTr(const QString& value) const noexcept {
     return QString();
 }
 
-QString AttrTypeInductance::printableValueTr(const QString& value,
-                                             const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypeInductance::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   bool ok = false;
   float v = value.toFloat(&ok);
   if (ok && unit)

--- a/libs/librepcb/core/attribute/attrtypepower.cpp
+++ b/libs/librepcb/core/attribute/attrtypepower.cpp
@@ -76,9 +76,8 @@ QString AttrTypePower::valueFromTr(const QString& value) const noexcept {
     return QString();
 }
 
-QString AttrTypePower::printableValueTr(const QString& value,
-                                        const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypePower::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   bool ok = false;
   float v = value.toFloat(&ok);
   if (ok && unit)

--- a/libs/librepcb/core/attribute/attrtyperesistance.cpp
+++ b/libs/librepcb/core/attribute/attrtyperesistance.cpp
@@ -68,9 +68,8 @@ QString AttrTypeResistance::valueFromTr(const QString& value) const noexcept {
     return QString();
 }
 
-QString AttrTypeResistance::printableValueTr(const QString& value,
-                                             const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypeResistance::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   bool ok = false;
   float v = value.toFloat(&ok);
   if (ok && unit)

--- a/libs/librepcb/core/attribute/attrtypestring.cpp
+++ b/libs/librepcb/core/attribute/attrtypestring.cpp
@@ -53,9 +53,8 @@ QString AttrTypeString::valueFromTr(const QString& value) const noexcept {
   return value;
 }
 
-QString AttrTypeString::printableValueTr(const QString& value,
-                                         const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypeString::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   Q_UNUSED(unit);
   return value;
 }

--- a/libs/librepcb/core/attribute/attrtypevoltage.cpp
+++ b/libs/librepcb/core/attribute/attrtypevoltage.cpp
@@ -74,9 +74,8 @@ QString AttrTypeVoltage::valueFromTr(const QString& value) const noexcept {
     return QString();
 }
 
-QString AttrTypeVoltage::printableValueTr(const QString& value,
-                                          const AttributeUnit* unit) const
-    noexcept {
+QString AttrTypeVoltage::printableValueTr(
+    const QString& value, const AttributeUnit* unit) const noexcept {
   bool ok = false;
   float v = value.toFloat(&ok);
   if (ok && unit)

--- a/libs/librepcb/core/export/gerberaperturelist.cpp
+++ b/libs/librepcb/core/export/gerberaperturelist.cpp
@@ -287,8 +287,8 @@ int GerberApertureList::addOutline(const QString& name, const Path& path,
   return addAperture(s, function);
 }
 
-QString GerberApertureList::buildOutlineMacro(Path path, const Angle& rot) const
-    noexcept {
+QString GerberApertureList::buildOutlineMacro(Path path,
+                                              const Angle& rot) const noexcept {
   path.close();
   Q_ASSERT(path.getVertices().count() >= 4);
   QString s = QString("4,1,%2,").arg(path.getVertices().count() - 1);

--- a/libs/librepcb/core/export/gerberattribute.cpp
+++ b/libs/librepcb/core/export/gerberattribute.cpp
@@ -113,7 +113,9 @@ QString GerberAttribute::toString() const noexcept {
       s += "D";
       break;
     }
-    default: { return QString(); }
+    default: {
+      return QString();
+    }
   }
   s += mKey;
   foreach (const QString& value, mValues) {

--- a/libs/librepcb/core/export/gerberattributewriter.cpp
+++ b/libs/librepcb/core/export/gerberattributewriter.cpp
@@ -82,8 +82,12 @@ QString GerberAttributeWriter::setAttributes(
 
   // Build string.
   QString s;
-  foreach (const GerberAttribute& a, toDelete) { s += a.toGerberString(); }
-  foreach (const GerberAttribute& a, toSet) { s += a.toGerberString(); }
+  foreach (const GerberAttribute& a, toDelete) {
+    s += a.toGerberString();
+  }
+  foreach (const GerberAttribute& a, toSet) {
+    s += a.toGerberString();
+  }
   return s;
 }
 

--- a/libs/librepcb/core/export/graphicsexportsettings.cpp
+++ b/libs/librepcb/core/export/graphicsexportsettings.cpp
@@ -126,8 +126,8 @@ QStringList GraphicsExportSettings::getPaintOrder() const noexcept {
   return l;
 }
 
-QColor GraphicsExportSettings::getColor(const QString& colorName) const
-    noexcept {
+QColor GraphicsExportSettings::getColor(
+    const QString& colorName) const noexcept {
   QColor color = getColorImpl(colorName);
   if (color.isValid() && mBlackWhite) {
     color = (mBackgroundColor == Qt::black) ? Qt::white : Qt::black;
@@ -258,8 +258,8 @@ GraphicsExportSettings& GraphicsExportSettings::operator=(
   return *this;
 }
 
-bool GraphicsExportSettings::operator==(const GraphicsExportSettings& rhs) const
-    noexcept {
+bool GraphicsExportSettings::operator==(
+    const GraphicsExportSettings& rhs) const noexcept {
   if (mPageSize != rhs.mPageSize) return false;
   if (mOrientation != rhs.mOrientation) return false;
   if (mMarginLeft != rhs.mMarginLeft) return false;
@@ -277,8 +277,8 @@ bool GraphicsExportSettings::operator==(const GraphicsExportSettings& rhs) const
   return true;
 }
 
-bool GraphicsExportSettings::operator!=(const GraphicsExportSettings& rhs) const
-    noexcept {
+bool GraphicsExportSettings::operator!=(
+    const GraphicsExportSettings& rhs) const noexcept {
   return !(*this == rhs);
 }
 
@@ -286,8 +286,8 @@ bool GraphicsExportSettings::operator!=(const GraphicsExportSettings& rhs) const
  *  Private Methods
  ******************************************************************************/
 
-QColor GraphicsExportSettings::getColorImpl(const QString& name) const
-    noexcept {
+QColor GraphicsExportSettings::getColorImpl(
+    const QString& name) const noexcept {
   foreach (const auto& pair, mColors) {
     if (pair.first == name) {
       return pair.second;

--- a/libs/librepcb/core/export/pickplacedata.cpp
+++ b/libs/librepcb/core/export/pickplacedata.cpp
@@ -55,12 +55,13 @@ void PickPlaceData::addItem(const PickPlaceDataItem& item) noexcept {
   mItems.append(item);
 
   // Sort items by designator to improve readability of the exported file.
-  Toolbox::sortNumeric(mItems,
-                       [](const QCollator& cmp, const PickPlaceDataItem& lhs,
-                          const PickPlaceDataItem& rhs) {
-                         return cmp(lhs.getDesignator(), rhs.getDesignator());
-                       },
-                       Qt::CaseInsensitive, false);
+  Toolbox::sortNumeric(
+      mItems,
+      [](const QCollator& cmp, const PickPlaceDataItem& lhs,
+         const PickPlaceDataItem& rhs) {
+        return cmp(lhs.getDesignator(), rhs.getDesignator());
+      },
+      Qt::CaseInsensitive, false);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/fileio/csvfile.cpp
+++ b/libs/librepcb/core/fileio/csvfile.cpp
@@ -66,7 +66,9 @@ void CsvFile::addValue(const QStringList& value) {
 QString CsvFile::toString() const noexcept {
   QString str = getCommentLines();
   str += lineToString(mHeader);
-  foreach (const QStringList& value, mValues) { str += lineToString(value); }
+  foreach (const QStringList& value, mValues) {
+    str += lineToString(value);
+  }
   return str;
 }
 

--- a/libs/librepcb/core/fileio/transactionaldirectory.cpp
+++ b/libs/librepcb/core/fileio/transactionaldirectory.cpp
@@ -76,18 +76,18 @@ bool TransactionalDirectory::isRestoredFromAutosave() const noexcept {
  *  Inherited from FileSystem
  ******************************************************************************/
 
-FilePath TransactionalDirectory::getAbsPath(const QString& path) const
-    noexcept {
+FilePath TransactionalDirectory::getAbsPath(
+    const QString& path) const noexcept {
   return mFileSystem->getAbsPath(mPath % "/" % path);
 }
 
-QStringList TransactionalDirectory::getDirs(const QString& path) const
-    noexcept {
+QStringList TransactionalDirectory::getDirs(
+    const QString& path) const noexcept {
   return mFileSystem->getDirs(mPath % "/" % path);
 }
 
-QStringList TransactionalDirectory::getFiles(const QString& path) const
-    noexcept {
+QStringList TransactionalDirectory::getFiles(
+    const QString& path) const noexcept {
   return mFileSystem->getFiles(mPath % "/" % path);
 }
 

--- a/libs/librepcb/core/fileio/transactionaldirectory.h
+++ b/libs/librepcb/core/fileio/transactionaldirectory.h
@@ -68,8 +68,8 @@ public:
   virtual ~TransactionalDirectory() noexcept;
 
   // Getters
-  std::shared_ptr<const TransactionalFileSystem> getFileSystem() const
-      noexcept {
+  std::shared_ptr<const TransactionalFileSystem> getFileSystem()
+      const noexcept {
     return mFileSystem;
   }
   std::shared_ptr<TransactionalFileSystem> getFileSystem() noexcept {
@@ -82,8 +82,8 @@ public:
   // Inherited from FileSystem
   virtual FilePath getAbsPath(const QString& path = "") const noexcept override;
   virtual QStringList getDirs(const QString& path = "") const noexcept override;
-  virtual QStringList getFiles(const QString& path = "") const
-      noexcept override;
+  virtual QStringList getFiles(
+      const QString& path = "") const noexcept override;
   virtual bool fileExists(const QString& path) const noexcept override;
   virtual QByteArray read(const QString& path) const override;
   virtual QByteArray readIfExists(const QString& path) const override;

--- a/libs/librepcb/core/fileio/transactionalfilesystem.cpp
+++ b/libs/librepcb/core/fileio/transactionalfilesystem.cpp
@@ -92,13 +92,13 @@ TransactionalFileSystem::~TransactionalFileSystem() noexcept {
  *  Inherited from FileSystem
  ******************************************************************************/
 
-FilePath TransactionalFileSystem::getAbsPath(const QString& path) const
-    noexcept {
+FilePath TransactionalFileSystem::getAbsPath(
+    const QString& path) const noexcept {
   return mFilePath.getPathTo(cleanPath(path));
 }
 
-QStringList TransactionalFileSystem::getDirs(const QString& path) const
-    noexcept {
+QStringList TransactionalFileSystem::getDirs(
+    const QString& path) const noexcept {
   QSet<QString> dirnames;
   QString dirpath = cleanPath(path);
   if (!dirpath.isEmpty()) dirpath.append("/");
@@ -126,8 +126,8 @@ QStringList TransactionalFileSystem::getDirs(const QString& path) const
   return dirnames.values();
 }
 
-QStringList TransactionalFileSystem::getFiles(const QString& path) const
-    noexcept {
+QStringList TransactionalFileSystem::getFiles(
+    const QString& path) const noexcept {
   QSet<QString> filenames;
   QString dirpath = cleanPath(path);
   if (!dirpath.isEmpty()) dirpath.append("/");

--- a/libs/librepcb/core/fileio/transactionalfilesystem.h
+++ b/libs/librepcb/core/fileio/transactionalfilesystem.h
@@ -161,8 +161,8 @@ public:
   // Inherited from FileSystem
   virtual FilePath getAbsPath(const QString& path = "") const noexcept override;
   virtual QStringList getDirs(const QString& path = "") const noexcept override;
-  virtual QStringList getFiles(const QString& path = "") const
-      noexcept override;
+  virtual QStringList getFiles(
+      const QString& path = "") const noexcept override;
   virtual bool fileExists(const QString& path) const noexcept override;
   virtual QByteArray read(const QString& path) const override;
   virtual QByteArray readIfExists(const QString& path) const override;

--- a/libs/librepcb/core/font/strokefont.cpp
+++ b/libs/librepcb/core/font/strokefont.cpp
@@ -241,7 +241,9 @@ QVector<Path> StrokeFont::polylines2paths(
 Path StrokeFont::polyline2path(const fb::Polyline& p,
                                const PositiveLength& height) noexcept {
   Path path;
-  foreach (const fb::Vertex& v, p) { path.addVertex(convertVertex(v, height)); }
+  foreach (const fb::Vertex& v, p) {
+    path.addVertex(convertVertex(v, height));
+  }
   return path;
 }
 

--- a/libs/librepcb/core/font/strokefont.h
+++ b/libs/librepcb/core/font/strokefont.h
@@ -73,8 +73,8 @@ public:
       const QString& text, const PositiveLength& height,
       const Length& letterSpacing, Length& width) const noexcept;
   QVector<Path> strokeLine(const QString& text, const PositiveLength& height,
-                           const Length& letterSpacing, Length& width) const
-      noexcept;
+                           const Length& letterSpacing,
+                           Length& width) const noexcept;
   QVector<Path> strokeGlyph(const QChar& glyph, const PositiveLength& height,
                             Length& spacing) const noexcept;
 
@@ -91,8 +91,8 @@ private:
                             const PositiveLength& height) noexcept;
   static Vertex convertVertex(const fontobene::Vertex& v,
                               const PositiveLength& height) noexcept;
-  Length convertLength(const PositiveLength& height, qreal length) const
-      noexcept;
+  Length convertLength(const PositiveLength& height,
+                       qreal length) const noexcept;
   static void computeBoundingRect(const QVector<Path>& paths, Point& bottomLeft,
                                   Point& topRight) noexcept;
 

--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -118,8 +118,8 @@ Path Path::toOpenPath() const noexcept {
   return p;
 }
 
-QVector<Path> Path::toOutlineStrokes(const PositiveLength& width) const
-    noexcept {
+QVector<Path> Path::toOutlineStrokes(
+    const PositiveLength& width) const noexcept {
   QVector<Path> paths;
   paths.reserve(mVertices.count());
   if (mVertices.count() == 1) {
@@ -218,8 +218,8 @@ Path& Path::mirror(Qt::Orientation orientation, const Point& center) noexcept {
   return *this;
 }
 
-Path Path::mirrored(Qt::Orientation orientation, const Point& center) const
-    noexcept {
+Path Path::mirrored(Qt::Orientation orientation,
+                    const Point& center) const noexcept {
   return Path(*this).mirror(orientation, center);
 }
 

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -88,8 +88,8 @@ public:
   Path& mapToGrid(const PositiveLength& gridInterval) noexcept;
   Path mappedToGrid(const PositiveLength& gridInterval) const noexcept;
   Path& rotate(const Angle& angle, const Point& center = Point(0, 0)) noexcept;
-  Path rotated(const Angle& angle, const Point& center = Point(0, 0)) const
-      noexcept;
+  Path rotated(const Angle& angle,
+               const Point& center = Point(0, 0)) const noexcept;
   Path& mirror(Qt::Orientation orientation,
                const Point& center = Point(0, 0)) noexcept;
   Path mirrored(Qt::Orientation orientation,

--- a/libs/librepcb/core/geometry/stroketext.h
+++ b/libs/librepcb/core/geometry/stroketext.h
@@ -101,8 +101,8 @@ public:
   bool getAutoRotate() const noexcept { return mAutoRotate; }
   const QString& getText() const noexcept { return mText; }
   QVector<Path> generatePaths(const StrokeFont& font) const noexcept;
-  QVector<Path> generatePaths(const StrokeFont& font, const QString& text) const
-      noexcept;
+  QVector<Path> generatePaths(const StrokeFont& font,
+                              const QString& text) const noexcept;
 
   // Setters
   bool setLayer(const Layer& layer) noexcept;

--- a/libs/librepcb/core/geometry/via.h
+++ b/libs/librepcb/core/geometry/via.h
@@ -95,8 +95,8 @@ public:
   bool isBuried() const noexcept;
   bool isOnLayer(const Layer& layer) const noexcept;
   bool isOnAnyLayer(const QSet<const Layer*>& layers) const noexcept;
-  QPainterPath toQPainterPathPx(const Length& expansion = Length(0)) const
-      noexcept;
+  QPainterPath toQPainterPathPx(
+      const Length& expansion = Length(0)) const noexcept;
 
   // Setters
   bool setUuid(const Uuid& uuid) noexcept;

--- a/libs/librepcb/core/job/gerberexcellonoutputjob.cpp
+++ b/libs/librepcb/core/job/gerberexcellonoutputjob.cpp
@@ -286,8 +286,8 @@ void GerberExcellonOutputJob::setOutputPath(const QString& path) noexcept {
  *  General Methods
  ******************************************************************************/
 
-std::shared_ptr<OutputJob> GerberExcellonOutputJob::cloneShared() const
-    noexcept {
+std::shared_ptr<OutputJob> GerberExcellonOutputJob::cloneShared()
+    const noexcept {
   return std::make_shared<GerberExcellonOutputJob>(*this);
 }
 

--- a/libs/librepcb/core/library/cmp/cmpsigpindisplaytype.cpp
+++ b/libs/librepcb/core/library/cmp/cmpsigpindisplaytype.cpp
@@ -57,8 +57,8 @@ CmpSigPinDisplayType::~CmpSigPinDisplayType() noexcept {
  *  Operator Overloadings
  ******************************************************************************/
 
-bool CmpSigPinDisplayType::operator==(const CmpSigPinDisplayType& rhs) const
-    noexcept {
+bool CmpSigPinDisplayType::operator==(
+    const CmpSigPinDisplayType& rhs) const noexcept {
   return mDisplayType == rhs.mDisplayType;
 }
 

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -93,8 +93,8 @@ std::shared_ptr<const ComponentSignal> Component::getSignalOfPin(
   }
 }
 
-int Component::getSymbolVariantIndexByNorm(const QStringList& normOrder) const
-    noexcept {
+int Component::getSymbolVariantIndexByNorm(
+    const QStringList& normOrder) const noexcept {
   foreach (const QString& norm, normOrder) {
     for (int i = 0; i < mSymbolVariants.count(); ++i) {
       std::shared_ptr<const ComponentSymbolVariant> var = mSymbolVariants.at(i);

--- a/libs/librepcb/core/library/cmp/componentsymbolvariant.cpp
+++ b/libs/librepcb/core/library/cmp/componentsymbolvariant.cpp
@@ -151,8 +151,8 @@ void ComponentSymbolVariant::serialize(SExpression& root) const {
  *  Operator Overloadings
  ******************************************************************************/
 
-bool ComponentSymbolVariant::operator==(const ComponentSymbolVariant& rhs) const
-    noexcept {
+bool ComponentSymbolVariant::operator==(
+    const ComponentSymbolVariant& rhs) const noexcept {
   if (mUuid != rhs.mUuid) return false;
   if (mNorm != rhs.mNorm) return false;
   if (mNames != rhs.mNames) return false;

--- a/libs/librepcb/core/library/dev/devicepadsignalmap.cpp
+++ b/libs/librepcb/core/library/dev/devicepadsignalmap.cpp
@@ -80,8 +80,8 @@ void DevicePadSignalMapItem::serialize(SExpression& root) const {
  *  Operator Overloadings
  ******************************************************************************/
 
-bool DevicePadSignalMapItem::operator==(const DevicePadSignalMapItem& rhs) const
-    noexcept {
+bool DevicePadSignalMapItem::operator==(
+    const DevicePadSignalMapItem& rhs) const noexcept {
   if (mPadUuid != rhs.mPadUuid) return false;
   if (mSignalUuid != rhs.mSignalUuid) return false;
   return true;

--- a/libs/librepcb/core/library/dev/devicepadsignalmap.h
+++ b/libs/librepcb/core/library/dev/devicepadsignalmap.h
@@ -125,7 +125,9 @@ public:
   }
 
   static void setPads(DevicePadSignalMap& map, QSet<Uuid> pads) noexcept {
-    foreach (const Uuid& pad, map.getUuidSet() - pads) { map.remove(pad); }
+    foreach (const Uuid& pad, map.getUuidSet() - pads) {
+      map.remove(pad);
+    }
     foreach (const Uuid& pad, pads - map.getUuidSet()) {
       map.append(std::make_shared<DevicePadSignalMapItem>(pad, tl::nullopt));
     }

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -95,10 +95,10 @@ QString Library::getElementsDirectoryName() const noexcept {
 }
 
 // explicit template instantiations
-template QString Library::getElementsDirectoryName<ComponentCategory>() const
-    noexcept;
-template QString Library::getElementsDirectoryName<PackageCategory>() const
-    noexcept;
+template QString Library::getElementsDirectoryName<ComponentCategory>()
+    const noexcept;
+template QString Library::getElementsDirectoryName<PackageCategory>()
+    const noexcept;
 template QString Library::getElementsDirectoryName<Symbol>() const noexcept;
 template QString Library::getElementsDirectoryName<Package>() const noexcept;
 template QString Library::getElementsDirectoryName<Component>() const noexcept;
@@ -157,10 +157,10 @@ QStringList Library::searchForElements() const noexcept {
 }
 
 // explicit template instantiations
-template QStringList Library::searchForElements<ComponentCategory>() const
-    noexcept;
-template QStringList Library::searchForElements<PackageCategory>() const
-    noexcept;
+template QStringList Library::searchForElements<ComponentCategory>()
+    const noexcept;
+template QStringList Library::searchForElements<PackageCategory>()
+    const noexcept;
 template QStringList Library::searchForElements<Symbol>() const noexcept;
 template QStringList Library::searchForElements<Package>() const noexcept;
 template QStringList Library::searchForElements<Component>() const noexcept;

--- a/libs/librepcb/core/library/pkg/footprintpad.h
+++ b/libs/librepcb/core/library/pkg/footprintpad.h
@@ -154,8 +154,8 @@ public:
   bool hasAutoTopSolderPaste() const noexcept;
   bool hasAutoBottomSolderPaste() const noexcept;
   PadGeometry getGeometry() const noexcept;
-  QHash<const Layer*, QList<PadGeometry>> buildPreviewGeometries() const
-      noexcept;
+  QHash<const Layer*, QList<PadGeometry>> buildPreviewGeometries()
+      const noexcept;
 
   // Setters
   bool setPackagePadUuid(const tl::optional<Uuid>& pad) noexcept;

--- a/libs/librepcb/core/library/pkg/footprintpainter.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpainter.cpp
@@ -69,9 +69,8 @@ FootprintPainter::~FootprintPainter() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void FootprintPainter::paint(QPainter& painter,
-                             const GraphicsExportSettings& settings) const
-    noexcept {
+void FootprintPainter::paint(
+    QPainter& painter, const GraphicsExportSettings& settings) const noexcept {
   // Determine what to paint on which color layer.
   initContentByColor();
 

--- a/libs/librepcb/core/library/pkg/footprintpainter.h
+++ b/libs/librepcb/core/library/pkg/footprintpainter.h
@@ -69,8 +69,8 @@ public:
   ~FootprintPainter() noexcept;
 
   // General Methods
-  void paint(QPainter& painter, const GraphicsExportSettings& settings) const
-      noexcept override;
+  void paint(QPainter& painter,
+             const GraphicsExportSettings& settings) const noexcept override;
 
   // Operator Overloadings
   FootprintPainter& operator=(const FootprintPainter& rhs) = delete;

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -115,8 +115,8 @@ Package::~Package() noexcept {
  *  Getters
  ******************************************************************************/
 
-Package::AssemblyType Package::getAssemblyType(bool resolveAuto) const
-    noexcept {
+Package::AssemblyType Package::getAssemblyType(
+    bool resolveAuto) const noexcept {
   if (resolveAuto && (mAssemblyType == AssemblyType::Auto)) {
     return guessAssemblyType();
   } else {

--- a/libs/librepcb/core/library/sym/symbolpainter.cpp
+++ b/libs/librepcb/core/library/sym/symbolpainter.cpp
@@ -63,9 +63,8 @@ SymbolPainter::~SymbolPainter() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void SymbolPainter::paint(QPainter& painter,
-                          const GraphicsExportSettings& settings) const
-    noexcept {
+void SymbolPainter::paint(
+    QPainter& painter, const GraphicsExportSettings& settings) const noexcept {
   GraphicsPainter p(painter);
   p.setMinLineWidth(settings.getMinLineWidth());
 

--- a/libs/librepcb/core/library/sym/symbolpainter.h
+++ b/libs/librepcb/core/library/sym/symbolpainter.h
@@ -57,8 +57,8 @@ public:
   ~SymbolPainter() noexcept;
 
   // General Methods
-  void paint(QPainter& painter, const GraphicsExportSettings& settings) const
-      noexcept override;
+  void paint(QPainter& painter,
+             const GraphicsExportSettings& settings) const noexcept override;
 
   // Operator Overloadings
   SymbolPainter& operator=(const SymbolPainter& rhs) = delete;

--- a/libs/librepcb/core/network/filedownload.cpp
+++ b/libs/librepcb/core/network/filedownload.cpp
@@ -25,8 +25,9 @@
 #include "../exceptions.h"
 #include "../utils/scopeguard.h"
 
-#include <QtCore>
 #include <quazip/JlCompress.h>
+
+#include <QtCore>
 
 /*******************************************************************************
  *  Namespace

--- a/libs/librepcb/core/network/networkrequestbase.cpp
+++ b/libs/librepcb/core/network/networkrequestbase.cpp
@@ -223,7 +223,9 @@ void NetworkRequestBase::replySslErrorsSlot(
   Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
   mErrored = true;
   QStringList errorsList;
-  foreach (const QSslError& e, errors) { errorsList.append(e.errorString()); }
+  foreach (const QSslError& e, errors) {
+    errorsList.append(e.errorString());
+  }
   finalize(tr("SSL errors occurred:\n\n%1").arg(errorsList.join("\n")));
 }
 

--- a/libs/librepcb/core/network/orderpcbapirequest.cpp
+++ b/libs/librepcb/core/network/orderpcbapirequest.cpp
@@ -143,8 +143,8 @@ void OrderPcbApiRequest::infoRequestResponseReceived(
   emit infoRequestSucceeded(mInfoUrl, mMaxFileSize);
 }
 
-void OrderPcbApiRequest::uploadResponseReceived(const QByteArray& data) const
-    noexcept {
+void OrderPcbApiRequest::uploadResponseReceived(
+    const QByteArray& data) const noexcept {
   qDebug().noquote() << "Received JSON:" << data.left(500).replace("\n", " ");
   QJsonDocument doc = QJsonDocument::fromJson(data);
   if (doc.isNull() || doc.isEmpty() || (!doc.isObject())) {

--- a/libs/librepcb/core/network/orderpcbapirequest.h
+++ b/libs/librepcb/core/network/orderpcbapirequest.h
@@ -113,8 +113,8 @@ public:
    * @param boardPath   Path to the pre-selected board (e.g.
    *                    "boards/default/board.lp"). Leave empty if unknown.
    */
-  void startUpload(const QByteArray& lppz, const QString& boardPath) const
-      noexcept;
+  void startUpload(const QByteArray& lppz,
+                   const QString& boardPath) const noexcept;
 
   // Operators
   OrderPcbApiRequest& operator=(const OrderPcbApiRequest& rhs) = delete;

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -146,22 +146,14 @@ bool Board::isEmpty() const noexcept {
 
 QList<BI_Base*> Board::getAllItems() const noexcept {
   QList<BI_Base*> items;
-  foreach (BI_Device* device, mDeviceInstances)
-    items.append(device);
-  foreach (BI_NetSegment* netsegment, mNetSegments)
-    items.append(netsegment);
-  foreach (BI_Plane* plane, mPlanes)
-    items.append(plane);
-  foreach (BI_Zone* zone, mZones)
-    items.append(zone);
-  foreach (BI_Polygon* polygon, mPolygons)
-    items.append(polygon);
-  foreach (BI_StrokeText* text, mStrokeTexts)
-    items.append(text);
-  foreach (BI_Hole* hole, mHoles)
-    items.append(hole);
-  foreach (BI_AirWire* airWire, mAirWires)
-    items.append(airWire);
+  foreach (BI_Device* device, mDeviceInstances) items.append(device);
+  foreach (BI_NetSegment* netsegment, mNetSegments) items.append(netsegment);
+  foreach (BI_Plane* plane, mPlanes) items.append(plane);
+  foreach (BI_Zone* zone, mZones) items.append(zone);
+  foreach (BI_Polygon* polygon, mPolygons) items.append(polygon);
+  foreach (BI_StrokeText* text, mStrokeTexts) items.append(text);
+  foreach (BI_Hole* hole, mHoles) items.append(hole);
+  foreach (BI_AirWire* airWire, mAirWires) items.append(airWire);
   return items;
 }
 
@@ -361,8 +353,8 @@ void Board::setDrcMessageApproved(const SExpression& approval,
  *  DeviceInstance Methods
  ******************************************************************************/
 
-BI_Device* Board::getDeviceInstanceByComponentUuid(const Uuid& uuid) const
-    noexcept {
+BI_Device* Board::getDeviceInstanceByComponentUuid(
+    const Uuid& uuid) const noexcept {
   return mDeviceInstances.value(uuid, nullptr);
 }
 
@@ -471,7 +463,9 @@ void Board::invalidatePlanes(const Layer* layer) noexcept {
 
 void Board::invalidatePlanes(const QSet<const Layer*>& layers) noexcept {
 #if defined(QT_NO_DEBUG)
-  foreach (const Layer* layer, layers) { Q_ASSERT(layer && layer->isCopper()); }
+  foreach (const Layer* layer, layers) {
+    Q_ASSERT(layer && layer->isCopper());
+  }
 #endif
   mScheduledLayersForPlanesRebuild |= layers;
 }
@@ -662,8 +656,8 @@ void Board::forceAirWiresRebuild() noexcept {
  *  General Methods
  ******************************************************************************/
 
-tl::optional<std::pair<Point, Point>> Board::calculateBoundingRect() const
-    noexcept {
+tl::optional<std::pair<Point, Point>> Board::calculateBoundingRect()
+    const noexcept {
   QList<Path> outlines;
   foreach (const BI_Polygon* polygon, mPolygons) {
     if ((polygon->getData().getLayer() == Layer::boardOutlines()) &&

--- a/libs/librepcb/core/project/board/board.h
+++ b/libs/librepcb/core/project/board/board.h
@@ -95,8 +95,8 @@ public:
   BoardFabricationOutputSettings& getFabricationOutputSettings() noexcept {
     return *mFabricationOutputSettings;
   }
-  const BoardFabricationOutputSettings& getFabricationOutputSettings() const
-      noexcept {
+  const BoardFabricationOutputSettings& getFabricationOutputSettings()
+      const noexcept {
     return *mFabricationOutputSettings;
   }
   bool isEmpty() const noexcept;

--- a/libs/librepcb/core/project/board/boardd356netlistexport.cpp
+++ b/libs/librepcb/core/project/board/boardd356netlistexport.cpp
@@ -20,7 +20,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "board.h"
+#include "boardd356netlistexport.h"
 
 #include "../../export/d356netlistgenerator.h"
 #include "../../library/pkg/footprintpad.h"
@@ -29,7 +29,7 @@
 #include "../circuit/componentinstance.h"
 #include "../circuit/netsignal.h"
 #include "../project.h"
-#include "boardd356netlistexport.h"
+#include "board.h"
 #include "items/bi_device.h"
 #include "items/bi_footprintpad.h"
 #include "items/bi_netsegment.h"

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -494,7 +494,9 @@ void BoardGerberExport::exportLayerTopSilkscreen(
                         *mProject.getVersion());
     gen.setFileFunctionLegend(GerberGenerator::BoardSide::Top,
                               GerberGenerator::Polarity::Positive);
-    foreach (const Layer* layer, layers) { drawLayer(gen, *layer); }
+    foreach (const Layer* layer, layers) {
+      drawLayer(gen, *layer);
+    }
     gen.setLayerPolarity(GerberGenerator::Polarity::Negative);
     drawLayer(gen, Layer::topStopMask());
     gen.generate();
@@ -516,7 +518,9 @@ void BoardGerberExport::exportLayerBottomSilkscreen(
                         *mProject.getVersion());
     gen.setFileFunctionLegend(GerberGenerator::BoardSide::Bottom,
                               GerberGenerator::Polarity::Positive);
-    foreach (const Layer* layer, layers) { drawLayer(gen, *layer); }
+    foreach (const Layer* layer, layers) {
+      drawLayer(gen, *layer);
+    }
     gen.setLayerPolarity(GerberGenerator::Polarity::Negative);
     drawLayer(gen, Layer::botStopMask());
     gen.generate();
@@ -968,7 +972,9 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator& gen,
         flashPadOutline();  // can throw
         break;
       }
-      default: { throw LogicError(__FILE__, __LINE__, "Unknown pad shape!"); }
+      default: {
+        throw LogicError(__FILE__, __LINE__, "Unknown pad shape!");
+      }
     }
   }
 }
@@ -1054,8 +1060,8 @@ FilePath BoardGerberExport::getOutputFilePath(QString path) const noexcept {
   }
 }
 
-QString BoardGerberExport::getAttributeValue(const QString& key) const
-    noexcept {
+QString BoardGerberExport::getAttributeValue(
+    const QString& key) const noexcept {
   auto getLayerName = [](const Layer* layer) {
     Q_ASSERT(layer && layer->isCopper());
     if (layer->isTop()) {

--- a/libs/librepcb/core/project/board/boardpainter.cpp
+++ b/libs/librepcb/core/project/board/boardpainter.cpp
@@ -138,9 +138,8 @@ BoardPainter::~BoardPainter() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void BoardPainter::paint(QPainter& painter,
-                         const GraphicsExportSettings& settings) const
-    noexcept {
+void BoardPainter::paint(
+    QPainter& painter, const GraphicsExportSettings& settings) const noexcept {
   // Determine what to paint on which color layer.
   initContentByColor();
 

--- a/libs/librepcb/core/project/board/boardpainter.h
+++ b/libs/librepcb/core/project/board/boardpainter.h
@@ -140,8 +140,8 @@ public:
   ~BoardPainter() noexcept;
 
   // General Methods
-  void paint(QPainter& painter, const GraphicsExportSettings& settings) const
-      noexcept override;
+  void paint(QPainter& painter,
+             const GraphicsExportSettings& settings) const noexcept override;
 
   // Operator Overloadings
   BoardPainter& operator=(const BoardPainter& rhs) = delete;

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -62,8 +62,9 @@ BoardPlaneFragmentsBuilder::BoardPlaneFragmentsBuilder(bool rebuildAirWires,
     mFuture(),
     mWatcher(),
     mAbort(false) {
-  connect(&mWatcher, &QFutureWatcherBase::finished, this,
-          [this]() { applyToBoard(mFuture.result()); }, Qt::QueuedConnection);
+  connect(
+      &mWatcher, &QFutureWatcherBase::finished, this,
+      [this]() { applyToBoard(mFuture.result()); }, Qt::QueuedConnection);
 }
 
 BoardPlaneFragmentsBuilder::~BoardPlaneFragmentsBuilder() noexcept {

--- a/libs/librepcb/core/project/board/boardstroketextdata.cpp
+++ b/libs/librepcb/core/project/board/boardstroketextdata.cpp
@@ -264,8 +264,8 @@ void BoardStrokeTextData::serialize(SExpression& root) const {
  *  Operator Overloadings
  ******************************************************************************/
 
-bool BoardStrokeTextData::operator==(const BoardStrokeTextData& rhs) const
-    noexcept {
+bool BoardStrokeTextData::operator==(
+    const BoardStrokeTextData& rhs) const noexcept {
   if (mUuid != rhs.mUuid) return false;
   if (mLayer != rhs.mLayer) return false;
   if (mText != rhs.mText) return false;

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -1975,8 +1975,8 @@ QVector<Path> BoardDesignRuleCheck::getDeviceLocation(
   return locations;
 }
 
-QVector<Path> BoardDesignRuleCheck::getViaLocation(const BI_Via& via) const
-    noexcept {
+QVector<Path> BoardDesignRuleCheck::getViaLocation(
+    const BI_Via& via) const noexcept {
   return {Path::circle(via.getSize()).translated(via.getPosition())};
 }
 
@@ -2003,8 +2003,8 @@ void BoardDesignRuleCheck::emitMessage(
   emit progressMessage(msg->getMessage());
 }
 
-QString BoardDesignRuleCheck::formatLength(const Length& length) const
-    noexcept {
+QString BoardDesignRuleCheck::formatLength(
+    const Length& length) const noexcept {
   return Toolbox::floatToString(length.toMm(), 6, QLocale()) % "mm";
 }
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -108,8 +108,8 @@ private:  // Methods
       const THole& hole, BoardDesignRuleCheckSettings::AllowedSlots allowed);
   ClipperLib::Paths getBoardClearanceArea(
       const UnsignedLength& clearance) const;
-  QVector<Path> getBoardOutlines(const QSet<const Layer*>& layers) const
-      noexcept;
+  QVector<Path> getBoardOutlines(
+      const QSet<const Layer*>& layers) const noexcept;
   const ClipperLib::Paths& getCopperPaths(
       const Layer& layer, const QSet<const NetSignal*>& netsignals);
   ClipperLib::Paths getDeviceOutlinePaths(const BI_Device& device,
@@ -117,9 +117,9 @@ private:  // Methods
   QVector<Path> getDeviceLocation(const BI_Device& device) const;
   QVector<Path> getViaLocation(const BI_Via& via) const noexcept;
   template <typename THole>
-  QVector<Path> getHoleLocation(const THole& hole,
-                                const Transform& transform = Transform()) const
-      noexcept;
+  QVector<Path> getHoleLocation(
+      const THole& hole,
+      const Transform& transform = Transform()) const noexcept;
   void emitProgress(int percent) noexcept;
   void emitStatus(const QString& status) noexcept;
   void emitMessage(const std::shared_ptr<const RuleCheckMessage>& msg) noexcept;

--- a/libs/librepcb/core/project/board/items/bi_device.cpp
+++ b/libs/librepcb/core/project/board/items/bi_device.cpp
@@ -215,8 +215,8 @@ QVector<std::shared_ptr<const Part>> BI_Device::getParts(
   return parts;
 }
 
-bool BI_Device::isInAssemblyVariant(const Uuid& assemblyVariant) const
-    noexcept {
+bool BI_Device::isInAssemblyVariant(
+    const Uuid& assemblyVariant) const noexcept {
   for (const ComponentAssemblyOption& opt :
        mCompInstance.getAssemblyOptions()) {
     if ((opt.getDevice() == mLibDevice->getUuid()) &&

--- a/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
+++ b/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
@@ -347,8 +347,8 @@ QString BI_FootprintPad::getNetSignalName() const noexcept {
   }
 }
 
-UnsignedLength BI_FootprintPad::getSizeForMaskOffsetCalculaton() const
-    noexcept {
+UnsignedLength BI_FootprintPad::getSizeForMaskOffsetCalculaton()
+    const noexcept {
   if (mFootprintPad->getShape() == FootprintPad::Shape::Custom) {
     // Width/height of the shape are not directly known and difficulat/heavy to
     // determine. So let's consider the pad as small to always get the smallest
@@ -360,8 +360,8 @@ UnsignedLength BI_FootprintPad::getSizeForMaskOffsetCalculaton() const
   }
 }
 
-QList<PadGeometry> BI_FootprintPad::getGeometryOnLayer(const Layer& layer) const
-    noexcept {
+QList<PadGeometry> BI_FootprintPad::getGeometryOnLayer(
+    const Layer& layer) const noexcept {
   if (layer.isCopper()) {
     return getGeometryOnCopperLayer(layer);
   }

--- a/libs/librepcb/core/project/board/items/bi_footprintpad.h
+++ b/libs/librepcb/core/project/board/items/bi_footprintpad.h
@@ -103,8 +103,8 @@ public:
   }
   NetSignal* getCompSigInstNetSignal() const noexcept;
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
-  const QHash<const Layer*, QList<PadGeometry>>& getGeometries() const
-      noexcept {
+  const QHash<const Layer*, QList<PadGeometry>>& getGeometries()
+      const noexcept {
     return mGeometries;
   }
   TraceAnchor toTraceAnchor() const noexcept override;
@@ -136,8 +136,8 @@ private:  // Methods
   QString getNetSignalName() const noexcept;
   UnsignedLength getSizeForMaskOffsetCalculaton() const noexcept;
   QList<PadGeometry> getGeometryOnLayer(const Layer& layer) const noexcept;
-  QList<PadGeometry> getGeometryOnCopperLayer(const Layer& layer) const
-      noexcept;
+  QList<PadGeometry> getGeometryOnCopperLayer(
+      const Layer& layer) const noexcept;
   bool isConnectedOnLayer(const Layer& layer) const noexcept;
 
 private:  // Data

--- a/libs/librepcb/core/project/board/items/bi_netline.h
+++ b/libs/librepcb/core/project/board/items/bi_netline.h
@@ -98,8 +98,8 @@ public:
   const PositiveLength& getWidth() const noexcept { return mTrace.getWidth(); }
   BI_NetLineAnchor& getStartPoint() const noexcept { return *mStartPoint; }
   BI_NetLineAnchor& getEndPoint() const noexcept { return *mEndPoint; }
-  BI_NetLineAnchor* getOtherPoint(const BI_NetLineAnchor& firstPoint) const
-      noexcept;
+  BI_NetLineAnchor* getOtherPoint(
+      const BI_NetLineAnchor& firstPoint) const noexcept;
   Path getSceneOutline(const Length& expansion = Length(0)) const noexcept;
   UnsignedLength getLength() const noexcept;
 

--- a/libs/librepcb/core/project/board/items/bi_netsegment.cpp
+++ b/libs/librepcb/core/project/board/items/bi_netsegment.cpp
@@ -359,8 +359,8 @@ bool BI_NetSegment::areAllNetPointsConnectedTogether() const noexcept {
 
 void BI_NetSegment::findAllConnectedNetPoints(
     const BI_NetLineAnchor& p, QSet<const BI_Via*>& vias,
-    QSet<const BI_FootprintPad*>& pads, QSet<const BI_NetPoint*>& points) const
-    noexcept {
+    QSet<const BI_FootprintPad*>& pads,
+    QSet<const BI_NetPoint*>& points) const noexcept {
   if (const BI_Via* via = dynamic_cast<const BI_Via*>(&p)) {
     if (vias.contains(via)) return;
     vias.insert(via);

--- a/libs/librepcb/core/project/board/items/bi_netsegment.h
+++ b/libs/librepcb/core/project/board/items/bi_netsegment.h
@@ -132,11 +132,10 @@ signals:
 private:
   bool checkAttributesValidity() const noexcept;
   bool areAllNetPointsConnectedTogether() const noexcept;
-  void findAllConnectedNetPoints(const BI_NetLineAnchor& p,
-                                 QSet<const BI_Via*>& vias,
-                                 QSet<const BI_FootprintPad*>& pads,
-                                 QSet<const BI_NetPoint*>& points) const
-      noexcept;
+  void findAllConnectedNetPoints(
+      const BI_NetLineAnchor& p, QSet<const BI_Via*>& vias,
+      QSet<const BI_FootprintPad*>& pads,
+      QSet<const BI_NetPoint*>& points) const noexcept;
 
   // Attributes
   Uuid mUuid;

--- a/libs/librepcb/core/project/board/items/bi_via.h
+++ b/libs/librepcb/core/project/board/items/bi_via.h
@@ -77,13 +77,13 @@ public:
   const tl::optional<PositiveLength>& getStopMaskDiameterTop() const noexcept {
     return mStopMaskDiameterTop;
   }
-  const tl::optional<PositiveLength>& getStopMaskDiameterBottom() const
-      noexcept {
+  const tl::optional<PositiveLength>& getStopMaskDiameterBottom()
+      const noexcept {
     return mStopMaskDiameterBottom;
   }
   bool isUsed() const noexcept { return (mRegisteredNetLines.count() > 0); }
-  tl::optional<std::pair<const Layer*, const Layer*> > getDrillLayerSpan() const
-      noexcept;
+  tl::optional<std::pair<const Layer*, const Layer*> > getDrillLayerSpan()
+      const noexcept;
   TraceAnchor toTraceAnchor() const noexcept override;
 
   // Setters

--- a/libs/librepcb/core/project/circuit/circuit.cpp
+++ b/libs/librepcb/core/project/circuit/circuit.cpp
@@ -47,24 +47,21 @@ Circuit::Circuit(Project& project) : QObject(&project), mProject(project) {
 
 Circuit::~Circuit() noexcept {
   // delete all component instances (and catch all thrown exceptions)
-  foreach (ComponentInstance* compInstance, mComponentInstances)
-    try {
+  foreach (ComponentInstance* compInstance, mComponentInstances) try {
       removeComponentInstance(*compInstance);
       delete compInstance;
     } catch (...) {
     }
 
   // delete all netsignals (and catch all thrown exceptions)
-  foreach (NetSignal* netsignal, mNetSignals)
-    try {
+  foreach (NetSignal* netsignal, mNetSignals) try {
       removeNetSignal(*netsignal);
       delete netsignal;
     } catch (...) {
     }
 
   // delete all netclasses (and catch all thrown exceptions)
-  foreach (NetClass* netclass, mNetClasses)
-    try {
+  foreach (NetClass* netclass, mNetClasses) try {
       removeNetClass(*netclass);
       delete netclass;
     } catch (...) {
@@ -282,8 +279,8 @@ QString Circuit::generateAutoComponentInstanceName(
   return name;
 }
 
-ComponentInstance* Circuit::getComponentInstanceByUuid(const Uuid& uuid) const
-    noexcept {
+ComponentInstance* Circuit::getComponentInstanceByUuid(
+    const Uuid& uuid) const noexcept {
   return mComponentInstances.value(uuid, nullptr);
 }
 

--- a/libs/librepcb/core/project/circuit/circuit.h
+++ b/libs/librepcb/core/project/circuit/circuit.h
@@ -119,10 +119,10 @@ public:
   const QMap<Uuid, ComponentInstance*>& getComponentInstances() const noexcept {
     return mComponentInstances;
   }
-  ComponentInstance* getComponentInstanceByUuid(const Uuid& uuid) const
-      noexcept;
-  ComponentInstance* getComponentInstanceByName(const QString& name) const
-      noexcept;
+  ComponentInstance* getComponentInstanceByUuid(
+      const Uuid& uuid) const noexcept;
+  ComponentInstance* getComponentInstanceByName(
+      const QString& name) const noexcept;
   void addComponentInstance(ComponentInstance& cmp);
   void removeComponentInstance(ComponentInstance& cmp);
   void setComponentInstanceName(ComponentInstance& cmp,

--- a/libs/librepcb/core/project/circuit/componentinstance.h
+++ b/libs/librepcb/core/project/circuit/componentinstance.h
@@ -77,8 +77,8 @@ public:
   const QMap<Uuid, ComponentSignalInstance*>& getSignals() const noexcept {
     return mSignals;
   }
-  ComponentSignalInstance* getSignalInstance(const Uuid& signalUuid) const
-      noexcept {
+  ComponentSignalInstance* getSignalInstance(
+      const Uuid& signalUuid) const noexcept {
     return mSignals.value(signalUuid);
   }
   const AttributeList& getAttributes() const noexcept { return *mAttributes; }

--- a/libs/librepcb/core/project/outputjobrunner.cpp
+++ b/libs/librepcb/core/project/outputjobrunner.cpp
@@ -84,8 +84,8 @@ const FilePath& OutputJobRunner::getOutputDirectory() const noexcept {
   return mWriter->getDirectoryPath();
 }
 
-const QMultiHash<Uuid, FilePath>& OutputJobRunner::getWrittenFiles() const
-    noexcept {
+const QMultiHash<Uuid, FilePath>& OutputJobRunner::getWrittenFiles()
+    const noexcept {
   return mWriter->getWrittenFiles();
 }
 

--- a/libs/librepcb/core/project/projectlibrary.h
+++ b/libs/librepcb/core/project/projectlibrary.h
@@ -85,8 +85,8 @@ public:
   }
 
   // Getters: Special Queries
-  QHash<Uuid, Device*> getDevicesOfComponent(const Uuid& compUuid) const
-      noexcept;
+  QHash<Uuid, Device*> getDevicesOfComponent(
+      const Uuid& compUuid) const noexcept;
 
   // Add/Remove Methods
   void addSymbol(Symbol& s);

--- a/libs/librepcb/core/project/schematic/items/si_netline.h
+++ b/libs/librepcb/core/project/schematic/items/si_netline.h
@@ -91,8 +91,8 @@ public:
   }
   SI_NetLineAnchor& getStartPoint() const noexcept { return *mStartPoint; }
   SI_NetLineAnchor& getEndPoint() const noexcept { return *mEndPoint; }
-  SI_NetLineAnchor* getOtherPoint(const SI_NetLineAnchor& firstPoint) const
-      noexcept;
+  SI_NetLineAnchor* getOtherPoint(
+      const SI_NetLineAnchor& firstPoint) const noexcept;
   NetSignal& getNetSignalOfNetSegment() const noexcept;
 
   // Setters

--- a/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
@@ -289,7 +289,9 @@ void SI_NetSegment::removeNetLabel(SI_NetLabel& netlabel) {
 }
 
 void SI_NetSegment::updateAllNetLabelAnchors() noexcept {
-  foreach (SI_NetLabel* netlabel, mNetLabels) { netlabel->updateAnchor(); }
+  foreach (SI_NetLabel* netlabel, mNetLabels) {
+    netlabel->updateAnchor();
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/items/si_netsegment.h
+++ b/libs/librepcb/core/project/schematic/items/si_netsegment.h
@@ -121,10 +121,9 @@ signals:
 private:
   bool checkAttributesValidity() const noexcept;
   bool areAllNetPointsConnectedTogether() const noexcept;
-  void findAllConnectedNetPoints(const SI_NetLineAnchor& p,
-                                 QSet<const SI_SymbolPin*>& pins,
-                                 QSet<const SI_NetPoint*>& points) const
-      noexcept;
+  void findAllConnectedNetPoints(
+      const SI_NetLineAnchor& p, QSet<const SI_SymbolPin*>& pins,
+      QSet<const SI_NetPoint*>& points) const noexcept;
 
   // Attributes
   Uuid mUuid;

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -130,9 +130,8 @@ SchematicPainter::~SchematicPainter() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void SchematicPainter::paint(QPainter& painter,
-                             const GraphicsExportSettings& settings) const
-    noexcept {
+void SchematicPainter::paint(
+    QPainter& painter, const GraphicsExportSettings& settings) const noexcept {
   GraphicsPainter p(painter);
   p.setMinLineWidth(settings.getMinLineWidth());
 

--- a/libs/librepcb/core/project/schematic/schematicpainter.h
+++ b/libs/librepcb/core/project/schematic/schematicpainter.h
@@ -95,8 +95,8 @@ public:
   ~SchematicPainter() noexcept;
 
   // General Methods
-  void paint(QPainter& painter, const GraphicsExportSettings& settings) const
-      noexcept override;
+  void paint(QPainter& painter,
+             const GraphicsExportSettings& settings) const noexcept override;
 
   // Operator Overloadings
   SchematicPainter& operator=(const SchematicPainter& rhs) = delete;

--- a/libs/librepcb/core/serialization/fileformatmigration.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigration.cpp
@@ -94,8 +94,8 @@ QList<std::shared_ptr<FileFormatMigration>> FileFormatMigration::getMigrations(
  ******************************************************************************/
 
 FileFormatMigration::Message FileFormatMigration::buildMessage(
-    Message::Severity severity, const QString& message, int affectedItems) const
-    noexcept {
+    Message::Severity severity, const QString& message,
+    int affectedItems) const noexcept {
   const Message msg{mFromVersion, mToVersion, severity, affectedItems, message};
   const QString multiplier =
       affectedItems > 0 ? QString(" (%1x)").arg(affectedItems) : "";

--- a/libs/librepcb/core/serialization/serializablekeyvaluemap.h
+++ b/libs/librepcb/core/serialization/serializablekeyvaluemap.h
@@ -111,8 +111,8 @@ public:
   bool contains(const QString& key) const noexcept {
     return mValues.contains(key);
   }
-  tl::optional<typename T::ValueType> tryGet(const QString& key) const
-      noexcept {
+  tl::optional<typename T::ValueType> tryGet(
+      const QString& key) const noexcept {
     auto i = mValues.find(key);
     if ((i != mValues.end()) && (i.key() == key)) {
       return i.value();
@@ -120,9 +120,8 @@ public:
       return tl::nullopt;
     }
   }
-  const typename T::ValueType& value(const QStringList& keyOrder,
-                                     QString* usedKey = nullptr) const
-      noexcept {
+  const typename T::ValueType& value(
+      const QStringList& keyOrder, QString* usedKey = nullptr) const noexcept {
     // search in the specified key order
     foreach (const QString& key, keyOrder) {
       auto i = mValues.find(key);

--- a/libs/librepcb/core/serialization/serializableobjectlist.h
+++ b/libs/librepcb/core/serialization/serializableobjectlist.h
@@ -179,7 +179,9 @@ public:
           *this,
           &SerializableObjectList<T, P,
                                   OnEditedArgs...>::elementEditedHandler) {
-    foreach (const std::shared_ptr<T>& obj, elements) { append(obj); }
+    foreach (const std::shared_ptr<T>& obj, elements) {
+      append(obj);
+    }
   }
   explicit SerializableObjectList(const SExpression& node)
     : onEdited(*this),
@@ -380,8 +382,8 @@ public:
 
   // Convenience Methods
   template <typename Compare>
-  SerializableObjectList<T, P, OnEditedArgs...> sorted(Compare lessThan) const
-      noexcept {
+  SerializableObjectList<T, P, OnEditedArgs...> sorted(
+      Compare lessThan) const noexcept {
     SerializableObjectList<T, P, OnEditedArgs...> copiedList;
     copiedList.mObjects = mObjects;  // copy only the pointers, not the objects!
     std::sort(copiedList.mObjects.begin(), copiedList.mObjects.end(),

--- a/libs/librepcb/core/serialization/sexpression.cpp
+++ b/libs/librepcb/core/serialization/sexpression.cpp
@@ -106,8 +106,8 @@ QList<SExpression*> SExpression::getChildren(const QString& name) noexcept {
   return children;
 }
 
-QList<const SExpression*> SExpression::getChildren(const QString& name) const
-    noexcept {
+QList<const SExpression*> SExpression::getChildren(
+    const QString& name) const noexcept {
   QList<const SExpression*> children;
   for (const SExpression& child : mChildren) {
     if (child.isList() && (child.mValue == name)) {
@@ -159,8 +159,8 @@ SExpression* SExpression::tryGetChild(const QString& path) noexcept {
   return child;
 }
 
-const SExpression* SExpression::tryGetChild(const QString& path) const
-    noexcept {
+const SExpression* SExpression::tryGetChild(
+    const QString& path) const noexcept {
   return const_cast<SExpression*>(this)->tryGetChild(path);
 }
 
@@ -302,7 +302,9 @@ QString SExpression::escapeString(const QString& string) noexcept {
 
   QString escaped;
   escaped.reserve(string.length() + (string.length() / 10));
-  foreach (const QChar& c, string) { escaped += replacements.value(c, c); }
+  foreach (const QChar& c, string) {
+    escaped += replacements.value(c, c);
+  }
   return escaped;
 }
 

--- a/libs/librepcb/core/types/boundedunsignedratio.cpp
+++ b/libs/librepcb/core/types/boundedunsignedratio.cpp
@@ -56,8 +56,8 @@ BoundedUnsignedRatio::~BoundedUnsignedRatio() noexcept {
  *  Getters
  ******************************************************************************/
 
-UnsignedLength BoundedUnsignedRatio::calcValue(const Length& input) const
-    noexcept {
+UnsignedLength BoundedUnsignedRatio::calcValue(
+    const Length& input) const noexcept {
   return UnsignedLength(
       qBound(*mMinValue, input.scaled(mRatio->toNormalized()), *mMaxValue));
 }
@@ -84,8 +84,8 @@ BoundedUnsignedRatio& BoundedUnsignedRatio::operator=(
   return *this;
 }
 
-bool BoundedUnsignedRatio::operator==(const BoundedUnsignedRatio& rhs) const
-    noexcept {
+bool BoundedUnsignedRatio::operator==(
+    const BoundedUnsignedRatio& rhs) const noexcept {
   return (mRatio == rhs.mRatio) && (mMinValue == rhs.mMinValue) &&
       (mMaxValue == rhs.mMaxValue);
 }

--- a/libs/librepcb/core/types/point.cpp
+++ b/libs/librepcb/core/types/point.cpp
@@ -111,8 +111,8 @@ Point& Point::rotate(const Angle& angle, const Point& center) noexcept {
   return *this;
 }
 
-Point Point::mirrored(Qt::Orientation orientation, const Point& center) const
-    noexcept {
+Point Point::mirrored(Qt::Orientation orientation,
+                      const Point& center) const noexcept {
   Point p(*this);
   p.mirror(orientation, center);
   return p;

--- a/libs/librepcb/core/types/point.h
+++ b/libs/librepcb/core/types/point.h
@@ -346,8 +346,8 @@ public:
    *
    * @see ::librepcb::Point::rotate()
    */
-  Point rotated(const Angle& angle, const Point& center = Point(0, 0)) const
-      noexcept;
+  Point rotated(const Angle& angle,
+                const Point& center = Point(0, 0)) const noexcept;
 
   /**
    * @brief Rotate the point by a specific angle with respect to a specific

--- a/libs/librepcb/core/types/stroketextspacing.cpp
+++ b/libs/librepcb/core/types/stroketextspacing.cpp
@@ -72,8 +72,8 @@ StrokeTextSpacing::~StrokeTextSpacing() noexcept {
  *  Operator Overloadings
  ******************************************************************************/
 
-bool StrokeTextSpacing::operator==(const StrokeTextSpacing& rhs) const
-    noexcept {
+bool StrokeTextSpacing::operator==(
+    const StrokeTextSpacing& rhs) const noexcept {
   return (mRatio == rhs.mRatio);
 }
 

--- a/libs/librepcb/core/utils/tangentpathjoiner.cpp
+++ b/libs/librepcb/core/utils/tangentpathjoiner.cpp
@@ -106,7 +106,9 @@ QVector<Path> TangentPathJoiner::join(QVector<Path> paths,
     }
   }
   std::sort(obsoletePaths.begin(), obsoletePaths.end(), std::greater<int>());
-  foreach (int i, obsoletePaths) { paths.removeAt(i); }
+  foreach (int i, obsoletePaths) {
+    paths.removeAt(i);
+  }
 
   // Add closed paths to the result and remove them from the input.
   for (int i = paths.count() - 1; i >= 0; --i) {

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
@@ -568,8 +568,8 @@ int WorkspaceLibraryDbWriter::addToCategory(const QString& elementsTable,
   return mDb.insert(query);
 }
 
-QString WorkspaceLibraryDbWriter::filePathToString(const FilePath& fp) const
-    noexcept {
+QString WorkspaceLibraryDbWriter::filePathToString(
+    const FilePath& fp) const noexcept {
   return fp.toRelative(mLibrariesRoot);
 }
 

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -54,9 +54,10 @@ WorkspaceLibraryScanner::WorkspaceLibraryScanner(
     mSemaphore(0),
     mAbort(false),
     mLastProgressPercent(100) {
-  connect(this, &WorkspaceLibraryScanner::scanProgressUpdate, this,
-          [this](int percent) { mLastProgressPercent = percent; },
-          Qt::QueuedConnection);
+  connect(
+      this, &WorkspaceLibraryScanner::scanProgressUpdate, this,
+      [this](int percent) { mLastProgressPercent = percent; },
+      Qt::QueuedConnection);
   start();
 }
 

--- a/libs/librepcb/editor/3d/openglscenebuilder.cpp
+++ b/libs/librepcb/editor/3d/openglscenebuilder.cpp
@@ -278,7 +278,9 @@ void OpenGlSceneBuilder::run(std::shared_ptr<SceneData3D> data) noexcept {
 
     // Remove all no longer existing devices.
     foreach (const Uuid& uuid, mDevices.keys().toSet() - deviceUuids) {
-      foreach (auto obj, mDevices.take(uuid)) { emit objectRemoved(obj); }
+      foreach (auto obj, mDevices.take(uuid)) {
+        emit objectRemoved(obj);
+      }
     }
 
     qDebug() << "Successfully built 3D scene in" << timer.elapsed() << "ms.";

--- a/libs/librepcb/editor/dialogs/graphicsexportdialog.cpp
+++ b/libs/librepcb/editor/dialogs/graphicsexportdialog.cpp
@@ -396,24 +396,26 @@ GraphicsExportDialog::GraphicsExportDialog(
 
   // Setup export.
   mExport->setDocumentName(documentName);
-  connect(mExport.data(), &GraphicsExport::succeeded, this,
-          [this]() {
-            const bool canceled = mProgressDialog->wasCanceled();
-            mProgressDialog->reset();
-            if (!canceled) {
-              if (mPathToOpenAfterExport.isValid()) {
-                emit requestOpenFile(mPathToOpenAfterExport);
-              }
-              close();
-            }
-          },
-          Qt::QueuedConnection);
-  connect(mExport.data(), &GraphicsExport::failed, this,
-          [this](const QString& msg) {
-            mProgressDialog->reset();
-            QMessageBox::critical(this, tr("Error"), msg);
-          },
-          Qt::QueuedConnection);
+  connect(
+      mExport.data(), &GraphicsExport::succeeded, this,
+      [this]() {
+        const bool canceled = mProgressDialog->wasCanceled();
+        mProgressDialog->reset();
+        if (!canceled) {
+          if (mPathToOpenAfterExport.isValid()) {
+            emit requestOpenFile(mPathToOpenAfterExport);
+          }
+          close();
+        }
+      },
+      Qt::QueuedConnection);
+  connect(
+      mExport.data(), &GraphicsExport::failed, this,
+      [this](const QString& msg) {
+        mProgressDialog->reset();
+        QMessageBox::critical(this, tr("Error"), msg);
+      },
+      Qt::QueuedConnection);
 
   // Setup progress dialog.
   mProgressDialog->reset();
@@ -422,15 +424,16 @@ GraphicsExportDialog::GraphicsExportDialog(
   mProgressDialog->setAutoReset(false);
   connect(mProgressDialog.data(), &QProgressDialog::canceled, mExport.data(),
           &GraphicsExport::cancel);
-  connect(mExport.data(), &GraphicsExport::progress, mProgressDialog.data(),
-          [this](int percent, int page, int total) {
-            if (mProgressDialog->isVisible()) {
-              mProgressDialog->setLabelText(
-                  tr("Processing page %1 of %2...").arg(page).arg(total));
-              mProgressDialog->setValue(percent);
-            }
-          },
-          Qt::QueuedConnection);
+  connect(
+      mExport.data(), &GraphicsExport::progress, mProgressDialog.data(),
+      [this](int percent, int page, int total) {
+        if (mProgressDialog->isVisible()) {
+          mProgressDialog->setLabelText(
+              tr("Processing page %1 of %2...").arg(page).arg(total));
+          mProgressDialog->setValue(percent);
+        }
+      },
+      Qt::QueuedConnection);
 
   // Load settings.
   loadDefaultSettings();
@@ -487,7 +490,9 @@ void GraphicsExportDialog::loadDefaultSettings() noexcept {
 
   // Page content.
   QSet<QString> allColors;
-  foreach (const auto& pair, mColors) { allColors.insert(pair.first); }
+  foreach (const auto& pair, mColors) {
+    allColors.insert(pair.first);
+  }
   QSet<QString> commonColors = {
       Theme::Color::sBoardMeasures,
       Theme::Color::sBoardFrames,
@@ -1232,8 +1237,8 @@ void GraphicsExportDialog::setOrientation(
   }
 }
 
-GraphicsExportSettings::Orientation GraphicsExportDialog::getOrientation() const
-    noexcept {
+GraphicsExportSettings::Orientation GraphicsExportDialog::getOrientation()
+    const noexcept {
   if (mUi->rbtnOrientationLandscape->isChecked()) {
     return GraphicsExportSettings::Orientation::Landscape;
   } else if (mUi->rbtnOrientationPortrait->isChecked()) {

--- a/libs/librepcb/editor/editorcommand.cpp
+++ b/libs/librepcb/editor/editorcommand.cpp
@@ -79,8 +79,8 @@ void EditorCommand::updateTranslations() noexcept {
       QCoreApplication::translate("EditorCommandSet", mDescriptionNoTr);
 }
 
-QAction* EditorCommand::createAction(QObject* parent, ActionFlags flags) const
-    noexcept {
+QAction* EditorCommand::createAction(QObject* parent,
+                                     ActionFlags flags) const noexcept {
   return setupAction(new QAction(parent), flags);
 }
 
@@ -88,8 +88,8 @@ QAction* EditorCommand::createAction(QObject* parent, ActionFlags flags) const
  *  Private Methods
  ******************************************************************************/
 
-QAction* EditorCommand::setupAction(QAction* action, ActionFlags flags) const
-    noexcept {
+QAction* EditorCommand::setupAction(QAction* action,
+                                    ActionFlags flags) const noexcept {
   QString name = "action";
   foreach (const QString& fragment, mIdentifier.split('.').last().split('_')) {
     name.append(fragment.mid(0, 1).toUpper() % fragment.midRef(1));

--- a/libs/librepcb/editor/graphics/defaultgraphicslayerprovider.h
+++ b/libs/librepcb/editor/graphics/defaultgraphicslayerprovider.h
@@ -51,8 +51,8 @@ public:
   ~DefaultGraphicsLayerProvider() noexcept;
 
   // Getters
-  std::shared_ptr<GraphicsLayer> getLayer(const QString& name) const
-      noexcept override;
+  std::shared_ptr<GraphicsLayer> getLayer(
+      const QString& name) const noexcept override;
   QList<std::shared_ptr<GraphicsLayer>> getAllLayers() const noexcept override {
     return mLayers;
   }

--- a/libs/librepcb/editor/graphics/graphicslayer.h
+++ b/libs/librepcb/editor/graphics/graphicslayer.h
@@ -111,10 +111,10 @@ protected:  // Data
 class IF_GraphicsLayerProvider {
 public:
   virtual ~IF_GraphicsLayerProvider() noexcept {}
-  virtual QList<std::shared_ptr<GraphicsLayer>> getAllLayers() const
-      noexcept = 0;
-  virtual std::shared_ptr<GraphicsLayer> getLayer(const QString& name) const
-      noexcept = 0;
+  virtual QList<std::shared_ptr<GraphicsLayer>> getAllLayers()
+      const noexcept = 0;
+  virtual std::shared_ptr<GraphicsLayer> getLayer(
+      const QString& name) const noexcept = 0;
   std::shared_ptr<GraphicsLayer> getLayer(const Layer& layer) const noexcept;
   std::shared_ptr<GraphicsLayer> getGrabAreaLayer(
       const Layer& outlineLayer) const noexcept;

--- a/libs/librepcb/editor/graphics/polygongraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/polygongraphicsitem.cpp
@@ -66,8 +66,8 @@ PolygonGraphicsItem::~PolygonGraphicsItem() noexcept {
  *  Public Methods
  ******************************************************************************/
 
-int PolygonGraphicsItem::getLineIndexAtPosition(const Point& pos) const
-    noexcept {
+int PolygonGraphicsItem::getLineIndexAtPosition(
+    const Point& pos) const noexcept {
   // We build temporary PrimitivePathGraphicsItem objects for each segment of
   // the polygon and check if the specified position is located within the shape
   // of one of these graphics items. This is quite ugly, but was easy to

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
@@ -96,13 +96,17 @@ void PrimitiveFootprintPadGraphicsItem::setPosition(
 void PrimitiveFootprintPadGraphicsItem::setRotation(
     const Angle& rotation) noexcept {
   mOriginCrossGraphicsItem->setRotation(rotation);
-  foreach (auto& item, mPathGraphicsItems) { item.item->setRotation(rotation); }
+  foreach (auto& item, mPathGraphicsItems) {
+    item.item->setRotation(rotation);
+  }
   // Keep the text always at 0° for readability.
 }
 
 void PrimitiveFootprintPadGraphicsItem::setMirrored(bool mirrored) noexcept {
   mMirror = mirrored;
-  foreach (auto& item, mPathGraphicsItems) { item.item->setMirrored(mirrored); }
+  foreach (auto& item, mPathGraphicsItems) {
+    item.item->setMirrored(mirrored);
+  }
 }
 
 void PrimitiveFootprintPadGraphicsItem::setText(const QString& text) noexcept {
@@ -114,7 +118,9 @@ void PrimitiveFootprintPadGraphicsItem::setText(const QString& text) noexcept {
   setToolTip(text);
   mOriginCrossGraphicsItem->setToolTip(text);
   mTextGraphicsItem->setPath(Path::toQPainterPathPx(paths, false));
-  foreach (auto& item, mPathGraphicsItems) { item.item->setToolTip(text); }
+  foreach (auto& item, mPathGraphicsItems) {
+    item.item->setToolTip(text);
+  }
   updateTextHeight();
 }
 

--- a/libs/librepcb/editor/graphics/primitivepathgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivepathgraphicsitem.cpp
@@ -221,8 +221,8 @@ void PrimitivePathGraphicsItem::updateVisibility() noexcept {
   setVisible((mPen.style() != Qt::NoPen) || (mBrush.style() != Qt::NoBrush));
 }
 
-QColor PrimitivePathGraphicsItem::convertColor(const QColor& color) const
-    noexcept {
+QColor PrimitivePathGraphicsItem::convertColor(
+    const QColor& color) const noexcept {
   return mLighterColors ? color.lighter(200) : color;
 }
 

--- a/libs/librepcb/editor/graphics/primitivezonegraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivezonegraphicsitem.cpp
@@ -78,8 +78,8 @@ PrimitiveZoneGraphicsItem::~PrimitiveZoneGraphicsItem() noexcept {
  *  Getters
  ******************************************************************************/
 
-int PrimitiveZoneGraphicsItem::getLineIndexAtPosition(const Point& pos) const
-    noexcept {
+int PrimitiveZoneGraphicsItem::getLineIndexAtPosition(
+    const Point& pos) const noexcept {
   // We build temporary PrimitivePathGraphicsItem objects for each segment of
   // the zone and check if the specified position is located within the shape
   // of one of these graphics items. This is quite ugly, but was easy to

--- a/libs/librepcb/editor/library/cat/categorychooserdialog.cpp
+++ b/libs/librepcb/editor/library/cat/categorychooserdialog.cpp
@@ -71,8 +71,8 @@ CategoryChooserDialog::~CategoryChooserDialog() noexcept {
  *  Getters
  ******************************************************************************/
 
-tl::optional<Uuid> CategoryChooserDialog::getSelectedCategoryUuid() const
-    noexcept {
+tl::optional<Uuid> CategoryChooserDialog::getSelectedCategoryUuid()
+    const noexcept {
   QModelIndex index = mUi->treeView->currentIndex();
   return Uuid::tryFromString(index.data(Qt::UserRole).toString());
 }

--- a/libs/librepcb/editor/library/cat/categorylisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cat/categorylisteditorwidget.cpp
@@ -76,7 +76,9 @@ void CategoryListEditorWidget::setRequiresMinimumOneEntry(bool v) noexcept {
 void CategoryListEditorWidget::setUuids(const QSet<Uuid>& uuids) noexcept {
   mUuids = uuids;
   mUi->listWidget->clear();
-  foreach (const Uuid& category, mUuids) { addItem(category); }
+  foreach (const Uuid& category, mUuids) {
+    addItem(category);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
@@ -175,15 +175,21 @@ void CmdDragSelectedFootprintItems::snapToGrid() noexcept {
   foreach (CmdFootprintPadEdit* cmd, mPadEditCmds) {
     cmd->snapToGrid(grid, true);
   }
-  foreach (CmdCircleEdit* cmd, mCircleEditCmds) { cmd->snapToGrid(grid, true); }
+  foreach (CmdCircleEdit* cmd, mCircleEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
   foreach (CmdPolygonEdit* cmd, mPolygonEditCmds) {
     cmd->snapToGrid(grid, true);
   }
   foreach (CmdStrokeTextEdit* cmd, mTextEditCmds) {
     cmd->snapToGrid(grid, true);
   }
-  foreach (CmdZoneEdit* cmd, mZoneEditCmds) { cmd->snapToGrid(grid, true); }
-  foreach (CmdHoleEdit* cmd, mHoleEditCmds) { cmd->snapToGrid(grid, true); }
+  foreach (CmdZoneEdit* cmd, mZoneEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
+  foreach (CmdHoleEdit* cmd, mHoleEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
   mSnappedToGrid = true;
 }
 
@@ -263,11 +269,21 @@ void CmdDragSelectedFootprintItems::mirrorGeometry(
 }
 
 void CmdDragSelectedFootprintItems::mirrorLayer() noexcept {
-  foreach (CmdFootprintPadEdit* cmd, mPadEditCmds) { cmd->mirrorLayer(true); }
-  foreach (CmdCircleEdit* cmd, mCircleEditCmds) { cmd->mirrorLayer(true); }
-  foreach (CmdPolygonEdit* cmd, mPolygonEditCmds) { cmd->mirrorLayer(true); }
-  foreach (CmdStrokeTextEdit* cmd, mTextEditCmds) { cmd->mirrorLayer(true); }
-  foreach (CmdZoneEdit* cmd, mZoneEditCmds) { cmd->mirrorLayers(true); }
+  foreach (CmdFootprintPadEdit* cmd, mPadEditCmds) {
+    cmd->mirrorLayer(true);
+  }
+  foreach (CmdCircleEdit* cmd, mCircleEditCmds) {
+    cmd->mirrorLayer(true);
+  }
+  foreach (CmdPolygonEdit* cmd, mPolygonEditCmds) {
+    cmd->mirrorLayer(true);
+  }
+  foreach (CmdStrokeTextEdit* cmd, mTextEditCmds) {
+    cmd->mirrorLayer(true);
+  }
+  foreach (CmdZoneEdit* cmd, mZoneEditCmds) {
+    cmd->mirrorLayers(true);
+  }
   mMirroredLayer = !mMirroredLayer;
 }
 

--- a/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
@@ -135,12 +135,18 @@ int CmdDragSelectedSymbolItems::getSelectedItemsCount() const noexcept {
 
 void CmdDragSelectedSymbolItems::snapToGrid() noexcept {
   PositiveLength grid = mContext.graphicsView.getGridInterval();
-  foreach (CmdSymbolPinEdit* cmd, mPinEditCmds) { cmd->snapToGrid(grid, true); }
-  foreach (CmdCircleEdit* cmd, mCircleEditCmds) { cmd->snapToGrid(grid, true); }
+  foreach (CmdSymbolPinEdit* cmd, mPinEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
+  foreach (CmdCircleEdit* cmd, mCircleEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
   foreach (CmdPolygonEdit* cmd, mPolygonEditCmds) {
     cmd->snapToGrid(grid, true);
   }
-  foreach (CmdTextEdit* cmd, mTextEditCmds) { cmd->snapToGrid(grid, true); }
+  foreach (CmdTextEdit* cmd, mTextEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
   mSnappedToGrid = true;
 }
 

--- a/libs/librepcb/editor/library/cmd/cmdpastesymbolitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpastesymbolitems.cpp
@@ -86,8 +86,8 @@ bool CmdPasteSymbolItems::performExecute() {
   collator.setNumericMode(true);
   collator.setCaseSensitivity(Qt::CaseInsensitive);
   collator.setIgnorePunctuation(false);
-  for (const SymbolPin &pin : mData->getPins().sorted(
-           [&collator](const SymbolPin&lhs, const SymbolPin&rhs) {
+  for (const SymbolPin& pin : mData->getPins().sorted(
+           [&collator](const SymbolPin& lhs, const SymbolPin& rhs) {
              return collator(*lhs.getName(), *rhs.getName());
            })) {
     Uuid uuid = pin.getUuid();

--- a/libs/librepcb/editor/library/cmp/cmpsigpindisplaytypecombobox.cpp
+++ b/libs/librepcb/editor/library/cmp/cmpsigpindisplaytypecombobox.cpp
@@ -60,8 +60,8 @@ CmpSigPinDisplayTypeComboBox::~CmpSigPinDisplayTypeComboBox() noexcept {
  *  Getters
  ******************************************************************************/
 
-CmpSigPinDisplayType CmpSigPinDisplayTypeComboBox::getCurrentItem() const
-    noexcept {
+CmpSigPinDisplayType CmpSigPinDisplayTypeComboBox::getCurrentItem()
+    const noexcept {
   int index = mComboBox->currentIndex();
   Q_ASSERT(index >= 0);
   Q_ASSERT(index < CmpSigPinDisplayType::getAllTypes().count());

--- a/libs/librepcb/editor/library/cmp/componentpinsignalmapmodel.h
+++ b/libs/librepcb/editor/library/cmp/componentpinsignalmapmodel.h
@@ -100,10 +100,10 @@ private:
                         ComponentSignalList::Event event) noexcept;
   void execCmd(UndoCommand* cmd);
   void updateSignalComboBoxItems() noexcept;
-  void getRowItem(int row, int& symbolItemIndex,
-                  std::shared_ptr<ComponentSymbolVariantItem>& symbolItem,
-                  std::shared_ptr<ComponentPinSignalMapItem>& mapItem) const
-      noexcept;
+  void getRowItem(
+      int row, int& symbolItemIndex,
+      std::shared_ptr<ComponentSymbolVariantItem>& symbolItem,
+      std::shared_ptr<ComponentPinSignalMapItem>& mapItem) const noexcept;
 
 private:  // Data
   ComponentSymbolVariant* mSymbolVariant;

--- a/libs/librepcb/editor/library/cmp/componentsymbolvarianteditdialog.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvarianteditdialog.cpp
@@ -193,7 +193,9 @@ void ComponentSymbolVariantEditDialog::updatePreview() noexcept {
     mUi->graphicsView->zoomAll();
   } else if (mPreviewTextsUpdateScheduled) {
     mPreviewTextsUpdateScheduled = false;
-    foreach (auto item, mGraphicsItems) { item->updateAllTexts(); }
+    foreach (auto item, mGraphicsItems) {
+      item->updateAllTexts();
+    }
   }
 }
 

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.cpp
@@ -173,8 +173,8 @@ DeviceEditorWidget::~DeviceEditorWidget() noexcept {
  *  Getters
  ******************************************************************************/
 
-QSet<EditorWidgetBase::Feature> DeviceEditorWidget::getAvailableFeatures() const
-    noexcept {
+QSet<EditorWidgetBase::Feature> DeviceEditorWidget::getAvailableFeatures()
+    const noexcept {
   return {
       EditorWidgetBase::Feature::Close,
   };

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizard.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizard.cpp
@@ -67,14 +67,15 @@ EagleLibraryImportWizard::EagleLibraryImportWizard(Workspace& workspace,
   // wizard. The button will be enabled in the last page, and removed when
   // clicking on it.
   setButtonText(QWizard::CustomButton1, tr("&Restart"));
-  connect(this, &QWizard::customButtonClicked, this,
-          [this]() {
-            // Hide restart button and start over.
-            setOption(QWizard::HaveCustomButton1, false);
-            restart();
-            next();
-          },
-          Qt::QueuedConnection);
+  connect(
+      this, &QWizard::customButtonClicked, this,
+      [this]() {
+        // Hide restart button and start over.
+        setOption(QWizard::HaveCustomButton1, false);
+        restart();
+        next();
+      },
+      Qt::QueuedConnection);
 
   // Load window geometry.
   QSettings clientSettings;

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_selectelements.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_selectelements.cpp
@@ -52,24 +52,27 @@ EagleLibraryImportWizardPage_SelectElements::
   mUi->setupUi(this);
   connect(mUi->treeWidget, &QTreeWidget::itemChanged, this,
           &EagleLibraryImportWizardPage_SelectElements::treeItemChanged);
-  connect(&mContext->getImport(), &EagleLibraryImport::symbolCheckStateChanged,
-          this,
-          [this](const QString& name, Qt::CheckState checkState) {
-            updateItemCheckState(ElementType::Symbol, name, checkState);
-          },
-          Qt::QueuedConnection);
-  connect(&mContext->getImport(), &EagleLibraryImport::packageCheckStateChanged,
-          this,
-          [this](const QString& name, Qt::CheckState checkState) {
-            updateItemCheckState(ElementType::Package, name, checkState);
-          },
-          Qt::QueuedConnection);
-  connect(&mContext->getImport(),
-          &EagleLibraryImport::componentCheckStateChanged, this,
-          [this](const QString& name, Qt::CheckState checkState) {
-            updateItemCheckState(ElementType::Component, name, checkState);
-          },
-          Qt::QueuedConnection);
+  connect(
+      &mContext->getImport(), &EagleLibraryImport::symbolCheckStateChanged,
+      this,
+      [this](const QString& name, Qt::CheckState checkState) {
+        updateItemCheckState(ElementType::Symbol, name, checkState);
+      },
+      Qt::QueuedConnection);
+  connect(
+      &mContext->getImport(), &EagleLibraryImport::packageCheckStateChanged,
+      this,
+      [this](const QString& name, Qt::CheckState checkState) {
+        updateItemCheckState(ElementType::Package, name, checkState);
+      },
+      Qt::QueuedConnection);
+  connect(
+      &mContext->getImport(), &EagleLibraryImport::componentCheckStateChanged,
+      this,
+      [this](const QString& name, Qt::CheckState checkState) {
+        updateItemCheckState(ElementType::Component, name, checkState);
+      },
+      Qt::QueuedConnection);
   connect(this, &EagleLibraryImportWizardPage_SelectElements::completeChanged,
           this, &EagleLibraryImportWizardPage_SelectElements::updateRootNodes,
           Qt::QueuedConnection);

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.cpp
@@ -548,7 +548,9 @@ void LibraryOverviewWidget::openContextMenuAtPos(const QPoint& pos) noexcept {
   QAction* action = menu.exec(QCursor::pos());
   if (action == aEdit) {
     Q_ASSERT(selectedItemPaths.count() > 0);
-    foreach (const FilePath& fp, selectedItemPaths) { editItem(list, fp); }
+    foreach (const FilePath& fp, selectedItemPaths) {
+      editItem(list, fp);
+    }
   } else if (action == aDuplicate) {
     Q_ASSERT(selectedItemPaths.count() == 1);
     duplicateItem(list, selectedItemPaths.values().first());

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -76,8 +76,8 @@ public:
   /**
    * @copydoc ::librepcb::editor::IF_GraphicsLayerProvider::getLayer()
    */
-  std::shared_ptr<GraphicsLayer> getLayer(const QString& name) const
-      noexcept override {
+  std::shared_ptr<GraphicsLayer> getLayer(
+      const QString& name) const noexcept override {
     foreach (const std::shared_ptr<GraphicsLayer>& layer, mLayers) {
       if (layer->getName() == name) {
         return layer;

--- a/libs/librepcb/editor/library/libraryelementcache.cpp
+++ b/libs/librepcb/editor/library/libraryelementcache.cpp
@@ -92,8 +92,8 @@ std::shared_ptr<const Device> LibraryElementCache::getDevice(
 
 template <typename T>
 std::shared_ptr<const T> LibraryElementCache::getElement(
-    QHash<Uuid, std::shared_ptr<const T>>& container, const Uuid& uuid) const
-    noexcept {
+    QHash<Uuid, std::shared_ptr<const T>>& container,
+    const Uuid& uuid) const noexcept {
   std::shared_ptr<const T> element = container.value(uuid);
   if ((!element) && mDb) {
     try {

--- a/libs/librepcb/editor/library/libraryelementcache.h
+++ b/libs/librepcb/editor/library/libraryelementcache.h
@@ -69,8 +69,8 @@ public:
       const Uuid& uuid) const noexcept;
   std::shared_ptr<const Symbol> getSymbol(const Uuid& uuid) const noexcept;
   std::shared_ptr<const Package> getPackage(const Uuid& uuid) const noexcept;
-  std::shared_ptr<const Component> getComponent(const Uuid& uuid) const
-      noexcept;
+  std::shared_ptr<const Component> getComponent(
+      const Uuid& uuid) const noexcept;
   std::shared_ptr<const Device> getDevice(const Uuid& uuid) const noexcept;
 
   // Operator Overloadings
@@ -79,8 +79,8 @@ public:
 private:  // Methods
   template <typename T>
   std::shared_ptr<const T> getElement(
-      QHash<Uuid, std::shared_ptr<const T>>& container, const Uuid& uuid) const
-      noexcept;
+      QHash<Uuid, std::shared_ptr<const T>>& container,
+      const Uuid& uuid) const noexcept;
 
 private:  // Data
   QPointer<const WorkspaceLibraryDb> mDb;

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardcontext.cpp
@@ -363,7 +363,9 @@ void NewElementWizardContext::copyElement(ElementType type,
       break;
     }
 
-    default: { break; }
+    default: {
+      break;
+    }
   }
 }
 

--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentsignals.h
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentsignals.h
@@ -67,9 +67,8 @@ public:
       const NewElementWizardPage_ComponentSignals& rhs) = delete;
 
 private:  // Methods
-  QHash<Uuid, CircuitIdentifier> getPinNames(const Uuid& symbol,
-                                             const QString& suffix) const
-      noexcept;
+  QHash<Uuid, CircuitIdentifier> getPinNames(
+      const Uuid& symbol, const QString& suffix) const noexcept;
   void initializePage() noexcept override;
   void cleanupPage() noexcept override;
 

--- a/libs/librepcb/editor/library/pkg/boardsideselectorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/boardsideselectorwidget.cpp
@@ -69,8 +69,8 @@ BoardSideSelectorWidget::~BoardSideSelectorWidget() noexcept {
  *  Getters
  ******************************************************************************/
 
-FootprintPad::ComponentSide BoardSideSelectorWidget::getCurrentBoardSide() const
-    noexcept {
+FootprintPad::ComponentSide BoardSideSelectorWidget::getCurrentBoardSide()
+    const noexcept {
   if (mBtnTop->isChecked()) return FootprintPad::ComponentSide::Top;
   if (mBtnBottom->isChecked()) return FootprintPad::ComponentSide::Bottom;
   return FootprintPad::ComponentSide::Top;

--- a/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
@@ -149,7 +149,9 @@ QPixmap FootprintClipboardData::generatePixmap(
   for (Hole& hole : mHoles) {
     items.append(std::make_shared<HoleGraphicsItem>(hole, lp, false));
   }
-  foreach (const auto& item, items) { scene.addItem(*item); }
+  foreach (const auto& item, items) {
+    scene.addItem(*item);
+  }
   return scene.toPixmap(300, Qt::black);
 }
 

--- a/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
@@ -281,8 +281,12 @@ void FootprintGraphicsItem::setRotation(const Angle& rot) noexcept {
 }
 
 void FootprintGraphicsItem::updateAllTexts() noexcept {
-  foreach (const auto& ptr, mPadGraphicsItems) { ptr->updateText(); }
-  foreach (const auto& ptr, mStrokeTextGraphicsItems) { substituteText(*ptr); }
+  foreach (const auto& ptr, mPadGraphicsItems) {
+    ptr->updateText();
+  }
+  foreach (const auto& ptr, mStrokeTextGraphicsItems) {
+    substituteText(*ptr);
+  }
 }
 
 void FootprintGraphicsItem::setSelectionRect(const QRectF rect) noexcept {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
@@ -170,8 +170,8 @@ EditorWidgetBase::Tool PackageEditorFsm::getCurrentTool() const noexcept {
   }
 }
 
-std::shared_ptr<Footprint> PackageEditorFsm::getCurrentFootprint() const
-    noexcept {
+std::shared_ptr<Footprint> PackageEditorFsm::getCurrentFootprint()
+    const noexcept {
   return mContext.currentFootprint;
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
@@ -64,8 +64,8 @@ public:
   // General Methods
   virtual bool entry() noexcept { return true; }
   virtual bool exit() noexcept { return true; }
-  virtual QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept = 0;
+  virtual QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept = 0;
 
   // Event Handlers
   virtual bool processKeyPressed(const QKeyEvent& e) noexcept {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addholes.h
@@ -63,8 +63,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.h
@@ -69,8 +69,8 @@ public:
   // General Methods
   virtual bool entry() noexcept override;
   virtual bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   virtual bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawcircle.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawcircle.h
@@ -64,8 +64,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -506,7 +506,9 @@ void PackageEditorState_DrawPolygonBase::updateOverlayText() noexcept {
       const UnsignedLength radius =
           (count >= 2) ? (p0 - mArcCenter).getLength() : UnsignedLength(0);
       Angle angle;
-      foreach (const Vertex& v, vertices) { angle += v.getAngle(); }
+      foreach (const Vertex& v, vertices) {
+        angle += v.getAngle();
+      }
       text += formatLength("X·", center.getX()) % "<br>";
       text += formatLength("Y·", center.getY()) % "<br>";
       text += formatLength("X0", p0.getX()) % "<br>";

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.h
@@ -71,8 +71,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processKeyPressed(const QKeyEvent& e) noexcept override;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawtextbase.h
@@ -76,8 +76,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.h
@@ -65,8 +65,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processKeyPressed(const QKeyEvent& e) noexcept override;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_measure.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_measure.h
@@ -56,8 +56,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processKeyPressed(const QKeyEvent& e) noexcept override;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -188,7 +188,9 @@ bool PackageEditorState_Select::processGraphicsSceneMouseMoved(
       mCmdZoneEdit->setOutline(Path(vertices), true);
       return true;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -284,7 +286,9 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       }
       return true;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -333,7 +337,9 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
       setState(SubState::IDLE);
       return true;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -363,7 +369,9 @@ bool PackageEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
     case SubState::PASTING: {
       return rotateSelectedItems(Angle::deg90());
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -381,7 +389,9 @@ bool PackageEditorState_Select::processSelectAll() noexcept {
       }
       return false;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -394,7 +404,9 @@ bool PackageEditorState_Select::processCut() noexcept {
         return false;
       }
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -403,7 +415,9 @@ bool PackageEditorState_Select::processCopy() noexcept {
     case SubState::IDLE: {
       return copySelectedItemsToClipboard();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -424,7 +438,9 @@ bool PackageEditorState_Select::processPaste() noexcept {
         return false;
       }
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
 
   return false;
@@ -486,7 +502,9 @@ bool PackageEditorState_Select::processRotate(const Angle& rotation) noexcept {
     case SubState::PASTING: {
       return rotateSelectedItems(rotation);
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -498,7 +516,9 @@ bool PackageEditorState_Select::processMirror(
     case SubState::PASTING: {
       return mirrorSelectedItems(orientation, false);
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -510,7 +530,9 @@ bool PackageEditorState_Select::processFlip(
     case SubState::PASTING: {
       return mirrorSelectedItems(orientation, true);
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -521,7 +543,9 @@ bool PackageEditorState_Select::processSnapToGrid() noexcept {
     case SubState::PASTING: {
       return snapSelectedItemsToGrid();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -530,7 +554,9 @@ bool PackageEditorState_Select::processRemove() noexcept {
     case SubState::IDLE: {
       return removeSelectedItems();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -559,7 +585,9 @@ bool PackageEditorState_Select::processEditProperties() noexcept {
       }
       break;
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
   return false;
 }
@@ -569,7 +597,9 @@ bool PackageEditorState_Select::processGenerateOutline() noexcept {
     case SubState::IDLE: {
       return generateOutline();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -578,7 +608,9 @@ bool PackageEditorState_Select::processGenerateCourtyard() noexcept {
     case SubState::IDLE: {
       return generateCourtyard();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
@@ -77,8 +77,8 @@ public:
 
   // General Methods
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -562,7 +562,9 @@ bool PackageEditorWidget::graphicsViewEventHandler(QEvent* event) noexcept {
       Q_ASSERT(e);
       return mFsm->processKeyReleased(*e);
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
@@ -64,8 +64,8 @@ public:
   // General Methods
   virtual bool entry() noexcept { return true; }
   virtual bool exit() noexcept { return true; }
-  virtual QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept = 0;
+  virtual QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept = 0;
 
   // Event Handlers
   virtual bool processKeyPressed(const QKeyEvent& e) noexcept {

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_addpins.h
@@ -66,8 +66,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawcircle.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawcircle.h
@@ -64,8 +64,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -503,7 +503,9 @@ void SymbolEditorState_DrawPolygonBase::updateOverlayText() noexcept {
       const UnsignedLength radius =
           (count >= 2) ? (p0 - mArcCenter).getLength() : UnsignedLength(0);
       Angle angle;
-      foreach (const Vertex& v, vertices) { angle += v.getAngle(); }
+      foreach (const Vertex& v, vertices) {
+        angle += v.getAngle();
+      }
       text += formatLength("X·", center.getX()) % "<br>";
       text += formatLength("Y·", center.getY()) % "<br>";
       text += formatLength("X0", p0.getX()) % "<br>";

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.h
@@ -73,8 +73,8 @@ public:
   bool processKeyReleased(const QKeyEvent& e) noexcept override;
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawtextbase.h
@@ -75,8 +75,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_measure.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_measure.h
@@ -56,8 +56,8 @@ public:
   // General Methods
   bool entry() noexcept override;
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processKeyPressed(const QKeyEvent& e) noexcept override;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -159,7 +159,9 @@ bool SymbolEditorState_Select::processGraphicsSceneMouseMoved(
       mCmdPolygonEdit->setPath(Path(vertices), true);
       return true;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -250,7 +252,9 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       }
       return true;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -287,7 +291,9 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
       setState(SubState::IDLE);
       return true;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -316,7 +322,9 @@ bool SymbolEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
     case SubState::PASTING: {
       return rotateSelectedItems(Angle::deg90());
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -331,7 +339,9 @@ bool SymbolEditorState_Select::processSelectAll() noexcept {
       emit availableFeaturesChanged();  // Selection might have changed.
       return true;
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -344,7 +354,9 @@ bool SymbolEditorState_Select::processCut() noexcept {
         return false;
       }
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -353,7 +365,9 @@ bool SymbolEditorState_Select::processCopy() noexcept {
     case SubState::IDLE: {
       return copySelectedItemsToClipboard();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -374,7 +388,9 @@ bool SymbolEditorState_Select::processPaste() noexcept {
         return false;
       }
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
 
   return false;
@@ -432,7 +448,9 @@ bool SymbolEditorState_Select::processRotate(const Angle& rotation) noexcept {
     case SubState::PASTING: {
       return rotateSelectedItems(rotation);
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -444,7 +462,9 @@ bool SymbolEditorState_Select::processMirror(
     case SubState::PASTING: {
       return mirrorSelectedItems(orientation);
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -455,7 +475,9 @@ bool SymbolEditorState_Select::processSnapToGrid() noexcept {
     case SubState::PASTING: {
       return snapSelectedItemsToGrid();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -464,7 +486,9 @@ bool SymbolEditorState_Select::processRemove() noexcept {
     case SubState::IDLE: {
       return removeSelectedItems();
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 
@@ -485,7 +509,9 @@ bool SymbolEditorState_Select::processEditProperties() noexcept {
       }
       break;
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
   return false;
 }

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.h
@@ -74,8 +74,8 @@ public:
 
   // General Methods
   bool exit() noexcept override;
-  QSet<EditorWidgetBase::Feature> getAvailableFeatures() const
-      noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
 
   // Event Handlers
   bool processGraphicsSceneMouseMoved(

--- a/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
+++ b/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
@@ -124,7 +124,9 @@ QPixmap SymbolClipboardData::generatePixmap(
   for (Text& text : mTexts) {
     items.append(std::make_shared<TextGraphicsItem>(text, lp));
   }
-  foreach (const auto& item, items) { scene.addItem(*item); }
+  foreach (const auto& item, items) {
+    scene.addItem(*item);
+  }
   return scene.toPixmap(300);
 }
 

--- a/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
+++ b/libs/librepcb/editor/library/sym/symboleditorwidget.cpp
@@ -188,8 +188,8 @@ SymbolEditorWidget::~SymbolEditorWidget() noexcept {
  *  Getters
  ******************************************************************************/
 
-QSet<EditorWidgetBase::Feature> SymbolEditorWidget::getAvailableFeatures() const
-    noexcept {
+QSet<EditorWidgetBase::Feature> SymbolEditorWidget::getAvailableFeatures()
+    const noexcept {
   QSet<EditorWidgetBase::Feature> features = {
       EditorWidgetBase::Feature::Close,
       EditorWidgetBase::Feature::GraphicsView,
@@ -456,7 +456,9 @@ bool SymbolEditorWidget::graphicsViewEventHandler(QEvent* event) noexcept {
       Q_ASSERT(e);
       return mFsm->processKeyReleased(*e);
     }
-    default: { return false; }
+    default: {
+      return false;
+    }
   }
 }
 

--- a/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
@@ -192,8 +192,12 @@ void SymbolGraphicsItem::setRotation(const Angle& rot) noexcept {
 }
 
 void SymbolGraphicsItem::updateAllTexts() noexcept {
-  foreach (const auto& ptr, mPinGraphicsItems) { ptr->updateText(); }
-  foreach (const auto& ptr, mTextGraphicsItems) { substituteText(*ptr); }
+  foreach (const auto& ptr, mPinGraphicsItems) {
+    ptr->updateText();
+  }
+  foreach (const auto& ptr, mTextGraphicsItems) {
+    substituteText(*ptr);
+  }
 }
 
 void SymbolGraphicsItem::setSelectionRect(const QRectF rect) noexcept {

--- a/libs/librepcb/editor/modelview/comboboxdelegate.cpp
+++ b/libs/librepcb/editor/modelview/comboboxdelegate.cpp
@@ -37,10 +37,12 @@ namespace editor {
  ******************************************************************************/
 
 void ComboBoxDelegate::Items::sort() noexcept {
-  Toolbox::sortNumeric(*this,
-                       [](const QCollator& cmp, const Item& lhs,
-                          const Item& rhs) { return cmp(lhs.text, rhs.text); },
-                       Qt::CaseInsensitive, false);
+  Toolbox::sortNumeric(
+      *this,
+      [](const QCollator& cmp, const Item& lhs, const Item& rhs) {
+        return cmp(lhs.text, rhs.text);
+      },
+      Qt::CaseInsensitive, false);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/modelview/editablelistmodel.h
+++ b/libs/librepcb/editor/modelview/editablelistmodel.h
@@ -320,9 +320,8 @@ private:  // Methods
     return value;
   }
 
-  tl::optional<Uuid> convertInputValue(const QVariant& input,
-                                       const tl::optional<Uuid>& tag) const
-      noexcept {
+  tl::optional<Uuid> convertInputValue(
+      const QVariant& input, const tl::optional<Uuid>& tag) const noexcept {
     Q_UNUSED(tag);  // used only for template tag dispatching
     return Uuid::tryFromString(input.toString());
   }
@@ -334,9 +333,8 @@ private:  // Methods
     return str.isEmpty() ? tl::nullopt : tl::make_optional(str);
   }
 
-  tl::optional<QUrl> convertInputValue(const QVariant& input,
-                                       const tl::optional<QUrl>& tag) const
-      noexcept {
+  tl::optional<QUrl> convertInputValue(
+      const QVariant& input, const tl::optional<QUrl>& tag) const noexcept {
     Q_UNUSED(tag);  // used only for template tag dispatching
     QUrl url = QUrl::fromUserInput(input.toString());
     return url.isValid() ? tl::make_optional(url) : tl::nullopt;

--- a/libs/librepcb/editor/modelview/keyboardshortcutsmodel.cpp
+++ b/libs/librepcb/editor/modelview/keyboardshortcutsmodel.cpp
@@ -75,8 +75,8 @@ void KeyboardShortcutsModel::setOverrides(
  *  Inherited Methods
  ******************************************************************************/
 
-int KeyboardShortcutsModel::columnCount(const QModelIndex& parent) const
-    noexcept {
+int KeyboardShortcutsModel::columnCount(
+    const QModelIndex& parent) const noexcept {
   Q_UNUSED(parent);
   return 3;
 }
@@ -91,9 +91,8 @@ int KeyboardShortcutsModel::rowCount(const QModelIndex& parent) const noexcept {
   }
 }
 
-QModelIndex KeyboardShortcutsModel::index(int row, int column,
-                                          const QModelIndex& parent) const
-    noexcept {
+QModelIndex KeyboardShortcutsModel::index(
+    int row, int column, const QModelIndex& parent) const noexcept {
   if (!parent.isValid()) {
     return createIndex(row, column, nullptr);
   } else if (Category* category = categoryFromIndex(parent)) {
@@ -103,8 +102,8 @@ QModelIndex KeyboardShortcutsModel::index(int row, int column,
   }
 }
 
-QModelIndex KeyboardShortcutsModel::parent(const QModelIndex& index) const
-    noexcept {
+QModelIndex KeyboardShortcutsModel::parent(
+    const QModelIndex& index) const noexcept {
   if (index.isValid()) {
     if (Category* category = static_cast<Category*>(index.internalPointer())) {
       int index = mCategories.indexOf(category);
@@ -115,8 +114,8 @@ QModelIndex KeyboardShortcutsModel::parent(const QModelIndex& index) const
   return QModelIndex();
 }
 
-Qt::ItemFlags KeyboardShortcutsModel::flags(const QModelIndex& index) const
-    noexcept {
+Qt::ItemFlags KeyboardShortcutsModel::flags(
+    const QModelIndex& index) const noexcept {
   Qt::ItemFlags flags = QAbstractItemModel::flags(index);
   if ((index.column() == 2) && (index.internalPointer())) {
     flags |= Qt::ItemIsEditable;
@@ -124,8 +123,8 @@ Qt::ItemFlags KeyboardShortcutsModel::flags(const QModelIndex& index) const
   return flags;
 }
 
-QVariant KeyboardShortcutsModel::data(const QModelIndex& index, int role) const
-    noexcept {
+QVariant KeyboardShortcutsModel::data(const QModelIndex& index,
+                                      int role) const noexcept {
   if (const Category* category = categoryFromIndex(index)) {
     if (index.column() == 0) {
       switch (role) {
@@ -197,7 +196,9 @@ QVariant KeyboardShortcutsModel::data(const QModelIndex& index, int role) const
         }
         break;
       }
-      default: { break; }
+      default: {
+        break;
+      }
     }
   }
   return QVariant();

--- a/libs/librepcb/editor/modelview/keyboardshortcutsmodel.h
+++ b/libs/librepcb/editor/modelview/keyboardshortcutsmodel.h
@@ -62,17 +62,17 @@ public:
       const QMap<QString, QList<QKeySequence>>& overrides) noexcept;
 
   // Inherited Methods
-  int columnCount(const QModelIndex& parent = QModelIndex()) const
-      noexcept override;
-  int rowCount(const QModelIndex& parent = QModelIndex()) const
-      noexcept override;
-  QModelIndex index(int row, int column,
-                    const QModelIndex& parent = QModelIndex()) const
-      noexcept override;
+  int columnCount(
+      const QModelIndex& parent = QModelIndex()) const noexcept override;
+  int rowCount(
+      const QModelIndex& parent = QModelIndex()) const noexcept override;
+  QModelIndex index(
+      int row, int column,
+      const QModelIndex& parent = QModelIndex()) const noexcept override;
   QModelIndex parent(const QModelIndex& index) const noexcept override;
   Qt::ItemFlags flags(const QModelIndex& index) const noexcept override;
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const
-      noexcept override;
+  QVariant data(const QModelIndex& index,
+                int role = Qt::DisplayRole) const noexcept override;
   bool setData(const QModelIndex& index, const QVariant& value,
                int role = Qt::EditRole) noexcept override;
 
@@ -81,8 +81,8 @@ public:
 
 private:  // Methods
   Category* categoryFromIndex(const QModelIndex& index) const noexcept;
-  const EditorCommand* commandFromIndex(const QModelIndex& index) const
-      noexcept;
+  const EditorCommand* commandFromIndex(
+      const QModelIndex& index) const noexcept;
   static QString format(const QList<QKeySequence>& sequences,
                         bool showNone) noexcept;
 

--- a/libs/librepcb/editor/modelview/keysequencedelegate.cpp
+++ b/libs/librepcb/editor/modelview/keysequencedelegate.cpp
@@ -56,15 +56,17 @@ QWidget* KeySequenceDelegate::createEditor(QWidget* parent,
       new KeySequencesEditorWidget(defaultSequences, parent);
   edt->setWindowFlags(Qt::Popup | Qt::FramelessWindowHint);
   KeySequenceDelegate* mutableThis = const_cast<KeySequenceDelegate*>(this);
-  connect(edt, &KeySequencesEditorWidget::applyTriggered, this,
-          [mutableThis, edt]() {
-            emit mutableThis->commitData(edt);
-            emit mutableThis->closeEditor(edt);
-          },
-          Qt::QueuedConnection);
-  connect(edt, &KeySequencesEditorWidget::cancelTriggered, this,
-          [mutableThis, edt]() { emit mutableThis->closeEditor(edt); },
-          Qt::QueuedConnection);
+  connect(
+      edt, &KeySequencesEditorWidget::applyTriggered, this,
+      [mutableThis, edt]() {
+        emit mutableThis->commitData(edt);
+        emit mutableThis->closeEditor(edt);
+      },
+      Qt::QueuedConnection);
+  connect(
+      edt, &KeySequencesEditorWidget::cancelTriggered, this,
+      [mutableThis, edt]() { emit mutableThis->closeEditor(edt); },
+      Qt::QueuedConnection);
   return edt;
 }
 

--- a/libs/librepcb/editor/project/addcomponentdialog.h
+++ b/libs/librepcb/editor/project/addcomponentdialog.h
@@ -106,8 +106,8 @@ public:
   std::shared_ptr<const Component> getSelectedComponent() const noexcept {
     return mSelectedComponent;
   }
-  std::shared_ptr<const ComponentSymbolVariant> getSelectedSymbolVariant() const
-      noexcept {
+  std::shared_ptr<const ComponentSymbolVariant> getSelectedSymbolVariant()
+      const noexcept {
     return mSelectedSymbVar;
   }
   std::shared_ptr<const Device> getSelectedDevice() const noexcept {
@@ -116,8 +116,8 @@ public:
   std::shared_ptr<const Part> getSelectedPart() const noexcept {
     return mSelectedPart;
   }
-  tl::optional<Package::AssemblyType> getSelectedPackageAssemblyType() const
-      noexcept;
+  tl::optional<Package::AssemblyType> getSelectedPackageAssemblyType()
+      const noexcept;
 
   /**
    * @brief Check if dialog shall be opened again after the current component

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.h
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.h
@@ -55,8 +55,8 @@ public:
   ~BoardClipboardDataBuilder() noexcept;
 
   // General Methods
-  std::unique_ptr<BoardClipboardData> generate(const Point& cursorPos) const
-      noexcept;
+  std::unique_ptr<BoardClipboardData> generate(
+      const Point& cursorPos) const noexcept;
 
   // Operator Overloadings
   BoardClipboardDataBuilder& operator=(const BoardClipboardDataBuilder& rhs) =

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -1185,7 +1185,9 @@ bool BoardEditor::graphicsViewEventHandler(QEvent* event) {
           mFsm->processGraphicsSceneLeftMouseButtonPressed(*e);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
       break;
     }
@@ -1202,7 +1204,9 @@ bool BoardEditor::graphicsViewEventHandler(QEvent* event) {
           mFsm->processGraphicsSceneRightMouseButtonReleased(*e);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
       break;
     }
@@ -1215,7 +1219,9 @@ bool BoardEditor::graphicsViewEventHandler(QEvent* event) {
           mFsm->processGraphicsSceneLeftMouseButtonDoubleClicked(*e);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
       break;
     }
@@ -1246,7 +1252,9 @@ bool BoardEditor::graphicsViewEventHandler(QEvent* event) {
       break;
     }
 
-    default: { break; }
+    default: {
+      break;
+    }
   }
 
   // Always accept graphics scene events, even if we do not react on some of

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.h
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.h
@@ -96,8 +96,8 @@ public:
   bool getIgnoreLocks() const noexcept;
 
   /// @copydoc ::librepcb::editor::IF_GraphicsLayerProvider::getLayer()
-  virtual std::shared_ptr<GraphicsLayer> getLayer(const QString& name) const
-      noexcept override {
+  virtual std::shared_ptr<GraphicsLayer> getLayer(
+      const QString& name) const noexcept override {
     foreach (const std::shared_ptr<GraphicsLayer>& layer, mLayers) {
       if (layer->getName() == name) {
         return layer;

--- a/libs/librepcb/editor/project/boardeditor/boardgraphicsscene.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardgraphicsscene.cpp
@@ -71,14 +71,30 @@ BoardGraphicsScene::BoardGraphicsScene(
     mBoard(board),
     mLayerProvider(lp),
     mHighlightedNetSignals(highlightedNetSignals) {
-  foreach (BI_Device* obj, mBoard.getDeviceInstances()) { addDevice(*obj); }
-  foreach (BI_NetSegment* obj, mBoard.getNetSegments()) { addNetSegment(*obj); }
-  foreach (BI_Plane* obj, mBoard.getPlanes()) { addPlane(*obj); }
-  foreach (BI_Zone* obj, mBoard.getZones()) { addZone(*obj); }
-  foreach (BI_Polygon* obj, mBoard.getPolygons()) { addPolygon(*obj); }
-  foreach (BI_StrokeText* obj, mBoard.getStrokeTexts()) { addStrokeText(*obj); }
-  foreach (BI_Hole* obj, mBoard.getHoles()) { addHole(*obj); }
-  foreach (BI_AirWire* obj, mBoard.getAirWires()) { addAirWire(*obj); }
+  foreach (BI_Device* obj, mBoard.getDeviceInstances()) {
+    addDevice(*obj);
+  }
+  foreach (BI_NetSegment* obj, mBoard.getNetSegments()) {
+    addNetSegment(*obj);
+  }
+  foreach (BI_Plane* obj, mBoard.getPlanes()) {
+    addPlane(*obj);
+  }
+  foreach (BI_Zone* obj, mBoard.getZones()) {
+    addZone(*obj);
+  }
+  foreach (BI_Polygon* obj, mBoard.getPolygons()) {
+    addPolygon(*obj);
+  }
+  foreach (BI_StrokeText* obj, mBoard.getStrokeTexts()) {
+    addStrokeText(*obj);
+  }
+  foreach (BI_Hole* obj, mBoard.getHoles()) {
+    addHole(*obj);
+  }
+  foreach (BI_AirWire* obj, mBoard.getAirWires()) {
+    addAirWire(*obj);
+  }
 
   connect(&mBoard, &Board::deviceAdded, this, &BoardGraphicsScene::addDevice);
   connect(&mBoard, &Board::deviceRemoved, this,
@@ -109,19 +125,39 @@ BoardGraphicsScene::BoardGraphicsScene(
 BoardGraphicsScene::~BoardGraphicsScene() noexcept {
   // Need to remove all graphics items from scene in case some shared pointers
   // are still hold outside of this class.
-  foreach (BI_Device* obj, mDevices.keys()) { removeDevice(*obj); }
+  foreach (BI_Device* obj, mDevices.keys()) {
+    removeDevice(*obj);
+  }
   foreach (BI_FootprintPad* obj, mFootprintPads.keys()) {
     removeFootprintPad(*obj);
   }
-  foreach (BI_Via* obj, mVias.keys()) { removeVia(*obj); }
-  foreach (BI_NetLine* obj, mNetLines.keys()) { removeNetLine(*obj); }
-  foreach (BI_NetPoint* obj, mNetPoints.keys()) { removeNetPoint(*obj); }
-  foreach (BI_Plane* obj, mPlanes.keys()) { removePlane(*obj); }
-  foreach (BI_Zone* obj, mZones.keys()) { removeZone(*obj); }
-  foreach (BI_Polygon* obj, mPolygons.keys()) { removePolygon(*obj); }
-  foreach (BI_StrokeText* obj, mStrokeTexts.keys()) { removeStrokeText(*obj); }
-  foreach (BI_Hole* obj, mHoles.keys()) { removeHole(*obj); }
-  foreach (BI_AirWire* obj, mAirWires.keys()) { removeAirWire(*obj); }
+  foreach (BI_Via* obj, mVias.keys()) {
+    removeVia(*obj);
+  }
+  foreach (BI_NetLine* obj, mNetLines.keys()) {
+    removeNetLine(*obj);
+  }
+  foreach (BI_NetPoint* obj, mNetPoints.keys()) {
+    removeNetPoint(*obj);
+  }
+  foreach (BI_Plane* obj, mPlanes.keys()) {
+    removePlane(*obj);
+  }
+  foreach (BI_Zone* obj, mZones.keys()) {
+    removeZone(*obj);
+  }
+  foreach (BI_Polygon* obj, mPolygons.keys()) {
+    removePolygon(*obj);
+  }
+  foreach (BI_StrokeText* obj, mStrokeTexts.keys()) {
+    removeStrokeText(*obj);
+  }
+  foreach (BI_Hole* obj, mHoles.keys()) {
+    removeHole(*obj);
+  }
+  foreach (BI_AirWire* obj, mAirWires.keys()) {
+    removeAirWire(*obj);
+  }
 }
 
 /*******************************************************************************
@@ -129,16 +165,36 @@ BoardGraphicsScene::~BoardGraphicsScene() noexcept {
  ******************************************************************************/
 
 void BoardGraphicsScene::selectAll() noexcept {
-  foreach (auto item, mDevices) { item->setSelected(true); }
-  foreach (auto item, mFootprintPads) { item->setSelected(true); }
-  foreach (auto item, mNetPoints) { item->setSelected(true); }
-  foreach (auto item, mNetLines) { item->setSelected(true); }
-  foreach (auto item, mVias) { item->setSelected(true); }
-  foreach (auto item, mPlanes) { item->setSelected(true); }
-  foreach (auto item, mZones) { item->setSelected(true); }
-  foreach (auto item, mPolygons) { item->setSelected(true); }
-  foreach (auto item, mStrokeTexts) { item->setSelected(true); }
-  foreach (auto item, mHoles) { item->setSelected(true); }
+  foreach (auto item, mDevices) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mFootprintPads) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mNetPoints) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mNetLines) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mVias) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mPlanes) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mZones) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mPolygons) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mStrokeTexts) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mHoles) {
+    item->setSelected(true);
+  }
 }
 
 void BoardGraphicsScene::selectItemsInRect(const Point& p1,
@@ -207,24 +263,54 @@ void BoardGraphicsScene::selectNetSegment(BI_NetSegment& netSegment) noexcept {
 }
 
 void BoardGraphicsScene::clearSelection() noexcept {
-  foreach (auto item, mDevices) { item->setSelected(false); }
-  foreach (auto item, mFootprintPads) { item->setSelected(false); }
-  foreach (auto item, mNetPoints) { item->setSelected(false); }
-  foreach (auto item, mNetLines) { item->setSelected(false); }
-  foreach (auto item, mVias) { item->setSelected(false); }
-  foreach (auto item, mPlanes) { item->setSelected(false); }
-  foreach (auto item, mZones) { item->setSelected(false); }
-  foreach (auto item, mPolygons) { item->setSelected(false); }
-  foreach (auto item, mStrokeTexts) { item->setSelected(false); }
-  foreach (auto item, mHoles) { item->setSelected(false); }
+  foreach (auto item, mDevices) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mFootprintPads) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mNetPoints) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mNetLines) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mVias) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mPlanes) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mZones) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mPolygons) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mStrokeTexts) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mHoles) {
+    item->setSelected(false);
+  }
 }
 
 void BoardGraphicsScene::updateHighlightedNetSignals() noexcept {
-  foreach (auto item, mFootprintPads) { item->updateHighlightedNetSignals(); }
-  foreach (auto item, mVias) { item->update(); }
-  foreach (auto item, mNetLines) { item->update(); }
-  foreach (auto item, mPlanes) { item->update(); }
-  foreach (auto item, mAirWires) { item->update(); }
+  foreach (auto item, mFootprintPads) {
+    item->updateHighlightedNetSignals();
+  }
+  foreach (auto item, mVias) {
+    item->update();
+  }
+  foreach (auto item, mNetLines) {
+    item->update();
+  }
+  foreach (auto item, mPlanes) {
+    item->update();
+  }
+  foreach (auto item, mAirWires) {
+    item->update();
+  }
 }
 
 qreal BoardGraphicsScene::getZValueOfCopperLayer(const Layer& layer) noexcept {
@@ -256,7 +342,9 @@ void BoardGraphicsScene::addDevice(BI_Device& device) noexcept {
   foreach (BI_FootprintPad* obj, device.getPads()) {
     addFootprintPad(*obj, item);
   }
-  foreach (BI_StrokeText* obj, device.getStrokeTexts()) { addStrokeText(*obj); }
+  foreach (BI_StrokeText* obj, device.getStrokeTexts()) {
+    addStrokeText(*obj);
+  }
 
   connect(&device, &BI_Device::strokeTextAdded, this,
           &BoardGraphicsScene::addStrokeText);
@@ -273,7 +361,9 @@ void BoardGraphicsScene::removeDevice(BI_Device& device) noexcept {
   foreach (BI_StrokeText* obj, device.getStrokeTexts()) {
     removeStrokeText(*obj);
   }
-  foreach (BI_FootprintPad* obj, device.getPads()) { removeFootprintPad(*obj); }
+  foreach (BI_FootprintPad* obj, device.getPads()) {
+    removeFootprintPad(*obj);
+  }
 
   if (std::shared_ptr<BGI_Device> item = mDevices.take(&device)) {
     removeItem(*item);
@@ -300,9 +390,15 @@ void BoardGraphicsScene::removeFootprintPad(BI_FootprintPad& pad) noexcept {
 }
 
 void BoardGraphicsScene::addNetSegment(BI_NetSegment& netSegment) noexcept {
-  foreach (BI_Via* obj, netSegment.getVias()) { addVia(*obj); }
-  foreach (BI_NetPoint* obj, netSegment.getNetPoints()) { addNetPoint(*obj); }
-  foreach (BI_NetLine* obj, netSegment.getNetLines()) { addNetLine(*obj); }
+  foreach (BI_Via* obj, netSegment.getVias()) {
+    addVia(*obj);
+  }
+  foreach (BI_NetPoint* obj, netSegment.getNetPoints()) {
+    addNetPoint(*obj);
+  }
+  foreach (BI_NetLine* obj, netSegment.getNetLines()) {
+    addNetLine(*obj);
+  }
   connect(&netSegment, &BI_NetSegment::elementsAdded, this,
           &BoardGraphicsScene::addNetSegmentElements);
   connect(&netSegment, &BI_NetSegment::elementsRemoved, this,
@@ -314,27 +410,43 @@ void BoardGraphicsScene::removeNetSegment(BI_NetSegment& netSegment) noexcept {
              &BoardGraphicsScene::addNetSegmentElements);
   disconnect(&netSegment, &BI_NetSegment::elementsRemoved, this,
              &BoardGraphicsScene::removeNetSegmentElements);
-  foreach (BI_NetLine* obj, netSegment.getNetLines()) { removeNetLine(*obj); }
+  foreach (BI_NetLine* obj, netSegment.getNetLines()) {
+    removeNetLine(*obj);
+  }
   foreach (BI_NetPoint* obj, netSegment.getNetPoints()) {
     removeNetPoint(*obj);
   }
-  foreach (BI_Via* obj, netSegment.getVias()) { removeVia(*obj); }
+  foreach (BI_Via* obj, netSegment.getVias()) {
+    removeVia(*obj);
+  }
 }
 
 void BoardGraphicsScene::addNetSegmentElements(
     const QList<BI_Via*>& vias, const QList<BI_NetPoint*>& netPoints,
     const QList<BI_NetLine*>& netLines) noexcept {
-  foreach (BI_Via* obj, vias) { addVia(*obj); }
-  foreach (BI_NetPoint* obj, netPoints) { addNetPoint(*obj); }
-  foreach (BI_NetLine* obj, netLines) { addNetLine(*obj); }
+  foreach (BI_Via* obj, vias) {
+    addVia(*obj);
+  }
+  foreach (BI_NetPoint* obj, netPoints) {
+    addNetPoint(*obj);
+  }
+  foreach (BI_NetLine* obj, netLines) {
+    addNetLine(*obj);
+  }
 }
 
 void BoardGraphicsScene::removeNetSegmentElements(
     const QList<BI_Via*>& vias, const QList<BI_NetPoint*>& netPoints,
     const QList<BI_NetLine*>& netLines) noexcept {
-  foreach (BI_NetLine* obj, netLines) { removeNetLine(*obj); }
-  foreach (BI_NetPoint* obj, netPoints) { removeNetPoint(*obj); }
-  foreach (BI_Via* obj, vias) { removeVia(*obj); }
+  foreach (BI_NetLine* obj, netLines) {
+    removeNetLine(*obj);
+  }
+  foreach (BI_NetPoint* obj, netPoints) {
+    removeNetPoint(*obj);
+  }
+  foreach (BI_Via* obj, vias) {
+    removeVia(*obj);
+  }
 }
 
 void BoardGraphicsScene::addVia(BI_Via& via) noexcept {

--- a/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardsetupdialog.cpp
@@ -452,8 +452,8 @@ bool BoardSetupDialog::apply() noexcept {
   }
 }
 
-QVector<const Layer*> BoardSetupDialog::getTopSilkscreenLayers() const
-    noexcept {
+QVector<const Layer*> BoardSetupDialog::getTopSilkscreenLayers()
+    const noexcept {
   QVector<const Layer*> layers;
   if (mUi->cbxSilkTopLegend->isChecked()) {
     layers << &Layer::topLegend();
@@ -467,8 +467,8 @@ QVector<const Layer*> BoardSetupDialog::getTopSilkscreenLayers() const
   return layers;
 }
 
-QVector<const Layer*> BoardSetupDialog::getBotSilkscreenLayers() const
-    noexcept {
+QVector<const Layer*> BoardSetupDialog::getBotSilkscreenLayers()
+    const noexcept {
   QVector<const Layer*> layers;
   if (mUi->cbxSilkBotLegend->isChecked()) {
     layers << &Layer::botLegend();

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.cpp
@@ -953,10 +953,8 @@ void BoardEditorState_DrawTrace::wireAutoWidthEditToggled(
   mCurrentAutoWidth = checked;
 }
 
-Point BoardEditorState_DrawTrace::calcMiddlePointPos(const Point& p1,
-                                                     const Point p2,
-                                                     WireMode mode) const
-    noexcept {
+Point BoardEditorState_DrawTrace::calcMiddlePointPos(
+    const Point& p1, const Point p2, WireMode mode) const noexcept {
   Point delta = p2 - p1;
   qreal xPositive = delta.getX() >= 0 ? 1 : -1;
   qreal yPositive = delta.getY() >= 0 ? 1 : -1;

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawtrace.h
@@ -186,8 +186,8 @@ private:
    * @param mode The selected WireMode.
    * @return Middle Point.
    */
-  Point calcMiddlePointPos(const Point& p1, const Point p2, WireMode mode) const
-      noexcept;
+  Point calcMiddlePointPos(const Point& p1, const Point p2,
+                           WireMode mode) const noexcept;
 
   // State
   SubState mSubState;  ///< the current substate

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_device.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_device.cpp
@@ -313,8 +313,8 @@ void BGI_Device::updateZoneLayers() noexcept {
   }
 }
 
-std::shared_ptr<GraphicsLayer> BGI_Device::getLayer(const Layer& layer) const
-    noexcept {
+std::shared_ptr<GraphicsLayer> BGI_Device::getLayer(
+    const Layer& layer) const noexcept {
   return mLayerProvider.getLayer(mDevice.getMirrored()
                                      ? layer.mirrored().getThemeColor()
                                      : layer.getThemeColor());

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_plane.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_plane.cpp
@@ -99,8 +99,8 @@ int BGI_Plane::getLineIndexAtPosition(const Point& pos) const noexcept {
   return -1;
 }
 
-QVector<int> BGI_Plane::getVertexIndicesAtPosition(const Point& pos) const
-    noexcept {
+QVector<int> BGI_Plane::getVertexIndicesAtPosition(
+    const Point& pos) const noexcept {
   QMultiMap<Length, int> indices;
   for (int i = 0; i < mPlane.getOutline().getVertices().count(); ++i) {
     const Length distance =
@@ -180,7 +180,9 @@ void BGI_Plane::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
     if (mPlane.isVisible()) {
       painter->setPen(Qt::NoPen);
       painter->setBrush(mLayer->getColor(highlight));
-      foreach (const QPainterPath& area, mAreas) { painter->drawPath(area); }
+      foreach (const QPainterPath& area, mAreas) {
+        painter->drawPath(area);
+      }
     }
   }
 }

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_stroketext.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_stroketext.cpp
@@ -151,7 +151,9 @@ void BGI_StrokeText::deviceGraphicsItemEdited(
       setSelected(obj.isSelected());
       break;
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
 }
 

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_zone.cpp
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_zone.cpp
@@ -69,8 +69,8 @@ int BGI_Zone::getLineIndexAtPosition(const Point& pos) const noexcept {
   return mGraphicsItem->getLineIndexAtPosition(pos);
 }
 
-QVector<int> BGI_Zone::getVertexIndicesAtPosition(const Point& pos) const
-    noexcept {
+QVector<int> BGI_Zone::getVertexIndicesAtPosition(
+    const Point& pos) const noexcept {
   return mGraphicsItem->getVertexIndicesAtPosition(pos);
 }
 

--- a/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
@@ -191,12 +191,13 @@ void UnplacedComponentsDock::updateComponentsList() noexcept {
     const QMap<Uuid, BI_Device*> boardDeviceList = mBoard->getDeviceInstances();
 
     // Sort components manually using numeric sort.
-    Toolbox::sortNumeric(componentsList,
-                         [](const QCollator& cmp, const ComponentInstance* lhs,
-                            const ComponentInstance* rhs) {
-                           return cmp(*lhs->getName(), *rhs->getName());
-                         },
-                         Qt::CaseInsensitive, false);
+    Toolbox::sortNumeric(
+        componentsList,
+        [](const QCollator& cmp, const ComponentInstance* lhs,
+           const ComponentInstance* rhs) {
+          return cmp(*lhs->getName(), *rhs->getName());
+        },
+        Qt::CaseInsensitive, false);
 
     foreach (ComponentInstance* component, componentsList) {
       if (boardDeviceList.contains(component->getUuid())) continue;
@@ -478,8 +479,8 @@ void UnplacedComponentsDock::autoAddDevicesToBoard(
 }
 
 std::pair<QList<UnplacedComponentsDock::DeviceMetadata>, int>
-    UnplacedComponentsDock::getAvailableDevices(ComponentInstance& cmp) const
-    noexcept {
+    UnplacedComponentsDock::getAvailableDevices(
+        ComponentInstance& cmp) const noexcept {
   QList<DeviceMetadata> devices;
   Uuid cmpUuid = cmp.getLibComponent().getUuid();
   QStringList localeOrder = mProject.getLocaleOrder();
@@ -547,12 +548,13 @@ std::pair<QList<UnplacedComponentsDock::DeviceMetadata>, int>
   }
 
   // Sort by device name, using numeric sort.
-  Toolbox::sortNumeric(devices,
-                       [](const QCollator& cmp, const DeviceMetadata& lhs,
-                          const DeviceMetadata& rhs) {
-                         return cmp(lhs.deviceName, rhs.deviceName);
-                       },
-                       Qt::CaseInsensitive, false);
+  Toolbox::sortNumeric(
+      devices,
+      [](const QCollator& cmp, const DeviceMetadata& lhs,
+         const DeviceMetadata& rhs) {
+        return cmp(lhs.deviceName, rhs.deviceName);
+      },
+      Qt::CaseInsensitive, false);
 
   // Prio 1: Use the device already used for the same component before, if it
   // is chosen in the component instance.

--- a/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.h
+++ b/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.h
@@ -129,8 +129,8 @@ private:  // Methods
    */
   std::pair<QList<DeviceMetadata>, int> getAvailableDevices(
       ComponentInstance& cmp) const noexcept;
-  tl::optional<Uuid> getSuggestedFootprint(const Uuid& libPkgUuid) const
-      noexcept;
+  tl::optional<Uuid> getSuggestedFootprint(
+      const Uuid& libPkgUuid) const noexcept;
 
 private:  // Data
   ProjectEditor& mProjectEditor;

--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -235,8 +235,8 @@ void BomGeneratorDialog::updateTable() noexcept {
   }
 }
 
-std::shared_ptr<AssemblyVariant> BomGeneratorDialog::getAssemblyVariant() const
-    noexcept {
+std::shared_ptr<AssemblyVariant> BomGeneratorDialog::getAssemblyVariant()
+    const noexcept {
   auto uuid = getAssemblyVariantUuid(false);
   return uuid ? mProject.getCircuit().getAssemblyVariants().find(*uuid)
               : std::shared_ptr<AssemblyVariant>();

--- a/libs/librepcb/editor/project/cmd/cmdaddcomponenttocircuit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdaddcomponenttocircuit.cpp
@@ -65,8 +65,8 @@ CmdAddComponentToCircuit::~CmdAddComponentToCircuit() noexcept {
  *  Getters
  ******************************************************************************/
 
-ComponentInstance* CmdAddComponentToCircuit::getComponentInstance() const
-    noexcept {
+ComponentInstance* CmdAddComponentToCircuit::getComponentInstance()
+    const noexcept {
   Q_ASSERT(mCmdAddToCircuit);
   return mCmdAddToCircuit ? mCmdAddToCircuit->getComponentInstance() : nullptr;
 }

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
@@ -204,7 +204,9 @@ void CmdDragSelectedBoardItems::snapToGrid() noexcept {
   foreach (CmdDeviceInstanceEdit* cmd, mDeviceEditCmds) {
     cmd->snapToGrid(grid, true);
   }
-  foreach (CmdBoardViaEdit* cmd, mViaEditCmds) { cmd->snapToGrid(grid, true); }
+  foreach (CmdBoardViaEdit* cmd, mViaEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
   foreach (CmdBoardNetPointEdit* cmd, mNetPointEditCmds) {
     cmd->snapToGrid(grid, true);
   }
@@ -234,15 +236,21 @@ void CmdDragSelectedBoardItems::setLocked(bool locked) noexcept {
   foreach (CmdDeviceInstanceEdit* cmd, mDeviceEditCmds) {
     cmd->setLocked(locked);
   }
-  foreach (CmdBoardPlaneEdit* cmd, mPlaneEditCmds) { cmd->setLocked(locked); }
-  foreach (CmdBoardZoneEdit* cmd, mZoneEditCmds) { cmd->setLocked(locked); }
+  foreach (CmdBoardPlaneEdit* cmd, mPlaneEditCmds) {
+    cmd->setLocked(locked);
+  }
+  foreach (CmdBoardZoneEdit* cmd, mZoneEditCmds) {
+    cmd->setLocked(locked);
+  }
   foreach (CmdBoardPolygonEdit* cmd, mPolygonEditCmds) {
     cmd->setLocked(locked);
   }
   foreach (CmdBoardStrokeTextEdit* cmd, mStrokeTextEditCmds) {
     cmd->setLocked(locked);
   }
-  foreach (CmdBoardHoleEdit* cmd, mHoleEditCmds) { cmd->setLocked(locked); }
+  foreach (CmdBoardHoleEdit* cmd, mHoleEditCmds) {
+    cmd->setLocked(locked);
+  }
   mLockedChanged = true;
 }
 

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -116,8 +116,8 @@ bool NewProjectWizardPage_Metadata::isLicenseSet() const noexcept {
   return !mUi->cbxLicense->currentData(Qt::UserRole).toString().isEmpty();
 }
 
-FilePath NewProjectWizardPage_Metadata::getProjectLicenseFilePath() const
-    noexcept {
+FilePath NewProjectWizardPage_Metadata::getProjectLicenseFilePath()
+    const noexcept {
   QString licenseFileName =
       mUi->cbxLicense->currentData(Qt::UserRole).toString();
   if (!licenseFileName.isEmpty()) {

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_versioncontrol.cpp
@@ -53,8 +53,8 @@ NewProjectWizardPage_VersionControl::
  *  Getters
  ******************************************************************************/
 
-bool NewProjectWizardPage_VersionControl::getInitGitRepository() const
-    noexcept {
+bool NewProjectWizardPage_VersionControl::getInitGitRepository()
+    const noexcept {
   return mUi->gbxInitGitRepo->isChecked();
 }
 

--- a/libs/librepcb/editor/project/projecteditor.h
+++ b/libs/librepcb/editor/project/projecteditor.h
@@ -238,8 +238,8 @@ public slots:
   void setErcMessageApproved(const RuleCheckMessage& msg,
                              bool approve) noexcept;
 
-  std::shared_ptr<const QSet<const NetSignal*>> getHighlightedNetSignals() const
-      noexcept {
+  std::shared_ptr<const QSet<const NetSignal*>> getHighlightedNetSignals()
+      const noexcept {
     return mHighlightedNetSignals;
   }
   void setHighlightedNetSignals(

--- a/libs/librepcb/editor/project/projectsetupdialog.cpp
+++ b/libs/librepcb/editor/project/projectsetupdialog.cpp
@@ -89,7 +89,9 @@ ProjectSetupDialog::ProjectSetupDialog(Project& project, UndoStack& undoStack,
     }
   });
   connect(mUi->btnLocaleRemove, &QToolButton::clicked, this, [this]() {
-    foreach (auto item, mUi->lstLocaleOrder->selectedItems()) { delete item; }
+    foreach (auto item, mUi->lstLocaleOrder->selectedItems()) {
+      delete item;
+    }
   });
   connect(mUi->btnLocaleUp, &QToolButton::clicked, this, [this]() {
     int row = mUi->lstLocaleOrder->currentRow();
@@ -116,7 +118,9 @@ ProjectSetupDialog::ProjectSetupDialog(Project& project, UndoStack& undoStack,
     }
   });
   connect(mUi->btnNormRemove, &QToolButton::clicked, this, [this]() {
-    foreach (auto item, mUi->lstNormOrder->selectedItems()) { delete item; }
+    foreach (auto item, mUi->lstNormOrder->selectedItems()) {
+      delete item;
+    }
   });
   connect(mUi->btnNormUp, &QToolButton::clicked, this, [this]() {
     int row = mUi->lstNormOrder->currentRow();

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.cpp
@@ -163,7 +163,9 @@ bool SchematicEditorState_DrawWire::processKeyPressed(
       break;
     }
 
-    default: { break; }
+    default: {
+      break;
+    }
   }
 
   return false;
@@ -180,7 +182,9 @@ bool SchematicEditorState_DrawWire::processKeyReleased(
       break;
     }
 
-    default: { break; }
+    default: {
+      break;
+    }
   }
 
   return false;
@@ -692,10 +696,8 @@ void SchematicEditorState_DrawWire::wireModeChanged(WireMode mode) noexcept {
   }
 }
 
-Point SchematicEditorState_DrawWire::calcMiddlePointPos(const Point& p1,
-                                                        const Point p2,
-                                                        WireMode mode) const
-    noexcept {
+Point SchematicEditorState_DrawWire::calcMiddlePointPos(
+    const Point& p1, const Point p2, WireMode mode) const noexcept {
   Point delta = p2 - p1;
   switch (mode) {
     case WireMode::HV:

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_drawwire.h
@@ -110,8 +110,8 @@ private:  //  Methods
       const QVector<std::shared_ptr<QGraphicsItem>>& except = {}) noexcept;
   Point updateNetpointPositions(bool snap) noexcept;
   void wireModeChanged(WireMode mode) noexcept;
-  Point calcMiddlePointPos(const Point& p1, const Point p2, WireMode mode) const
-      noexcept;
+  Point calcMiddlePointPos(const Point& p1, const Point p2,
+                           WireMode mode) const noexcept;
 
 private:  // Data
   Circuit& mCircuit;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -260,7 +260,9 @@ bool SchematicEditorState_Select::processAbortCommand() noexcept {
         mSubState = SubState::IDLE;
         return true;
       }
-      default: { break; }
+      default: {
+        break;
+      }
     }
   } catch (Exception& e) {
     QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());

--- a/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_text.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_text.cpp
@@ -129,7 +129,9 @@ void SGI_Text::symbolGraphicsItemEdited(const SGI_Symbol& obj,
       setSelected(obj.isSelected());
       break;
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
 }
 

--- a/libs/librepcb/editor/project/schematiceditor/renamenetsegmentdialog.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/renamenetsegmentdialog.cpp
@@ -147,7 +147,9 @@ void RenameNetSegmentDialog::accept() noexcept {
         transaction.commit();  // can throw
         break;
       }
-      default: { break; }
+      default: {
+        break;
+      }
     }
     QDialog::accept();
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.h
@@ -56,8 +56,8 @@ public:
   ~SchematicClipboardDataBuilder() noexcept;
 
   // General Methods
-  std::unique_ptr<SchematicClipboardData> generate(const Point& cursorPos) const
-      noexcept;
+  std::unique_ptr<SchematicClipboardData> generate(
+      const Point& cursorPos) const noexcept;
 
   // Operator Overloadings
   SchematicClipboardDataBuilder& operator=(

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -925,7 +925,9 @@ bool SchematicEditor::graphicsViewEventHandler(QEvent* event) {
           mFsm->processGraphicsSceneLeftMouseButtonPressed(*e);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
       break;
     }
@@ -942,7 +944,9 @@ bool SchematicEditor::graphicsViewEventHandler(QEvent* event) {
           mFsm->processGraphicsSceneRightMouseButtonReleased(*e);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
       break;
     }
@@ -955,7 +959,9 @@ bool SchematicEditor::graphicsViewEventHandler(QEvent* event) {
           mFsm->processGraphicsSceneLeftMouseButtonDoubleClicked(*e);
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
       break;
     }
@@ -986,7 +992,9 @@ bool SchematicEditor::graphicsViewEventHandler(QEvent* event) {
       break;
     }
 
-    default: { break; }
+    default: {
+      break;
+    }
   }
 
   // Always accept graphics scene events, even if we do not react on some of

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.h
@@ -90,8 +90,8 @@ public:
   }
 
   /// @copydoc ::librepcb::editor::IF_GraphicsLayerProvider::getLayer()
-  virtual std::shared_ptr<GraphicsLayer> getLayer(const QString& name) const
-      noexcept override {
+  virtual std::shared_ptr<GraphicsLayer> getLayer(
+      const QString& name) const noexcept override {
     foreach (std::shared_ptr<GraphicsLayer> layer, mLayers) {
       if (layer->getName() == name) {
         return layer;
@@ -100,8 +100,8 @@ public:
     return nullptr;
   }
 
-  virtual QList<std::shared_ptr<GraphicsLayer>> getAllLayers() const
-      noexcept override {
+  virtual QList<std::shared_ptr<GraphicsLayer>> getAllLayers()
+      const noexcept override {
     return mLayers;
   }
 

--- a/libs/librepcb/editor/project/schematiceditor/schematicgraphicsscene.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicgraphicsscene.cpp
@@ -62,12 +62,18 @@ SchematicGraphicsScene::SchematicGraphicsScene(
     mSchematic(schematic),
     mLayerProvider(lp),
     mHighlightedNetSignals(highlightedNetSignals) {
-  foreach (SI_Symbol* obj, mSchematic.getSymbols()) { addSymbol(*obj); }
+  foreach (SI_Symbol* obj, mSchematic.getSymbols()) {
+    addSymbol(*obj);
+  }
   foreach (SI_NetSegment* obj, mSchematic.getNetSegments()) {
     addNetSegment(*obj);
   }
-  foreach (SI_Polygon* obj, mSchematic.getPolygons()) { addPolygon(*obj); }
-  foreach (SI_Text* obj, mSchematic.getTexts()) { addText(*obj); }
+  foreach (SI_Polygon* obj, mSchematic.getPolygons()) {
+    addPolygon(*obj);
+  }
+  foreach (SI_Text* obj, mSchematic.getTexts()) {
+    addText(*obj);
+  }
 
   connect(&mSchematic, &Schematic::symbolAdded, this,
           &SchematicGraphicsScene::addSymbol);
@@ -90,13 +96,27 @@ SchematicGraphicsScene::SchematicGraphicsScene(
 SchematicGraphicsScene::~SchematicGraphicsScene() noexcept {
   // Need to remove all graphics items from scene in case some shared pointers
   // are still hold outside of this class.
-  foreach (SI_Symbol* obj, mSymbols.keys()) { removeSymbol(*obj); }
-  foreach (SI_SymbolPin* obj, mSymbolPins.keys()) { removeSymbolPin(*obj); }
-  foreach (SI_NetLabel* obj, mNetLabels.keys()) { removeNetLabel(*obj); }
-  foreach (SI_NetLine* obj, mNetLines.keys()) { removeNetLine(*obj); }
-  foreach (SI_NetPoint* obj, mNetPoints.keys()) { removeNetPoint(*obj); }
-  foreach (SI_Polygon* obj, mPolygons.keys()) { removePolygon(*obj); }
-  foreach (SI_Text* obj, mTexts.keys()) { removeText(*obj); }
+  foreach (SI_Symbol* obj, mSymbols.keys()) {
+    removeSymbol(*obj);
+  }
+  foreach (SI_SymbolPin* obj, mSymbolPins.keys()) {
+    removeSymbolPin(*obj);
+  }
+  foreach (SI_NetLabel* obj, mNetLabels.keys()) {
+    removeNetLabel(*obj);
+  }
+  foreach (SI_NetLine* obj, mNetLines.keys()) {
+    removeNetLine(*obj);
+  }
+  foreach (SI_NetPoint* obj, mNetPoints.keys()) {
+    removeNetPoint(*obj);
+  }
+  foreach (SI_Polygon* obj, mPolygons.keys()) {
+    removePolygon(*obj);
+  }
+  foreach (SI_Text* obj, mTexts.keys()) {
+    removeText(*obj);
+  }
 }
 
 /*******************************************************************************
@@ -104,13 +124,27 @@ SchematicGraphicsScene::~SchematicGraphicsScene() noexcept {
  ******************************************************************************/
 
 void SchematicGraphicsScene::selectAll() noexcept {
-  foreach (auto item, mSymbols) { item->setSelected(true); }
-  foreach (auto item, mSymbolPins) { item->setSelected(true); }
-  foreach (auto item, mNetPoints) { item->setSelected(true); }
-  foreach (auto item, mNetLines) { item->setSelected(true); }
-  foreach (auto item, mNetLabels) { item->setSelected(true); }
-  foreach (auto item, mPolygons) { item->setSelected(true); }
-  foreach (auto item, mTexts) { item->setSelected(true); }
+  foreach (auto item, mSymbols) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mSymbolPins) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mNetPoints) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mNetLines) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mNetLabels) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mPolygons) {
+    item->setSelected(true);
+  }
+  foreach (auto item, mTexts) {
+    item->setSelected(true);
+  }
 }
 
 void SchematicGraphicsScene::selectItemsInRect(const Point& p1,
@@ -152,20 +186,42 @@ void SchematicGraphicsScene::selectItemsInRect(const Point& p1,
 }
 
 void SchematicGraphicsScene::clearSelection() noexcept {
-  foreach (auto item, mSymbols) { item->setSelected(false); }
-  foreach (auto item, mSymbolPins) { item->setSelected(false); }
-  foreach (auto item, mNetPoints) { item->setSelected(false); }
-  foreach (auto item, mNetLines) { item->setSelected(false); }
-  foreach (auto item, mNetLabels) { item->setSelected(false); }
-  foreach (auto item, mPolygons) { item->setSelected(false); }
-  foreach (auto item, mTexts) { item->setSelected(false); }
+  foreach (auto item, mSymbols) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mSymbolPins) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mNetPoints) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mNetLines) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mNetLabels) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mPolygons) {
+    item->setSelected(false);
+  }
+  foreach (auto item, mTexts) {
+    item->setSelected(false);
+  }
 }
 
 void SchematicGraphicsScene::updateHighlightedNetSignals() noexcept {
-  foreach (auto item, mSymbolPins) { item->updateHighlightedState(); }
-  foreach (auto item, mNetPoints) { item->update(); }
-  foreach (auto item, mNetLines) { item->update(); }
-  foreach (auto item, mNetLabels) { item->update(); }
+  foreach (auto item, mSymbolPins) {
+    item->updateHighlightedState();
+  }
+  foreach (auto item, mNetPoints) {
+    item->update();
+  }
+  foreach (auto item, mNetLines) {
+    item->update();
+  }
+  foreach (auto item, mNetLabels) {
+    item->update();
+  }
 }
 
 /*******************************************************************************
@@ -179,8 +235,12 @@ void SchematicGraphicsScene::addSymbol(SI_Symbol& symbol) noexcept {
   addItem(*item);
   mSymbols.insert(&symbol, item);
 
-  foreach (SI_SymbolPin* obj, symbol.getPins()) { addSymbolPin(*obj, item); }
-  foreach (SI_Text* obj, symbol.getTexts()) { addText(*obj); }
+  foreach (SI_SymbolPin* obj, symbol.getPins()) {
+    addSymbolPin(*obj, item);
+  }
+  foreach (SI_Text* obj, symbol.getTexts()) {
+    addText(*obj);
+  }
 
   connect(&symbol, &SI_Symbol::textAdded, this,
           &SchematicGraphicsScene::addText);
@@ -194,8 +254,12 @@ void SchematicGraphicsScene::removeSymbol(SI_Symbol& symbol) noexcept {
   disconnect(&symbol, &SI_Symbol::textRemoved, this,
              &SchematicGraphicsScene::removeText);
 
-  foreach (SI_Text* obj, symbol.getTexts()) { removeText(*obj); }
-  foreach (SI_SymbolPin* obj, symbol.getPins()) { removeSymbolPin(*obj); }
+  foreach (SI_Text* obj, symbol.getTexts()) {
+    removeText(*obj);
+  }
+  foreach (SI_SymbolPin* obj, symbol.getPins()) {
+    removeSymbolPin(*obj);
+  }
 
   if (std::shared_ptr<SGI_Symbol> item = mSymbols.take(&symbol)) {
     removeItem(*item);
@@ -222,9 +286,15 @@ void SchematicGraphicsScene::removeSymbolPin(SI_SymbolPin& pin) noexcept {
 }
 
 void SchematicGraphicsScene::addNetSegment(SI_NetSegment& netSegment) noexcept {
-  foreach (SI_NetPoint* obj, netSegment.getNetPoints()) { addNetPoint(*obj); }
-  foreach (SI_NetLine* obj, netSegment.getNetLines()) { addNetLine(*obj); }
-  foreach (SI_NetLabel* obj, netSegment.getNetLabels()) { addNetLabel(*obj); }
+  foreach (SI_NetPoint* obj, netSegment.getNetPoints()) {
+    addNetPoint(*obj);
+  }
+  foreach (SI_NetLine* obj, netSegment.getNetLines()) {
+    addNetLine(*obj);
+  }
+  foreach (SI_NetLabel* obj, netSegment.getNetLabels()) {
+    addNetLabel(*obj);
+  }
   connect(&netSegment, &SI_NetSegment::netPointsAndNetLinesAdded, this,
           &SchematicGraphicsScene::addNetPointsAndNetLines);
   connect(&netSegment, &SI_NetSegment::netPointsAndNetLinesRemoved, this,
@@ -248,7 +318,9 @@ void SchematicGraphicsScene::removeNetSegment(
   foreach (SI_NetPoint* obj, netSegment.getNetPoints()) {
     removeNetPoint(*obj);
   }
-  foreach (SI_NetLine* obj, netSegment.getNetLines()) { removeNetLine(*obj); }
+  foreach (SI_NetLine* obj, netSegment.getNetLines()) {
+    removeNetLine(*obj);
+  }
   foreach (SI_NetLabel* obj, netSegment.getNetLabels()) {
     removeNetLabel(*obj);
   }
@@ -257,15 +329,23 @@ void SchematicGraphicsScene::removeNetSegment(
 void SchematicGraphicsScene::addNetPointsAndNetLines(
     const QList<SI_NetPoint*>& netPoints,
     const QList<SI_NetLine*>& netLines) noexcept {
-  foreach (SI_NetPoint* obj, netPoints) { addNetPoint(*obj); }
-  foreach (SI_NetLine* obj, netLines) { addNetLine(*obj); }
+  foreach (SI_NetPoint* obj, netPoints) {
+    addNetPoint(*obj);
+  }
+  foreach (SI_NetLine* obj, netLines) {
+    addNetLine(*obj);
+  }
 }
 
 void SchematicGraphicsScene::removeNetPointsAndNetLines(
     const QList<SI_NetPoint*>& netPoints,
     const QList<SI_NetLine*>& netLines) noexcept {
-  foreach (SI_NetPoint* obj, netPoints) { removeNetPoint(*obj); }
-  foreach (SI_NetLine* obj, netLines) { removeNetLine(*obj); }
+  foreach (SI_NetPoint* obj, netPoints) {
+    removeNetPoint(*obj);
+  }
+  foreach (SI_NetLine* obj, netLines) {
+    removeNetLine(*obj);
+  }
 }
 
 void SchematicGraphicsScene::addNetPoint(SI_NetPoint& netPoint) noexcept {

--- a/libs/librepcb/editor/utils/shortcutsreferencegenerator.cpp
+++ b/libs/librepcb/editor/utils/shortcutsreferencegenerator.cpp
@@ -157,11 +157,9 @@ bool ShortcutsReferenceGenerator::generatePdf(const FilePath& fp) {
  *  Private Methods
  ******************************************************************************/
 
-void ShortcutsReferenceGenerator::drawSectionTitle(QPdfWriter& writer,
-                                                   QPainter& painter, qreal x1,
-                                                   qreal x2, qreal y,
-                                                   const QString& text) const
-    noexcept {
+void ShortcutsReferenceGenerator::drawSectionTitle(
+    QPdfWriter& writer, QPainter& painter, qreal x1, qreal x2, qreal y,
+    const QString& text) const noexcept {
   int textLength = drawText(writer, painter, (x1 + x2) / 2, y - 0.25, 3, 0,
                             text, Flag::AlignCenter);
 
@@ -242,8 +240,8 @@ int ShortcutsReferenceGenerator::drawText(QPdfWriter& writer, QPainter& painter,
   return boundingRect.width();
 }
 
-int ShortcutsReferenceGenerator::mmToPx(QPdfWriter& writer, qreal mm) const
-    noexcept {
+int ShortcutsReferenceGenerator::mmToPx(QPdfWriter& writer,
+                                        qreal mm) const noexcept {
   return qRound(mm * writer.resolution() / 25.4);
 }
 

--- a/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
+++ b/libs/librepcb/editor/utils/standardeditorcommandhandler.cpp
@@ -71,8 +71,8 @@ void StandardEditorCommandHandler::website() const noexcept {
   ds.openWebUrl(QUrl("https://librepcb.org"));
 }
 
-void StandardEditorCommandHandler::fileManager(const FilePath& fp) const
-    noexcept {
+void StandardEditorCommandHandler::fileManager(
+    const FilePath& fp) const noexcept {
   DesktopServices ds(mSettings, mParent);
   ds.openLocalPath(fp);
 }

--- a/libs/librepcb/editor/widgets/graphicsview.cpp
+++ b/libs/librepcb/editor/widgets/graphicsview.cpp
@@ -249,9 +249,8 @@ Point GraphicsView::mapGlobalPosToScenePos(const QPoint& globalPosPx,
   return scenePos;
 }
 
-QPainterPath GraphicsView::calcPosWithTolerance(const Point& pos,
-                                                qreal multiplier) const
-    noexcept {
+QPainterPath GraphicsView::calcPosWithTolerance(
+    const Point& pos, qreal multiplier) const noexcept {
   const qreal tolerance = 5 * multiplier;  // Screen pixel tolerance.
   const QRectF deviceRect(-tolerance, -tolerance, 2 * tolerance, 2 * tolerance);
   const QTransform t(transform().inverted());

--- a/libs/librepcb/editor/widgets/lengtheditbase.cpp
+++ b/libs/librepcb/editor/widgets/lengtheditbase.cpp
@@ -308,8 +308,8 @@ void LengthEditBase::updateText() noexcept {
   lineEdit()->setText(getValueStr(getDisplayedUnit()));
 }
 
-LengthUnit LengthEditBase::extractUnitFromExpression(QString& expression) const
-    noexcept {
+LengthUnit LengthEditBase::extractUnitFromExpression(
+    QString& expression) const noexcept {
   foreach (const LengthUnit& unit, LengthUnit::getAllUnits()) {
     foreach (const QString& suffix, unit.getUserInputSuffixes()) {
       if (expression.endsWith(suffix)) {

--- a/libs/librepcb/editor/widgets/openglview.cpp
+++ b/libs/librepcb/editor/widgets/openglview.cpp
@@ -254,7 +254,9 @@ void OpenGlView::paintGL() {
   mProgram.setUniformValue("mvp_matrix", mProjection * mTransform);
 
   // Draw all objects.
-  foreach (const auto& obj, mObjects) { obj->draw(*this, mProgram); }
+  foreach (const auto& obj, mObjects) {
+    obj->draw(*this, mProgram);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/workspace/categorytreemodel.cpp
+++ b/libs/librepcb/editor/workspace/categorytreemodel.cpp
@@ -111,8 +111,8 @@ QVariant CategoryTreeModel::headerData(int section, Qt::Orientation orientation,
   return QVariant();
 }
 
-QVariant CategoryTreeModel::data(const QModelIndex& index, int role) const
-    noexcept {
+QVariant CategoryTreeModel::data(const QModelIndex& index,
+                                 int role) const noexcept {
   if (const Item* item = itemFromIndex(index)) {
     switch (role) {
       case Qt::DisplayRole:

--- a/libs/librepcb/editor/workspace/categorytreemodel.h
+++ b/libs/librepcb/editor/workspace/categorytreemodel.h
@@ -84,26 +84,26 @@ public:
   void setLocaleOrder(const QStringList& order) noexcept;
 
   // Inherited Methods
-  int columnCount(const QModelIndex& parent = QModelIndex()) const
-      noexcept override;
-  int rowCount(const QModelIndex& parent = QModelIndex()) const
-      noexcept override;
-  QModelIndex index(int row, int column,
-                    const QModelIndex& parent = QModelIndex()) const
-      noexcept override;
+  int columnCount(
+      const QModelIndex& parent = QModelIndex()) const noexcept override;
+  int rowCount(
+      const QModelIndex& parent = QModelIndex()) const noexcept override;
+  QModelIndex index(
+      int row, int column,
+      const QModelIndex& parent = QModelIndex()) const noexcept override;
   QModelIndex parent(const QModelIndex& index) const noexcept override;
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role = Qt::DisplayRole) const noexcept override;
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const
-      noexcept override;
+  QVariant data(const QModelIndex& index,
+                int role = Qt::DisplayRole) const noexcept override;
 
   // Operator Overloadings
   CategoryTreeModel& operator=(const CategoryTreeModel& rhs) = delete;
 
 private:  // Methods
   void update() noexcept;
-  QVector<std::shared_ptr<Item>> getChilds(std::shared_ptr<Item> parent) const
-      noexcept;
+  QVector<std::shared_ptr<Item>> getChilds(
+      std::shared_ptr<Item> parent) const noexcept;
   bool containsItems(const tl::optional<Uuid>& uuid) const;
   bool listAll() const noexcept;
   bool listPackageCategories() const noexcept;

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -578,8 +578,8 @@ bool ControlPanel::closeAllProjects(bool askForSave) noexcept {
   return success;
 }
 
-ProjectEditor* ControlPanel::getOpenProject(const FilePath& filepath) const
-    noexcept {
+ProjectEditor* ControlPanel::getOpenProject(
+    const FilePath& filepath) const noexcept {
   if (mOpenProjectEditors.contains(filepath.toUnique().toStr()))
     return mOpenProjectEditors.value(filepath.toUnique().toStr());
   else
@@ -852,10 +852,10 @@ void ControlPanel::on_recentProjectsListView_customContextMenuRequested(
   QMenu menu;
   MenuBuilder mb(&menu);
   const EditorCommandSet& cmd = EditorCommandSet::instance();
-  mb.addAction(
-      cmd.itemOpen.createAction(&menu, this, [this, fp]() { openProject(fp); },
-                                EditorCommand::ActionFlag::NoShortcuts),
-      MenuBuilder::Flag::DefaultAction);
+  mb.addAction(cmd.itemOpen.createAction(
+                   &menu, this, [this, fp]() { openProject(fp); },
+                   EditorCommand::ActionFlag::NoShortcuts),
+               MenuBuilder::Flag::DefaultAction);
   mb.addSeparator();
   if (isFavorite) {
     mb.addAction(cmd.favoriteRemove.createAction(
@@ -884,10 +884,10 @@ void ControlPanel::on_favoriteProjectsListView_customContextMenuRequested(
   QMenu menu;
   MenuBuilder mb(&menu);
   const EditorCommandSet& cmd = EditorCommandSet::instance();
-  mb.addAction(
-      cmd.itemOpen.createAction(&menu, this, [this, fp]() { openProject(fp); },
-                                EditorCommand::ActionFlag::NoShortcuts),
-      MenuBuilder::Flag::DefaultAction);
+  mb.addAction(cmd.itemOpen.createAction(
+                   &menu, this, [this, fp]() { openProject(fp); },
+                   EditorCommand::ActionFlag::NoShortcuts),
+               MenuBuilder::Flag::DefaultAction);
   mb.addSeparator();
   mb.addAction(cmd.favoriteRemove.createAction(
       &menu, this,

--- a/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
@@ -67,8 +67,8 @@ FavoriteProjectsModel::~FavoriteProjectsModel() noexcept {
  *  General Methods
  ******************************************************************************/
 
-bool FavoriteProjectsModel::isFavoriteProject(const FilePath& filepath) const
-    noexcept {
+bool FavoriteProjectsModel::isFavoriteProject(
+    const FilePath& filepath) const noexcept {
   return mAllProjects.contains(filepath);
 }
 

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -116,7 +116,9 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
     QList<QLocale> locales = QLocale::matchingLocales(
         QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry);
     QStringList localesStr;
-    foreach (const QLocale& l, locales) { localesStr.append(l.name()); }
+    foreach (const QLocale& l, locales) {
+      localesStr.append(l.name());
+    }
     mLibLocaleOrderModel->setPlaceholderText(tr("Click here to add a locale"));
     mLibLocaleOrderModel->setDefaultValue(QString(""));
     mLibLocaleOrderModel->setChoices(localesStr);
@@ -493,12 +495,13 @@ void WorkspaceSettingsDialog::externalApplicationListIndexChanged(
           mExternalApplications[index].currentValue.append(edit->text());
         }
       });
-      connect(edit, &QLineEdit::editingFinished, edit,
-              [this]() {
-                externalApplicationListIndexChanged(
-                    mUi->lstExternalApplications->currentRow());
-              },
-              Qt::QueuedConnection);
+      connect(
+          edit, &QLineEdit::editingFinished, edit,
+          [this]() {
+            externalApplicationListIndexChanged(
+                mUi->lstExternalApplications->currentRow());
+          },
+          Qt::QueuedConnection);
     }
     mUi->layoutExternalApplicationCommands->addWidget(edit);
 

--- a/tests/unittests/core/export/graphicsexporttest.cpp
+++ b/tests/unittests/core/export/graphicsexporttest.cpp
@@ -77,7 +77,9 @@ protected:
 
   std::string str(const QVector<FilePath>& paths) const {
     QStringList l;
-    foreach (const FilePath& fp, paths) { l.append(fp.toStr()); }
+    foreach (const FilePath& fp, paths) {
+      l.append(fp.toStr());
+    }
     return l.join(", ").toStdString();
   }
 

--- a/tests/unittests/core/export/graphicsexporttest.h
+++ b/tests/unittests/core/export/graphicsexporttest.h
@@ -52,8 +52,8 @@ public:
 
   virtual ~GraphicsPagePainterMock() noexcept {}
 
-  void paint(QPainter& painter, const GraphicsExportSettings& settings) const
-      noexcept override {
+  void paint(QPainter& painter,
+             const GraphicsExportSettings& settings) const noexcept override {
     Q_UNUSED(settings);
 
     Point topLeft(mPos.getX() - mWidth / 2, mPos.getY() + mHeight / 2);

--- a/tests/unittests/core/fileio/asynccopyoperationtest.cpp
+++ b/tests/unittests/core/fileio/asynccopyoperationtest.cpp
@@ -77,32 +77,36 @@ protected:
 
   bool run(AsyncCopyOperation& copy, unsigned long timeout) {
     // Connect all signals by hand because QSignalSpy is not threadsafe!
-    QObject::connect(&copy, &AsyncCopyOperation::started, &mContext,
-                     [this]() { ++mSignalStarted; }, Qt::QueuedConnection);
-    QObject::connect(&copy, &AsyncCopyOperation::progressStatus, &mContext,
-                     [this](const QString& status) {
-                       std::cout << "STATUS: " << status.toStdString()
-                                 << std::endl;
-                       mSignalProgressStatus.append(status);
-                     },
-                     Qt::QueuedConnection);
-    QObject::connect(&copy, &AsyncCopyOperation::progressPercent, &mContext,
-                     [this](int percent) {
-                       std::cout << "PROGRESS: " << percent << std::endl;
-                       mSignalProgressPercent.append(percent);
-                     },
-                     Qt::QueuedConnection);
-    QObject::connect(&copy, &AsyncCopyOperation::succeeded, &mContext,
-                     [this]() { ++mSignalSucceeded; }, Qt::QueuedConnection);
-    QObject::connect(&copy, &AsyncCopyOperation::failed, &mContext,
-                     [this](const QString& error) {
-                       std::cout << "ERROR: " << error.toStdString()
-                                 << std::endl;
-                       mSignalFailed.append(error);
-                     },
-                     Qt::QueuedConnection);
-    QObject::connect(&copy, &AsyncCopyOperation::finished, &mContext,
-                     [this]() { ++mSignalFinished; }, Qt::QueuedConnection);
+    QObject::connect(
+        &copy, &AsyncCopyOperation::started, &mContext,
+        [this]() { ++mSignalStarted; }, Qt::QueuedConnection);
+    QObject::connect(
+        &copy, &AsyncCopyOperation::progressStatus, &mContext,
+        [this](const QString& status) {
+          std::cout << "STATUS: " << status.toStdString() << std::endl;
+          mSignalProgressStatus.append(status);
+        },
+        Qt::QueuedConnection);
+    QObject::connect(
+        &copy, &AsyncCopyOperation::progressPercent, &mContext,
+        [this](int percent) {
+          std::cout << "PROGRESS: " << percent << std::endl;
+          mSignalProgressPercent.append(percent);
+        },
+        Qt::QueuedConnection);
+    QObject::connect(
+        &copy, &AsyncCopyOperation::succeeded, &mContext,
+        [this]() { ++mSignalSucceeded; }, Qt::QueuedConnection);
+    QObject::connect(
+        &copy, &AsyncCopyOperation::failed, &mContext,
+        [this](const QString& error) {
+          std::cout << "ERROR: " << error.toStdString() << std::endl;
+          mSignalFailed.append(error);
+        },
+        Qt::QueuedConnection);
+    QObject::connect(
+        &copy, &AsyncCopyOperation::finished, &mContext,
+        [this]() { ++mSignalFinished; }, Qt::QueuedConnection);
 
     copy.start();
     const bool success = copy.wait(timeout);

--- a/tests/unittests/core/fileio/transactionalfilesystemtest.cpp
+++ b/tests/unittests/core/fileio/transactionalfilesystemtest.cpp
@@ -25,7 +25,6 @@
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/utils/toolbox.h>
-
 #include <quazip/quazip.h>
 
 /*******************************************************************************

--- a/tests/unittests/core/library/cmp/componenttest.cpp
+++ b/tests/unittests/core/library/cmp/componenttest.cpp
@@ -52,8 +52,8 @@ protected:
     QDir(mTmpDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mTmpDir, writable)));
   }

--- a/tests/unittests/core/library/cmpcat/componentcategorytest.cpp
+++ b/tests/unittests/core/library/cmpcat/componentcategorytest.cpp
@@ -52,8 +52,8 @@ protected:
     QDir(mTmpDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mTmpDir, writable)));
   }

--- a/tests/unittests/core/library/dev/devicetest.cpp
+++ b/tests/unittests/core/library/dev/devicetest.cpp
@@ -52,8 +52,8 @@ protected:
     QDir(mTmpDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mTmpDir, writable)));
   }

--- a/tests/unittests/core/library/librarytest.cpp
+++ b/tests/unittests/core/library/librarytest.cpp
@@ -51,8 +51,8 @@ protected:
     QDir(mTmpDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mTmpDir, writable)));
   }

--- a/tests/unittests/core/library/pkg/packagetest.cpp
+++ b/tests/unittests/core/library/pkg/packagetest.cpp
@@ -52,8 +52,8 @@ protected:
     QDir(mTmpDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mTmpDir, writable)));
   }

--- a/tests/unittests/core/library/pkgcat/packagecategorytest.cpp
+++ b/tests/unittests/core/library/pkgcat/packagecategorytest.cpp
@@ -52,8 +52,8 @@ protected:
     QDir(mTmpDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mTmpDir, writable)));
   }

--- a/tests/unittests/core/library/sym/symboltest.cpp
+++ b/tests/unittests/core/library/sym/symboltest.cpp
@@ -52,8 +52,8 @@ protected:
     QDir(mTmpDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mTmpDir, writable)));
   }

--- a/tests/unittests/core/project/projecttest.cpp
+++ b/tests/unittests/core/project/projecttest.cpp
@@ -54,8 +54,8 @@ protected:
     QDir(mProjectDir.getParentDir().toStr()).removeRecursively();
   }
 
-  std::unique_ptr<TransactionalDirectory> createDir(bool writable = true) const
-      noexcept {
+  std::unique_ptr<TransactionalDirectory> createDir(
+      bool writable = true) const noexcept {
     return std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory(
         TransactionalFileSystem::open(mProjectDir, writable)));
   }

--- a/tests/unittests/core/utils/signalslottest.cpp
+++ b/tests/unittests/core/utils/signalslottest.cpp
@@ -86,7 +86,9 @@ TEST(SignalSlotTest, testDuringCallbackDetachedSlotsAreNotCalled) {
     std::shared_ptr<Slot<Sender, int>> receiver =
         std::make_shared<Slot<Sender, int>>([&](const Sender&, int) {
           ++callbackCounter;
-          foreach (const auto& r, receivers) { sender.signal.detach(*r); }
+          foreach (const auto& r, receivers) {
+            sender.signal.detach(*r);
+          }
         });
     receivers.append(receiver);
     sender.signal.attach(*receiver);

--- a/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
+++ b/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
@@ -74,7 +74,9 @@ protected:
 
   std::string str(const QList<Uuid>& set) {
     QStringList s;
-    foreach (const Uuid& uuid, set) { s.append(uuid.toStr()); }
+    foreach (const Uuid& uuid, set) {
+      s.append(uuid.toStr());
+    }
     return s.join(", ").toStdString();
   }
 

--- a/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
+++ b/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
@@ -94,7 +94,9 @@ protected:
   QList<std::shared_ptr<GraphicsExportSettings>> getSettings(
       const GraphicsExportDialog& dlg, int expectedCount = -1) {
     QList<std::shared_ptr<GraphicsExportSettings>> settings;
-    foreach (const auto& pair, dlg.getPages()) { settings.append(pair.second); }
+    foreach (const auto& pair, dlg.getPages()) {
+      settings.append(pair.second);
+    }
     if ((expectedCount >= 0) && (settings.count() != expectedCount)) {
       throw Exception(__FILE__, __LINE__,
                       QString("Expected %1 pages, but got %2 pages.")


### PR DESCRIPTION
To get `qmlformat` in our `devtools` Docker image, we have to update it to Ubuntu 22.04 where clang-format 6 is not available anymore. I think it's fine to update to a more recent clang-format version anyway.

I have chosen clang-format 15.0.7 because it's the latest version available on Ubuntu 22.04 and still contained in the latest Ubuntu 23.10.

Some reformatting seems to be required as I didn't find a configuration which leads to unchanged output.