### PR TITLE
Control Panel: Support delete shortcut in projects tree

### DIFF
--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -113,6 +113,7 @@ private:
   void openLibraryManager() noexcept;
   void switchWorkspace() noexcept;
   void showProjectReadmeInBrowser(const FilePath& projectFilePath) noexcept;
+  void removeProjectsTreeItem(const FilePath& fp) noexcept;
 
   // Project Management
 


### PR DESCRIPTION
Support the *delete* keyboard shortcut in the projects tree view of the Control Panel to avoid needing the context menu for this very basic functionality.