### PR TITLE
Library editor: Reduce minimum window height

### DIFF
--- a/libs/librepcb/editor/library/cat/categorylisteditorwidget.ui
+++ b/libs/librepcb/editor/library/cat/categorylisteditorwidget.ui
@@ -13,7 +13,10 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -43,20 +46,47 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
      <item>
-      <widget class="QPushButton" name="btnAdd">
+      <widget class="QToolButton" name="btnAdd">
        <property name="text">
-        <string>Add category</string>
+        <string notr="true"/>
        </property>
+<property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/add.png</normaloff>:/img/actions/add.png</iconset>
+           </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemove">
-       <property name="text">
-        <string>Remove selected</string>
+      <widget class="QToolButton" name="btnRemove">
+       <property name="toolTip">
+        <string>Remove selected category</string>
        </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+<property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/minus.png</normaloff>:/img/actions/minus.png</iconset>
+           </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
@@ -63,8 +63,11 @@ ComponentEditorWidget::ComponentEditorWidget(const Context& context,
   mUi->cbxSchematicOnly->setCheckable(!mContext.readOnly);
   mUi->edtPrefix->setReadOnly(mContext.readOnly);
   mUi->edtDefaultValue->setReadOnly(mContext.readOnly);
+  mUi->signalEditorWidget->setFrameStyle(QFrame::NoFrame);
   mUi->signalEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->symbolVariantsEditorWidget->setFrameStyle(QFrame::NoFrame);
   mUi->symbolVariantsEditorWidget->setReadOnly(mContext.readOnly);
+  mUi->attributesEditorWidget->setFrameStyle(QFrame::NoFrame);
   mUi->attributesEditorWidget->setReadOnly(mContext.readOnly);
   setupErrorNotificationWidget(*mUi->errorNotificationWidget);
   setWindowIcon(QIcon(":/img/library/component.png"));

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
@@ -78,16 +78,16 @@
            <number>0</number>
           </property>
           <property name="leftMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="topMargin">
-           <number>6</number>
+           <number>0</number>
           </property>
           <property name="rightMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="bottomMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <item>
            <widget class="librepcb::editor::ComponentSignalListEditorWidget" name="signalEditorWidget" native="true"/>
@@ -105,16 +105,16 @@
            <number>0</number>
           </property>
           <property name="leftMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="topMargin">
-           <number>6</number>
+           <number>0</number>
           </property>
           <property name="rightMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="bottomMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <item>
            <widget class="librepcb::editor::ComponentSymbolVariantListWidget" name="symbolVariantsEditorWidget" native="true"/>
@@ -132,16 +132,16 @@
            <number>0</number>
           </property>
           <property name="leftMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="topMargin">
-           <number>6</number>
+           <number>0</number>
           </property>
           <property name="rightMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <property name="bottomMargin">
-           <number>3</number>
+           <number>0</number>
           </property>
           <item>
            <widget class="librepcb::editor::AttributeListEditorWidget" name="attributesEditorWidget" native="true"/>

--- a/libs/librepcb/editor/library/cmp/componentsignallisteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsignallisteditorwidget.cpp
@@ -77,6 +77,10 @@ ComponentSignalListEditorWidget::~ComponentSignalListEditorWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void ComponentSignalListEditorWidget::setFrameStyle(int style) noexcept {
+  mView->setFrameStyle(style);
+}
+
 void ComponentSignalListEditorWidget::setReadOnly(bool readOnly) noexcept {
   mView->setReadOnly(readOnly);
 }

--- a/libs/librepcb/editor/library/cmp/componentsignallisteditorwidget.h
+++ b/libs/librepcb/editor/library/cmp/componentsignallisteditorwidget.h
@@ -57,6 +57,7 @@ public:
   ~ComponentSignalListEditorWidget() noexcept;
 
   // Setters
+  void setFrameStyle(int style) noexcept;
   void setReadOnly(bool readOnly) noexcept;
   void setReferences(UndoStack* undoStack, ComponentSignalList* list) noexcept;
 

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.cpp
@@ -92,6 +92,10 @@ ComponentSymbolVariantListWidget::~ComponentSymbolVariantListWidget() noexcept {
  *  Setters
  ******************************************************************************/
 
+void ComponentSymbolVariantListWidget::setFrameStyle(int style) noexcept {
+  mView->setFrameStyle(style);
+}
+
 void ComponentSymbolVariantListWidget::setReadOnly(bool readOnly) noexcept {
   mView->setReadOnly(readOnly);
 }

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.h
@@ -58,6 +58,7 @@ public:
   ~ComponentSymbolVariantListWidget() noexcept;
 
   // Setters
+  void setFrameStyle(int style) noexcept;
   void setReadOnly(bool readOnly) noexcept;
   void setReferences(
       UndoStack* undoStack, ComponentSymbolVariantList* list,

--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.ui
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.ui
@@ -324,18 +324,6 @@
        </property>
        <item row="0" column="0" colspan="2">
         <widget class="QPushButton" name="btnIcon">
-         <property name="minimumSize">
-          <size>
-           <width>300</width>
-           <height>140</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>128</height>
-          </size>
-         </property>
          <property name="cursor">
           <cursorShape>PointingHandCursor</cursorShape>
          </property>
@@ -347,8 +335,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>128</width>
-           <height>128</height>
+           <width>64</width>
+           <height>64</height>
           </size>
          </property>
          <property name="flat">
@@ -356,28 +344,21 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="2">
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Name:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="1" column="1">
         <widget class="QLineEdit" name="edtName">
          <property name="maxLength">
           <number>50</number>
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Description:</string>
@@ -387,91 +368,91 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="1">
         <widget class="librepcb::editor::PlainTextEdit" name="edtDescription">
          <property name="tabChangesFocus">
           <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Keywords:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QLineEdit" name="edtKeywords">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Author:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="edtAuthor">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Version:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="5" column="1">
         <widget class="QLineEdit" name="edtVersion">
          <property name="maxLength">
           <number>100</number>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Deprecated:</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="6" column="1">
         <widget class="QCheckBox" name="cbxDeprecated">
          <property name="text">
           <string>Library should no longer be used.</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="0" colspan="2">
+       <item row="7" column="0" colspan="2">
         <widget class="Line" name="line_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>URL:</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="8" column="1">
         <widget class="QLineEdit" name="edtUrl">
          <property name="maxLength">
           <number>255</number>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="lblDependencies">
          <property name="text">
           <string>Dependencies:</string>
@@ -481,14 +462,31 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0" colspan="2">
+       <item row="10" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>Manufacturer:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QLineEdit" name="edtManufacturer">
+         <property name="toolTip">
+          <string>Manufacturer name, in case the library refers to a single manufacturer.</string>
+         </property>
+         <property name="maxLength">
+          <number>255</number>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
         <widget class="Line" name="line_3">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Messages:</string>
@@ -498,30 +496,13 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="12" column="1">
         <widget class="librepcb::editor::RuleCheckListWidget" name="lstMessages" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>1</verstretch>
           </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="text">
-          <string>Manufacturer:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QLineEdit" name="edtManufacturer">
-         <property name="toolTip">
-          <string>Manufacturer name, in case the library refers to a single manufacturer.</string>
-         </property>
-         <property name="maxLength">
-          <number>255</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Slightly polish the library editor UI to reduce the required minimum window height.

Closes #1056.