### PR TITLE
Improve stacking order of graphics items

### DIFF
--- a/libs/librepcb/editor/graphics/circlegraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/circlegraphicsitem.cpp
@@ -49,6 +49,7 @@ CircleGraphicsItem::CircleGraphicsItem(Circle& circle,
   setLineWidth(mCircle.getLineWidth());
   setLineLayer(mLayerProvider.getLayer(mCircle.getLayer()));
   updateFillLayer();
+  updateZValue();
   setFlag(QGraphicsItem::ItemIsSelectable, true);
 
   // register to the circle to get attribute updates
@@ -75,6 +76,7 @@ void CircleGraphicsItem::circleEdited(const Circle& circle,
     case Circle::Event::IsFilledChanged:
     case Circle::Event::IsGrabAreaChanged:
       updateFillLayer();
+      updateZValue();
       break;
     case Circle::Event::CenterChanged:
       setPosition(circle.getCenter());
@@ -97,6 +99,17 @@ void CircleGraphicsItem::updateFillLayer() noexcept {
     setFillLayer(mLayerProvider.getGrabAreaLayer(mCircle.getLayer()));
   } else {
     setFillLayer(nullptr);
+  }
+}
+
+void CircleGraphicsItem::updateZValue() noexcept {
+  // Fix for https://github.com/LibrePCB/LibrePCB/issues/1278.
+  if (mCircle.isFilled()) {
+    setZValue(0);
+  } else if (mCircle.isGrabArea()) {
+    setZValue(-1);
+  } else {
+    setZValue(1);
   }
 }
 

--- a/libs/librepcb/editor/graphics/circlegraphicsitem.h
+++ b/libs/librepcb/editor/graphics/circlegraphicsitem.h
@@ -63,6 +63,7 @@ public:
 private:  // Methods
   void circleEdited(const Circle& circle, Circle::Event event) noexcept;
   void updateFillLayer() noexcept;
+  void updateZValue() noexcept;
 
 private:  // Data
   Circle& mCircle;

--- a/libs/librepcb/editor/graphics/polygongraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/polygongraphicsitem.cpp
@@ -53,6 +53,7 @@ PolygonGraphicsItem::PolygonGraphicsItem(Polygon& polygon,
   setLineLayer(mLayerProvider.getLayer(mPolygon.getLayer()));
   updatePath();
   updateFillLayer();
+  updateZValue();
   setFlag(QGraphicsItem::ItemIsSelectable, true);
 
   // register to the polygon to get attribute updates
@@ -175,6 +176,7 @@ void PolygonGraphicsItem::polygonEdited(const Polygon& polygon,
     case Polygon::Event::IsFilledChanged:
     case Polygon::Event::IsGrabAreaChanged:
       updateFillLayer();
+      updateZValue();
       break;
     case Polygon::Event::PathChanged:
       updatePath();
@@ -216,6 +218,17 @@ void PolygonGraphicsItem::updatePath() noexcept {
   }
   setPath(mPolygon.getPathForRendering().toQPainterPathPx());
   updateBoundingRectMargin();
+}
+
+void PolygonGraphicsItem::updateZValue() noexcept {
+  // Fix for https://github.com/LibrePCB/LibrePCB/issues/1278.
+  if (mPolygon.isFilled()) {
+    setZValue(0);
+  } else if (mPolygon.isGrabArea()) {
+    setZValue(-1);
+  } else {
+    setZValue(1);
+  }
 }
 
 void PolygonGraphicsItem::updateBoundingRectMargin() noexcept {

--- a/libs/librepcb/editor/graphics/polygongraphicsitem.h
+++ b/libs/librepcb/editor/graphics/polygongraphicsitem.h
@@ -98,6 +98,7 @@ private:  // Methods
   void polygonEdited(const Polygon& polygon, Polygon::Event event) noexcept;
   void updateFillLayer() noexcept;
   void updatePath() noexcept;
+  void updateZValue() noexcept;
   void updateBoundingRectMargin() noexcept;
 
 private:  // Data

--- a/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
@@ -157,17 +157,17 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
   //     0: holes
   //    10: pads tht
   //    20: texts board layer
-  //    30: polygons/circles board layer
+  //    30: polygons/circles board layer (±1 for stacking order)
   //   110: pads top
   //   120: texts top
-  //   130: polygons/circles top
+  //   130: polygons/circles top (±1 for stacking order)
   //   140: zones top
   //   220: texts inner
-  //   230: polygons/circles inner
+  //   230: polygons/circles inner (±1 for stacking order)
   //   240: zones inner
   //   310: pads bottom
   //   320: texts bottom
-  //   330: polygons/circles bottom
+  //   330: polygons/circles bottom (±1 for stacking order)
   //   340: zones bottom
   //
   // So the system is:
@@ -236,16 +236,20 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
 
   if (flags.testFlag(FindFlag::Circles)) {
     foreach (auto ptr, mCircleGraphicsItems) {
-      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr),
-                  30 + priorityFromLayer(ptr->getCircle().getLayer()),
+      int priority = 30 + priorityFromLayer(ptr->getCircle().getLayer());
+      if (ptr->zValue() > 0) priority -= 1;
+      if (ptr->zValue() < 0) priority += 1;
+      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
                   true);  // Probably large grab area makes sense?
     }
   }
 
   if (flags.testFlag(FindFlag::Polygons)) {
     foreach (auto ptr, mPolygonGraphicsItems) {
-      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr),
-                  30 + priorityFromLayer(ptr->getPolygon().getLayer()),
+      int priority = 30 + priorityFromLayer(ptr->getPolygon().getLayer());
+      if (ptr->zValue() > 0) priority -= 1;
+      if (ptr->zValue() < 0) priority += 1;
+      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
                   true);  // Probably large grab area makes sense?
     }
   }

--- a/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
@@ -129,7 +129,7 @@ QList<std::shared_ptr<QGraphicsItem>> SymbolGraphicsItem::findItemsAtPos(
   //
   //    0: pins
   //   10: texts
-  //   20: circles/polygons
+  //   20: circles/polygons (±1 for stacking order)
   //
   // And for items not directly under the cursor, but very close to the cursor,
   // add +1000.
@@ -164,14 +164,20 @@ QList<std::shared_ptr<QGraphicsItem>> SymbolGraphicsItem::findItemsAtPos(
 
   if (flags.testFlag(FindFlag::Circles)) {
     foreach (auto ptr, mCircleGraphicsItems) {
-      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 20,
+      int priority = 20;
+      if (ptr->zValue() > 0) priority -= 1;
+      if (ptr->zValue() < 0) priority += 1;
+      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
                   true);  // Probably large grab area makes sense?
     }
   }
 
   if (flags.testFlag(FindFlag::Polygons)) {
     foreach (auto ptr, mPolygonGraphicsItems) {
-      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), 20,
+      int priority = 20;
+      if (ptr->zValue() > 0) priority -= 1;
+      if (ptr->zValue() < 0) priority += 1;
+      processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
                   true);  // Probably large grab area makes sense?
     }
   }

--- a/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbol.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/graphicsitems/sgi_symbol.cpp
@@ -63,37 +63,31 @@ SGI_Symbol::SGI_Symbol(SI_Symbol& symbol,
       lp.getLayer(Theme::Color::sSchematicReferences));
   mShape.addRect(mOriginCrossGraphicsItem->boundingRect());
 
-  // Draw grab areas first to make them appearing behind every other graphics
-  // item. Otherwise they might completely cover (hide) other items.
-  for (bool grabArea : {true, false}) {
-    for (const auto& obj : mSymbol.getLibSymbol().getCircles()) {
-      if (obj.isGrabArea() != grabArea) continue;
-      auto i = std::make_shared<CircleGraphicsItem>(const_cast<Circle&>(obj),
-                                                    lp, this);
-      i->setFlag(QGraphicsItem::ItemIsSelectable, true);
-      i->setFlag(QGraphicsItem::ItemStacksBehindParent, true);
-      if (obj.isGrabArea()) {
-        const qreal r = (obj.getDiameter() + obj.getLineWidth())->toPx() / 2;
-        QPainterPath path;
-        path.addEllipse(obj.getCenter().toPxQPointF(), r, r);
-        mShape |= path;
-      }
-      mCircleGraphicsItems.append(i);
+  for (const auto& obj : mSymbol.getLibSymbol().getCircles()) {
+    auto i = std::make_shared<CircleGraphicsItem>(const_cast<Circle&>(obj), lp,
+                                                  this);
+    i->setFlag(QGraphicsItem::ItemIsSelectable, true);
+    i->setFlag(QGraphicsItem::ItemStacksBehindParent, true);
+    if (obj.isGrabArea()) {
+      const qreal r = (obj.getDiameter() + obj.getLineWidth())->toPx() / 2;
+      QPainterPath path;
+      path.addEllipse(obj.getCenter().toPxQPointF(), r, r);
+      mShape |= path;
     }
+    mCircleGraphicsItems.append(i);
+  }
 
-    for (const auto& obj : mSymbol.getLibSymbol().getPolygons()) {
-      if (obj.isGrabArea() != grabArea) continue;
-      auto i = std::make_shared<PolygonGraphicsItem>(const_cast<Polygon&>(obj),
-                                                     lp, this);
-      i->setFlag(QGraphicsItem::ItemIsSelectable, true);
-      i->setFlag(QGraphicsItem::ItemStacksBehindParent, true);
-      if (obj.isGrabArea()) {
-        mShape |= Toolbox::shapeFromPath(obj.getPath().toQPainterPathPx(),
-                                         Qt::SolidLine, Qt::SolidPattern,
-                                         obj.getLineWidth());
-      }
-      mPolygonGraphicsItems.append(i);
+  for (const auto& obj : mSymbol.getLibSymbol().getPolygons()) {
+    auto i = std::make_shared<PolygonGraphicsItem>(const_cast<Polygon&>(obj),
+                                                   lp, this);
+    i->setFlag(QGraphicsItem::ItemIsSelectable, true);
+    i->setFlag(QGraphicsItem::ItemStacksBehindParent, true);
+    if (obj.isGrabArea()) {
+      mShape |= Toolbox::shapeFromPath(obj.getPath().toQPainterPathPx(),
+                                       Qt::SolidLine, Qt::SolidPattern,
+                                       obj.getLineWidth());
     }
+    mPolygonGraphicsItems.append(i);
   }
 
   updatePosition();


### PR DESCRIPTION
Always paint grab area polygons/circles in background and pure outlines (not filled or grab area) in foreground to avoid hiding lines behind filled graphics items.

Fixes #1278.