### PR TITLE
3D Viewer: Improve behavior of zoom/pan/rotate

### DIFF
--- a/libs/librepcb/editor/widgets/openglview.h
+++ b/libs/librepcb/editor/widgets/openglview.h
@@ -74,32 +74,48 @@ protected:
   void mousePressEvent(QMouseEvent* e) override;
   void mouseMoveEvent(QMouseEvent* e) override;
   void wheelEvent(QWheelEvent* e) override;
-  void smoothTo(const QMatrix4x4& transform) noexcept;
+  void smoothTo(qreal fov, const QPointF& center,
+                const QMatrix4x4& transform) noexcept;
   void initializeGL() override;
   void resizeGL(int w, int h) override;
   void paintGL() override;
+
+private:
+  void zoom(const QPoint& center, qreal factor) noexcept;
+  QPointF toNormalizedPos(const QPoint& pos) const noexcept;
+  QPointF toModelPos(const QPointF& pos) const noexcept;
 
 private:
   QScopedPointer<QVBoxLayout> mLayout;
   QScopedPointer<QLabel> mErrorLabel;
   bool mInitialized;
   QOpenGLShaderProgram mProgram;
-  QMatrix4x4 mProjection;
+  qreal mProjectionAspectRatio;
+  qreal mProjectionFov;
+  QPointF mProjectionCenter;
   QMatrix4x4 mTransform;
+  QPoint mMousePressPosition;
   QMatrix4x4 mMousePressTransform;
-  QVector2D mMousePressPosition;
+  QPointF mMousePressCenter;
   qint64 mIdleTimeMs;
   QScopedPointer<WaitingSpinnerWidget> mWaitingSpinner;
 
   // Transform Animation
-  QMatrix4x4 mAnimationTransformStart;
-  QMatrix4x4 mAnimationTransformDelta;
+  struct TransformData {
+    qreal fov;
+    QPointF center;
+    QMatrix4x4 transform;
+  };
+  TransformData mAnimationDataStart;
+  TransformData mAnimationDataDelta;
   QScopedPointer<QVariantAnimation> mAnimation;
 
   // Content
   QVector<std::shared_ptr<OpenGlObject>> mObjects;
 
   // Static Variables
+  static constexpr qreal sCameraPosZ = 5.0;
+  static constexpr qreal sInitialFov = 15.0;
   static constexpr qreal sZoomStepFactor = 1.3;
 };
 


### PR DESCRIPTION
Heavily improve the behavior of zoom/pan/rotate in the 3D viewers, which is now **way** more intuitive:

- While panning, *exactly* keep the grabbed position below the cursor (no slip anymore).
- Zoom exactly to the point below the cursor (instead of PCB center).
- Implement zoom by modifying camera FOV angle instead of camera Z-position to avoid collision with surfaces at high zoom levels (no longer possible to look into a PCB).
- Allow rotating around Z-axis by pressing Shift.

The original idea of rotating around the point which is in the center of the screen is not implemented unfortunately because I didn't find a working solution - allowing arbitrary rotation centers would break the constant camera Z-position, probably leading to strange/non-deterministic behavior of the view (depending on all previous rotations). Thus the rotation center is kept at the PCB center for now.

![librepcb-3d](https://github.com/LibrePCB/LibrePCB/assets/5374821/0fc94889-1b25-435e-8e71-6920f6caf02d)

Fixes #1262