### PR TITLE
Show waiting spinner while opening external applications

### DIFF
--- a/libs/librepcb/editor/workspace/desktopservices.cpp
+++ b/libs/librepcb/editor/workspace/desktopservices.cpp
@@ -59,6 +59,7 @@ bool DesktopServices::openUrl(const QUrl& url) const noexcept {
 }
 
 bool DesktopServices::openWebUrl(const QUrl& url) const noexcept {
+  showWaitCursor();
   foreach (QString cmd, mSettings.externalWebBrowserCommands.get()) {
     cmd.replace("{{URL}}", url.toString());
     if (QProcess::startDetached(cmd)) {
@@ -72,6 +73,7 @@ bool DesktopServices::openWebUrl(const QUrl& url) const noexcept {
 }
 
 bool DesktopServices::openLocalPath(const FilePath& filePath) const noexcept {
+  showWaitCursor();
   const QString ext = filePath.getSuffix().toLower();
   if (filePath.isExistingDir()) {
     return openDirectory(filePath);
@@ -135,6 +137,15 @@ bool DesktopServices::openUrlFallback(const QUrl& url) const noexcept {
                                  .arg(url.toString());
   }
   return success;
+}
+
+void DesktopServices::showWaitCursor() noexcept {
+  // While waiting for an external application to appear, change the cursor
+  // to a waiting spinner for a moment to give immediate feedback about the
+  // ongoing operation. Since we don't know how long the operation takes,
+  // we just use a fixed delay before restoring the normal cursor.
+  qApp->setOverrideCursor(Qt::WaitCursor);
+  QTimer::singleShot(2000, qApp, []() { qApp->restoreOverrideCursor(); });
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/workspace/desktopservices.h
+++ b/libs/librepcb/editor/workspace/desktopservices.h
@@ -43,7 +43,8 @@ namespace editor {
  * @brief Provides methods to access common desktop services
  *
  * Similar to `QDesktopServices`, but respecting the workspace settings (e.g.
- * custom PDF viewer).
+ * custom PDF viewer). In addition, the cursor is automatically changed to
+ * a waiting spinner while opening an external application.
  *
  * @see https://doc.qt.io/qt-5/qdesktopservices.html
  */
@@ -71,6 +72,7 @@ private:  // Methods
   bool openLocalPathWithCommand(const FilePath& filePath,
                                 const QStringList& commands) const noexcept;
   bool openUrlFallback(const QUrl& url) const noexcept;
+  static void showWaitCursor() noexcept;
 
 private:  // Data
   const WorkspaceSettings& mSettings;


### PR DESCRIPTION
After triggering an external application from within LibrePCB (web browser, PDF viewer, ...), change the cursor to a waiting spinner for a moment to give immediate feedback that the operation has been successfully triggered. This is a much better user experience than silently waiting seconds for the requested application to appear.