### PR TITLE
Schematic editor: Display live parts information (prices etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ productive use, please install an official release as described in the
 
 ### Requirements
 
-To compile LibrePCB, you need the following software components:
+To compile and run LibrePCB, you need the following software components:
 
 - g++ >= 4.8, MinGW >= 4.8, or Clang >= 3.3 (C++11 support is required)
-- [Qt](http://www.qt.io/download-open-source/) >= 5.5
+- [Qt](http://www.qt.io/download-open-source/) >= 5.5 (make sure the
+  [imageformats](https://doc.qt.io/qt-5/qtimageformats-index.html) plugin
+  is installed too as it will be needed at runtime!).
 - [OpenCASCADE](https://www.opencascade.com/) OCCT or OCE (optional)
 - [OpenGL Utility Library](https://en.wikipedia.org/wiki/OpenGL_Utility_Library)
   GLU (optional)
@@ -75,7 +77,7 @@ actually used for CI, but are also useful to build LibrePCB locally.
 sudo apt-get install build-essential git cmake openssl zlib1g zlib1g-dev \
      qtbase5-dev qtdeclarative5-dev qttools5-dev-tools qttools5-dev \
      qtquickcontrols2-5-dev libqt5opengl5-dev libqt5svg5-dev \
-     libglu1-mesa-dev liboce-*-dev
+     qt5-image-formats-plugins libglu1-mesa-dev liboce-*-dev
 sudo apt-get install qt5-doc qtcreator # optional
 ```
 
@@ -83,7 +85,8 @@ sudo apt-get install qt5-doc qtcreator # optional
 
 ```bash
 sudo pacman -S base-devel git cmake openssl zlib desktop-file-utils shared-mime-info \
-     qt5-base qt5-declarative qt5-quickcontrols2 qt5-svg qt5-tools opencascade
+     qt5-base qt5-declarative qt5-quickcontrols2 qt5-svg qt5-tools qt5-imageformats \
+     opencascade
 sudo pacman -S qt5-doc qtcreator # optional
 ```
 

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -28,6 +28,7 @@
 #include <librepcb/core/workspace/workspacesettings.h>
 #include <librepcb/editor/dialogs/directorylockhandlerdialog.h>
 #include <librepcb/editor/editorcommandset.h>
+#include <librepcb/editor/project/partinformationprovider.h>
 #include <librepcb/editor/workspace/controlpanel/controlpanel.h>
 #include <librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard.h>
 
@@ -276,6 +277,17 @@ static int openWorkspace(FilePath& path) {
     Application::setTranslationLocale(locale);
     EditorCommandSet::instance().updateTranslations();
   }
+
+  // Setup global parts information provider (with cache).
+  PartInformationProvider::instance().setCacheDir(Application::getCacheDir());
+  auto applyPartInformationProviderSettings = [&ws]() {
+    PartInformationProvider::instance().setApiEndpoint(
+        ws.getSettings().apiEndpoints.get().value(0));
+  };
+  applyPartInformationProviderSettings();
+  QObject::connect(
+      &ws.getSettings().apiEndpoints, &WorkspaceSettingsItem::edited,
+      &ws.getSettings().apiEndpoints, applyPartInformationProviderSettings);
 
   // Apply keyboard shortcuts from workspace settings globally.
   auto applyKeyboardShortcuts = [&ws]() {

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -28,7 +28,10 @@ jobs:
         CXX: clang++
         # Note: QtQuick Controls not available in Docker image (yet).
         CMAKE_OPTIONS: "-DBUILD_QTQUICK_TEST=0"
-  container: $[ variables['IMAGE'] ]
+  container:
+    image: $[ variables['IMAGE'] ]
+    # Temporari hack for installing the imageformats plugin!
+    options: '--name mycontainer -v /usr/bin/docker:/tmp/docker:ro'
   steps:
   - checkout: self
     clean: true

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -5,6 +5,21 @@ set -euv -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# Install the Qt image formats plugin since it is not yet available in our
+# Docker images. Needs to be removed when added to the images.
+if [ "$OS" = "windows" ]
+then
+  QT_IMAGEFORMATS_URL="https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5152/qt.qt5.5152.win32_mingw81/5.15.2-0-202011130602qtimageformats-Windows-Windows_7-Mingw-Windows-Windows_7-X86.7z"
+  powershell -Command "Invoke-WebRequest $QT_IMAGEFORMATS_URL -OutFile 'C:/tmp.7z' -UseBasicParsing ;" \
+    && 7z x C:/tmp.7z -oC:/Qt -bsp1 \
+    && rm C:/tmp.7z
+elif [ "$OS" = "linux" ] && [ "${DEPLOY-}" = "true" ]
+then
+  QT_IMAGEFORMATS_URL="https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt5_5152/qt.qt5.5152.gcc_64/5.15.2-0-202011130601qtimageformats-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z"
+  wget -c "$QT_IMAGEFORMATS_URL" -O /tmp/tmp.7z
+  /tmp/docker exec -t -u root mycontainer 7za x /tmp/tmp.7z -o/opt/qt
+fi
+
 # On MacOS, we have to install some dependencies since we can't use a custom
 # Docker container with all tools preinstalled.
 if [ "$OS" = "mac" ]

--- a/libs/librepcb/core/export/bom.cpp
+++ b/libs/librepcb/core/export/bom.cpp
@@ -46,15 +46,39 @@ void BomItem::addDesignator(const QString& designator) noexcept {
  *  Constructors / Destructor
  ******************************************************************************/
 
-Bom::Bom(const QStringList& columns) noexcept : mColumns(columns), mItems() {
+Bom::Bom(const QStringList& columns,
+         const QVector<IndexPair>& mpnManufacturerColumns) noexcept
+  : mColumns(columns),
+    mMpnManufacturerColumns(mpnManufacturerColumns),
+    mItems() {
 }
 
 Bom::~Bom() noexcept {
 }
 
 /*******************************************************************************
- *  General Methods
+ *  Public Methods
  ******************************************************************************/
+
+int Bom::getAssembledRowsCount() const noexcept {
+  int count = 0;
+  for (const BomItem& item : mItems) {
+    if (item.isMount()) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+int Bom::getTotalAssembledPartsCount() const noexcept {
+  int count = 0;
+  for (const BomItem& item : mItems) {
+    if (item.isMount()) {
+      count += item.getDesignators().count();
+    }
+  }
+  return count;
+}
 
 void Bom::addItem(const QString& designator, const QStringList& attributes,
                   bool mount) noexcept {

--- a/libs/librepcb/core/export/bom.h
+++ b/libs/librepcb/core/export/bom.h
@@ -85,15 +85,24 @@ class Bom final {
   Q_DECLARE_TR_FUNCTIONS(Bom)
 
 public:
+  // Types
+  typedef std::pair<int, int> IndexPair;
+
   // Constructors / Destructor
   Bom() = delete;
   Bom(const Bom& other) noexcept = delete;
-  explicit Bom(const QStringList& columns) noexcept;
+  Bom(const QStringList& columns,
+      const QVector<IndexPair>& mpnManufacturerColumns) noexcept;
   ~Bom() noexcept;
 
   // Getters
   const QStringList& getColumns() const noexcept { return mColumns; }
+  const QVector<IndexPair>& getMpnManufacturerColumns() const noexcept {
+    return mMpnManufacturerColumns;
+  }
   const QList<BomItem>& getItems() const noexcept { return mItems; }
+  int getAssembledRowsCount() const noexcept;
+  int getTotalAssembledPartsCount() const noexcept;
 
   // General Methods
   void addItem(const QString& designator, const QStringList& attributes,
@@ -104,6 +113,7 @@ public:
 
 private:
   QStringList mColumns;
+  QVector<IndexPair> mMpnManufacturerColumns;
   QList<BomItem> mItems;
 };
 

--- a/libs/librepcb/core/network/apiendpoint.h
+++ b/libs/librepcb/core/network/apiendpoint.h
@@ -43,6 +43,12 @@ class ApiEndpoint final : public QObject {
   Q_OBJECT
 
 public:
+  // Types
+  struct Part {
+    QString mpn;
+    QString manufacturer;
+  };
+
   // Constructors / Destructor
   ApiEndpoint() = delete;
   ApiEndpoint(const ApiEndpoint& other) = delete;
@@ -54,6 +60,9 @@ public:
 
   // General Methods
   void requestLibraryList() const noexcept;
+  void requestPartsInformationStatus() const noexcept;
+  void requestPartsInformation(const QUrl& url,
+                               const QVector<Part>& parts) const noexcept;
 
   // Operators
   ApiEndpoint& operator=(const ApiEndpoint& rhs) = delete;
@@ -61,10 +70,16 @@ public:
 signals:
   void libraryListReceived(const QJsonArray& libs);
   void errorWhileFetchingLibraryList(const QString& errorMsg);
+  void errorWhileFetchingPartsInformationStatus(const QString& errorMsg);
+  void partsInformationStatusReceived(const QJsonObject& status);
+  void partsInformationReceived(const QJsonObject& info);
+  void errorWhileFetchingPartsInformation(const QString& errorMsg);
 
 private:  // Methods
   void requestLibraryList(const QUrl& url) const noexcept;
-  void requestedDataReceived(const QByteArray& data) noexcept;
+  void libraryListResponseReceived(const QByteArray& data) noexcept;
+  void partsInformationStatusResponseReceived(const QByteArray& data) noexcept;
+  void partsInformationResponseReceived(const QByteArray& data) noexcept;
 
 private:  // Data
   QUrl mUrl;

--- a/libs/librepcb/core/network/networkrequestbase.h
+++ b/libs/librepcb/core/network/networkrequestbase.h
@@ -74,6 +74,17 @@ public:
   void setHeaderField(const QByteArray& name, const QByteArray& value) noexcept;
 
   /**
+   * @brief Set the cache load control attribute
+   *
+   * Allows to control the caching behavior, e.g. enforcing download only from
+   * cache but not from the network. For details, see documentation of
+   * `QNetworkRequest::setAttribute()`.
+   *
+   * @param value   The new cache control value
+   */
+  void setCacheLoadControl(QNetworkRequest::CacheLoadControl value) noexcept;
+
+  /**
    * @brief Set the expected size of the requested content
    *
    * If set, this size will be used to calculate the download progress in

--- a/libs/librepcb/core/project/bomgenerator.cpp
+++ b/libs/librepcb/core/project/bomgenerator.cpp
@@ -160,19 +160,23 @@ std::shared_ptr<Bom> BomGenerator::generate(
 
   // Build BOM header.
   QStringList columns{"Package"};
+  QVector<std::pair<int, int>> mpnManufacturerColumns;
   columns += customCommonAttributes;
   for (int i = 0; i < maxPartNumber; ++i) {
     const QString suffix = (i > 0) ? QString("[%1]").arg(i + 1) : QString();
     columns.append("Value" % suffix);
     columns.append("MPN" % suffix);
     columns.append("Manufacturer" % suffix);
+    mpnManufacturerColumns.append(
+        std::make_pair(columns.count() - 2, columns.count() - 1));
     foreach (const QString& attribute, customPartAttributes) {
       columns.append(attribute % suffix);
     }
   }
 
   // Generate BOM.
-  std::shared_ptr<Bom> bom = std::make_shared<Bom>(columns);
+  std::shared_ptr<Bom> bom =
+      std::make_shared<Bom>(columns, mpnManufacturerColumns);
   foreach (const ComponentItem& item, items) {
     QStringList attributes;
     attributes.append(item.pkgName);

--- a/libs/librepcb/core/serialization/sexpression.cpp
+++ b/libs/librepcb/core/serialization/sexpression.cpp
@@ -604,6 +604,16 @@ SExpression serialize(const int& obj) {
 }
 
 template <>
+SExpression serialize(const long& obj) {
+  return SExpression::createToken(QString::number(obj));
+}
+
+template <>
+SExpression serialize(const qlonglong& obj) {
+  return SExpression::createToken(QString::number(obj));
+}
+
+template <>
 SExpression serialize(const bool& obj) {
   return SExpression::createToken(obj ? "true" : "false");
 }
@@ -673,6 +683,30 @@ int deserialize(const SExpression& node) {
   } else {
     throw RuntimeError(__FILE__, __LINE__,
                        QString("Invalid integer: '%1'").arg(node.getValue()));
+  }
+}
+
+template <>
+long deserialize(const SExpression& node) {
+  bool ok = false;
+  const long value = node.getValue().toLong(&ok);
+  if (ok) {
+    return value;
+  } else {
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("Invalid long: '%1'").arg(node.getValue()));
+  }
+}
+
+template <>
+qlonglong deserialize(const SExpression& node) {
+  bool ok = false;
+  const qlonglong value = node.getValue().toLongLong(&ok);
+  if (ok) {
+    return value;
+  } else {
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("Invalid longlong: '%1'").arg(node.getValue()));
   }
 }
 

--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -53,6 +53,7 @@ WorkspaceSettings::WorkspaceSettings(QObject* parent)
     libraryNormOrder("library_norm_order", "norm", QStringList(), this),
     apiEndpoints("api_endpoints", "url",
                  QList<QUrl>{QUrl("https://api.librepcb.org")}, this),
+    autofetchLivePartInformation("autofetch_live_part_information", true, this),
     externalWebBrowserCommands("external_web_browser", "command", QStringList(),
                                this),
     externalFileManagerCommands("external_file_manager", "command",

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -209,6 +209,13 @@ public:
   WorkspaceSettingsItem_GenericValueList<QList<QUrl>> apiEndpoints;
 
   /**
+   * @brief Enable auto-fetch of live parts information (through #apiEndpoints)
+   *
+   * Default: True
+   */
+  WorkspaceSettingsItem_GenericValue<bool> autofetchLivePartInformation;
+
+  /**
    * @brief Custom command(s) to be used for opening web URLs
    *
    * When opening an URL, the application will iterate through this list of

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -398,6 +398,8 @@ add_library(
   modelview/keysequencedelegate.h
   modelview/lengthdelegate.cpp
   modelview/lengthdelegate.h
+  modelview/partinformationdelegate.cpp
+  modelview/partinformationdelegate.h
   modelview/pathmodel.cpp
   modelview/pathmodel.h
   modelview/sortfilterproxymodel.cpp
@@ -739,6 +741,9 @@ add_library(
   project/outputjobsdialog/projectjsonoutputjobwidget.ui
   project/partinformationprovider.cpp
   project/partinformationprovider.h
+  project/partinformationtooltip.cpp
+  project/partinformationtooltip.h
+  project/partinformationtooltip.ui
   project/projecteditor.cpp
   project/projecteditor.h
   project/projectsetupdialog.cpp

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -737,6 +737,8 @@ add_library(
   project/outputjobsdialog/projectjsonoutputjobwidget.cpp
   project/outputjobsdialog/projectjsonoutputjobwidget.h
   project/outputjobsdialog/projectjsonoutputjobwidget.ui
+  project/partinformationprovider.cpp
+  project/partinformationprovider.h
   project/projecteditor.cpp
   project/projecteditor.h
   project/projectsetupdialog.cpp

--- a/libs/librepcb/editor/modelview/partinformationdelegate.cpp
+++ b/libs/librepcb/editor/modelview/partinformationdelegate.cpp
@@ -1,0 +1,212 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "partinformationdelegate.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Class PartInformationDelegate::Data
+ ******************************************************************************/
+
+QSize PartInformationDelegate::Data::calcSizeHint(
+    const QStyleOptionViewItem& option) const noexcept {
+  QFont f = option.font;
+  f.setPointSize(f.pointSize() - 2);
+  QFontMetrics fm(f);
+  const QString text = getDisplayText(true);
+  QSize s = fm.size(Qt::AlignCenter, text);
+  if (text.isEmpty()) {
+    s.setWidth(6);  // Make it a square resp. circle.
+  }
+  return s;
+}
+
+QString PartInformationDelegate::Data::getDisplayText(
+    bool maxLen) const noexcept {
+  QString s;
+  if (info && (info->results == 1)) {
+    s = info->getPriceStr(priceQuantity);
+    if (s.isEmpty()) {
+      s = info->getStatusTr();
+    }
+  } else if ((!info) && (progress > 0)) {
+    const QStringList values = {"․", "‥", "…"};
+    return maxLen ? values.last() : values[progress % values.count()];
+  }
+  return s;
+}
+
+bool PartInformationDelegate::Data::getColors(QBrush& background, QPen& outline,
+                                              QPen& text) const noexcept {
+  if (info && (info->results == 1)) {
+    const QString sts = info->status.toLower();
+    const tl::optional<int> av = info->availability;
+    if (sts == "preview") {
+      // Ignore availability in this case since preview state somehow indicates
+      // the part might not be available *yet*, which users probably expect.
+      background = Qt::blue;
+      outline = Qt::NoPen;
+      text = QPen(Qt::white);
+      return true;
+    } else if ((sts == "obsolete") || (av && ((*av) < -5))) {
+      background = Qt::red;
+      outline = Qt::NoPen;
+      text = QPen(Qt::white);
+      return true;
+    } else if (av && ((*av) < 0)) {
+      background = QColor::fromRgb(0xFFA500);  // Orange
+      outline = Qt::NoPen;
+      text = QPen(Qt::black);
+      return true;
+    } else if (sts == "nrnd") {
+      background = Qt::darkGray;
+      outline = Qt::NoPen;
+      text = QPen(Qt::white);
+      return true;
+    } else if ((sts.isEmpty() || (sts == "active")) && (av && ((*av) < 5))) {
+      background = Qt::yellow;
+      outline = Qt::NoPen;
+      text = QPen(Qt::black);
+      return true;
+    } else if ((sts.isEmpty() && (av) && ((*av) >= 5)) ||
+               ((sts == "active") && (!av))) {
+      background = Qt::darkGreen;
+      outline = Qt::NoPen;
+      text = QPen(Qt::white);
+      return true;
+    } else if ((sts == "active") && (av) && ((*av) >= 5)) {
+      background = Qt::green;
+      outline = Qt::NoPen;
+      text = QPen(Qt::black);
+      return true;
+    } else {
+      background = Qt::white;
+      outline = QPen(Qt::black);
+      text = QPen(Qt::black);
+      return true;
+    }
+  } else if ((!info) && (progress > 0)) {
+    background = Qt::transparent;
+    outline = QPen(Qt::transparent);
+    text = QPen(Qt::gray);
+    return true;
+  }
+  return false;
+}
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PartInformationDelegate::PartInformationDelegate(bool fillCell,
+                                                 QObject* parent) noexcept
+  : QStyledItemDelegate(parent), mFillCell(fillCell) {
+}
+
+PartInformationDelegate::~PartInformationDelegate() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from QStyledItemDelegate
+ ******************************************************************************/
+
+QSize PartInformationDelegate::sizeHint(
+    const QStyleOptionViewItem& option,
+    const QModelIndex& index) const noexcept {
+  QSize size = QStyledItemDelegate::sizeHint(option, index);
+
+  Data data;
+  if (getData(index, data)) {
+    const QSize s = data.calcSizeHint(option);
+    size.setWidth(size.width() + s.width() + s.height() - 2);
+    size.setHeight(std::max(size.height(), s.height() + 2));
+  }
+  return size;
+}
+
+void PartInformationDelegate::paint(QPainter* painter,
+                                    const QStyleOptionViewItem& option,
+                                    const QModelIndex& index) const {
+  QStyledItemDelegate::paint(painter, option, index);
+
+  Data data;
+  if (getData(index, data)) {
+    QBrush bgBrush;
+    QPen outlinePen;
+    QPen textPen;
+    if (data.getColors(bgBrush, outlinePen, textPen)) {
+      const QSize textSize = data.calcSizeHint(option);
+      const QSize bgSize(textSize.width() + textSize.height() - 4,
+                         textSize.height());
+      QRect rect(QPoint(0, 0), bgSize);
+      if (mFillCell) {
+        rect.setWidth(option.rect.width() - 2);
+        rect.translate(option.rect.center() - rect.center());
+      } else {
+        rect.translate(option.rect.right() - rect.right() - 1,
+                       option.rect.center().y() - rect.center().y());
+      }
+      painter->setBrush(bgBrush);
+      painter->setPen(outlinePen);
+      painter->drawRoundedRect(rect, rect.height() / 2, rect.height() / 2);
+
+      const QString text = data.getDisplayText();
+      if (!text.isEmpty()) {
+        QFont f = option.font;
+        f.setPointSize(f.pointSize() - 2);
+        painter->setFont(f);
+        painter->setPen(textPen);
+        painter->drawText(rect, Qt::AlignCenter, text);
+      }
+    }
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+bool PartInformationDelegate::getData(const QModelIndex& index,
+                                      Data& data) const noexcept {
+  const QVariant d = index.data(Qt::UserRole);
+  if (d.canConvert<Data>()) {
+    data = d.value<Data>();
+    return (data.info && (data.info->results == 1)) ||
+        ((!data.info) && (data.progress > 0));
+  } else {
+    return false;
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/modelview/partinformationdelegate.h
+++ b/libs/librepcb/editor/modelview/partinformationdelegate.h
@@ -1,0 +1,94 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_PARTINFORMATIONDELEGATE_H
+#define LIBREPCB_EDITOR_PARTINFORMATIONDELEGATE_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../project/partinformationprovider.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Class PartInformationDelegate
+ ******************************************************************************/
+
+/**
+ * @brief Subclass of QStyledItemDelegate to display part status/price
+ */
+class PartInformationDelegate final : public QStyledItemDelegate {
+  Q_OBJECT
+
+public:
+  struct Data {
+    bool initialized = false;
+    bool infoRequested = false;
+    int progress = 0;
+    PartInformationProvider::Part part;
+    std::shared_ptr<const PartInformationProvider::PartInformation> info;
+    int priceQuantity = 1;
+
+    QSize calcSizeHint(const QStyleOptionViewItem& option) const noexcept;
+    QString getDisplayText(bool maxLen = false) const noexcept;
+    bool getColors(QBrush& background, QPen& outline,
+                   QPen& text) const noexcept;
+  };
+
+  // Constructors / Destructor
+  explicit PartInformationDelegate(bool fillCell,
+                                   QObject* parent = nullptr) noexcept;
+  PartInformationDelegate(const PartInformationDelegate& other) = delete;
+  ~PartInformationDelegate() noexcept;
+
+  // Inherited from QStyledItemDelegate
+  virtual QSize sizeHint(const QStyleOptionViewItem& option,
+                         const QModelIndex& index) const noexcept override;
+  virtual void paint(QPainter* painter, const QStyleOptionViewItem& option,
+                     const QModelIndex& index) const override;
+
+  // Operator Overloadings
+  PartInformationDelegate& operator=(const PartInformationDelegate& rhs) =
+      delete;
+
+private:  // Methods
+  bool getData(const QModelIndex& index, Data& data) const noexcept;
+
+private:  // Data
+  const bool mFillCell;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+Q_DECLARE_METATYPE(librepcb::editor::PartInformationDelegate::Data)
+
+#endif

--- a/libs/librepcb/editor/project/addcomponentdialog.ui
+++ b/libs/librepcb/editor/project/addcomponentdialog.ui
@@ -13,11 +13,23 @@
   <property name="windowTitle">
    <string>Add Component</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0,1,0" columnstretch="4,5,4">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0,1,0" columnstretch="7,10,7">
    <item row="0" column="0" rowspan="4">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QLineEdit" name="edtSearch">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="placeholderText">
         <string>What are you looking for?</string>
        </property>
@@ -28,8 +40,23 @@
      </item>
      <item>
       <widget class="QTreeView" name="treeCategories">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="editTriggers">
         <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="indentation">
+        <number>15</number>
        </property>
        <property name="headerHidden">
         <bool>true</bool>
@@ -49,6 +76,9 @@
      <property name="verticalScrollMode">
       <enum>QAbstractItemView::ScrollPerPixel</enum>
      </property>
+     <property name="indentation">
+      <number>15</number>
+     </property>
      <property name="headerHidden">
       <bool>true</bool>
      </property>
@@ -58,12 +88,21 @@
      <property name="columnCount">
       <number>0</number>
      </property>
+     <attribute name="headerMinimumSectionSize">
+      <number>10</number>
+     </attribute>
     </widget>
    </item>
    <item row="0" column="2">
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
       <widget class="QLabel" name="lblCompName">
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <pointsize>11</pointsize>
@@ -83,6 +122,12 @@
      </item>
      <item>
       <widget class="QLabel" name="lblCompDescription">
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <italic>true</italic>
@@ -100,26 +145,41 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
-       <item>
-        <widget class="QLabel" name="lblSymbVar">
-         <property name="text">
-          <string>Variant:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="cbxSymbVar"/>
-       </item>
-      </layout>
+      <widget class="QComboBox" name="cbxSymbVar">
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
    <item row="1" column="2">
-    <widget class="librepcb::editor::GraphicsView" name="viewComponent" native="true"/>
+    <widget class="librepcb::editor::GraphicsView" name="viewComponent">
+     <property name="maximumSize">
+      <size>
+       <width>400</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
    </item>
    <item row="2" column="2">
     <widget class="QLabel" name="lblDeviceName">
+     <property name="maximumSize">
+      <size>
+       <width>400</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <property name="font">
       <font>
        <pointsize>11</pointsize>
@@ -135,7 +195,20 @@
     </widget>
    </item>
    <item row="3" column="2">
-    <widget class="librepcb::editor::GraphicsView" name="viewDevice" native="true"/>
+    <widget class="librepcb::editor::GraphicsView" name="viewDevice">
+     <property name="maximumSize">
+      <size>
+       <width>400</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
    </item>
    <item row="4" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0,0">
@@ -218,8 +291,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>889</x>
+     <y>489</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -234,28 +307,12 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>889</x>
+     <y>489</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>treeComponents</sender>
-   <signal>itemDoubleClicked(QTreeWidgetItem*,int)</signal>
-   <receiver>librepcb::editor::AddComponentDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>419</x>
-     <y>301</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>492</x>
-     <y>463</y>
     </hint>
    </hints>
   </connection>

--- a/libs/librepcb/editor/project/bomgeneratordialog.h
+++ b/libs/librepcb/editor/project/bomgeneratordialog.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "partinformationprovider.h"
+
 #include <librepcb/core/fileio/filepath.h>
 #include <optional/tl/optional.hpp>
 
@@ -44,6 +46,8 @@ class Uuid;
 class WorkspaceSettings;
 
 namespace editor {
+
+class PartInformationToolTip;
 
 namespace Ui {
 class BomGeneratorDialog;
@@ -68,6 +72,9 @@ public:
                      QWidget* parent = nullptr) noexcept;
   ~BomGeneratorDialog() noexcept;
 
+  // General Methods
+  virtual bool eventFilter(QObject* obj, QEvent* e) noexcept override;
+
   // Operator Overloads
   BomGeneratorDialog& operator=(const BomGeneratorDialog& rhs) = delete;
 
@@ -79,11 +86,13 @@ private:  // GUI Event Handlers
   void btnChooseOutputPathClicked() noexcept;
   void btnOpenOutputDirectoryClicked() noexcept;
   void btnGenerateClicked() noexcept;
+  void tableCellDoubleClicked(int row, int column) noexcept;
 
 private:  // Methods
   void updateAttributes() noexcept;
   void updateBom() noexcept;
   void updateTable() noexcept;
+  void updatePartsInformation() noexcept;
   std::shared_ptr<AssemblyVariant> getAssemblyVariant() const noexcept;
   tl::optional<Uuid> getAssemblyVariantUuid(bool throwIfNullopt) const;
   FilePath getOutputFilePath() const noexcept;
@@ -94,6 +103,9 @@ private:  // Data
   std::shared_ptr<Bom> mBom;
   QScopedPointer<Ui::BomGeneratorDialog> mUi;
   QPointer<QPushButton> mBtnGenerate;
+  QScopedPointer<PartInformationToolTip> mPartToolTip;
+  uint mPartInfoProgress;
+  bool mUpdatePartInformationScheduled;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/bomgeneratordialog.ui
+++ b/libs/librepcb/editor/project/bomgeneratordialog.ui
@@ -81,6 +81,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="btnBrowseOutputDir">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Browse Output Directory</string>
        </property>
@@ -91,6 +97,12 @@
      </item>
      <item>
       <widget class="QLabel" name="lblNote">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="font">
         <font>
          <italic>true</italic>
@@ -102,7 +114,26 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="lblTotalPrice">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true">lblTotalPrice</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>

--- a/libs/librepcb/editor/project/componentassemblyoptionlisteditorwidget.cpp
+++ b/libs/librepcb/editor/project/componentassemblyoptionlisteditorwidget.cpp
@@ -210,9 +210,9 @@ void ComponentAssemblyOptionListEditorWidget::addOption() noexcept {
         ? (currentIndices.first + 1)
         : mOptions.count();
 
-    AddComponentDialog dlg(mWorkspace->getLibraryDb(),
-                           mProject->getLocaleOrder(), mProject->getNormOrder(),
-                           mWorkspace->getSettings().themes.getActive(), this);
+    AddComponentDialog dlg(
+        mWorkspace->getLibraryDb(), mWorkspace->getSettings(),
+        mProject->getLocaleOrder(), mProject->getNormOrder(), this);
     dlg.selectComponentByKeyword(
         mComponent->getLibComponent().getUuid().toStr());
     if (dlg.exec() != QDialog::Accepted) {
@@ -277,9 +277,9 @@ bool ComponentAssemblyOptionListEditorWidget::addPart() noexcept {
         ? (currentIndices.second + 1)
         : option->getParts().count();
 
-    AddComponentDialog dlg(mWorkspace->getLibraryDb(),
-                           mProject->getLocaleOrder(), mProject->getNormOrder(),
-                           mWorkspace->getSettings().themes.getActive(), this);
+    AddComponentDialog dlg(
+        mWorkspace->getLibraryDb(), mWorkspace->getSettings(),
+        mProject->getLocaleOrder(), mProject->getNormOrder(), this);
     dlg.selectComponentByKeyword(
         mComponent->getLibComponent().getUuid().toStr(), option->getDevice());
     if (dlg.exec() != QDialog::Accepted) {

--- a/libs/librepcb/editor/project/partinformationprovider.cpp
+++ b/libs/librepcb/editor/project/partinformationprovider.cpp
@@ -133,6 +133,21 @@ QString PartInformationProvider::PartInformation::getPriceStr(
   return s;
 }
 
+QString PartInformationProvider::PartInformation::formatQuantity(
+    const QLocale& locale, int qty) noexcept {
+  QString number;
+  QString suffix;
+  if (qty >= 1000000) {
+    number = locale.toString(qty / qreal(1000000), 'f', 6);
+    while (number.endsWith(locale.zeroDigit())) number.chop(1);
+    if (number.endsWith(locale.decimalPoint())) number.chop(1);
+    suffix = "M";
+  } else {
+    number = locale.toString(qty);
+  }
+  return number + suffix;
+}
+
 void PartInformationProvider::PartInformation::serialize(
     SExpression& root) const {
   root.appendChild("mpn", mpn);

--- a/libs/librepcb/editor/project/partinformationprovider.cpp
+++ b/libs/librepcb/editor/project/partinformationprovider.cpp
@@ -1,0 +1,542 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "partinformationprovider.h"
+
+#include <librepcb/core/exceptions.h>
+#include <librepcb/core/fileio/fileutils.h>
+#include <librepcb/core/network/apiendpoint.h>
+#include <librepcb/core/network/networkrequest.h>
+#include <librepcb/core/serialization/sexpression.h>
+#include <librepcb/core/types/length.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Struct PartInformation
+ ******************************************************************************/
+
+QString PartInformationProvider::PartInformation::getStatusTr() const noexcept {
+  const QHash<QString, QString> translations = {
+      //: Part lifecycle status. Please keep it very very short!
+      {"preview", tr("Preview")},
+      //: Part lifecycle status. Please keep it very very short!
+      {"active", tr("Active")},
+      //: Part lifecycle status. Please keep it very very short! Don't use
+      //: "not recommended for new designs"! If in doubt, just keep the
+      //: English abbreviation.
+      {"nrnd", tr("NRND")},
+      //: Part lifecycle status. Please keep it very very short!
+      {"obsolete", tr("Obsolete")},
+  };
+  return translations.value(status.toLower(), status);
+}
+
+QString PartInformationProvider::PartInformation::getStatusColorName()
+    const noexcept {
+  const QHash<QString, QString> map = {
+      {"preview", "blue"},
+      {"active", "lime"},
+      {"nrnd", "gray"},
+      {"obsolete", "red"},
+  };
+  return map.value(status.toLower());
+}
+
+QString PartInformationProvider::PartInformation::getAvailabilityTr()
+    const noexcept {
+  QString s;
+  if (availability) {
+    if (*availability > 5) {
+      //: Part supplier availability. Please keep it relatively short!
+      s = tr("Excellent Availability");
+    } else if (*availability > 0) {
+      //: Part supplier availability. Please keep it relatively short!
+      s = tr("Good Availability");
+    } else if (*availability > -5) {
+      //: Part supplier availability. Please keep it relatively short!
+      s = tr("Available");
+    } else if (*availability > -10) {
+      //: Part supplier availability. Please keep it relatively short!
+      s = tr("Bad Availability");
+    } else {
+      //: Part supplier availability. Please keep it relatively short!
+      s = tr("Not Available");
+    }
+  }
+  return s;
+}
+
+QString PartInformationProvider::PartInformation::getAvailabilityColorName()
+    const noexcept {
+  QString s;
+  if (availability) {
+    if (*availability > 5) {
+      s = "lime";
+    } else if (*availability > 0) {
+      s = "green";
+    } else if (*availability > -5) {
+      s = "gold";
+    } else if (*availability > -10) {
+      s = "darkorange";
+    } else {
+      s = "red";
+    }
+  }
+  return s;
+}
+
+qreal PartInformationProvider::PartInformation::getPrice(
+    int quantity) const noexcept {
+  qreal price = 0;
+  for (auto it = prices.begin(); it != prices.end(); it++) {
+    if ((quantity >= it.key()) || (price == 0)) {
+      price = it.value();
+    }
+  }
+  return price;
+}
+
+QString PartInformationProvider::PartInformation::getPriceStr(
+    int quantity, const char* prefix, const char* suffix) const noexcept {
+  QString s;
+  if (auto price = getPrice(quantity)) {
+    s = QString("%1%2").arg(prefix).arg(price, 0, 'f', 3);
+    if (s.endsWith('0')) s.chop(1);
+    s += suffix;
+  }
+  return s;
+}
+
+void PartInformationProvider::PartInformation::serialize(
+    SExpression& root) const {
+  root.appendChild("mpn", mpn);
+  root.appendChild("manufacturer", manufacturer);
+  root.ensureLineBreak();
+  root.appendChild("timestamp", timestamp);
+  root.ensureLineBreak();
+  root.appendChild("results", results);
+  root.ensureLineBreak();
+  if (!status.isEmpty()) {
+    root.appendChild("status", status);
+    root.ensureLineBreak();
+  }
+  if (availability) {
+    root.appendChild("availability", *availability);
+    root.ensureLineBreak();
+  }
+  if (!productUrl.isEmpty()) {
+    root.appendChild("product_url", productUrl);
+    root.ensureLineBreak();
+  }
+  if (!pictureUrl.isEmpty()) {
+    root.appendChild("picture_url", pictureUrl);
+    root.ensureLineBreak();
+  }
+  if (!pricingUrl.isEmpty()) {
+    root.appendChild("pricing_url", pricingUrl);
+    root.ensureLineBreak();
+  }
+  for (auto it = prices.begin(); it != prices.end(); it++) {
+    SExpression& child = root.appendList("price");
+    child.appendChild("quantity", it.key());
+    child.appendChild("price", Length::fromMm(it.value()));  // No comment!
+    root.ensureLineBreak();
+  }
+  foreach (const PartResource& resource, resources) {
+    SExpression& child = root.appendList("resource");
+    child.appendChild("name", resource.name);
+    child.appendChild("media_type", resource.mediaType);
+    child.ensureLineBreak();
+    child.appendChild("url", resource.url);
+    root.ensureLineBreak();
+  }
+}
+
+void PartInformationProvider::PartInformation::load(const SExpression& node) {
+  timestamp = deserialize<qint64>(node.getChild("timestamp/@0"));
+  mpn = node.getChild("mpn/@0").getValue();
+  manufacturer = node.getChild("manufacturer/@0").getValue();
+  if (const SExpression* e = node.tryGetChild("results/@0")) {
+    results = deserialize<int>(*e);
+  }
+  if (const SExpression* e = node.tryGetChild("product_url/@0")) {
+    productUrl = deserialize<QUrl>(*e);
+  }
+  if (const SExpression* e = node.tryGetChild("picture_url/@0")) {
+    pictureUrl = deserialize<QUrl>(*e);
+  }
+  if (const SExpression* e = node.tryGetChild("pricing_url/@0")) {
+    pricingUrl = deserialize<QUrl>(*e);
+  }
+  if (const SExpression* e = node.tryGetChild("status/@0")) {
+    status = e->getValue();
+  }
+  if (const SExpression* e = node.tryGetChild("availability/@0")) {
+    availability = deserialize<int>(*e);
+  }
+  foreach (const SExpression* child, node.getChildren("price")) {
+    prices.insert(deserialize<int>(child->getChild("quantity/@0")),
+                  deserialize<Length>(child->getChild("price/@0")).toMm());
+  }
+  foreach (const SExpression* child, node.getChildren("resource")) {
+    resources.append(
+        PartResource{child->getChild("name/@0").getValue(),
+                     child->getChild("media_type/@0").getValue(),
+                     deserialize<QUrl>(child->getChild("url/@0"))});
+  }
+}
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PartInformationProvider::PartInformationProvider(QObject* parent) noexcept
+  : QObject(parent),
+    mCacheFp(),
+    mErrorCounter(0),
+    mDisabledDueToErrors(false),
+    mStatusRequestedTimestamp(0),
+    mStatusReceived(false),
+    mQueryMaxPartCount(0),
+    mCacheModified(false) {
+  // Try to recover from errors every hour.
+  {
+    QTimer* timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, [this]() {
+      if (mDisabledDueToErrors) {
+        qInfo() << "Reset parts information provider to recover from errors.";
+        reset();
+      }
+    });
+    timer->start(3600 * 1000);
+  }
+
+  // Clean up cache regularly and save it to disk.
+  {
+    QTimer* timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, [this]() {
+      removeOutdatedInformation();
+      saveCacheToDisk();
+    });
+    timer->start(15 * 60 * 1000);
+  }
+
+  // Save cache before exiting the application.
+  connect(qApp, &QGuiApplication::aboutToQuit, this,
+          &PartInformationProvider::saveCacheToDisk);
+}
+
+PartInformationProvider::~PartInformationProvider() noexcept {
+}
+
+/*******************************************************************************
+ *  Getters
+ ******************************************************************************/
+
+bool PartInformationProvider::isOperational() const noexcept {
+  return mEndpoint && mStatusReceived && mQueryUrl.isValid() &&
+      (!mDisabledDueToErrors) && (mQueryMaxPartCount > 0);
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void PartInformationProvider::setCacheDir(const FilePath& dir) noexcept {
+  mCacheFp = dir.getPathTo("parts.lp");
+  loadCacheFromDisk();
+}
+
+void PartInformationProvider::setApiEndpoint(const QUrl& url) noexcept {
+  if (mEndpoint && (mEndpoint->getUrl() == url)) {
+    return;
+  }
+
+  mEndpoint.reset();
+  if (url.isValid()) {
+    mEndpoint.reset(new ApiEndpoint(url));
+    connect(mEndpoint.data(),
+            &ApiEndpoint::errorWhileFetchingPartsInformationStatus, this,
+            &PartInformationProvider::errorWhileFetchingStatus);
+    connect(mEndpoint.data(), &ApiEndpoint::partsInformationStatusReceived,
+            this, &PartInformationProvider::statusReceived);
+    connect(mEndpoint.data(), &ApiEndpoint::errorWhileFetchingPartsInformation,
+            this, &PartInformationProvider::errorWhileFetchingPartsInformation);
+    connect(mEndpoint.data(), &ApiEndpoint::partsInformationReceived, this,
+            &PartInformationProvider::partsInformationReceived);
+  }
+  reset();
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void PartInformationProvider::startOperation() noexcept {
+  requestStatus();
+}
+
+std::shared_ptr<PartInformationProvider::PartInformation>
+    PartInformationProvider::getPartInfo(const Part& part) noexcept {
+  return mCache.value(part);
+}
+
+bool PartInformationProvider::isOngoing(const Part& part) const noexcept {
+  return mScheduledParts.contains(part) || mRequestedParts.contains(part);
+}
+
+void PartInformationProvider::scheduleRequest(const Part& part) noexcept {
+  if (isOperational() && (!mScheduledParts.contains(part))) {
+    mScheduledParts.append(part);
+  }
+}
+
+void PartInformationProvider::requestScheduledParts() noexcept {
+  if ((!isOperational()) || (!mRequestedParts.isEmpty()) ||
+      (mScheduledParts.isEmpty())) {
+    return;
+  }
+
+  QVector<ApiEndpoint::Part> batch;
+  const int batchSize = std::min(mScheduledParts.count(), mQueryMaxPartCount);
+  for (int i = 0; i < batchSize; ++i) {
+    const auto& part = mScheduledParts.at(i);
+    if (mCache.contains(part)) {
+      qWarning() << "Requested part information of already cached part.";
+    }
+    batch.append(ApiEndpoint::Part{part.mpn, part.manufacturer});
+    mRequestedParts.insert(part);
+  }
+  mScheduledParts.remove(0, batchSize);
+  mEndpoint->requestPartsInformation(mQueryUrl, batch);
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void PartInformationProvider::reset() noexcept {
+  mErrorCounter = 0;
+  mDisabledDueToErrors = false;
+  mStatusRequestedTimestamp = 0;
+  mStatusReceived = mEndpoint.isNull();
+  mProviderName.clear();
+  mProviderUrl.clear();
+  mProviderLogoUrl.clear();
+  mProviderLogo = QPixmap();
+  mInfoUrl.clear();
+  mQueryUrl.clear();
+  mQueryMaxPartCount = 0;
+  mScheduledParts.clear();
+  mRequestedParts.clear();
+  emit providerInfoChanged();
+}
+
+void PartInformationProvider::requestStatus() noexcept {
+  const qint64 ts = QDateTime::currentSecsSinceEpoch();
+  if (mEndpoint && (!mStatusReceived) && (!mDisabledDueToErrors) &&
+      (ts - mStatusRequestedTimestamp > 30)) {
+    mStatusRequestedTimestamp = ts;
+    mEndpoint->requestPartsInformationStatus();
+  }
+}
+
+void PartInformationProvider::statusReceived(const QJsonObject& json) noexcept {
+  mProviderName = json["provider_name"].toString();
+  mProviderUrl = json["provider_url"].toString();
+  mProviderLogoUrl = json["provider_logo_url"].toString();
+  mInfoUrl = json["info_url"].toString();
+  mQueryUrl = json["query_url"].toString();
+  mQueryMaxPartCount = std::min(10, json["max_parts"].toInt());
+  mErrorCounter = 0;
+  mDisabledDueToErrors = false;
+  mStatusRequestedTimestamp = 0;
+  mStatusReceived = true;
+  emit providerInfoChanged();
+
+  // Request provider logo if an URL is given.
+  if (mProviderLogoUrl.isValid()) {
+    NetworkRequest* request = new NetworkRequest(mProviderLogoUrl);
+    request->setMinimumCacheTime(7 * 24 * 3600);  // 7 days
+    connect(
+        request, &NetworkRequest::dataReceived, this,
+        [this](const QByteArray& data) {
+          mProviderLogo.loadFromData(data);
+          if (!mProviderLogo.isNull()) {
+            emit providerInfoChanged();
+          }
+        },
+        Qt::QueuedConnection);
+    request->start();
+  }
+
+  if (mQueryUrl.isValid()) {
+    qInfo() << "Live parts information API is operational.";
+    emit serviceOperational();
+  } else {
+    qInfo() << "Live parts information API is currently not available.";
+  }
+}
+
+void PartInformationProvider::errorWhileFetchingStatus(
+    const QString& errorMsg) noexcept {
+  qCritical().noquote() << "Failed to request parts information API status:"
+                        << errorMsg;
+  if (mErrorCounter < 1) {
+    ++mErrorCounter;
+  } else if (!mDisabledDueToErrors) {
+    qInfo() << "Live parts information disabled due to errors.";
+    mDisabledDueToErrors = true;
+  }
+}
+
+void PartInformationProvider::partsInformationReceived(
+    const QJsonObject& json) noexcept {
+  const qint64 timestamp = QDateTime::currentSecsSinceEpoch();
+  const auto parts = json["parts"].toArray();
+  foreach (const QJsonValue& partJson, parts) {
+    const QJsonObject partObj = partJson.toObject();
+    const Part part{
+        partObj["mpn"].toString(),
+        partObj["manufacturer"].toString(),
+    };
+    std::shared_ptr<PartInformation> info = std::make_shared<PartInformation>();
+    info->timestamp = timestamp;
+    info->mpn = part.mpn;
+    info->manufacturer = part.manufacturer;
+    info->results = partObj["results"].toInt();
+    info->productUrl = partObj["product_url"].toString();
+    info->pictureUrl = partObj["picture_url"].toString();
+    info->pricingUrl = partObj["pricing_url"].toString();
+    info->status = partObj["status"].toString();
+    const int availability = partObj["availability"].toInt(INT_MIN);
+    if (availability != INT_MIN) {
+      info->availability = availability;
+    }
+    foreach (const QJsonValue& priceJson, partJson["prices"].toArray()) {
+      info->prices.insert(priceJson["quantity"].toInt(),
+                          priceJson["price"].toDouble());
+    }
+    foreach (const QJsonValue& resJson, partJson["resources"].toArray()) {
+      info->resources.append(PartResource{
+          resJson["name"].toString(),
+          resJson["mediatype"].toString(),
+          resJson["url"].toString(),
+      });
+    }
+    mCache[part] = info;
+    mCacheModified = true;
+  }
+  mRequestedParts.clear();
+  mErrorCounter = 0;
+  mDisabledDueToErrors = false;
+
+  qDebug() << "Received live information about" << parts.count() << "parts.";
+  emit newPartsInformationAvailable();
+  requestScheduledParts();  // Request next batch.
+}
+
+void PartInformationProvider::errorWhileFetchingPartsInformation(
+    const QString& errorMsg) noexcept {
+  qCritical().noquote() << "Failed to request parts information:" << errorMsg;
+  mRequestedParts.clear();
+  if (mErrorCounter < 3) {
+    ++mErrorCounter;
+  } else if (!mDisabledDueToErrors) {
+    qInfo() << "Live parts information disabled due to errors.";
+    mDisabledDueToErrors = true;
+  }
+}
+
+void PartInformationProvider::removeOutdatedInformation() noexcept {
+  int count = 0;
+  const qint64 timestamp = QDateTime::currentSecsSinceEpoch();
+  foreach (const Part& part, mCache.keys()) {
+    const qint64 lifetimeSecs = timestamp - mCache.value(part)->timestamp;
+    if (lifetimeSecs > 6 * 3600) {  // 6 hours
+      mCache.remove(part);
+      mCacheModified = true;
+      ++count;
+    }
+  }
+  qDebug() << "Cleaned outdated live information about" << count << "parts.";
+}
+
+void PartInformationProvider::loadCacheFromDisk() noexcept {
+  if (!mCacheFp.isExistingFile()) return;
+
+  try {
+    const SExpression root =
+        SExpression::parse(FileUtils::readFile(mCacheFp), mCacheFp);
+    foreach (const SExpression* node, root.getChildren("part")) {
+      std::shared_ptr<PartInformation> info =
+          std::make_shared<PartInformation>();
+      info->load(*node);
+      const Part part{info->mpn, info->manufacturer};
+      auto it = mCache.find(part);
+      if ((it == mCache.end()) || (info->timestamp > it.value()->timestamp)) {
+        mCache.insert(part, info);
+      }
+    }
+    qInfo().nospace() << "Loaded parts information cache from "
+                      << mCacheFp.toNative() << ".";
+  } catch (const Exception& e) {
+    qCritical().nospace() << "Failed to load parts information cache from "
+                          << mCacheFp.toNative() << ": " << e.getMsg();
+  }
+
+  removeOutdatedInformation();
+}
+
+void PartInformationProvider::saveCacheToDisk() noexcept {
+  if (!mCacheModified) return;
+
+  try {
+    SExpression root = SExpression::createList("librepcb_parts_cache");
+    root.ensureLineBreak();
+    for (auto it = mCache.begin(); it != mCache.end(); it++) {
+      it.value()->serialize(root.appendList("part"));
+      root.ensureLineBreak();
+    }
+    FileUtils::writeFile(mCacheFp, root.toByteArray());
+    qInfo().nospace() << "Saved parts information cache to "
+                      << mCacheFp.toNative() << ".";
+    mCacheModified = false;
+  } catch (const Exception& e) {
+    qCritical().nospace() << "Failed to save parts information cache to "
+                          << mCacheFp.toNative() << ": " << e.getMsg();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/partinformationprovider.h
+++ b/libs/librepcb/editor/project/partinformationprovider.h
@@ -1,0 +1,205 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_PARTINFORMATIONPROVIDER_H
+#define LIBREPCB_EDITOR_PARTINFORMATIONPROVIDER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/fileio/filepath.h>
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+#include <QtGui>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class ApiEndpoint;
+class SExpression;
+
+namespace editor {
+
+/*******************************************************************************
+ *  Class PartInformationProvider
+ ******************************************************************************/
+
+/**
+ * @brief Parts information provider & cache
+ *
+ * To avoid duplicate API requests, received information is cached in the
+ * global instance #instance().
+ */
+class PartInformationProvider final : public QObject {
+  Q_OBJECT
+
+public:
+  // Types
+  struct Part {
+    QString mpn;
+    QString manufacturer;
+    inline bool operator==(const Part& rhs) const noexcept {
+      return (mpn == rhs.mpn) && (manufacturer == rhs.manufacturer);
+    }
+    inline bool operator<(const Part& rhs) const noexcept {
+      if (mpn != rhs.mpn) {
+        return mpn < rhs.mpn;
+      } else {
+        return manufacturer < rhs.manufacturer;
+      }
+    }
+  };
+  struct PartResource {
+    QString name;
+    QString mediaType;
+    QUrl url;
+  };
+  struct PartInformation {
+    qint64 timestamp;  // Seconds since epoch
+    QString mpn;
+    QString manufacturer;
+    int results;
+    QUrl productUrl;  // Empty if N/A
+    QUrl pictureUrl;  // Empty if N/A
+    QUrl pricingUrl;  // Empty if N/A
+    QString status;  // Empty if N/A
+    tl::optional<int> availability;  // nullopt if N/A
+    QMap<int, qreal> prices;  // Empty if N/A
+    QVector<PartResource> resources;  // Empty if N/A
+
+    QString getStatusTr() const noexcept;
+    QString getStatusColorName() const noexcept;
+    QString getAvailabilityTr() const noexcept;
+    QString getAvailabilityColorName() const noexcept;
+    qreal getPrice(int quantity = 1) const noexcept;
+    QString getPriceStr(int quantity = 1, const char* prefix = "$ ",
+                        const char* suffix = "") const noexcept;
+
+    /**
+     * @brief Serialize into ::librepcb::SExpression node
+     *
+     * @param root    Root node to serialize into.
+     */
+    void serialize(SExpression& root) const;
+
+    void load(const SExpression& node);
+  };
+
+  // Constructors / Destructor
+  PartInformationProvider(const PartInformationProvider& other) noexcept =
+      delete;
+  explicit PartInformationProvider(QObject* parent = nullptr) noexcept;
+  ~PartInformationProvider() noexcept;
+
+  // Getters
+  bool isOperational() const noexcept;
+  const QString& getProviderName() const noexcept { return mProviderName; }
+  const QUrl& getProviderUrl() const noexcept { return mProviderUrl; }
+  const QUrl& getProviderLogoUrl() const noexcept { return mProviderLogoUrl; }
+  const QPixmap getProviderLogo() const noexcept { return mProviderLogo; }
+  const QUrl& getInfoUrl() const noexcept { return mInfoUrl; }
+
+  // Setters
+  void setCacheDir(const FilePath& dir) noexcept;
+  void setApiEndpoint(const QUrl& url) noexcept;
+
+  // General Methods
+  void startOperation() noexcept;
+  std::shared_ptr<PartInformation> getPartInfo(const Part& part) noexcept;
+  bool isOngoing(const Part& part) const noexcept;
+  void scheduleRequest(const Part& part) noexcept;
+  void requestScheduledParts() noexcept;
+
+  // Static Methods
+  static PartInformationProvider& instance() noexcept {
+    static PartInformationProvider obj;
+    return obj;
+  }
+
+  // Operator Overloadings
+  PartInformationProvider& operator=(
+      const PartInformationProvider& rhs) noexcept = delete;
+
+signals:
+  void serviceOperational();
+  void providerInfoChanged();
+  void newPartsInformationAvailable();
+
+private:  // Methods
+  void reset() noexcept;
+  void requestStatus() noexcept;
+  void statusReceived(const QJsonObject& json) noexcept;
+  void errorWhileFetchingStatus(const QString& errorMsg) noexcept;
+  void partsInformationReceived(const QJsonObject& json) noexcept;
+  void errorWhileFetchingPartsInformation(const QString& errorMsg) noexcept;
+  void removeOutdatedInformation() noexcept;
+  void loadCacheFromDisk() noexcept;
+  void saveCacheToDisk() noexcept;
+
+private:  // Data
+  // Configuration
+  FilePath mCacheFp;
+  QScopedPointer<ApiEndpoint> mEndpoint;
+
+  // Error handling
+  int mErrorCounter;
+  bool mDisabledDueToErrors;
+
+  // Status request state
+  qint64 mStatusRequestedTimestamp;
+  bool mStatusReceived;
+  QString mProviderName;  ///< Valid only if #mStatusReceived is `true`
+  QUrl mProviderUrl;  ///< Valid only if #mStatusReceived is `true`
+  QUrl mProviderLogoUrl;  ///< Valid only if #mStatusReceived is `true`
+  QPixmap mProviderLogo;  ///< Requested asynchronously.
+  QUrl mInfoUrl;  ///< Valid only if #mStatusReceived is `true`
+  QUrl mQueryUrl;  ///< Valid only if #mStatusReceived is `true`
+  int mQueryMaxPartCount;  ///< Valid only if #mStatusReceived is `true`
+
+  // Query request state
+  QVector<Part> mScheduledParts;
+  QSet<Part> mRequestedParts;
+
+  // Cache
+  QMap<Part, std::shared_ptr<PartInformation>> mCache;  // Sorted for file I/O!
+  bool mCacheModified;
+};
+
+/*******************************************************************************
+ *  Non-Member Functions
+ ******************************************************************************/
+
+inline uint qHash(const PartInformationProvider::Part& key,
+                  uint seed = 0) noexcept {
+  return ::qHash(qMakePair(key.mpn, key.manufacturer), seed);
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+Q_DECLARE_METATYPE(librepcb::editor::PartInformationProvider::PartInformation)
+
+#endif

--- a/libs/librepcb/editor/project/partinformationprovider.h
+++ b/libs/librepcb/editor/project/partinformationprovider.h
@@ -93,6 +93,7 @@ public:
     qreal getPrice(int quantity = 1) const noexcept;
     QString getPriceStr(int quantity = 1, const char* prefix = "$ ",
                         const char* suffix = "") const noexcept;
+    static QString formatQuantity(const QLocale& locale, int qty) noexcept;
 
     /**
      * @brief Serialize into ::librepcb::SExpression node

--- a/libs/librepcb/editor/project/partinformationtooltip.cpp
+++ b/libs/librepcb/editor/project/partinformationtooltip.cpp
@@ -1,0 +1,389 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "partinformationtooltip.h"
+
+#include "../widgets/waitingspinnerwidget.h"
+#include "../workspace/desktopservices.h"
+#include "ui_partinformationtooltip.h"
+
+#include <librepcb/core/network/networkrequest.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+using PartInformation = PartInformationProvider::PartInformation;
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PartInformationToolTip::PartInformationToolTip(
+    const WorkspaceSettings& settings, QWidget* parent) noexcept
+  : QFrame(parent),
+    mSettings(settings),
+    mUi(new Ui::PartInformationToolTip),
+    mWaitingSpinner(new WaitingSpinnerWidget(this)),
+    mExpandAnimation(new QVariantAnimation(this)),
+    mPopUpDelayTimer(new QTimer(this)),
+    mArrowPositionY(0),
+    mPictureDelayTimer(new QTimer(this)) {
+  mUi->setupUi(this);
+  mUi->lblSourceDetails->setMinimumWidth(minimumWidth() - 20);  // Fix sizHint()
+  setWindowFlags(Qt::ToolTip);
+  mWaitingSpinner->hide();
+
+  // Set up stylesheet.
+  mWaitingSpinner->setColor(Qt::darkGray);
+  setStyleSheet(QString("QWidget{"
+                        " background-color: #FFFFCA;"
+                        " color: black;"
+                        "}"
+                        "librepcb--editor--PartInformationToolTip{"
+                        " border: %1px solid darkgray; "
+                        " border-right: 1px solid gray; "
+                        " border-top: 1px solid gray;"
+                        " border-bottom: 1px solid gray;"
+                        "};")
+                    .arg(sWindowArrowSize + 1));
+
+  // Set up expand/collapse animation.
+  mExpandAnimation->setStartValue(0);
+  mExpandAnimation->setEndValue(0);
+  mExpandAnimation->setEasingCurve(QEasingCurve::InQuad);
+  mExpandAnimation->setDuration(300);
+  connect(mExpandAnimation.data(), &QVariantAnimation::valueChanged, this,
+          [this](const QVariant& value) {
+            mUi->lblSourceDetails->setFixedHeight(value.toInt());
+            updateShape();
+          });
+
+  // Install label click event handlers.
+  mUi->lblExpand->installEventFilter(this);
+  mUi->lblSource->installEventFilter(this);
+  mUi->lblProviderLogo->installEventFilter(this);
+  connect(mUi->lblHeader, &QLabel::linkActivated, this,
+          &PartInformationToolTip::openUrl);
+  connect(mUi->lblDetails, &QLabel::linkActivated, this,
+          &PartInformationToolTip::openUrl);
+  connect(mUi->lblSourceDetails, &QLabel::linkActivated, this,
+          &PartInformationToolTip::openUrl);
+
+  // Close popup if parent has been hidden.
+  if (parent) {
+    parent->installEventFilter(this);
+  }
+
+  // Setup popup delay timer.
+  mPopUpDelayTimer->setSingleShot(true);
+  connect(mPopUpDelayTimer.data(), &QTimer::timeout, this,
+          &PartInformationToolTip::show);
+
+  // Set up picture loading delay timer.
+  mPictureDelayTimer->setSingleShot(true);
+  connect(mPictureDelayTimer.data(), &QTimer::timeout, this,
+          [this]() { startLoadPicture(false); });
+
+  setProviderInfo(QString(), QUrl(), QPixmap(), QUrl());
+  hideAndReset();
+}
+
+PartInformationToolTip::~PartInformationToolTip() noexcept {
+}
+
+/*******************************************************************************
+ *  Setters
+ ******************************************************************************/
+
+void PartInformationToolTip::setProviderInfo(const QString& name,
+                                             const QUrl& url,
+                                             const QPixmap& logo,
+                                             const QUrl& infoUrl) noexcept {
+  QString text;
+  if (name.isEmpty()) {
+    text = tr("This service is currently not available.");
+  } else {
+    const QString provider =
+        QString("<a href=\"%1\" style=\"color:black\">%2</a>")
+            .arg(url.toString())
+            .arg(name.toHtmlEscaped());
+    text = tr("This information is kindly provided by %1 through the "
+              "LibrePCB&nbsp;API, see details "
+              "<a href=\"%2\" style=\"color:black;\">here</a>.")
+               .arg(provider)
+               .arg(infoUrl.toString().toHtmlEscaped());
+    text += " ";
+    text += tr(
+        "For more information about the part, click on the source logo above.");
+  }
+  mUi->lblSourceDetails->setText(text);
+  if (logo.isNull()) {
+    mUi->lblProviderLogo->setText(name);
+  } else {
+    setLabelPixmap(mUi->lblProviderLogo, logo, QSize(150, 13));
+  }
+  updateShape();
+}
+
+void PartInformationToolTip::showPart(
+    const std::shared_ptr<const PartInformationProvider::PartInformation>& info,
+    const QPoint& pos) noexcept {
+  if (!info) {
+    hideAndReset();
+    return;
+  }
+
+  if ((!mPartInfo) || (info->mpn != mPartInfo->mpn) ||
+      (info->manufacturer != mPartInfo->manufacturer)) {
+    mPartInfo = info;
+
+    QString header = QString(
+                         "<span style=\"font-size:large\"><b><a href=\"%1\" "
+                         "style=\"color:black\">%2</a></b></span>")
+                         .arg(info->productUrl.toString())
+                         .arg(info->mpn.toHtmlEscaped());
+    if (!info->manufacturer.isEmpty()) {
+      header +=
+          QString("&nbsp;&nbsp;%1").arg(info->manufacturer.toHtmlEscaped());
+    }
+    mUi->lblHeader->setText(header);
+
+    QString details;
+    if (!info->getStatusTr().isEmpty()) {
+      details += QString("<div><span style=\"color:%1\">⬤</span> %2</div>")
+                     .arg(info->getStatusColorName())
+                     .arg(info->getStatusTr().toHtmlEscaped());
+    }
+    if (!info->getAvailabilityTr().isEmpty()) {
+      details += QString("<div><span style=\"color:%1\">⬤</span> %2</div>")
+                     .arg(info->getAvailabilityColorName())
+                     .arg(info->getAvailabilityTr().toHtmlEscaped());
+    }
+    if (!info->prices.isEmpty()) {
+      details += "<div><table>";
+      foreach (int quantity, info->prices.keys().mid(0, 3)) {
+        details +=
+            QString("<tr><td align=\"right\">%1 %2:</td><td>%3</td></tr>")
+                .arg(PartInformation::formatQuantity(locale(), quantity))
+                //: Abbreviation for "pieces", keep it very short!
+                .arg(tr("pcs").toHtmlEscaped())
+                .arg(info->getPriceStr(quantity, "", " USD").toHtmlEscaped());
+      }
+      details += "</table></div>";
+    }
+    foreach (const auto& resource, info->resources.mid(0, 2)) {
+      details +=
+          QString("<div>➤ <a href=\"%1\" style=\"color:black\">%2</a></div>")
+              .arg(resource.url.toString())
+              .arg(resource.name.toHtmlEscaped());
+    }
+    mUi->lblDetails->setText(details);
+
+    if (info->pricingUrl.isValid()) {
+      mUi->lblProviderLogo->setCursor(Qt::PointingHandCursor);
+    } else {
+      mUi->lblProviderLogo->unsetCursor();
+    }
+
+    mUi->lblPicture->hide();
+    mPictureDelayTimer->stop();
+  }
+
+  mArrowPositionY = height() / 2;
+  move(pos - QPoint(sWindowArrowSize, mArrowPositionY));
+  setSourceDetailsExpanded(false, false);
+
+  if (isVisible()) {
+    mWaitingSpinner->hide();
+    scheduleLoadPicture();
+    updateShape();
+  } else {
+    mPopUpDelayTimer->start();
+  }
+}
+
+void PartInformationToolTip::hideAndReset(bool resetTimer) noexcept {
+  mPopUpDelayTimer->stop();
+  if (resetTimer) {
+    mPopUpDelayTimer->setInterval(sPopupDelayMs);
+  }
+  QFrame::hide();
+}
+
+bool PartInformationToolTip::eventFilter(QObject* watched,
+                                         QEvent* event) noexcept {
+  if (event->type() == QEvent::MouseButtonPress) {
+    if ((watched == mUi->lblExpand) || (watched == mUi->lblSource)) {
+      setSourceDetailsExpanded(mUi->lblSourceDetails->height() == 0, true);
+    } else if ((watched == mUi->lblProviderLogo) && mPartInfo &&
+               mPartInfo->pricingUrl.isValid()) {
+      openUrl(mPartInfo->pricingUrl);
+    }
+  }
+  if ((watched == parentWidget()) &&
+      ((event->type() == QEvent::Hide) || (event->type() == QEvent::Close))) {
+    hideAndReset();
+  }
+  return QFrame::eventFilter(watched, event);
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+void PartInformationToolTip::showEvent(QShowEvent* e) noexcept {
+  QFrame::showEvent(e);
+  mPopUpDelayTimer->setInterval(50);
+  mWaitingSpinner->hide();
+  scheduleLoadPicture();
+  updateShape();
+}
+
+void PartInformationToolTip::hideEvent(QHideEvent* e) noexcept {
+  QFrame::hideEvent(e);
+  mPictureDelayTimer->stop();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void PartInformationToolTip::scheduleLoadPicture() noexcept {
+  if (mPartInfo && mPartInfo->pictureUrl.isValid() &&
+      (!mUi->lblPicture->isVisible())) {
+    mWaitingSpinner->show();
+    startLoadPicture(true);
+    mPictureDelayTimer->start(1000);
+  }
+}
+
+void PartInformationToolTip::startLoadPicture(bool onlyCache) noexcept {
+  if (mPartInfo && mPartInfo->pictureUrl.isValid() &&
+      (!mUi->lblPicture->isVisible())) {
+    NetworkRequest* request = new NetworkRequest(mPartInfo->pictureUrl);
+    if (onlyCache) {
+      // Immediately after showing the tooltip, only load the image from cache
+      // to avoid extensive network load!
+      request->setCacheLoadControl(QNetworkRequest::AlwaysCache);
+    }
+    request->setMinimumCacheTime(14 * 24 * 3600);  // 14 days
+    const QString format =
+        mPartInfo->pictureUrl.fileName().split('.').last().toLower();
+    connect(
+        request, &NetworkRequest::dataReceived, this,
+        [this, format](const QByteArray& data) {
+          QPixmap pixmap;
+          if (!format.isEmpty()) {
+            pixmap.loadFromData(data, qPrintable(format));
+          }
+          if (pixmap.isNull()) {
+            pixmap.loadFromData(data);
+          }
+          if (!pixmap.isNull()) {
+            mUi->lblPicture->setFrameShape(pixmap.hasAlpha() ? QFrame::NoFrame
+                                                             : QFrame::Box);
+            setLabelPixmap(mUi->lblPicture, pixmap,
+                           mUi->pictureContainer->contentsRect().size());
+          } else if (!data.isEmpty()) {
+            qWarning().nospace()
+                << "Failed to display image of format " << format
+                << ". Maybe the Qt image formats plugin is not installed?";
+          }
+          mPictureDelayTimer->stop();
+        },
+        Qt::QueuedConnection);
+    connect(request, &NetworkRequest::finished, this,
+            [this, onlyCache](bool success) {
+              if (success || (!onlyCache)) {
+                mWaitingSpinner->hide();
+              }
+            });
+    request->start();
+  }
+}
+
+void PartInformationToolTip::setLabelPixmap(QLabel* label,
+                                            const QPixmap& pixmap,
+                                            const QSize& space) noexcept {
+  const qreal scaleFactor = std::min(space.width() / qreal(pixmap.width()),
+                                     space.height() / qreal(pixmap.height()));
+  label->setFixedSize(pixmap.size() * scaleFactor);
+  label->setPixmap(pixmap);
+  label->show();
+}
+
+void PartInformationToolTip::updateShape() noexcept {
+  adjustSize();
+  const int w = width();
+  const int h = height();
+  setMask(QRegion(QPolygon({
+      QPoint(0, mArrowPositionY),
+      QPoint(sWindowArrowSize, mArrowPositionY - sWindowArrowSize),
+      QPoint(sWindowArrowSize, 0),
+      QPoint(w, 0),
+      QPoint(w, h),
+      QPoint(sWindowArrowSize, h),
+      QPoint(sWindowArrowSize, mArrowPositionY + sWindowArrowSize),
+      QPoint(0, mArrowPositionY),
+  })));
+}
+
+void PartInformationToolTip::setSourceDetailsExpanded(bool expanded,
+                                                      bool animated) noexcept {
+  if (expanded) {
+    mUi->lblExpand->setText("▼");
+    mExpandAnimation->setEndValue(mUi->lblSourceDetails->sizeHint().height());
+    mExpandAnimation->setDirection(QVariantAnimation::Forward);
+  } else {
+    mUi->lblExpand->setText("▶");
+    mExpandAnimation->setEndValue(mUi->lblSourceDetails->height());
+    mExpandAnimation->setDirection(QVariantAnimation::Backward);
+  }
+  if (animated) {
+    mExpandAnimation->start();
+  } else {
+    mExpandAnimation->stop();
+    mUi->lblSourceDetails->setFixedHeight(
+        expanded ? mExpandAnimation->endValue().toInt()
+                 : mExpandAnimation->startValue().toInt());
+  }
+}
+
+void PartInformationToolTip::openUrl(const QUrl& url) noexcept {
+  DesktopServices ds(mSettings, this);
+  if (ds.openWebUrl(url)) {
+    hideAndReset();
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/partinformationtooltip.h
+++ b/libs/librepcb/editor/project/partinformationtooltip.h
@@ -1,0 +1,118 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_PARTINFORMATIONTOOLTIP_H
+#define LIBREPCB_EDITOR_PARTINFORMATIONTOOLTIP_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "partinformationprovider.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class NetworkRequest;
+class WorkspaceSettings;
+
+namespace editor {
+
+class WaitingSpinnerWidget;
+
+namespace Ui {
+class PartInformationToolTip;
+}
+
+/*******************************************************************************
+ *  Class PartInformationToolTip
+ ******************************************************************************/
+
+/**
+ * @brief The PartInformationToolTip class
+ */
+class PartInformationToolTip final : public QFrame {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  PartInformationToolTip() = delete;
+  PartInformationToolTip(const PartInformationToolTip& other) = delete;
+  explicit PartInformationToolTip(const WorkspaceSettings& settings,
+                                  QWidget* parent = nullptr) noexcept;
+  ~PartInformationToolTip() noexcept;
+
+  // Setters
+  void setProviderInfo(const QString& name, const QUrl& url,
+                       const QPixmap& logo, const QUrl& infoUrl) noexcept;
+  void showPart(const std::shared_ptr<
+                    const PartInformationProvider::PartInformation>& info,
+                const QPoint& pos) noexcept;
+
+  // General Methods
+  void hideAndReset(bool reset = true) noexcept;
+  virtual bool eventFilter(QObject* watched, QEvent* event) noexcept override;
+
+  // Operator Overloads
+  PartInformationToolTip& operator=(const PartInformationToolTip& rhs) = delete;
+
+protected:
+  virtual void showEvent(QShowEvent* e) noexcept override;
+  virtual void hideEvent(QHideEvent* e) noexcept override;
+
+private:  // Methods
+  void scheduleLoadPicture() noexcept;
+  void startLoadPicture(bool onlyCache) noexcept;
+  void setLabelPixmap(QLabel* label, const QPixmap& pixmap,
+                      const QSize& space) noexcept;
+  void updateShape() noexcept;
+  void setSourceDetailsExpanded(bool expanded, bool animated) noexcept;
+  void openUrl(const QUrl& url) noexcept;
+
+private:  // Data
+  const WorkspaceSettings& mSettings;
+  QScopedPointer<Ui::PartInformationToolTip> mUi;
+  QScopedPointer<WaitingSpinnerWidget> mWaitingSpinner;
+  QScopedPointer<QVariantAnimation> mExpandAnimation;
+
+  QScopedPointer<QTimer> mPopUpDelayTimer;
+
+  int mArrowPositionY;
+  std::shared_ptr<const PartInformationProvider::PartInformation> mPartInfo;
+  QScopedPointer<QTimer> mPictureDelayTimer;
+
+  // Constants
+  static const constexpr int sPopupDelayMs = 300;
+  static const constexpr int sWindowArrowSize = 8;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/project/partinformationtooltip.ui
+++ b/libs/librepcb/editor/project/partinformationtooltip.ui
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::editor::PartInformationToolTip</class>
+ <widget class="QFrame" name="librepcb::editor::PartInformationToolTip">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>169</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>350</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>600</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Part Information</string>
+  </property>
+  <layout class="QVBoxLayout" name="vLayoutMain">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>7</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="lblHeader">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true">lblHeader</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
+     <property name="spacing">
+      <number>15</number>
+     </property>
+     <property name="topMargin">
+      <number>3</number>
+     </property>
+     <property name="bottomMargin">
+      <number>3</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="lblDetails">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true">lblDetails</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QWidget" name="pictureContainer" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>80</height>
+        </size>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="lblPicture">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+          <property name="scaledContents">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0">
+     <property name="spacing">
+      <number>3</number>
+     </property>
+     <property name="topMargin">
+      <number>3</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="lblExpand">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>7</pointsize>
+        </font>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="text">
+        <string notr="true">lblExpand</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblSource">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+         <italic>true</italic>
+        </font>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="text">
+        <string>Source:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>5</width>
+         <height>5</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblProviderLogo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string notr="true">lblProviderLogo</string>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblSourceDetails">
+     <property name="font">
+      <font>
+       <pointsize>10</pointsize>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>lblSourceDetails</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_addcomponent.cpp
@@ -364,9 +364,8 @@ void SchematicEditorState_AddComponent::startAddingComponent(
         mAddComponentDialog->setNormOrder(mContext.project.getNormOrder());
       } else {
         mAddComponentDialog.reset(new AddComponentDialog(
-            mContext.workspace.getLibraryDb(),
+            mContext.workspace.getLibraryDb(), mContext.workspace.getSettings(),
             mContext.project.getLocaleOrder(), mContext.project.getNormOrder(),
-            mContext.workspace.getSettings().themes.getActive(),
             parentWidget()));
       }
       if (!searchTerm.isEmpty()) {

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -674,8 +674,12 @@ void WorkspaceSettingsDialog::loadSettings() noexcept {
   // Library Norm Order
   mLibNormOrderModel->setValues(mSettings.libraryNormOrder.get());
 
-  // API endpoints
+  // API Endpoints
   mApiEndpointModel->setValues(mSettings.apiEndpoints.get());
+
+  // Auto-Fetch Live Part Information
+  mUi->cbxAutofetchLivePartInformation->setChecked(
+      mSettings.autofetchLivePartInformation.get());
 
   // External Applications
   for (auto& app : mExternalApplications) {
@@ -723,8 +727,12 @@ void WorkspaceSettingsDialog::saveSettings() noexcept {
     // Library Norm Order
     mSettings.libraryNormOrder.set(mLibNormOrderModel->getValues());
 
-    // API endpoints
+    // API Endpoints
     mSettings.apiEndpoints.set(mApiEndpointModel->getValues());
+
+    // Auto-Fetch Live Part Information
+    mSettings.autofetchLivePartInformation.set(
+        mUi->cbxAutofetchLivePartInformation->isChecked());
 
     // External Applications
     for (auto& app : mExternalApplications) {

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
@@ -770,6 +770,16 @@ To completely disable Internet access, just remove all entries.&lt;/p&gt;
          </attribute>
         </widget>
        </item>
+       <item>
+        <widget class="QCheckBox" name="cbxAutofetchLivePartInformation">
+         <property name="toolTip">
+          <string>&lt;p&gt;Allow the editors to automatically display live information about parts (lifecycle status, stock availability, price, ...) by requesting it from the configured API endpoints.&lt;/p&gt;&lt;p&gt;This may generate many API requests, especially while adding components to schematics.&lt;/p&gt;&lt;p&gt;If this feature is disabled, no such API requests are made (and no live information is displayed) without explicit user interaction.&lt;/p&gt;</string>
+         </property>
+         <property name="text">
+          <string>Auto-Fetch Live Part Information</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>


### PR DESCRIPTION
### Summary

This PR adds an initial integration of live parts information to the schematic editor, in particular to the "Add Component" dialog and the "Generate BOM" dialog. Live part information means part lifecycle status, supplier availability, pricing and more. Since this information is very volatile, it is fetched from the internet on demand and not stored in any file (except for caching).

Note that this PR adds the feature to the application (i.e. client-side), but it also requires a server-side implementation which provides the data to be displayed. The server-side implementation is added in https://github.com/LibrePCB/librepcb-api-server/pull/1. And the actual availability of this feature in the application depends on whether the server provides this data or not - if we don't have access to a corresponding database, the server replies with a "not available" status and the application silently doesn't show any life part information.

### API Specification

The underlying API for the server requests/responses is specified here: https://developers.librepcb.org/_branches/live-part-information/d1/dcb/doc_server_api.html#doc_server_api_resources_parts (link might be down if the branch is not pushed for some time).

### Add-Component Dialog

Preview with dummy data since we don't have access to a parts information database yet:

![librepcb-live-part-info](https://github.com/LibrePCB/LibrePCB/assets/5374821/e7a4a5e5-e46f-42d9-afd3-667c26c973a5)

### BOM Export

The same information is provided in the BOM export (incl. mouse hover), plus the total price for all parts of the project:

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/38f2ab55-7ba1-43ec-82c3-ccc3fde5ea32)

### Internet Access

Whenever the user opens a window where life parts information should be displayed, the application requests the information from the configured API server (api.librepcb.org by default). The received data is cached locally to avoid extensive network traffic if the same data is requested multiple times in a short time span.

The part information itself is all requested through the API, i.e. LibrePCB only talks to our own server. This allows us to ensure proper data privacy (no tracking etc.), independent of the underlying data provider. So the data provider only gets anonymous requests from our own server, not from our users directly (keeping e.g. their IP address private). However, images are not embedded in the API responses, so they might (and probably will be) downloaded directly from other domains (e.g. semiconductor companies). I hope this compromise is okay for our users, as it would be a big overhead to also route this traffic through our own server. I think it's not really relevant for privacy since requests do not contain any useful information (just fetching static content) and are spread across many domains, not possible for a company to track all user requests.

However, for users who are concerned about internet traffic, data privacy or something like that, the feature can be disabled in the workspace settings (details are provided as tooltip):

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/0fb46bf5-25e6-46cb-98b7-b4906c6c0dc6)