### PR TITLE
Fix file extension in Protel-style Gerber output job

### DIFF
--- a/libs/librepcb/core/job/gerberexcellonoutputjob.cpp
+++ b/libs/librepcb/core/job/gerberexcellonoutputjob.cpp
@@ -308,7 +308,7 @@ std::shared_ptr<GerberExcellonOutputJob>
   obj->setSuffixDrillsNpth("_NPTH.drl");
   obj->setSuffixDrillsPth("_PTH.drl");
   obj->setSuffixDrillsBlindBuried("_L{{START_NUMBER}}-L{{END_NUMBER}}.drl");
-  obj->setSuffixOutlines(".gml");
+  obj->setSuffixOutlines(".gm1");
   obj->setSuffixCopperTop(".gtl");
   obj->setSuffixCopperInner(".g{{CU_LAYER}}");
   obj->setSuffixCopperBot(".gbl");


### PR DESCRIPTION
The Protel-style suffix for the board outlines layer was "gml" instead of "gm1". Very nasty bug, I hope it doesn't lead to serious issues for users :sob: