### PR TITLE
OpenGlView: Factor out shader programs into files

### DIFF
--- a/libs/librepcb/editor/widgets/openglview.cpp
+++ b/libs/librepcb/editor/widgets/openglview.cpp
@@ -25,6 +25,9 @@
 #include "../3d/openglobject.h"
 #include "waitingspinnerwidget.h"
 
+#include <librepcb/core/application.h>
+#include <librepcb/core/fileio/filepath.h>
+
 #include <QtCore>
 #include <QtOpenGL>
 #include <QtWidgets>
@@ -46,36 +49,6 @@
  ******************************************************************************/
 namespace librepcb {
 namespace editor {
-
-static const char* sVertexShader =
-    "#ifdef GL_ES\n"
-    "precision mediump int;\n"
-    "precision mediump float;\n"
-    "#endif\n"
-    "\n"
-    "uniform mat4 mvp_matrix;\n"
-    "\n"
-    "attribute vec4 a_position;\n"
-    "attribute vec4 a_color;\n"
-    "\n"
-    "varying vec4 v_color;\n"
-    "\n"
-    "void main() {\n"
-    "    v_color = a_color;\n"
-    "    gl_Position = mvp_matrix * a_position;\n"
-    "}\n";
-
-static const char* sFragmentShader =
-    "#ifdef GL_ES\n"
-    "precision mediump int;\n"
-    "precision mediump float;\n"
-    "#endif\n"
-    "\n"
-    "varying vec4 v_color;\n"
-    "\n"
-    "void main() {\n"
-    "    gl_FragColor = v_color;\n"
-    "}\n";
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -230,9 +203,11 @@ void OpenGlView::initializeGL() {
   initializeOpenGLFunctions();
 
   // Compile shaders.
-  if (mProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, sVertexShader) &&
-      mProgram.addShaderFromSourceCode(QOpenGLShader::Fragment,
-                                       sFragmentShader) &&
+  const FilePath dir = Application::getResourcesDir().getPathTo("opengl");
+  const QString vertexShaderFp = dir.getPathTo("3d-vertex-shader.glsl").toStr();
+  const QString fragShaderFp = dir.getPathTo("3d-fragment-shader.glsl").toStr();
+  if (mProgram.addShaderFromSourceFile(QOpenGLShader::Vertex, vertexShaderFp) &&
+      mProgram.addShaderFromSourceFile(QOpenGLShader::Fragment, fragShaderFp) &&
       mProgram.link() && mProgram.bind()) {
     mInitialized = true;
   } else {

--- a/share/librepcb/opengl/3d-fragment-shader.glsl
+++ b/share/librepcb/opengl/3d-fragment-shader.glsl
@@ -1,0 +1,10 @@
+#ifdef GL_ES
+precision mediump int;
+precision mediump float;
+#endif
+
+varying vec4 v_color;
+
+void main() {
+    gl_FragColor = v_color;
+}

--- a/share/librepcb/opengl/3d-vertex-shader.glsl
+++ b/share/librepcb/opengl/3d-vertex-shader.glsl
@@ -1,0 +1,16 @@
+#ifdef GL_ES
+precision mediump int;
+precision mediump float;
+#endif
+
+uniform mat4 mvp_matrix;
+
+attribute vec4 a_position;
+attribute vec4 a_color;
+
+varying vec4 v_color;
+
+void main() {
+    v_color = a_color;
+    gl_Position = mvp_matrix * a_position;
+}


### PR DESCRIPTION
Instead of hardcoding OpenGl shader programs as strings, now storing them in files loaded at runtime as this provides some advantages:

- They are much more readable without the C++ syntax
- They are easier to write since some editors provide syntax highlighting and auto-formatting
- Development iterations are shorter because no recompiling is needed after modifying shader programs