### PR TITLE
Heavily improve EAGLE library import

### DIFF
--- a/libs/librepcb/core/library/cmp/componentprefix.h
+++ b/libs/librepcb/core/library/cmp/componentprefix.h
@@ -25,6 +25,7 @@
  ******************************************************************************/
 #include "../../exceptions.h"
 #include "../../serialization/sexpression.h"
+#include "../../utils/toolbox.h"
 
 #include <type_safe/constrained_type.hpp>
 
@@ -38,6 +39,11 @@ namespace librepcb {
 /*******************************************************************************
  *  Class ComponentPrefix
  ******************************************************************************/
+
+inline static QString cleanComponentPrefix(const QString& userInput) noexcept {
+  return Toolbox::cleanUserInputString(
+      userInput, QRegularExpression("[^a-zA-Z_]"), true, false, false, "_", 16);
+}
 
 struct ComponentPrefixVerifier {
   template <typename Value, typename Predicate>

--- a/libs/librepcb/core/types/boundedunsignedratio.cpp
+++ b/libs/librepcb/core/types/boundedunsignedratio.cpp
@@ -35,6 +35,13 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
+BoundedUnsignedRatio::BoundedUnsignedRatio(
+    const BoundedUnsignedRatio& other) noexcept
+  : mRatio(other.mRatio),
+    mMinValue(other.mMinValue),
+    mMaxValue(other.mMaxValue) {
+}
+
 BoundedUnsignedRatio::BoundedUnsignedRatio(const UnsignedRatio& ratio,
                                            const UnsignedLength& min,
                                            const UnsignedLength& max)

--- a/libs/librepcb/eagleimport/CMakeLists.txt
+++ b/libs/librepcb/eagleimport/CMakeLists.txt
@@ -5,8 +5,9 @@ set(CMAKE_AUTORCC OFF)
 
 # Export library
 add_library(
-  librepcb_eagleimport STATIC eaglelibraryimport.cpp eaglelibraryimport.h
-                              eagletypeconverter.cpp eagletypeconverter.h
+  librepcb_eagleimport STATIC
+  eaglelibraryconverter.cpp eaglelibraryconverter.h eaglelibraryimport.cpp
+  eaglelibraryimport.h eagletypeconverter.cpp eagletypeconverter.h
 )
 target_include_directories(
   librepcb_eagleimport

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -1,0 +1,365 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "eaglelibraryconverter.h"
+
+#include "eagletypeconverter.h"
+
+#include <librepcb/core/library/cmp/component.h>
+#include <librepcb/core/library/dev/device.h>
+#include <librepcb/core/library/pkg/footprint.h>
+#include <librepcb/core/library/pkg/package.h>
+#include <librepcb/core/library/sym/symbol.h>
+#include <parseagle/library.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace eagleimport {
+
+using C = EagleTypeConverter;
+
+/*******************************************************************************
+ *  Struct EagleLibraryConverterSettings
+ ******************************************************************************/
+
+EagleLibraryConverterSettings::EagleLibraryConverterSettings() noexcept
+  : namePrefix(),
+    version(Version::fromString("0.1")),
+    author("EAGLE Import"),
+    keywords("eagle,import") {
+}
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+EagleLibraryConverter::EagleLibraryConverter(
+    const EagleLibraryConverterSettings& settings, QObject* parent) noexcept
+  : QObject(parent), mSettings(settings) {
+}
+
+EagleLibraryConverter::~EagleLibraryConverter() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+Uuid EagleLibraryConverter::getComponentSignalOfSymbolPin(
+    const QString& libName, const QString& devSetName, const QString& gateName,
+    const QString& pinName) const {
+  auto uuid = mComponentSignalMap[std::make_pair(libName, devSetName)][gateName]
+                                 [pinName];
+  if (!uuid) {
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        QString("Could not find component signal from pin name: %1")
+            .arg(pinName));
+  }
+  return *uuid;
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void EagleLibraryConverter::reset() noexcept {
+  mSymbolMap.clear();
+  mSymbolPinMap.clear();
+  mPackageMap.clear();
+  mPackagePadMap.clear();
+  mComponentMap.clear();
+  mComponentSignalMap.clear();
+}
+
+std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
+    const QString& libName, const parseagle::Symbol& eagleSymbol) {
+  const auto key = std::make_pair(libName, eagleSymbol.getName());
+  if (mSymbolMap.contains(key)) {
+    throw LogicError(__FILE__, __LINE__, "Duplicate import.");
+  }
+  std::unique_ptr<Symbol> symbol(new Symbol(
+      Uuid::createRandom(), mSettings.version, mSettings.author,
+      C::convertElementName(mSettings.namePrefix + eagleSymbol.getName()),
+      C::convertElementDescription(eagleSymbol.getDescription()),
+      mSettings.keywords));
+  symbol->setCategories(mSettings.symbolCategories);
+  foreach (const auto& obj, C::convertAndJoinWires(eagleSymbol.getWires())) {
+    if (obj->getPath().isClosed()) {
+      obj->setIsGrabArea(true);
+    }
+    symbol->getPolygons().append(obj);
+  }
+  foreach (const auto& obj, eagleSymbol.getRectangles()) {
+    tryOrRaiseError(eagleSymbol.getName(), [&]() {
+      symbol->getPolygons().append(C::convertRectangle(obj, true));
+    });
+  }
+  foreach (const auto& obj, eagleSymbol.getPolygons()) {
+    tryOrRaiseError(eagleSymbol.getName(), [&]() {
+      symbol->getPolygons().append(C::convertPolygon(obj, true));
+    });
+  }
+  foreach (const auto& obj, eagleSymbol.getCircles()) {
+    tryOrRaiseError(eagleSymbol.getName(), [&]() {
+      symbol->getCircles().append(C::convertCircle(obj, true));
+    });
+  }
+  foreach (const auto& obj, eagleSymbol.getTexts()) {
+    tryOrRaiseError(eagleSymbol.getName(), [&]() {
+      symbol->getTexts().append(C::convertSchematicText(obj));
+    });
+  }
+  foreach (const auto& obj, eagleSymbol.getPins()) {
+    tryOrRaiseError(eagleSymbol.getName(), [&]() {
+      auto pin = C::convertSymbolPin(obj);
+      symbol->getPins().append(pin);
+      mSymbolPinMap[key][obj.getName()] =
+          std::make_pair(std::make_shared<parseagle::Pin>(obj), pin->getUuid());
+    });
+  }
+  mSymbolMap[key] = symbol->getUuid();
+  return symbol;
+}
+
+std::unique_ptr<Package> EagleLibraryConverter::createPackage(
+    const QString& libName, const parseagle::Package& eaglePackage) {
+  const auto key = std::make_pair(libName, eaglePackage.getName());
+  if (mPackageMap.contains(key)) {
+    throw LogicError(__FILE__, __LINE__, "Duplicate import.");
+  }
+  std::unique_ptr<Package> package(new Package(
+      Uuid::createRandom(), mSettings.version, mSettings.author,
+      C::convertElementName(mSettings.namePrefix + eaglePackage.getName()),
+      C::convertElementDescription(eaglePackage.getDescription()),
+      mSettings.keywords, librepcb::Package::AssemblyType::Auto));
+  package->setCategories(mSettings.packageCategories);
+  auto footprint = std::make_shared<Footprint>(Uuid::createRandom(),
+                                               ElementName("default"), "");
+  package->getFootprints().append(footprint);
+  foreach (const auto& obj, C::convertAndJoinWires(eaglePackage.getWires())) {
+    footprint->getPolygons().append(obj);
+  }
+  foreach (const auto& obj, eaglePackage.getRectangles()) {
+    tryOrRaiseError(eaglePackage.getName(), [&]() {
+      footprint->getPolygons().append(C::convertRectangle(obj, false));
+    });
+  }
+  foreach (const auto& obj, eaglePackage.getPolygons()) {
+    tryOrRaiseError(eaglePackage.getName(), [&]() {
+      footprint->getPolygons().append(C::convertPolygon(obj, false));
+    });
+  }
+  foreach (const auto& obj, eaglePackage.getCircles()) {
+    tryOrRaiseError(eaglePackage.getName(), [&]() {
+      footprint->getCircles().append(C::convertCircle(obj, false));
+    });
+  }
+  foreach (const auto& obj, eaglePackage.getTexts()) {
+    tryOrRaiseError(eaglePackage.getName(), [&]() {
+      footprint->getStrokeTexts().append(C::convertBoardText(obj));
+    });
+  }
+  foreach (const auto& obj, eaglePackage.getHoles()) {
+    tryOrRaiseError(eaglePackage.getName(), [&]() {
+      footprint->getHoles().append(C::convertHole(obj));
+    });
+  }
+  foreach (const auto& obj, eaglePackage.getThtPads()) {
+    tryOrRaiseError(eaglePackage.getName(), [&]() {
+      auto pair = C::convertThtPad(obj);
+      package->getPads().append(pair.first);
+      footprint->getPads().append(pair.second);
+      mPackagePadMap[key][obj.getName()] = pair.first->getUuid();
+    });
+  }
+  foreach (const auto& obj, eaglePackage.getSmtPads()) {
+    tryOrRaiseError(eaglePackage.getName(), [&]() {
+      auto pair = C::convertSmtPad(obj);
+      package->getPads().append(pair.first);
+      footprint->getPads().append(pair.second);
+      mPackagePadMap[key][obj.getName()] = pair.first->getUuid();
+    });
+  }
+  mPackageMap[key] = package->getUuid();
+  return package;
+}
+
+std::unique_ptr<Component> EagleLibraryConverter::createComponent(
+    const QString& libName, const parseagle::DeviceSet& eagleDeviceSet) {
+  const QMap<parseagle::PinVisibility, const CmpSigPinDisplayType*>
+      displayTypeMap = {
+          {parseagle::PinVisibility::Off, &CmpSigPinDisplayType::none()},
+          {parseagle::PinVisibility::Pad, &CmpSigPinDisplayType::none()},
+          {parseagle::PinVisibility::Pin,
+           &CmpSigPinDisplayType::componentSignal()},
+          {parseagle::PinVisibility::Both,
+           &CmpSigPinDisplayType::componentSignal()},
+      };
+  const QMap<parseagle::PinDirection, const SignalRole*> signalRoleMap = {
+      {parseagle::PinDirection::NotConnected, &SignalRole::passive()},
+      {parseagle::PinDirection::Input, &SignalRole::input()},
+      {parseagle::PinDirection::Output, &SignalRole::output()},
+      {parseagle::PinDirection::IO, &SignalRole::inout()},
+      {parseagle::PinDirection::OpenCollector, &SignalRole::opendrain()},
+      {parseagle::PinDirection::Power, &SignalRole::power()},
+      {parseagle::PinDirection::Passive, &SignalRole::passive()},
+      {parseagle::PinDirection::HighZ, &SignalRole::passive()},
+      {parseagle::PinDirection::Supply, &SignalRole::passive()},
+  };
+
+  const auto key = std::make_pair(libName, eagleDeviceSet.getName());
+  if (mComponentMap.contains(key)) {
+    throw LogicError(__FILE__, __LINE__, "Duplicate import.");
+  }
+  std::unique_ptr<Component> component(new Component(
+      Uuid::createRandom(), mSettings.version, mSettings.author,
+      C::convertComponentName(mSettings.namePrefix + eagleDeviceSet.getName()),
+      C::convertElementDescription(eagleDeviceSet.getDescription()),
+      mSettings.keywords));
+  component->setCategories(mSettings.componentCategories);
+  component->setPrefixes(NormDependentPrefixMap(
+      ComponentPrefix(eagleDeviceSet.getPrefix().trimmed())));
+  component->setDefaultValue("{{ MPN or DEVICE }}");
+  auto symbolVariant = std::make_shared<ComponentSymbolVariant>(
+      Uuid::createRandom(), "", ElementName("default"), "");
+  component->getSymbolVariants().append(symbolVariant);
+  QHash<QString, int> pinCount;
+  foreach (const auto& gate, eagleDeviceSet.getGates()) {
+    const auto symbolKey = std::make_pair(libName, gate.getSymbol());
+    for (auto pinIt = mSymbolPinMap[symbolKey].constBegin();
+         pinIt != mSymbolPinMap[symbolKey].constEnd(); pinIt++) {
+      pinCount[pinIt.key()]++;
+    }
+  }
+  foreach (const auto& gate, eagleDeviceSet.getGates()) {
+    const auto symbolKey = std::make_pair(libName, gate.getSymbol());
+    const tl::optional<Uuid> symbolUuid = mSymbolMap.value(symbolKey);
+    if (!symbolUuid) {
+      throw RuntimeError(
+          __FILE__, __LINE__,
+          tr("Dependent symbol \"%1\" not imported.").arg(gate.getSymbol()));
+    }
+    auto item = std::make_shared<ComponentSymbolVariantItem>(
+        Uuid::createRandom(), *symbolUuid, C::convertPoint(gate.getPosition()),
+        Angle(0), true, C::convertGateName(gate.getName()));
+    symbolVariant->getSymbolItems().append(item);
+    for (auto pinIt = mSymbolPinMap[symbolKey].constBegin();
+         pinIt != mSymbolPinMap[symbolKey].constEnd(); pinIt++) {
+      Uuid signalUuid = Uuid::createRandom();
+      QString signalName = pinIt.key();
+      if ((pinCount[signalName] > 1) ||
+          (component->getSignals().contains(signalName))) {
+        // Name conflict -> add prefix to ensure unique signal names.
+        signalName.prepend(*item->getSuffix() % "_");
+      }
+      const SignalRole& signalRole = *signalRoleMap.value(
+          pinIt->first->getDirection(), &SignalRole::passive());
+      const CmpSigPinDisplayType& displayType =
+          *displayTypeMap.value(pinIt->first->getVisibility(),
+                                &CmpSigPinDisplayType::componentSignal());
+      const QString forcedNetName =
+          (pinIt->first->getDirection() == parseagle::PinDirection::Supply)
+          ? pinIt.key()
+          : QString();
+      const bool isRequired = false;
+      const bool isNegated =
+          (pinIt->first->getFunction() == parseagle::PinFunction::Dot) ||
+          (pinIt->first->getFunction() == parseagle::PinFunction::DotClock);
+      const bool isClock =
+          (pinIt->first->getFunction() == parseagle::PinFunction::Clock) ||
+          (pinIt->first->getFunction() == parseagle::PinFunction::DotClock);
+      component->getSignals().append(std::make_shared<ComponentSignal>(
+          signalUuid, C::convertPinOrPadName(signalName), signalRole,
+          forcedNetName, isRequired, isNegated, isClock));
+      item->getPinSignalMap().append(
+          std::make_shared<ComponentPinSignalMapItem>(pinIt->second.value(),
+                                                      signalUuid, displayType));
+      mComponentSignalMap[key][gate.getName()][pinIt.key()] = signalUuid;
+    }
+  }
+  mComponentMap[key] = component->getUuid();
+  return component;
+}
+
+std::unique_ptr<Device> EagleLibraryConverter::createDevice(
+    const QString& libName, const parseagle::DeviceSet& eagleDeviceSet,
+    const parseagle::Device& eagleDevice) {
+  const auto componentKey = std::make_pair(libName, eagleDeviceSet.getName());
+  const tl::optional<Uuid> componentUuid = mComponentMap.value(componentKey);
+  if (!componentUuid) {
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Dependent component \"%1\" not imported.")
+                           .arg(eagleDeviceSet.getName()));
+  }
+  const auto packageKey = std::make_pair(libName, eagleDevice.getPackage());
+  const tl::optional<Uuid> packageUuid = mPackageMap.value(packageKey);
+  if (!packageUuid) {
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Dependent package \"%1\" not imported.")
+                           .arg(eagleDevice.getPackage()));
+  }
+  std::unique_ptr<Device> device(new Device(
+      Uuid::createRandom(), mSettings.version, mSettings.author,
+      C::convertDeviceName(mSettings.namePrefix + eagleDeviceSet.getName(),
+                           eagleDevice.getName()),
+      C::convertElementDescription(eagleDeviceSet.getDescription()),
+      mSettings.keywords, *componentUuid, *packageUuid));
+  device->setCategories(mSettings.deviceCategories);
+  for (auto padIt = mPackagePadMap[packageKey].constBegin();
+       padIt != mPackagePadMap[packageKey].constEnd(); padIt++) {
+    tl::optional<Uuid> signalUuid;
+    foreach (const auto& connection, eagleDevice.getConnections()) {
+      if (connection.getPads().contains(padIt.key())) {
+        signalUuid = mComponentSignalMap[componentKey][connection.getGate()]
+                                        [connection.getPin()];
+      }
+    }
+    device->getPadSignalMap().append(
+        std::make_shared<DevicePadSignalMapItem>(padIt->value(), signalUuid));
+  }
+  return device;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void EagleLibraryConverter::tryOrRaiseError(const QString& element,
+                                            std::function<void()> func) {
+  try {
+    func();
+  } catch (const Exception& e) {
+    emit errorOccurred(element, e.getMsg());
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace eagleimport
+}  // namespace librepcb

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -110,7 +110,10 @@ std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
 
   QList<C::Geometry> geometries;
   tryOrRaiseError(eagleSymbol.getName(), [&]() {
-    geometries += C::convertAndJoinWires(eagleSymbol.getWires(), true);
+    // Enable grab areas on closed polygons. However, don't do this for sheet
+    // frames as it would look ugly. We guess that by the absence of pins.
+    const bool grabArea = !eagleSymbol.getPins().isEmpty();
+    geometries += C::convertAndJoinWires(eagleSymbol.getWires(), grabArea);
   });
   foreach (const auto& obj, eagleSymbol.getRectangles()) {
     geometries.append(C::convertRectangle(obj, true));
@@ -120,6 +123,9 @@ std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
   }
   foreach (const auto& obj, eagleSymbol.getCircles()) {
     geometries.append(C::convertCircle(obj, true));
+  }
+  foreach (const auto& obj, eagleSymbol.getFrames()) {
+    geometries.append(C::convertFrame(obj));
   }
   foreach (const auto& g, geometries) {
     tryOrRaiseError(eagleSymbol.getName(), [&]() {

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -323,6 +323,15 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
       mComponentSignalMap[key][gate.getName()][pinIt.key()] = signalUuid;
     }
   }
+  // If the device set has no package at all, we consider it as a schematic-only
+  // component to avoid the "unplaced devices" warning in the board editor.
+  bool hasPackage = false;
+  foreach (const auto& device, eagleDeviceSet.getDevices()) {
+    if (!device.getPackage().isEmpty()) {
+      hasPackage = true;
+    }
+  }
+  component->setIsSchematicOnly(!hasPackage);
   mComponentMap[key] = component->getUuid();
   return component;
 }

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -273,6 +273,7 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
       pinCount[pinIt.key()]++;
     }
   }
+  const bool addGateSuffixes = eagleDeviceSet.getGates().count() > 1;
   foreach (const auto& gate, eagleDeviceSet.getGates()) {
     const auto symbolKey = std::make_pair(libName, gate.getSymbol());
     const tl::optional<Uuid> symbolUuid = mSymbolMap.value(symbolKey);
@@ -283,7 +284,8 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
     }
     auto item = std::make_shared<ComponentSymbolVariantItem>(
         Uuid::createRandom(), *symbolUuid, C::convertPoint(gate.getPosition()),
-        Angle(0), true, C::convertGateName(gate.getName()));
+        Angle(0), true,
+        C::convertGateName(addGateSuffixes ? gate.getName() : ""));
     symbolVariant->getSymbolItems().append(item);
     for (auto pinIt = mSymbolPinMap[symbolKey].constBegin();
          pinIt != mSymbolPinMap[symbolKey].constEnd(); pinIt++) {

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -261,7 +261,9 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
   component->setCategories(mSettings.componentCategories);
   component->setPrefixes(NormDependentPrefixMap(
       C::convertComponentPrefix(eagleDeviceSet.getPrefix())));
-  component->setDefaultValue("{{ MPN or DEVICE }}");
+  component->setDefaultValue(eagleDeviceSet.getUserValue()
+                                 ? "{{ MPN }}"
+                                 : "{{ MPN or DEVICE or COMPONENT }}");
   auto symbolVariant = std::make_shared<ComponentSymbolVariant>(
       Uuid::createRandom(), "", ElementName("default"), "");
   component->getSymbolVariants().append(symbolVariant);

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -191,7 +191,12 @@ std::unique_ptr<Package> EagleLibraryConverter::createPackage(
   }
   foreach (const auto& g, geometries) {
     tryOrRaiseError(eaglePackage.getName(), [&]() {
-      if (auto o = C::tryConvertToBoardCircle(g)) {
+      const auto zones = C::tryConvertToBoardZones(g);
+      if (!zones.isEmpty()) {
+        foreach (const auto& o, zones) {
+          footprint->getZones().append(o);
+        }
+      } else if (auto o = C::tryConvertToBoardCircle(g)) {
         footprint->getCircles().append(o);
       } else if (auto o = C::tryConvertToBoardPolygon(g)) {
         footprint->getPolygons().append(o);

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -260,7 +260,7 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
       mSettings.keywords));
   component->setCategories(mSettings.componentCategories);
   component->setPrefixes(NormDependentPrefixMap(
-      ComponentPrefix(eagleDeviceSet.getPrefix().trimmed())));
+      C::convertComponentPrefix(eagleDeviceSet.getPrefix())));
   component->setDefaultValue("{{ MPN or DEVICE }}");
   auto symbolVariant = std::make_shared<ComponentSymbolVariant>(
       Uuid::createRandom(), "", ElementName("default"), "");

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.h
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.h
@@ -1,0 +1,163 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EAGLEIMPORT_EAGLELIBRARYCONVERTER_H
+#define LIBREPCB_EAGLEIMPORT_EAGLELIBRARYCONVERTER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/types/uuid.h>
+#include <librepcb/core/types/version.h>
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace parseagle {
+class Device;
+class DeviceSet;
+class Package;
+class Pin;
+class Symbol;
+}  // namespace parseagle
+
+namespace librepcb {
+
+class Component;
+class Device;
+class Package;
+class Polygon;
+class Symbol;
+
+namespace eagleimport {
+
+/*******************************************************************************
+ *  Struct EagleLibraryConverterSettings
+ ******************************************************************************/
+
+/**
+ * @brief Settings for ::librepcb::eagleimport::EagleLibraryConverter
+ */
+struct EagleLibraryConverterSettings final {
+  EagleLibraryConverterSettings() noexcept;
+
+  QString namePrefix;
+  Version version;
+  QString author;
+  QString keywords;
+  QSet<Uuid> symbolCategories;
+  QSet<Uuid> packageCategories;
+  QSet<Uuid> componentCategories;
+  QSet<Uuid> deviceCategories;
+};
+
+/*******************************************************************************
+ *  Class EagleLibraryConverter
+ ******************************************************************************/
+
+/**
+ * @brief Converts EAGLE library elements to LibrePCB
+ */
+class EagleLibraryConverter final : public QObject {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  EagleLibraryConverter(const EagleLibraryConverter& other) = delete;
+  explicit EagleLibraryConverter(const EagleLibraryConverterSettings& settings,
+                                 QObject* parent = nullptr) noexcept;
+  ~EagleLibraryConverter() noexcept;
+
+  // Getters
+  Uuid getComponentSignalOfSymbolPin(const QString& libName,
+                                     const QString& devSetName,
+                                     const QString& gateName,
+                                     const QString& pinName) const;
+
+  // General Methods
+  void reset() noexcept;
+  std::unique_ptr<Symbol> createSymbol(const QString& libName,
+                                       const parseagle::Symbol& eagleSymbol);
+  std::unique_ptr<Package> createPackage(
+      const QString& libName, const parseagle::Package& eaglePackage);
+  std::unique_ptr<Component> createComponent(
+      const QString& libName, const parseagle::DeviceSet& eagleDeviceSet);
+  std::unique_ptr<Device> createDevice(
+      const QString& libName, const parseagle::DeviceSet& eagleDeviceSet,
+      const parseagle::Device& eagleDevice);
+
+  // Operator Overloadings
+  EagleLibraryConverter& operator=(const EagleLibraryConverter& rhs) = delete;
+
+signals:
+  void errorOccurred(const QString& elementName, const QString& msg);
+
+private:  // Methods
+  void tryOrRaiseError(const QString& element, std::function<void()> func);
+
+private:  // Data
+  EagleLibraryConverterSettings mSettings;
+
+  // State
+
+  /// Key: (Library Name, Symbol Name)
+  /// Value: LibrePCB Symbol UUID
+  QHash<std::pair<QString, QString>, tl::optional<Uuid> > mSymbolMap;
+
+  /// Key: (Library Name, Symbol Name) | Pin Name
+  /// Value: (EAGLE Pin Object, LibrePCB Symbol Pin UUID)
+  QHash<
+      std::pair<QString, QString>,
+      QHash<QString,
+            std::pair<std::shared_ptr<parseagle::Pin>, tl::optional<Uuid> > > >
+      mSymbolPinMap;
+
+  /// Key: (Library Name, Package Name)
+  /// Value: LibrePCB Package UUID
+  QHash<std::pair<QString, QString>, tl::optional<Uuid> > mPackageMap;
+
+  /// Key: (Library Name, Package Name) | Pad Name
+  /// Value: LibrePCB Package Pad UUID
+  QHash<std::pair<QString, QString>, QHash<QString, tl::optional<Uuid> > >
+      mPackagePadMap;
+
+  /// Key: (Library Name, Device Set Name)
+  /// Value: LibrePCB Component UUID
+  QHash<std::pair<QString, QString>, tl::optional<Uuid> > mComponentMap;
+
+  /// Key: (Library Name, Device Set Name) | Gate Name | Pin Name
+  /// Value: LibrePCB Component Signal UUID
+  QHash<std::pair<QString, QString>,
+        QHash<QString, QHash<QString, tl::optional<Uuid> > > >
+      mComponentSignalMap;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace eagleimport
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.h
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/core/types/boundedunsignedratio.h>
 #include <librepcb/core/types/uuid.h>
 #include <librepcb/core/types/version.h>
 #include <optional/tl/optional.hpp>
@@ -70,6 +71,7 @@ struct EagleLibraryConverterSettings final {
   QSet<Uuid> packageCategories;
   QSet<Uuid> componentCategories;
   QSet<Uuid> deviceCategories;
+  BoundedUnsignedRatio autoThtAnnularWidth;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -92,12 +92,8 @@ ComponentPrefix EagleTypeConverter::convertComponentPrefix(const QString& p) {
 
 ComponentSymbolVariantItemSuffix EagleTypeConverter::convertGateName(
     const QString& n) {
-  QString suffix = n.trimmed();
-  if (suffix.startsWith("G$")) {
-    suffix = "";  // Convert EAGLE default name to LibrePCB default name.
-  }
-  suffix = cleanComponentSymbolVariantItemSuffix(suffix);
-  return ComponentSymbolVariantItemSuffix(suffix);
+  return ComponentSymbolVariantItemSuffix(
+      cleanComponentSymbolVariantItemSuffix(n));
 }
 
 CircuitIdentifier EagleTypeConverter::convertPinOrPadName(const QString& n) {

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -97,7 +97,7 @@ ComponentSymbolVariantItemSuffix EagleTypeConverter::convertGateName(
 }
 
 CircuitIdentifier EagleTypeConverter::convertPinOrPadName(const QString& n) {
-  QString name = cleanCircuitIdentifier(n);
+  QString name = convertInversionSyntax(cleanCircuitIdentifier(n));
   if ((name.length() > 2) && (name.startsWith("P$"))) {
     name.remove(0, 2);
   }
@@ -105,6 +105,27 @@ CircuitIdentifier EagleTypeConverter::convertPinOrPadName(const QString& n) {
     name = "Unnamed";
   }
   return CircuitIdentifier(name);
+}
+
+QString EagleTypeConverter::convertInversionSyntax(const QString& s) noexcept {
+  QString out;
+  bool inputOverlined = false;
+  bool outputOverlined = false;
+  for (int i = 0; i < s.count(); ++i) {
+    if (s.at(i) == "!") {
+      inputOverlined = !inputOverlined;
+      continue;
+    }
+    if (s.at(i) == "/") {
+      outputOverlined = false;
+    }
+    if (inputOverlined != outputOverlined) {
+      out += "!";
+      outputOverlined = inputOverlined;
+    }
+    out += s.at(i);
+  }
+  return out;
 }
 
 const Layer* EagleTypeConverter::tryConvertSchematicLayer(int id) noexcept {

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -85,6 +85,11 @@ ElementName EagleTypeConverter::convertDeviceName(const QString& deviceSetName,
   return convertElementName(name);  // Can theoretically throw, but should not.
 }
 
+ComponentPrefix EagleTypeConverter::convertComponentPrefix(const QString& p) {
+  return ComponentPrefix(
+      cleanComponentPrefix(p));  // Can theoretically throw, but should not.
+}
+
 ComponentSymbolVariantItemSuffix EagleTypeConverter::convertGateName(
     const QString& n) {
   QString suffix = n.trimmed();

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -189,6 +189,15 @@ public:
   static CircuitIdentifier convertPinOrPadName(const QString& n);
 
   /**
+   * @brief Convert the inversion syntax of a text
+   *
+   * @param s   EAGLE text possibly containing inversion signs (e.g. "!RST!/EN")
+   *
+   * @return Same text but with LibrePCB inversion syntax (e.g. "!RST/EN")
+   */
+  static QString convertInversionSyntax(const QString& s) noexcept;
+
+  /**
    * @brief Try to convert a layer ID to a schematic layer
    *
    * @param id  EAGLE layer ID

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -89,7 +89,7 @@ public:
   /**
    * @brief Convert an element (e.g. symbol) name
    *
-   * Removes all invalid characters from an EAGLe element name and convert it
+   * Removes all invalid characters from an EAGLE element name and convert it
    * to the corresponding LibrePCB type. If completely invalid, "Unnamed" will
    * be returned (no error).
    *
@@ -109,6 +109,32 @@ public:
    * @return LibrePCB element description (no HTML)
    */
   static QString convertElementDescription(const QString& d);
+
+  /**
+   * @brief Convert a component name
+   *
+   * Like #convertElementName(), but also removes trailing separation
+   * characters.
+   *
+   * @param n   EAGLE component name (e.g. "R-0805-")
+   *
+   * @return LibrePCB component name (e.g. "R-0805")
+   */
+  static ElementName convertComponentName(QString n);
+
+  /**
+   * @brief Convert a device name
+   *
+   * Like #convertElementName(), but concatenating the EAGLE device set name
+   * with the EAGLE device name.
+   *
+   * @param deviceSetName   EAGLE device set name
+   * @param deviceName      EAGLE device name
+   *
+   * @return LibrePCB device name
+   */
+  static ElementName convertDeviceName(const QString& deviceSetName,
+                                       const QString& deviceName);
 
   /**
    * @brief Convert a component gate name
@@ -199,6 +225,17 @@ public:
    * @return LibrePCB polygon containing 1 line segment
    */
   static std::shared_ptr<Polygon> convertWire(const parseagle::Wire& w);
+
+  /**
+   * @brief Convert and try to join tangent wires
+   *
+   * @param wires   EAGLE wires (line segments)
+   * @param errors  Error messages output
+   *
+   * @return LibrePCB polygons containing 1 or more line segments
+   */
+  static QVector<std::shared_ptr<Polygon> > convertAndJoinWires(
+      const QList<parseagle::Wire>& wires, QStringList* errors = nullptr);
 
   /**
    * @brief Convert a rectangle

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -38,6 +38,7 @@
 #include <librepcb/core/types/elementname.h>
 #include <librepcb/core/types/point.h>
 #include <optional/tl/optional.hpp>
+#include <parseagle/common/enums.h>
 
 #include <QtCore>
 
@@ -216,6 +217,15 @@ public:
   static const Layer* tryConvertBoardLayer(int id) noexcept;
 
   /**
+   * @brief Convert an alignment
+   *
+   * @param a   EAGLE alignment
+   *
+   * @return LibrePCB alignment
+   */
+  static Alignment convertAlignment(parseagle::Alignment a);
+
+  /**
    * @brief Convert a length
    *
    * @param l   EAGLE length [mm]
@@ -339,6 +349,15 @@ public:
   static QString convertTextValue(const QString& v);
 
   /**
+   * @brief Convert the size (height) of a schematic text
+   *
+   * @param s   EAGLE text size [mm]
+   *
+   * @return LibrePCB text size
+   */
+  static PositiveLength convertSchematicTextSize(double s);
+
+  /**
    * @brief Try to convert a schematic/symbol text
    *
    * @param t   EAGLE text
@@ -347,6 +366,28 @@ public:
    */
   static std::shared_ptr<Text> tryConvertSchematicText(
       const parseagle::Text& t);
+
+  /**
+   * @brief Convert the size (height) of a board text
+   *
+   * @param layerId EAGLE layer ID
+   * @param size    EAGLE text size [mm]
+   *
+   * @return LibrePCB text size
+   */
+  static PositiveLength convertBoardTextSize(int layerId, double size);
+
+  /**
+   * @brief Convert the stroke width of a board text
+   *
+   * @param layerId EAGLE layer ID
+   * @param size    EAGLE text size [mm]
+   * @param ratio   EAGLE text ratio [%]
+   *
+   * @return LibrePCB stroke text width
+   */
+  static UnsignedLength convertBoardTextStrokeWidth(int layerId, double size,
+                                                    int ratio);
 
   /**
    * @brief Try to cnvert a board/footprint text

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -29,6 +29,7 @@
 #include <librepcb/core/geometry/polygon.h>
 #include <librepcb/core/geometry/stroketext.h>
 #include <librepcb/core/geometry/text.h>
+#include <librepcb/core/library/cmp/componentprefix.h>
 #include <librepcb/core/library/cmp/componentsymbolvariantitemsuffix.h>
 #include <librepcb/core/library/pkg/footprintpad.h>
 #include <librepcb/core/library/pkg/packagepad.h>
@@ -150,6 +151,18 @@ public:
    */
   static ElementName convertDeviceName(const QString& deviceSetName,
                                        const QString& deviceName);
+
+  /**
+   * @brief Convert a component prefix
+   *
+   * Removes all invalid characters and returns the component prefix in the
+   * corresponding LibrePCB type.
+   *
+   * @param p   EAGLE device set prefix
+   *
+   * @return LibrePCB component prefix
+   */
+  static ComponentPrefix convertComponentPrefix(const QString& p);
 
   /**
    * @brief Convert a component gate name

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -29,6 +29,7 @@
 #include <librepcb/core/geometry/polygon.h>
 #include <librepcb/core/geometry/stroketext.h>
 #include <librepcb/core/geometry/text.h>
+#include <librepcb/core/geometry/zone.h>
 #include <librepcb/core/library/cmp/componentprefix.h>
 #include <librepcb/core/library/cmp/componentsymbolvariantitemsuffix.h>
 #include <librepcb/core/library/pkg/footprintpad.h>
@@ -470,6 +471,31 @@ public:
    * @return A polygon if the layer is valid for schematics, otherwise `nullptr`
    */
   static std::shared_ptr<Polygon> tryConvertToSchematicPolygon(
+      const Geometry& g);
+
+  /**
+   * @brief Convert the outline of a board zone
+   *
+   * Our zones do not support setting aline width, so we have to offet the
+   * outline to get the same keepout area.
+   *
+   * @param outline   EAGLE keepout zone outline
+   * @param lineWidth EAGLE keepout zone line width
+   *
+   * @return Possibly multiple paths with the LibrePCB zone outline(s)
+   */
+  static QVector<Path> convertBoardZoneOutline(const Path& outline,
+                                               const Length& lineWidth);
+
+  /**
+   * @brief Try to convert an intermediate geometry to board keepout zones
+   *
+   * @param g   intermediate geometry
+   *
+   * @return    A keepout zone(s) if the geometry represents a zone,
+   *            otherwise an empty vector
+   */
+  static QVector<std::shared_ptr<Zone>> tryConvertToBoardZones(
       const Geometry& g);
 
   /**

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -225,6 +225,19 @@ public:
   static Length convertLength(double l);
 
   /**
+   * @brief Convert a line width for a given layer
+   *
+   * Applies line width rules for some special purpose layers (like board
+   * outline).
+   *
+   * @param w         EAGLE line width [mm]
+   * @param layerId   EAGLE layer ID
+   *
+   * @return LibrePCB line width length
+   */
+  static UnsignedLength convertLineWidth(double w, int layerId);
+
+  /**
    * @brief Convert a point
    *
    * @param p   EAGLE point [mm]

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -50,6 +50,7 @@
 namespace parseagle {
 class Circle;
 class DeviceSet;
+class Frame;
 class Gate;
 class Hole;
 class Library;
@@ -338,6 +339,15 @@ public:
    * @return LibrePCB hole
    */
   static std::shared_ptr<Hole> convertHole(const parseagle::Hole& h);
+
+  /**
+   * @brief Convert a frame
+   *
+   * @param f   EAGLE frame
+   *
+   * @return Intermediate geometry containing 4 line segments
+   */
+  static Geometry convertFrame(const parseagle::Frame& f);
 
   /**
    * @brief Convert a text value

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -34,6 +34,7 @@
 #include <librepcb/core/library/pkg/footprintpad.h>
 #include <librepcb/core/library/pkg/packagepad.h>
 #include <librepcb/core/library/sym/symbolpin.h>
+#include <librepcb/core/types/boundedunsignedratio.h>
 #include <librepcb/core/types/circuitidentifier.h>
 #include <librepcb/core/types/elementname.h>
 #include <librepcb/core/types/point.h>
@@ -97,6 +98,15 @@ public:
     bool grabArea;
     Path path;
     tl::optional<std::pair<Point, PositiveLength>> circle;
+  };
+
+  /**
+   * @brief LibrePCB data structure to represent an EAGLE symbol pin
+   */
+  struct Pin {
+    std::shared_ptr<SymbolPin> pin;
+    std::shared_ptr<Circle> circle;
+    std::shared_ptr<Polygon> polygon;
   };
 
   // Constructors / Destructor
@@ -414,19 +424,23 @@ public:
    *
    * @param p   EAGLE pin
    *
-   * @return LibrePCB pin
+   * @return LibrePCB objects to represent the pin
    */
-  static std::shared_ptr<SymbolPin> convertSymbolPin(const parseagle::Pin& p);
+  static Pin convertSymbolPin(const parseagle::Pin& p);
 
   /**
    * @brief Convert a THT pad
    *
-   * @param p   EAGLE pad
+   * @param p                 EAGLE pad
+   * @param autoAnnularWidth  How to calculate the annular width (and thus the
+   *                          outer pad size) if it is set to 'auto' in EAGLE.
+   *                          See #getDefaultAutoThtAnnularWidth().
    *
    * @return LibrePCB package pad + footprint pad
    */
   static std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
-      convertThtPad(const parseagle::ThtPad& p);
+      convertThtPad(const parseagle::ThtPad& p,
+                    const BoundedUnsignedRatio& autoAnnularWidth);
 
   /**
    * @brief Convert an SMT pad
@@ -476,6 +490,15 @@ public:
    * @return A polygon if the layer is valid for boards, otherwise `nullptr`
    */
   static std::shared_ptr<Polygon> tryConvertToBoardPolygon(const Geometry& g);
+
+  /**
+   * @brief Get the default annular width of THT pads with 'auto' size
+   *
+   * This is the value used by the EAGLE footprint editor.
+   *
+   * @return Ratio to calculate the annular width from the drill diameter
+   */
+  static BoundedUnsignedRatio getDefaultAutoThtAnnularWidth() noexcept;
 
   // Operator Overloadings
   EagleTypeConverter& operator=(const EagleTypeConverter& rhs) = delete;

--- a/tests/unittests/core/library/cmp/componentprefixtest.cpp
+++ b/tests/unittests/core/library/cmp/componentprefixtest.cpp
@@ -59,6 +59,17 @@ TEST_P(ComponentPrefixTest, testConstructor) {
   }
 }
 
+TEST_P(ComponentPrefixTest, testClean) {
+  const ComponentPrefixTestData& data = GetParam();
+
+  if (data.valid) {
+    EXPECT_EQ(data.input, cleanComponentPrefix(data.input));
+  } else {
+    QString cleaned = cleanComponentPrefix(data.input);
+    ComponentPrefix suffix(cleaned);  // must not throw
+  }
+}
+
 /*******************************************************************************
  *  Test Data
  ******************************************************************************/

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -448,26 +448,31 @@ TEST_F(EagleTypeConverterTest, testTryConvertBoardText) {
 TEST_F(EagleTypeConverterTest, testConvertSymbolPin) {
   QString xml = "<pin name=\"P$1\" x=\"1\" y=\"2\" length=\"point\"/>";
   auto out = C::convertSymbolPin(parseagle::Pin(dom(xml)));
-  EXPECT_EQ("1", out->getName()->toStdString());
-  EXPECT_EQ(Point(1000000, 2000000), out->getPosition());
-  EXPECT_EQ(UnsignedLength(0), out->getLength());
-  EXPECT_EQ(Angle(0), out->getRotation());
+  EXPECT_EQ("1", out.pin->getName()->toStdString());
+  EXPECT_EQ(Point(1000000, 2000000), out.pin->getPosition());
+  EXPECT_EQ(UnsignedLength(0), out.pin->getLength());
+  EXPECT_EQ(Angle(0), out.pin->getRotation());
+  EXPECT_EQ(nullptr, out.circle);
+  EXPECT_EQ(nullptr, out.polygon);
 }
 
 TEST_F(EagleTypeConverterTest, testConvertSymbolPinRotated) {
   QString xml =
       "<pin name=\"P$1\" x=\"1\" y=\"2\" length=\"middle\" rot=\"R90\"/>";
   auto out = C::convertSymbolPin(parseagle::Pin(dom(xml)));
-  EXPECT_EQ("1", out->getName()->toStdString());
-  EXPECT_EQ(Point(1000000, 2000000), out->getPosition());
-  EXPECT_EQ(UnsignedLength(5080000), out->getLength());
-  EXPECT_EQ(Angle(90000000), out->getRotation());
+  EXPECT_EQ("1", out.pin->getName()->toStdString());
+  EXPECT_EQ(Point(1000000, 2000000), out.pin->getPosition());
+  EXPECT_EQ(UnsignedLength(5080000), out.pin->getLength());
+  EXPECT_EQ(Angle(90000000), out.pin->getRotation());
+  EXPECT_EQ(nullptr, out.circle);
+  EXPECT_EQ(nullptr, out.polygon);
 }
 
 TEST_F(EagleTypeConverterTest, testConvertThtPad) {
   QString xml =
       "<pad name=\"P$1\" x=\"1\" y=\"2\" drill=\"1.5\" shape=\"square\"/>";
-  auto out = C::convertThtPad(parseagle::ThtPad(dom(xml)));
+  auto out = C::convertThtPad(parseagle::ThtPad(dom(xml)),
+                              C::getDefaultAutoThtAnnularWidth());
   EXPECT_EQ("1", out.first->getName()->toStdString());
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
@@ -485,7 +490,8 @@ TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
   QString xml =
       "<pad name=\"P$1\" x=\"1\" y=\"2\" drill=\"1.5\" diameter=\"2.54\" "
       "shape=\"octagon\" rot=\"R90\"/>";
-  auto out = C::convertThtPad(parseagle::ThtPad(dom(xml)));
+  auto out = C::convertThtPad(parseagle::ThtPad(dom(xml)),
+                              C::getDefaultAutoThtAnnularWidth());
   EXPECT_EQ("1", out.first->getName()->toStdString());
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -114,7 +114,7 @@ TEST_F(EagleTypeConverterTest, testConvertComponentPrefix) {
 
 TEST_F(EagleTypeConverterTest, testConvertGateName) {
   EXPECT_EQ("", C::convertGateName("")->toStdString());
-  EXPECT_EQ("", C::convertGateName("G$42")->toStdString());
+  EXPECT_EQ("G42", C::convertGateName("G$42")->toStdString());
   EXPECT_EQ("1", C::convertGateName("-1")->toStdString());
   EXPECT_EQ("Foo_Bar", C::convertGateName(" Foo Bar ")->toStdString());
 }

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -124,6 +124,18 @@ TEST_F(EagleTypeConverterTest, testConvertPinOrPadName) {
   EXPECT_EQ("42", C::convertPinOrPadName("P$42")->toStdString());
   EXPECT_EQ("3", C::convertPinOrPadName("3")->toStdString());
   EXPECT_EQ("Foo_Bar", C::convertPinOrPadName(" Foo Bar ")->toStdString());
+  EXPECT_EQ("!FOO!/BAR", C::convertPinOrPadName("!FOO/BAR")->toStdString());
+}
+
+TEST_F(EagleTypeConverterTest, testConvertInversionSyntax) {
+  EXPECT_EQ("FOO", C::convertInversionSyntax("FOO").toStdString());
+  EXPECT_EQ("!FOO", C::convertInversionSyntax("!FOO").toStdString());
+  EXPECT_EQ("!FOO", C::convertInversionSyntax("!FOO!").toStdString());
+  EXPECT_EQ("!FOO/BAR", C::convertInversionSyntax("!FOO!/BAR").toStdString());
+  EXPECT_EQ("!FOO!/BAR", C::convertInversionSyntax("!FOO/BAR").toStdString());
+  EXPECT_EQ("FOO/!BAR", C::convertInversionSyntax("FOO/!BAR").toStdString());
+  EXPECT_EQ("FOO/!BAR", C::convertInversionSyntax("FOO/!BAR!").toStdString());
+  EXPECT_EQ("A/!B/C", C::convertInversionSyntax("A/!B!/C").toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertSchematicLayer) {

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -158,6 +158,16 @@ TEST_F(EagleTypeConverterTest, testConvertLength) {
   EXPECT_EQ(Length(1234567), C::convertLength(1.234567));
 }
 
+TEST_F(EagleTypeConverterTest, testConvertLineWidth) {
+  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(0, 20));  // dimension
+  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(0, 46));  // milling
+  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(1.23, 20));  // dimension
+  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(1.23, 46));  // milling
+  EXPECT_EQ(UnsignedLength(1230000), C::convertLineWidth(1.23, 1));  // tCu
+  EXPECT_EQ(UnsignedLength(1230000), C::convertLineWidth(1.23, 94));  // symbols
+  EXPECT_THROW(C::convertLineWidth(-1.23, 94), Exception);
+}
+
 TEST_F(EagleTypeConverterTest, testConvertPoint) {
   EXPECT_EQ(Point(0, 0), C::convertPoint(parseagle::Point{0, 0}));
   EXPECT_EQ(Point(-1234567, 1234567),

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -363,6 +363,26 @@ TEST_F(EagleTypeConverterTest, testConvertHole) {
             out->getPath()->getVertices().first().getPos());
 }
 
+TEST_F(EagleTypeConverterTest, testConvertFrame) {
+  QString xml =
+      "<frame x1=\"10\" y1=\"20\" x2=\"40\" y2=\"30\" columns=\"6\" rows=\"4\" "
+      "layer=\"94\"/>";
+  auto out = C::convertFrame(parseagle::Frame(dom(xml)));
+  EXPECT_EQ(94, out.layerId);
+  EXPECT_EQ(UnsignedLength(200000), out.lineWidth);
+  EXPECT_EQ(false, out.filled);  // Filled frames make no sense.
+  EXPECT_EQ(false, out.grabArea);  // Grab area makes no sense.
+  EXPECT_EQ(Path({
+                Vertex(Point(13810000, 23810000), Angle(0)),
+                Vertex(Point(36190000, 23810000), Angle(0)),
+                Vertex(Point(36190000, 26190000), Angle(0)),
+                Vertex(Point(13810000, 26190000), Angle(0)),
+                Vertex(Point(13810000, 23810000), Angle(0)),
+            }),
+            out.path);
+  EXPECT_EQ(tl::nullopt, out.circle);
+}
+
 TEST_F(EagleTypeConverterTest, testConvertTextValue) {
   EXPECT_EQ("", C::convertTextValue("").toStdString());
   EXPECT_EQ("{{NAME}}", C::convertTextValue(">NAME").toStdString());

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -105,6 +105,13 @@ TEST_F(EagleTypeConverterTest, testConvertDeviceName) {
   EXPECT_EQ("Unnamed", C::convertDeviceName("", "")->toStdString());
 }
 
+TEST_F(EagleTypeConverterTest, testConvertComponentPrefix) {
+  EXPECT_EQ("", C::convertComponentPrefix("")->toStdString());
+  EXPECT_EQ("", C::convertComponentPrefix("$42+")->toStdString());
+  EXPECT_EQ("C", C::convertComponentPrefix("C")->toStdString());
+  EXPECT_EQ("Foo_Bar", C::convertComponentPrefix(" Foo Bar ")->toStdString());
+}
+
 TEST_F(EagleTypeConverterTest, testConvertGateName) {
   EXPECT_EQ("", C::convertGateName("")->toStdString());
   EXPECT_EQ("", C::convertGateName("G$42")->toStdString());


### PR DESCRIPTION
For #1268, imported EAGLE library elements need to be much more accurate and respecting as many EAGLE properties as possible, otherwise we'll get too many problems in schematics and boards. Thus as a preparation, this PR heavily extends the EAGLE library import and fixes some issues:

- Fix failure in case of invalid component prefix
- Fix gate suffix on single-gate components
- Fix conversion of text inversion syntax
- Set more reasonable component default value
- Detect and mark schematic-only components
- Convert board outlines/cutouts to zero width
- Support many more text element properties
- Support sheet frames in symbols
- Support keepout zones in footprints
- Support more pin & pad properties

The EAGLE parser has been extended accordingly in https://github.com/LibrePCB/parseagle/pull/9.