### PR TITLE
Globally enable HTTP caching

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -83,9 +83,10 @@ int main(int argc, char* argv[]) {
   // (from http://www.qtcentre.org/threads/1904)
   app.setStyleSheet("QStatusBar::item { border: 0px solid black; }");
 
-  // Start network access manager thread
+  // Start network access manager thread with HTTP cache to avoid extensive
+  // requests (e.g. downloading library pictures each time opening the manager).
   QScopedPointer<NetworkAccessManager> networkAccessManager(
-      new NetworkAccessManager());
+      new NetworkAccessManager(Application::getCacheDir().getPathTo("http")));
 
   // Run the actual application
   int retval = runApplication();
@@ -150,9 +151,12 @@ static void writeLogHeader() noexcept {
   qInfo() << "Resources directory:"
           << Application::getResourcesDir().toNative();
 
-  // write application settings directory to log (nice to know for users)
+  // write application settings file to log (nice to know for users)
   qInfo() << "Application settings:"
           << FilePath(QSettings().fileName()).toNative();
+
+  // write cache directory to log (nice to know for users)
+  qInfo() << "Cache directory:" << Application::getCacheDir().toNative();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/application.cpp
+++ b/libs/librepcb/core/application.cpp
@@ -70,6 +70,24 @@ bool Application::isFileFormatStable() noexcept {
   return LIBREPCB_FILE_FORMAT_STABLE;
 }
 
+FilePath Application::getCacheDir() noexcept {
+  auto detect = []() {
+    // Use different configuration directory if supplied by environment
+    // variable "LIBREPCB_CACHE_DIR" (useful for functional testing).
+    FilePath fp(qgetenv("LIBREPCB_CACHE_DIR"));
+
+    // If no valid path was specified, use the default cache directory.
+    if (!fp.isValid()) {
+      fp.setPath(
+          QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
+    }
+    return fp;
+  };
+
+  static const FilePath value = detect();
+  return value;
+}
+
 const FilePath& Application::getResourcesDir() noexcept {
   auto detect = []() {
     // get the directory of the currently running executable

--- a/libs/librepcb/core/application.h
+++ b/libs/librepcb/core/application.h
@@ -107,6 +107,16 @@ public:
   static bool isFileFormatStable() noexcept;
 
   /**
+   * @brief Get the path to the cache directory
+   *
+   * @note This function is thread-safe.
+   *
+   * @return Guaranteed valid file path
+   *         (e.g. "/home/user/.cache/LibrePCB/LibrePCB/")
+   */
+  static FilePath getCacheDir() noexcept;
+
+  /**
    * @brief Get the path to the resources directory
    *
    * @note This function is thread-safe.

--- a/libs/librepcb/core/fileio/filepath.cpp
+++ b/libs/librepcb/core/fileio/filepath.cpp
@@ -174,6 +174,8 @@ FilePath FilePath::getParentDir() const noexcept {
 }
 
 FilePath FilePath::getPathTo(const QString& filename) const noexcept {
+  if (!mIsValid) return FilePath();  // Avoid converting invalid path to valid.
+
   return FilePath(mFileInfo.filePath() % QLatin1Char('/') % filename);
 }
 

--- a/libs/librepcb/core/network/networkaccessmanager.cpp
+++ b/libs/librepcb/core/network/networkaccessmanager.cpp
@@ -95,6 +95,25 @@ QNetworkReply* NetworkAccessManager::post(const QNetworkRequest& request,
   }
 }
 
+bool NetworkAccessManager::setMinimumCacheExpirationDate(
+    const QUrl& url, const QDateTime& dt) noexcept {
+  Q_ASSERT(QThread::currentThread() == this);
+
+  if (mManager) {
+    if (QAbstractNetworkCache* cache = mManager->cache()) {
+      QNetworkCacheMetaData data = cache->metaData(url);
+      if (data.isValid() && (data.expirationDate() < dt)) {
+        data.setExpirationDate(dt);
+        cache->updateMetaData(data);
+        return true;
+      }
+    }
+  } else {
+    qCritical() << "No network access manager available! Thread not running?!";
+  }
+  return false;
+}
+
 /*******************************************************************************
  *  Static Methods
  ******************************************************************************/

--- a/libs/librepcb/core/network/networkaccessmanager.cpp
+++ b/libs/librepcb/core/network/networkaccessmanager.cpp
@@ -41,8 +41,11 @@ NetworkAccessManager* NetworkAccessManager::sInstance = nullptr;
  *  Constructors / Destructor
  ******************************************************************************/
 
-NetworkAccessManager::NetworkAccessManager() noexcept
-  : QThread(nullptr), mThreadStartSemaphore(0), mManager(nullptr) {
+NetworkAccessManager::NetworkAccessManager(const FilePath& cache) noexcept
+  : QThread(nullptr),
+    mCacheFp(cache),
+    mThreadStartSemaphore(0),
+    mManager(nullptr) {
   // This thread must only be started once, and from within the main application
   // thread!
   Q_ASSERT(QThread::currentThread() == qApp->thread());
@@ -108,6 +111,11 @@ void NetworkAccessManager::run() noexcept {
   Q_ASSERT(QThread::currentThread() == this);
   qDebug() << "Network access manager thread started.";
   mManager = new QNetworkAccessManager();
+  if (mCacheFp.isValid()) {
+    QNetworkDiskCache* cache = new QNetworkDiskCache();
+    cache->setCacheDirectory(mCacheFp.toStr());
+    mManager->setCache(cache);
+  }
   mThreadStartSemaphore.release();
   try {
     exec();  // event loop (blocking)

--- a/libs/librepcb/core/network/networkaccessmanager.h
+++ b/libs/librepcb/core/network/networkaccessmanager.h
@@ -72,6 +72,8 @@ public:
   QNetworkReply* get(const QNetworkRequest& request) noexcept;
   QNetworkReply* post(const QNetworkRequest& request,
                       const QByteArray& data) noexcept;
+  bool setMinimumCacheExpirationDate(const QUrl& url,
+                                     const QDateTime& dt) noexcept;
 
   // Operator Overloadings
   NetworkAccessManager& operator=(const NetworkAccessManager& rhs) = delete;

--- a/libs/librepcb/core/network/networkaccessmanager.h
+++ b/libs/librepcb/core/network/networkaccessmanager.h
@@ -64,7 +64,7 @@ class NetworkAccessManager final : public QThread {
 
 public:
   // Constructors / Destructor
-  NetworkAccessManager() noexcept;
+  explicit NetworkAccessManager(const FilePath& cache = FilePath()) noexcept;
   NetworkAccessManager(const NetworkAccessManager& other) = delete;
   ~NetworkAccessManager() noexcept;
 
@@ -84,6 +84,7 @@ private:  // Methods
   void stop() noexcept;
 
 private:  // Data
+  const FilePath mCacheFp;
   QSemaphore mThreadStartSemaphore;
   QNetworkAccessManager* mManager;
   static NetworkAccessManager* sInstance;

--- a/libs/librepcb/core/network/networkrequestbase.cpp
+++ b/libs/librepcb/core/network/networkrequestbase.cpp
@@ -289,7 +289,10 @@ void NetworkRequestBase::finalize(const QString& errorMsg) noexcept {
   Q_ASSERT(QThread::currentThread() == NetworkAccessManager::instance());
 
   if (errorMsg.isNull()) {
-    qDebug() << "Request successfully finished:" << mUrl.toString();
+    const bool fromCache = mReply &&
+        mReply->attribute(QNetworkRequest::SourceIsFromCacheAttribute).toBool();
+    qDebug() << "Request successfully finished:" << mUrl.toString()
+             << (fromCache ? "(from cache)" : "");
     emit progressState(tr("Request successfully finished."));
     emitSuccessfullyFinishedSignals();
     emit succeeded();

--- a/libs/librepcb/core/network/networkrequestbase.h
+++ b/libs/librepcb/core/network/networkrequestbase.h
@@ -84,6 +84,18 @@ public:
    */
   void setExpectedReplyContentSize(qint64 bytes) noexcept;
 
+  /**
+   * @brief Set the minimum time the request should be cached
+   *
+   * This allows to cache requests longer than specified in response headers,
+   * which is useful for URLs not under our own control where rather uncritical
+   * content like images are downloaded from. If the response header specifies
+   * a higher max-age value, it has priority so this method has no effect.
+   *
+   * @param seconds       Minimum cache time in seconds (default is 0)
+   */
+  void setMinimumCacheTime(int seconds) noexcept;
+
   // Operator Overloadings
   NetworkRequestBase& operator=(const NetworkRequestBase& rhs) = delete;
 
@@ -194,6 +206,7 @@ protected:  // Data
   QUrl mUrl;
   QByteArray mPostData;
   qint64 mExpectedContentSize;
+  int mMinimumCacheTime;
 
   // internal data
   QList<QUrl> mRedirectedUrls;

--- a/libs/librepcb/editor/workspace/librarymanager/onlinelibrarylistwidgetitem.cpp
+++ b/libs/librepcb/editor/workspace/librarymanager/onlinelibrarylistwidgetitem.cpp
@@ -84,6 +84,7 @@ OnlineLibraryListWidgetItem::OnlineLibraryListWidgetItem(
   mUi->lblAuthor->setText(QString("Author: %1").arg(author));
 
   NetworkRequest* request = new NetworkRequest(iconUrl);
+  request->setMinimumCacheTime(24 * 3600);  // 1 day
   connect(request, &NetworkRequest::dataReceived, this,
           &OnlineLibraryListWidgetItem::iconReceived, Qt::QueuedConnection);
   request->start();

--- a/tests/funq/conftest.py
+++ b/tests/funq/conftest.py
@@ -75,6 +75,8 @@ class LibrePcbFixture(object):
         self.env['LC_ALL'] = 'C'
         # Override configuration location to make tests independent of existing configs
         self.env['LIBREPCB_CONFIG_DIR'] = os.path.join(self.tmpdir, 'config')
+        # Override cache location to make each test indepotent
+        self.env['LIBREPCB_CACHE_DIR'] = os.path.join(self.tmpdir, 'cache')
         # Use a neutral username
         self.env['USERNAME'] = 'testuser'
         # Force LibrePCB to use Qt-style file dialogs because native dialogs don't work

--- a/tests/unittests/core/applicationtest.cpp
+++ b/tests/unittests/core/applicationtest.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 #include <librepcb/core/application.h>
 #include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/types/version.h>
 
 #include <QtCore>
@@ -49,6 +50,15 @@ TEST(ApplicationTest, testGetVersion) {
 
 TEST(ApplicationTest, testGetFileFormatVersion) {
   EXPECT_GE(Application::getFileFormatVersion(), Version::fromString("0.1"));
+}
+
+TEST(ApplicationTest, testGetCacheDir) {
+  // Check if the resources directory is valid and writable.
+  EXPECT_TRUE(Application::getCacheDir().isValid());
+  const FilePath tmpFp = Application::getCacheDir().getPathTo("test.txt");
+  FileUtils::writeFile(tmpFp, "test");
+  EXPECT_EQ("test", FileUtils::readFile(tmpFp));
+  FileUtils::removeFile(tmpFp);
 }
 
 TEST(ApplicationTest, testGetResourcesDir) {


### PR DESCRIPTION
Using `QNetworkDiskCache` to support the standard HTTP cache mechanisms, reducing the overall network load of LibrePCB. The cache is set up at the default, platform-specific cache location provided by Qt, with subdirectory "http" (seems to be "/home/user/.ccache/LibrePCB/LibrePCB/http/" on Linux) with Qt's default cache size limit (50MB in total, according docs).

However, since not all accessed URLs are under our control (e.g. the library manager downloads library icons directly from GitHub), the `Cache-Control` response header may or may not be set to sensible values. GitHub uses `max-age=300`, which is way too conservative for uncritical things like library icons. Therefore I implemented the option to enforce a longer caching for particular URLs, which is now set to 1 day for library icons.

I also updated our API server to add the `Cache-Control` header to its responses. It's set to 1 hour for the library index (`/libraries`) resp. 5 minutes for the order service status URL (`/order`).

The effect of caching is clearly visible in the library manager which now loads libraries much faster :slightly_smiling_face: 