### PR TITLE
CMake: Improve suppression of deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,20 @@ if(WIN32)
   add_definitions(-DUNICODE -D_UNICODE)
 endif()
 
+# Disable Qt functions which are deprecated in Qt <= 5.5 to enforce us
+# migrating away from them. Always set this to the lowest Qt version we want
+# to support.
+add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0x050500)
+
+# Not sure what we should do with deprecation warnings. Better keeping
+# backwards compatibility with already existing & supported environments
+# instead of forward compatibility with not yet existing environments, no?
+add_definitions(
+  -DQT_NO_DEPRECATED_WARNINGS # Qt
+  -DGL_SILENCE_DEPRECATION # OpenGL
+  -DOCCT_NO_DEPRECATED # OpenCascade
+)
+
 # Find required Qt packages
 find_package(
   Qt5 5.5.0
@@ -140,15 +154,6 @@ if(BUILD_TESTS)
   )
 endif()
 message(STATUS "Building with Qt${Qt5Core_VERSION}")
-
-# In Qt 5.15, a lot of things were marked as deprecated, without providing
-# alternatives available in previous Qt versions. It would require a lot of
-# preprocessor conditionals to avoid these deprecation warnings, so let's just
-# disable them for now. We are using CI anyway to ensure LibrePCB compiles with
-# the targeted Qt versions.
-if("${Qt5Core_VERSION_MAJOR}.${Qt5Core_VERSION_MINOR}" VERSION_GREATER 5.14)
-  target_compile_options(common INTERFACE -Wno-deprecated-declarations)
-endif()
 
 # Find third party libraries
 find_package(DelaunayTriangulation REQUIRED)

--- a/cmake/FindDxflib.cmake
+++ b/cmake/FindDxflib.cmake
@@ -11,6 +11,9 @@ if(EXISTS "${DXFLIB_SUBMODULE_BASEPATH}"
     EXCLUDE_FROM_ALL
   )
 
+  # Disable deprecation warnings since they are not under our control.
+  target_compile_options(dxflib PRIVATE -Wno-deprecated-declarations)
+
   # Stop here, we're done
   return()
 endif()

--- a/cmake/FindMuParser.cmake
+++ b/cmake/FindMuParser.cmake
@@ -25,6 +25,9 @@ if(EXISTS "${MUPARSER_SUBMODULE_BASEPATH}"
     EXCLUDE_FROM_ALL
   )
 
+  # Disable deprecation warnings since they are not under our control.
+  target_compile_options(muparser PRIVATE -Wno-deprecated-declarations)
+
   # Alias lib to namespaced variant
   add_library(MuParser::MuParser ALIAS muparser)
 


### PR DESCRIPTION
- Remove global `-Wno-deprecated-declarations` compile flag which was used for Qt 5.15 and thus completely disabled deprecation warnings on our macOS and Windows CI jobs.
- Completely disable Qt features which were already marked as deprecated in the oldest Qt version we support, so we're enforced to get rid of very legacy Qt features.
- Suppress any Qt deprecations added in more recent version since they are not useful for us (backward compatibility is more important than forward compatibility).
- Suppress any deprecation warnings in 3rd-party libraries since they are not under our control.