### PR TITLE
Package check: Warn about invalid pad connections

### DIFF
--- a/libs/librepcb/core/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheck.cpp
@@ -58,6 +58,7 @@ RuleCheckMessageList PackageCheck::runChecks() const {
   checkWrongTextLayers(msgs);
   checkPackageOutlines(msgs);
   checkCourtyards(msgs);
+  checkPadsPackagePadUuid(msgs);
   checkPadsClearanceToPads(msgs);
   checkPadsClearanceToLegend(msgs);
   checkPadsAnnularRing(msgs);
@@ -187,6 +188,21 @@ void PackageCheck::checkCourtyards(MsgList& msgs) const {
       }
       if (count == 0) {
         msgs.append(std::make_shared<MsgMissingCourtyard>(itFtp.ptr()));
+      }
+    }
+  }
+}
+
+void PackageCheck::checkPadsPackagePadUuid(MsgList& msgs) const {
+  for (auto itFtp = mPackage.getFootprints().begin();
+       itFtp != mPackage.getFootprints().end(); ++itFtp) {
+    std::shared_ptr<const Footprint> footprint = itFtp.ptr();
+    for (auto itPad = (*itFtp).getPads().begin();
+         itPad != (*itFtp).getPads().end(); ++itPad) {
+      std::shared_ptr<const FootprintPad> pad = itPad.ptr();
+      if ((pad->getPackagePadUuid()) &&
+          (!mPackage.getPads().find(*pad->getPackagePadUuid()))) {
+        msgs.append(std::make_shared<MsgInvalidPadConnection>(footprint, pad));
       }
     }
   }

--- a/libs/librepcb/core/library/pkg/packagecheck.h
+++ b/libs/librepcb/core/library/pkg/packagecheck.h
@@ -63,6 +63,7 @@ protected:  // Methods
   void checkWrongTextLayers(MsgList& msgs) const;
   void checkPackageOutlines(MsgList& msgs) const;
   void checkCourtyards(MsgList& msgs) const;
+  void checkPadsPackagePadUuid(MsgList& msgs) const;
   void checkPadsClearanceToPads(MsgList& msgs) const;
   void checkPadsClearanceToLegend(MsgList& msgs) const;
   void checkPadsAnnularRing(MsgList& msgs) const;

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
@@ -175,6 +175,29 @@ MsgInvalidCustomPadOutline::MsgInvalidCustomPadOutline(
 }
 
 /*******************************************************************************
+ *  MsgInvalidPadConnection
+ ******************************************************************************/
+
+MsgInvalidPadConnection::MsgInvalidPadConnection(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const FootprintPad> pad) noexcept
+  : RuleCheckMessage(
+        Severity::Error,
+        tr("Invalid pad connection in '%1'")
+            .arg(*footprint->getNames().getDefaultValue()),
+        tr("A footprint pad is connected to a package pad which doesn't exist. "
+           "Check all pads for proper connections."),
+        "invalid_pad_connection"),
+    mFootprint(footprint),
+    mPad(pad) {
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("footprint", footprint->getUuid());
+  mApproval.ensureLineBreak();
+  mApproval.appendChild("pad", pad->getUuid());
+  mApproval.ensureLineBreak();
+}
+
+/*******************************************************************************
  *  MsgMissingCourtyard
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.h
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.h
@@ -223,6 +223,36 @@ private:
 };
 
 /*******************************************************************************
+ *  Class MsgInvalidPadConnection
+ ******************************************************************************/
+
+/**
+ * @brief The MsgInvalidPadConnection class
+ */
+class MsgInvalidPadConnection final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgInvalidPadConnection)
+
+public:
+  // Constructors / Destructor
+  MsgInvalidPadConnection() = delete;
+  MsgInvalidPadConnection(std::shared_ptr<const Footprint> footprint,
+                          std::shared_ptr<const FootprintPad> pad) noexcept;
+  MsgInvalidPadConnection(const MsgInvalidPadConnection& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint), mPad(other.mPad) {}
+  virtual ~MsgInvalidPadConnection() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const FootprintPad> getPad() const noexcept { return mPad; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
  *  Class MsgMissingCourtyard
  ******************************************************************************/
 


### PR DESCRIPTION
I saw the situation where some footprint pads have been assigned to package pad UUIDs which actually didn't exist, but the package editor didn't warn about this situation. Now an error is shown in that case.