### PR TITLE
Add component dialog: Add context menu to parts

### DIFF
--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -1707,6 +1707,33 @@ public:
       {},
       &categoryContextMenu,
   };
+  EditorCommand copyMpnToClipboard{
+      "copy_mpn_to_clipboard",  // clang-format break
+      QT_TR_NOOP("Copy MPN to Clipboard"),
+      QT_TR_NOOP("Copy this MPN into the clipboard"),
+      ":/img/actions/copy.png",
+      EditorCommand::Flags(),
+      {QKeySequence(Qt::CTRL + Qt::Key_C)},
+      &categoryContextMenu,
+  };
+  EditorCommand openProductWebsite{
+      "open_product_website",  // clang-format break
+      QT_TR_NOOP("Open Product Website"),
+      QT_TR_NOOP("Open product details about this part in the web browser"),
+      ":/img/actions/open_browser.png",
+      EditorCommand::Flag::OpensPopup,
+      {},
+      &categoryContextMenu,
+  };
+  EditorCommand openPricingWebsite{
+      "open_pricing_website",  // clang-format break
+      QT_TR_NOOP("Open Pricing Website"),
+      QT_TR_NOOP("Open pricing details about this part in the web browser"),
+      ":/img/library/part.png",
+      EditorCommand::Flag::OpensPopup,
+      {},
+      &categoryContextMenu,
+  };
   EditorCommand generateContent{
       // Actually not really for the context menu :-/
       "generate_content",  // clang-format break

--- a/libs/librepcb/editor/project/addcomponentdialog.h
+++ b/libs/librepcb/editor/project/addcomponentdialog.h
@@ -158,6 +158,7 @@ private slots:
                                         int column) noexcept;
   void treeComponents_itemExpanded(QTreeWidgetItem* item) noexcept;
   void cbxSymbVar_currentIndexChanged(int index) noexcept;
+  void customComponentsContextMenuRequested(const QPoint& pos) noexcept;
 
 private:
   // Private Methods
@@ -203,6 +204,9 @@ private:
   QList<std::shared_ptr<Symbol>> mPreviewSymbols;
   QList<std::shared_ptr<SymbolGraphicsItem>> mPreviewSymbolGraphicsItems;
   QScopedPointer<FootprintGraphicsItem> mPreviewFootprintGraphicsItem;
+
+  // Actions
+  QScopedPointer<QAction> mActionCopyMpn;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
Adding a context menu to parts in the "Add Component"-dialog:

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/8809df8f-cfa7-46b9-9c32-2a575443c7a7)

The last two menu entries (and a third one "Open Product Website") open the web browser and are only shown if the corresponding URL is available (retrieved through the part information API).

Copying the MPN is also possible directly with Ctrl+C, i.e. without opening the context menu.

Closes #1330