### PR TITLE
SExpression: Refactor memory management of children

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -697,9 +697,9 @@ bool CommandLineInterface::openProject(
         try {
           qDebug() << "Load custom DRC settings:" << drcSettingsPath;
           const FilePath fp(QFileInfo(drcSettingsPath).absoluteFilePath());
-          const SExpression root =
+          const std::unique_ptr<const SExpression> root =
               SExpression::parse(FileUtils::readFile(fp), fp);
-          customSettings = BoardDesignRuleCheckSettings(root);  // can throw
+          customSettings = BoardDesignRuleCheckSettings(*root);  // can throw
         } catch (const Exception& e) {
           printErr(
               tr("ERROR: Failed to load custom settings: %1").arg(e.getMsg()));
@@ -734,9 +734,9 @@ bool CommandLineInterface::openProject(
         try {
           qDebug() << "Load custom output jobs:" << customJobsPath;
           const FilePath fp(QFileInfo(customJobsPath).absoluteFilePath());
-          const SExpression root =
+          const std::unique_ptr<const SExpression> root =
               SExpression::parse(FileUtils::readFile(fp), fp);
-          allJobs = deserialize<OutputJobList>(root);  // can throw
+          allJobs = deserialize<OutputJobList>(*root);  // can throw
         } catch (const Exception& e) {
           printErr(tr("ERROR: Failed to load custom output jobs: %1")
                        .arg(e.getMsg()));
@@ -897,9 +897,9 @@ bool CommandLineInterface::openProject(
                    << pcbFabricationSettingsPath;
           const FilePath fp(
               QFileInfo(pcbFabricationSettingsPath).absoluteFilePath());
-          const SExpression root =
+          const std::unique_ptr<const SExpression> root =
               SExpression::parse(FileUtils::readFile(fp), fp);
-          customSettings = BoardFabricationOutputSettings(root);  // can throw
+          customSettings = BoardFabricationOutputSettings(*root);  // can throw
         } catch (const Exception& e) {
           printErr(
               tr("ERROR: Failed to load custom settings: %1").arg(e.getMsg()));

--- a/libs/librepcb/core/attribute/attributekey.h
+++ b/libs/librepcb/core/attribute/attributekey.h
@@ -96,7 +96,7 @@ inline bool operator!=(const QString& lhs, const AttributeKey& rhs) noexcept {
 }
 
 template <>
-inline SExpression serialize(const AttributeKey& obj) {
+inline std::unique_ptr<SExpression> serialize(const AttributeKey& obj) {
   return SExpression::createString(*obj);
 }
 

--- a/libs/librepcb/core/attribute/attributetype.cpp
+++ b/libs/librepcb/core/attribute/attributetype.cpp
@@ -129,7 +129,7 @@ const AttributeType& AttributeType::fromString(const QString& type) {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const AttributeType& obj) {
+std::unique_ptr<SExpression> serialize(const AttributeType& obj) {
   return SExpression::createToken(obj.getName());
 }
 

--- a/libs/librepcb/core/attribute/attributeunit.cpp
+++ b/libs/librepcb/core/attribute/attributeunit.cpp
@@ -48,7 +48,7 @@ AttributeUnit::~AttributeUnit() noexcept {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const AttributeUnit& obj) {
+std::unique_ptr<SExpression> serialize(const AttributeUnit& obj) {
   return SExpression::createToken(obj.getName());
 }
 

--- a/libs/librepcb/core/export/graphicsexportsettings.cpp
+++ b/libs/librepcb/core/export/graphicsexportsettings.cpp
@@ -39,7 +39,8 @@ namespace librepcb {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const GraphicsExportSettings::Orientation& obj) {
+std::unique_ptr<SExpression> serialize(
+    const GraphicsExportSettings::Orientation& obj) {
   if (obj == GraphicsExportSettings::Orientation::Landscape) {
     return SExpression::createToken("landscape");
   } else if (obj == GraphicsExportSettings::Orientation::Portrait) {
@@ -66,7 +67,7 @@ GraphicsExportSettings::Orientation deserialize(const SExpression& node) {
 }
 
 template <>
-SExpression serialize(const tl::optional<UnsignedRatio>& obj) {
+std::unique_ptr<SExpression> serialize(const tl::optional<UnsignedRatio>& obj) {
   if (obj) {
     return serialize(*obj);
   } else {

--- a/libs/librepcb/core/job/graphicsoutputjob.cpp
+++ b/libs/librepcb/core/job/graphicsoutputjob.cpp
@@ -35,7 +35,8 @@ namespace librepcb {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const GraphicsOutputJob::Content::Type& obj) {
+std::unique_ptr<SExpression> serialize(
+    const GraphicsOutputJob::Content::Type& obj) {
   if (obj == GraphicsOutputJob::Content::Type::Schematic) {
     return SExpression::createToken("schematic");
   } else if (obj == GraphicsOutputJob::Content::Type::Board) {

--- a/libs/librepcb/core/library/cat/componentcategory.cpp
+++ b/libs/librepcb/core/library/cat/componentcategory.cpp
@@ -75,10 +75,10 @@ std::unique_ptr<ComponentCategory> ComponentCategory::open(
 
   // Load element.
   const QString fileName = getLongElementName() % ".lp";
-  const SExpression root = SExpression::parse(directory->read(fileName),
-                                              directory->getAbsPath(fileName));
+  const std::unique_ptr<const SExpression> root = SExpression::parse(
+      directory->read(fileName), directory->getAbsPath(fileName));
   std::unique_ptr<ComponentCategory> obj(
-      new ComponentCategory(std::move(directory), root));
+      new ComponentCategory(std::move(directory), *root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
     obj->save();  // Format all files correctly as the migration doesn't!

--- a/libs/librepcb/core/library/cat/packagecategory.cpp
+++ b/libs/librepcb/core/library/cat/packagecategory.cpp
@@ -75,10 +75,10 @@ std::unique_ptr<PackageCategory> PackageCategory::open(
 
   // Load element.
   const QString fileName = getLongElementName() % ".lp";
-  const SExpression root = SExpression::parse(directory->read(fileName),
-                                              directory->getAbsPath(fileName));
+  const std::unique_ptr<const SExpression> root = SExpression::parse(
+      directory->read(fileName), directory->getAbsPath(fileName));
   std::unique_ptr<PackageCategory> obj(
-      new PackageCategory(std::move(directory), root));
+      new PackageCategory(std::move(directory), *root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
     obj->save();  // Format all files correctly as the migration doesn't!

--- a/libs/librepcb/core/library/cmp/cmpsigpindisplaytype.cpp
+++ b/libs/librepcb/core/library/cmp/cmpsigpindisplaytype.cpp
@@ -101,7 +101,7 @@ const QList<CmpSigPinDisplayType>&
  ******************************************************************************/
 
 template <>
-SExpression serialize(const CmpSigPinDisplayType& obj) {
+std::unique_ptr<SExpression> serialize(const CmpSigPinDisplayType& obj) {
   return SExpression::createToken(obj.toString());
 }
 

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -143,9 +143,9 @@ std::unique_ptr<Component> Component::open(
 
   // Load element.
   const QString fileName = getLongElementName() % ".lp";
-  const SExpression root = SExpression::parse(directory->read(fileName),
-                                              directory->getAbsPath(fileName));
-  std::unique_ptr<Component> obj(new Component(std::move(directory), root));
+  const std::unique_ptr<const SExpression> root = SExpression::parse(
+      directory->read(fileName), directory->getAbsPath(fileName));
+  std::unique_ptr<Component> obj(new Component(std::move(directory), *root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
     obj->save();  // Format all files correctly as the migration doesn't!

--- a/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
+++ b/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
@@ -46,7 +46,7 @@ MsgDuplicateSignalName::MsgDuplicateSignalName(
            "component signal. The assignment to multiple pins should be done "
            "in the device editor instead."),
         "duplicate_signal_name") {
-  mApproval.appendChild("name", *signal.getName());
+  mApproval->appendChild("name", *signal.getName());
 }
 
 /*******************************************************************************
@@ -109,9 +109,9 @@ MsgMissingSymbolVariantItem::MsgMissingSymbolVariantItem(
            "it can't be added to schematics."),
         "missing_gates"),
     mSymbVar(symbVar) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("variant", symbVar->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("variant", symbVar->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -131,9 +131,9 @@ MsgNonFunctionalComponentSignalInversionSign::
             .arg("!"),
         "nonfunctional_inversion_sign"),
     mSignal(signal) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("signal", signal->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("signal", signal->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/cmp/componentprefix.h
+++ b/libs/librepcb/core/library/cmp/componentprefix.h
@@ -109,7 +109,7 @@ inline QString operator%(const QString& lhs,
 }
 
 template <>
-inline SExpression serialize(const ComponentPrefix& obj) {
+inline std::unique_ptr<SExpression> serialize(const ComponentPrefix& obj) {
   return SExpression::createString(*obj);
 }
 

--- a/libs/librepcb/core/library/cmp/componentsymbolvariantitemsuffix.h
+++ b/libs/librepcb/core/library/cmp/componentsymbolvariantitemsuffix.h
@@ -113,7 +113,8 @@ inline QString operator%(const QString& lhs,
 }
 
 template <>
-inline SExpression serialize(const ComponentSymbolVariantItemSuffix& obj) {
+inline std::unique_ptr<SExpression> serialize(
+    const ComponentSymbolVariantItemSuffix& obj) {
   return SExpression::createString(*obj);
 }
 

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -106,9 +106,9 @@ std::unique_ptr<Device> Device::open(
 
   // Load element.
   const QString fileName = getLongElementName() % ".lp";
-  const SExpression root = SExpression::parse(directory->read(fileName),
-                                              directory->getAbsPath(fileName));
-  std::unique_ptr<Device> obj(new Device(std::move(directory), root));
+  const std::unique_ptr<const SExpression> root = SExpression::parse(
+      directory->read(fileName), directory->getAbsPath(fileName));
+  std::unique_ptr<Device> obj(new Device(std::move(directory), *root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
     obj->save();  // Format all files correctly as the migration doesn't!

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -184,9 +184,9 @@ std::unique_ptr<Library> Library::open(
 
   // Load element.
   const QString fileName = getLongElementName() % ".lp";
-  const SExpression root = SExpression::parse(directory->read(fileName),
-                                              directory->getAbsPath(fileName));
-  std::unique_ptr<Library> obj(new Library(std::move(directory), root));
+  const std::unique_ptr<const SExpression> root = SExpression::parse(
+      directory->read(fileName), directory->getAbsPath(fileName));
+  std::unique_ptr<Library> obj(new Library(std::move(directory), *root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
     obj->save();  // Format all files correctly as the migration doesn't!

--- a/libs/librepcb/core/library/librarybaseelement.cpp
+++ b/libs/librepcb/core/library/librarybaseelement.cpp
@@ -121,9 +121,10 @@ RuleCheckMessageList LibraryBaseElement::runChecks() const {
 
 void LibraryBaseElement::save() {
   // Content.
-  SExpression root = SExpression::createList("librepcb_" % mLongElementName);
-  serialize(root);
-  mDirectory->write(mLongElementName % ".lp", root.toByteArray());
+  std::unique_ptr<SExpression> root =
+      SExpression::createList("librepcb_" % mLongElementName);
+  serialize(*root);
+  mDirectory->write(mLongElementName % ".lp", root->toByteArray());
 
   // Version file.
   mDirectory->write(

--- a/libs/librepcb/core/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpad.cpp
@@ -36,7 +36,7 @@ namespace librepcb {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const FootprintPad::Shape& obj) {
+std::unique_ptr<SExpression> serialize(const FootprintPad::Shape& obj) {
   switch (obj) {
     case FootprintPad::Shape::RoundedRect:
       return SExpression::createToken("roundrect");
@@ -65,7 +65,7 @@ inline FootprintPad::Shape deserialize(const SExpression& node) {
 }
 
 template <>
-SExpression serialize(const FootprintPad::ComponentSide& obj) {
+std::unique_ptr<SExpression> serialize(const FootprintPad::ComponentSide& obj) {
   switch (obj) {
     case FootprintPad::ComponentSide::Top:
       return SExpression::createToken("top");
@@ -91,7 +91,7 @@ inline FootprintPad::ComponentSide deserialize(const SExpression& node) {
 }
 
 template <>
-SExpression serialize(const FootprintPad::Function& obj) {
+std::unique_ptr<SExpression> serialize(const FootprintPad::Function& obj) {
   switch (obj) {
     case FootprintPad::Function::Unspecified:
       return SExpression::createToken("unspecified");

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -37,7 +37,7 @@ namespace librepcb {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const Package::AssemblyType& obj) {
+std::unique_ptr<SExpression> serialize(const Package::AssemblyType& obj) {
   switch (obj) {
     case Package::AssemblyType::None:
       return SExpression::createToken("none");
@@ -195,9 +195,9 @@ std::unique_ptr<Package> Package::open(
 
   // Load element.
   const QString fileName = getLongElementName() % ".lp";
-  const SExpression root = SExpression::parse(directory->read(fileName),
-                                              directory->getAbsPath(fileName));
-  std::unique_ptr<Package> obj(new Package(std::move(directory), root));
+  const std::unique_ptr<const SExpression> root = SExpression::parse(
+      directory->read(fileName), directory->getAbsPath(fileName));
+  std::unique_ptr<Package> obj(new Package(std::move(directory), *root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
     obj->save();  // Format all files correctly as the migration doesn't!

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
@@ -72,7 +72,7 @@ MsgDuplicatePadName::MsgDuplicatePadName(const PackagePad& pad) noexcept
            "be named only by numbers anyway, not by functionality (e.g. name "
            "them '1', '2', '3' instead of 'D', 'G', 'S')."),
         "duplicate_pad_name") {
-  mApproval.appendChild("name", *pad.getName());
+  mApproval->appendChild("name", *pad.getName());
 }
 
 /*******************************************************************************
@@ -93,11 +93,11 @@ MsgFiducialClearanceLessThanStopMask::MsgFiducialClearanceLessThanStopMask(
         "fiducial_copper_clearance_less_than_stop_mask"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -117,11 +117,11 @@ MsgFiducialStopMaskNotSet::MsgFiducialStopMaskNotSet(
         "fiducial_stop_mask_not_set"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -143,11 +143,11 @@ MsgHoleWithoutStopMask::MsgHoleWithoutStopMask(
         "hole_without_stop_mask"),
     mFootprint(footprint),
     mHole(hole) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -167,11 +167,11 @@ MsgInvalidCustomPadOutline::MsgInvalidCustomPadOutline(
         "invalid_custom_pad_outline"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -190,11 +190,11 @@ MsgInvalidPadConnection::MsgInvalidPadConnection(
         "invalid_pad_connection"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -217,9 +217,9 @@ MsgMissingCourtyard::MsgMissingCourtyard(
                "small offset. If you're unsure, just ignore this message."),
         "missing_courtyard"),
     mFootprint(footprint) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -248,9 +248,9 @@ MsgMissingFootprintModel::MsgMissingFootprintModel(
            "missing in the 3D viewer and in 3D data exports. However, this has "
            "no impact on the PCB production data."),
         "missing_footprint_3d_model") {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -270,9 +270,9 @@ MsgMissingFootprintName::MsgMissingFootprintName(
            "ignore this message."),
         "missing_name_text"),
     mFootprint(footprint) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -292,9 +292,9 @@ MsgMissingFootprintValue::MsgMissingFootprintValue(
            "ignore this message."),
         "missing_value_text"),
     mFootprint(footprint) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -314,9 +314,9 @@ MsgMissingPackageOutline::MsgMissingPackageOutline(
             .arg(Layer::topPackageOutlines().getNameTr()),
         "missing_package_outline"),
     mFootprint(footprint) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -361,11 +361,11 @@ MsgPadAnnularRingViolation::MsgPadAnnularRingViolation(
         "small_pad_annular_ring"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -391,13 +391,13 @@ MsgPadClearanceViolation::MsgPadClearanceViolation(
     mFootprint(footprint),
     mPad1(pad1),
     mPad2(pad2) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", std::min(pad1->getUuid(), pad2->getUuid()));
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", std::max(pad1->getUuid(), pad2->getUuid()));
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", std::min(pad1->getUuid(), pad2->getUuid()));
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", std::max(pad1->getUuid(), pad2->getUuid()));
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -417,11 +417,11 @@ MsgPadHoleOutsideCopper::MsgPadHoleOutsideCopper(
         "pad_hole_outside_copper"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -443,11 +443,11 @@ MsgPadOriginOutsideCopper::MsgPadOriginOutsideCopper(
         "pad_origin_outside_copper"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -469,11 +469,11 @@ MsgPadOverlapsWithLegend::MsgPadOverlapsWithLegend(
         "pad_overlaps_legend"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -494,11 +494,11 @@ MsgPadStopMaskOff::MsgPadStopMaskOff(std::shared_ptr<const Footprint> footprint,
         "pad_stop_mask_off"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -521,11 +521,11 @@ MsgPadWithCopperClearance::MsgPadWithCopperClearance(
         "pad_with_copper_clearance"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -546,11 +546,11 @@ MsgSmtPadWithSolderPaste::MsgSmtPadWithSolderPaste(
         "smt_pad_with_solder_paste"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -571,11 +571,11 @@ MsgSmtPadWithoutSolderPaste::MsgSmtPadWithoutSolderPaste(
         "smt_pad_without_solder_paste"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -598,11 +598,11 @@ MsgSuspiciousPadFunction::MsgSuspiciousPadFunction(
         "suspicious_pad_function"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -624,11 +624,11 @@ MsgThtPadWithSolderPaste::MsgThtPadWithSolderPaste(
         "tht_pad_with_solder_paste"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -653,11 +653,11 @@ MsgUnspecifiedPadFunction::MsgUnspecifiedPadFunction(
         "pad_function_unspecified"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -676,11 +676,11 @@ MsgUnusedCustomPadOutline::MsgUnusedCustomPadOutline(
         "unused_custom_pad_outline"),
     mFootprint(footprint),
     mPad(pad) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -698,11 +698,11 @@ MsgUselessZone::MsgUselessZone(std::shared_ptr<const Footprint> footprint,
         "useless_zone"),
     mFootprint(footprint),
     mZone(zone) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("zone", zone->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("zone", zone->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -723,11 +723,11 @@ MsgWrongFootprintTextLayer::MsgWrongFootprintTextLayer(
     mFootprint(footprint),
     mText(text),
     mExpectedLayer(&expectedLayer) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("footprint", footprint->getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("text", text->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("text", text->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -105,9 +105,9 @@ std::unique_ptr<Symbol> Symbol::open(
 
   // Load element.
   const QString fileName = getLongElementName() % ".lp";
-  const SExpression root = SExpression::parse(directory->read(fileName),
-                                              directory->getAbsPath(fileName));
-  std::unique_ptr<Symbol> obj(new Symbol(std::move(directory), root));
+  const std::unique_ptr<const SExpression> root = SExpression::parse(
+      directory->read(fileName), directory->getAbsPath(fileName));
+  std::unique_ptr<Symbol> obj(new Symbol(std::move(directory), *root));
   if (!migrations.isEmpty()) {
     obj->removeObsoleteMessageApprovals();
     obj->save();  // Format all files correctly as the migration doesn't!

--- a/libs/librepcb/core/library/sym/symbolcheckmessages.cpp
+++ b/libs/librepcb/core/library/sym/symbolcheckmessages.cpp
@@ -45,7 +45,7 @@ MsgDuplicatePinName::MsgDuplicatePinName(const SymbolPin& pin) noexcept
            "should add only one of these pins to the symbol. The assignment to "
            "multiple leads should be done in the device editor instead."),
         "duplicate_pin_name") {
-  mApproval.appendChild("name", *pin.getName());
+  mApproval->appendChild("name", *pin.getName());
 }
 
 /*******************************************************************************
@@ -92,9 +92,9 @@ MsgNonFunctionalSymbolPinInversionSign::MsgNonFunctionalSymbolPinInversionSign(
             .arg("!"),
         "nonfunctional_inversion_sign"),
     mPin(pin) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pin", pin->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pin", pin->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -117,10 +117,10 @@ MsgOverlappingSymbolPins::MsgOverlappingSymbolPins(
               return a->getUuid() < b->getUuid();
             });
   foreach (const auto& pin, pins) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("pin", pin->getUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("pin", pin->getUuid());
   }
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 QString MsgOverlappingSymbolPins::buildMessage(
@@ -150,9 +150,9 @@ MsgSymbolPinNotOnGrid::MsgSymbolPinNotOnGrid(
         "pin_not_on_grid"),
     mPin(pin),
     mGridInterval(gridInterval) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pin", pin->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pin", pin->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -170,9 +170,9 @@ MsgWrongSymbolTextLayer::MsgWrongSymbolTextLayer(
         "unusual_text_layer"),
     mText(text),
     mExpectedLayer(&expectedLayer) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("text", text->getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("text", text->getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -884,46 +884,47 @@ void Board::removeFromProject() {
 void Board::save() {
   // Content.
   {
-    SExpression root = SExpression::createList("librepcb_board");
-    root.appendChild(mUuid);
-    root.ensureLineBreak();
-    root.appendChild("name", mName);
-    root.ensureLineBreak();
-    root.appendChild("default_font", mDefaultFontFileName);
-    root.ensureLineBreak();
-    SExpression& gridNode = root.appendList("grid");
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_board");
+    root->appendChild(mUuid);
+    root->ensureLineBreak();
+    root->appendChild("name", mName);
+    root->ensureLineBreak();
+    root->appendChild("default_font", mDefaultFontFileName);
+    root->ensureLineBreak();
+    SExpression& gridNode = root->appendList("grid");
     gridNode.appendChild("interval", mGridInterval);
     gridNode.appendChild("unit", mGridUnit);
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     {
-      SExpression& node = root.appendList("layers");
+      SExpression& node = root->appendList("layers");
       node.appendChild("inner", mInnerLayerCount);
     }
-    root.ensureLineBreak();
-    root.appendChild("thickness", mPcbThickness);
-    root.ensureLineBreak();
-    root.appendChild("solder_resist", mSolderResist);
-    root.ensureLineBreak();
-    root.appendChild("silkscreen", mSilkscreenColor);
-    root.ensureLineBreak();
+    root->ensureLineBreak();
+    root->appendChild("thickness", mPcbThickness);
+    root->ensureLineBreak();
+    root->appendChild("solder_resist", mSolderResist);
+    root->ensureLineBreak();
+    root->appendChild("silkscreen", mSilkscreenColor);
+    root->ensureLineBreak();
     {
-      SExpression& node = root.appendList("silkscreen_layers_top");
+      SExpression& node = root->appendList("silkscreen_layers_top");
       foreach (const Layer* layer, mSilkscreenLayersTop) {
         node.appendChild(*layer);
       }
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     {
-      SExpression& node = root.appendList("silkscreen_layers_bot");
+      SExpression& node = root->appendList("silkscreen_layers_bot");
       foreach (const Layer* layer, mSilkscreenLayersBot) {
         node.appendChild(*layer);
       }
     }
-    root.ensureLineBreak();
-    mDesignRules->serialize(root.appendList("design_rules"));
-    root.ensureLineBreak();
+    root->ensureLineBreak();
+    mDesignRules->serialize(root->appendList("design_rules"));
+    root->ensureLineBreak();
     {
-      SExpression& node = root.appendList("design_rule_check");
+      SExpression& node = root->appendList("design_rule_check");
       mDrcSettings->serialize(node);
       node.appendChild("approvals_version", mDrcMessageApprovalsVersion);
       node.ensureLineBreak();
@@ -933,67 +934,67 @@ void Board::save() {
         node.ensureLineBreak();
       }
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     mFabricationOutputSettings->serialize(
-        root.appendList("fabrication_output_settings"));
-    root.ensureLineBreak();
+        root->appendList("fabrication_output_settings"));
+    root->ensureLineBreak();
     for (const BI_Device* obj : mDeviceInstances) {
-      root.ensureLineBreak();
-      obj->serialize(root.appendList("device"));
+      root->ensureLineBreak();
+      obj->serialize(root->appendList("device"));
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     for (const BI_NetSegment* obj : mNetSegments) {
-      root.ensureLineBreak();
-      obj->serialize(root.appendList("netsegment"));
+      root->ensureLineBreak();
+      obj->serialize(root->appendList("netsegment"));
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     for (const BI_Plane* obj : mPlanes) {
-      root.ensureLineBreak();
-      obj->serialize(root.appendList("plane"));
+      root->ensureLineBreak();
+      obj->serialize(root->appendList("plane"));
     }
     for (const BI_Zone* obj : mZones) {
-      root.ensureLineBreak();
-      obj->getData().serialize(root.appendList("zone"));
+      root->ensureLineBreak();
+      obj->getData().serialize(root->appendList("zone"));
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     for (const BI_Polygon* obj : mPolygons) {
-      root.ensureLineBreak();
-      obj->getData().serialize(root.appendList("polygon"));
+      root->ensureLineBreak();
+      obj->getData().serialize(root->appendList("polygon"));
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     for (const BI_StrokeText* obj : mStrokeTexts) {
-      root.ensureLineBreak();
-      obj->getData().serialize(root.appendList("stroke_text"));
+      root->ensureLineBreak();
+      obj->getData().serialize(root->appendList("stroke_text"));
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     for (const BI_Hole* obj : mHoles) {
-      root.ensureLineBreak();
-      obj->getData().serialize(root.appendList("hole"));
+      root->ensureLineBreak();
+      obj->getData().serialize(root->appendList("hole"));
     }
-    root.ensureLineBreak();
-    mDirectory->write("board.lp", root.toByteArray());
+    root->ensureLineBreak();
+    mDirectory->write("board.lp", root->toByteArray());
   }
 
   // User settings.
   {
-    SExpression root = SExpression::createList("librepcb_board_user_settings");
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_board_user_settings");
     for (auto it = mLayersVisibility.begin(); it != mLayersVisibility.end();
          it++) {
-      root.ensureLineBreak();
-      SExpression& child = root.appendList("layer");
+      root->ensureLineBreak();
+      SExpression& child = root->appendList("layer");
       child.appendChild(SExpression::createToken(it.key()));
       child.appendChild("visible", it.value());
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     for (const BI_Plane* plane : mPlanes) {
-      root.ensureLineBreak();
-      SExpression node = SExpression::createList("plane");
+      root->ensureLineBreak();
+      SExpression& node = root->appendList("plane");
       node.appendChild(plane->getUuid());
       node.appendChild("visible", plane->isVisible());
-      root.appendChild(node);
     }
-    root.ensureLineBreak();
-    mDirectory->write("settings.user.lp", root.toByteArray());
+    root->ensureLineBreak();
+    mDirectory->write("settings.user.lp", root->toByteArray());
   }
 }
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
@@ -71,9 +71,9 @@ DrcMsgMissingDevice::DrcMsgMissingDevice(
            "device in the board, so the circuit of the PCB is not "
            "complete.\n\nUse the \"Place Devices\" dock to add the device."),
         "missing_device", {}) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", component.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", component.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -95,11 +95,11 @@ DrcMsgMissingConnection::DrcMsgMissingConnection(const BI_NetLineAnchor& p1,
            "origin of footprint pads to make the airwire and this message "
            "disappearing."),
         "missing_connection", locations) {
-  mApproval.ensureLineBreak();
-  SExpression& fromNode = mApproval.appendList("tmp");
-  mApproval.ensureLineBreak();
-  SExpression& toNode = mApproval.appendList("tmp");
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  SExpression& fromNode = mApproval->appendList("tmp");
+  mApproval->ensureLineBreak();
+  SExpression& toNode = mApproval->appendList("tmp");
+  mApproval->ensureLineBreak();
 
   // Sort nodes to make the approval canonical.
   serializeAnchor(fromNode, p1);
@@ -195,13 +195,13 @@ DrcMsgOpenBoardOutlinePolygon::DrcMsgOpenBoardOutlinePolygon(
                "polygon and append an explicit last vertex to make the polygon "
                "closed."),
         "open_board_outline", locations) {
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
   if (device) {
-    mApproval.appendChild("device", device->getComponentInstanceUuid());
-    mApproval.ensureLineBreak();
+    mApproval->appendChild("device", device->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
   }
-  mApproval.appendChild("polygon", polygon);
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("polygon", polygon);
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -244,9 +244,9 @@ DrcMsgEmptyNetSegment::DrcMsgEmptyNetSegment(
                      "bug. But no worries, this issue is not harmful at all "
                      "so you can safely ignore this message.",
                      "empty_netsegment", {}) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", netSegment.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", netSegment.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -264,13 +264,13 @@ DrcMsgUnconnectedJunction::DrcMsgUnconnectedJunction(
         "no worries, this issue is not harmful at all so you can safely "
         "ignore this message.",
         "unconnected_junction", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("board", netPoint.getBoard().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", netPoint.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("junction", netPoint.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("board", netPoint.getBoard().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", netPoint.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("junction", netPoint.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -295,13 +295,13 @@ DrcMsgMinimumTextHeightViolation::DrcMsgMinimumTextHeightViolation(
             tr("Check the DRC settings and increase the text height if "
                "needed."),
         "minimum_text_height_violation", locations) {
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
   if (const BI_Device* device = text.getDevice()) {
-    mApproval.appendChild("device", device->getComponentInstanceUuid());
-    mApproval.ensureLineBreak();
+    mApproval->appendChild("device", device->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
   }
-  mApproval.appendChild("stroke_text", text.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("stroke_text", text.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -324,11 +324,11 @@ DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
             tr("Check the DRC settings and increase the trace width if "
                "needed."),
         "minimum_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", netLine.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("trace", netLine.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", netLine.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("trace", netLine.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
@@ -347,9 +347,9 @@ DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
             tr("Check the DRC settings and increase the minimum plane width in "
                "its properties if needed."),
         "minimum_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("plane", plane.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("plane", plane.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
@@ -368,9 +368,9 @@ DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
             tr("Check the DRC settings and increase the polygon line width if "
                "needed."),
         "minimum_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("polygon", polygon.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
@@ -389,13 +389,13 @@ DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
             tr("Check the DRC settings and increase the text stroke width if "
                "needed."),
         "minimum_width_violation", locations) {
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
   if (const BI_Device* device = text.getDevice()) {
-    mApproval.appendChild("device", device->getComponentInstanceUuid());
-    mApproval.ensureLineBreak();
+    mApproval->appendChild("device", device->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
   }
-  mApproval.appendChild("stroke_text", text.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("stroke_text", text.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
@@ -417,11 +417,11 @@ DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
             tr("Check the DRC settings and increase the polygon line width if "
                "needed."),
         "minimum_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("polygon", polygon.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
@@ -442,11 +442,11 @@ DrcMsgMinimumWidthViolation::DrcMsgMinimumWidthViolation(
             tr("Check the DRC settings and increase the circle line width if "
                "needed."),
         "minimum_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("circle", circle.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("circle", circle.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -475,11 +475,11 @@ DrcMsgCopperCopperClearanceViolation::DrcMsgCopperCopperClearanceViolation(
             tr("Check the DRC settings and move the objects to increase their "
                "clearance if needed."),
         "copper_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  SExpression& node1 = mApproval.appendList("object");
-  mApproval.ensureLineBreak();
-  SExpression& node2 = mApproval.appendList("object");
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  SExpression& node1 = mApproval->appendList("object");
+  mApproval->ensureLineBreak();
+  SExpression& node2 = mApproval->appendList("object");
+  mApproval->ensureLineBreak();
 
   // Sort nodes to make the approval canonical.
   serializeObject(node1, item1, polygon1, circle1);
@@ -604,11 +604,11 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
                          tr("Check the DRC settings and move the via away from "
                             "the board outline if needed."),
                      "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", via.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", via.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
@@ -626,11 +626,11 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
             tr("Check the DRC settings and move the trace away from the board "
                "outline if needed."),
         "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", netLine.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("trace", netLine.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", netLine.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("trace", netLine.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
@@ -648,11 +648,11 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
             tr("Check the DRC settings and move the device away from the board "
                "outline if needed."),
         "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
@@ -670,9 +670,9 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
             tr("Check the DRC settings and increase the configured plane "
                "clearance if needed."),
         "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("plane", plane.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("plane", plane.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
@@ -681,9 +681,9 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
   : RuleCheckMessage(Severity::Warning, getPolygonMessage(minClearance),
                      getPolygonDescription(),
                      "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("polygon", polygon.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
@@ -692,11 +692,11 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
   : RuleCheckMessage(Severity::Warning, getPolygonMessage(minClearance),
                      getPolygonDescription(),
                      "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("polygon", polygon.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
@@ -713,11 +713,11 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
             tr("Check the DRC settings and move the circle away from the board "
                "outline if needed."),
         "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("circle", circle.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("circle", circle.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
@@ -735,13 +735,13 @@ DrcMsgCopperBoardClearanceViolation::DrcMsgCopperBoardClearanceViolation(
             tr("Check the DRC settings and move the stroke text away from the "
                "board outline if needed."),
         "copper_board_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
   if (const BI_Device* device = strokeText.getDevice()) {
-    mApproval.appendChild("device", device->getComponentInstanceUuid());
-    mApproval.ensureLineBreak();
+    mApproval->appendChild("device", device->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
   }
-  mApproval.appendChild("stroke_text", strokeText.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("stroke_text", strokeText.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString DrcMsgCopperBoardClearanceViolation::getPolygonMessage(
@@ -770,9 +770,9 @@ DrcMsgCopperHoleClearanceViolation::DrcMsgCopperHoleClearanceViolation(
   : RuleCheckMessage(Severity::Error, getMessage(minClearance),
                      getDescription(), "copper_hole_clearance_violation",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperHoleClearanceViolation::DrcMsgCopperHoleClearanceViolation(
@@ -781,11 +781,11 @@ DrcMsgCopperHoleClearanceViolation::DrcMsgCopperHoleClearanceViolation(
   : RuleCheckMessage(Severity::Error, getMessage(minClearance),
                      getDescription(), "copper_hole_clearance_violation",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString DrcMsgCopperHoleClearanceViolation::getMessage(
@@ -816,12 +816,12 @@ DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
         tr("Pad in copper keepout zone: '%1'", "Placeholder is pad name")
             .arg(pad.getText()),
         getDescription(), "copper_in_keepout_zone", locations) {
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
@@ -833,12 +833,12 @@ DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
         tr("Via in copper keepout zone: '%1'", "Placeholder is net name")
             .arg(via.getNetSegment().getNetNameToDisplay(true)),
         getDescription(), "copper_in_keepout_zone", locations) {
-  mApproval.appendChild("netsegment", via.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("netsegment", via.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
@@ -850,12 +850,12 @@ DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
         tr("Trace in copper keepout zone: '%1'", "Placeholder is net name")
             .arg(netLine.getNetSegment().getNetNameToDisplay(true)),
         getDescription(), "copper_in_keepout_zone", locations) {
-  mApproval.appendChild("netsegment", netLine.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("trace", netLine.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("netsegment", netLine.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("trace", netLine.getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
@@ -864,10 +864,10 @@ DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
     const QVector<Path>& locations) noexcept
   : RuleCheckMessage(Severity::Error, tr("Polygon in copper keepout zone"),
                      getDescription(), "copper_in_keepout_zone", locations) {
-  mApproval.appendChild("polygon", polygon.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getData().getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
@@ -879,12 +879,12 @@ DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
         tr("Polygon in copper keepout zone: '%1'", "Placeholder is device name")
             .arg(*device.getComponentInstance().getName()),
         getDescription(), "copper_in_keepout_zone", locations) {
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("polygon", polygon.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
@@ -896,29 +896,29 @@ DrcMsgCopperInKeepoutZone::DrcMsgCopperInKeepoutZone(
         tr("Circle in copper keepout zone: '%1'", "Placeholder is device name")
             .arg(*device.getComponentInstance().getName()),
         getDescription(), "copper_in_keepout_zone", locations) {
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("circle", circle.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("circle", circle.getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 void DrcMsgCopperInKeepoutZone::addZoneApprovalNodes(
     const BI_Zone* boardZone, const BI_Device* zoneDevice,
     const Zone* deviceZone) noexcept {
   if (boardZone) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("zone", boardZone->getData().getUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("zone", boardZone->getData().getUuid());
   }
   if (deviceZone) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("zone", deviceZone->getUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("zone", deviceZone->getUuid());
   }
   if (zoneDevice) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("from_device",
-                          zoneDevice->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("from_device",
+                           zoneDevice->getComponentInstanceUuid());
   }
 }
 
@@ -945,11 +945,11 @@ DrcMsgDrillDrillClearanceViolation::DrcMsgDrillDrillClearanceViolation(
                          tr("Check the DRC settings and move the drills to "
                             "increase their distance if needed."),
                      "drill_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
-  SExpression& node1 = mApproval.appendList("drill");
-  mApproval.ensureLineBreak();
-  SExpression& node2 = mApproval.appendList("drill");
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  SExpression& node1 = mApproval->appendList("drill");
+  mApproval->ensureLineBreak();
+  SExpression& node2 = mApproval->appendList("drill");
+  mApproval->ensureLineBreak();
 
   // Sort nodes to make the approval canonical.
   serializeObject(node1, item1, hole1);
@@ -1000,11 +1000,11 @@ DrcMsgDrillBoardClearanceViolation::DrcMsgDrillBoardClearanceViolation(
   : RuleCheckMessage(Severity::Error, getMessage(minClearance),
                      getDescription(), "drill_board_clearance_violation",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", via.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", via.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgDrillBoardClearanceViolation::DrcMsgDrillBoardClearanceViolation(
@@ -1013,13 +1013,13 @@ DrcMsgDrillBoardClearanceViolation::DrcMsgDrillBoardClearanceViolation(
   : RuleCheckMessage(Severity::Error, getMessage(minClearance),
                      getDescription(), "drill_board_clearance_violation",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgDrillBoardClearanceViolation::DrcMsgDrillBoardClearanceViolation(
@@ -1028,9 +1028,9 @@ DrcMsgDrillBoardClearanceViolation::DrcMsgDrillBoardClearanceViolation(
   : RuleCheckMessage(Severity::Error, getMessage(minClearance),
                      getDescription(), "drill_board_clearance_violation",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgDrillBoardClearanceViolation::DrcMsgDrillBoardClearanceViolation(
@@ -1039,11 +1039,11 @@ DrcMsgDrillBoardClearanceViolation::DrcMsgDrillBoardClearanceViolation(
   : RuleCheckMessage(Severity::Error, getMessage(minClearance),
                      getDescription(), "drill_board_clearance_violation",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString DrcMsgDrillBoardClearanceViolation::getMessage(
@@ -1083,15 +1083,15 @@ DrcMsgDeviceInCourtyard::DrcMsgDeviceInCourtyard(
                "this message if you're sure they can be assembled without "
                "problems."),
         "device_in_courtyard", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device",
-                        std::min(device1.getComponentInstanceUuid(),
-                                 device2.getComponentInstanceUuid()));
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device",
-                        std::max(device1.getComponentInstanceUuid(),
-                                 device2.getComponentInstanceUuid()));
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device",
+                         std::min(device1.getComponentInstanceUuid(),
+                                  device2.getComponentInstanceUuid()));
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device",
+                         std::max(device1.getComponentInstanceUuid(),
+                                  device2.getComponentInstanceUuid()));
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -1116,15 +1116,15 @@ DrcMsgOverlappingDevices::DrcMsgOverlappingDevices(
                "this message if you're sure they can be assembled without "
                "problems (or only one of them gets assembled)."),
         "overlapping_devices", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device",
-                        std::min(device1.getComponentInstanceUuid(),
-                                 device2.getComponentInstanceUuid()));
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device",
-                        std::max(device1.getComponentInstanceUuid(),
-                                 device2.getComponentInstanceUuid()));
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device",
+                         std::min(device1.getComponentInstanceUuid(),
+                                  device2.getComponentInstanceUuid()));
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device",
+                         std::max(device1.getComponentInstanceUuid(),
+                                  device2.getComponentInstanceUuid()));
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -1140,27 +1140,27 @@ DrcMsgDeviceInKeepoutZone::DrcMsgDeviceInKeepoutZone(
         tr("Device in keepout zone: '%1'", "Placeholder is device name")
             .arg(*device.getComponentInstance().getName()),
         getDescription(), "device_in_keepout_zone", locations) {
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 void DrcMsgDeviceInKeepoutZone::addZoneApprovalNodes(
     const BI_Zone* boardZone, const BI_Device* zoneDevice,
     const Zone* deviceZone) noexcept {
   if (boardZone) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("zone", boardZone->getData().getUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("zone", boardZone->getData().getUuid());
   }
   if (deviceZone) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("zone", deviceZone->getUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("zone", deviceZone->getUuid());
   }
   if (zoneDevice) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("from_device",
-                          zoneDevice->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("from_device",
+                           zoneDevice->getComponentInstanceUuid());
   }
 }
 
@@ -1182,12 +1182,12 @@ DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
         tr("Pad in exposure keepout zone: '%1'", "Placeholder is pad name")
             .arg(pad.getText()),
         getDescription(), "exposure_in_keepout_zone", locations) {
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
@@ -1199,12 +1199,12 @@ DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
         tr("Via in exposure keepout zone: '%1'", "Placeholder is net name")
             .arg(via.getNetSegment().getNetNameToDisplay(true)),
         getDescription(), "exposure_in_keepout_zone", locations) {
-  mApproval.appendChild("netsegment", via.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("netsegment", via.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
@@ -1213,10 +1213,10 @@ DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
     const QVector<Path>& locations) noexcept
   : RuleCheckMessage(Severity::Error, tr("Polygon in exposure keepout zone"),
                      getDescription(), "exposure_in_keepout_zone", locations) {
-  mApproval.appendChild("polygon", polygon.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getData().getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
@@ -1228,12 +1228,12 @@ DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
                         "Placeholder is device name")
                          .arg(*device.getComponentInstance().getName()),
                      getDescription(), "exposure_in_keepout_zone", locations) {
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("polygon", polygon.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("polygon", polygon.getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
@@ -1245,29 +1245,29 @@ DrcMsgExposureInKeepoutZone::DrcMsgExposureInKeepoutZone(
                         "Placeholder is device name")
                          .arg(*device.getComponentInstance().getName()),
                      getDescription(), "exposure_in_keepout_zone", locations) {
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("circle", circle.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("circle", circle.getUuid());
+  mApproval->ensureLineBreak();
   addZoneApprovalNodes(boardZone, zoneDevice, deviceZone);
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
 }
 
 void DrcMsgExposureInKeepoutZone::addZoneApprovalNodes(
     const BI_Zone* boardZone, const BI_Device* zoneDevice,
     const Zone* deviceZone) noexcept {
   if (boardZone) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("zone", boardZone->getData().getUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("zone", boardZone->getData().getUuid());
   }
   if (deviceZone) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("zone", deviceZone->getUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("zone", deviceZone->getUuid());
   }
   if (zoneDevice) {
-    mApproval.ensureLineBreak();
-    mApproval.appendChild("from_device",
-                          zoneDevice->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
+    mApproval->appendChild("from_device",
+                           zoneDevice->getComponentInstanceUuid());
   }
 }
 
@@ -1296,11 +1296,11 @@ DrcMsgMinimumAnnularRingViolation::DrcMsgMinimumAnnularRingViolation(
             " " % seriousTroublesTr() % "\n\n" %
             tr("Check the DRC settings and increase the via size if needed."),
         "minimum_annular_ring_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", via.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", via.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumAnnularRingViolation::DrcMsgMinimumAnnularRingViolation(
@@ -1317,11 +1317,11 @@ DrcMsgMinimumAnnularRingViolation::DrcMsgMinimumAnnularRingViolation(
             " " % seriousTroublesTr() % "\n\n" %
             tr("Check the DRC settings and increase the pad size if needed."),
         "minimum_annular_ring_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -1336,9 +1336,9 @@ DrcMsgMinimumDrillDiameterViolation::DrcMsgMinimumDrillDiameterViolation(
         determineMessage(hole.getData().getDiameter(), minDiameter),
         determineDescription(false, false), "minimum_drill_diameter_violation",
         locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumDrillDiameterViolation::DrcMsgMinimumDrillDiameterViolation(
@@ -1348,11 +1348,11 @@ DrcMsgMinimumDrillDiameterViolation::DrcMsgMinimumDrillDiameterViolation(
                      determineMessage(hole.getDiameter(), minDiameter),
                      determineDescription(false, false),
                      "minimum_drill_diameter_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumDrillDiameterViolation::DrcMsgMinimumDrillDiameterViolation(
@@ -1367,11 +1367,11 @@ DrcMsgMinimumDrillDiameterViolation::DrcMsgMinimumDrillDiameterViolation(
                  minDiameter->toMmString(), "mm"),
         determineDescription(true, false), "minimum_drill_diameter_violation",
         locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", via.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", via.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumDrillDiameterViolation::DrcMsgMinimumDrillDiameterViolation(
@@ -1385,13 +1385,13 @@ DrcMsgMinimumDrillDiameterViolation::DrcMsgMinimumDrillDiameterViolation(
                  minDiameter->toMmString(), "mm"),
         determineDescription(false, true), "minimum_drill_diameter_violation",
         locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", padHole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", padHole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString DrcMsgMinimumDrillDiameterViolation::determineMessage(
@@ -1434,9 +1434,9 @@ DrcMsgMinimumSlotWidthViolation::DrcMsgMinimumSlotWidthViolation(
                      determineMessage(hole.getData().getDiameter(), minWidth),
                      determineDescription(false),
                      "minimum_slot_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumSlotWidthViolation::DrcMsgMinimumSlotWidthViolation(
@@ -1446,11 +1446,11 @@ DrcMsgMinimumSlotWidthViolation::DrcMsgMinimumSlotWidthViolation(
                      determineMessage(hole.getDiameter(), minWidth),
                      determineDescription(false),
                      "minimum_slot_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgMinimumSlotWidthViolation::DrcMsgMinimumSlotWidthViolation(
@@ -1463,13 +1463,13 @@ DrcMsgMinimumSlotWidthViolation::DrcMsgMinimumSlotWidthViolation(
             .arg(pad.getText(), padHole.getDiameter()->toMmString(),
                  minWidth->toMmString(), "mm"),
         determineDescription(true), "minimum_slot_width_violation", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", padHole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", padHole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString DrcMsgMinimumSlotWidthViolation::determineMessage(
@@ -1514,12 +1514,12 @@ DrcMsgInvalidPadConnection::DrcMsgInvalidPadConnection(
            "connected fully. This issue needs to be fixed in the "
            "library."),
         "invalid_pad_connection", locations) {
-  mApproval.appendChild("layer", layer);
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("layer", layer);
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -1532,9 +1532,9 @@ DrcMsgForbiddenSlot::DrcMsgForbiddenSlot(
                      determineMessage(hole.getData().getPath()),
                      determineDescription(hole.getData().getPath()),
                      "forbidden_slot", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgForbiddenSlot::DrcMsgForbiddenSlot(
@@ -1543,11 +1543,11 @@ DrcMsgForbiddenSlot::DrcMsgForbiddenSlot(
   : RuleCheckMessage(Severity::Warning, determineMessage(hole.getPath()),
                      determineDescription(hole.getPath()), "forbidden_slot",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", device.getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", hole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", device.getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", hole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 DrcMsgForbiddenSlot::DrcMsgForbiddenSlot(
@@ -1556,13 +1556,13 @@ DrcMsgForbiddenSlot::DrcMsgForbiddenSlot(
   : RuleCheckMessage(Severity::Warning, determineMessage(padHole.getPath()),
                      determineDescription(padHole.getPath()), "forbidden_slot",
                      locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("device", pad.getDevice().getComponentInstanceUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pad", pad.getLibPadUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("hole", padHole.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("device", pad.getDevice().getComponentInstanceUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pad", pad.getLibPadUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("hole", padHole.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString DrcMsgForbiddenSlot::determineMessage(
@@ -1609,9 +1609,9 @@ DrcMsgForbiddenVia::DrcMsgForbiddenVia(const BI_Via& via,
                                        const QVector<Path>& locations) noexcept
   : RuleCheckMessage(Severity::Error, determineMessage(via),
                      determineDescription(via), "forbidden_via", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString DrcMsgForbiddenVia::determineMessage(const BI_Via& via) noexcept {
@@ -1659,13 +1659,13 @@ DrcMsgSilkscreenClearanceViolation::DrcMsgSilkscreenClearanceViolation(
             tr("Check the DRC settings and move the text away from the "
                "solder resist opening if needed."),
         "silkscreen_clearance_violation", locations) {
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
   if (const BI_Device* device = strokeText.getDevice()) {
-    mApproval.appendChild("device", device->getComponentInstanceUuid());
-    mApproval.ensureLineBreak();
+    mApproval->appendChild("device", device->getComponentInstanceUuid());
+    mApproval->ensureLineBreak();
   }
-  mApproval.appendChild("stroke_text", strokeText.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->appendChild("stroke_text", strokeText.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -1678,9 +1678,9 @@ DrcMsgUselessZone::DrcMsgUselessZone(const BI_Zone& zone,
         Severity::Warning, tr("Useless zone"),
         tr("The zone has no layer or rule enabled so it is useless."),
         "useless_zone", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("zone", zone.getData().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("zone", zone.getData().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -1695,9 +1695,9 @@ DrcMsgUselessVia::DrcMsgUselessVia(const BI_Via& via,
                      tr("The via is connected on less than two layers, thus it "
                         "seems to be useless."),
                      "useless_via", locations) {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("via", via.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/drc/boarddesignrulechecksettings.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulechecksettings.cpp
@@ -36,7 +36,8 @@ namespace librepcb {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const BoardDesignRuleCheckSettings::AllowedSlots& obj) {
+std::unique_ptr<SExpression> serialize(
+    const BoardDesignRuleCheckSettings::AllowedSlots& obj) {
   switch (obj) {
     case BoardDesignRuleCheckSettings::AllowedSlots::None:
       return SExpression::createToken("none");

--- a/libs/librepcb/core/project/board/items/bi_plane.cpp
+++ b/libs/librepcb/core/project/board/items/bi_plane.cpp
@@ -237,7 +237,7 @@ void BI_Plane::serialize(SExpression& root) const {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const BI_Plane::ConnectStyle& obj) {
+std::unique_ptr<SExpression> serialize(const BI_Plane::ConnectStyle& obj) {
   switch (obj) {
     case BI_Plane::ConnectStyle::None:
       return SExpression::createToken("none");

--- a/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
@@ -49,7 +49,7 @@ ErcMsgUnusedNetClass::ErcMsgUnusedNetClass(const NetClass& netClass) noexcept
                      tr("There are no nets assigned to the net class, so you "
                         "could remove it."),
                      "unused_netclass") {
-  mApproval.appendChild("netclass", netClass.getUuid());
+  mApproval->appendChild("netclass", netClass.getUuid());
 }
 
 /*******************************************************************************
@@ -63,7 +63,7 @@ ErcMsgOpenNet::ErcMsgOpenNet(const NetSignal& net) noexcept
                         "does not represent an electrical connection. Check if "
                         "you missed to connect more pins."),
                      "open_net") {
-  mApproval.appendChild("net", net.getUuid());
+  mApproval->appendChild("net", net.getUuid());
 }
 
 /*******************************************************************************
@@ -80,7 +80,7 @@ ErcMsgOpenWireInSegment::ErcMsgOpenWireInSegment(
            "if a connection to another wire or pin is missing (denoted by a "
            "cross mark)."),
         "open_wire") {
-  mApproval.appendChild("segment", segment.getUuid());
+  mApproval->appendChild("segment", segment.getUuid());
 }
 
 /*******************************************************************************
@@ -97,11 +97,11 @@ ErcMsgUnconnectedRequiredSignal::ErcMsgUnconnectedRequiredSignal(
                         "not connected to any net. Add a wire to the "
                         "corresponding symbol pin to connect it to a net."),
                      "unconnected_required_signal") {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("component", signal.getComponentInstance().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("signal", signal.getCompSignal().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("component", signal.getComponentInstance().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("signal", signal.getCompSignal().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -121,11 +121,11 @@ ErcMsgForcedNetSignalNameConflict::ErcMsgForcedNetSignalNameConflict(
            "this connection.")
             .arg(signal.getForcedNetSignalName(), getSignalNet(signal)),
         "forced_net_name_conflict") {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("component", signal.getComponentInstance().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("signal", signal.getCompSignal().getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("component", signal.getComponentInstance().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("signal", signal.getCompSignal().getUuid());
+  mApproval->ensureLineBreak();
 }
 
 QString ErcMsgForcedNetSignalNameConflict::getSignalNet(
@@ -148,11 +148,11 @@ ErcMsgUnplacedRequiredGate::ErcMsgUnplacedRequiredGate(
                         "is not added to the schematic.")
                          .arg(*gate.getSuffix(), *component.getName()),
                      "unplaced_required_gate") {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("component", component.getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("gate", gate.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("component", component.getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("gate", gate.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -169,11 +169,11 @@ ErcMsgUnplacedOptionalGate::ErcMsgUnplacedOptionalGate(
         tr("The optional gate '%1' of '%2' is not added to the schematic.")
             .arg(*gate.getSuffix(), *component.getName()),
         "unplaced_optional_gate") {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("component", component.getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("gate", gate.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("component", component.getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("gate", gate.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -190,13 +190,13 @@ ErcMsgConnectedPinWithoutWire::ErcMsgConnectedPinWithoutWire(
            "attached so this connection is not visible in the schematic. Add a "
            "wire to make the connection visible."),
         "connected_pin_without_wire") {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("schematic", pin.getSchematic().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("symbol", pin.getSymbol().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("pin", pin.getLibPinUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("schematic", pin.getSchematic().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("symbol", pin.getSymbol().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("pin", pin.getLibPinUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************
@@ -214,13 +214,13 @@ ErcMsgUnconnectedJunction::ErcMsgUnconnectedJunction(
         "no worries, this issue is not harmful at all so you can safely "
         "ignore this message.",
         "unconnected_junction") {
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("schematic", netPoint.getSchematic().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("netsegment", netPoint.getNetSegment().getUuid());
-  mApproval.ensureLineBreak();
-  mApproval.appendChild("junction", netPoint.getUuid());
-  mApproval.ensureLineBreak();
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("schematic", netPoint.getSchematic().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", netPoint.getNetSegment().getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("junction", netPoint.getUuid());
+  mApproval->ensureLineBreak();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/project.cpp
+++ b/libs/librepcb/core/project/project.cpp
@@ -381,112 +381,118 @@ void Project::save() {
 
   // Metadata.
   {
-    SExpression root = SExpression::createList("librepcb_project_metadata");
-    root.appendChild(mUuid);
-    root.ensureLineBreak();
-    root.appendChild("name", mName);
-    root.ensureLineBreak();
-    root.appendChild("author", mAuthor);
-    root.ensureLineBreak();
-    root.appendChild("version", mVersion);
-    root.ensureLineBreak();
-    root.appendChild("created", mCreated);
-    root.ensureLineBreak();
-    mAttributes.serialize(root);
-    root.ensureLineBreak();
-    mDirectory->write("project/metadata.lp", root.toByteArray());
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_project_metadata");
+    root->appendChild(mUuid);
+    root->ensureLineBreak();
+    root->appendChild("name", mName);
+    root->ensureLineBreak();
+    root->appendChild("author", mAuthor);
+    root->ensureLineBreak();
+    root->appendChild("version", mVersion);
+    root->ensureLineBreak();
+    root->appendChild("created", mCreated);
+    root->ensureLineBreak();
+    mAttributes.serialize(*root);
+    root->ensureLineBreak();
+    mDirectory->write("project/metadata.lp", root->toByteArray());
   }
 
   // Settings.
   {
-    SExpression root = SExpression::createList("librepcb_project_settings");
-    root.ensureLineBreak();
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_project_settings");
+    root->ensureLineBreak();
     {
-      SExpression& node = root.appendList("library_locale_order");
+      SExpression& node = root->appendList("library_locale_order");
       foreach (const QString& locale, mLocaleOrder) {
         node.ensureLineBreak();
         node.appendChild("locale", locale);
       }
       node.ensureLineBreak();
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     {
-      SExpression& node = root.appendList("library_norm_order");
+      SExpression& node = root->appendList("library_norm_order");
       foreach (const QString& norm, mNormOrder) {
         node.ensureLineBreak();
         node.appendChild("norm", norm);
       }
       node.ensureLineBreak();
     }
-    root.ensureLineBreak();
+    root->ensureLineBreak();
     {
-      SExpression& node = root.appendList("custom_bom_attributes");
+      SExpression& node = root->appendList("custom_bom_attributes");
       foreach (const QString& key, mCustomBomAttributes) {
         node.ensureLineBreak();
         node.appendChild("attribute", key);
       }
       node.ensureLineBreak();
     }
-    root.ensureLineBreak();
-    root.appendChild("default_lock_component_assembly",
-                     mDefaultLockComponentAssembly);
-    root.ensureLineBreak();
-    mDirectory->write("project/settings.lp", root.toByteArray());
+    root->ensureLineBreak();
+    root->appendChild("default_lock_component_assembly",
+                      mDefaultLockComponentAssembly);
+    root->ensureLineBreak();
+    mDirectory->write("project/settings.lp", root->toByteArray());
   }
 
   // Output jobs.
   {
-    SExpression root = SExpression::createList("librepcb_jobs");
-    root.ensureLineBreak();
-    mOutputJobs.serialize(root);
-    root.ensureLineBreak();
-    mDirectory->write("project/jobs.lp", root.toByteArray());
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_jobs");
+    root->ensureLineBreak();
+    mOutputJobs.serialize(*root);
+    root->ensureLineBreak();
+    mDirectory->write("project/jobs.lp", root->toByteArray());
   }
 
   // Circuit.
   {
-    SExpression root = SExpression::createList("librepcb_circuit");
-    mCircuit->serialize(root);
-    mDirectory->write("circuit/circuit.lp", root.toByteArray());
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_circuit");
+    mCircuit->serialize(*root);
+    mDirectory->write("circuit/circuit.lp", root->toByteArray());
   }
 
   // ERC.
   {
-    SExpression root = SExpression::createList("librepcb_erc");
+    std::unique_ptr<SExpression> root = SExpression::createList("librepcb_erc");
     foreach (const SExpression& node,
              Toolbox::sortedQSet(mErcMessageApprovals)) {
-      root.ensureLineBreak();
-      root.appendChild(node);
+      root->ensureLineBreak();
+      root->appendChild(node);
     }
-    root.ensureLineBreak();
-    mDirectory->write("circuit/erc.lp", root.toByteArray());
+    root->ensureLineBreak();
+    mDirectory->write("circuit/erc.lp", root->toByteArray());
   }
 
   // Schematics.
   {
-    SExpression root = SExpression::createList("librepcb_schematics");
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_schematics");
     foreach (Schematic* schematic, mSchematics) {
-      root.ensureLineBreak();
-      root.appendChild(
+      root->ensureLineBreak();
+      root->appendChild(
           "schematic",
           "schematics/" + schematic->getDirectoryName() + "/schematic.lp");
       schematic->save();
     }
-    root.ensureLineBreak();
-    mDirectory->write("schematics/schematics.lp", root.toByteArray());
+    root->ensureLineBreak();
+    mDirectory->write("schematics/schematics.lp", root->toByteArray());
   }
 
   // Boards.
   {
-    SExpression root = SExpression::createList("librepcb_boards");
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_boards");
     foreach (Board* board, mBoards) {
-      root.ensureLineBreak();
-      root.appendChild("board",
-                       "boards/" + board->getDirectoryName() + "/board.lp");
+      root->ensureLineBreak();
+      root->appendChild("board",
+                        "boards/" + board->getDirectoryName() + "/board.lp");
       board->save();
     }
-    root.ensureLineBreak();
-    mDirectory->write("boards/boards.lp", root.toByteArray());
+    root->ensureLineBreak();
+    mDirectory->write("boards/boards.lp", root->toByteArray());
   }
 
   // Update the datetime attribute of the project.

--- a/libs/librepcb/core/project/schematic/schematic.cpp
+++ b/libs/librepcb/core/project/schematic/schematic.cpp
@@ -292,36 +292,37 @@ void Schematic::removeFromProject() {
 }
 
 void Schematic::save() {
-  SExpression root = SExpression::createList("librepcb_schematic");
-  root.appendChild(mUuid);
-  root.ensureLineBreak();
-  root.appendChild("name", mName);
-  root.ensureLineBreak();
-  SExpression& gridNode = root.appendList("grid");
+  std::unique_ptr<SExpression> root =
+      SExpression::createList("librepcb_schematic");
+  root->appendChild(mUuid);
+  root->ensureLineBreak();
+  root->appendChild("name", mName);
+  root->ensureLineBreak();
+  SExpression& gridNode = root->appendList("grid");
   gridNode.appendChild("interval", mGridInterval);
   gridNode.appendChild("unit", mGridUnit);
-  root.ensureLineBreak();
+  root->ensureLineBreak();
   for (const SI_Symbol* obj : mSymbols) {
-    root.ensureLineBreak();
-    obj->serialize(root.appendList("symbol"));
+    root->ensureLineBreak();
+    obj->serialize(root->appendList("symbol"));
   }
-  root.ensureLineBreak();
+  root->ensureLineBreak();
   for (const SI_NetSegment* obj : mNetSegments) {
-    root.ensureLineBreak();
-    obj->serialize(root.appendList("netsegment"));
+    root->ensureLineBreak();
+    obj->serialize(root->appendList("netsegment"));
   }
-  root.ensureLineBreak();
+  root->ensureLineBreak();
   for (const SI_Polygon* obj : mPolygons) {
-    root.ensureLineBreak();
-    obj->getPolygon().serialize(root.appendList("polygon"));
+    root->ensureLineBreak();
+    obj->getPolygon().serialize(root->appendList("polygon"));
   }
-  root.ensureLineBreak();
+  root->ensureLineBreak();
   for (const SI_Text* obj : mTexts) {
-    root.ensureLineBreak();
-    obj->getTextObj().serialize(root.appendList("text"));
+    root->ensureLineBreak();
+    obj->getTextObj().serialize(root->appendList("text"));
   }
-  root.ensureLineBreak();
-  mDirectory->write("schematic.lp", root.toByteArray());
+  root->ensureLineBreak();
+  mDirectory->write("schematic.lp", root->toByteArray());
 }
 
 void Schematic::updateAllNetLabelAnchors() noexcept {

--- a/libs/librepcb/core/rulecheck/rulecheckmessage.cpp
+++ b/libs/librepcb/core/rulecheck/rulecheckmessage.cpp
@@ -35,7 +35,7 @@ RuleCheckMessage::RuleCheckMessage(const RuleCheckMessage& other) noexcept
   : mSeverity(other.mSeverity),
     mMessage(other.mMessage),
     mDescription(other.mDescription),
-    mApproval(other.mApproval),
+    mApproval(new SExpression(*other.mApproval)),
     mLocations(other.mLocations) {
 }
 
@@ -48,7 +48,7 @@ RuleCheckMessage::RuleCheckMessage(Severity severity, const QString& msg,
     mDescription(description),
     mApproval(SExpression::createList("approved")),
     mLocations(locations) {
-  mApproval.appendChild(SExpression::createToken(approvalName));  // snake_case
+  mApproval->appendChild(SExpression::createToken(approvalName));  // snake_case
 }
 
 RuleCheckMessage::~RuleCheckMessage() noexcept {

--- a/libs/librepcb/core/rulecheck/rulecheckmessage.h
+++ b/libs/librepcb/core/rulecheck/rulecheckmessage.h
@@ -62,7 +62,7 @@ public:
   const QIcon& getSeverityIcon() const noexcept;
   const QString& getMessage() const noexcept { return mMessage; }
   const QString& getDescription() const noexcept { return mDescription; }
-  const SExpression& getApproval() const noexcept { return mApproval; }
+  const SExpression& getApproval() const noexcept { return *mApproval; }
   const QVector<Path>& getLocations() const noexcept { return mLocations; }
 
   // General Methods
@@ -97,7 +97,7 @@ protected:  // Data
   Severity mSeverity;
   QString mMessage;
   QString mDescription;
-  SExpression mApproval;
+  std::unique_ptr<SExpression> mApproval;
   QVector<Path> mLocations;
 };
 

--- a/libs/librepcb/core/types/alignment.cpp
+++ b/libs/librepcb/core/types/alignment.cpp
@@ -51,7 +51,7 @@ HAlign& HAlign::mirror() noexcept {
 }
 
 template <>
-SExpression serialize(const VAlign& obj) {
+std::unique_ptr<SExpression> serialize(const VAlign& obj) {
   switch (obj.toQtAlignFlag()) {
     case Qt::AlignTop:
       return SExpression::createToken("top");
@@ -101,7 +101,7 @@ VAlign& VAlign::mirror() noexcept {
 }
 
 template <>
-SExpression serialize(const HAlign& obj) {
+std::unique_ptr<SExpression> serialize(const HAlign& obj) {
   switch (obj.toQtAlignFlag()) {
     case Qt::AlignLeft:
       return SExpression::createToken("left");

--- a/libs/librepcb/core/types/angle.cpp
+++ b/libs/librepcb/core/types/angle.cpp
@@ -144,7 +144,7 @@ qint32 Angle::degStringToMicrodeg(const QString& degrees) {
 // Non-Member Functions
 
 template <>
-SExpression serialize(const Angle& obj) {
+std::unique_ptr<SExpression> serialize(const Angle& obj) {
   return SExpression::createToken(obj.toDegString());
 }
 

--- a/libs/librepcb/core/types/circuitidentifier.h
+++ b/libs/librepcb/core/types/circuitidentifier.h
@@ -124,7 +124,7 @@ inline QString operator%(const CircuitIdentifier& lhs,
 }
 
 template <>
-inline SExpression serialize(const CircuitIdentifier& obj) {
+inline std::unique_ptr<SExpression> serialize(const CircuitIdentifier& obj) {
   return SExpression::createString(*obj);
 }
 
@@ -134,7 +134,8 @@ inline CircuitIdentifier deserialize(const SExpression& node) {
 }
 
 template <>
-inline SExpression serialize(const tl::optional<CircuitIdentifier>& obj) {
+inline std::unique_ptr<SExpression> serialize(
+    const tl::optional<CircuitIdentifier>& obj) {
   if (obj) {
     return serialize(*obj);
   } else {

--- a/libs/librepcb/core/types/elementname.h
+++ b/libs/librepcb/core/types/elementname.h
@@ -106,7 +106,7 @@ inline ElementName operator%(const ElementName& lhs,
 }
 
 template <>
-inline SExpression serialize(const ElementName& obj) {
+inline std::unique_ptr<SExpression> serialize(const ElementName& obj) {
   return SExpression::createString(*obj);
 }
 
@@ -116,7 +116,8 @@ inline ElementName deserialize(const SExpression& node) {
 }
 
 template <>
-inline SExpression serialize(const tl::optional<ElementName>& obj) {
+inline std::unique_ptr<SExpression> serialize(
+    const tl::optional<ElementName>& obj) {
   return SExpression::createString(obj ? **obj : "");
 }
 

--- a/libs/librepcb/core/types/fileproofname.h
+++ b/libs/librepcb/core/types/fileproofname.h
@@ -113,7 +113,7 @@ inline FileProofName operator%(const FileProofName& lhs,
 }
 
 template <>
-inline SExpression serialize(const FileProofName& obj) {
+inline std::unique_ptr<SExpression> serialize(const FileProofName& obj) {
   return SExpression::createString(*obj);
 }
 

--- a/libs/librepcb/core/types/layer.cpp
+++ b/libs/librepcb/core/types/layer.cpp
@@ -466,7 +466,7 @@ bool Layer::lessThan(const Layer* a, const Layer* b) noexcept {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const Layer& obj) {
+std::unique_ptr<SExpression> serialize(const Layer& obj) {
   return SExpression::createToken(obj.getId());
 }
 

--- a/libs/librepcb/core/types/length.cpp
+++ b/libs/librepcb/core/types/length.cpp
@@ -206,17 +206,17 @@ LengthBase_t Length::mmStringToNm(const QString& millimeters) {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const Length& obj) {
+std::unique_ptr<SExpression> serialize(const Length& obj) {
   return SExpression::createToken(obj.toMmString());
 }
 
 template <>
-SExpression serialize(const UnsignedLength& obj) {
+std::unique_ptr<SExpression> serialize(const UnsignedLength& obj) {
   return serialize(*obj);
 }
 
 template <>
-SExpression serialize(const PositiveLength& obj) {
+std::unique_ptr<SExpression> serialize(const PositiveLength& obj) {
   return serialize(*obj);
 }
 

--- a/libs/librepcb/core/types/lengthunit.cpp
+++ b/libs/librepcb/core/types/lengthunit.cpp
@@ -261,7 +261,7 @@ QList<LengthUnit> LengthUnit::getAllUnits() noexcept {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const LengthUnit& obj) {
+std::unique_ptr<SExpression> serialize(const LengthUnit& obj) {
   return SExpression::createToken(obj.toStr());
 }
 

--- a/libs/librepcb/core/types/maskconfig.cpp
+++ b/libs/librepcb/core/types/maskconfig.cpp
@@ -66,7 +66,7 @@ MaskConfig& MaskConfig::operator=(const MaskConfig& rhs) noexcept {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const MaskConfig& obj) {
+std::unique_ptr<SExpression> serialize(const MaskConfig& obj) {
   if (!obj.isEnabled()) {
     return SExpression::createToken("off");
   } else if (tl::optional<Length> offset = obj.getOffset()) {

--- a/libs/librepcb/core/types/pcbcolor.cpp
+++ b/libs/librepcb/core/types/pcbcolor.cpp
@@ -188,12 +188,12 @@ const PcbColor& PcbColor::get(const QString& id) {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const PcbColor& obj) {
+std::unique_ptr<SExpression> serialize(const PcbColor& obj) {
   return SExpression::createToken(obj.getId());
 }
 
 template <>
-SExpression serialize(const PcbColor* const& obj) {
+std::unique_ptr<SExpression> serialize(const PcbColor* const& obj) {
   if (obj) {
     return SExpression::createToken(obj->getId());
   } else {

--- a/libs/librepcb/core/types/ratio.cpp
+++ b/libs/librepcb/core/types/ratio.cpp
@@ -75,17 +75,17 @@ qint32 Ratio::normalizedStringToPpm(const QString& normalized) {
 // Non-Member Functions
 
 template <>
-SExpression serialize(const Ratio& obj) {
+std::unique_ptr<SExpression> serialize(const Ratio& obj) {
   return SExpression::createToken(obj.toNormalizedString());
 }
 
 template <>
-SExpression serialize(const UnsignedRatio& obj) {
+std::unique_ptr<SExpression> serialize(const UnsignedRatio& obj) {
   return serialize(*obj);
 }
 
 template <>
-SExpression serialize(const UnsignedLimitedRatio& obj) {
+std::unique_ptr<SExpression> serialize(const UnsignedLimitedRatio& obj) {
   return serialize(*obj);
 }
 

--- a/libs/librepcb/core/types/signalrole.cpp
+++ b/libs/librepcb/core/types/signalrole.cpp
@@ -75,7 +75,7 @@ const QList<SignalRole>& SignalRole::getAllRoles() noexcept {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const SignalRole& obj) {
+std::unique_ptr<SExpression> serialize(const SignalRole& obj) {
   return SExpression::createToken(obj.toStr());
 }
 

--- a/libs/librepcb/core/types/simplestring.h
+++ b/libs/librepcb/core/types/simplestring.h
@@ -113,7 +113,7 @@ inline static SimpleString cleanSimpleString(
 }
 
 template <>
-inline SExpression serialize(const SimpleString& obj) {
+inline std::unique_ptr<SExpression> serialize(const SimpleString& obj) {
   return SExpression::createString(*obj);
 }
 

--- a/libs/librepcb/core/types/stroketextspacing.cpp
+++ b/libs/librepcb/core/types/stroketextspacing.cpp
@@ -36,7 +36,7 @@ namespace librepcb {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const StrokeTextSpacing& obj) {
+std::unique_ptr<SExpression> serialize(const StrokeTextSpacing& obj) {
   if (const tl::optional<Ratio>& ratio = obj.getRatio()) {
     return serialize(*ratio);
   } else {

--- a/libs/librepcb/core/types/uuid.cpp
+++ b/libs/librepcb/core/types/uuid.cpp
@@ -129,12 +129,12 @@ tl::optional<Uuid> Uuid::tryFromString(const QString& str) noexcept {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const Uuid& obj) {
+std::unique_ptr<SExpression> serialize(const Uuid& obj) {
   return SExpression::createToken(obj.toStr());
 }
 
 template <>
-SExpression serialize(const tl::optional<Uuid>& obj) {
+std::unique_ptr<SExpression> serialize(const tl::optional<Uuid>& obj) {
   if (obj) {
     return serialize(*obj);
   } else {

--- a/libs/librepcb/core/types/version.cpp
+++ b/libs/librepcb/core/types/version.cpp
@@ -128,7 +128,7 @@ tl::optional<Version> Version::tryFromString(const QString& str) noexcept {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const Version& obj) {
+std::unique_ptr<SExpression> serialize(const Version& obj) {
   return SExpression::createString(obj.toStr());
 }
 

--- a/libs/librepcb/core/workspace/theme.cpp
+++ b/libs/librepcb/core/workspace/theme.cpp
@@ -37,7 +37,7 @@ namespace librepcb {
  ******************************************************************************/
 
 template <>
-SExpression serialize(const Theme::GridStyle& obj) {
+std::unique_ptr<SExpression> serialize(const Theme::GridStyle& obj) {
   switch (obj) {
     case Theme::GridStyle::None:
       return SExpression::createToken("none");
@@ -244,7 +244,8 @@ void Theme::setColors(const QList<ThemeColor>& colors) noexcept {
     // Merge modified settings into existing settings.
     foreach (const ThemeColor& color, colors) {
       if (color.isEdited()) {
-        childs[color.getIdentifier()] = color.serialize();
+        std::unique_ptr<const SExpression> sexpr = color.serialize();
+        childs[color.getIdentifier()] = *sexpr;
       }
     }
 
@@ -375,7 +376,8 @@ void Theme::addColor(const QString& id, const QString& category,
 }
 
 SExpression& Theme::addNode(const QString& name) noexcept {
-  mNodes[name] = SExpression::createList(name);
+  std::unique_ptr<const SExpression> sexpr = SExpression::createList(name);
+  mNodes[name] = *sexpr;
   return mNodes[name];
 }
 

--- a/libs/librepcb/core/workspace/themecolor.cpp
+++ b/libs/librepcb/core/workspace/themecolor.cpp
@@ -92,11 +92,11 @@ void ThemeColor::load(const SExpression& root) {
   tryLoadColor(mSecondary, "secondary/@0");
 }
 
-SExpression ThemeColor::serialize() const {
-  SExpression root = SExpression::createList(mIdentifier);
-  root.appendChild("primary", mPrimary);
+std::unique_ptr<SExpression> ThemeColor::serialize() const {
+  std::unique_ptr<SExpression> root = SExpression::createList(mIdentifier);
+  root->appendChild("primary", mPrimary);
   if (mSecondary.isValid()) {
-    root.appendChild("secondary", mSecondary);
+    root->appendChild("secondary", mSecondary);
   }
   return root;
 }

--- a/libs/librepcb/core/workspace/themecolor.h
+++ b/libs/librepcb/core/workspace/themecolor.h
@@ -64,7 +64,7 @@ public:
 
   // General Methods
   void load(const SExpression& root);
-  SExpression serialize() const;
+  std::unique_ptr<SExpression> serialize() const;
 
   // Operator Overloadings
   bool operator==(const ThemeColor& rhs) const noexcept;

--- a/libs/librepcb/core/workspace/workspace.cpp
+++ b/libs/librepcb/core/workspace/workspace.cpp
@@ -106,10 +106,10 @@ Workspace::Workspace(const FilePath& wsPath, const QString& dataDirName,
   const QString settingsFilePath = "settings.lp";
   if (mFileSystem->fileExists(settingsFilePath)) {
     qDebug("Load workspace settings...");
-    SExpression root =
+    const std::unique_ptr<const SExpression> root =
         SExpression::parse(mFileSystem->read(settingsFilePath),
                            mFileSystem->getAbsPath(settingsFilePath));
-    mWorkspaceSettings->load(root, loadedFileFormat);
+    mWorkspaceSettings->load(*root, loadedFileFormat);
     qDebug("Successfully loaded workspace settings.");
   } else {
     qInfo("Workspace settings file not found, default settings will be used.");
@@ -276,9 +276,10 @@ void Workspace::setMostRecentlyUsedWorkspacePath(
  ******************************************************************************/
 
 void Workspace::saveSettingsToTransactionalFileSystem() {
-  mFileSystem->write(
-      "settings.lp",
-      mWorkspaceSettings->serialize().toByteArray());  // can throw
+  const std::unique_ptr<const SExpression> sexpr =
+      mWorkspaceSettings->serialize();  // can throw
+  mFileSystem->write("settings.lp",
+                     sexpr->toByteArray());  // can throw
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -100,24 +100,26 @@ void WorkspaceSettings::restoreDefaults() noexcept {
   mFileContent.clear();  // Remove even unknown settings!
 }
 
-SExpression WorkspaceSettings::serialize() {
+std::unique_ptr<SExpression> WorkspaceSettings::serialize() {
   foreach (const WorkspaceSettingsItem* item, getAllItems()) {
     if (item->isEdited() || mUpgradeRequired) {
       if (item->isDefaultValue()) {
         mFileContent.remove(item->getKey());
       } else {
-        SExpression node = SExpression::createList(item->getKey());
-        item->serialize(node);  // can throw
-        mFileContent.insert(item->getKey(), node);
+        std::unique_ptr<SExpression> node =
+            SExpression::createList(item->getKey());
+        item->serialize(*node);  // can throw
+        mFileContent.insert(item->getKey(), *node);
       }
     }
   }
-  SExpression root = SExpression::createList("librepcb_workspace_settings");
+  std::unique_ptr<SExpression> root =
+      SExpression::createList("librepcb_workspace_settings");
   foreach (const SExpression& child, mFileContent) {
-    root.ensureLineBreak();
-    root.appendChild(child);
+    root->ensureLineBreak();
+    root->appendChild(child);
   }
-  root.ensureLineBreak();
+  root->ensureLineBreak();
   return root;
 }
 

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -84,7 +84,7 @@ public:
    *
    * @return ::librepcb::SExpression node containing all settings.
    */
-  SExpression serialize();
+  std::unique_ptr<SExpression> serialize();
 
   // Operator Overloadings
   WorkspaceSettings& operator=(const WorkspaceSettings& rhs) = delete;

--- a/libs/librepcb/core/workspace/workspacesettingsitem_keyboardshortcuts.cpp
+++ b/libs/librepcb/core/workspace/workspacesettingsitem_keyboardshortcuts.cpp
@@ -65,12 +65,12 @@ void WorkspaceSettingsItem_KeyboardShortcuts::set(
   for (auto it = overrides.begin(); it != overrides.end(); it++) {
     if (!mOverrides.contains(it.key()) ||
         (mOverrides.value(it.key()) != it.value())) {
-      SExpression node = SExpression::createList("shortcut");
-      node.appendChild(SExpression::createToken(it.key()));
+      std::unique_ptr<SExpression> node = SExpression::createList("shortcut");
+      node->appendChild(SExpression::createToken(it.key()));
       foreach (const QKeySequence& sequence, it.value()) {
-        node.appendChild(sequence.toString(QKeySequence::PortableText));
+        node->appendChild(sequence.toString(QKeySequence::PortableText));
       }
-      mNodes.insert(it.key(), node);
+      mNodes.insert(it.key(), *node);
       mOverrides[it.key()] = it.value();
       modified = true;
     }

--- a/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintclipboarddata.cpp
@@ -74,31 +74,32 @@ FootprintClipboardData::~FootprintClipboardData() noexcept {
 
 std::unique_ptr<QMimeData> FootprintClipboardData::toMimeData(
     const IF_GraphicsLayerProvider& lp) {
-  SExpression root = SExpression::createList("librepcb_clipboard_footprint");
-  root.ensureLineBreak();
-  mCursorPos.serialize(root.appendList("cursor_position"));
-  root.ensureLineBreak();
-  root.appendChild("footprint", mFootprintUuid);
-  root.ensureLineBreak();
+  std::unique_ptr<SExpression> root =
+      SExpression::createList("librepcb_clipboard_footprint");
+  root->ensureLineBreak();
+  mCursorPos.serialize(root->appendList("cursor_position"));
+  root->ensureLineBreak();
+  root->appendChild("footprint", mFootprintUuid);
+  root->ensureLineBreak();
   {
-    SExpression& node = root.appendList("package");
+    SExpression& node = root->appendList("package");
     mPackagePads.serialize(node);
   }
-  root.ensureLineBreak();
-  mFootprintPads.serialize(root);
-  root.ensureLineBreak();
-  mPolygons.serialize(root);
-  root.ensureLineBreak();
-  mCircles.serialize(root);
-  root.ensureLineBreak();
-  mStrokeTexts.serialize(root);
-  root.ensureLineBreak();
-  mZones.serialize(root);
-  root.ensureLineBreak();
-  mHoles.serialize(root);
-  root.ensureLineBreak();
+  root->ensureLineBreak();
+  mFootprintPads.serialize(*root);
+  root->ensureLineBreak();
+  mPolygons.serialize(*root);
+  root->ensureLineBreak();
+  mCircles.serialize(*root);
+  root->ensureLineBreak();
+  mStrokeTexts.serialize(*root);
+  root->ensureLineBreak();
+  mZones.serialize(*root);
+  root->ensureLineBreak();
+  mHoles.serialize(*root);
+  root->ensureLineBreak();
 
-  const QByteArray sexpr = root.toByteArray();
+  const QByteArray sexpr = root->toByteArray();
   std::unique_ptr<QMimeData> data(new QMimeData());
   data->setImageData(generatePixmap(lp));
   data->setData(getMimeType(), sexpr);
@@ -113,9 +114,10 @@ std::unique_ptr<FootprintClipboardData> FootprintClipboardData::fromMimeData(
     const QMimeData* mime) {
   QByteArray content = mime ? mime->data(getMimeType()) : QByteArray();
   if (!content.isNull()) {
-    SExpression root = SExpression::parse(content, FilePath());
+    const std::unique_ptr<const SExpression> root =
+        SExpression::parse(content, FilePath());
     return std::unique_ptr<FootprintClipboardData>(
-        new FootprintClipboardData(root));  // can throw
+        new FootprintClipboardData(*root));  // can throw
   } else {
     return nullptr;
   }

--- a/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
+++ b/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
@@ -66,22 +66,23 @@ SymbolClipboardData::~SymbolClipboardData() noexcept {
 
 std::unique_ptr<QMimeData> SymbolClipboardData::toMimeData(
     const IF_GraphicsLayerProvider& lp) {
-  SExpression root = SExpression::createList("librepcb_clipboard_symbol");
-  root.ensureLineBreak();
-  mCursorPos.serialize(root.appendList("cursor_position"));
-  root.ensureLineBreak();
-  root.appendChild("symbol", mSymbolUuid);
-  root.ensureLineBreak();
-  mPins.serialize(root);
-  root.ensureLineBreak();
-  mPolygons.serialize(root);
-  root.ensureLineBreak();
-  mCircles.serialize(root);
-  root.ensureLineBreak();
-  mTexts.serialize(root);
-  root.ensureLineBreak();
+  std::unique_ptr<SExpression> root =
+      SExpression::createList("librepcb_clipboard_symbol");
+  root->ensureLineBreak();
+  mCursorPos.serialize(root->appendList("cursor_position"));
+  root->ensureLineBreak();
+  root->appendChild("symbol", mSymbolUuid);
+  root->ensureLineBreak();
+  mPins.serialize(*root);
+  root->ensureLineBreak();
+  mPolygons.serialize(*root);
+  root->ensureLineBreak();
+  mCircles.serialize(*root);
+  root->ensureLineBreak();
+  mTexts.serialize(*root);
+  root->ensureLineBreak();
 
-  const QByteArray sexpr = root.toByteArray();
+  const QByteArray sexpr = root->toByteArray();
   std::unique_ptr<QMimeData> data(new QMimeData());
   data->setImageData(generatePixmap(lp));
   data->setData(getMimeType(), sexpr);
@@ -96,9 +97,10 @@ std::unique_ptr<SymbolClipboardData> SymbolClipboardData::fromMimeData(
     const QMimeData* mime) {
   QByteArray content = mime ? mime->data(getMimeType()) : QByteArray();
   if (!content.isNull()) {
-    SExpression root = SExpression::parse(content, FilePath());
+    const std::unique_ptr<const SExpression> root =
+        SExpression::parse(content, FilePath());
     return std::unique_ptr<SymbolClipboardData>(
-        new SymbolClipboardData(root));  // can throw
+        new SymbolClipboardData(*root));  // can throw
   } else {
     return nullptr;
   }

--- a/libs/librepcb/editor/project/partinformationprovider.cpp
+++ b/libs/librepcb/editor/project/partinformationprovider.cpp
@@ -507,9 +507,9 @@ void PartInformationProvider::loadCacheFromDisk() noexcept {
   if (!mCacheFp.isExistingFile()) return;
 
   try {
-    const SExpression root =
+    const std::unique_ptr<const SExpression> root =
         SExpression::parse(FileUtils::readFile(mCacheFp), mCacheFp);
-    foreach (const SExpression* node, root.getChildren("part")) {
+    foreach (const SExpression* node, root->getChildren("part")) {
       std::shared_ptr<PartInformation> info =
           std::make_shared<PartInformation>();
       info->load(*node);
@@ -533,13 +533,14 @@ void PartInformationProvider::saveCacheToDisk() noexcept {
   if (!mCacheModified) return;
 
   try {
-    SExpression root = SExpression::createList("librepcb_parts_cache");
-    root.ensureLineBreak();
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_parts_cache");
+    root->ensureLineBreak();
     for (auto it = mCache.begin(); it != mCache.end(); it++) {
-      it.value()->serialize(root.appendList("part"));
-      root.ensureLineBreak();
+      it.value()->serialize(root->appendList("part"));
+      root->ensureLineBreak();
     }
-    FileUtils::writeFile(mCacheFp, root.toByteArray());
+    FileUtils::writeFile(mCacheFp, root->toByteArray());
     qInfo().nospace() << "Saved parts information cache to "
                       << mCacheFp.toNative() << ".";
     mCacheModified = false;

--- a/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicclipboarddata.cpp
@@ -58,16 +58,16 @@ SchematicClipboardData::SchematicClipboardData(const QByteArray& mimeData)
   : SchematicClipboardData(Uuid::createRandom(), Point(), {}) {
   mFileSystem->loadFromZip(mimeData);  // can throw
 
-  SExpression root =
+  const std::unique_ptr<const SExpression> root =
       SExpression::parse(mFileSystem->read("schematic.lp"), FilePath());
-  mSchematicUuid = deserialize<Uuid>(root.getChild("schematic/@0"));
-  mCursorPos = Point(root.getChild("cursor_position"));
-  mAssemblyVariants.loadFromSExpression(root);
-  mComponentInstances.loadFromSExpression(root);
-  mSymbolInstances.loadFromSExpression(root);
-  mNetSegments.loadFromSExpression(root);
-  mPolygons.loadFromSExpression(root);
-  mTexts.loadFromSExpression(root);
+  mSchematicUuid = deserialize<Uuid>(root->getChild("schematic/@0"));
+  mCursorPos = Point(root->getChild("cursor_position"));
+  mAssemblyVariants.loadFromSExpression(*root);
+  mComponentInstances.loadFromSExpression(*root);
+  mSymbolInstances.loadFromSExpression(*root);
+  mNetSegments.loadFromSExpression(*root);
+  mPolygons.loadFromSExpression(*root);
+  mTexts.loadFromSExpression(*root);
 }
 
 SchematicClipboardData::~SchematicClipboardData() noexcept {
@@ -93,26 +93,27 @@ std::unique_ptr<TransactionalDirectory> SchematicClipboardData::getDirectory(
  ******************************************************************************/
 
 std::unique_ptr<QMimeData> SchematicClipboardData::toMimeData() const {
-  SExpression root = SExpression::createList("librepcb_clipboard_schematic");
-  root.ensureLineBreak();
-  mCursorPos.serialize(root.appendList("cursor_position"));
-  root.ensureLineBreak();
-  root.appendChild("schematic", mSchematicUuid);
-  root.ensureLineBreak();
-  mAssemblyVariants.serialize(root);
-  root.ensureLineBreak();
-  mComponentInstances.serialize(root);
-  root.ensureLineBreak();
-  mSymbolInstances.serialize(root);
-  root.ensureLineBreak();
-  mNetSegments.serialize(root);
-  root.ensureLineBreak();
-  mPolygons.serialize(root);
-  root.ensureLineBreak();
-  mTexts.serialize(root);
-  root.ensureLineBreak();
+  std::unique_ptr<SExpression> root =
+      SExpression::createList("librepcb_clipboard_schematic");
+  root->ensureLineBreak();
+  mCursorPos.serialize(root->appendList("cursor_position"));
+  root->ensureLineBreak();
+  root->appendChild("schematic", mSchematicUuid);
+  root->ensureLineBreak();
+  mAssemblyVariants.serialize(*root);
+  root->ensureLineBreak();
+  mComponentInstances.serialize(*root);
+  root->ensureLineBreak();
+  mSymbolInstances.serialize(*root);
+  root->ensureLineBreak();
+  mNetSegments.serialize(*root);
+  root->ensureLineBreak();
+  mPolygons.serialize(*root);
+  root->ensureLineBreak();
+  mTexts.serialize(*root);
+  root->ensureLineBreak();
 
-  const QByteArray sexpr = root.toByteArray();
+  const QByteArray sexpr = root->toByteArray();
   mFileSystem->write("schematic.lp", sexpr);
   const QByteArray zip = mFileSystem->exportToZip();
 

--- a/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/favoriteprojectsmodel.cpp
@@ -46,9 +46,9 @@ FavoriteProjectsModel::FavoriteProjectsModel(
   try {
     mFilePath = mWorkspace.getDataPath().getPathTo("favorite_projects.lp");
     if (mFilePath.isExistingFile()) {
-      const SExpression root =
+      const std::unique_ptr<const SExpression> root =
           SExpression::parse(FileUtils::readFile(mFilePath), mFilePath);
-      foreach (const SExpression* child, root.getChildren("project")) {
+      foreach (const SExpression* child, root->getChildren("project")) {
         QString path = child->getChild("@0").getValue();
         FilePath absPath = FilePath::fromRelative(mWorkspace.getPath(), path);
         mAllProjects.append(absPath);
@@ -108,13 +108,14 @@ void FavoriteProjectsModel::updateVisibleProjects() noexcept {
 void FavoriteProjectsModel::save() noexcept {
   try {
     // save the new list in the workspace
-    SExpression root = SExpression::createList("librepcb_favorite_projects");
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_favorite_projects");
     foreach (const FilePath& filepath, mAllProjects) {
-      root.ensureLineBreak();
-      root.appendChild("project", filepath.toRelative(mWorkspace.getPath()));
+      root->ensureLineBreak();
+      root->appendChild("project", filepath.toRelative(mWorkspace.getPath()));
     }
-    root.ensureLineBreak();
-    FileUtils::writeFile(mFilePath, root.toByteArray());  // can throw
+    root->ensureLineBreak();
+    FileUtils::writeFile(mFilePath, root->toByteArray());  // can throw
   } catch (const Exception& e) {
     qWarning() << "Failed to save favorite projects file:" << e.getMsg();
   }

--- a/libs/librepcb/editor/workspace/controlpanel/recentprojectsmodel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/recentprojectsmodel.cpp
@@ -45,9 +45,9 @@ RecentProjectsModel::RecentProjectsModel(const Workspace& workspace) noexcept
   try {
     mFilePath = mWorkspace.getDataPath().getPathTo("recent_projects.lp");
     if (mFilePath.isExistingFile()) {
-      const SExpression root =
+      const std::unique_ptr<const SExpression> root =
           SExpression::parse(FileUtils::readFile(mFilePath), mFilePath);
-      foreach (const SExpression* child, root.getChildren("project")) {
+      foreach (const SExpression* child, root->getChildren("project")) {
         QString path = child->getChild("@0").getValue();
         FilePath absPath = FilePath::fromRelative(mWorkspace.getPath(), path);
         mAllProjects.append(absPath);
@@ -100,13 +100,14 @@ void RecentProjectsModel::updateVisibleProjects() noexcept {
 void RecentProjectsModel::save() noexcept {
   try {
     // save the new list in the workspace
-    SExpression root = SExpression::createList("librepcb_recent_projects");
+    std::unique_ptr<SExpression> root =
+        SExpression::createList("librepcb_recent_projects");
     foreach (const FilePath& filepath, mAllProjects) {
-      root.ensureLineBreak();
-      root.appendChild("project", filepath.toRelative(mWorkspace.getPath()));
+      root->ensureLineBreak();
+      root->appendChild("project", filepath.toRelative(mWorkspace.getPath()));
     }
-    root.ensureLineBreak();
-    FileUtils::writeFile(mFilePath, root.toByteArray());  // can throw
+    root->ensureLineBreak();
+    FileUtils::writeFile(mFilePath, root->toByteArray());  // can throw
   } catch (const Exception& e) {
     qWarning() << "Failed to save recent projects file:" << e.getMsg();
   }

--- a/tests/unittests/core/attribute/attributekeytest.cpp
+++ b/tests/unittests/core/attribute/attributekeytest.cpp
@@ -78,20 +78,19 @@ TEST_P(AttributeKeyTest, testSerialize) {
 
   if (data.valid) {
     AttributeKey obj(data.input);
-    EXPECT_EQ("\"" % data.input % "\"\n", serialize(obj).toByteArray());
+    EXPECT_EQ("\"" % data.input % "\"\n", serialize(obj)->toByteArray());
   }
 }
 
 TEST_P(AttributeKeyTest, testDeserialize) {
   const AttributeKeyTestData& data = GetParam();
 
+  std::unique_ptr<const SExpression> sexpr =
+      SExpression::createString(data.input);
   if (data.valid) {
-    EXPECT_EQ(AttributeKey(data.input),
-              deserialize<AttributeKey>(SExpression::createString(data.input)));
+    EXPECT_EQ(AttributeKey(data.input), deserialize<AttributeKey>(*sexpr));
   } else {
-    EXPECT_THROW(
-        deserialize<AttributeKey>(SExpression::createString(data.input)),
-        RuntimeError);
+    EXPECT_THROW(deserialize<AttributeKey>(*sexpr), RuntimeError);
   }
 }
 

--- a/tests/unittests/core/attribute/attributetest.cpp
+++ b/tests/unittests/core/attribute/attributetest.cpp
@@ -60,12 +60,13 @@ TEST_P(AttributeTest, testConstructFromSExpression) {
   const AttributeType& type = AttributeType::fromString(data.type);
   Attribute attribute(AttributeKey(data.key), type, data.value,
                       type.getUnitFromString(data.unit));
-  SExpression sexpr = SExpression::parse(data.serialized, FilePath());
+  std::unique_ptr<SExpression> sexpr =
+      SExpression::parse(data.serialized, FilePath());
 
   if (data.validSExpression) {
-    EXPECT_EQ(attribute, Attribute(sexpr));
+    EXPECT_EQ(attribute, Attribute(*sexpr));
   } else {
-    EXPECT_THROW({ Attribute a(sexpr); }, Exception);
+    EXPECT_THROW({ Attribute a(*sexpr); }, Exception);
   }
 }
 
@@ -77,9 +78,9 @@ TEST_P(AttributeTest, testSerialize) {
                       type.getUnitFromString(data.unit));
 
   if (data.validSExpression) {
-    SExpression sexpr = SExpression::createList("attribute");
-    attribute.serialize(sexpr);
-    EXPECT_EQ(data.serialized, sexpr.toByteArray());
+    std::unique_ptr<SExpression> sexpr = SExpression::createList("attribute");
+    attribute.serialize(*sexpr);
+    EXPECT_EQ(data.serialized, sexpr->toByteArray());
   }
 }
 

--- a/tests/unittests/core/attribute/attributetypetest.cpp
+++ b/tests/unittests/core/attribute/attributetypetest.cpp
@@ -42,7 +42,7 @@ class AttributeTypeTest : public ::testing::Test {};
 
 TEST_F(AttributeTypeTest, testSerialize) {
   const AttributeType& type = AttrTypeVoltage::instance();
-  EXPECT_EQ("voltage\n", serialize(type).toByteArray());
+  EXPECT_EQ("voltage\n", serialize(type)->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/attribute/attributeunittest.cpp
+++ b/tests/unittests/core/attribute/attributeunittest.cpp
@@ -42,7 +42,7 @@ class AttributeUnitTest : public ::testing::Test {};
 
 TEST_F(AttributeUnitTest, testSerialize) {
   AttributeUnit unit("volt", "V", {});
-  EXPECT_EQ("volt\n", serialize(unit).toByteArray());
+  EXPECT_EQ("volt\n", serialize(unit)->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/geometry/holetest.cpp
+++ b/tests/unittests/core/geometry/holetest.cpp
@@ -41,13 +41,13 @@ class HoleTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(HoleTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(hole b9445237-8982-4a9f-af06-bfc6c507e010"
       " (diameter 0.5) (stop_mask auto)"
       " (vertex (position 1.234 2.345) (angle 45.0))"
       ")",
       FilePath());
-  Hole obj(sexpr);
+  Hole obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("b9445237-8982-4a9f-af06-bfc6c507e010"),
             obj.getUuid());
   EXPECT_EQ(PositiveLength(500000), obj.getDiameter());
@@ -63,14 +63,14 @@ TEST_F(HoleTest, testSerializeAndDeserialize) {
             NonEmptyPath(Path({Vertex(Point(123, 456), Angle::deg45()),
                                Vertex(Point(789, 321), Angle::deg0())})),
             MaskConfig::manual(Length(123456)));
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  Hole obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  Hole obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -37,9 +37,9 @@ namespace tests {
 class PathTest : public ::testing::Test {
 protected:
   std::string str(const Path& path) const {
-    SExpression sexpr = SExpression::createList("path");
-    path.serialize(sexpr);
-    return sexpr.toByteArray().toStdString();
+    std::unique_ptr<SExpression> sexpr = SExpression::createList("path");
+    path.serialize(*sexpr);
+    return sexpr->toByteArray().toStdString();
   }
 };
 

--- a/tests/unittests/core/geometry/polygontest.cpp
+++ b/tests/unittests/core/geometry/polygontest.cpp
@@ -42,7 +42,7 @@ class PolygonTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(PolygonTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(polygon 2889d60c-1d18-44c3-bf9e-07733b67e480 (layer bot_stop_mask)\n"
       " (width 0.1) (fill true) (grab_area false)\n"
       " (vertex (position 0.0 0.0) (angle 0.0))\n"
@@ -52,7 +52,7 @@ TEST_F(PolygonTest, testConstructFromSExpression) {
       " (vertex (position 0.0 0.0) (angle 0.0))\n"
       ")\n",
       FilePath());
-  Polygon obj(sexpr);
+  Polygon obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("2889d60c-1d18-44c3-bf9e-07733b67e480"),
             obj.getUuid());
   EXPECT_EQ("bot_stop_mask", obj.getLayer().getId());
@@ -67,14 +67,14 @@ TEST_F(PolygonTest, testSerializeAndDeserialize) {
       Uuid::createRandom(), Layer::botCopper(), UnsignedLength(456), true,
       false,
       Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}));
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  Polygon obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  Polygon obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/geometry/stroketexttest.cpp
+++ b/tests/unittests/core/geometry/stroketexttest.cpp
@@ -42,14 +42,14 @@ class StrokeTextTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(StrokeTextTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(stroke_text 0a8d7180-68e1-4749-bf8c-538b0d88f08c "
       "(layer bot_names) (height 1.0) (stroke_width 0.2) "
       "(letter_spacing auto) (line_spacing auto) (align left bottom) "
       "(position 1.234 2.345) (rotation 45.0) (auto_rotate true) "
       "(mirror true) (value \"Foo Bar\"))",
       FilePath());
-  StrokeText obj(sexpr);
+  StrokeText obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("0a8d7180-68e1-4749-bf8c-538b0d88f08c"),
             obj.getUuid());
   EXPECT_EQ("bot_names", obj.getLayer().getId());
@@ -71,14 +71,14 @@ TEST_F(StrokeTextTest, testSerializeAndDeserialize) {
                   UnsignedLength(456), StrokeTextSpacing(),
                   StrokeTextSpacing(Ratio(1234)),
                   Alignment(HAlign::right(), VAlign::center()), true, false);
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  StrokeText obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  StrokeText obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/geometry/texttest.cpp
+++ b/tests/unittests/core/geometry/texttest.cpp
@@ -42,12 +42,12 @@ class TextTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(TextTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(text eabf43fb-496b-4dc8-8ff7-ffac67991390 (layer sym_names) "
       "(value \"{{NAME}}\") (align center bottom) (height 2.54) "
       "(position 1.234 2.345) (rotation 45.0))",
       FilePath());
-  Text obj(sexpr);
+  Text obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("eabf43fb-496b-4dc8-8ff7-ffac67991390"),
             obj.getUuid());
   EXPECT_EQ("sym_names", obj.getLayer().getId());
@@ -62,14 +62,14 @@ TEST_F(TextTest, testSerializeAndDeserialize) {
   Text obj1(Uuid::createRandom(), Layer::botCopper(), "foo bar", Point(12, 34),
             Angle(56), PositiveLength(78),
             Alignment(HAlign::right(), VAlign::center()));
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  Text obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  Text obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/geometry/tracetest.cpp
+++ b/tests/unittests/core/geometry/tracetest.cpp
@@ -42,13 +42,13 @@ class TraceTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(TraceTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(trace c893f5a0-3fec-498b-99d6-467d5d69825d (layer bot_cu) (width 0.5) "
       "(from (device 0d8f2ef9-34f4-4400-a313-f17cdcdfe924) "
       "(pad 65ab6c75-b264-4fed-b445-d3d98c956008)) "
       "(to (via 1e80206f-158b-48e6-9cb4-6e368af7b7d7)))",
       FilePath());
-  Trace obj(sexpr);
+  Trace obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("c893f5a0-3fec-498b-99d6-467d5d69825d"),
             obj.getUuid());
   EXPECT_EQ("bot_cu", obj.getLayer().getId());
@@ -66,14 +66,14 @@ TEST_F(TraceTest, testSerializeAndDeserialize) {
   Trace obj1(Uuid::createRandom(), Layer::topCopper(), PositiveLength(123),
              TraceAnchor::junction(Uuid::createRandom()),
              TraceAnchor::pad(Uuid::createRandom(), Uuid::createRandom()));
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  Trace obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  Trace obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/geometry/vertextest.cpp
+++ b/tests/unittests/core/geometry/vertextest.cpp
@@ -41,23 +41,23 @@ class VertexTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(VertexTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(vertex (position 1.2 3.4) (angle 45.0))", FilePath());
-  Vertex obj(sexpr);
+  Vertex obj(*sexpr);
   EXPECT_EQ(Point(1200000, 3400000), obj.getPos());
   EXPECT_EQ(Angle::deg45(), obj.getAngle());
 }
 
 TEST_F(VertexTest, testSerializeAndDeserialize) {
   Vertex obj1(Point(123, 567), Angle(789));
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  Vertex obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  Vertex obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/geometry/viatest.cpp
+++ b/tests/unittests/core/geometry/viatest.cpp
@@ -42,12 +42,12 @@ class ViaTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(ViaTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(via b9445237-8982-4a9f-af06-bfc6c507e010 (from top_cu) (to in2_cu)"
       " (position 1.234 2.345) (size 0.9) (drill 0.4) (exposure off)"
       ")",
       FilePath());
-  Via obj(sexpr);
+  Via obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("b9445237-8982-4a9f-af06-bfc6c507e010"),
             obj.getUuid());
   EXPECT_EQ(&Layer::topCopper(), &obj.getStartLayer());
@@ -62,14 +62,14 @@ TEST_F(ViaTest, testSerializeAndDeserialize) {
   Via obj1(Uuid::createRandom(), Layer::topCopper(), Layer::botCopper(),
            Point(123, 456), PositiveLength(789), PositiveLength(321),
            MaskConfig::off());
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  Via obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  Via obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/import/dxfreadertest.cpp
+++ b/tests/unittests/core/import/dxfreadertest.cpp
@@ -54,19 +54,19 @@ protected:
    */
   template <typename T>
   static std::string str(const T& obj) {
-    SExpression node = SExpression::createList("object");
-    obj.serialize(node);
-    return node.toByteArray().toStdString();
+    std::unique_ptr<SExpression> node = SExpression::createList("object");
+    obj.serialize(*node);
+    return node->toByteArray().toStdString();
   }
 
   /**
    * @brief Helper to easily compare objects as strings for easier debugging
    */
   static std::string str(const DxfReader::Circle& circle) {
-    SExpression s = SExpression::createList("object");
-    circle.position.serialize(s.appendList("position"));
-    s.appendChild("diameter", circle.diameter);
-    return s.toByteArray().toStdString();
+    std::unique_ptr<SExpression> s = SExpression::createList("object");
+    circle.position.serialize(s->appendList("position"));
+    s->appendChild("diameter", circle.diameter);
+    return s->toByteArray().toStdString();
   }
 };
 

--- a/tests/unittests/core/library/pkg/footprintpadtest.cpp
+++ b/tests/unittests/core/library/pkg/footprintpadtest.cpp
@@ -43,7 +43,7 @@ class FootprintPadTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side top) (shape roundrect)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
       " (stop_mask auto) (solder_paste 0.25) (clearance 0.33)"
@@ -51,7 +51,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
       " (package_pad d48b8bd2-a46c-4495-87a5-662747034098)\n"
       ")",
       FilePath());
-  FootprintPad obj(sexpr);
+  FootprintPad obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("7040952d-7016-49cd-8c3e-6078ecca98b9"),
             obj.getUuid());
   EXPECT_EQ(Uuid::fromString("d48b8bd2-a46c-4495-87a5-662747034098"),
@@ -71,7 +71,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionConnected) {
 }
 
 TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(pad 7040952d-7016-49cd-8c3e-6078ecca98b9 (side bottom) (shape custom)\n"
       " (position 1.234 2.345) (rotation 45.0) (size 1.1 2.2) (radius 0.5)\n"
       " (stop_mask off) (solder_paste auto) (clearance 0.33)"
@@ -88,7 +88,7 @@ TEST_F(FootprintPadTest, testConstructFromSExpressionUnconnected) {
       " )\n"
       ")",
       FilePath());
-  FootprintPad obj(sexpr);
+  FootprintPad obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("7040952d-7016-49cd-8c3e-6078ecca98b9"),
             obj.getUuid());
   EXPECT_EQ(tl::nullopt, obj.getPackagePadUuid());
@@ -124,14 +124,14 @@ TEST_F(FootprintPadTest, testSerializeAndDeserialize) {
                                     PositiveLength(200000),
                                     makeNonEmptyPath(Point(300, 400))),
       });
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  FootprintPad obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  FootprintPad obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/library/sym/symbolpintest.cpp
+++ b/tests/unittests/core/library/sym/symbolpintest.cpp
@@ -43,14 +43,14 @@ class SymbolPinTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(SymbolPinTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(pin d48b8bd2-a46c-4495-87a5-662747034098 (name \"1\")\n"
       " (position 1.234 2.345) (rotation 45.0) (length 0.5)\n"
       " (name_position 0.1 0.2) (name_rotation -90.0) (name_height 1.234)\n"
       " (name_align center bottom)\n"
       ")",
       FilePath());
-  SymbolPin obj(sexpr);
+  SymbolPin obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("d48b8bd2-a46c-4495-87a5-662747034098"),
             obj.getUuid());
   EXPECT_EQ("1", obj.getName()->toStdString());
@@ -69,14 +69,14 @@ TEST_F(SymbolPinTest, testSerializeAndDeserialize) {
                  Point(123, 567), UnsignedLength(321), Angle(789),
                  Point(100000, 200000), Angle(321), PositiveLength(123456),
                  Alignment(HAlign::center(), VAlign::bottom()));
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  SymbolPin obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  SymbolPin obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/project/board/boarddesignrulestest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulestest.cpp
@@ -41,7 +41,7 @@ class BoardDesignRulesTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
-  SExpression sexpr = SExpression::parse(
+  std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(design_rules\n"
       " (stopmask_max_via_drill_diameter 0.2)\n"
       " (stopmask_clearance (ratio 0.1) (min 1.1) (max 2.1))\n"
@@ -51,7 +51,7 @@ TEST_F(BoardDesignRulesTest, testConstructFromSExpression) {
       " (via_annular_ring (ratio 0.5) (min 1.5) (max 2.5))\n"
       ")",
       FilePath());
-  BoardDesignRules obj(sexpr);
+  BoardDesignRules obj(*sexpr);
   EXPECT_EQ(UnsignedLength(200000), obj.getStopMaskMaxViaDiameter());
   EXPECT_EQ(UnsignedRatio(Ratio(100000)),
             obj.getStopMaskClearance().getRatio());
@@ -86,14 +86,14 @@ TEST_F(BoardDesignRulesTest, testSerializeAndDeserialize) {
       UnsignedRatio(Ratio(88)), UnsignedLength(99), UnsignedLength(111)));
   obj1.setViaAnnularRing(BoundedUnsignedRatio(
       UnsignedRatio(Ratio(222)), UnsignedLength(333), UnsignedLength(444)));
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  BoardDesignRules obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  BoardDesignRules obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/project/board/boardfabricationoutputsettingstest.cpp
+++ b/tests/unittests/core/project/board/boardfabricationoutputsettingstest.cpp
@@ -62,14 +62,14 @@ TEST_F(BoardFabricationOutputSettingsTest, testSerializeAndDeserialize) {
   obj1.setUseG85SlotCommand(!obj1.getUseG85SlotCommand());
   obj1.setEnableSolderPasteTop(!obj1.getEnableSolderPasteTop());
   obj1.setEnableSolderPasteBot(!obj1.getEnableSolderPasteBot());
-  SExpression sexpr1 = SExpression::createList("obj");
-  obj1.serialize(sexpr1);
+  std::unique_ptr<SExpression> sexpr1 = SExpression::createList("obj");
+  obj1.serialize(*sexpr1);
 
-  BoardFabricationOutputSettings obj2(sexpr1);
-  SExpression sexpr2 = SExpression::createList("obj");
-  obj2.serialize(sexpr2);
+  BoardFabricationOutputSettings obj2(*sexpr1);
+  std::unique_ptr<SExpression> sexpr2 = SExpression::createList("obj");
+  obj2.serialize(*sexpr2);
 
-  EXPECT_EQ(sexpr1.toByteArray(), sexpr2.toByteArray());
+  EXPECT_EQ(sexpr1->toByteArray(), sexpr2->toByteArray());
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
+++ b/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
@@ -84,20 +84,20 @@ TEST(BoardPlaneFragmentsBuilderTest, testFragments) {
   }
 
   // write actual plane fragments into file (useful for debugging purposes)
-  SExpression actualSexpr = SExpression::createList("actual");
+  std::unique_ptr<SExpression> actualSexpr = SExpression::createList("actual");
   foreach (const Uuid& uuid, actualPlaneFragments.keys()) {
-    SExpression child = SExpression::createList("plane");
-    child.appendChild(uuid);
+    std::unique_ptr<SExpression> child = SExpression::createList("plane");
+    child->appendChild(uuid);
     foreach (const Path& fragment, actualPlaneFragments[uuid]) {
-      child.ensureLineBreak();
-      fragment.serialize(child.appendList("fragment"));
+      child->ensureLineBreak();
+      fragment.serialize(child->appendList("fragment"));
     }
-    child.ensureLineBreak();
-    actualSexpr.ensureLineBreak();
-    actualSexpr.appendChild(child);
+    child->ensureLineBreak();
+    actualSexpr->ensureLineBreak();
+    actualSexpr->appendChild(std::move(child));
   }
-  actualSexpr.ensureLineBreak();
-  QByteArray actual = actualSexpr.toByteArray();
+  actualSexpr->ensureLineBreak();
+  QByteArray actual = actualSexpr->toByteArray();
   FileUtils::writeFile(testDataDir.getPathTo("actual.lp"), actual);
 
   // compare with expected plane fragments loaded from file

--- a/tests/unittests/core/types/alignmenttest.cpp
+++ b/tests/unittests/core/types/alignmenttest.cpp
@@ -56,12 +56,13 @@ class AlignmentTest : public ::testing::TestWithParam<AlignmentTestData> {};
 TEST_P(AlignmentTest, testConstructFromSExpression) {
   const AlignmentTestData& data = GetParam();
 
-  SExpression sexpr = SExpression::parse(data.serialized, FilePath());
+  std::unique_ptr<SExpression> sexpr =
+      SExpression::parse(data.serialized, FilePath());
 
   if (data.validSExpression) {
-    EXPECT_EQ(Alignment(data.hAlign, data.vAlign), Alignment(sexpr));
+    EXPECT_EQ(Alignment(data.hAlign, data.vAlign), Alignment(*sexpr));
   } else {
-    EXPECT_THROW({ Alignment a(sexpr); }, RuntimeError);
+    EXPECT_THROW({ Alignment a(*sexpr); }, RuntimeError);
   }
 }
 
@@ -70,9 +71,9 @@ TEST_P(AlignmentTest, testSerialize) {
 
   if (data.validSExpression) {
     Alignment alignment(data.hAlign, data.vAlign);
-    SExpression sexpr = SExpression::createList("align");
-    alignment.serialize(sexpr);
-    EXPECT_EQ(data.serialized, sexpr.toByteArray());
+    std::unique_ptr<SExpression> sexpr = SExpression::createList("align");
+    alignment.serialize(*sexpr);
+    EXPECT_EQ(data.serialized, sexpr->toByteArray());
   }
 }
 

--- a/tests/unittests/core/types/angletest.cpp
+++ b/tests/unittests/core/types/angletest.cpp
@@ -96,18 +96,18 @@ TEST_P(AngleTest, testSerialize) {
   const AngleTestData& data = GetParam();
 
   if (data.valid) {
-    EXPECT_EQ(data.genStr % "\n", serialize(data.value).toByteArray());
+    EXPECT_EQ(data.genStr % "\n", serialize(data.value)->toByteArray());
   }
 }
 
 TEST_P(AngleTest, testDeserialize) {
   const AngleTestData& data = GetParam();
 
-  SExpression sexpr = SExpression::createString(data.origStr);
+  std::unique_ptr<SExpression> sexpr = SExpression::createString(data.origStr);
   if (data.valid) {
-    EXPECT_EQ(data.value, deserialize<Angle>(sexpr));
+    EXPECT_EQ(data.value, deserialize<Angle>(*sexpr));
   } else {
-    EXPECT_THROW(deserialize<Angle>(sexpr), RuntimeError);
+    EXPECT_THROW(deserialize<Angle>(*sexpr), RuntimeError);
   }
 }
 

--- a/tests/unittests/core/types/circuitidentifiertest.cpp
+++ b/tests/unittests/core/types/circuitidentifiertest.cpp
@@ -77,24 +77,25 @@ TEST_P(CircuitIdentifierTest, testSerialize) {
   const CircuitIdentifierTestData& data = GetParam();
   if (data.valid) {
     CircuitIdentifier identifier(data.input);
-    EXPECT_EQ(data.input, serialize(identifier).getValue());
-    EXPECT_EQ(data.input, serialize(tl::make_optional(identifier)).getValue());
+    EXPECT_EQ(data.input, serialize(identifier)->getValue());
+    EXPECT_EQ(data.input, serialize(tl::make_optional(identifier))->getValue());
   }
 }
 
 TEST_P(CircuitIdentifierTest, testDeserialize) {
   const CircuitIdentifierTestData& data = GetParam();
-  SExpression sexpr = SExpression::createToken(data.input);
+  std::unique_ptr<SExpression> sexpr = SExpression::createToken(data.input);
   if (data.valid) {
-    EXPECT_EQ(data.input, *deserialize<CircuitIdentifier>(sexpr));
-    EXPECT_EQ(data.input, *deserialize<tl::optional<CircuitIdentifier>>(sexpr));
+    EXPECT_EQ(data.input, *deserialize<CircuitIdentifier>(*sexpr));
+    EXPECT_EQ(data.input,
+              *deserialize<tl::optional<CircuitIdentifier>>(*sexpr));
   } else {
-    EXPECT_THROW(deserialize<CircuitIdentifier>(sexpr), Exception);
+    EXPECT_THROW(deserialize<CircuitIdentifier>(*sexpr), Exception);
     if (data.input.isEmpty()) {
       EXPECT_EQ(tl::nullopt,
-                deserialize<tl::optional<CircuitIdentifier>>(sexpr));
+                deserialize<tl::optional<CircuitIdentifier>>(*sexpr));
     } else {
-      EXPECT_THROW(deserialize<tl::optional<CircuitIdentifier>>(sexpr),
+      EXPECT_THROW(deserialize<tl::optional<CircuitIdentifier>>(*sexpr),
                    Exception);
     }
   }
@@ -102,12 +103,12 @@ TEST_P(CircuitIdentifierTest, testDeserialize) {
 
 TEST(CircuitIdentifierTest, testSerializeOptional) {
   tl::optional<CircuitIdentifier> identifier = tl::nullopt;
-  EXPECT_EQ("", serialize(identifier).getValue());
+  EXPECT_EQ("", serialize(identifier)->getValue());
 }
 
 TEST(CircuitIdentifierTest, testDeserializeOptional) {
-  SExpression sexpr = SExpression::createToken("");
-  EXPECT_EQ(tl::nullopt, deserialize<tl::optional<CircuitIdentifier>>(sexpr));
+  std::unique_ptr<SExpression> sexpr = SExpression::createToken("");
+  EXPECT_EQ(tl::nullopt, deserialize<tl::optional<CircuitIdentifier>>(*sexpr));
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/types/fileproofnametest.cpp
+++ b/tests/unittests/core/types/fileproofnametest.cpp
@@ -72,21 +72,19 @@ TEST_P(FileProofNameTest, testSerialize) {
 
   if (data.valid) {
     FileProofName obj(data.input);
-    EXPECT_EQ("\"" % data.input % "\"\n", serialize(obj).toByteArray());
+    EXPECT_EQ("\"" % data.input % "\"\n", serialize(obj)->toByteArray());
   }
 }
 
 TEST_P(FileProofNameTest, testDeserialize) {
   const FileProofNameTestData& data = GetParam();
 
+  const std::unique_ptr<const SExpression> sexpr =
+      SExpression::createString(data.input);
   if (data.valid) {
-    EXPECT_EQ(
-        FileProofName(data.input),
-        deserialize<FileProofName>(SExpression::createString(data.input)));
+    EXPECT_EQ(FileProofName(data.input), deserialize<FileProofName>(*sexpr));
   } else {
-    EXPECT_THROW(
-        deserialize<FileProofName>(SExpression::createString(data.input)),
-        RuntimeError);
+    EXPECT_THROW(deserialize<FileProofName>(*sexpr), RuntimeError);
   }
 }
 

--- a/tests/unittests/core/types/ratiotest.cpp
+++ b/tests/unittests/core/types/ratiotest.cpp
@@ -200,24 +200,24 @@ TEST(RatioTest, testOperatorBool) {
 TEST_P(RatioTest, testSerialize) {
   const RatioTestData_t& data = GetParam();
 
-  EXPECT_EQ(data.string % "\n", serialize(data.ratio).toByteArray());
+  EXPECT_EQ(data.string % "\n", serialize(data.ratio)->toByteArray());
 }
 
 TEST_P(RatioTest, testDeserialize) {
   const RatioTestData_t& data = GetParam();
 
-  SExpression sexpr = SExpression::createString(data.string);
-  EXPECT_EQ(data.ratio, deserialize<Ratio>(sexpr));
+  std::unique_ptr<SExpression> sexpr = SExpression::createString(data.string);
+  EXPECT_EQ(data.ratio, deserialize<Ratio>(*sexpr));
 }
 
 TEST(RatioTest, testDeserializeEmpty) {
-  SExpression sexpr = SExpression::createString("");
-  EXPECT_THROW(deserialize<Ratio>(sexpr), RuntimeError);
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("");
+  EXPECT_THROW(deserialize<Ratio>(*sexpr), RuntimeError);
 }
 
 TEST(RatioTest, testDeserializeInvalid) {
-  SExpression sexpr = SExpression::createString("foo");
-  EXPECT_THROW(deserialize<Ratio>(sexpr), RuntimeError);
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("foo");
+  EXPECT_THROW(deserialize<Ratio>(*sexpr), RuntimeError);
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/types/signalroletest.cpp
+++ b/tests/unittests/core/types/signalroletest.cpp
@@ -43,22 +43,22 @@ class SignalRoleTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST(SignalRoleTest, testSerialize) {
-  EXPECT_EQ("opendrain\n", serialize(SignalRole::opendrain()).toByteArray());
+  EXPECT_EQ("opendrain\n", serialize(SignalRole::opendrain())->toByteArray());
 }
 
 TEST(SignalRoleTest, testDeserialize) {
-  SExpression sexpr = SExpression::createString("opendrain");
-  EXPECT_EQ(SignalRole::opendrain(), deserialize<SignalRole>(sexpr));
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("opendrain");
+  EXPECT_EQ(SignalRole::opendrain(), deserialize<SignalRole>(*sexpr));
 }
 
 TEST(SignalRoleTest, testDeserializeEmpty) {
-  SExpression sexpr = SExpression::createString("");
-  EXPECT_THROW(deserialize<SignalRole>(sexpr), RuntimeError);
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("");
+  EXPECT_THROW(deserialize<SignalRole>(*sexpr), RuntimeError);
 }
 
 TEST(SignalRoleTest, testDeserializeInvalid) {
-  SExpression sexpr = SExpression::createString("foo");
-  EXPECT_THROW(deserialize<SignalRole>(sexpr), RuntimeError);
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("foo");
+  EXPECT_THROW(deserialize<SignalRole>(*sexpr), RuntimeError);
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/types/simplestringtest.cpp
+++ b/tests/unittests/core/types/simplestringtest.cpp
@@ -72,20 +72,19 @@ TEST_P(SimpleStringTest, testSerialize) {
 
   if (data.valid) {
     SimpleString obj(data.input);
-    EXPECT_EQ("\"" % data.input % "\"\n", serialize(obj).toByteArray());
+    EXPECT_EQ("\"" % data.input % "\"\n", serialize(obj)->toByteArray());
   }
 }
 
 TEST_P(SimpleStringTest, testDeserialize) {
   const SimpleStringTestData& data = GetParam();
 
+  const std::unique_ptr<const SExpression> sexpr =
+      SExpression::createString(data.input);
   if (data.valid) {
-    EXPECT_EQ(SimpleString(data.input),
-              deserialize<SimpleString>(SExpression::createString(data.input)));
+    EXPECT_EQ(SimpleString(data.input), deserialize<SimpleString>(*sexpr));
   } else {
-    EXPECT_THROW(
-        deserialize<SimpleString>(SExpression::createString(data.input)),
-        RuntimeError);
+    EXPECT_THROW(deserialize<SimpleString>(*sexpr), RuntimeError);
   }
 }
 

--- a/tests/unittests/core/types/uuidtest.cpp
+++ b/tests/unittests/core/types/uuidtest.cpp
@@ -184,31 +184,31 @@ TEST_P(UuidTest, testSerialize) {
   const UuidTestData& data = GetParam();
   if (data.valid) {
     Uuid uuid = Uuid::fromString(data.uuid);
-    EXPECT_EQ(data.uuid, serialize(uuid).getValue());
-    EXPECT_EQ(data.uuid, serialize(tl::make_optional(uuid)).getValue());
+    EXPECT_EQ(data.uuid, serialize(uuid)->getValue());
+    EXPECT_EQ(data.uuid, serialize(tl::make_optional(uuid))->getValue());
   }
 }
 
 TEST_P(UuidTest, testDeserialize) {
   const UuidTestData& data = GetParam();
-  SExpression sexpr = SExpression::createToken(data.uuid);
+  std::unique_ptr<SExpression> sexpr = SExpression::createToken(data.uuid);
   if (data.valid) {
-    EXPECT_EQ(data.uuid, deserialize<Uuid>(sexpr).toStr());
-    EXPECT_EQ(data.uuid, deserialize<tl::optional<Uuid>>(sexpr)->toStr());
+    EXPECT_EQ(data.uuid, deserialize<Uuid>(*sexpr).toStr());
+    EXPECT_EQ(data.uuid, deserialize<tl::optional<Uuid>>(*sexpr)->toStr());
   } else {
-    EXPECT_THROW(deserialize<Uuid>(sexpr), Exception);
-    EXPECT_THROW(deserialize<tl::optional<Uuid>>(sexpr), Exception);
+    EXPECT_THROW(deserialize<Uuid>(*sexpr), Exception);
+    EXPECT_THROW(deserialize<tl::optional<Uuid>>(*sexpr), Exception);
   }
 }
 
 TEST(UuidTest, testSerializeOptional) {
   tl::optional<Uuid> uuid = tl::nullopt;
-  EXPECT_EQ("none", serialize(uuid).getValue());
+  EXPECT_EQ("none", serialize(uuid)->getValue());
 }
 
 TEST(UuidTest, testDeserializeOptional) {
-  SExpression sexpr = SExpression::createToken("none");
-  EXPECT_EQ(tl::nullopt, deserialize<tl::optional<Uuid>>(sexpr));
+  std::unique_ptr<SExpression> sexpr = SExpression::createToken("none");
+  EXPECT_EQ(tl::nullopt, deserialize<tl::optional<Uuid>>(*sexpr));
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/types/versiontest.cpp
+++ b/tests/unittests/core/types/versiontest.cpp
@@ -242,22 +242,22 @@ TEST(VersionTest, testOperatorNotEqual) {
 
 TEST(VersionTest, testSerialize) {
   Version obj = Version::fromString("0.1.0");
-  EXPECT_EQ(QByteArray("\"0.1\"\n"), serialize(obj).toByteArray());
+  EXPECT_EQ(QByteArray("\"0.1\"\n"), serialize(obj)->toByteArray());
 }
 
 TEST(VersionTest, testDeserialize) {
-  SExpression sexpr = SExpression::createString("0.1");
-  EXPECT_EQ(Version::fromString("0.1"), deserialize<Version>(sexpr));
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("0.1");
+  EXPECT_EQ(Version::fromString("0.1"), deserialize<Version>(*sexpr));
 }
 
 TEST(VersionTest, testDeserializeEmpty) {
-  SExpression sexpr = SExpression::createString("");
-  EXPECT_THROW(deserialize<Version>(sexpr), RuntimeError);
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("");
+  EXPECT_THROW(deserialize<Version>(*sexpr), RuntimeError);
 }
 
 TEST(VersionTest, testDeserializeInvalid) {
-  SExpression sexpr = SExpression::createString("foo");
-  EXPECT_THROW(deserialize<Version>(sexpr), RuntimeError);
+  std::unique_ptr<SExpression> sexpr = SExpression::createString("foo");
+  EXPECT_THROW(deserialize<Version>(*sexpr), RuntimeError);
 }
 
 /*******************************************************************************

--- a/tests/unittests/core/utils/tangentpathjoinertest.cpp
+++ b/tests/unittests/core/utils/tangentpathjoinertest.cpp
@@ -39,13 +39,13 @@ namespace tests {
 class TangentPathJoinerTest : public ::testing::Test {
 protected:
   std::string str(QVector<Path> paths, const QString& name = "paths") const {
-    SExpression root = SExpression::createList(name);
+    std::unique_ptr<SExpression> root = SExpression::createList(name);
     foreach (const Path& p, paths) {
-      root.ensureLineBreak();
-      p.serialize(root.appendList("path"));
+      root->ensureLineBreak();
+      p.serialize(root->appendList("path"));
     }
-    root.ensureLineBreak();
-    return root.toByteArray().toStdString();
+    root->ensureLineBreak();
+    return root->toByteArray().toStdString();
   }
 
   std::string debug(const QVector<Path>& expected,

--- a/tests/unittests/core/utils/transformtest.cpp
+++ b/tests/unittests/core/utils/transformtest.cpp
@@ -45,9 +45,9 @@ protected:
   std::string str(const Layer& l) const { return l.getId().toStdString(); }
 
   std::string str(const Point& p) const {
-    SExpression sexpr = SExpression::createList("pos");
-    p.serialize(sexpr);
-    return sexpr.toByteArray().toStdString();
+    std::unique_ptr<SExpression> sexpr = SExpression::createList("pos");
+    p.serialize(*sexpr);
+    return sexpr->toByteArray().toStdString();
   }
 
   std::string str(const Angle& a) const {
@@ -55,9 +55,9 @@ protected:
   }
 
   std::string str(const Path& p) const {
-    SExpression sexpr = SExpression::createList("path");
-    p.serialize(sexpr);
-    return sexpr.toByteArray().toStdString();
+    std::unique_ptr<SExpression> sexpr = SExpression::createList("path");
+    p.serialize(*sexpr);
+    return sexpr->toByteArray().toStdString();
   }
 };
 


### PR DESCRIPTION
Replacing the children container type `QList<SExpression>` by `std::vector<std::unique_ptr<SExpression>>` because the implementation relied on `QList` storing the actual objects on heap with stable addresses even when adding/removing other children. But this is no longer the case with Qt6, which leads to segmentation faults. The old concept can be kept by using `std::vector` and `std::unique_ptr` which seems to work fine.

Also optimized the parsing of S-Expressions a bit (avoiding unnecessary allocations & copies), which speeds up parsing of files by roughly 30% :muscle: Also the creation of S-Expressions should be a bit faster, but I didn't verify it since it is not as relevant as parsing speed.