### PR TITLE
Initialize new workspace with some example projects

### DIFF
--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -448,6 +448,15 @@ public:
 
   EditorCommandCategory categoryImportExport{
       "categoryImportExport", QT_TR_NOOP("Import/Export"), true, &categoryRoot};
+  EditorCommand addExampleProjects{
+      "add_example_projects",  // clang-format break
+      QT_TR_NOOP("Add Example Projects"),
+      QT_TR_NOOP("Add some example projects to the workspace"),
+      ":/img/logo/32x32.png",
+      EditorCommand::Flag::OpensPopup,
+      {},
+      nullptr,  // Exclude from shortcuts overview & configuration
+  };
   EditorCommand importDxf{
       "import_dxf",  // clang-format break
       QT_TR_NOOP("Import DXF"),

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -283,6 +283,8 @@ void ControlPanel::createActions() noexcept {
   mActionCloseAllProjects.reset(cmd.projectCloseAll.createAction(
       this, this, [this]() { closeAllProjects(true); },
       EditorCommand::ActionFlag::ApplicationShortcut));
+  mActionAddExampleProjects.reset(cmd.addExampleProjects.createAction(
+      this, this, &ControlPanel::addExampleProjects));
   mActionImportEagleProject.reset(cmd.importEagleProject.createAction(
       this, this, [this]() { newProject(true); }));
   mActionAboutLibrePcb.reset(cmd.aboutLibrePcb.createAction(
@@ -349,6 +351,7 @@ void ControlPanel::createMenus() noexcept {
   mb.addSeparator();
   {
     MenuBuilder smb(mb.addSubMenu(&MenuBuilder::createImportMenu));
+    smb.addAction(mActionAddExampleProjects);
     smb.addAction(mActionImportEagleProject);
   }
   mb.addSeparator();
@@ -441,6 +444,24 @@ void ControlPanel::openLibraryManager() noexcept {
   mLibraryManager->raise();
   mLibraryManager->activateWindow();
   mLibraryManager->updateOnlineLibraryList();
+}
+
+void ControlPanel::addExampleProjects() noexcept {
+  const QString msg =
+      tr("This downloads some example projects from the internet and copies "
+         "them into the workspace to help you evaluating LibrePCB with real "
+         "projects.") %
+      "\n\n" %
+      tr("Once you don't need them anymore, just delete the examples directory "
+         "to get rid of them.");
+  const int ret = QMessageBox::information(
+      this, EditorCommandSet::instance().addExampleProjects.getText(), msg,
+      QMessageBox::Ok | QMessageBox::Cancel);
+  if (ret == QMessageBox::Ok) {
+    InitializeWorkspaceWizardContext ctx(this);
+    ctx.setWorkspacePath(mWorkspace.getPath());
+    ctx.installExampleProjects();
+  }
 }
 
 void ControlPanel::switchWorkspace() noexcept {

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -111,6 +111,7 @@ private:
   void loadSettings();
   void updateDesktopIntegrationMessage() noexcept;
   void openLibraryManager() noexcept;
+  void addExampleProjects() noexcept;
   void switchWorkspace() noexcept;
   void showProjectReadmeInBrowser(const FilePath& projectFilePath) noexcept;
   void removeProjectsTreeItem(const FilePath& fp) noexcept;
@@ -221,6 +222,7 @@ private:
   QScopedPointer<QAction> mActionNewProject;
   QScopedPointer<QAction> mActionOpenProject;
   QScopedPointer<QAction> mActionCloseAllProjects;
+  QScopedPointer<QAction> mActionAddExampleProjects;
   QScopedPointer<QAction> mActionImportEagleProject;
   QScopedPointer<QAction> mActionAboutLibrePcb;
   QScopedPointer<QAction> mActionAboutQt;

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_choosesettings.ui
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard_choosesettings.ui
@@ -71,6 +71,12 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>250</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
         <string>This name will be used as author when creating new projects or libraries.</string>
        </property>

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizardcontext.h
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizardcontext.h
@@ -88,6 +88,7 @@ public:
 
   // General Methods
   void initializeEmptyWorkspace() const;
+  void installExampleProjects() const noexcept;
 
   // Operator Overloadings
   InitializeWorkspaceWizardContext& operator=(


### PR DESCRIPTION
So far, new workspaces didn't contain any projects after their initial creation so the Control Panel project tree was completely empty. However, as suggested in #1267 it would be useful to have some example projects available to help new users evaluating LibrePCB. Thus this PR implements this feature in two ways:

### Auto-Initialize New Workspaces

The initial idea was actually to provide a way to open example projects, for example through a menu item *File -> Open -> Example Project*. However, the question was where they will be opened from and if they are read-only or writable. Also the menu option might not be visible and convenient enough for new users to make them actually using this feature.

Now I decided to go with a different approach. When creating a new workspace, just automatically add some example projects in a subdirectory named "Examples" to the workspace. So the projects will immediately be shown in the Control Panel for new users, ready to be opened like normal projects (also writable!). One might argue that not everyone likes to have these example projects, but in the end it's very easy to just delete them and you only need to do this once. Also I remember EAGLE did it the same way and it never felt annoying to me.

The only question left was whether these example projects shall be bundled with the application or downloaded from the internet on demand. Since this feature is not really important (no problem if the download takes some time or even fails), I decided for the on-demand download to avoid bloating the application with example projects. We just should store them at some reliable, persistent URL.

### Manually Add Example Projects

To also allow adding the example projects to existing workspaces, the Control Panel contains a new menu item *File -> Import -> Add Example Projects* which initiates the download and installation of these projects asynchronously, exactly the same way as described above.

### Demo

![librepcb-example-projects](https://github.com/LibrePCB/LibrePCB/assets/5374821/beac1488-b298-46d0-860a-a45ddfafa854)

### ToDo

Decide which and how many example projects to install, and make sure to host them at a reliable location.

Closes #1267