### PR TITLE
Implement EAGLE project importer

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -463,6 +463,8 @@ add_library(
   utils/clipperhelpers.h
   utils/mathparser.cpp
   utils/mathparser.h
+  utils/messagelogger.cpp
+  utils/messagelogger.h
   utils/overlinemarkupparser.cpp
   utils/overlinemarkupparser.h
   utils/qtmetatyperegistration.h

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -311,6 +311,8 @@ add_library(
   project/board/boardgerberexport.h
   project/board/boardholedata.cpp
   project/board/boardholedata.h
+  project/board/boardnetsegmentsplitter.cpp
+  project/board/boardnetsegmentsplitter.h
   project/board/boardpainter.cpp
   project/board/boardpainter.h
   project/board/boardpickplacegenerator.cpp
@@ -409,6 +411,8 @@ add_library(
   project/schematic/items/si_text.h
   project/schematic/schematic.cpp
   project/schematic/schematic.h
+  project/schematic/schematicnetsegmentsplitter.cpp
+  project/schematic/schematicnetsegmentsplitter.h
   project/schematic/schematicpainter.cpp
   project/schematic/schematicpainter.h
   rulecheck/rulecheckmessage.cpp

--- a/libs/librepcb/core/geometry/padgeometry.cpp
+++ b/libs/librepcb/core/geometry/padgeometry.cpp
@@ -214,13 +214,13 @@ PadGeometry PadGeometry::stroke(const PositiveLength& diameter,
                                 const NonEmptyPath& path,
                                 const PadHoleList& holes) noexcept {
   return PadGeometry(Shape::Stroke, *diameter, Length(0),
-                     UnsignedLimitedRatio(Ratio::percent0()), *path, Length(0),
-                     holes);
+                     UnsignedLimitedRatio(Ratio::fromPercent(0)), *path,
+                     Length(0), holes);
 }
 
 PadGeometry PadGeometry::custom(const Path& outline, const PadHoleList& holes) {
   return PadGeometry(Shape::Custom, Length(0), Length(0),
-                     UnsignedLimitedRatio(Ratio::percent0()), outline,
+                     UnsignedLimitedRatio(Ratio::fromPercent(0)), outline,
                      Length(0), holes);
 }
 

--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -83,6 +83,21 @@ UnsignedLength Path::getTotalStraightLength() const noexcept {
   return length;
 }
 
+qreal Path::calcAreaOfStraightSegments() const noexcept {
+  // https://en.wikipedia.org/wiki/Shoelace_formula
+  // https://www.geeksforgeeks.org/area-of-a-polygon-with-given-n-ordered-vertices/
+  qreal area = 0;
+  const int n = isClosed() ? (mVertices.count() - 1) : mVertices.count();
+  int j = n - 1;
+  for (int i = 0; i < n; ++i) {
+    const QPointF pj = mVertices.at(j).getPos().toMmQPointF();
+    const QPointF pi = mVertices.at(i).getPos().toMmQPointF();
+    area += (pj.x() + pi.x()) * (pj.y() - pi.y());
+    j = i;
+  }
+  return std::abs(area / 2);
+}
+
 Point Path::calcNearestPointBetweenVertices(const Point& p) const noexcept {
   if (!mVertices.isEmpty()) {
     // Note: Does not take arcs into account yet.

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -75,6 +75,7 @@ public:
   }
   const QVector<Vertex>& getVertices() const noexcept { return mVertices; }
   UnsignedLength getTotalStraightLength() const noexcept;
+  qreal calcAreaOfStraightSegments() const noexcept;
   Point calcNearestPointBetweenVertices(const Point& p) const noexcept;
   Path cleaned() const noexcept;
   Path toClosedPath() const noexcept;

--- a/libs/librepcb/core/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpad.cpp
@@ -560,10 +560,10 @@ UnsignedLimitedRatio FootprintPad::getRecommendedRadius(
   // Use 50% ratio, but maximum 0.25mm as recommended by IPC7351C.
   const PositiveLength size = std::min(width, height);
   Ratio maxRadius = Ratio::fromNormalized(qreal(0.5) / size->toMm());
-  maxRadius /= Ratio::percent1();
-  maxRadius *= Ratio::percent1();
+  maxRadius /= Ratio::fromPercent(1);
+  maxRadius *= Ratio::fromPercent(1);
   return UnsignedLimitedRatio(
-      qBound(Ratio::percent0(), maxRadius, Ratio::percent50()));
+      qBound(Ratio::fromPercent(0), maxRadius, Ratio::fromPercent(50)));
 }
 
 QString FootprintPad::getFunctionDescriptionTr(Function function) noexcept {

--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -38,21 +38,21 @@ namespace librepcb {
 BoardDesignRules::BoardDesignRules() noexcept
   :  // stop mask
     mStopMaskMaxViaDrillDiameter(500000),  // 0.5mm
-    mStopMaskClearance(UnsignedRatio(Ratio::percent0()),  // 0%
+    mStopMaskClearance(UnsignedRatio(Ratio::fromPercent(0)),  // 0%
                        UnsignedLength(100000),  // 0.1mm
                        UnsignedLength(100000)),  // 0.1mm
     // solder paste
-    mSolderPasteClearance(UnsignedRatio(Ratio::percent100() / 10),  // 10%
+    mSolderPasteClearance(UnsignedRatio(Ratio::fromPercent(10)),  // 10%
                           UnsignedLength(0),  // 0mm
                           UnsignedLength(1000000)),  // 1mm
     // pad annular ring
     mPadCmpSideAutoAnnularRing(false),
     mPadInnerAutoAnnularRing(true),
-    mPadAnnularRing(UnsignedRatio(Ratio::percent100() / 4),  // 25%
+    mPadAnnularRing(UnsignedRatio(Ratio::fromPercent(25)),  // 25%
                     UnsignedLength(250000),  // 0.25mm
                     UnsignedLength(2000000)),  // 2mm
     // via annular ring
-    mViaAnnularRing(UnsignedRatio(Ratio::percent100() / 4),  // 25%
+    mViaAnnularRing(UnsignedRatio(Ratio::fromPercent(25)),  // 25%
                     UnsignedLength(200000),  // 0.2mm
                     UnsignedLength(2000000))  // 2mm
 {

--- a/libs/librepcb/core/project/board/boardnetsegmentsplitter.cpp
+++ b/libs/librepcb/core/project/board/boardnetsegmentsplitter.cpp
@@ -22,7 +22,7 @@
  ******************************************************************************/
 #include "boardnetsegmentsplitter.h"
 
-#include <librepcb/core/utils/toolbox.h>
+#include "../../utils/toolbox.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -31,7 +31,6 @@
  *  Namespace
  ******************************************************************************/
 namespace librepcb {
-namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -158,5 +157,4 @@ void BoardNetSegmentSplitter::findConnectedLinesAndPoints(
  *  End of File
  ******************************************************************************/
 
-}  // namespace editor
 }  // namespace librepcb

--- a/libs/librepcb/core/project/board/boardnetsegmentsplitter.h
+++ b/libs/librepcb/core/project/board/boardnetsegmentsplitter.h
@@ -17,15 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_SCHEMATICNETSEGMENTSPLITTER_H
-#define LIBREPCB_EDITOR_SCHEMATICNETSEGMENTSPLITTER_H
+#ifndef LIBREPCB_CORE_BOARDNETSEGMENTSPLITTER_H
+#define LIBREPCB_CORE_BOARDNETSEGMENTSPLITTER_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/core/geometry/junction.h>
-#include <librepcb/core/geometry/netlabel.h>
-#include <librepcb/core/geometry/netline.h>
+#include "../../geometry/junction.h"
+#include "../../geometry/trace.h"
+#include "../../geometry/via.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -34,69 +34,64 @@
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
-namespace editor {
+
+class Layer;
 
 /*******************************************************************************
- *  Class SchematicNetSegmentSplitter
+ *  Class BoardNetSegmentSplitter
  ******************************************************************************/
 
 /**
- * @brief The SchematicNetSegmentSplitter class
+ * @brief The BoardNetSegmentSplitter class
  */
-class SchematicNetSegmentSplitter final {
+class BoardNetSegmentSplitter final {
 public:
   // Types
   struct Segment {
     JunctionList junctions;
-    NetLineList netlines;
-    NetLabelList netlabels;
+    ViaList vias;
+    TraceList traces;
   };
 
   // Constructors / Destructor
-  SchematicNetSegmentSplitter() noexcept;
-  SchematicNetSegmentSplitter(const SchematicNetSegmentSplitter& other) =
-      delete;
-  ~SchematicNetSegmentSplitter() noexcept;
+  BoardNetSegmentSplitter() noexcept;
+  BoardNetSegmentSplitter(const BoardNetSegmentSplitter& other) = delete;
+  ~BoardNetSegmentSplitter() noexcept;
 
   // General Methods
-  void addSymbolPin(const NetLineAnchor& anchor, const Point& pos,
-                    bool replaceByJunction = false) noexcept;
+  void replaceFootprintPadByJunctions(const TraceAnchor& anchor,
+                                      const Point& pos) noexcept;
   void addJunction(const Junction& junction) noexcept;
-  void addNetLine(const NetLine& netline) noexcept;
-  void addNetLabel(const NetLabel& netlabel) noexcept;
+  void addVia(const Via& via, bool replaceByJunctions) noexcept;
+  void addTrace(const Trace& trace) noexcept;
   QList<Segment> split() noexcept;
 
   // Operator Overloadings
-  SchematicNetSegmentSplitter& operator=(
-      const SchematicNetSegmentSplitter& rhs) = delete;
+  BoardNetSegmentSplitter& operator=(const BoardNetSegmentSplitter& rhs) =
+      delete;
 
 private:  // Methods
-  NetLineAnchor replacePinAnchor(const NetLineAnchor& anchor) noexcept;
-  void findConnectedLinesAndPoints(const NetLineAnchor& anchor,
-                                   NetLineList& availableNetLines,
-                                   Segment& segment)
+  TraceAnchor replaceAnchor(const TraceAnchor& anchor,
+                            const Layer& layer) noexcept;
+  void findConnectedLinesAndPoints(const TraceAnchor& anchor,
+                                   ViaList& availableVias,
+                                   TraceList& availableTraces, Segment& segment)
 
       noexcept;
-  void addNetLabelToNearestNetSegment(const NetLabel& netlabel,
-                                      QList<Segment>& segments) const noexcept;
-  Length getDistanceBetweenNetLabelAndNetSegment(
-      const NetLabel& netlabel, const Segment& netsegment) const noexcept;
-  Point getAnchorPosition(const NetLineAnchor& anchor) const noexcept;
 
 private:  // Data
   JunctionList mJunctions;
-  NetLineList mNetLines;
-  NetLabelList mNetLabels;
+  ViaList mVias;
+  TraceList mTraces;
 
-  QHash<NetLineAnchor, NetLineAnchor> mPinAnchorsToReplace;
-  QHash<NetLineAnchor, Point> mPinPositions;
+  QHash<TraceAnchor, Point> mAnchorsToReplace;
+  QHash<QPair<TraceAnchor, const Layer*>, TraceAnchor> mReplacedAnchors;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
-}  // namespace editor
 }  // namespace librepcb
 
 #endif

--- a/libs/librepcb/core/project/schematic/schematicnetsegmentsplitter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicnetsegmentsplitter.cpp
@@ -22,7 +22,7 @@
  ******************************************************************************/
 #include "schematicnetsegmentsplitter.h"
 
-#include <librepcb/core/utils/toolbox.h>
+#include "../../utils/toolbox.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -31,7 +31,6 @@
  *  Namespace
  ******************************************************************************/
 namespace librepcb {
-namespace editor {
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -188,5 +187,4 @@ Point SchematicNetSegmentSplitter::getAnchorPosition(
  *  End of File
  ******************************************************************************/
 
-}  // namespace editor
 }  // namespace librepcb

--- a/libs/librepcb/core/project/schematic/schematicnetsegmentsplitter.h
+++ b/libs/librepcb/core/project/schematic/schematicnetsegmentsplitter.h
@@ -17,15 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_BOARDNETSEGMENTSPLITTER_H
-#define LIBREPCB_EDITOR_BOARDNETSEGMENTSPLITTER_H
+#ifndef LIBREPCB_CORE_SCHEMATICNETSEGMENTSPLITTER_H
+#define LIBREPCB_CORE_SCHEMATICNETSEGMENTSPLITTER_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/core/geometry/junction.h>
-#include <librepcb/core/geometry/trace.h>
-#include <librepcb/core/geometry/via.h>
+#include "../../geometry/junction.h"
+#include "../../geometry/netlabel.h"
+#include "../../geometry/netline.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -35,66 +35,66 @@
  ******************************************************************************/
 namespace librepcb {
 
-class Layer;
-
-namespace editor {
-
 /*******************************************************************************
- *  Class BoardNetSegmentSplitter
+ *  Class SchematicNetSegmentSplitter
  ******************************************************************************/
 
 /**
- * @brief The BoardNetSegmentSplitter class
+ * @brief The SchematicNetSegmentSplitter class
  */
-class BoardNetSegmentSplitter final {
+class SchematicNetSegmentSplitter final {
 public:
   // Types
   struct Segment {
     JunctionList junctions;
-    ViaList vias;
-    TraceList traces;
+    NetLineList netlines;
+    NetLabelList netlabels;
   };
 
   // Constructors / Destructor
-  BoardNetSegmentSplitter() noexcept;
-  BoardNetSegmentSplitter(const BoardNetSegmentSplitter& other) = delete;
-  ~BoardNetSegmentSplitter() noexcept;
+  SchematicNetSegmentSplitter() noexcept;
+  SchematicNetSegmentSplitter(const SchematicNetSegmentSplitter& other) =
+      delete;
+  ~SchematicNetSegmentSplitter() noexcept;
 
   // General Methods
-  void replaceFootprintPadByJunctions(const TraceAnchor& anchor,
-                                      const Point& pos) noexcept;
+  void addSymbolPin(const NetLineAnchor& anchor, const Point& pos,
+                    bool replaceByJunction = false) noexcept;
   void addJunction(const Junction& junction) noexcept;
-  void addVia(const Via& via, bool replaceByJunctions) noexcept;
-  void addTrace(const Trace& trace) noexcept;
+  void addNetLine(const NetLine& netline) noexcept;
+  void addNetLabel(const NetLabel& netlabel) noexcept;
   QList<Segment> split() noexcept;
 
   // Operator Overloadings
-  BoardNetSegmentSplitter& operator=(const BoardNetSegmentSplitter& rhs) =
-      delete;
+  SchematicNetSegmentSplitter& operator=(
+      const SchematicNetSegmentSplitter& rhs) = delete;
 
 private:  // Methods
-  TraceAnchor replaceAnchor(const TraceAnchor& anchor,
-                            const Layer& layer) noexcept;
-  void findConnectedLinesAndPoints(const TraceAnchor& anchor,
-                                   ViaList& availableVias,
-                                   TraceList& availableTraces, Segment& segment)
+  NetLineAnchor replacePinAnchor(const NetLineAnchor& anchor) noexcept;
+  void findConnectedLinesAndPoints(const NetLineAnchor& anchor,
+                                   NetLineList& availableNetLines,
+                                   Segment& segment)
 
       noexcept;
+  void addNetLabelToNearestNetSegment(const NetLabel& netlabel,
+                                      QList<Segment>& segments) const noexcept;
+  Length getDistanceBetweenNetLabelAndNetSegment(
+      const NetLabel& netlabel, const Segment& netsegment) const noexcept;
+  Point getAnchorPosition(const NetLineAnchor& anchor) const noexcept;
 
 private:  // Data
   JunctionList mJunctions;
-  ViaList mVias;
-  TraceList mTraces;
+  NetLineList mNetLines;
+  NetLabelList mNetLabels;
 
-  QHash<TraceAnchor, Point> mAnchorsToReplace;
-  QHash<QPair<TraceAnchor, const Layer*>, TraceAnchor> mReplacedAnchors;
+  QHash<NetLineAnchor, NetLineAnchor> mPinAnchorsToReplace;
+  QHash<NetLineAnchor, Point> mPinPositions;
 };
 
 /*******************************************************************************
  *  End of File
  ******************************************************************************/
 
-}  // namespace editor
 }  // namespace librepcb
 
 #endif

--- a/libs/librepcb/core/types/ratio.cpp
+++ b/libs/librepcb/core/types/ratio.cpp
@@ -42,6 +42,12 @@ QString Ratio::toNormalizedString() const noexcept {
 
 // Static Methods
 
+Ratio Ratio::fromPercent(int percent) noexcept {
+  Ratio ratio;
+  ratio.setRatioPercent(percent);
+  return ratio;
+}
+
 Ratio Ratio::fromPercent(qreal percent) noexcept {
   Ratio ratio;
   ratio.setRatioPercent(percent);

--- a/libs/librepcb/core/types/ratio.h
+++ b/libs/librepcb/core/types/ratio.h
@@ -84,11 +84,16 @@ public:
    * @brief Set the ratio in percent
    *
    * @param percent       The ratio in percent
+   */
+  void setRatioPercent(int percent) noexcept { mPpm = percent * 1e4; }
+
+  /**
+   * @brief Set the ratio in percent
    *
-   * @warning If you want to set the ratio exactly to common values like 0%, 50%
-   * or 100%, you should not use this method. Please use #setRatioPpm() instead
-   * because it is more accurate (no use of floating point numbers). Or you can
-   * also use the static methods #percent0(), #percent50() and so on.
+   * @param percent       The ratio in percent
+   *
+   * @warning To set an exact value, please use the overload
+   *          #setRatioPercent(int) instead.
    */
   void setRatioPercent(qreal percent) noexcept { mPpm = percent * 1e4; }
 
@@ -97,10 +102,11 @@ public:
    *
    * @param normalized    The normalized ratio
    *
-   * @warning If you want to set the ratio exactly to common values like 0%, 50%
-   * or 100%, you should not use this method. Please use #setRatioPpm() instead
-   * because it is more accurate (no use of floating point numbers). Or you can
-   * also use the static methods #percent0(), #percent50() and so on.
+   * @warning If you want to set the ratio exactly to common values like
+   *          0%, 50% or 100%, you should not use this method. Please use
+   *          #setRatioPercent(int) or #setRatioPpm() instead because it is
+   *          more accurate (no use of floating point numbers). Or you can
+   *          also use the static method #setRatioPercent(int).
    */
   void setRatioNormalized(qreal normalized) noexcept {
     mPpm = normalized * 1e6;
@@ -161,6 +167,15 @@ public:
    *
    * @return A new Ratio object with the specified ratio
    */
+  static Ratio fromPercent(int percent) noexcept;
+
+  /**
+   * @brief Get a Ratio object with a specific ratio
+   *
+   * @param percent   See #setRatioPercent()
+   *
+   * @return A new Ratio object with the specified ratio
+   */
   static Ratio fromPercent(qreal percent) noexcept;
 
   /**
@@ -190,14 +205,6 @@ public:
    * thrown
    */
   static Ratio fromNormalized(const QString& normalized);
-
-  // Static Methods to create often used ratios
-  static Ratio percent0() noexcept { return Ratio(0); }
-  static Ratio percent1() noexcept { return Ratio(10000); }
-  static Ratio percent5() noexcept { return Ratio(50000); }
-  static Ratio percent10() noexcept { return Ratio(100000); }
-  static Ratio percent50() noexcept { return Ratio(500000); }
-  static Ratio percent100() noexcept { return Ratio(1000000); }
 
   // Operators
   Ratio& operator=(const Ratio& rhs) {
@@ -352,7 +359,7 @@ struct UnsignedLimitedRatioVerifier {
 
 struct UnsignedLimitedRatioConstraint {
   constexpr bool operator()(const Ratio& r) const noexcept {
-    return (r >= 0) && (r <= Ratio::percent100());
+    return (r >= 0) && (r <= Ratio::fromPercent(100));
   }
 };
 

--- a/libs/librepcb/core/utils/messagelogger.cpp
+++ b/libs/librepcb/core/utils/messagelogger.cpp
@@ -1,0 +1,156 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "messagelogger.h"
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class MessageLogger::Message
+ ******************************************************************************/
+
+QString MessageLogger::Message::toRichText(bool colored,
+                                           bool bulletPoint) const noexcept {
+  static const QHash<QtMsgType, QString> colorMap = {
+      {QtDebugMsg, "blue"},
+      {QtInfoMsg, "darkblue"},
+      {QtWarningMsg, "orangered"},
+      {QtCriticalMsg, "red"},
+  };
+
+  QString s;
+  if (colored && colorMap.contains(type)) {
+    s += QString("<font color=\"%1\">").arg(colorMap[type]);
+  }
+  if (bulletPoint) {
+    s += "&#x2022; ";
+  }
+  s += QString(message).replace("\n", "<br>");
+  if (colored && colorMap.contains(type)) {
+    s += "</font>";
+  }
+  return s;
+}
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+MessageLogger::MessageLogger(bool record, QObject* parent) noexcept
+  : QObject(parent), mMutex(QMutex::Recursive), mParent(), mRecord(record) {
+}
+
+MessageLogger::MessageLogger(MessageLogger* parentLogger, const QString& group,
+                             bool record, QObject* parent) noexcept
+  : QObject(parent),
+    mMutex(QMutex::Recursive),
+    mParent(parentLogger),
+    mRecord(record) {
+  if (!group.isEmpty()) {
+    mPrefix = "[" % group % "] ";
+  }
+}
+
+MessageLogger::~MessageLogger() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+bool MessageLogger::hasMessages() const noexcept {
+  QMutexLocker lock(&mMutex);
+  return !mMessages.isEmpty();
+}
+
+QList<MessageLogger::Message> MessageLogger::getMessages() const noexcept {
+  QMutexLocker lock(&mMutex);
+  if (!mRecord) {
+    qWarning() << "Attempted to retrieve messages from a logger which does not "
+                  "record!";
+  }
+  return QList<MessageLogger::Message>(mMessages);
+}
+
+QStringList MessageLogger::getMessagesPlain() const noexcept {
+  QStringList l;
+  foreach (const Message& msg, getMessages()) {
+    l.append(msg.message);
+  }
+  return l;
+}
+
+QString MessageLogger::getMessagesRichText() const noexcept {
+  QStringList l;
+  foreach (const Message& msg, getMessages()) {
+    l.append(msg.toRichText());
+  }
+  return l.join("<br>");
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void MessageLogger::clear() noexcept {
+  QMutexLocker lock(&mMutex);
+  mMessages.clear();
+}
+
+void MessageLogger::log(QtMsgType type, const QString& msg) noexcept {
+  QMutexLocker lock(&mMutex);
+  if (mParent) {
+    mParent->log(type, mPrefix % msg);
+  } else {
+    qt_message_output(type, QMessageLogContext(), msg);
+  }
+  const Message obj{type, msg};
+  if (mRecord) {
+    mMessages.append(obj);
+  }
+  emit msgEmitted(obj);
+}
+
+void MessageLogger::debug(const QString& msg) noexcept {
+  log(QtDebugMsg, msg);
+}
+
+void MessageLogger::info(const QString& msg) noexcept {
+  log(QtInfoMsg, msg);
+}
+
+void MessageLogger::warning(const QString& msg) noexcept {
+  log(QtWarningMsg, msg);
+}
+
+void MessageLogger::critical(const QString& msg) noexcept {
+  log(QtCriticalMsg, msg);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/utils/messagelogger.h
+++ b/libs/librepcb/core/utils/messagelogger.h
@@ -1,0 +1,114 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_MESSAGELOGGER_H
+#define LIBREPCB_CORE_MESSAGELOGGER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Class MessageLogger
+ ******************************************************************************/
+
+/**
+ * @brief Generic logger class to pass messages between objects
+ *
+ * @note  This class is thread-safe, i.e. several threads can log or retrieve
+ *        logging messages simultanously.
+ */
+class MessageLogger final : public QObject {
+  Q_OBJECT
+
+public:
+  struct Message {
+    QtMsgType type;
+    QString message;
+
+    QString toRichText(bool colored = true,
+                       bool bulletPoint = false) const noexcept;
+  };
+
+  // Constructors / Destructor
+
+  /**
+   * @brief (Default) construdtor creating a top-level logger
+   */
+  MessageLogger(bool record = true, QObject* parent = nullptr) noexcept;
+
+  /**
+   * @brief Constructor for a (conditionally) child logger
+   */
+  MessageLogger(MessageLogger* parentLogger, const QString& group = QString(),
+                bool record = false, QObject* parent = nullptr) noexcept;
+
+  /**
+   * @brief Copy constructor
+   *
+   * @param other Object to copy.
+   */
+  MessageLogger(const MessageLogger& other) noexcept;
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~MessageLogger() noexcept;
+
+  // Getters
+  bool hasMessages() const noexcept;
+  QList<Message> getMessages() const noexcept;
+  QStringList getMessagesPlain() const noexcept;
+  QString getMessagesRichText() const noexcept;
+
+  // General Methods
+  void clear() noexcept;
+  void log(QtMsgType type, const QString& msg) noexcept;
+  void debug(const QString& msg) noexcept;
+  void info(const QString& msg) noexcept;
+  void warning(const QString& msg) noexcept;
+  void critical(const QString& msg) noexcept;
+
+  // Operator Overloadings
+  MessageLogger& operator=(const MessageLogger& rhs) = delete;
+
+signals:
+  void msgEmitted(const Message& msg);
+
+private:  // Data
+  mutable QMutex mMutex;
+  QPointer<MessageLogger> mParent;
+  QString mPrefix;
+  bool mRecord;
+  QList<Message> mMessages;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/core/utils/tangentpathjoiner.h
+++ b/libs/librepcb/core/utils/tangentpathjoiner.h
@@ -64,8 +64,8 @@ public:
   ~TangentPathJoiner() = delete;
 
   // General Methods
-  static QVector<Path> join(QVector<Path> paths,
-                            qint64 timeoutMs = -1) noexcept;
+  static QVector<Path> join(QVector<Path> paths, qint64 timeoutMs = -1,
+                            bool* timedOut = nullptr) noexcept;
 
   // Operator Overloadings
   TangentPathJoiner& operator=(const TangentPathJoiner& rhs) = delete;
@@ -120,7 +120,8 @@ private:
 
   static void findAllPaths(QVector<Result>& result, const QVector<Path>& paths,
                            const QElapsedTimer& timer, qint64 timeoutMs,
-                           const Result& prefix = Result()) noexcept;
+                           const Result& prefix = Result(),
+                           bool* timedOut = nullptr) noexcept;
 
   static tl::optional<Result> join(const QVector<Path>& paths,
                                    const Result& prefix, int index,

--- a/libs/librepcb/eagleimport/CMakeLists.txt
+++ b/libs/librepcb/eagleimport/CMakeLists.txt
@@ -6,8 +6,14 @@ set(CMAKE_AUTORCC OFF)
 # Export library
 add_library(
   librepcb_eagleimport STATIC
-  eaglelibraryconverter.cpp eaglelibraryconverter.h eaglelibraryimport.cpp
-  eaglelibraryimport.h eagletypeconverter.cpp eagletypeconverter.h
+  eaglelibraryconverter.cpp
+  eaglelibraryconverter.h
+  eaglelibraryimport.cpp
+  eaglelibraryimport.h
+  eagleprojectimport.cpp
+  eagleprojectimport.h
+  eagletypeconverter.cpp
+  eagletypeconverter.h
 )
 target_include_directories(
   librepcb_eagleimport

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.h
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.h
@@ -47,6 +47,7 @@ namespace librepcb {
 
 class Component;
 class Device;
+class MessageLogger;
 class Package;
 class Polygon;
 class Symbol;
@@ -100,23 +101,23 @@ public:
   // General Methods
   void reset() noexcept;
   std::unique_ptr<Symbol> createSymbol(const QString& libName,
-                                       const parseagle::Symbol& eagleSymbol);
-  std::unique_ptr<Package> createPackage(
-      const QString& libName, const parseagle::Package& eaglePackage);
+                                       const parseagle::Symbol& eagleSymbol,
+                                       MessageLogger& log);
+  std::unique_ptr<Package> createPackage(const QString& libName,
+                                         const parseagle::Package& eaglePackage,
+                                         MessageLogger& log);
   std::unique_ptr<Component> createComponent(
-      const QString& libName, const parseagle::DeviceSet& eagleDeviceSet);
+      const QString& libName, const parseagle::DeviceSet& eagleDeviceSet,
+      MessageLogger& log);
   std::unique_ptr<Device> createDevice(
       const QString& libName, const parseagle::DeviceSet& eagleDeviceSet,
-      const parseagle::Device& eagleDevice);
+      const parseagle::Device& eagleDevice, MessageLogger& log);
 
   // Operator Overloadings
   EagleLibraryConverter& operator=(const EagleLibraryConverter& rhs) = delete;
 
-signals:
-  void errorOccurred(const QString& elementName, const QString& msg);
-
 private:  // Methods
-  void tryOrRaiseError(const QString& element, std::function<void()> func);
+  void tryOrLogError(std::function<void()> func, MessageLogger& log);
 
 private:  // Data
   EagleLibraryConverterSettings mSettings;

--- a/libs/librepcb/eagleimport/eaglelibraryimport.h
+++ b/libs/librepcb/eagleimport/eaglelibraryimport.h
@@ -42,6 +42,9 @@ class Wire;
 }  // namespace parseagle
 
 namespace librepcb {
+
+class MessageLogger;
+
 namespace eagleimport {
 
 struct EagleLibraryConverterSettings;
@@ -96,6 +99,7 @@ public:
   ~EagleLibraryImport() noexcept;
 
   // Getters
+  std::shared_ptr<MessageLogger> getLogger() const noexcept { return mLogger; }
   const FilePath& getLoadedFilePath() const noexcept { return mLoadedFilePath; }
   int getTotalElementsCount() const noexcept;
   int getCheckedElementsCount() const noexcept;
@@ -134,8 +138,7 @@ signals:
   void componentCheckStateChanged(const QString& name, Qt::CheckState state);
   void progressStatus(const QString& status);
   void progressPercent(int percent);
-  void errorOccurred(const QString& error);
-  void finished(const QStringList& errors);
+  void finished();
 
 private:  // Methods
   template <typename T>
@@ -151,6 +154,7 @@ private:  // Methods
 private:  // Data
   const FilePath mDestinationLibraryFp;
   QScopedPointer<EagleLibraryConverterSettings> mSettings;
+  std::shared_ptr<MessageLogger> mLogger;
 
   // State
   bool mAbort;

--- a/libs/librepcb/eagleimport/eagleprojectimport.cpp
+++ b/libs/librepcb/eagleimport/eagleprojectimport.cpp
@@ -1,0 +1,1353 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "eagleprojectimport.h"
+
+#include "eaglelibraryconverter.h"
+#include "eagletypeconverter.h"
+
+#include <librepcb/core/attribute/attrtypestring.h>
+#include <librepcb/core/fileio/transactionaldirectory.h>
+#include <librepcb/core/library/cmp/component.h>
+#include <librepcb/core/library/cmp/componentsymbolvariant.h>
+#include <librepcb/core/library/dev/device.h>
+#include <librepcb/core/library/pkg/package.h>
+#include <librepcb/core/library/sym/symbol.h>
+#include <librepcb/core/project/board/board.h>
+#include <librepcb/core/project/board/boarddesignrules.h>
+#include <librepcb/core/project/board/boardnetsegmentsplitter.h>
+#include <librepcb/core/project/board/drc/boarddesignrulechecksettings.h>
+#include <librepcb/core/project/board/items/bi_device.h>
+#include <librepcb/core/project/board/items/bi_footprintpad.h>
+#include <librepcb/core/project/board/items/bi_hole.h>
+#include <librepcb/core/project/board/items/bi_netline.h>
+#include <librepcb/core/project/board/items/bi_netpoint.h>
+#include <librepcb/core/project/board/items/bi_netsegment.h>
+#include <librepcb/core/project/board/items/bi_plane.h>
+#include <librepcb/core/project/board/items/bi_polygon.h>
+#include <librepcb/core/project/board/items/bi_stroketext.h>
+#include <librepcb/core/project/board/items/bi_via.h>
+#include <librepcb/core/project/board/items/bi_zone.h>
+#include <librepcb/core/project/circuit/circuit.h>
+#include <librepcb/core/project/circuit/componentinstance.h>
+#include <librepcb/core/project/circuit/componentsignalinstance.h>
+#include <librepcb/core/project/circuit/netsignal.h>
+#include <librepcb/core/project/project.h>
+#include <librepcb/core/project/projectlibrary.h>
+#include <librepcb/core/project/schematic/items/si_netlabel.h>
+#include <librepcb/core/project/schematic/items/si_netline.h>
+#include <librepcb/core/project/schematic/items/si_netpoint.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
+#include <librepcb/core/project/schematic/items/si_polygon.h>
+#include <librepcb/core/project/schematic/items/si_symbolpin.h>
+#include <librepcb/core/project/schematic/items/si_text.h>
+#include <librepcb/core/project/schematic/schematic.h>
+#include <librepcb/core/project/schematic/schematicnetsegmentsplitter.h>
+#include <librepcb/core/utils/messagelogger.h>
+#include <librepcb/core/utils/transform.h>
+#include <parseagle/board/board.h>
+#include <parseagle/schematic/schematic.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace eagleimport {
+
+using C = EagleTypeConverter;
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+EagleProjectImport::EagleProjectImport(QObject* parent) noexcept
+  : QObject(parent), mLogger(new MessageLogger(true)) {
+}
+
+EagleProjectImport::~EagleProjectImport() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+int EagleProjectImport::getSheetCount() const noexcept {
+  return mSchematic ? mSchematic->getSheets().count() : 0;
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void EagleProjectImport::reset() noexcept {
+  mProjectName.clear();
+  mSchematic.reset();
+  mBoard.reset();
+  mLibSymbolMap.clear();
+  mLibComponentMap.clear();
+  mLibComponentGateMap.clear();
+  mLibPackageMap.clear();
+  mLibDeviceMap.clear();
+  mComponentMap.clear();
+  mSchematicDirNames.clear();
+  mNetSignalMap.clear();
+  mLogger->clear();
+}
+
+QStringList EagleProjectImport::open(const FilePath& sch, const FilePath& brd) {
+  reset();
+
+  QStringList warnings;
+  QScopedPointer<parseagle::Schematic> schematic;
+  QScopedPointer<parseagle::Board> board;
+
+  try {
+    schematic.reset(new parseagle::Schematic(sch.toStr(), &warnings));
+    if (schematic->getSheets().isEmpty()) {
+      warnings.append(tr("Project contains no schematic sheets."));
+    }
+    if (!schematic->getModules().isEmpty()) {
+      warnings.append(
+          tr("Project contains modules which are not supported yet!"));
+    }
+    if (hasBuses(*schematic)) {
+      warnings.append(
+          tr("Project contains buses which are not supported yet!"));
+    }
+    if (brd.isValid()) {
+      board.reset(new parseagle::Board(brd.toStr(), &warnings));
+    }
+  } catch (const std::exception& e) {
+    qWarning() << "Failed to parse EAGLE project:" << e.what();
+    throw RuntimeError(__FILE__, __LINE__, e.what());
+  }
+
+  mProjectName = sch.getCompleteBasename();
+  mSchematic.reset(schematic.take());
+  mBoard.reset(board.take());
+  return warnings;
+}
+
+void EagleProjectImport::import(Project& project) {
+  if (!mSchematic) {
+    throw LogicError(__FILE__, __LINE__);
+  }
+
+  try {
+    mLogger->info(tr("Importing project, this may take a moment..."));
+    mLogger->info(tr("If you experience any issues with the import, please "
+                     "<a href=\"%1\">let us know</a> so we can improve it.")
+                      .arg("https://librepcb.org/help/"));
+
+    // Try to apply the automatic THT annular width to get correct pad sizes in
+    // footprints.
+    EagleLibraryConverterSettings settings;
+    try {
+      if (auto r = tryGetDrcRatio("rvPadBottom", "rlMinPadBottom",
+                                  "rlMaxPadBottom")) {
+        settings.autoThtAnnularWidth = *r;
+      }
+    } catch (const Exception& e) {
+      mLogger->critical(QString("Could not configure automatic pad sizes: %1")
+                            .arg(e.getMsg()));
+    }
+
+    EagleLibraryConverter converter(settings, this);
+
+    // Add components.
+    foreach (const parseagle::Part& part, mSchematic->getParts()) {
+      MessageLogger log(mLogger.get(), part.getName());
+      const Component& libCmp = importLibraryComponent(
+          converter, project.getLibrary(), part.getLibrary(),
+          part.getLibraryUrn(), part.getDeviceSet());
+      auto symbVar = libCmp.getSymbolVariants().value(0);
+      if (!symbVar) throw LogicError(__FILE__, __LINE__);
+      QString name = cleanCircuitIdentifier(part.getName());
+      if (name.isEmpty()) {
+        name = libCmp.getUuid().toStr().left(8);  // Not so nice...
+      }
+      ComponentInstance* cmp = new ComponentInstance(
+          project.getCircuit(), Uuid::createRandom(), libCmp,
+          symbVar->getUuid(), CircuitIdentifier(name));
+      if (!part.getValue().isEmpty()) {
+        cmp->setValue(part.getValue());
+      }
+      AttributeList attributes = cmp->getAttributes();
+      C::tryConvertAttributes(part.getAttributes(), attributes, log);
+      const parseagle::Library& eagleLib = getLibrary(
+          mSchematic->getLibraries(), part.getLibrary(), part.getLibraryUrn());
+      const parseagle::DeviceSet eagleDevSet =
+          getDeviceSet(eagleLib, part.getDeviceSet());
+      const parseagle::Device eagleDev =
+          getDevice(eagleDevSet, part.getDevice());
+      if (const parseagle::Technology* eagleTech =
+              tryGetTechnology(eagleDev, part.getTechnology())) {
+        C::tryConvertAttributes(eagleTech->getAttributes(), attributes, log);
+        if ((!attributes.contains("MPN")) &&
+            (!attributes.contains("MANUFACTURER_PART_NUMBER")) &&
+            (!attributes.contains("PART_NUMBER")) &&
+            (!eagleTech->getName().trimmed().isEmpty())) {
+          // Memorize it since it could be an MPN.
+          attributes.append(std::make_shared<Attribute>(
+              AttributeKey("EAGLE_TECHNOLOGY"), AttrTypeString::instance(),
+              eagleTech->getName(), nullptr));
+        }
+      }
+      cmp->setAttributes(attributes);
+      mComponentMap.insert(part.getName(),
+                           std::make_tuple(part.getDeviceSet(),
+                                           part.getDevice(), cmp->getUuid()));
+      project.getCircuit().addComponentInstance(*cmp);
+    }
+
+    // Warn about unsupported objects.
+    if (!mSchematic->getModules().isEmpty()) {
+      mLogger->critical(
+          tr("Skipped modules because they are not supported yet!"));
+    }
+
+    // Import schematics.
+    foreach (const parseagle::Sheet& sheet, mSchematic->getSheets()) {
+      importSchematic(project, converter, sheet);
+    }
+
+    // Import board, if given.
+    if (mBoard) {
+      importBoard(project, converter);
+    }
+
+    // Status messages.
+    mLogger->info(
+        tr("Imported %n schematic sheet(s). Please check the ERC messages in "
+           "the schematic editor.",
+           nullptr, mSchematic->getSheets().count()));
+    if (mBoard) {
+      mLogger->info(
+          tr("Imported a board. Please run the DRC in the board editor and fix "
+             "remaining issues manually."));
+    }
+  } catch (const Exception& e) {
+    mLogger->critical(tr("Import failed:") % " " % e.getMsg());
+    throw e;
+  } catch (const std::exception& e) {
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("Parser error: %1").arg(e.what()));
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+const Symbol& EagleProjectImport::importLibrarySymbol(
+    EagleLibraryConverter& converter, ProjectLibrary& library,
+    const QString& libName, const QString& libUrn, const QString& symName) {
+  const QStringList key = {libName, libUrn, symName};
+  auto it = mLibSymbolMap.find(key);
+  if (it == mLibSymbolMap.end()) {
+    const parseagle::Library& eagleLib =
+        getLibrary(mSchematic->getLibraries(), libName, libUrn);
+    const parseagle::Symbol& eagleSymbol = getSymbol(eagleLib, symName);
+    MessageLogger log(mLogger.get(), eagleSymbol.getName());
+    std::unique_ptr<Symbol> sym =
+        converter.createSymbol(eagleLib.getEmbeddedName(), eagleSymbol, log);
+    it = mLibSymbolMap.insert(key, sym->getUuid());
+    library.addSymbol(*sym.release());
+  }
+  auto sym = library.getSymbol(*it);
+  Q_ASSERT(sym);
+  return *sym;
+}
+
+const Component& EagleProjectImport::importLibraryComponent(
+    EagleLibraryConverter& converter, ProjectLibrary& library,
+    const QString& libName, const QString& libUrn, const QString& devSetName) {
+  const QStringList key = {libName, libUrn, devSetName};
+  auto it = mLibComponentMap.find(key);
+  if (it == mLibComponentMap.end()) {
+    const parseagle::Library& eagleLib =
+        getLibrary(mSchematic->getLibraries(), libName, libUrn);
+    const parseagle::DeviceSet& eagleDevSet =
+        getDeviceSet(eagleLib, devSetName);
+    foreach (const parseagle::Gate& eagleGate, eagleDevSet.getGates()) {
+      importLibrarySymbol(converter, library, libName, libUrn,
+                          eagleGate.getSymbol());
+    }
+    MessageLogger log(mLogger.get(), eagleDevSet.getName());
+    std::unique_ptr<Component> cmp =
+        converter.createComponent(eagleLib.getEmbeddedName(), eagleDevSet, log);
+    if ((cmp->getSymbolVariants().count() != 1) ||
+        (cmp->getSymbolVariants().first()->getSymbolItems().count() !=
+         eagleDevSet.getGates().count())) {
+      throw LogicError(__FILE__, __LINE__);
+    }
+    for (int i = 0; i < eagleDevSet.getGates().count(); ++i) {
+      const QString gateName = eagleDevSet.getGates().at(i).getName();
+      const Uuid gateUuid =
+          cmp->getSymbolVariants().first()->getSymbolItems().at(i)->getUuid();
+      const QStringList key = {cmp->getUuid().toStr(), gateName};
+      mLibComponentGateMap.insert(key, gateUuid);
+    }
+    it = mLibComponentMap.insert(key, cmp->getUuid());
+    library.addComponent(*cmp.release());
+  }
+  auto cmp = library.getComponent(*it);
+  Q_ASSERT(cmp);
+  return *cmp;
+}
+
+const Package& EagleProjectImport::importLibraryPackage(
+    EagleLibraryConverter& converter, ProjectLibrary& library,
+    const QString& libName, const QString& libUrn, const QString& pkgName) {
+  const QStringList key = {libName, libUrn, pkgName};
+  auto it = mLibPackageMap.find(key);
+  if (it == mLibPackageMap.end()) {
+    const parseagle::Library& eagleLib =
+        getLibrary(mBoard->getLibraries(), libName, libUrn);
+    const parseagle::Package& eaglePackage = getPackage(eagleLib, pkgName);
+    MessageLogger log(mLogger.get(), eaglePackage.getName());
+    std::unique_ptr<Package> pkg =
+        converter.createPackage(eagleLib.getEmbeddedName(), eaglePackage, log);
+    it = mLibPackageMap.insert(key, pkg->getUuid());
+    library.addPackage(*pkg.release());
+  }
+  auto pkg = library.getPackage(*it);
+  Q_ASSERT(pkg);
+  return *pkg;
+}
+
+const Device& EagleProjectImport::importLibraryDevice(
+    EagleLibraryConverter& converter, ProjectLibrary& library,
+    const QString& libName, const QString& libUrn, const QString& devSetName,
+    const QString& devName) {
+  const QStringList key = {libName, libUrn, devSetName, devName};
+  auto it = mLibDeviceMap.find(key);
+  if (it == mLibDeviceMap.end()) {
+    const parseagle::Library& eagleLib =
+        getLibrary(mSchematic->getLibraries(), libName, libUrn);
+    const parseagle::DeviceSet& eagleDevSet =
+        getDeviceSet(eagleLib, devSetName);
+    const parseagle::Device& eagleDev = getDevice(eagleDevSet, devName);
+    importLibraryPackage(converter, library, libName, libUrn,
+                         eagleDev.getPackage());
+    MessageLogger log(mLogger.get(), eagleDev.getName());
+    std::unique_ptr<Device> dev = converter.createDevice(
+        eagleLib.getEmbeddedName(), eagleDevSet, eagleDev, log);
+    it = mLibDeviceMap.insert(key, dev->getUuid());
+    library.addDevice(*dev.release());
+  }
+  auto dev = library.getDevice(*it);
+  Q_ASSERT(dev);
+  return *dev;
+}
+
+void EagleProjectImport::importSchematic(Project& project,
+                                         EagleLibraryConverter& converter,
+                                         const parseagle::Sheet& sheet) {
+  // Determine directory name.
+  QString dirName = FilePath::cleanFileName(
+      sheet.getDescription(), FilePath::ReplaceSpaces | FilePath::ToLowerCase);
+  if (dirName.startsWith("sheet_")) {
+    dirName.clear();  // Avoid conflicts!
+  }
+  if (dirName.isEmpty()) {
+    dirName = QString("sheet_%1").arg(mSchematicDirNames.count() + 1);
+  }
+  mSchematicDirNames.insert(dirName);
+
+  // Determine schematic name.
+  QString name = cleanElementName(sheet.getDescription());
+  if (name.isEmpty()) {
+    // No translation to avoid exceptions!
+    name = QString("Sheet %1").arg(mSchematicDirNames.count());
+  }
+
+  // Create schematic.
+  MessageLogger log(mLogger.get(), name);
+  Schematic* schematic = new librepcb::Schematic(
+      project,
+      std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory()),
+      dirName, Uuid::createRandom(),
+      ElementName(name));  // can throw
+  project.addSchematic(*schematic);
+
+  // Grid settings
+  PositiveLength gridInterval = schematic->getGridInterval();
+  LengthUnit gridUnit = schematic->getGridUnit();
+  C::convertGrid(mSchematic->getGrid(), gridInterval, gridUnit);
+  schematic->setGridInterval(gridInterval);
+  schematic->setGridUnit(gridUnit);
+
+  // Symbols
+  foreach (const parseagle::Instance& eagleInst, sheet.getInstances()) {
+    auto cmpIt = mComponentMap.find(eagleInst.getPart());
+    if (cmpIt == mComponentMap.end()) {
+      throw RuntimeError(
+          __FILE__, __LINE__,
+          QString("Component instance not found: %1").arg(eagleInst.getPart()));
+    }
+    ComponentInstance* cmpInst =
+        project.getCircuit().getComponentInstanceByUuid(std::get<2>(*cmpIt));
+    if (!cmpInst) throw LogicError(__FILE__, __LINE__);
+    auto gateIt = mLibComponentGateMap.find(QStringList{
+        cmpInst->getLibComponent().getUuid().toStr(), eagleInst.getGate()});
+    if (gateIt == mLibComponentGateMap.end()) {
+      throw LogicError(__FILE__, __LINE__);
+    }
+    const bool mirror = eagleInst.getRotation().getMirror();
+    const Angle rotation =
+        C::convertAngle(mirror ? -eagleInst.getRotation().getAngle()
+                               : eagleInst.getRotation().getAngle());
+    SI_Symbol* symInst =
+        new SI_Symbol(*schematic, Uuid::createRandom(), *cmpInst, *gateIt,
+                      C::convertPoint(eagleInst.getPosition()), rotation,
+                      mirror, !eagleInst.getSmashed());
+    if (eagleInst.getSmashed()) {
+      foreach (const parseagle::Attribute& eagleAttr,
+               eagleInst.getAttributes()) {
+        if (eagleAttr.getDisplay() != parseagle::AttributeDisplay::Value) {
+          continue;
+        }
+        try {
+          if (auto lpObj = C::tryConvertSchematicAttribute(eagleAttr)) {
+            SI_Text* obj = new SI_Text(*schematic, *lpObj);
+            symInst->addText(*obj);
+          } else {
+            log.warning(tr("Skipped text on layer %1 (%2).")
+                            .arg(eagleAttr.getLayer())
+                            .arg(C::getLayerName(eagleAttr.getLayer())));
+          }
+        } catch (const Exception& e) {
+          log.warning(QString("Skipped attribute text: %1").arg(e.getMsg()));
+        }
+      }
+      const Transform transform(*symInst);
+      for (const Text& text : symInst->getLibSymbol().getTexts()) {
+        if (!text.getText().startsWith("{{")) {
+          Text copy(text);
+          copy.setPosition(transform.map(copy.getPosition()));
+          copy.setRotation(transform.mapNonMirrorable(copy.getRotation()));
+          if (symInst->getMirrored()) {
+            copy.setAlign(copy.getAlign().mirroredV());
+          }
+          SI_Text* obj = new SI_Text(*schematic, copy);
+          symInst->addText(*obj);
+        }
+      }
+    }
+    schematic->addSymbol(*symInst);
+  }
+
+  // Geometry
+  QList<C::Geometry> geometries;
+  try {
+    geometries += C::convertAndJoinWires(sheet.getWires(), true, log);
+  } catch (const Exception& e) {
+    log.warning(QString("Failed to join wires: %1").arg(e.getMsg()));
+  }
+  foreach (const parseagle::Rectangle& eagleObj, sheet.getRectangles()) {
+    geometries.append(C::convertRectangle(eagleObj, true));
+  }
+  foreach (const parseagle::Polygon& eagleObj, sheet.getPolygons()) {
+    geometries.append(C::convertPolygon(eagleObj, true));
+  }
+  foreach (const parseagle::Circle& eagleObj, sheet.getCircles()) {
+    geometries.append(C::convertCircle(eagleObj, true));
+  }
+  foreach (const parseagle::Frame& eagleObj, sheet.getFrames()) {
+    geometries.append(C::convertFrame(eagleObj));
+  }
+  foreach (const auto& g, geometries) {
+    if (auto o = C::tryConvertToSchematicPolygon(g)) {
+      o->setIsGrabArea(g.grabArea && o->isFilled());
+      SI_Polygon* obj = new SI_Polygon(*schematic, *o);
+      schematic->addPolygon(*obj);
+    } else {
+      log.warning(tr("Skipped graphics object on layer %1 (%2).")
+                      .arg(g.layerId)
+                      .arg(C::getLayerName(g.layerId)));
+    }
+  }
+
+  // Texts
+  foreach (const parseagle::Text& eagleObj, sheet.getTexts()) {
+    try {
+      if (auto lpObj = C::tryConvertSchematicText(eagleObj)) {
+        SI_Text* obj = new SI_Text(*schematic, *lpObj);
+        schematic->addText(*obj);
+      } else {
+        log.warning(tr("Skipped text on layer %1 (%2).")
+                        .arg(eagleObj.getLayer())
+                        .arg(C::getLayerName(eagleObj.getLayer())));
+      }
+    } catch (const Exception& e) {
+      log.warning(QString("Skipped text: %1").arg(e.getMsg()));
+    }
+  }
+
+  // Nets
+  foreach (const parseagle::Net& eagleNet, sheet.getNets()) {
+    NetSignal& netSignal = importNet(project, eagleNet);
+    try {
+      SchematicNetSegmentSplitter splitter;
+      QMap<std::pair<Uuid, Uuid>, SI_SymbolPin*> pinMap;
+      QHash<Uuid, SI_NetPoint*> netPointMap;
+      QHash<Point, NetLineAnchor> anchorMap;
+
+      // Collect pin refs.
+      foreach (const parseagle::Segment& eagleSegment, eagleNet.getSegments()) {
+        foreach (const parseagle::PinRef& eaglePinRef,
+                 eagleSegment.getPinRefs()) {
+          auto cmpIt = mComponentMap.find(eaglePinRef.getPart());
+          if (cmpIt == mComponentMap.end()) {
+            throw LogicError(__FILE__, __LINE__, "Component not found.");
+          }
+          ComponentInstance* cmpInst =
+              project.getCircuit().getComponentInstanceByUuid(
+                  std::get<2>(*cmpIt));
+          if (!cmpInst) {
+            throw LogicError(__FILE__, __LINE__, "Component not found.");
+          }
+          const parseagle::Part& part = getPart(eaglePinRef.getPart());
+          const Uuid sigUuid = converter.getComponentSignalOfSymbolPin(
+              part.getLibrary(), part.getDeviceSet(), eaglePinRef.getGate(),
+              eaglePinRef.getPin());
+          ComponentSignalInstance* cmpSigInst =
+              cmpInst->getSignalInstance(sigUuid);
+          if (!cmpSigInst) {
+            throw LogicError(__FILE__, __LINE__, "Component signal not found.");
+          }
+          cmpSigInst->setNetSignal(&netSignal);
+          if (cmpSigInst->isNetSignalNameForced()) {
+            netSignal.setName(netSignal.getName(), false);  // No auto-name
+          }
+          if (cmpSigInst->getRegisteredSymbolPins().count() != 1) {
+            throw LogicError(__FILE__, __LINE__,
+                             "unexpected symbol pin count.");
+          }
+          auto symbolPin = cmpSigInst->getRegisteredSymbolPins().first();
+          pinMap.insert(std::make_pair(symbolPin->getSymbol().getUuid(),
+                                       symbolPin->getLibPinUuid()),
+                        symbolPin);
+          const NetLineAnchor pinAnchor = NetLineAnchor::pin(
+              symbolPin->getSymbol().getUuid(), symbolPin->getLibPinUuid());
+          splitter.addSymbolPin(pinAnchor, symbolPin->getPosition());
+          auto it = anchorMap.find(symbolPin->getPosition());
+          if (it != anchorMap.end()) {
+            // There's another pin on the same position -> add a netline to
+            // connect them since EAGLE implicitly consider them as connected.
+            splitter.addNetLine(NetLine(
+                Uuid::createRandom(), UnsignedLength(158750), *it, pinAnchor));
+          }
+          anchorMap.insert(symbolPin->getPosition(), pinAnchor);
+        }
+
+        // Convert wires.
+        auto getOrCreateAnchor = [&anchorMap, &splitter](const Point& pos) {
+          auto it = anchorMap.find(pos);
+          if (it == anchorMap.end()) {
+            const Junction junction(Uuid::createRandom(), pos);
+            splitter.addJunction(junction);
+            it = anchorMap.insert(pos,
+                                  NetLineAnchor::junction(junction.getUuid()));
+          }
+          return *it;
+        };
+        foreach (const parseagle::Wire& eagleWire, eagleSegment.getWires()) {
+          // Skip zero-length wires to avoid possible redundant wires.
+          if (eagleWire.getP1() == eagleWire.getP2()) {
+            continue;
+          }
+          splitter.addNetLine(
+              NetLine(Uuid::createRandom(), UnsignedLength(158750),
+                      getOrCreateAnchor(C::convertPoint(eagleWire.getP1())),
+                      getOrCreateAnchor(C::convertPoint(eagleWire.getP2()))));
+          if (eagleWire.getWireStyle() != parseagle::WireStyle::Continuous) {
+            log.warning(
+                tr("Dashed/dotted line is not supported, converting to "
+                   "continuous."));
+          }
+          if (eagleWire.getWireCap() != parseagle::WireCap::Round) {
+            log.warning(
+                tr("Flat line end is not supported, converting to round."));
+          }
+        }
+        foreach (const parseagle::Label& eagleLabel, eagleSegment.getLabels()) {
+          const Angle rot =
+              C::convertAngle(eagleLabel.getRotation().getAngle());
+          const bool mirror = eagleLabel.getRotation().getMirror();
+          Point pos = C::convertPoint(eagleLabel.getPosition());
+          if (eagleLabel.getXref()) {
+            pos += Point(mirror ? -254000 : 254000, -1270000)
+                       .rotated(mirror ? -rot : rot);
+            log.warning(
+                tr("XRef-style net label is not supported, converting to "
+                   "normal net label."));
+          }
+          splitter.addNetLabel(
+              NetLabel(Uuid::createRandom(), pos, mirror ? -rot : rot, mirror));
+        }
+      }
+
+      // Determine segments and add them to the schematic.
+      auto getAnchor = [&pinMap, &netPointMap](const NetLineAnchor& anchor) {
+        if (auto pin = anchor.tryGetPin()) {
+          auto pinPtr = pinMap.value(std::make_pair(pin->symbol, pin->pin));
+          if (pinPtr) {
+            return static_cast<SI_NetLineAnchor*>(pinPtr);
+          }
+        } else if (auto junction = anchor.tryGetJunction()) {
+          if (auto netPoint = netPointMap.value(*junction)) {
+            return static_cast<SI_NetLineAnchor*>(netPoint);
+          }
+        }
+        throw LogicError(__FILE__, __LINE__, "Unknown net line anchor.");
+      };
+      foreach (const auto& segment, splitter.split()) {
+        SI_NetSegment* netSegment =
+            new SI_NetSegment(*schematic, Uuid::createRandom(), netSignal);
+        schematic->addNetSegment(*netSegment);
+        QList<SI_NetPoint*> netPoints;
+        QList<SI_NetLine*> netLines;
+        for (const Junction& junction : segment.junctions) {
+          SI_NetPoint* np = new SI_NetPoint(*netSegment, junction.getUuid(),
+                                            junction.getPosition());
+          netPointMap.insert(np->getUuid(), np);
+          netPoints.append(np);
+        }
+        for (const NetLine& line : segment.netlines) {
+          netLines.append(new SI_NetLine(
+              *netSegment, line.getUuid(), *getAnchor(line.getStartPoint()),
+              *getAnchor(line.getEndPoint()), line.getWidth()));
+        }
+        netSegment->addNetPointsAndNetLines(netPoints, netLines);
+        for (const NetLabel& label : segment.netlabels) {
+          SI_NetLabel* nl = new SI_NetLabel(*netSegment, label);
+          netSegment->addNetLabel(*nl);
+          netSignal.setName(netSignal.getName(), false);  // No auto-name
+        }
+      }
+    } catch (const Exception& e) {
+      log.critical(QString("Failed to import segment of net '%1': %2")
+                       .arg(eagleNet.getName(), e.getMsg()));
+    }
+  }
+
+  // Warn about unsupported objects.
+  if (!sheet.getBuses().isEmpty()) {
+    log.critical(tr("Skipped %n bus(es) because they are not supported yet!",
+                    nullptr, sheet.getBuses().count()));
+  }
+}
+
+NetSignal& EagleProjectImport::importNet(Project& project,
+                                         const parseagle::Net& net) {
+  auto it = mNetSignalMap.find(net.getName());
+  if (it == mNetSignalMap.end()) {
+    const Uuid uuid = Uuid::createRandom();
+    QString name =
+        C::convertInversionSyntax(cleanCircuitIdentifier(net.getName()));
+    if (name.isEmpty()) {
+      name = uuid.toStr().left(8);
+    } else if (project.getCircuit().getNetSignalByName(name)) {
+      name = name.left(20) % "_" % uuid.toStr().left(8);
+    }
+    if (project.getCircuit().getNetClasses().count() != 1) {
+      throw LogicError(__FILE__, __LINE__, "Unexpected count of net classes.");
+    }
+    NetSignal* netSignal =
+        new NetSignal(project.getCircuit(), uuid,
+                      *project.getCircuit().getNetClasses().first(),
+                      CircuitIdentifier(name), true);
+    project.getCircuit().addNetSignal(*netSignal);
+    it = mNetSignalMap.insert(net.getName(), uuid);
+  }
+  NetSignal* netSignal = project.getCircuit().getNetSignals().value(*it);
+  Q_ASSERT(netSignal);
+  return *netSignal;
+}
+
+void EagleProjectImport::importBoard(Project& project,
+                                     EagleLibraryConverter& converter) {
+  // Create board.
+  MessageLogger log(mLogger.get(), "BOARD");
+  Board* board = new librepcb::Board(
+      project,
+      std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory()),
+      "default", Uuid::createRandom(),
+      ElementName("default"));  // can throw
+  project.addBoard(*board);
+
+  // Grid settings
+  PositiveLength gridInterval = board->getGridInterval();
+  LengthUnit gridUnit = board->getGridUnit();
+  C::convertGrid(mBoard->getGrid(), gridInterval, gridUnit);
+  board->setGridInterval(gridInterval);
+  board->setGridUnit(gridUnit);
+
+  // Layer setup
+  QHash<const Layer*, const Layer*> copperLayerMap;
+  if (auto p = mBoard->getDesignRules().tryGetParam("layerSetup")) {
+    copperLayerMap = C::convertLayerSetup(p->getValue());
+  }
+  copperLayerMap.insert(&Layer::topCopper(), &Layer::topCopper());
+  copperLayerMap.insert(&Layer::botCopper(), &Layer::botCopper());
+  board->setInnerLayerCount(copperLayerMap.count() - 2);
+  // Warning: With automatic return type deduction, the application crashes?!?!
+  auto mapLayer = [&copperLayerMap](const Layer* layer) -> const Layer* {
+    return copperLayerMap.value(layer, layer);
+  };
+
+  // Design rules
+  UnsignedLength minViaAnnularWidth(0);
+  try {
+    BoardDesignRules r = board->getDesignRules();
+    r.setPadCmpSideAutoAnnularRing(false);  // Not sure if EAGLE supports this.
+    r.setPadInnerAutoAnnularRing(true);  // Not sure if EAGLE supports this.
+    if (auto p = mBoard->getDesignRules().tryGetParam("mlViaStopLimit")) {
+      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      r.setStopMaskMaxViaDiameter(value);
+    }
+    if (board->getInnerLayerCount() > 0) {
+      // Take automatic THT annular width from inner layers since it is probably
+      // the smaller one and thus should reduce the risk of DRC warnings.
+      if (auto v =
+              tryGetDrcRatio("rvPadInner", "rlMinPadInner", "rlMaxPadInner")) {
+        r.setPadAnnularRing(*v);
+      }
+    } else {
+      // Take automatic THT annular width from bottom layer since inner layers
+      // are not disabled so these values might not be reasonable.
+      if (auto v = tryGetDrcRatio("rvPadBottom", "rlMinPadBottom",
+                                  "rlMaxPadBottom")) {
+        r.setPadAnnularRing(*v);
+      }
+    }
+    if (auto v =
+            tryGetDrcRatio("rvViaOuter", "rlMinViaOuter", "rlMaxViaOuter")) {
+      r.setViaAnnularRing(*v);
+      minViaAnnularWidth = v->getMinValue();
+    }
+    if (auto v =
+            tryGetDrcRatio("mvStopFrame", "mlMinStopFrame", "mlMaxStopFrame")) {
+      r.setStopMaskClearance(*v);
+    }
+    if (auto v = tryGetDrcRatio("mvCreamFrame", "mlMinCreamFrame",
+                                "mlMaxCreamFrame")) {
+      r.setSolderPasteClearance(*v);
+    }
+    board->setDesignRules(r);
+  } catch (const Exception& e) {
+    log.critical(QString("Failed to import design rules: %1").arg(e.getMsg()));
+  }
+
+  // DRC settings
+  try {
+    BoardDesignRuleCheckSettings s = board->getDrcSettings();
+    if (auto p = mBoard->getDesignRules().tryGetParam("mdWireWire")) {
+      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      s.setMinCopperCopperClearance(value);
+    }
+    if (auto p = mBoard->getDesignRules().tryGetParam("mdCopperDimension")) {
+      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      s.setMinCopperBoardClearance(value);
+      s.setMinCopperNpthClearance(value);
+    }
+    if (auto p = mBoard->getDesignRules().tryGetParam("mdDrill")) {
+      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      s.setMinDrillDrillClearance(value);
+      s.setMinDrillBoardClearance(value);
+    }
+    if (auto p = mBoard->getDesignRules().tryGetParam("msWidth")) {
+      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      s.setMinCopperWidth(value);
+    }
+    if (auto p = mBoard->getDesignRules().tryGetParam("rlMinViaInner")) {
+      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      s.setMinPthAnnularRing(value);
+    }
+    if (auto p = mBoard->getDesignRules().tryGetParam("msDrill")) {
+      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      s.setMinNpthDrillDiameter(value);
+      s.setMinPthDrillDiameter(value);
+    }
+    board->setDrcSettings(s);
+  } catch (const Exception& e) {
+    log.critical(QString("Failed to import DRC settings: %1").arg(e.getMsg()));
+  }
+
+  // Devices
+  foreach (const parseagle::Element& eagleElem, mBoard->getElements()) {
+    auto cmpIt = mComponentMap.find(eagleElem.getName());
+    if (cmpIt == mComponentMap.end()) {
+      log.critical(QString("Component '%1' (%2) not found in circuit. Note "
+                           "that LibrePCB does not yet support placing devices "
+                           "on the board which don't exist in the schematic.")
+                       .arg(eagleElem.getName())
+                       .arg(eagleElem.getPackage()));
+      continue;
+    }
+    ComponentInstance* cmpInst =
+        project.getCircuit().getComponentInstanceByUuid(std::get<2>(*cmpIt));
+    if (!cmpInst) throw LogicError(__FILE__, __LINE__);
+    const Package& libPkg = importLibraryPackage(
+        converter, project.getLibrary(), eagleElem.getLibrary(),
+        eagleElem.getLibraryUrn(), eagleElem.getPackage());
+    if (libPkg.getFootprints().count() != 1) {
+      throw LogicError(__FILE__, __LINE__);
+    }
+    const Device& libDev = importLibraryDevice(
+        converter, project.getLibrary(), eagleElem.getLibrary(),
+        eagleElem.getLibraryUrn(), std::get<0>(*cmpIt), std::get<1>(*cmpIt));
+    const bool mirror = eagleElem.getRotation().getMirror();
+    const Angle rotation = C::convertAngle(eagleElem.getRotation().getAngle());
+    BI_Device* devInst = new BI_Device(
+        *board, *cmpInst, libDev.getUuid(),
+        libPkg.getFootprints().first()->getUuid(),
+        C::convertPoint(eagleElem.getPosition()), mirror ? -rotation : rotation,
+        mirror, eagleElem.getLocked(), !eagleElem.getSmashed());
+    board->addDeviceInstance(*devInst);
+
+    // Add stroke texts.
+    if (eagleElem.getSmashed()) {
+      foreach (const parseagle::Attribute& eagleAttr,
+               eagleElem.getAttributes()) {
+        if (eagleAttr.getDisplay() != parseagle::AttributeDisplay::Value) {
+          continue;
+        }
+        try {
+          if (auto lpObj = C::tryConvertBoardAttribute(eagleAttr)) {
+            BI_StrokeText* obj = new BI_StrokeText(
+                *board,
+                BoardStrokeTextData(
+                    lpObj->getUuid(), lpObj->getLayer(), lpObj->getText(),
+                    lpObj->getPosition(), lpObj->getRotation(),
+                    lpObj->getHeight(), lpObj->getStrokeWidth(),
+                    lpObj->getLetterSpacing(), lpObj->getLineSpacing(),
+                    lpObj->getAlign(), lpObj->getMirrored(),
+                    lpObj->getAutoRotate(), false));
+            devInst->addStrokeText(*obj);
+          } else {
+            log.warning(tr("Skipped text on layer %1 (%2).")
+                            .arg(eagleAttr.getLayer())
+                            .arg(C::getLayerName(eagleAttr.getLayer())));
+          }
+        } catch (const Exception& e) {
+          log.warning(QString("Skipped attribute text: %1").arg(e.getMsg()));
+        }
+      }
+      const Transform transform(*devInst);
+      for (const StrokeText& text :
+           devInst->getLibFootprint().getStrokeTexts()) {
+        if (!text.getText().startsWith("{{")) {
+          BI_StrokeText* obj = new BI_StrokeText(
+              *board,
+              BoardStrokeTextData(
+                  text.getUuid(), text.getLayer(), text.getText(),
+                  transform.map(text.getPosition()),
+                  transform.mapMirrorable(text.getRotation()), text.getHeight(),
+                  text.getStrokeWidth(), text.getLetterSpacing(),
+                  text.getLineSpacing(), text.getAlign(),
+                  devInst->getMirrored() != text.getMirrored(),
+                  text.getAutoRotate(), false));
+          devInst->addStrokeText(*obj);
+        }
+      }
+    }
+
+    // Add assembly options.
+    AttributeList attributes = cmpInst->getAttributes();
+    auto assemblyOption = std::make_shared<ComponentAssemblyOption>(
+        libDev.getUuid(), AttributeList(), QSet<Uuid>(), PartList());
+    if (eagleElem.getPopulate()) {
+      assemblyOption->setAssemblyVariants(
+          project.getCircuit().getAssemblyVariants().getUuidSet());
+    }
+    SimpleString mpn(""), manufacturer("");
+    C::tryExtractMpnAndManufacturer(attributes, mpn, manufacturer);
+    if (!mpn->isEmpty()) {
+      // Convert attributes to a Part.
+      assemblyOption->getParts().append(
+          std::make_shared<Part>(mpn, manufacturer, AttributeList()));
+      cmpInst->setAttributes(attributes);
+    }
+    cmpInst->setAssemblyOptions(ComponentAssemblyOptionList{assemblyOption});
+  }
+
+  // Geometry
+  QList<C::Geometry> geometries;
+  try {
+    geometries += C::convertAndJoinWires(mBoard->getWires(), true, log);
+  } catch (const Exception& e) {
+    log.warning(QString("Failed to join wires: %1").arg(e.getMsg()));
+  }
+  foreach (const parseagle::Rectangle& eagleObj, mBoard->getRectangles()) {
+    geometries.append(C::convertRectangle(eagleObj, true));
+  }
+  foreach (const parseagle::Polygon& eagleObj, mBoard->getPolygons()) {
+    geometries.append(C::convertPolygon(eagleObj, true));
+  }
+  foreach (const parseagle::Circle& eagleObj, mBoard->getCircles()) {
+    geometries.append(C::convertCircle(eagleObj, true));
+  }
+  foreach (const auto& g, geometries) {
+    const auto zones = C::tryConvertToBoardZones(g);
+    if (!zones.isEmpty()) {
+      foreach (const auto zone, zones) {
+        QSet<const Layer*> layers;
+        if (zone->getLayers().testFlag(Zone::Layer::Top)) {
+          layers.insert(&Layer::topCopper());
+        }
+        if (zone->getLayers().testFlag(Zone::Layer::Inner)) {
+          for (int i = 1; i <= board->getInnerLayerCount(); ++i) {
+            layers.insert(Layer::innerCopper(i));
+          }
+        }
+        if (zone->getLayers().testFlag(Zone::Layer::Bottom)) {
+          layers.insert(&Layer::botCopper());
+        }
+        BI_Zone* obj =
+            new BI_Zone(*board,
+                        BoardZoneData(zone->getUuid(), layers, zone->getRules(),
+                                      zone->getOutline(), false));
+        board->addZone(*obj);
+      }
+    } else if (auto o = C::tryConvertToBoardPolygon(g)) {
+      o->setIsGrabArea(g.grabArea && o->isFilled());
+      BI_Polygon* obj = new BI_Polygon(
+          *board,
+          BoardPolygonData(o->getUuid(), *mapLayer(&o->getLayer()),
+                           o->getLineWidth(), o->getPath(), o->isFilled(),
+                           o->isGrabArea(), false));
+      board->addPolygon(*obj);
+    } else {
+      log.warning(tr("Skipped graphics object on layer %1 (%2).")
+                      .arg(g.layerId)
+                      .arg(C::getLayerName(g.layerId)));
+    }
+  }
+
+  // Texts
+  foreach (const parseagle::Text& eagleObj, mBoard->getTexts()) {
+    try {
+      if (auto lpObj = C::tryConvertBoardText(eagleObj)) {
+        BI_StrokeText* obj = new BI_StrokeText(
+            *board,
+            BoardStrokeTextData(
+                lpObj->getUuid(), *mapLayer(&lpObj->getLayer()),
+                lpObj->getText(), lpObj->getPosition(), lpObj->getRotation(),
+                lpObj->getHeight(), lpObj->getStrokeWidth(),
+                lpObj->getLetterSpacing(), lpObj->getLineSpacing(),
+                lpObj->getAlign(), lpObj->getMirrored(), lpObj->getAutoRotate(),
+                false));
+        board->addStrokeText(*obj);
+      } else {
+        log.warning(tr("Skipped text on layer %1 (%2).")
+                        .arg(eagleObj.getLayer())
+                        .arg(C::getLayerName(eagleObj.getLayer())));
+      }
+    } catch (const Exception& e) {
+      log.warning(QString("Skipped text: %1").arg(e.getMsg()));
+    }
+  }
+
+  // Holes
+  foreach (const parseagle::Hole& eagleObj, mBoard->getHoles()) {
+    try {
+      std::shared_ptr<Hole> lpObj = C::convertHole(eagleObj);
+      BI_Hole* obj = new BI_Hole(
+          *board,
+          BoardHoleData(lpObj->getUuid(), lpObj->getDiameter(),
+                        lpObj->getPath(), lpObj->getStopMaskConfig(), false));
+      board->addHole(*obj);
+    } catch (const Exception& e) {
+      log.critical(QString("Skipped hole: %1").arg(e.getMsg()));
+    }
+  }
+
+  // Make the longest polygon the board outline, and all others cutouts.
+  // This logic is needed because EAGLE does not distinguish these two layers.
+  BI_Polygon* outlineCandidate = nullptr;
+  foreach (auto polygon, board->getPolygons()) {
+    if ((polygon->getData().getLayer() == Layer::boardOutlines()) ||
+        (polygon->getData().getLayer() == Layer::boardCutouts())) {
+      if ((!outlineCandidate) ||
+          (polygon->getData().getPath().getTotalStraightLength() >
+           outlineCandidate->getData().getPath().getTotalStraightLength())) {
+        outlineCandidate = polygon;
+      }
+      polygon->setLayer(Layer::boardCutouts());
+    }
+  }
+  if (outlineCandidate) {
+    outlineCandidate->setLayer(Layer::boardOutlines());
+  }
+
+  // Net segments
+  foreach (const parseagle::Signal& eagleSignal, mBoard->getSignals()) {
+    // Find net signal.
+    NetSignal* netSignal = nullptr;
+    auto it = mNetSignalMap.find(eagleSignal.getName());
+    if (it != mNetSignalMap.end()) {
+      netSignal = project.getCircuit().getNetSignals().value(*it);
+      if (!netSignal) {
+        throw LogicError(__FILE__, __LINE__);
+      }
+    }
+
+    try {
+      BoardNetSegmentSplitter splitter;
+      QMap<std::pair<Uuid, Uuid>, BI_FootprintPad*> padMap;
+      QHash<Uuid, BI_Via*> viaMap;
+      QHash<Uuid, BI_NetPoint*> netPointMap;
+      QHash<std::pair<const Layer*, Point>, TraceAnchor> anchorMap;
+
+      // Convert vias.
+      foreach (const parseagle::Via& eagleVia, eagleSignal.getVias()) {
+        int startLayerId = 0, endLayerId = 0;
+        const bool validLayers = eagleVia.tryGetStartLayer(startLayerId) &&
+            eagleVia.tryGetEndLayer(endLayerId);
+        const Layer* startLayer =
+            mapLayer(C::tryConvertBoardLayer(startLayerId));
+        const Layer* endLayer = mapLayer(C::tryConvertBoardLayer(endLayerId));
+        if ((!validLayers) || (!startLayer) || (!endLayer) ||
+            (!startLayer->isCopper()) || (!endLayer->isCopper()) ||
+            (startLayer->getCopperNumber() > endLayer->getCopperNumber())) {
+          throw RuntimeError(__FILE__, __LINE__,
+                             QString("Invalid via layer extent: %1")
+                                 .arg(eagleVia.getExtent()));
+        }
+        const PositiveLength drillDiameter(
+            C::convertLength(eagleVia.getDrill()));
+        const Length size = std::max(C::convertLength(eagleVia.getDiameter()),
+                                     drillDiameter + minViaAnnularWidth * 2);
+        const MaskConfig stopMaskConfig = eagleVia.getAlwaysStop()
+            ? MaskConfig::automatic()
+            : MaskConfig::off();
+        if (eagleVia.getShape() != parseagle::ViaShape::Round) {
+          log.warning(
+              tr("Square/octagon via shape not supported, converting to "
+                 "circular."));
+        }
+        const Via via(Uuid::createRandom(), *startLayer, *endLayer,
+                      C::convertPoint(eagleVia.getPosition()),
+                      PositiveLength(size), drillDiameter, stopMaskConfig);
+        splitter.addVia(via, false);
+        const TraceAnchor viaAnchor = TraceAnchor::via(via.getUuid());
+        anchorMap.insert(std::make_pair(nullptr, via.getPosition()), viaAnchor);
+      }
+
+      // Convert traces.
+      auto getOrCreateAnchor = [&padMap, &anchorMap, &splitter, netSignal](
+                                   const Layer& layer, const Point& pos) {
+        // Find via.
+        auto it = anchorMap.find(std::make_pair(nullptr, pos));
+        // Find net point.
+        if (it == anchorMap.end()) {
+          it = anchorMap.find(std::make_pair(&layer, pos));
+        }
+        // Find pad.
+        if ((it == anchorMap.end()) && netSignal) {
+          foreach (ComponentSignalInstance* cmpSigInst,
+                   netSignal->getComponentSignals()) {
+            foreach (BI_FootprintPad* pad,
+                     cmpSigInst->getRegisteredFootprintPads()) {
+              if ((pad->isOnLayer(layer)) &&
+                  (pad->getPosition() - pos).getLength() < Length(100)) {
+                padMap.insert(
+                    std::make_pair(pad->getDevice().getComponentInstanceUuid(),
+                                   pad->getLibPadUuid()),
+                    pad);
+                return TraceAnchor::pad(
+                    pad->getDevice().getComponentInstanceUuid(),
+                    pad->getLibPadUuid());
+              }
+            }
+          }
+        }
+        // Find or add net point.
+        if (it == anchorMap.end()) {
+          const Junction junction(Uuid::createRandom(), pos);
+          splitter.addJunction(junction);
+          it = anchorMap.insert(std::make_pair(&layer, pos),
+                                TraceAnchor::junction(junction.getUuid()));
+        }
+        return *it;
+      };
+      foreach (const parseagle::Wire& eagleWire, eagleSignal.getWires()) {
+        // Skip zero-length wires to avoid possible redundant wires.
+        if (eagleWire.getP1() == eagleWire.getP2()) {
+          continue;
+        }
+        // Skip "unrouted" wires (i.e. airwires) since they will be rebuilt.
+        if (eagleWire.getLayer() == 19) {
+          continue;
+        }
+        const Layer* layer =
+            mapLayer(C::tryConvertBoardLayer(eagleWire.getLayer()));
+        if ((!layer) || (!layer->isCopper())) {
+          log.critical(QString("Skipped trace on invalid layer: %1")
+                           .arg(eagleWire.getLayer()));
+          continue;
+        }
+        const TraceAnchor startAnchor =
+            getOrCreateAnchor(*layer, C::convertPoint(eagleWire.getP1()));
+        const TraceAnchor endAnchor =
+            getOrCreateAnchor(*layer, C::convertPoint(eagleWire.getP2()));
+        if (startAnchor == endAnchor) {
+          log.info("Attaching a trace to a pad removed a short trace segment.");
+          continue;
+        }
+        if (eagleWire.getWireStyle() != parseagle::WireStyle::Continuous) {
+          log.critical(
+              tr("Dashed/dotted trace is not supported, converting to "
+                 "continuous."));
+        }
+        if (eagleWire.getWireCap() != parseagle::WireCap::Round) {
+          log.critical(
+              tr("Flat trace end is not supported, converting to round."));
+        }
+        if (eagleWire.getCurve() != 0) {
+          log.critical(
+              tr("Curved trace is not supported, converting to straight."));
+        }
+        splitter.addTrace(
+            Trace(Uuid::createRandom(), *layer,
+                  PositiveLength(C::convertLength(eagleWire.getWidth())),
+                  startAnchor, endAnchor));
+      }
+
+      // Determine segments and add them to the board.
+      auto getAnchor = [&padMap, &viaMap,
+                        &netPointMap](const TraceAnchor& anchor) {
+        if (auto pad = anchor.tryGetPad()) {
+          auto padPtr = padMap.value(std::make_pair(pad->device, pad->pad));
+          if (padPtr) {
+            return static_cast<BI_NetLineAnchor*>(padPtr);
+          }
+        } else if (auto via = anchor.tryGetVia()) {
+          if (auto viaPtr = viaMap.value(*via)) {
+            return static_cast<BI_NetLineAnchor*>(viaPtr);
+          }
+        } else if (auto junction = anchor.tryGetJunction()) {
+          if (auto netPoint = netPointMap.value(*junction)) {
+            return static_cast<BI_NetLineAnchor*>(netPoint);
+          }
+        }
+        throw LogicError(__FILE__, __LINE__, "Unknown trace anchor.");
+      };
+      foreach (const auto& segment, splitter.split()) {
+        BI_NetSegment* netSegment =
+            new BI_NetSegment(*board, Uuid::createRandom(), netSignal);
+        board->addNetSegment(*netSegment);
+        QList<BI_Via*> vias;
+        QList<BI_NetPoint*> netPoints;
+        QList<BI_NetLine*> netLines;
+        for (const Via& via : segment.vias) {
+          BI_Via* v = new BI_Via(*netSegment, via);
+          viaMap.insert(v->getUuid(), v);
+          vias.append(v);
+        }
+        for (const Junction& junction : segment.junctions) {
+          BI_NetPoint* np = new BI_NetPoint(*netSegment, junction.getUuid(),
+                                            junction.getPosition());
+          netPointMap.insert(np->getUuid(), np);
+          netPoints.append(np);
+        }
+        for (const Trace& trace : segment.traces) {
+          netLines.append(new BI_NetLine(*netSegment, trace.getUuid(),
+                                         *getAnchor(trace.getStartPoint()),
+                                         *getAnchor(trace.getEndPoint()),
+                                         trace.getLayer(), trace.getWidth()));
+        }
+        netSegment->addElements(vias, netPoints, netLines);
+      }
+    } catch (const Exception& e) {
+      log.critical(QString("Failed to import segment of net '%1': %2")
+                       .arg(eagleSignal.getName(), e.getMsg()));
+    }
+
+    // Add planes and keepout zones.
+    foreach (const parseagle::Polygon& eagleObj, eagleSignal.getPolygons()) {
+      try {
+        const Layer* layer =
+            mapLayer(C::tryConvertBoardLayer(eagleObj.getLayer()));
+        if ((!layer) || (!layer->isCopper())) {
+          throw RuntimeError(__FILE__, __LINE__, "Plane not on copper layer.");
+        }
+        if (eagleObj.getPour() == parseagle::PolygonPour::Cutout) {
+          const Path path = C::convertVertices(eagleObj.getVertices(), false);
+          const Length lineWidth = C::convertLength(eagleObj.getWidth());
+          foreach (const Path& outline,
+                   C::convertBoardZoneOutline(path, lineWidth)) {
+            BI_Zone* zone = new BI_Zone(
+                *board,
+                BoardZoneData(Uuid::createRandom(), {layer},
+                              Zone::Rule::NoPlanes, outline, false));
+            board->addZone(*zone);
+          }
+        } else {
+          const Length isolate = C::convertLength(eagleObj.getIsolate());
+          BI_Plane* obj =
+              new BI_Plane(*board, Uuid::createRandom(), *layer, netSignal,
+                           C::convertVertices(eagleObj.getVertices(), false));
+          obj->setMinWidth(
+              UnsignedLength(C::convertLength(eagleObj.getWidth())));
+          obj->setMinClearance(
+              (isolate > 0)
+                  ? UnsignedLength(isolate)
+                  : board->getDrcSettings().getMinCopperCopperClearance());
+          obj->setConnectStyle(eagleObj.getThermals()
+                                   ? BI_Plane::ConnectStyle::ThermalRelief
+                                   : BI_Plane::ConnectStyle::Solid);
+          // obj->setThermalGap();
+          if (obj->getThermalSpokeWidth() < obj->getMinWidth()) {
+            // Avoid possibly disappearing planes.
+            obj->setThermalSpokeWidth(PositiveLength(*obj->getMinWidth()));
+          }
+          obj->setPriority(6 - eagleObj.getRank());  // EAGLE: 1..6
+          obj->setKeepIslands(eagleObj.getOrphans());
+          board->addPlane(*obj);
+        }
+      } catch (const Exception& e) {
+        log.critical(QString("Skipped plane: %1").arg(e.getMsg()));
+      }
+    }
+  }
+}
+
+bool EagleProjectImport::hasBuses(
+    const parseagle::Schematic& schematic) const noexcept {
+  int buses = 0;
+  foreach (const parseagle::Sheet& sheet, schematic.getSheets()) {
+    buses += sheet.getBuses().count();
+  }
+  return buses > 0;
+}
+
+tl::optional<BoundedUnsignedRatio> EagleProjectImport::tryGetDrcRatio(
+    const QString& nr, const QString& nmin, const QString& nmax) const {
+  if (mBoard) {
+    const auto pr = mBoard->getDesignRules().tryGetParam(nr);
+    const auto pmin = mBoard->getDesignRules().tryGetParam(nmin);
+    const auto pmax = mBoard->getDesignRules().tryGetParam(nmax);
+    if (pr && pmin && pmax) {
+      const auto vr = C::convertParamTo<UnsignedRatio>(*pr);
+      const auto vmin = C::convertParamTo<UnsignedLength>(*pmin);
+      const auto vmax = C::convertParamTo<UnsignedLength>(*pmax);
+      // Note: Eagle allows to specify min>max so we have to correct this
+      // case. It seems the min value is ignored then.
+      return tl::make_optional(
+          BoundedUnsignedRatio(vr, std::min(vmin, vmax), vmax));
+    }
+  }
+  return tl::nullopt;
+}
+
+const parseagle::Library& EagleProjectImport::getLibrary(
+    const QList<parseagle::Library>& libs, const QString& name,
+    const QString& urn) const {
+  foreach (const parseagle::Library& obj, libs) {
+    if ((obj.getEmbeddedName() == name) && (obj.getEmbeddedUrn() == urn)) {
+      return obj;
+    }
+  }
+  throw RuntimeError(__FILE__, __LINE__,
+                     QString("Embedded library not found: %1").arg(name));
+}
+
+const parseagle::Symbol& EagleProjectImport::getSymbol(
+    const parseagle::Library& lib, const QString& name) const {
+  foreach (const parseagle::Symbol& obj, lib.getSymbols()) {
+    if (obj.getName() == name) {
+      return obj;
+    }
+  }
+  throw RuntimeError(
+      __FILE__, __LINE__,
+      QString("Symbol not found in embedded library: %1").arg(name));
+}
+
+const parseagle::Package& EagleProjectImport::getPackage(
+    const parseagle::Library& lib, const QString& name) const {
+  foreach (const parseagle::Package& obj, lib.getPackages()) {
+    if (obj.getName() == name) {
+      return obj;
+    }
+  }
+  throw RuntimeError(
+      __FILE__, __LINE__,
+      QString("Package not found in embedded library: %1").arg(name));
+}
+
+const parseagle::DeviceSet& EagleProjectImport::getDeviceSet(
+    const parseagle::Library& lib, const QString& name) const {
+  foreach (const parseagle::DeviceSet& obj, lib.getDeviceSets()) {
+    if (obj.getName() == name) {
+      return obj;
+    }
+  }
+  throw RuntimeError(
+      __FILE__, __LINE__,
+      QString("Device set not found in embedded library: %1").arg(name));
+}
+
+const parseagle::Device& EagleProjectImport::getDevice(
+    const parseagle::DeviceSet& devSet, const QString& name) const {
+  foreach (const parseagle::Device& obj, devSet.getDevices()) {
+    if (obj.getName() == name) {
+      return obj;
+    }
+  }
+  throw RuntimeError(
+      __FILE__, __LINE__,
+      QString("Device not found in embedded library: %1").arg(name));
+}
+
+const parseagle::Technology* EagleProjectImport::tryGetTechnology(
+    const parseagle::Device& dev, const QString& name) const {
+  foreach (const parseagle::Technology& obj, dev.getTechnologies()) {
+    if (obj.getName() == name) {
+      return &obj;
+    }
+  }
+  return nullptr;
+}
+
+const parseagle::Part& EagleProjectImport::getPart(const QString& name) const {
+  foreach (const parseagle::Part& obj, mSchematic->getParts()) {
+    if (obj.getName() == name) {
+      return obj;
+    }
+  }
+  throw RuntimeError(__FILE__, __LINE__,
+                     QString("Part not found: %1").arg(name));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace eagleimport
+}  // namespace librepcb

--- a/libs/librepcb/eagleimport/eagleprojectimport.h
+++ b/libs/librepcb/eagleimport/eagleprojectimport.h
@@ -1,0 +1,183 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EAGLEIMPORT_EAGLEPROJECTIMPORT_H
+#define LIBREPCB_EAGLEIMPORT_EAGLEPROJECTIMPORT_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/types/boundedunsignedratio.h>
+#include <librepcb/core/types/uuid.h>
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace parseagle {
+class Board;
+class Device;
+class DeviceSet;
+class Library;
+class Net;
+class Package;
+class Part;
+class Schematic;
+class Sheet;
+class Symbol;
+class Technology;
+}  // namespace parseagle
+
+namespace librepcb {
+
+class Board;
+class Component;
+class Device;
+class FilePath;
+class MessageLogger;
+class NetSignal;
+class Package;
+class Project;
+class ProjectLibrary;
+class Schematic;
+class Symbol;
+
+namespace eagleimport {
+
+class EagleLibraryConverter;
+
+/*******************************************************************************
+ *  Class EagleProjectImport
+ ******************************************************************************/
+
+/**
+ * @brief Loads and imports an EAGLE project into a ::librepcb::Project
+ */
+class EagleProjectImport final : public QObject {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  EagleProjectImport(const EagleProjectImport& other) = delete;
+  explicit EagleProjectImport(QObject* parent = nullptr) noexcept;
+  ~EagleProjectImport() noexcept;
+
+  // Getters
+  std::shared_ptr<MessageLogger> getLogger() const noexcept { return mLogger; }
+  bool isReady() const noexcept { return mSchematic; }
+  const QString& getProjectName() const noexcept { return mProjectName; }
+  int getSheetCount() const noexcept;
+  bool hasBoard() const noexcept { return mBoard; }
+
+  // General Methods
+  void reset() noexcept;
+  QStringList open(const FilePath& sch, const FilePath& brd);
+  void import(Project& project);
+
+  // Operator Overloadings
+  EagleProjectImport& operator=(const EagleProjectImport& rhs) = delete;
+
+private:  // Methods
+  const Symbol& importLibrarySymbol(EagleLibraryConverter& converter,
+                                    ProjectLibrary& library,
+                                    const QString& libName,
+                                    const QString& libUrn,
+                                    const QString& symName);
+  const Component& importLibraryComponent(EagleLibraryConverter& converter,
+                                          ProjectLibrary& library,
+                                          const QString& libName,
+                                          const QString& libUrn,
+                                          const QString& devSetName);
+  const Package& importLibraryPackage(EagleLibraryConverter& converter,
+                                      ProjectLibrary& library,
+                                      const QString& libName,
+                                      const QString& libUrn,
+                                      const QString& pkgName);
+  const Device& importLibraryDevice(EagleLibraryConverter& converter,
+                                    ProjectLibrary& library,
+                                    const QString& libName,
+                                    const QString& libUrn,
+                                    const QString& devSetName,
+                                    const QString& devName);
+  NetSignal& importNet(Project& project, const parseagle::Net& net);
+  void importSchematic(Project& project, EagleLibraryConverter& converter,
+                       const parseagle::Sheet& sheet);
+  void importBoard(Project& project, EagleLibraryConverter& converter);
+  bool hasBuses(const parseagle::Schematic& schematic) const noexcept;
+  tl::optional<BoundedUnsignedRatio> tryGetDrcRatio(const QString& nr,
+                                                    const QString& nmin,
+                                                    const QString& nmax) const;
+  const parseagle::Library& getLibrary(const QList<parseagle::Library>& libs,
+                                       const QString& name,
+                                       const QString& urn) const;
+  const parseagle::Symbol& getSymbol(const parseagle::Library& lib,
+                                     const QString& name) const;
+  const parseagle::Package& getPackage(const parseagle::Library& lib,
+                                       const QString& name) const;
+  const parseagle::DeviceSet& getDeviceSet(const parseagle::Library& lib,
+                                           const QString& name) const;
+  const parseagle::Device& getDevice(const parseagle::DeviceSet& devSet,
+                                     const QString& name) const;
+  const parseagle::Technology* tryGetTechnology(const parseagle::Device& dev,
+                                                const QString& name) const;
+  const parseagle::Part& getPart(const QString& name) const;
+
+private:  // Data
+  std::shared_ptr<MessageLogger> mLogger;
+  QString mProjectName;
+  QScopedPointer<parseagle::Schematic> mSchematic;
+  QScopedPointer<parseagle::Board> mBoard;
+
+  /// Key={libName, libUrn, symName}, Value=libSymUuid
+  QHash<QStringList, Uuid> mLibSymbolMap;
+
+  /// Key={libName, libUrn, deviceSetName}, Value=libCmpUuid
+  QHash<QStringList, Uuid> mLibComponentMap;
+
+  /// Key={libCmpUuid, gateName}, Value=libCmpGateUuid
+  QHash<QStringList, Uuid> mLibComponentGateMap;
+
+  /// Key={libName, libUrn, pkgName}, Value=libPkgUuid
+  QHash<QStringList, Uuid> mLibPackageMap;
+
+  /// Key={libName, libUrn, devSetname, devName}, Value=libDevUuid
+  QHash<QStringList, Uuid> mLibDeviceMap;
+
+  /// Key=partName, Value={devSetname, devName, circuitCmpUuid}
+  QHash<QString, std::tuple<QString, QString, Uuid>> mComponentMap;
+
+  /// All already imported schematic directory names
+  QSet<QString> mSchematicDirNames;
+
+  /// Key=eagleNetName, Value=netSignalUuid
+  QHash<QString, Uuid> mNetSignalMap;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace eagleimport
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -616,7 +616,7 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
   }
   PositiveLength width(size);
   PositiveLength height(size);
-  UnsignedLimitedRatio radius(Ratio::percent0());
+  UnsignedLimitedRatio radius(Ratio::fromPercent(0));
   FootprintPad::Shape shape;
   Path customShapeOutline;
   switch (p.getShape()) {
@@ -628,16 +628,16 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
       break;
     case parseagle::PadShape::Round:
       shape = FootprintPad::Shape::RoundedRect;
-      radius = UnsignedLimitedRatio(Ratio::percent100());
+      radius = UnsignedLimitedRatio(Ratio::fromPercent(100));
       break;
     case parseagle::PadShape::Long:
       shape = FootprintPad::Shape::RoundedRect;
-      radius = UnsignedLimitedRatio(Ratio::percent100());
+      radius = UnsignedLimitedRatio(Ratio::fromPercent(100));
       width = PositiveLength(size * 2);
       break;
     case parseagle::PadShape::Offset:
       shape = FootprintPad::Shape::Custom;
-      radius = UnsignedLimitedRatio(Ratio::percent100());
+      radius = UnsignedLimitedRatio(Ratio::fromPercent(100));
       width = PositiveLength(size * 2);
       customShapeOutline =
           Path::obround(width, height).translated(Point(size / 2, 0));
@@ -925,7 +925,7 @@ BoundedUnsignedRatio
     EagleTypeConverter::getDefaultAutoThtAnnularWidth() noexcept {
   // The EAGLE footprint editor displays an annular ring of 25% of the drill
   // diameter then, bounded to 10..20mils (0.254..0.508mm).
-  return BoundedUnsignedRatio(UnsignedRatio(Ratio::percent50() / 2),
+  return BoundedUnsignedRatio(UnsignedRatio(Ratio::fromPercent(25)),
                               UnsignedLength(254000), UnsignedLength(508000));
 }
 

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -22,12 +22,19 @@
  ******************************************************************************/
 #include "eagletypeconverter.h"
 
+#include <librepcb/core/attribute/attribute.h>
+#include <librepcb/core/attribute/attributekey.h>
+#include <librepcb/core/attribute/attrtypestring.h>
 #include <librepcb/core/types/boundedunsignedratio.h>
+#include <librepcb/core/types/lengthunit.h>
 #include <librepcb/core/utils/clipperhelpers.h>
 #include <librepcb/core/utils/messagelogger.h>
 #include <librepcb/core/utils/tangentpathjoiner.h>
+#include <parseagle/board/param.h>
+#include <parseagle/common/attribute.h>
 #include <parseagle/common/circle.h>
 #include <parseagle/common/frame.h>
+#include <parseagle/common/grid.h>
 #include <parseagle/common/point.h>
 #include <parseagle/common/polygon.h>
 #include <parseagle/common/rectangle.h>
@@ -130,6 +137,51 @@ QString EagleTypeConverter::convertInversionSyntax(const QString& s) noexcept {
     out += s.at(i);
   }
   return out;
+}
+
+std::shared_ptr<Attribute> EagleTypeConverter::tryConvertAttribute(
+    const parseagle::Attribute& a, MessageLogger& log) {
+  const QString key = cleanAttributeKey(a.getName());
+  if (key.isEmpty()) {
+    log.warning(QString("Skipped attribute '%1' due to invalid name.")
+                    .arg(a.getName()));
+    return nullptr;
+  }
+  return std::make_shared<Attribute>(
+      AttributeKey(key), AttrTypeString::instance(), a.getValue(), nullptr);
+}
+
+void EagleTypeConverter::tryConvertAttributes(
+    const QList<parseagle::Attribute>& in, AttributeList& out,
+    MessageLogger& log) {
+  foreach (const auto& eagleAttr, in) {
+    if (auto lpObj = tryConvertAttribute(eagleAttr, log)) {
+      if (!out.contains(*lpObj->getKey())) {
+        out.append(lpObj);
+      }
+    }
+  }
+}
+
+void EagleTypeConverter::tryExtractMpnAndManufacturer(
+    AttributeList& attributes, SimpleString& mpn,
+    SimpleString& manufacturer) noexcept {
+  for (auto name : {"MPN", "MANUFACTURER_PART_NUMBER", "PART_NUMBER"}) {
+    if (auto a = attributes.find(name)) {
+      if (mpn->isEmpty()) {
+        mpn = cleanSimpleString(a->getValue());
+        attributes.remove(name);
+      }
+    }
+  }
+  for (auto name : {"MANUFACTURER", "MFR", "MF", "VENDOR"}) {
+    if (auto a = attributes.find(name)) {
+      if (manufacturer->isEmpty()) {
+        manufacturer = cleanSimpleString(a->getValue());
+        attributes.remove(name);
+      }
+    }
+  }
 }
 
 const Layer* EagleTypeConverter::tryConvertSchematicLayer(int id) noexcept {
@@ -265,6 +317,35 @@ const Layer* EagleTypeConverter::tryConvertBoardLayer(int id) noexcept {
   return nullptr;
 }
 
+QHash<const Layer*, const Layer*> EagleTypeConverter::convertLayerSetup(
+    const QString& s) {
+  QString tmp = s;
+  tmp.replace(QRegularExpression("[:\\*+\\(\\)\\[\\]]"), " ");
+  QSet<int> numbers;
+  foreach (const QString& numberStr, tmp.split(" ", QString::SkipEmptyParts)) {
+    const int id = numberStr.toInt();
+    if ((id < 1) || (id > 16)) {
+      throw RuntimeError(__FILE__, __LINE__,
+                         QString("Unsupported layer setup: %1").arg(s));
+    }
+    numbers.insert(id);
+  }
+  QHash<const Layer*, const Layer*> result;
+  int nextInnerLayer = 1;
+  foreach (int id, Toolbox::sortedQSet(numbers)) {
+    if (id == 1) {
+      result.insert(&Layer::topCopper(), &Layer::topCopper());
+    } else if (id == 16) {
+      result.insert(&Layer::botCopper(), &Layer::botCopper());
+    } else {
+      result.insert(Layer::innerCopper(id - 1),
+                    Layer::innerCopper(nextInnerLayer));
+      ++nextInnerLayer;
+    }
+  }
+  return result;
+}
+
 Alignment EagleTypeConverter::convertAlignment(parseagle::Alignment a) {
   switch (a) {
     case parseagle::Alignment::BottomLeft:
@@ -308,12 +389,79 @@ UnsignedLength EagleTypeConverter::convertLineWidth(double w, int layerId) {
   return UnsignedLength(l);  // can throw
 }
 
+template <>
+Length EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+  const QMap<QString, LengthUnit> unitMap = {
+      {"mic", LengthUnit::micrometers()},
+      {"mm", LengthUnit::millimeters()},
+      {"mil", LengthUnit::mils()},
+      {"inch", LengthUnit::inches()},
+  };
+
+  double value;
+  QString unit;
+  if (p.tryGetValueAsDoubleWithUnit(value, unit) && unitMap.contains(unit)) {
+    return unitMap[unit].convertFromUnit(value);
+  } else {
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        QString("Invalid length parameter value: '%1'").arg(p.getValue()));
+  }
+}
+
+template <>
+UnsignedLength EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+  return UnsignedLength(convertParamTo<Length>(p));
+}
+
+template <>
+PositiveLength EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+  return PositiveLength(convertParamTo<Length>(p));
+}
+
+template <>
+Ratio EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+  double value;
+  if (p.tryGetValueAsDouble(value)) {
+    return Ratio::fromNormalized(value);
+  } else {
+    throw RuntimeError(
+        __FILE__, __LINE__,
+        QString("Invalid ratio parameter value: '%1'").arg(p.getValue()));
+  }
+}
+
+template <>
+UnsignedRatio EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+  return UnsignedRatio(convertParamTo<Ratio>(p));
+}
+
 Point EagleTypeConverter::convertPoint(const parseagle::Point& p) {
   return Point::fromMm(p.x, p.y);
 }
 
 Angle EagleTypeConverter::convertAngle(double a) {
   return Angle::fromDeg(a);
+}
+
+void EagleTypeConverter::convertGrid(const parseagle::Grid& g,
+                                     PositiveLength& interval,
+                                     LengthUnit& unit) {
+  const QMap<parseagle::GridUnit, LengthUnit> unitMap = {
+      {parseagle::GridUnit::Micrometers, LengthUnit::micrometers()},
+      {parseagle::GridUnit::Millimeters, LengthUnit::millimeters()},
+      {parseagle::GridUnit::Mils, LengthUnit::mils()},
+      {parseagle::GridUnit::Inches, LengthUnit::inches()},
+  };
+  const LengthUnit distUnit =
+      unitMap.value(g.getUnitDistance(), LengthUnit::millimeters());
+  const Length value = distUnit.convertFromUnit(g.getDistance());
+  if ((g.getDistance() > 0) && (value > 0)) {
+    interval = PositiveLength(value);
+  }
+  if (unitMap.contains(g.getUnit())) {
+    unit = unitMap.value(g.getUnit());
+  }
 }
 
 Vertex EagleTypeConverter::convertVertex(const parseagle::Vertex& v) {
@@ -350,6 +498,15 @@ QList<EagleTypeConverter::Geometry> EagleTypeConverter::convertAndJoinWires(
         paths.append(Path::line(convertPoint(wire.getP1()),
                                 convertPoint(wire.getP2()),
                                 convertAngle(wire.getCurve())));
+        if (wire.getWireStyle() != parseagle::WireStyle::Continuous) {
+          log.warning(
+              tr("Dashed/dotted line is not supported, converting to "
+                 "continuous."));
+        }
+        if (wire.getWireCap() != parseagle::WireCap::Round) {
+          log.warning(
+              tr("Flat line end is not supported, converting to round."));
+        }
       }
       foreach (const Path& p, TangentPathJoiner::join(paths, 5000, &timedOut)) {
         polygons.append(Geometry{
@@ -486,6 +643,26 @@ std::shared_ptr<Text> EagleTypeConverter::tryConvertSchematicText(
   }
 }
 
+std::shared_ptr<Text> EagleTypeConverter::tryConvertSchematicAttribute(
+    const parseagle::Attribute& t) {
+  if (auto layer = tryConvertSchematicLayer(t.getLayer())) {
+    const bool mirror = t.getRotation().getMirror();
+    const Angle rotation = convertAngle(t.getRotation().getAngle());
+    const Alignment alignment = convertAlignment(t.getAlignment());
+    return std::make_shared<Text>(
+        Uuid::createRandom(),  // UUID
+        *layer,  // Layer
+        convertTextValue(">" % t.getName()),  // Text
+        convertPoint(t.getPosition()),  // Position
+        mirror ? -rotation : rotation,  // Rotation
+        convertSchematicTextSize(t.getSize()),  // Height
+        mirror ? alignment.mirroredH() : alignment  // Alignment
+    );
+  } else {
+    return nullptr;
+  }
+}
+
 PositiveLength EagleTypeConverter::convertBoardTextSize(int layerId,
                                                         double size) {
   Length newSize = Length::fromMm(size * 0.85);
@@ -539,6 +716,31 @@ std::shared_ptr<StrokeText> EagleTypeConverter::tryConvertBoardText(
         Uuid::createRandom(),  // UUID
         *layer,  // Layer
         convertTextValue(t.getValue()),  // Text
+        convertPoint(t.getPosition()),  // Position
+        mirror ? -rotation : rotation,  // Rotation
+        convertBoardTextSize(t.getLayer(), t.getSize()),  // Height
+        convertBoardTextStrokeWidth(t.getLayer(), t.getSize(),
+                                    t.getRatio()),  // Stroke width
+        StrokeTextSpacing(),  // Letter spacing
+        StrokeTextSpacing(),  // Line spacing
+        convertAlignment(t.getAlignment()),  // Alignment
+        mirror,  // Mirrored
+        !t.getRotation().getSpin()  // Auto rotate
+    );
+  } else {
+    return nullptr;
+  }
+}
+
+std::shared_ptr<StrokeText> EagleTypeConverter::tryConvertBoardAttribute(
+    const parseagle::Attribute& t) {
+  if (auto layer = tryConvertBoardLayer(t.getLayer())) {
+    const bool mirror = t.getRotation().getMirror();
+    const Angle rotation = convertAngle(t.getRotation().getAngle());
+    return std::make_shared<StrokeText>(
+        Uuid::createRandom(),  // UUID
+        *layer,  // Layer
+        convertTextValue(">" % t.getName()),  // Text
         convertPoint(t.getPosition()),  // Position
         mirror ? -rotation : rotation,  // Rotation
         convertBoardTextSize(t.getLayer(), t.getSize()),  // Height

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -72,6 +72,7 @@ struct Point;
 namespace librepcb {
 
 class Layer;
+class MessageLogger;
 
 namespace eagleimport {
 
@@ -302,14 +303,13 @@ public:
    * @param wires                 EAGLE wires
    * @param isGrabAreaIfClosed    If true, grab area will be enabled on
    *                              closed polygons
-   * @param errors                If not `nullptr`, any errors will be
-   *                              appended to this list
+   * @param log                   Logging message handler
    *
    * @return Joined polygons as intermediate geometries
    */
   static QList<Geometry> convertAndJoinWires(
       const QList<parseagle::Wire>& wires, bool isGrabAreaIfClosed,
-      QStringList* errors = nullptr);
+      MessageLogger& log);
 
   /**
    * @brief Convert a rectangle
@@ -516,6 +516,17 @@ public:
    * @return A polygon if the layer is valid for boards, otherwise `nullptr`
    */
   static std::shared_ptr<Polygon> tryConvertToBoardPolygon(const Geometry& g);
+
+  /**
+   * @brief Get the EAGLE layer name for a given layer ID
+   *
+   * @param id        EAGLE layer ID
+   * @param fallback  The string to return if the given layer is unknown
+   *
+   * @return EAGLE layer name (fallback if unknown)
+   */
+  static QString getLayerName(int id,
+                              const QString& fallback = "unknown") noexcept;
 
   /**
    * @brief Get the default annular width of THT pads with 'auto' size

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -421,8 +421,6 @@ add_library(
   project/boardeditor/boardlayersdock.cpp
   project/boardeditor/boardlayersdock.h
   project/boardeditor/boardlayersdock.ui
-  project/boardeditor/boardnetsegmentsplitter.cpp
-  project/boardeditor/boardnetsegmentsplitter.h
   project/boardeditor/boardpickplacegeneratordialog.cpp
   project/boardeditor/boardpickplacegeneratordialog.h
   project/boardeditor/boardpickplacegeneratordialog.ui
@@ -783,8 +781,6 @@ add_library(
   project/schematiceditor/schematiceditor.ui
   project/schematiceditor/schematicgraphicsscene.cpp
   project/schematiceditor/schematicgraphicsscene.h
-  project/schematiceditor/schematicnetsegmentsplitter.cpp
-  project/schematiceditor/schematicnetsegmentsplitter.h
   project/schematiceditor/schematicpagesdock.cpp
   project/schematiceditor/schematicpagesdock.h
   project/schematiceditor/schematicpagesdock.ui

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -680,6 +680,9 @@ add_library(
   project/newprojectwizard/newprojectwizard.cpp
   project/newprojectwizard/newprojectwizard.h
   project/newprojectwizard/newprojectwizard.ui
+  project/newprojectwizard/newprojectwizardpage_eagleimport.cpp
+  project/newprojectwizard/newprojectwizardpage_eagleimport.h
+  project/newprojectwizard/newprojectwizardpage_eagleimport.ui
   project/newprojectwizard/newprojectwizardpage_initialization.cpp
   project/newprojectwizard/newprojectwizardpage_initialization.h
   project/newprojectwizard/newprojectwizardpage_initialization.ui

--- a/libs/librepcb/editor/dialogs/graphicsexportdialog.cpp
+++ b/libs/librepcb/editor/dialogs/graphicsexportdialog.cpp
@@ -475,7 +475,7 @@ void GraphicsExportDialog::loadDefaultSettings() noexcept {
   setFitToPage(!mDefaultSettings->getScale().has_value());
   setScaleFactor(mDefaultSettings->getScale()
                      ? *mDefaultSettings->getScale()
-                     : UnsignedRatio(Ratio::percent100()));
+                     : UnsignedRatio(Ratio::fromPercent(100)));
   setDpi(mDefaultSettings->getPixmapDpi());
   setBlackWhite(mDefaultSettings->getBlackWhite());
   setBackgroundColor(mDefaultSettings->getBackgroundColor());

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -466,6 +466,15 @@ public:
       {},
       &categoryImportExport,
   };
+  EditorCommand importEagleProject{
+      "import_eagle_project",  // clang-format break
+      QT_TR_NOOP("Import EAGLE Project"),
+      QT_TR_NOOP("Import schematic/board from EAGLE *.sch/*.brd files"),
+      QIcon(),
+      EditorCommand::Flag::OpensPopup,
+      {},
+      &categoryImportExport,
+  };
   EditorCommand exportLppz{
       "export_lppz",  // clang-format break
       QT_TR_NOOP("Export *.lppz Archive"),

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.cpp
@@ -25,6 +25,7 @@
 #include "eaglelibraryimportwizardcontext.h"
 #include "ui_eaglelibraryimportwizardpage_result.h"
 
+#include <librepcb/core/utils/messagelogger.h>
 #include <librepcb/core/workspace/workspace.h>
 #include <librepcb/core/workspace/workspacelibrarydb.h>
 #include <librepcb/eagleimport/eaglelibraryimport.h>
@@ -99,8 +100,7 @@ bool EagleLibraryImportWizardPage_Result::isComplete() const {
  *  Private Methods
  ******************************************************************************/
 
-void EagleLibraryImportWizardPage_Result::importFinished(
-    const QStringList& errors) noexcept {
+void EagleLibraryImportWizardPage_Result::importFinished() noexcept {
   while (!mProgressBarConnections.isEmpty()) {
     disconnect(mProgressBarConnections.takeLast());
   }
@@ -109,9 +109,10 @@ void EagleLibraryImportWizardPage_Result::importFinished(
               &WorkspaceLibraryDb::scanProgressUpdate, mUi->prgImport,
               &QProgressBar::setValue, Qt::QueuedConnection));
 
-  mUi->lblMessages->setText(errors.join("\n"));
+  const auto log = mContext->getImport().getLogger();
+  mUi->lblMessages->setText(log->getMessagesRichText());
   mUi->prgImport->setFormat(tr("Scanning libraries") % " (%p%)");
-  mUi->gbxErrors->setVisible(!errors.isEmpty());
+  mUi->gbxErrors->setVisible(!log->getMessages().isEmpty());
   if (QWizard* wiz = wizard()) {
     // Show restart button to allow importing a next library.
     wiz->setOption(QWizard::HaveCustomButton1, true);

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.h
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.h
@@ -69,7 +69,7 @@ public:
       const EagleLibraryImportWizardPage_Result& rhs) = delete;
 
 private:  // Methods
-  void importFinished(const QStringList& errors) noexcept;
+  void importFinished() noexcept;
 
 private:  // Data
   QScopedPointer<Ui::EagleLibraryImportWizardPage_Result> mUi;

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.ui
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.ui
@@ -44,7 +44,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Import Errors</string>
+      <string>Import messages:</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="leftMargin">
@@ -109,7 +109,7 @@
              <string notr="true"/>
             </property>
             <property name="textFormat">
-             <enum>Qt::PlainText</enum>
+             <enum>Qt::RichText</enum>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
@@ -210,11 +210,12 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   }
   switch (mPad.getShape()) {
     case FootprintPad::Shape::RoundedRect:
-      mUi->btnShapeRound->setChecked(*mPad.getRadius() == Ratio::percent100());
-      mUi->btnShapeRect->setChecked(*mPad.getRadius() == Ratio::percent0());
+      mUi->btnShapeRound->setChecked(*mPad.getRadius() ==
+                                     Ratio::fromPercent(100));
+      mUi->btnShapeRect->setChecked(*mPad.getRadius() == Ratio::fromPercent(0));
       mUi->btnShapeRoundedRect->setChecked(
-          (*mPad.getRadius() != Ratio::percent0()) &&
-          (*mPad.getRadius() != Ratio::percent100()));
+          (*mPad.getRadius() != Ratio::fromPercent(0)) &&
+          (*mPad.getRadius() != Ratio::fromPercent(100)));
       break;
     case FootprintPad::Shape::RoundedOctagon:
       mUi->btnShapeOctagon->setChecked(true);
@@ -331,11 +332,13 @@ void FootprintPadPropertiesDialog::updateShapeDependentWidgets(
     mUi->edtWidth->setEnabled(!custom);
     mUi->edtHeight->setEnabled(!custom);
     if (round) {
-      mUi->edtRadiusRatio->setValue(UnsignedLimitedRatio(Ratio::percent100()));
+      mUi->edtRadiusRatio->setValue(
+          UnsignedLimitedRatio(Ratio::fromPercent(100)));
     } else if (roundedRect) {
       applyRecommendedRadius();
     } else {
-      mUi->edtRadiusRatio->setValue(UnsignedLimitedRatio(Ratio::percent0()));
+      mUi->edtRadiusRatio->setValue(
+          UnsignedLimitedRatio(Ratio::fromPercent(0)));
     }
   }
 }
@@ -355,9 +358,10 @@ void FootprintPadPropertiesDialog::updateRelativeRadius() noexcept {
   const UnsignedLength value = mUi->edtRadiusAbs->getValue();
   const Length maxValue =
       std::min(mUi->edtWidth->getValue(), mUi->edtHeight->getValue()) / 2;
-  mUi->edtRadiusRatio->setValue(UnsignedLimitedRatio(qBound(
-      Ratio::percent0(), Ratio::fromNormalized(value->toMm() / maxValue.toMm()),
-      Ratio::percent100())));
+  mUi->edtRadiusRatio->setValue(UnsignedLimitedRatio(
+      qBound(Ratio::fromPercent(0),
+             Ratio::fromNormalized(value->toMm() / maxValue.toMm()),
+             Ratio::fromPercent(100))));
 }
 
 void FootprintPadPropertiesDialog::applyRecommendedRadius() noexcept {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_addpads.cpp
@@ -61,7 +61,7 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(
         FootprintPad::Shape::RoundedRect,  // Commonly used pad shape
         PositiveLength(2500000),  // There is no default/recommended pad size
         PositiveLength(1300000),  // -> choose reasonable multiple of 0.1mm
-        UnsignedLimitedRatio(Ratio::percent100()),  // Rounded pad
+        UnsignedLimitedRatio(Ratio::fromPercent(100)),  // Rounded pad
         Path(),  // Custom shape outline
         MaskConfig::automatic(),  // Stop mask
         MaskConfig::off(),  // Solder paste
@@ -70,34 +70,34 @@ PackageEditorState_AddPads::PackageEditorState_AddPads(
         function,  // Supplied by library editor
         PadHoleList{}) {
   if (mPadType == PadType::SMT) {
-    mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent50()));
+    mLastPad.setRadius(UnsignedLimitedRatio(Ratio::fromPercent(50)));
     mLastPad.setWidth(PositiveLength(1500000));
     mLastPad.setHeight(PositiveLength(700000));
     mLastPad.setSolderPasteConfig(MaskConfig::automatic());
     switch (function) {
       case FootprintPad::Function::ThermalPad:
-        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent0()));
+        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::fromPercent(0)));
         mLastPad.setWidth(PositiveLength(2000000));
         mLastPad.setHeight(PositiveLength(2000000));
         break;
       case FootprintPad::Function::BgaPad:
-        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent100()));
+        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::fromPercent(100)));
         mLastPad.setWidth(PositiveLength(300000));
         mLastPad.setHeight(PositiveLength(300000));
         break;
       case FootprintPad::Function::EdgeConnectorPad:
-        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent0()));
+        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::fromPercent(0)));
         mLastPad.setSolderPasteConfig(MaskConfig::off());
         break;
       case FootprintPad::Function::TestPad:
-        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent100()));
+        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::fromPercent(100)));
         mLastPad.setWidth(PositiveLength(700000));
         mLastPad.setHeight(PositiveLength(700000));
         mLastPad.setSolderPasteConfig(MaskConfig::off());
         break;
       case FootprintPad::Function::LocalFiducial:
       case FootprintPad::Function::GlobalFiducial:
-        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::percent100()));
+        mLastPad.setRadius(UnsignedLimitedRatio(Ratio::fromPercent(100)));
         mLastPad.setWidth(PositiveLength(1000000));
         mLastPad.setHeight(PositiveLength(1000000));
         mLastPad.setCopperClearance(UnsignedLength(500000));
@@ -168,41 +168,41 @@ bool PackageEditorState_AddPads::entry() noexcept {
       cmd.shapeRound.createAction(shapeActionGroup.get(), this, [this]() {
         shapeSelectorCurrentShapeChanged(
             FootprintPad::Shape::RoundedRect,
-            UnsignedLimitedRatio(Ratio::percent100()), false);
+            UnsignedLimitedRatio(Ratio::fromPercent(100)), false);
       });
   aShapeRound->setCheckable(true);
   aShapeRound->setChecked(
       (mLastPad.getShape() == FootprintPad::Shape::RoundedRect) &&
-      (*mLastPad.getRadius() == Ratio::percent100()));
+      (*mLastPad.getRadius() == Ratio::fromPercent(100)));
   aShapeRound->setActionGroup(shapeActionGroup.get());
   QAction* aShapeRoundedRect =
       cmd.shapeRoundedRect.createAction(shapeActionGroup.get(), this, [this]() {
         shapeSelectorCurrentShapeChanged(
             FootprintPad::Shape::RoundedRect,
-            UnsignedLimitedRatio(Ratio::percent50()), true);
+            UnsignedLimitedRatio(Ratio::fromPercent(50)), true);
       });
   aShapeRoundedRect->setCheckable(true);
   aShapeRoundedRect->setChecked(
       (mLastPad.getShape() == FootprintPad::Shape::RoundedRect) &&
-      (*mLastPad.getRadius() != Ratio::percent0()) &&
-      (*mLastPad.getRadius() != Ratio::percent100()));
+      (*mLastPad.getRadius() != Ratio::fromPercent(0)) &&
+      (*mLastPad.getRadius() != Ratio::fromPercent(100)));
   aShapeRoundedRect->setActionGroup(shapeActionGroup.get());
   QAction* aShapeRect =
       cmd.shapeRect.createAction(shapeActionGroup.get(), this, [this]() {
         shapeSelectorCurrentShapeChanged(
             FootprintPad::Shape::RoundedRect,
-            UnsignedLimitedRatio(Ratio::percent0()), false);
+            UnsignedLimitedRatio(Ratio::fromPercent(0)), false);
       });
   aShapeRect->setCheckable(true);
   aShapeRect->setChecked(
       (mLastPad.getShape() == FootprintPad::Shape::RoundedRect) &&
-      (*mLastPad.getRadius() == Ratio::percent0()));
+      (*mLastPad.getRadius() == Ratio::fromPercent(0)));
   aShapeRect->setActionGroup(shapeActionGroup.get());
   QAction* aShapeOctagon =
       cmd.shapeOctagon.createAction(shapeActionGroup.get(), this, [this]() {
         shapeSelectorCurrentShapeChanged(
             FootprintPad::Shape::RoundedOctagon,
-            UnsignedLimitedRatio(Ratio::percent0()), true);
+            UnsignedLimitedRatio(Ratio::fromPercent(0)), true);
       });
   aShapeOctagon->setCheckable(true);
   aShapeOctagon->setChecked(mLastPad.getShape() ==
@@ -588,8 +588,8 @@ void PackageEditorState_AddPads::pressFitCheckedChanged(bool value) noexcept {
 }
 
 void PackageEditorState_AddPads::applyRecommendedRoundedRectRadius() noexcept {
-  if ((*mLastPad.getRadius() > Ratio::percent0()) &&
-      (*mLastPad.getRadius() < Ratio::percent100())) {
+  if ((*mLastPad.getRadius() > Ratio::fromPercent(0)) &&
+      (*mLastPad.getRadius() < Ratio::fromPercent(100))) {
     emit requestRadius(FootprintPad::getRecommendedRadius(
         mLastPad.getWidth(), mLastPad.getHeight()));
   }

--- a/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardclipboarddatabuilder.cpp
@@ -23,12 +23,12 @@
 #include "boardclipboarddatabuilder.h"
 
 #include "boardgraphicsscene.h"
-#include "boardnetsegmentsplitter.h"
 #include "boardselectionquery.h"
 
 #include <librepcb/core/library/dev/device.h>
 #include <librepcb/core/library/pkg/package.h>
 #include <librepcb/core/project/board/board.h>
+#include <librepcb/core/project/board/boardnetsegmentsplitter.h>
 #include <librepcb/core/project/board/items/bi_device.h>
 #include <librepcb/core/project/board/items/bi_footprintpad.h>
 #include <librepcb/core/project/board/items/bi_hole.h>

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -35,7 +35,6 @@
 #include "../../project/cmd/cmdprojectlibraryaddelement.h"
 #include "../boardeditor/boardclipboarddata.h"
 #include "../boardeditor/boardgraphicsscene.h"
-#include "../boardeditor/boardnetsegmentsplitter.h"
 #include "../boardeditor/graphicsitems/bgi_device.h"
 #include "../boardeditor/graphicsitems/bgi_hole.h"
 #include "../boardeditor/graphicsitems/bgi_netline.h"
@@ -50,6 +49,7 @@
 #include <librepcb/core/library/dev/device.h>
 #include <librepcb/core/library/pkg/package.h>
 #include <librepcb/core/project/board/board.h>
+#include <librepcb/core/project/board/boardnetsegmentsplitter.h>
 #include <librepcb/core/project/board/items/bi_device.h>
 #include <librepcb/core/project/board/items/bi_footprintpad.h>
 #include <librepcb/core/project/board/items/bi_hole.h>

--- a/libs/librepcb/editor/project/cmd/cmdremoveboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveboarditems.cpp
@@ -32,10 +32,10 @@
 #include "../../project/cmd/cmdboardzoneremove.h"
 #include "../../project/cmd/cmddeviceinstanceremove.h"
 #include "../../project/cmd/cmddevicestroketextremove.h"
-#include "../boardeditor/boardnetsegmentsplitter.h"
 #include "cmdremoveunusedlibraryelements.h"
 
 #include <librepcb/core/project/board/board.h>
+#include <librepcb/core/project/board/boardnetsegmentsplitter.h>
 #include <librepcb/core/project/board/items/bi_device.h>
 #include <librepcb/core/project/board/items/bi_footprintpad.h>
 #include <librepcb/core/project/board/items/bi_hole.h>

--- a/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
@@ -34,7 +34,6 @@
 #include "../../project/cmd/cmdsymbolinstanceremove.h"
 #include "../../project/cmd/cmdsymbolinstancetextremove.h"
 #include "../schematiceditor/schematicgraphicsscene.h"
-#include "../schematiceditor/schematicnetsegmentsplitter.h"
 #include "../schematiceditor/schematicselectionquery.h"
 #include "cmdchangenetsignalofschematicnetsegment.h"
 #include "cmdremoveboarditems.h"
@@ -60,6 +59,7 @@
 #include <librepcb/core/project/schematic/items/si_symbolpin.h>
 #include <librepcb/core/project/schematic/items/si_text.h>
 #include <librepcb/core/project/schematic/schematic.h>
+#include <librepcb/core/project/schematic/schematicnetsegmentsplitter.h>
 #include <librepcb/core/utils/scopeguard.h>
 #include <librepcb/core/utils/toolbox.h>
 

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.h
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.h
@@ -40,12 +40,9 @@ class Workspace;
 
 namespace editor {
 
+class NewProjectWizardPage_EagleImport;
 class NewProjectWizardPage_Initialization;
 class NewProjectWizardPage_Metadata;
-
-//
-
-class NewProjectWizardPage_VersionControl;
 
 namespace Ui {
 class NewProjectWizard;
@@ -62,10 +59,13 @@ class NewProjectWizard final : public QWizard {
   Q_OBJECT
 
 public:
+  // Types
+  enum class Mode { NewProject, EagleImport };
+
   // Constructors / Destructor
   NewProjectWizard() = delete;
   NewProjectWizard(const NewProjectWizard& other) = delete;
-  explicit NewProjectWizard(const Workspace& ws,
+  explicit NewProjectWizard(const Workspace& ws, Mode mode,
                             QWidget* parent = nullptr) noexcept;
   ~NewProjectWizard() noexcept;
 
@@ -80,10 +80,11 @@ public:
 
 private:  // Data
   const Workspace& mWorkspace;
+  const Mode mMode;
   QScopedPointer<Ui::NewProjectWizard> mUi;
+  NewProjectWizardPage_EagleImport* mPageEagleImport;
   NewProjectWizardPage_Metadata* mPageMetadata;
   NewProjectWizardPage_Initialization* mPageInitialization;
-  // NewProjectWizardPage_VersionControl* mPageVersionControl;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>531</width>
+    <width>650</width>
     <height>370</height>
    </rect>
   </property>

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.cpp
@@ -1,0 +1,267 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "newprojectwizardpage_eagleimport.h"
+
+#include "../../dialogs/filedialog.h"
+#include "../../editorcommandset.h"
+#include "../../widgets/waitingspinnerwidget.h"
+#include "../../workspace/desktopservices.h"
+#include "ui_newprojectwizardpage_eagleimport.h"
+
+#include <librepcb/core/exceptions.h>
+#include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/utils/messagelogger.h>
+#include <librepcb/core/workspace/workspace.h>
+#include <librepcb/eagleimport/eagleprojectimport.h>
+
+#include <QtConcurrent>
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+NewProjectWizardPage_EagleImport::NewProjectWizardPage_EagleImport(
+    const Workspace& ws, QWidget* parent) noexcept
+  : QWizardPage(parent),
+    mWorkspace(ws),
+    mUi(new Ui::NewProjectWizardPage_EagleImport) {
+  mUi->setupUi(this);
+  setPixmap(QWizard::LogoPixmap, QPixmap(":/img/actions/plus_2.png"));
+  setPixmap(QWizard::WatermarkPixmap, QPixmap(":/img/wizards/watermark.jpg"));
+  mWaitingSpinner.reset(new WaitingSpinnerWidget(mUi->sclMessages));
+  mWaitingSpinner->hide();
+
+  // Setup schematic input field.
+  const EditorCommandSet& cmd = EditorCommandSet::instance();
+  QAction* aBrowseSch = cmd.inputBrowse.createAction(
+      mUi->edtSchematicFilePath, this,
+      [this]() {
+        const QString fp = FileDialog::getOpenFileName(
+            this, tr("Select EAGLE Schematic"),
+            mUi->edtSchematicFilePath->text(), "*.sch");
+        if (!fp.isEmpty()) {
+          mUi->edtSchematicFilePath->setText(fp);
+          const QString brdFp = fp.chopped(4) % ".brd";
+          if (FilePath(brdFp).isExistingFile()) {
+            mUi->edtBoardFilePath->setText(brdFp);  // Import board too.
+          } else {
+            mUi->edtBoardFilePath->clear();  // Don't import any board.
+          }
+        }
+      },
+      EditorCommand::ActionFlag::WidgetShortcut);
+  mUi->edtSchematicFilePath->addAction(aBrowseSch, QLineEdit::TrailingPosition);
+  connect(mUi->edtSchematicFilePath, &QLineEdit::textChanged, this,
+          &NewProjectWizardPage_EagleImport::updateStatus);
+
+  // Setup board input field.
+  QAction* aBrowseBrd = cmd.inputBrowse.createAction(
+      mUi->edtBoardFilePath, this,
+      [this]() {
+        const QString fp =
+            FileDialog::getOpenFileName(this, tr("Select EAGLE Board"),
+                                        mUi->edtBoardFilePath->text(), "*.brd");
+        if (!fp.isEmpty()) {
+          mUi->edtBoardFilePath->setText(fp);
+        }
+      },
+      EditorCommand::ActionFlag::WidgetShortcut);
+  mUi->edtBoardFilePath->addAction(aBrowseBrd, QLineEdit::TrailingPosition);
+  connect(mUi->edtBoardFilePath, &QLineEdit::textChanged, this,
+          &NewProjectWizardPage_EagleImport::updateStatus);
+  mUi->edtBoardFilePath->setEnabled(false);
+
+  // Load settings.
+  QSettings clientSettings;
+  mUi->edtSchematicFilePath->setText(
+      clientSettings.value("new_project_wizard/eagle_import/schematic_file")
+          .toString());
+  mUi->edtBoardFilePath->setText(
+      clientSettings.value("new_project_wizard/eagle_import/board_file")
+          .toString());
+
+  // Periodically update status.
+  QTimer* timer = new QTimer(this);
+  connect(timer, &QTimer::timeout, this,
+          &NewProjectWizardPage_EagleImport::updateStatus);
+  timer->start(100);
+}
+
+NewProjectWizardPage_EagleImport::~NewProjectWizardPage_EagleImport() noexcept {
+  // Save settings.
+  QSettings clientSettings;
+  clientSettings.setValue("new_project_wizard/eagle_import/schematic_file",
+                          mUi->edtSchematicFilePath->text());
+  clientSettings.setValue("new_project_wizard/eagle_import/board_file",
+                          mUi->edtBoardFilePath->text());
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void NewProjectWizardPage_EagleImport::import(Project& project) {
+  if (!mImport) {
+    throw LogicError(__FILE__, __LINE__, "No importer available.");
+  }
+
+  // Displaying the messages in a dialog which remains open even after the
+  // import finished. Unfortunately this is a bit hacky, some day it should be
+  // improved.
+  QDialog* dialog = new QDialog();
+  dialog->setWindowTitle(tr("EAGLE Project Import"));
+  dialog->setWindowIcon(QIcon(":/img/logo/64x64.png"));
+  QVBoxLayout* layout = new QVBoxLayout(dialog);
+  QTextBrowser* browser = new QTextBrowser(dialog);
+  browser->setWordWrapMode(QTextOption::NoWrap);
+  browser->setOpenLinks(false);
+  const Workspace* ws = &mWorkspace;
+  connect(browser, &QTextBrowser::anchorClicked, ws, [ws](const QUrl& url) {
+    DesktopServices ds(ws->getSettings(), nullptr);
+    ds.openUrl(url);
+  });
+  connect(mImport->getLogger().get(), &MessageLogger::msgEmitted, browser,
+          [browser](const MessageLogger::Message& msg) {
+            browser->append(msg.toRichText(true, true));
+            browser->verticalScrollBar()->setValue(
+                browser->verticalScrollBar()->maximum());
+            qApp->processEvents();
+          });
+  layout->addWidget(browser);
+  QPushButton* btnClose = new QPushButton(tr("Close"), dialog);
+  btnClose->setEnabled(false);
+  connect(this, &NewProjectWizardPage_EagleImport::destroyed, btnClose,
+          &QPushButton::setEnabled);
+  connect(btnClose, &QPushButton::clicked, dialog, &QDialog::close);
+  layout->addWidget(btnClose);
+  dialog->resize(800, 600);
+  dialog->show();
+  qApp->processEvents();
+
+  // Run the import (long-running blocking operation).
+  mImport->import(project);  // can throw
+
+  // After the project editor has been opened, bring messages dialog to front.
+  // A bit hacky, probably some day we will need a better solution for this...
+  QTimer::singleShot(2500, dialog, [dialog]() {
+    dialog->raise();
+    dialog->activateWindow();
+  });
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void NewProjectWizardPage_EagleImport::updateStatus() noexcept {
+  const QString sch = mUi->edtSchematicFilePath->text().trimmed();
+  const QString brd = mUi->edtBoardFilePath->text().trimmed();
+  const FilePath schFp(sch);
+  const FilePath brdFp(brd);
+  mUi->edtBoardFilePath->setEnabled(schFp.isValid());
+
+  if (((sch != mCurrentSchematic) || (brd != mCurrentBoard)) &&
+      (!mFuture.isRunning())) {
+    mImport.reset();
+    mCurrentSchematic = sch;
+    mCurrentBoard = brd;
+    if (sch.isEmpty()) {
+      mUi->lblMessages->hide();
+    } else if (schFp.isValid() && (brdFp.isValid() || brd.isEmpty())) {
+      mWaitingSpinner->show();
+      mUi->lblMessages->setText("<font color=\"blue\">" %
+                                tr("Parsing project...") % "</font>");
+      mUi->lblMessages->show();
+      mFuture = QtConcurrent::run(
+          &parseAsync, std::make_shared<eagleimport::EagleProjectImport>(),
+          schFp, brdFp);
+    } else {
+      mUi->lblMessages->setText("<font color=\"red\">⚠ " %
+                                tr("Invalid file path(s).") % "</font>");
+      mUi->lblMessages->show();
+    }
+    emit completeChanged();
+  }
+
+  if (mFuture.isResultReadyAt(0)) {
+    const auto result = mFuture.result();
+    mFuture = {};
+    mImport = result.import;
+    mUi->lblMessages->setText(result.messages.join("<br>"));
+    mUi->lblMessages->setVisible(!result.messages.isEmpty());
+    mWaitingSpinner->hide();
+    emit completeChanged();
+  }
+}
+
+NewProjectWizardPage_EagleImport::ParserResult
+    NewProjectWizardPage_EagleImport::parseAsync(
+        std::shared_ptr<eagleimport::EagleProjectImport> import,
+        const FilePath& schFp, const FilePath& brdFp) noexcept {
+  ParserResult result;
+  try {
+    result.import = import;
+    const QStringList warnings = result.import->open(schFp, brdFp);
+    foreach (const QString& warning, warnings) {
+      result.messages.append("<font color=\"blue\">➤ " % warning % "</font>");
+    }
+    const QString msg = result.import->hasBoard()
+        ? tr("Ready to import %n sheet(s) and a board.", nullptr,
+             result.import->getSheetCount())
+        : tr("Ready to import %n sheet(s) without board.", nullptr,
+             result.import->getSheetCount());
+    result.messages.append("<font color=\"green\">✔ " % msg % "</font>");
+  } catch (const Exception& e) {
+    result.messages.append("<font color=\"red\">⚠ " % tr("ERROR:") % " " %
+                           e.getMsg() % "</font>");
+  }
+  return result;
+}
+
+bool NewProjectWizardPage_EagleImport::isComplete() const noexcept {
+  // Check base class.
+  if (!QWizardPage::isComplete()) return false;
+
+  // Check EAGLE project.
+  if ((!mImport) || (!mImport->isReady())) return false;
+
+  // Preselect project name for next wizard page.
+  emit projectSelected(mImport->getProjectName());
+
+  return true;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.h
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.h
@@ -17,14 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_NEWPROJECTWIZARDPAGE_METADATA_H
-#define LIBREPCB_EDITOR_NEWPROJECTWIZARDPAGE_METADATA_H
+#ifndef LIBREPCB_EDITOR_NEWPROJECTWIZARDPAGE_EAGLEIMPORT_H
+#define LIBREPCB_EDITOR_NEWPROJECTWIZARDPAGE_EAGLEIMPORT_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <librepcb/core/fileio/filepath.h>
-
 #include <QtCore>
 #include <QtWidgets>
 
@@ -33,61 +31,70 @@
  ******************************************************************************/
 namespace librepcb {
 
+namespace eagleimport {
+class EagleProjectImport;
+}
+
+class Project;
+class FilePath;
 class Workspace;
 
 namespace editor {
 
 namespace Ui {
-class NewProjectWizardPage_Metadata;
+class NewProjectWizardPage_EagleImport;
 }
 
+class WaitingSpinnerWidget;
+
 /*******************************************************************************
- *  Class NewProjectWizardPage_Metadata
+ *  Class NewProjectWizardPage_EagleImport
  ******************************************************************************/
 
 /**
- * @brief The NewProjectWizardPage_Metadata class
+ * @brief The NewProjectWizardPage_EagleImport class
  */
-class NewProjectWizardPage_Metadata final : public QWizardPage {
+class NewProjectWizardPage_EagleImport final : public QWizardPage {
   Q_OBJECT
+
+  struct ParserResult {
+    std::shared_ptr<eagleimport::EagleProjectImport> import;
+    QStringList messages;
+  };
 
 public:
   // Constructors / Destructor
-  explicit NewProjectWizardPage_Metadata(const Workspace& ws,
-                                         QWidget* parent = nullptr) noexcept;
-  NewProjectWizardPage_Metadata(const NewProjectWizardPage_Metadata& other) =
-      delete;
-  ~NewProjectWizardPage_Metadata() noexcept;
+  explicit NewProjectWizardPage_EagleImport(const Workspace& ws,
+                                            QWidget* parent = nullptr) noexcept;
+  NewProjectWizardPage_EagleImport(
+      const NewProjectWizardPage_EagleImport& other) = delete;
+  ~NewProjectWizardPage_EagleImport() noexcept;
 
-  // Setters
-  void setProjectName(const QString& name) noexcept;
-  void setDefaultLocation(const FilePath& dir) noexcept;
-
-  // Getters
-  QString getProjectName() const noexcept;
-  QString getProjectAuthor() const noexcept;
-  bool isLicenseSet() const noexcept;
-  FilePath getProjectLicenseFilePath() const noexcept;
-  FilePath getFullFilePath() const noexcept;
+  // General Methods
+  void import(Project& project);
 
   // Operator Overloadings
-  NewProjectWizardPage_Metadata& operator=(
-      const NewProjectWizardPage_Metadata& rhs) = delete;
+  NewProjectWizardPage_EagleImport& operator=(
+      const NewProjectWizardPage_EagleImport& rhs) = delete;
 
-private:  // GUI Action Handlers
-  void nameChanged(const QString& name) noexcept;
-  void locationChanged(const QString& dir) noexcept;
-  void chooseLocationClicked() noexcept;
+signals:
+  void projectSelected(const QString& name) const;
 
 private:  // Methods
-  void updateProjectFilePath() noexcept;
+  void updateStatus() noexcept;
+  static NewProjectWizardPage_EagleImport::ParserResult parseAsync(
+      std::shared_ptr<eagleimport::EagleProjectImport> import,
+      const FilePath& schFp, const FilePath& brdFp) noexcept;
   bool isComplete() const noexcept override;
-  bool validatePage() noexcept override;
 
 private:  // Data
   const Workspace& mWorkspace;
-  QScopedPointer<Ui::NewProjectWizardPage_Metadata> mUi;
-  FilePath mFullFilePath;
+  QScopedPointer<Ui::NewProjectWizardPage_EagleImport> mUi;
+  QScopedPointer<WaitingSpinnerWidget> mWaitingSpinner;
+  QString mCurrentSchematic;
+  QString mCurrentBoard;
+  QFuture<ParserResult> mFuture;
+  std::shared_ptr<eagleimport::EagleProjectImport> mImport;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.ui
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::editor::NewProjectWizardPage_EagleImport</class>
+ <widget class="QWizardPage" name="librepcb::editor::NewProjectWizardPage_EagleImport">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>586</width>
+    <height>222</height>
+   </rect>
+  </property>
+  <property name="title">
+   <string>Select EAGLE (v6 or later) project files</string>
+  </property>
+  <property name="subTitle">
+   <string>Please choose the EAGLE schematic and optionally board files to import.</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLineEdit" name="edtSchematicFilePath">
+     <property name="maxLength">
+      <number>500</number>
+     </property>
+     <property name="placeholderText">
+      <string>Select EAGLE schematic file</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="edtBoardFilePath">
+     <property name="maxLength">
+      <number>500</number>
+     </property>
+     <property name="placeholderText">
+      <string>Select EAGLE board file (optional)</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="sclMessages">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>568</width>
+        <height>76</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="lblMessages">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblNote">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>Note that due to conceptual differences between EDA tools, migrations won't be perfect and you should review the result carefully. Whenever possible, creating a new project from scratch is preferred.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.cpp
@@ -94,6 +94,11 @@ NewProjectWizardPage_Metadata::~NewProjectWizardPage_Metadata() noexcept {
  *  Setters
  ******************************************************************************/
 
+void NewProjectWizardPage_Metadata::setProjectName(
+    const QString& name) noexcept {
+  mUi->edtName->setText(name);
+}
+
 void NewProjectWizardPage_Metadata::setDefaultLocation(
     const FilePath& dir) noexcept {
   mUi->edtLocation->setText(dir.toNative());

--- a/libs/librepcb/editor/project/outputjobsdialog/graphicsoutputjobwidget.cpp
+++ b/libs/librepcb/editor/project/outputjobsdialog/graphicsoutputjobwidget.cpp
@@ -437,7 +437,7 @@ void GraphicsOutputJobWidget::currentContentChanged(int index) noexcept {
     // Scale.
     mUi->cbxScaleAuto->setChecked(!c.scale);
     mUi->spbxScaleFactor->setValue(
-        c.scale ? *c.scale : UnsignedRatio(Ratio::percent100()));
+        c.scale ? *c.scale : UnsignedRatio(Ratio::fromPercent(100)));
 
     // Pixmap DPI.
     mUi->spbxResolutionDpi->setValue(c.pixmapDpi);

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddatabuilder.cpp
@@ -23,7 +23,6 @@
 #include "schematicclipboarddatabuilder.h"
 
 #include "schematicgraphicsscene.h"
-#include "schematicnetsegmentsplitter.h"
 #include "schematicselectionquery.h"
 
 #include <librepcb/core/fileio/transactionalfilesystem.h>
@@ -42,6 +41,7 @@
 #include <librepcb/core/project/schematic/items/si_symbolpin.h>
 #include <librepcb/core/project/schematic/items/si_text.h>
 #include <librepcb/core/project/schematic/schematic.h>
+#include <librepcb/core/project/schematic/schematicnetsegmentsplitter.h>
 
 #include <QtCore>
 #include <QtWidgets>

--- a/libs/librepcb/editor/utils/shortcutsreferencegenerator.cpp
+++ b/libs/librepcb/editor/utils/shortcutsreferencegenerator.cpp
@@ -104,12 +104,12 @@ bool ShortcutsReferenceGenerator::generatePdf(const FilePath& fp) {
       &mCommands.categoryWindowManagement,  //
       &mCommands.categoryImportExport,  //
       &mCommands.categoryModify,  // long
+      &mCommands.categoryTextInput,  //
       &mCommands.categoryView,  //
       &mCommands.categoryTools,  // long
       &mCommands.categoryComponents,  //
       &mCommands.categoryDocks,  //
       &mCommands.categoryCommands,  // long
-      &mCommands.categoryTextInput,  //
       &mCommands.categoryHelp,  //
       &mCommands.categoryContextMenu,  // Not visible
   };

--- a/libs/librepcb/editor/widgets/unsignedlimitedratioedit.cpp
+++ b/libs/librepcb/editor/widgets/unsignedlimitedratioedit.cpp
@@ -36,9 +36,9 @@ namespace editor {
 
 UnsignedLimitedRatioEdit::UnsignedLimitedRatioEdit(QWidget* parent) noexcept
   : NumberEditBase(parent),
-    mMinValue(Ratio::percent0()),
-    mMaxValue(Ratio::percent100()),
-    mValue(Ratio::percent0()) {
+    mMinValue(Ratio::fromPercent(0)),
+    mMaxValue(Ratio::fromPercent(100)),
+    mValue(Ratio::fromPercent(0)) {
   mSpinBox->setSuffix("%");
   updateSpinBox();
 }

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -116,7 +116,8 @@ private:
 
   // Project Management
 
-  ProjectEditor* newProject(FilePath parentDir = FilePath()) noexcept;
+  ProjectEditor* newProject(bool eagleImport = false,
+                            FilePath parentDir = FilePath()) noexcept;
 
   /**
    * @brief Open a project with the editor (or bring an already opened editor to
@@ -219,6 +220,7 @@ private:
   QScopedPointer<QAction> mActionNewProject;
   QScopedPointer<QAction> mActionOpenProject;
   QScopedPointer<QAction> mActionCloseAllProjects;
+  QScopedPointer<QAction> mActionImportEagleProject;
   QScopedPointer<QAction> mActionAboutLibrePcb;
   QScopedPointer<QAction> mActionAboutQt;
   QScopedPointer<QAction> mActionOnlineDocumentation;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(
   core/workspace/workspacesettingstest.cpp
   core/workspace/workspacetest.cpp
   eagleimport/eaglelibraryimporttest.cpp
+  eagleimport/eagleprojectimporttest.cpp
   eagleimport/eagletypeconvertertest.cpp
   editor/dialogs/dxfimportdialogtest.cpp
   editor/dialogs/graphicsexportdialogtest.cpp

--- a/tests/unittests/core/library/pkg/footprintpadtest.cpp
+++ b/tests/unittests/core/library/pkg/footprintpadtest.cpp
@@ -61,7 +61,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
   EXPECT_EQ(FootprintPad::Shape::RoundedRect, obj.getShape());
   EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
   EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
-  EXPECT_EQ(UnsignedLimitedRatio(Ratio::percent50()), obj.getRadius());
+  EXPECT_EQ(UnsignedLimitedRatio(Ratio::fromPercent(50)), obj.getRadius());
   EXPECT_EQ(MaskConfig::automatic(), obj.getStopMaskConfig());
   EXPECT_EQ(MaskConfig::manual(Length(250000)), obj.getSolderPasteConfig());
   EXPECT_EQ(UnsignedLength(330000), obj.getCopperClearance());
@@ -97,7 +97,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
   EXPECT_EQ(FootprintPad::Shape::Custom, obj.getShape());
   EXPECT_EQ(PositiveLength(1100000), obj.getWidth());
   EXPECT_EQ(UnsignedLength(2200000), obj.getHeight());
-  EXPECT_EQ(UnsignedLimitedRatio(Ratio::percent50()), obj.getRadius());
+  EXPECT_EQ(UnsignedLimitedRatio(Ratio::fromPercent(50)), obj.getRadius());
   EXPECT_EQ(MaskConfig::off(), obj.getStopMaskConfig());
   EXPECT_EQ(MaskConfig::automatic(), obj.getSolderPasteConfig());
   EXPECT_EQ(UnsignedLength(330000), obj.getCopperClearance());
@@ -111,7 +111,7 @@ TEST_F(FootprintPadTest, testSerializeAndDeserialize) {
   FootprintPad obj1(
       Uuid::createRandom(), Uuid::createRandom(), Point(123, 567), Angle(789),
       FootprintPad::Shape::RoundedOctagon, PositiveLength(123),
-      PositiveLength(456), UnsignedLimitedRatio(Ratio::percent50()),
+      PositiveLength(456), UnsignedLimitedRatio(Ratio::fromPercent(50)),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
       UnsignedLength(98765), FootprintPad::ComponentSide::Top,

--- a/tests/unittests/core/types/ratiotest.cpp
+++ b/tests/unittests/core/types/ratiotest.cpp
@@ -81,7 +81,13 @@ TEST_P(RatioTest, testSetRatioPpm) {
   EXPECT_EQ(data.ppm, r.toPpm());
 }
 
-TEST_P(RatioTest, testSetRatioPercent) {
+TEST(RatioTest, testSetRatioPercentInt) {
+  Ratio r;
+  r.setRatioPercent(42);
+  EXPECT_EQ(420000, r.toPpm());
+}
+
+TEST_P(RatioTest, testSetRatioPercentFloat) {
   const RatioTestData_t& data = GetParam();
 
   Ratio r;
@@ -140,10 +146,17 @@ TEST_P(RatioTest, testFromNormalizedString) {
   EXPECT_EQ(data.ppm, Ratio::fromNormalized(data.string).toPpm());
 }
 
-TEST(RatioTest, testStaticPercentMethods) {
-  EXPECT_NEAR(0.0, Ratio::percent0().toPercent(), 0.0002);
-  EXPECT_NEAR(50.0, Ratio::percent50().toPercent(), 0.0002);
-  EXPECT_NEAR(100.0, Ratio::percent100().toPercent(), 0.0002);
+TEST(RatioTest, testFromPercentInt) {
+  EXPECT_EQ(0, Ratio::fromPercent(0).toPpm());
+  EXPECT_EQ(500000, Ratio::fromPercent(50).toPpm());
+  EXPECT_EQ(1000000, Ratio::fromPercent(100).toPpm());
+}
+
+TEST(RatioTest, testFromPercentFloat) {
+  EXPECT_NEAR(0.0, Ratio::fromPercent(0.0).toPercent(), 0.0002);
+  EXPECT_NEAR(50.0, Ratio::fromPercent(50.0).toPercent(), 0.0002);
+  EXPECT_NEAR(100.0, Ratio::fromPercent(100.0).toPercent(), 0.0002);
+  EXPECT_NEAR(42.42, Ratio::fromPercent(42.42).toPercent(), 0.0002);
 }
 
 TEST_P(RatioTest, testOperatorAssign) {

--- a/tests/unittests/eagleimport/eaglelibraryimporttest.cpp
+++ b/tests/unittests/eagleimport/eaglelibraryimporttest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/utils/messagelogger.h>
 #include <librepcb/eagleimport/eaglelibraryimport.h>
 
 #include <QtCore>
@@ -50,12 +51,8 @@ TEST_F(EagleLibraryImportTest, testImport) {
 
   // Connect signals by hand because QSignalSpy is not threadsafe!
   int signalFinished = 0;
-  QStringList importErrors;
   QObject::connect(&import, &EagleLibraryImport::finished,
-                   [&signalFinished, &importErrors](const QStringList& e) {
-                     ++signalFinished;
-                     importErrors = e;
-                   });
+                   [&signalFinished]() { ++signalFinished; });
 
   QStringList parseErrors = import.open(src);
   EXPECT_EQ(1, import.getSymbols().count());
@@ -67,7 +64,7 @@ TEST_F(EagleLibraryImportTest, testImport) {
   import.start();
   EXPECT_TRUE(import.wait(10000));
   EXPECT_EQ(1, signalFinished);
-  EXPECT_EQ(0, importErrors.count());
+  EXPECT_EQ(0, import.getLogger()->getMessages().count());
 }
 
 /*******************************************************************************

--- a/tests/unittests/eagleimport/eagleprojectimporttest.cpp
+++ b/tests/unittests/eagleimport/eagleprojectimporttest.cpp
@@ -1,0 +1,134 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/fileio/transactionaldirectory.h>
+#include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/project/project.h>
+#include <librepcb/core/project/projectloader.h>
+#include <librepcb/eagleimport/eagleprojectimport.h>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace eagleimport {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class EagleProjectImportTest : public ::testing::Test {
+protected:
+  FilePath mTmpDir;
+
+  EagleProjectImportTest() : mTmpDir(FilePath::getRandomTempPath()) {}
+
+  ~EagleProjectImportTest() { QDir(mTmpDir.toStr()).removeRecursively(); }
+
+  FilePath getSch() const noexcept {
+    return FilePath(TEST_DATA_DIR "/unittests/eagleimport/testproject.sch");
+  }
+
+  FilePath getBrd() const noexcept {
+    return FilePath(TEST_DATA_DIR "/unittests/eagleimport/testproject.brd");
+  }
+
+  std::unique_ptr<TransactionalDirectory> getProjectDir() const {
+    return std::unique_ptr<TransactionalDirectory>(
+        new TransactionalDirectory(TransactionalFileSystem::openRW(mTmpDir)));
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(EagleProjectImportTest, testImportOnlySchematic) {
+  EagleProjectImport import;
+  EXPECT_FALSE(import.isReady());
+
+  const QStringList msgs = import.open(getSch(), FilePath());
+  EXPECT_TRUE(import.isReady());
+  EXPECT_EQ("testproject", import.getProjectName().toStdString());
+  EXPECT_EQ("Project contains buses which are not supported yet!",
+            msgs.join(";").toStdString());
+
+  {
+    // Populate and save project.
+    std::unique_ptr<Project> project =
+        Project::create(getProjectDir(), "test.lpp");
+    import.import(*project);
+    project->save();
+    project->getDirectory().getFileSystem()->save();
+  }
+
+  {
+    // Open project again to see if there's no problem with it.
+    ProjectLoader loader;
+    std::unique_ptr<Project> project = loader.open(getProjectDir(), "test.lpp");
+    EXPECT_EQ(1, project->getSchematics().count());
+    EXPECT_EQ(0, project->getBoards().count());
+  }
+}
+
+TEST_F(EagleProjectImportTest, testImportWithBoard) {
+  EagleProjectImport import;
+  EXPECT_FALSE(import.isReady());
+
+  const QStringList msgs = import.open(getSch(), getBrd());
+  EXPECT_TRUE(import.isReady());
+  EXPECT_EQ("testproject", import.getProjectName().toStdString());
+  EXPECT_EQ("Project contains buses which are not supported yet!",
+            msgs.join(";").toStdString());
+
+  {
+    // Populate and save project.
+    std::unique_ptr<Project> project =
+        Project::create(getProjectDir(), "test.lpp");
+    import.import(*project);
+    project->save();
+    project->getDirectory().getFileSystem()->save();
+  }
+
+  {
+    // Open project again to see if there's no problem with it.
+    ProjectLoader loader;
+    std::unique_ptr<Project> project = loader.open(getProjectDir(), "test.lpp");
+    EXPECT_EQ(1, project->getSchematics().count());
+    EXPECT_EQ(1, project->getBoards().count());
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace eagleimport
+}  // namespace librepcb

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -26,6 +26,7 @@
 #include <librepcb/core/library/sym/symbolpin.h>
 #include <librepcb/core/types/layer.h>
 #include <librepcb/core/types/point.h>
+#include <librepcb/core/utils/messagelogger.h>
 #include <librepcb/eagleimport/eagletypeconverter.h>
 #include <parseagle/common/domelement.h>
 #include <parseagle/library.h>
@@ -212,7 +213,7 @@ TEST_F(EagleTypeConverterTest, testConvertVertices) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertAndJoinWires) {
-  QStringList errors;
+  MessageLogger log;
   QList<parseagle::Wire> wires{
       // clang-format off
       parseagle::Wire(dom("<wire x1=\"1\" y1=\"2\" x2=\"3\" y2=\"4\" width=\"0.254\" layer=\"1\"/>")),
@@ -222,9 +223,9 @@ TEST_F(EagleTypeConverterTest, testConvertAndJoinWires) {
       parseagle::Wire(dom("<wire x1=\"7\" y1=\"8\" x2=\"9\" y2=\"9\" width=\"-1\" layer=\"2\"/>")),
       // clang-format on
   };
-  auto out = C::convertAndJoinWires(wires, true, &errors);
+  auto out = C::convertAndJoinWires(wires, true, log);
   ASSERT_EQ(3, out.count());
-  EXPECT_EQ(1, errors.count());
+  EXPECT_EQ(1, log.getMessages().count());
 
   EXPECT_EQ(1, out.at(0).layerId);
   EXPECT_EQ(UnsignedLength(254000), out.at(0).lineWidth);

--- a/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
+++ b/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
@@ -689,14 +689,14 @@ TEST_F(GraphicsExportDialogTest, testScale) {
     // Check the default value.
     EXPECT_EQ(!defaultValue, cbx.isChecked());
     EXPECT_EQ(defaultValue.has_value(), spbx.isEnabled());
-    EXPECT_EQ(defaultValue ? **defaultValue : Ratio::percent100(),
+    EXPECT_EQ(defaultValue ? **defaultValue : Ratio::fromPercent(100),
               *spbx.getValue());
     EXPECT_EQ(defaultValue, getSettings(dlg, 1).at(0)->getScale());
 
     // Check if the value can be changed and are applied properly.
     cbx.setChecked(!newValue);
     EXPECT_EQ(newValue.has_value(), spbx.isEnabled());
-    EXPECT_EQ(UnsignedRatio(Ratio::percent100()),
+    EXPECT_EQ(UnsignedRatio(Ratio::fromPercent(100)),
               getSettings(dlg, 1).at(0)->getScale());
     spbx.setValue(*newValue);
     EXPECT_EQ(newValue, getSettings(dlg, 1).at(0)->getScale());
@@ -718,14 +718,15 @@ TEST_F(GraphicsExportDialogTest, testScale) {
     // Check new value.
     EXPECT_EQ(!newValue, cbx.isChecked());
     EXPECT_EQ(newValue.has_value(), spbx.isEnabled());
-    EXPECT_EQ(newValue ? **newValue : Ratio::percent100(), *spbx.getValue());
+    EXPECT_EQ(newValue ? **newValue : Ratio::fromPercent(100),
+              *spbx.getValue());
     EXPECT_EQ(newValue, getSettings(dlg, 1).at(0)->getScale());
 
     // Restore default value.
     restoreDefaults(dlg);
     EXPECT_EQ(!defaultValue, cbx.isChecked());
     EXPECT_EQ(defaultValue.has_value(), spbx.isEnabled());
-    EXPECT_EQ(defaultValue ? **defaultValue : Ratio::percent100(),
+    EXPECT_EQ(defaultValue ? **defaultValue : Ratio::fromPercent(100),
               *spbx.getValue());
     EXPECT_EQ(defaultValue, getSettings(dlg, 1).at(0)->getScale());
 

--- a/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
+++ b/tests/unittests/editor/library/pkg/footprintclipboarddatatest.cpp
@@ -87,7 +87,7 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
   std::shared_ptr<FootprintPad> footprintPad1 = std::make_shared<FootprintPad>(
       Uuid::createRandom(), packagePad1->getUuid(), Point(12, 34), Angle(56),
       FootprintPad::Shape::RoundedOctagon, PositiveLength(11),
-      PositiveLength(22), UnsignedLimitedRatio(Ratio::percent50()), Path(),
+      PositiveLength(22), UnsignedLimitedRatio(Ratio::fromPercent(50)), Path(),
       MaskConfig::off(), MaskConfig::automatic(), UnsignedLength(0),
       FootprintPad::ComponentSide::Bottom, FootprintPad::Function::Unspecified,
       PadHoleList{});
@@ -95,7 +95,7 @@ TEST(FootprintClipboardDataTest, testToFromMimeDataPopulated) {
   std::shared_ptr<FootprintPad> footprintPad2 = std::make_shared<FootprintPad>(
       Uuid::createRandom(), tl::nullopt, Point(12, 34), Angle(56),
       FootprintPad::Shape::RoundedRect, PositiveLength(123),
-      PositiveLength(456), UnsignedLimitedRatio(Ratio::percent100()),
+      PositiveLength(456), UnsignedLimitedRatio(Ratio::fromPercent(100)),
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
       MaskConfig::automatic(), MaskConfig::manual(Length(123456)),
       UnsignedLength(123456), FootprintPad::ComponentSide::Top,


### PR DESCRIPTION
This adds an initial EAGLE project importer to allow EAGLE users smoothly switching to LibrePCB now since EAGLE is discontinued by Autodesk.

Generally the result of the import looks pretty accurate as far as I can tell from my tests. But due to architectural differences between EAGLE and LibrePCB, and because some features are not available in LibrePCB yet, there are some limitations:

- Hierarchical sheets (modules) cannot be imported (they are ignored). This is probably the biggest limitation.
- If the symbols of a multi-gate component are spread across multiple schematic sheets, the import fails because LibrePCB doesn't support that (yet).
- Schematic buses are not imported (doesn't seem to cause any electrical issues though as far as I can see).
- Schematic net labels might have different layout since we don't support configuring the text alignment and we don't support "Xref"-style labels.
- Only boards and devices can be imported if there's also a schematic for them. Pure boards or board-only devices cannot be imported.
- Objects on custom (user-defined) layers are ignored, only official EAGLE layers are respected.
- Rounded traces are converted to straight traces.
- Square or octagonal vias are converted to circular.
- Plane calculations will most probably lead to slightly different results (the algorithm cannot be migrated of course).
- Text fonts / layouting cannot be migrated as well, so texts will look slightly different.
- Probably some more limitations especially in edge cases I don't know yet. We'll need the feedback from real-world scenarios to find them, so the import contains a hyperlink where to report problems.

![eagle-project-import](https://github.com/LibrePCB/LibrePCB/assets/5374821/fda8b238-28dd-4216-920d-887d94f15dc5)

Testers welcome! Nightly builds are available here: https://download.librepcb.org/nightly_builds/1268-eagle-project-importer/

Closes #1268