### PR TITLE
"New Project"-wizard: Allow modifying project directory & filename

### DIFF
--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.h
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.h
@@ -70,7 +70,7 @@ public:
   ~NewProjectWizard() noexcept;
 
   // Setters
-  void setLocation(const FilePath& dir) noexcept;
+  void setLocationOverride(const FilePath& dir) noexcept;
 
   // General Methods
   std::unique_ptr<Project> createProject() const;

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizard.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>650</width>
+    <width>750</width>
     <height>370</height>
    </rect>
   </property>

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.h
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.h
@@ -61,14 +61,14 @@ public:
 
   // Setters
   void setProjectName(const QString& name) noexcept;
-  void setDefaultLocation(const FilePath& dir) noexcept;
+  void setLocationOverride(const FilePath& dir) noexcept;
 
   // Getters
   QString getProjectName() const noexcept;
   QString getProjectAuthor() const noexcept;
   bool isLicenseSet() const noexcept;
   FilePath getProjectLicenseFilePath() const noexcept;
-  FilePath getFullFilePath() const noexcept;
+  FilePath getFullFilePath() const noexcept { return mFullFilePath; }
 
   // Operator Overloadings
   NewProjectWizardPage_Metadata& operator=(
@@ -76,17 +76,19 @@ public:
 
 private:  // GUI Action Handlers
   void nameChanged(const QString& name) noexcept;
-  void locationChanged(const QString& dir) noexcept;
+  void pathChanged(const QString& fp) noexcept;
   void chooseLocationClicked() noexcept;
 
 private:  // Methods
-  void updateProjectFilePath() noexcept;
   bool isComplete() const noexcept override;
   bool validatePage() noexcept override;
+  void setStatusMessage(const QString& msg) const noexcept;
 
 private:  // Data
   const Workspace& mWorkspace;
   QScopedPointer<Ui::NewProjectWizardPage_Metadata> mUi;
+  FilePath mLocation;
+  bool mLocationOverridden;
   FilePath mFullFilePath;
 };
 

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_metadata.ui
@@ -67,80 +67,6 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Location:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Full Path:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QLabel" name="lblFullFilePath">
-     <property name="font">
-      <font>
-       <italic>true</italic>
-      </font>
-     </property>
-     <property name="text">
-      <string notr="true">-</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="minimumSize">
-      <size>
-       <width>32</width>
-       <height>32</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>32</width>
-       <height>32</height>
-      </size>
-     </property>
-     <property name="pixmap">
-      <pixmap>:/img/status/info.png</pixmap>
-     </property>
-     <property name="scaledContents">
-      <bool>true</bool>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>A LibrePCB project consists of a whole directory, not only of a single file. Just select the new project's parent directory, and the subdirectory and filename will be set automatically.</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <property name="spacing">
@@ -180,8 +106,66 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="edtLocation"/>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Path:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="edtPath"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="label_9">
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>A LibrePCB project consists of a whole directory, not only of a single file. Just select the new project's parent directory, and the subdirectory and filename will be appended automatically.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="lblStatus">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -462,15 +462,13 @@ void ControlPanel::showProjectReadmeInBrowser(
 
 ProjectEditor* ControlPanel::newProject(bool eagleImport,
                                         FilePath parentDir) noexcept {
-  if (!parentDir.isValid()) {
-    parentDir = mWorkspace.getProjectsPath();
-  }
-
   const NewProjectWizard::Mode mode = eagleImport
       ? NewProjectWizard::Mode::EagleImport
       : NewProjectWizard::Mode::NewProject;
   NewProjectWizard wizard(mWorkspace, mode, this);
-  wizard.setLocation(parentDir);
+  if (parentDir.isValid()) {
+    wizard.setLocationOverride(parentDir);
+  }
   if (wizard.exec() == QWizard::Accepted) {
     try {
       std::unique_ptr<Project> project = wizard.createProject();  // can throw

--- a/tests/funq/aliases
+++ b/tests/funq/aliases
@@ -57,7 +57,7 @@ controlPanelNewProjectWizardFinishButton = {controlPanelNewProjectWizardWidget}:
 controlPanelNewProjectWizardFrame = {controlPanelNewProjectWizardWidget}::QFrame
 controlPanelNewProjectWizardMetadataPage = {controlPanelNewProjectWizardFrame}::librepcb__editor__NewProjectWizardPage_Metadata
 controlPanelNewProjectWizardMetadataNameEdit = {controlPanelNewProjectWizardMetadataPage}::edtName
-controlPanelNewProjectWizardMetadataPathLabel = {controlPanelNewProjectWizardMetadataPage}::lblFullFilePath
+controlPanelNewProjectWizardMetadataPathEdit = {controlPanelNewProjectWizardMetadataPage}::edtPath
 
 # Workspace settings dialog
 controlPanelWorkspaceSettingsDialog = librepcb__editor__WorkspaceSettingsDialog

--- a/tests/funq/controlpanel/test_create_project.py
+++ b/tests/funq/controlpanel/test_create_project.py
@@ -19,7 +19,7 @@ def test_new_project_wizard(librepcb):
         # Enter metadata
         name = 'New Project'
         app.widget('controlPanelNewProjectWizardMetadataNameEdit').set_property('text', name)
-        path = app.widget('controlPanelNewProjectWizardMetadataPathLabel').properties()['text']
+        path = app.widget('controlPanelNewProjectWizardMetadataPathEdit').properties()['text']
         app.widget('controlPanelNewProjectWizardNextButton').click()
         # Setup schematic/board
         app.widget('controlPanelNewProjectWizardFinishButton').click()


### PR DESCRIPTION
Support changing the filename and directory name when creating a new project. This also allows to create a project within an already existing, empty directory.

![librepcb-new-project](https://github.com/LibrePCB/LibrePCB/assets/5374821/5dc4a749-0c5a-45ed-8a78-2a30333a9f68)

In addition, memorize and restore the window size of the wizard and the entered project file location for convenience.

Fixes #1029