### PR TITLE
Graphics output job: Add support for realistic PCB rendering

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -359,6 +359,8 @@ add_library(
   project/board/items/bi_via.h
   project/board/items/bi_zone.cpp
   project/board/items/bi_zone.h
+  project/board/realisticboardpainter.cpp
+  project/board/realisticboardpainter.h
   project/bomgenerator.cpp
   project/bomgenerator.h
   project/circuit/assemblyvariant.cpp

--- a/libs/librepcb/core/job/graphicsoutputjob.h
+++ b/libs/librepcb/core/job/graphicsoutputjob.h
@@ -90,7 +90,8 @@ public:
     AssemblyVariantSet assemblyVariants;
 
     // Arbitrary options for forward compatibility in case we really need to
-    // add new settings in a minor release.
+    // add new settings in a minor release. Supported options:
+    //  - realistic: If present, render boards in realistic mode
     QMap<QString, QList<SExpression>> options;
 
     Content(Preset preset) noexcept

--- a/libs/librepcb/core/project/board/realisticboardpainter.cpp
+++ b/libs/librepcb/core/project/board/realisticboardpainter.cpp
@@ -1,0 +1,213 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "realisticboardpainter.h"
+
+#include "../../3d/scenedata3d.h"
+#include "../../types/pcbcolor.h"
+#include "../../utils/clipperhelpers.h"
+#include "../../utils/transform.h"
+
+#include <QtCore>
+#include <QtGui>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+RealisticBoardPainter::RealisticBoardPainter(std::shared_ptr<SceneData3D> data)
+  : GraphicsPagePainter(),
+    mMaxArcTolerance(5000),
+    mData(data),
+    mDrawSolderPaste(false),
+    mDataPreprocessed(false) {
+  Q_ASSERT(data);
+}
+
+RealisticBoardPainter::~RealisticBoardPainter() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void RealisticBoardPainter::paint(
+    QPainter& painter, const GraphicsExportSettings& settings) const noexcept {
+  const Content& content = getContent(settings.getMirror());
+
+  painter.setPen(Qt::NoPen);
+
+  // Body.
+  painter.setBrush(QColor(70, 80, 70));
+  painter.drawPath(content.body);
+
+  // Copper.
+  painter.setBrush(QColor(188, 156, 105));
+  painter.drawPath(content.copper);
+
+  // Solder resist.
+  if (auto color = mData->getSolderResist()) {
+    painter.setBrush(color->toSolderResistColor());
+    painter.drawPath(content.solderResist);
+  }
+
+  // Silkscreen.
+  if (auto color = mData->getSilkscreen()) {
+    painter.setBrush(color->toSilkscreenColor());
+    painter.drawPath(content.silkscreen);
+  }
+
+  // Solder paste.
+  if (mDrawSolderPaste) {
+    painter.setBrush(Qt::darkGray);
+    painter.drawPath(content.solderPaste);
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+const RealisticBoardPainter::Content& RealisticBoardPainter::getContent(
+    bool mirrored) const noexcept {
+  QMutexLocker lock(&mMutex);
+  RealisticBoardPainter::Content& content =
+      mirrored ? mContentBot : mContentTop;
+
+  try {
+    if (!mDataPreprocessed) {
+      mData->preprocess(false);
+    }
+
+    if (!content.initialized) {
+      const Transform transform(Point(), Angle(), mirrored);
+
+      auto getPaths = [this](const QStringList layers) {
+        ClipperLib::Paths paths;
+        foreach (const auto& area, mData->getAreas()) {
+          if (layers.contains(area.layer->getId())) {
+            paths.push_back(
+                ClipperHelpers::convert(area.outline, mMaxArcTolerance));
+          }
+        }
+        return paths;
+      };
+
+      auto toPainterPath = [](const ClipperLib::Paths& paths) {
+        QPainterPath p;
+        p.setFillRule(Qt::OddEvenFill);
+        foreach (const auto& path, paths) {
+          p.addPath(ClipperHelpers::convert(path).toQPainterPathPx());
+        }
+        return p;
+      };
+
+      // Holes/cutouts.
+      QStringList layers = {Layer::boardCutouts().getId(),
+                            Layer::boardPlatedCutouts().getId()};
+      ClipperLib::Paths holes = getPaths(layers);
+      ClipperLib::Paths copperHoles;
+      for (auto& hole : mData->getHoles()) {
+        const auto paths = ClipperHelpers::convert(
+            hole.path->toOutlineStrokes(hole.diameter), mMaxArcTolerance);
+        if (hole.copperLayer && (hole.copperLayer->isBottom() == mirrored)) {
+          copperHoles.insert(copperHoles.end(), paths.begin(), paths.end());
+        } else {
+          holes.insert(holes.end(), paths.begin(), paths.end());
+        }
+      }
+      ClipperHelpers::unite(holes, {}, ClipperLib::pftNonZero,
+                            ClipperLib::pftNonZero);
+
+      // Board body.
+      layers = QStringList{Layer::boardOutlines().getId()};
+      ClipperLib::Paths boardOutlines = getPaths(layers);
+      ClipperLib::Paths boardArea = boardOutlines;
+      ClipperHelpers::subtract(boardArea, holes, ClipperLib::pftNonZero,
+                               ClipperLib::pftNonZero);
+      content.body = toPainterPath(boardArea);
+
+      // Copper.
+      layers = QStringList{transform.map(Layer::topCopper()).getId()};
+      ClipperLib::Paths paths = boardArea;
+      if (!copperHoles.empty()) {
+        ClipperHelpers::subtract(paths, copperHoles, ClipperLib::pftEvenOdd,
+                                 ClipperLib::pftNonZero);
+      }
+      ClipperHelpers::intersect(paths, getPaths(layers), ClipperLib::pftEvenOdd,
+                                ClipperLib::pftNonZero);
+      content.copper = toPainterPath(paths);
+
+      // Solder resist.
+      ClipperLib::Paths solderResist;
+      if (mData->getSolderResist()) {
+        layers = QStringList{transform.map(Layer::topStopMask()).getId(),
+                             Layer::boardCutouts().getId(),
+                             Layer::boardPlatedCutouts().getId()};
+        solderResist = boardOutlines;
+        ClipperHelpers::subtract(solderResist, getPaths(layers),
+                                 ClipperLib::pftEvenOdd,
+                                 ClipperLib::pftNonZero);
+        content.solderResist = toPainterPath(solderResist);
+      }
+
+      // Silkscreen.
+      if (mData->getSilkscreen()) {
+        layers = QStringList();
+        foreach (const Layer* layer,
+                 mirrored ? mData->getSilkscreenLayersBot()
+                          : mData->getSilkscreenLayersTop()) {
+          layers.append(layer->getId());
+        }
+        paths = getPaths(layers);
+        ClipperHelpers::intersect(paths, solderResist, ClipperLib::pftNonZero,
+                                  ClipperLib::pftEvenOdd);
+        content.silkscreen = toPainterPath(paths);
+      }
+
+      // Solder paste.
+      if (mDrawSolderPaste) {
+        layers = QStringList{transform.map(Layer::topSolderPaste()).getId()};
+        paths = getPaths(layers);
+        ClipperHelpers::intersect(paths, boardArea, ClipperLib::pftNonZero,
+                                  ClipperLib::pftEvenOdd);
+        content.solderPaste = toPainterPath(paths);
+      }
+
+      content.initialized = true;
+    }
+  } catch (const Exception& e) {
+    qCritical() << "Failed to export realistic board graphics:" << e.getMsg();
+  }
+  return content;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/project/board/realisticboardpainter.h
+++ b/libs/librepcb/core/project/board/realisticboardpainter.h
@@ -1,0 +1,105 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_REALISTICBOARDPAINTER_H
+#define LIBREPCB_CORE_REALISTICBOARDPAINTER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../export/graphicsexport.h"
+
+#include <QtCore>
+#include <QtGui>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class SceneData3D;
+
+/*******************************************************************************
+ *  Class RealisticBoardPainter
+ ******************************************************************************/
+
+/**
+ * @brief Paints a ::librepcb::Board in realistic mode to a QPainter
+ *
+ * Similar to ::librepcb::BoardPainter, but rendering physical layers instead
+ * of logical layers, i.e. the output will be a realistic PCB with gray
+ * body, golden copper, (typically) green solder resist and (typically)
+ * white silkscreen instead of just rendering all objects the same way as
+ * on screen.
+ *
+ * Used in conjuction with ::librepcb::GraphicsExport. Colors are obtained from
+ * ::librepcb::SceneData3D and whether the top or the bottom side is rendered
+ * is controlled by ::librepcb::GraphicsExportSettings::getMirror().
+ *
+ * @see ::librepcb::GraphicsPagePainter
+ * @see ::librepcb::GraphicsExport
+ * @see ::librepcb::SceneData3D
+ */
+class RealisticBoardPainter final : public GraphicsPagePainter {
+  struct Content {
+    bool initialized = false;
+    QPainterPath body;
+    QPainterPath copper;
+    QPainterPath solderResist;
+    QPainterPath silkscreen;
+    QPainterPath solderPaste;
+  };
+
+public:
+  // Constructors / Destructor
+  RealisticBoardPainter() = delete;
+  explicit RealisticBoardPainter(std::shared_ptr<SceneData3D> data);
+  RealisticBoardPainter(const RealisticBoardPainter& other) = delete;
+  ~RealisticBoardPainter() noexcept;
+
+  // General Methods
+  void paint(QPainter& painter,
+             const GraphicsExportSettings& settings) const noexcept override;
+
+  // Operator Overloadings
+  RealisticBoardPainter& operator=(const RealisticBoardPainter& rhs) = delete;
+
+private:  // Methods
+  const Content& getContent(bool mirrored) const noexcept;
+
+private:  // Data
+  const PositiveLength mMaxArcTolerance;
+  std::shared_ptr<SceneData3D> mData;
+  bool mDrawSolderPaste;
+
+  mutable QMutex mMutex;
+  mutable bool mDataPreprocessed;
+  mutable Content mContentTop;
+  mutable Content mContentBot;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/core/project/outputjobrunner.cpp
+++ b/libs/librepcb/core/project/outputjobrunner.cpp
@@ -50,6 +50,7 @@
 #include "board/boardgerberexport.h"
 #include "board/boardpainter.h"
 #include "board/boardpickplacegenerator.h"
+#include "board/realisticboardpainter.h"
 #include "bomgenerator.h"
 #include "circuit/circuit.h"
 #include "project.h"
@@ -184,8 +185,17 @@ GraphicsExport::Pages OutputJobRunner::buildPages(
       foreach (const Board* board, boards) {
         foreach (auto av, assemblyVariants) {
           Q_UNUSED(av);  // TODO
-          std::shared_ptr<GraphicsPagePainter> painter =
-              std::make_shared<BoardPainter>(*board);
+          std::shared_ptr<GraphicsPagePainter> painter;
+          // New option "realistic" was added after the v1.0.0 release, thus
+          // not officially supported in file format v1.0. Should probably be
+          // migrated to a new content type in file format v2, maybe with
+          // some configuration options.
+          if (content.options.contains("realistic")) {
+            painter = std::make_shared<RealisticBoardPainter>(
+                board->buildScene3D(tl::nullopt));
+          } else {
+            painter = std::make_shared<BoardPainter>(*board);
+          }
           pages.append(std::make_pair(painter, settings));
         }
       }


### PR DESCRIPTION
The graphics export (PDF/PNG/...) so far only supported to render boards the same way as on screen. This PR adds the option to render boards in a realistic mode, with proper clipping of objects to the board area etc. We'll need this feature on the LibrePCB Fab website to generate the preview pictures since our current solution of using a 3rd-party Python library has some problems.

Example output of this new feature:

![preview1](https://github.com/LibrePCB/LibrePCB/assets/5374821/559e72bf-a6e3-4891-a8d2-041b058fbf56) ![preview2](https://github.com/LibrePCB/LibrePCB/assets/5374821/79d9373a-e428-421c-9f9a-44939f19162e)

I didn't add this option to the GUI yet because the data structure needs to be changed a bit for file format v2 anyway, which can be done together then. If someone still wants to use it already, just add these S-Expression nodes to the desired output job in `project/jobs.lp`:

```scheme
  (content (type board) (title "Rendering Top")
   (paper auto) (orientation auto) (rotate false) (mirror false) (scale auto)
   (margins (left 10.0) (top 10.0) (right 10.0) (bottom 10.0))
   (dpi 600) (min_line_width 0.1) (monochrome false) (background "#00000000")
   (board default)
   (variant none)
   (option realistic)
  )
  (content (type board) (title "Rendering Bottom")
   (paper auto) (orientation auto) (rotate false) (mirror true) (scale auto)
   (margins (left 10.0) (top 10.0) (right 10.0) (bottom 10.0))
   (dpi 600) (min_line_width 0.1) (monochrome false) (background "#00000000")
   (board default)
   (variant none)
   (option realistic)
  )
```