### PR TITLE
BOM export dialog: Don't scale columns with window width

### DIFF
--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -64,6 +64,11 @@ BomGeneratorDialog::BomGeneratorDialog(const WorkspaceSettings& settings,
     mUi(new Ui::BomGeneratorDialog) {
   mUi->setupUi(this);
   mUi->tableWidget->setWordWrap(false);
+  // Note: Don't stretch columns since it leads to cropped text in some
+  // columns and unused space in other columns. Better resize all columns
+  // to their content and show a horizontal scrollbar when needed.
+  mUi->tableWidget->horizontalHeader()->setSectionResizeMode(
+      QHeaderView::Interactive);
   mUi->tableWidget->verticalHeader()->setMinimumSectionSize(10);
   mUi->tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
   mUi->tableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -228,9 +233,6 @@ void BomGeneratorDialog::updateTable() noexcept {
     mUi->tableWidget->setColumnCount(csv->getHeader().count());
     mUi->tableWidget->setHorizontalHeaderLabels(csv->getHeader());
     for (int column = 0; column < csv->getHeader().count(); ++column) {
-      mUi->tableWidget->horizontalHeader()->setSectionResizeMode(
-          column,
-          column <= 1 ? QHeaderView::ResizeToContents : QHeaderView::Stretch);
       for (int row = 0; row < csv->getValues().count(); ++row) {
         QString text = csv->getValues()[row][column];
         text.replace("\n", " ");
@@ -241,6 +243,7 @@ void BomGeneratorDialog::updateTable() noexcept {
         mUi->tableWidget->setItem(row, column, item);
       }
     }
+    mUi->tableWidget->resizeColumnsToContents();
     mUi->tableWidget->resizeRowsToContents();
   } catch (Exception& e) {
     qCritical() << "Failed to update BOM table widget:" << e.getMsg();

--- a/libs/librepcb/editor/project/bomgeneratordialog.ui
+++ b/libs/librepcb/editor/project/bomgeneratordialog.ui
@@ -69,6 +69,12 @@
        <verstretch>1</verstretch>
       </sizepolicy>
      </property>
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
+     <property name="horizontalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
     </widget>
    </item>
    <item row="4" column="0" colspan="4">


### PR DESCRIPTION
Currently the width of most columns in the BOM export dialog was scaled with the window width to avoid a horizontal scrollbar to appear. However, usually this caused cropped text in columns with long texts and unused space in columns with short texts. Thus now changed the behavior to always fit all columns to their content and showing a horizontal scrollbar if not all columns fit into the window. In addition, the columns can now manually be resized when needed (not memorized though since the optimal width depends on the content).