### PR TITLE
Slightly improve robustness of some math functions

### DIFF
--- a/libs/librepcb/core/3d/occmodel.cpp
+++ b/libs/librepcb/core/3d/occmodel.cpp
@@ -262,18 +262,18 @@ static TopoDS_Face pathToFace(const Path& path, const Length& z) {
     const gp_Pnt p1(v1.getPos().getX().toMm(), v1.getPos().getY().toMm(),
                     z.toMm());
     TopoDS_Edge edge;
-    if (v0.getAngle() == 0) {
-      edge = BRepBuilderAPI_MakeEdge(p0, p1);
-    } else {
-      const Point center =
-          Toolbox::arcCenter(v0.getPos(), v1.getPos(), v0.getAngle());
-      const Length radius =
-          Toolbox::arcRadius(v0.getPos(), v1.getPos(), v0.getAngle());
+    if (auto center =
+            Toolbox::arcCenter(v0.getPos(), v1.getPos(), v0.getAngle())) {
+      // Arc segment.
+      const UnsignedLength radiusAbs = (v0.getPos() - (*center)).getLength();
       gp_Circ arc(
-          gp_Ax2(gp_Pnt(center.getX().toMm(), center.getY().toMm(), z.toMm()),
+          gp_Ax2(gp_Pnt(center->getX().toMm(), center->getY().toMm(), z.toMm()),
                  gp_Dir(0.0, 0.0, (v0.getAngle() < 0) ? -1.0 : 1.0)),
-          radius.abs().toMm());
+          radiusAbs->toMm());
       edge = BRepBuilderAPI_MakeEdge(arc, p0, p1);
+    } else {
+      // Straight segment.
+      edge = BRepBuilderAPI_MakeEdge(p0, p1);
     }
     wire.Add(edge);
   }

--- a/libs/librepcb/core/export/gerbergenerator.cpp
+++ b/libs/librepcb/core/export/gerbergenerator.cpp
@@ -503,20 +503,19 @@ void GerberGenerator::circularInterpolateToPosition(const Point& start,
 
 void GerberGenerator::interpolateBetween(const Vertex& from,
                                          const Vertex& to) noexcept {
-  if (from.getAngle() == 0) {
-    // linear segment
-    linearInterpolateToPosition(to.getPos());
-  } else {
+  if (auto center =
+          Toolbox::arcCenter(from.getPos(), to.getPos(), from.getAngle())) {
     // arc segment
     if (from.getAngle() < 0) {
       switchToCircularCwInterpolationModeG02();
     } else {
       switchToCircularCcwInterpolationModeG03();
     }
-    Point center =
-        Toolbox::arcCenter(from.getPos(), to.getPos(), from.getAngle());
-    circularInterpolateToPosition(from.getPos(), center, to.getPos());
+    circularInterpolateToPosition(from.getPos(), *center, to.getPos());
     switchToLinearInterpolationModeG01();
+  } else {
+    // linear segment
+    linearInterpolateToPosition(to.getPos());
   }
 }
 

--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -168,9 +168,9 @@ const QPainterPath& Path::toQPainterPathPx() const noexcept {
         const QPointF centerPx = center->toPxQPointF();
         const QPointF diffPx = v0.getPos().toPxQPointF() - centerPx;
         const qreal radiusPx =
-            qSqrt(diffPx.x() * diffPx.x() + diffPx.y() * diffPx.y());
+            std::sqrt(diffPx.x() * diffPx.x() + diffPx.y() * diffPx.y());
         const qreal startAngleDeg =
-            -qRadiansToDegrees(qAtan2(diffPx.y(), diffPx.x()));
+            -qRadiansToDegrees(std::atan2(diffPx.y(), diffPx.x()));
         mPainterPathPx.arcTo(centerPx.x() - radiusPx, centerPx.y() - radiusPx,
                              radiusPx * 2, radiusPx * 2, startAngleDeg,
                              v0.getAngle().toDeg());
@@ -402,7 +402,7 @@ Path Path::obround(const Point& p1, const Point& p2,
                    const PositiveLength& width) noexcept {
   Point diff = p2 - p1;
   Path p = obround(UnsignedLength(diff.getLength()) + width, width);
-  p.rotate(Angle::fromRad(qAtan2(diff.getY().toMm(), diff.getX().toMm())));
+  p.rotate(Angle::fromRad(std::atan2(diff.getY().toMm(), diff.getX().toMm())));
   p.translate((p1 + p2) / 2);
   return p;
 }
@@ -415,8 +415,8 @@ Path Path::arcObround(const Point& p1, const Point& p2, const Angle& angle,
   if (auto center = Toolbox::arcCenter(p1, p2, angle)) {
     Point delta1 = p1 - (*center);
     Point delta2 = p2 - (*center);
-    qreal angle1Rad = qAtan2(delta1.getY().toPx(), delta1.getX().toPx());
-    qreal angle2Rad = qAtan2(delta2.getY().toPx(), delta2.getX().toPx());
+    qreal angle1Rad = std::atan2(delta1.getY().toPx(), delta1.getX().toPx());
+    qreal angle2Rad = std::atan2(delta2.getY().toPx(), delta2.getX().toPx());
     UnsignedLength radius = delta1.getLength();
     Length innerRadius = (*radius) - (*width / 2);
     Length outerRadius = (*radius) + (*width / 2);
@@ -489,7 +489,7 @@ Path Path::octagon(const PositiveLength& width, const PositiveLength& height,
   const Length ry = height / 2;
   const Length innerChamfer =
       Length::fromMm(std::min(rx - cornerRadius, ry - cornerRadius).toMm() *
-                     (2 - qSqrt(2))) +
+                     (2 - std::sqrt(2))) +
       cornerRadius;
   if (cornerRadius == 0) {
     // Regular polygon without rounded corners.
@@ -507,7 +507,7 @@ Path Path::octagon(const PositiveLength& width, const PositiveLength& height,
   } else {
     // Octagon with rounded corners.
     const Length chamferOffset =
-        Length::fromMm(cornerRadius->toMm() * (1 - (1 / qSqrt(2))));
+        Length::fromMm(cornerRadius->toMm() * (1 - (1 / std::sqrt(2))));
     const Length outerChamfer = innerChamfer - cornerRadius + chamferOffset;
     Q_ASSERT(chamferOffset >= 0);
     Q_ASSERT(chamferOffset <= outerChamfer);
@@ -544,7 +544,7 @@ Path Path::flatArc(const Point& p1, const Point& p2, const Angle& angle,
           qBound(qreal(0.0), static_cast<qreal>(maxTolerance->toNm()),
                  radiusAbsNm / qreal(4));
       const qreal stepsPerRad = std::min(
-          qreal(0.5) / qAcos(1 - y / radiusAbsNm), radiusAbsNm / qreal(2));
+          qreal(0.5) / std::acos(1 - y / radiusAbsNm), radiusAbsNm / qreal(2));
       const int steps = qCeil(stepsPerRad * angle.abs().toRad());
 
       // create line segments

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -957,7 +957,7 @@ void BoardGerberExport::drawFootprintPad(GerberGenerator& gen,
             const PositiveLength height(width);
             const PositiveLength width = height + (p1 - p0).getLength();
             const Angle rotation = Angle::fromRad(
-                qAtan2(delta.getY().toMm(), delta.getX().toMm()));
+                std::atan2(delta.getY().toMm(), delta.getX().toMm()));
             gen.flashObround(center, width, height, rotation, function, net,
                              component, pin, signal);
           } else {

--- a/libs/librepcb/core/types/angle.h
+++ b/libs/librepcb/core/types/angle.h
@@ -127,7 +127,10 @@ public:
    * and so on.
    */
   void setAngleDeg(qreal degrees) noexcept {
-    setAngleMicroDeg(qRound(std::fmod(degrees * 1e6, 360e6)));
+    const qreal value = std::fmod(degrees * 1e6, 360e6);
+    // Note: Don't use qRound() because in Qt5 it is implemented strange.
+    setAngleMicroDeg((value >= 0.0) ? qint64(value + qreal(0.5))
+                                    : qint64(value - qreal(0.5)));
   }
 
   /**

--- a/libs/librepcb/core/types/length.cpp
+++ b/libs/librepcb/core/types/length.cpp
@@ -134,19 +134,26 @@ Length Length::max() noexcept {
  ******************************************************************************/
 
 void Length::setLengthFromFloat(qreal nanometers) {
-  LengthBase_t min = std::numeric_limits<LengthBase_t>::min();
-  LengthBase_t max = std::numeric_limits<LengthBase_t>::max();
-  if ((nanometers > static_cast<qreal>(max)) ||
-      (nanometers < static_cast<qreal>(min))) {
-    throw RangeError(__FILE__, __LINE__, nanometers, min, max);
-  }
-
+  checkRange(nanometers, true);  // Throws on range error.
   mNanometers = qRound64(nanometers);
 }
 
 /*******************************************************************************
  *  Private Static Methods
  ******************************************************************************/
+
+bool Length::checkRange(qreal nanometers, bool doThrow) {
+  const LengthBase_t min = std::numeric_limits<LengthBase_t>::min();
+  const LengthBase_t max = std::numeric_limits<LengthBase_t>::max();
+  if ((nanometers >= static_cast<qreal>(min)) &&
+      (nanometers <= static_cast<qreal>(max))) {
+    return true;
+  } else if (!doThrow) {
+    return false;
+  } else {
+    throw RangeError(__FILE__, __LINE__, nanometers, min, max);
+  }
+}
 
 LengthBase_t Length::mapNmToGrid(LengthBase_t nanometers,
                                  const Length& gridInterval) noexcept {

--- a/libs/librepcb/core/types/length.cpp
+++ b/libs/librepcb/core/types/length.cpp
@@ -135,7 +135,9 @@ Length Length::max() noexcept {
 
 void Length::setLengthFromFloat(qreal nanometers) {
   checkRange(nanometers, true);  // Throws on range error.
-  mNanometers = qRound64(nanometers);
+  // Note: Don't use qRound() because in Qt5 it is implemented strange.
+  mNanometers = (nanometers >= 0.0) ? qint64(nanometers + qreal(0.5))
+                                    : qint64(nanometers - qreal(0.5));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/types/length.h
+++ b/libs/librepcb/core/types/length.h
@@ -356,6 +356,18 @@ public:
   // Static Functions
 
   /**
+   * @brief Check if a float value in millimeters is in the allowed range
+   *
+   * @param millimeters   The value to check
+   *
+   * @retval true   Value is valid, can construct a #Length from it.
+   * @retval false  Value is invalid, constructing a #Length would throw.
+   */
+  static bool isValidMm(qreal millimeters) noexcept {
+    return checkRange(millimeters * 1e6);
+  }
+
+  /**
    * @brief Get a Length object with a specific length and map it to a specific
    * grid
    *
@@ -580,6 +592,18 @@ private:
   void setLengthFromFloat(qreal nanometers);
 
   // Private Static Functions
+
+  /**
+   * @brief Check if a float value in nanometers is in the allowed range
+   *
+   * @param nanometers    The value to check
+   * @param doThrow       If true, throw a ::librepcb::RangeError if out of
+   *                      range instead of returning the result
+   *
+   * @retval true   Value is valid, can construct a #Length from it.
+   * @retval false  Value is invalid, constructing a #Length would throw.
+   */
+  static bool checkRange(qreal nanometers, bool doThrow = false);
 
   /**
    * @brief Map a length in nanometers to a grid interval in nanometers

--- a/libs/librepcb/core/types/point.cpp
+++ b/libs/librepcb/core/types/point.cpp
@@ -100,8 +100,8 @@ Point& Point::rotate(const Angle& angle, const Point& center) noexcept {
   } else if (angle != Angle::deg0()) {
     // angle is not a multiple of 90 degrees --> we must use floating point
     // arithmetic
-    qreal sin = qSin(angle.toRad());
-    qreal cos = qCos(angle.toRad());
+    qreal sin = std::sin(angle.toRad());
+    qreal cos = std::cos(angle.toRad());
     setX(Length::fromMm(center.getX().toMm() + cos * dx.toMm() -
                         sin * dy.toMm()));
     setY(Length::fromMm(center.getY().toMm() + sin * dx.toMm() +

--- a/libs/librepcb/core/types/point.cpp
+++ b/libs/librepcb/core/types/point.cpp
@@ -193,8 +193,8 @@ QDataStream& operator<<(QDataStream& stream, const Point& point) {
 
 QDebug operator<<(QDebug stream, const Point& point) {
   stream << QString("Point(%1mm, %2mm)")
-                .arg(point.toMmQPointF().x())
-                .arg(point.toMmQPointF().y());
+                .arg(point.getX().toMmString())
+                .arg(point.getY().toMmString());
   return stream;
 }
 

--- a/libs/librepcb/core/utils/toolbox.cpp
+++ b/libs/librepcb/core/utils/toolbox.cpp
@@ -72,8 +72,8 @@ tl::optional<Length> Toolbox::arcRadius(const Point& p1, const Point& p2,
   const qreal y1 = p1.getY().toMm();
   const qreal x2 = p2.getX().toMm();
   const qreal y2 = p2.getY().toMm();
-  const qreal d = qSqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
-  const qreal r = d / (2 * qSin(angleMapped.toRad() / 2));
+  const qreal d = std::sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+  const qreal r = d / (2 * std::sin(angleMapped.toRad() / 2));
   if (Length::isValidMm(r)) {
     return Length::fromMm(r);
   } else {
@@ -94,10 +94,10 @@ tl::optional<Point> Toolbox::arcCenter(const Point& p1, const Point& p2,
   const qreal x1 = p2.getX().toMm();
   const qreal y1 = p2.getY().toMm();
   const qreal angleSgn = (angleMapped >= 0) ? 1 : -1;
-  const qreal d = qSqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
-  const qreal r = d / (2 * qSin(angleMapped.toRad() / 2));
+  const qreal d = std::sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
+  const qreal r = d / (2 * std::sin(angleMapped.toRad() / 2));
   // Note: std::max() fixes https://github.com/LibrePCB/LibrePCB/issues/974
-  const qreal h = qSqrt(std::max(r * r - d * d / 4.0, qreal(0)));
+  const qreal h = std::sqrt(std::max(r * r - d * d / 4.0, qreal(0)));
   const qreal u = (x1 - x0) / d;
   const qreal v = (y1 - y0) / d;
   const qreal a = ((x0 + x1) / 2) - h * v * angleSgn;
@@ -116,8 +116,8 @@ Angle Toolbox::arcAngle(const Point& p1, const Point& p2,
   if (delta1.isOrigin() || delta2.isOrigin()) {
     return Angle::deg0();
   }
-  qreal angle1 = qAtan2(delta1.getY().toMm(), delta1.getX().toMm());
-  qreal angle2 = qAtan2(delta2.getY().toMm(), delta2.getX().toMm());
+  qreal angle1 = std::atan2(delta1.getY().toMm(), delta1.getX().toMm());
+  qreal angle2 = std::atan2(delta2.getY().toMm(), delta2.getX().toMm());
   return Angle::fromRad(angle2 - angle1).mapTo0_360deg();
 }
 
@@ -126,7 +126,7 @@ Angle Toolbox::angleBetweenPoints(const Point& p1, const Point& p2) noexcept {
   if (delta.isOrigin()) {
     return Angle::deg0();
   }
-  return Angle::fromRad(qAtan2(delta.getY().toMm(), delta.getX().toMm()))
+  return Angle::fromRad(std::atan2(delta.getY().toMm(), delta.getX().toMm()))
       .mapTo0_360deg();
 }
 

--- a/libs/librepcb/core/utils/toolbox.cpp
+++ b/libs/librepcb/core/utils/toolbox.cpp
@@ -61,44 +61,51 @@ QPainterPath Toolbox::shapeFromPath(const QPainterPath& path, const QPen& pen,
   }
 }
 
-Length Toolbox::arcRadius(const Point& p1, const Point& p2,
-                          const Angle& a) noexcept {
-  if (a == 0) {
-    return Length(0);
-  } else {
-    qreal x1 = p1.getX().toMm();
-    qreal y1 = p1.getY().toMm();
-    qreal x2 = p2.getX().toMm();
-    qreal y2 = p2.getY().toMm();
-    qreal angle = a.mappedTo180deg().toRad();
-    qreal d = qSqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
-    qreal r = d / (2 * qSin(angle / 2));
+tl::optional<Length> Toolbox::arcRadius(const Point& p1, const Point& p2,
+                                        const Angle& angle) noexcept {
+  const Angle angleMapped = angle.mappedTo180deg();
+  if ((angleMapped == 0) || (p1 == p2)) {
+    return tl::nullopt;  // Given input is a straight line.
+  }
+
+  const qreal x1 = p1.getX().toMm();
+  const qreal y1 = p1.getY().toMm();
+  const qreal x2 = p2.getX().toMm();
+  const qreal y2 = p2.getY().toMm();
+  const qreal d = qSqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+  const qreal r = d / (2 * qSin(angleMapped.toRad() / 2));
+  if (Length::isValidMm(r)) {
     return Length::fromMm(r);
+  } else {
+    return tl::nullopt;  // Too large radius.
   }
 }
 
-Point Toolbox::arcCenter(const Point& p1, const Point& p2,
-                         const Angle& a) noexcept {
-  if (a == 0) {
-    // there is no arc center...just return the middle of start- and endpoint
-    return (p1 + p2) / 2;
-  } else {
-    // http://math.stackexchange.com/questions/27535/how-to-find-center-of-an-arc-given-start-point-end-point-radius-and-arc-direc
-    qreal x0 = p1.getX().toMm();
-    qreal y0 = p1.getY().toMm();
-    qreal x1 = p2.getX().toMm();
-    qreal y1 = p2.getY().toMm();
-    qreal angle = a.mappedTo180deg().toRad();
-    qreal angleSgn = (angle >= 0) ? 1 : -1;
-    qreal d = qSqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
-    qreal r = d / (2 * qSin(angle / 2));
-    // Note: std::max() fixes https://github.com/LibrePCB/LibrePCB/issues/974
-    qreal h = qSqrt(std::max(r * r - d * d / 4.0, qreal(0)));
-    qreal u = (x1 - x0) / d;
-    qreal v = (y1 - y0) / d;
-    qreal a = ((x0 + x1) / 2) - h * v * angleSgn;
-    qreal b = ((y0 + y1) / 2) + h * u * angleSgn;
+tl::optional<Point> Toolbox::arcCenter(const Point& p1, const Point& p2,
+                                       const Angle& angle) noexcept {
+  const Angle angleMapped = angle.mappedTo180deg();
+  if ((angleMapped == 0) || (p1 == p2)) {
+    return tl::nullopt;  // Given input is a straight line.
+  }
+
+  // http://math.stackexchange.com/questions/27535/how-to-find-center-of-an-arc-given-start-point-end-point-radius-and-arc-direc
+  const qreal x0 = p1.getX().toMm();
+  const qreal y0 = p1.getY().toMm();
+  const qreal x1 = p2.getX().toMm();
+  const qreal y1 = p2.getY().toMm();
+  const qreal angleSgn = (angleMapped >= 0) ? 1 : -1;
+  const qreal d = qSqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
+  const qreal r = d / (2 * qSin(angleMapped.toRad() / 2));
+  // Note: std::max() fixes https://github.com/LibrePCB/LibrePCB/issues/974
+  const qreal h = qSqrt(std::max(r * r - d * d / 4.0, qreal(0)));
+  const qreal u = (x1 - x0) / d;
+  const qreal v = (y1 - y0) / d;
+  const qreal a = ((x0 + x1) / 2) - h * v * angleSgn;
+  const qreal b = ((y0 + y1) / 2) + h * u * angleSgn;
+  if (Length::isValidMm(a) && Length::isValidMm(b)) {
     return Point::fromMm(a, b);
+  } else {
+    return tl::nullopt;  // Center too far away, consider it as a straight line.
   }
 }
 

--- a/libs/librepcb/core/utils/toolbox.h
+++ b/libs/librepcb/core/utils/toolbox.h
@@ -28,6 +28,7 @@
 #include "../types/length.h"
 #include "../types/point.h"
 
+#include <optional/tl/optional.hpp>
 #include <type_traits>
 
 #include <QtCore>
@@ -178,10 +179,10 @@ public:
       const QPainterPath& path, const QPen& pen, const QBrush& brush,
       const UnsignedLength& minWidth = UnsignedLength(0)) noexcept;
 
-  static Length arcRadius(const Point& p1, const Point& p2,
-                          const Angle& a) noexcept;
-  static Point arcCenter(const Point& p1, const Point& p2,
-                         const Angle& a) noexcept;
+  static tl::optional<Length> arcRadius(const Point& p1, const Point& p2,
+                                        const Angle& angle) noexcept;
+  static tl::optional<Point> arcCenter(const Point& p1, const Point& p2,
+                                       const Angle& angle) noexcept;
 
   /**
    * @brief Calculate the angle between two given points

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -475,7 +475,7 @@ void PackageEditorState_DrawPolygonBase::updateOverlayText() noexcept {
       const Point diff = p1 - p0;
       const UnsignedLength length = (p1 - p0).getLength();
       const Angle angle = Angle::fromRad(
-          qAtan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
+          std::atan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
       text += formatLength("X0", p0.getX()) % "<br>";
       text += formatLength("Y0", p0.getY()) % "<br>";
       text += formatLength("X1", p1.getX()) % "<br>";

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
@@ -379,8 +379,8 @@ void PackageEditorState_DrawZone::updateOverlayText() noexcept {
   const Point p1 = (count >= 2) ? vertices[count - 1].getPos() : mCursorPos;
   const Point diff = p1 - p0;
   const UnsignedLength length = (p1 - p0).getLength();
-  const Angle angle =
-      Angle::fromRad(qAtan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
+  const Angle angle = Angle::fromRad(
+      std::atan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
   text += formatLength("X0", p0.getX()) % "<br>";
   text += formatLength("Y0", p0.getY()) % "<br>";
   text += formatLength("X1", p1.getX()) % "<br>";

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -472,7 +472,7 @@ void SymbolEditorState_DrawPolygonBase::updateOverlayText() noexcept {
       const Point diff = p1 - p0;
       const UnsignedLength length = (p1 - p0).getLength();
       const Angle angle = Angle::fromRad(
-          qAtan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
+          std::atan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
       text += formatLength("X0", p0.getX()) % "<br>";
       text += formatLength("Y0", p0.getY()) % "<br>";
       text += formatLength("X1", p1.getX()) % "<br>";

--- a/libs/librepcb/editor/utils/measuretool.cpp
+++ b/libs/librepcb/editor/utils/measuretool.cpp
@@ -428,8 +428,8 @@ void MeasureTool::updateRulerPositions() noexcept {
 
   const Point diff = endPos - startPos;
   const UnsignedLength length = diff.getLength();
-  const Angle angle =
-      Angle::fromRad(qAtan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
+  const Angle angle = Angle::fromRad(
+      std::atan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()));
   int decimals = mUnit.getReasonableNumberOfDecimals() + 1;
 
   QString text;

--- a/libs/librepcb/editor/widgets/graphicsview.cpp
+++ b/libs/librepcb/editor/widgets/graphicsview.cpp
@@ -530,7 +530,8 @@ void GraphicsView::drawForeground(QPainter* painter, const QRectF& rect) {
     const Point diff = mRulerPositions->second - mRulerPositions->first;
     const Length distance = *diff.getLength();
     const Angle angle = (!diff.isOrigin())
-        ? Angle::fromRad(qAtan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()))
+        ? Angle::fromRad(
+              std::atan2(diff.toMmQPointF().y(), diff.toMmQPointF().x()))
         : -Angle::deg90();
 
     // Transform painter to allow drawing from (0,0) to (0,distance).

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -413,6 +413,20 @@ TEST_F(PathTest, testFlatArc) {
   EXPECT_EQ(str(expected), str(actual));
 }
 
+// Test to reproduce another case where small deviations were observed
+TEST_F(PathTest, testFlatArc2) {
+  Path expected = Path({
+      Vertex(Point(-21401446, 16018901)),
+      Vertex(Point(-22394290, 15545339)),
+      Vertex(Point(-23300829, 16168386)),
+      Vertex(Point(-23214523, 17264994)),
+  });
+  Path actual =
+      Path::flatArc(Point(-21401446, 16018901), Point(-23214523, 17264994),
+                    -Angle::deg180(), PositiveLength(2000000));
+  EXPECT_EQ(str(expected), str(actual));
+}
+
 /*******************************************************************************
  *  Parametrized obround(width, height) Tests
  ******************************************************************************/

--- a/tests/unittests/core/types/lengthtest.cpp
+++ b/tests/unittests/core/types/lengthtest.cpp
@@ -157,6 +157,42 @@ INSTANTIATE_TEST_SUITE_P(LengthMappedToGrid, LengthMappedToGrid, ::testing::Valu
 // clang-format on
 
 /*******************************************************************************
+ *  Tests for fromMm(float)
+ ******************************************************************************/
+
+struct LengthFromMmTestData {
+  qreal input;
+  Length output;
+};
+
+class LengthFromMmTest : public ::testing::TestWithParam<LengthFromMmTestData> {
+};
+
+TEST_P(LengthFromMmTest, test) {
+  const LengthFromMmTestData& data = GetParam();
+
+  const Length actual = Length::fromMm(data.input);
+
+  // On Windows, accept small deviations since the results on CI are slightly
+  // different. See discussion here:
+  // https://github.com/LibrePCB/LibrePCB/pull/511#issuecomment-529089212
+#if defined(Q_OS_WIN32) || defined(Q_OS_WIN64)
+  EXPECT_LE(std::abs(actual.toNm() - data.output.toNm()), 5);
+#else
+  EXPECT_EQ(data.output.toNm(), actual.toNm());
+#endif
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(LengthFromMmTest, LengthFromMmTest, ::testing::Values(
+    //                   {input,       output            }
+    LengthFromMmTestData({0,           Length(0)         }),
+    LengthFromMmTestData({-22.3079845, Length(-22307985) }),
+    LengthFromMmTestData({16.6419475,  Length(16641948)  })
+));
+// clang-format on
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 

--- a/tests/unittests/core/utils/toolboxtest.cpp
+++ b/tests/unittests/core/utils/toolboxtest.cpp
@@ -124,7 +124,9 @@ static ToolboxArcCenterTestData sToolboxArcCenterTestData[] = {
   {Point(1000, 2000),          Point(5000, 4000),          Angle::deg0(),      tl::nullopt},
   {Point(47744137, 37820591),  Point(55364137, 24622364),  -Angle::deg90(),    Point(44955023, 27411478)},
   // Test to reproduce https://github.com/LibrePCB/LibrePCB/issues/974
-  {Point(30875000, 32385000),  Point(26275000, 32385000),  -Angle::deg180(),   Point(28575000, 32385000)}
+  {Point(30875000, 32385000),  Point(26275000, 32385000),  -Angle::deg180(),   Point(28575000, 32385000)},
+  // Test to reproduce another case where small deviations were observed
+  {Point(-21401446, 16018901), Point(-23214523, 17264994), -Angle::deg180(),   Point(-22307985, 16641948)},
 };
 // clang-format on
 


### PR DESCRIPTION
Initially started this change because I observed small differences of the result of some calculations (e.g. arc center) between Qt5 and Qt6, which made some unit tests fail. During investigation, I decided to slightly rewrite some of the mathematical calculations, so I split it into this separate PR:

- Toolbox: Make arc calculations more robust by returning `tl::optional` in case of invalid results (e.g. division by zero on arcs with a center way too far away). For example the Gerber generator will now export a straight line segment instead of an invalid arc segment.
- Replace Qt math functions by C++ std functions whenever possible (no reason to use Qt functions anymore if they are available in C++11).
- Replace `qRound()` and `qRound64()` with own implementation because it returns slightly different results between Qt5 and Qt6 (it was the root cause of the failed tests in Qt6).
- Add some more unit tests with the numbers to reproduce the observed numerical differences.