### PR TITLE
EAGLE Import: Fix ignoring library URNs

### DIFF
--- a/libs/librepcb/eagleimport/eaglelibraryconverter.h
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.h
@@ -94,6 +94,7 @@ public:
 
   // Getters
   Uuid getComponentSignalOfSymbolPin(const QString& libName,
+                                     const QString& libUrn,
                                      const QString& devSetName,
                                      const QString& gateName,
                                      const QString& pinName) const;
@@ -101,16 +102,19 @@ public:
   // General Methods
   void reset() noexcept;
   std::unique_ptr<Symbol> createSymbol(const QString& libName,
+                                       const QString& libUrn,
                                        const parseagle::Symbol& eagleSymbol,
                                        MessageLogger& log);
   std::unique_ptr<Package> createPackage(const QString& libName,
+                                         const QString& libUrn,
                                          const parseagle::Package& eaglePackage,
                                          MessageLogger& log);
   std::unique_ptr<Component> createComponent(
-      const QString& libName, const parseagle::DeviceSet& eagleDeviceSet,
-      MessageLogger& log);
+      const QString& libName, const QString& libUrn,
+      const parseagle::DeviceSet& eagleDeviceSet, MessageLogger& log);
   std::unique_ptr<Device> createDevice(
-      const QString& libName, const parseagle::DeviceSet& eagleDeviceSet,
+      const QString& libName, const QString& libUrn,
+      const parseagle::DeviceSet& eagleDeviceSet,
       const parseagle::Device& eagleDevice, MessageLogger& log);
 
   // Operator Overloadings
@@ -124,36 +128,32 @@ private:  // Data
 
   // State
 
-  /// Key: (Library Name, Symbol Name)
+  /// Key: [Library Name, Library URN, Symbol Name]
   /// Value: LibrePCB Symbol UUID
-  QHash<std::pair<QString, QString>, tl::optional<Uuid> > mSymbolMap;
+  QHash<QStringList, tl::optional<Uuid> > mSymbolMap;
 
-  /// Key: (Library Name, Symbol Name) | Pin Name
+  /// Key: [Library Name, Library URN, Symbol Name] | Pin Name
   /// Value: (EAGLE Pin Object, LibrePCB Symbol Pin UUID)
-  QHash<
-      std::pair<QString, QString>,
-      QHash<QString,
-            std::pair<std::shared_ptr<parseagle::Pin>, tl::optional<Uuid> > > >
+  QHash<QStringList,
+        QMap<QString,
+             std::pair<std::shared_ptr<parseagle::Pin>, tl::optional<Uuid> > > >
       mSymbolPinMap;
 
-  /// Key: (Library Name, Package Name)
+  /// Key: [Library Name, Library URN, Package Name]
   /// Value: LibrePCB Package UUID
-  QHash<std::pair<QString, QString>, tl::optional<Uuid> > mPackageMap;
+  QHash<QStringList, tl::optional<Uuid> > mPackageMap;
 
-  /// Key: (Library Name, Package Name) | Pad Name
+  /// Key: [Library Name, Library URN, Package Name] | Pad Name
   /// Value: LibrePCB Package Pad UUID
-  QHash<std::pair<QString, QString>, QHash<QString, tl::optional<Uuid> > >
-      mPackagePadMap;
+  QHash<QStringList, QMap<QString, tl::optional<Uuid> > > mPackagePadMap;
 
-  /// Key: (Library Name, Device Set Name)
+  /// Key: [Library Name, Library URN, Device Set Name]
   /// Value: LibrePCB Component UUID
-  QHash<std::pair<QString, QString>, tl::optional<Uuid> > mComponentMap;
+  QHash<QStringList, tl::optional<Uuid> > mComponentMap;
 
-  /// Key: (Library Name, Device Set Name) | Gate Name | Pin Name
+  /// Key: [Library Name, Library URN, Device Set Name, Gate Name, Pin Name]
   /// Value: LibrePCB Component Signal UUID
-  QHash<std::pair<QString, QString>,
-        QHash<QString, QHash<QString, tl::optional<Uuid> > > >
-      mComponentSignalMap;
+  QHash<QStringList, tl::optional<Uuid> > mComponentSignalMap;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/eagleimport/eaglelibraryimport.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryimport.cpp
@@ -335,8 +335,8 @@ void EagleLibraryImport::run() noexcept {
     MessageLogger log(globalLog.get(), sym.displayName);
     try {
       emit progressStatus(sym.displayName);
-      auto symbol =
-          converter.createSymbol(QString(), *sym.symbol, log);  // can throw
+      auto symbol = converter.createSymbol(QString(), QString(), *sym.symbol,
+                                           log);  // can throw
       TransactionalDirectory dir(TransactionalFileSystem::openRW(
           mDestinationLibraryFp
               .getPathTo(librepcb::Symbol::getShortElementName())
@@ -360,8 +360,8 @@ void EagleLibraryImport::run() noexcept {
     MessageLogger log(globalLog.get(), pkg.displayName);
     try {
       emit progressStatus(pkg.displayName);
-      auto package =
-          converter.createPackage(QString(), *pkg.package, log);  // can throw
+      auto package = converter.createPackage(QString(), QString(), *pkg.package,
+                                             log);  // can throw
       TransactionalDirectory dir(TransactionalFileSystem::openRW(
           mDestinationLibraryFp
               .getPathTo(librepcb::Package::getShortElementName())
@@ -385,8 +385,9 @@ void EagleLibraryImport::run() noexcept {
     MessageLogger log(globalLog.get(), cmp.displayName);
     try {
       emit progressStatus(cmp.displayName);
-      auto component = converter.createComponent(QString(), *cmp.deviceSet,
-                                                 log);  // can throw
+      auto component =
+          converter.createComponent(QString(), QString(), *cmp.deviceSet,
+                                    log);  // can throw
       TransactionalDirectory dir(TransactionalFileSystem::openRW(
           mDestinationLibraryFp
               .getPathTo(librepcb::Component::getShortElementName())
@@ -410,7 +411,7 @@ void EagleLibraryImport::run() noexcept {
     MessageLogger log(globalLog.get(), dev.displayName);
     try {
       emit progressStatus(dev.displayName);
-      auto device = converter.createDevice(QString(), *dev.deviceSet,
+      auto device = converter.createDevice(QString(), QString(), *dev.deviceSet,
                                            *dev.device, log);  // can throw
       TransactionalDirectory dir(TransactionalFileSystem::openRW(
           mDestinationLibraryFp

--- a/libs/librepcb/eagleimport/eagleprojectimport.cpp
+++ b/libs/librepcb/eagleimport/eagleprojectimport.cpp
@@ -271,7 +271,8 @@ const Symbol& EagleProjectImport::importLibrarySymbol(
     const parseagle::Symbol& eagleSymbol = getSymbol(eagleLib, symName);
     MessageLogger log(mLogger.get(), eagleSymbol.getName());
     std::unique_ptr<Symbol> sym =
-        converter.createSymbol(eagleLib.getEmbeddedName(), eagleSymbol, log);
+        converter.createSymbol(eagleLib.getEmbeddedName(),
+                               eagleLib.getEmbeddedUrn(), eagleSymbol, log);
     it = mLibSymbolMap.insert(key, sym->getUuid());
     library.addSymbol(*sym.release());
   }
@@ -296,7 +297,8 @@ const Component& EagleProjectImport::importLibraryComponent(
     }
     MessageLogger log(mLogger.get(), eagleDevSet.getName());
     std::unique_ptr<Component> cmp =
-        converter.createComponent(eagleLib.getEmbeddedName(), eagleDevSet, log);
+        converter.createComponent(eagleLib.getEmbeddedName(),
+                                  eagleLib.getEmbeddedUrn(), eagleDevSet, log);
     if ((cmp->getSymbolVariants().count() != 1) ||
         (cmp->getSymbolVariants().first()->getSymbolItems().count() !=
          eagleDevSet.getGates().count())) {
@@ -328,7 +330,8 @@ const Package& EagleProjectImport::importLibraryPackage(
     const parseagle::Package& eaglePackage = getPackage(eagleLib, pkgName);
     MessageLogger log(mLogger.get(), eaglePackage.getName());
     std::unique_ptr<Package> pkg =
-        converter.createPackage(eagleLib.getEmbeddedName(), eaglePackage, log);
+        converter.createPackage(eagleLib.getEmbeddedName(),
+                                eagleLib.getEmbeddedUrn(), eaglePackage, log);
     it = mLibPackageMap.insert(key, pkg->getUuid());
     library.addPackage(*pkg.release());
   }
@@ -353,7 +356,8 @@ const Device& EagleProjectImport::importLibraryDevice(
                          eagleDev.getPackage());
     MessageLogger log(mLogger.get(), eagleDev.getName());
     std::unique_ptr<Device> dev = converter.createDevice(
-        eagleLib.getEmbeddedName(), eagleDevSet, eagleDev, log);
+        eagleLib.getEmbeddedName(), eagleLib.getEmbeddedUrn(), eagleDevSet,
+        eagleDev, log);
     it = mLibDeviceMap.insert(key, dev->getUuid());
     library.addDevice(*dev.release());
   }
@@ -531,8 +535,8 @@ void EagleProjectImport::importSchematic(Project& project,
           }
           const parseagle::Part& part = getPart(eaglePinRef.getPart());
           const Uuid sigUuid = converter.getComponentSignalOfSymbolPin(
-              part.getLibrary(), part.getDeviceSet(), eaglePinRef.getGate(),
-              eaglePinRef.getPin());
+              part.getLibrary(), part.getLibraryUrn(), part.getDeviceSet(),
+              eaglePinRef.getGate(), eaglePinRef.getPin());
           ComponentSignalInstance* cmpSigInst =
               cmpInst->getSignalInstance(sigUuid);
           if (!cmpSigInst) {


### PR DESCRIPTION
Fixes importing EAGLE projects which contain multiple libraries with the same name, but different URNs. Reported in https://www.mikrocontroller.net/topic/565050#7614223.