### PR TITLE
Add "toggle 2D/3D" button to toolbars

### DIFF
--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -772,6 +772,7 @@ void LibraryEditor::createToolBars() noexcept {
   mToolBarView->addAction(mActionZoomIn.data());
   mToolBarView->addAction(mActionZoomOut.data());
   mToolBarView->addAction(mActionZoomFit.data());
+  mToolBarView->addAction(mActionToggle3D.data());
   addToolBar(Qt::TopToolBarArea, mToolBarView.data());
 
   // Search.

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -905,6 +905,7 @@ void BoardEditor::createToolBars() noexcept {
   mToolBarView->addAction(mActionZoomIn.data());
   mToolBarView->addAction(mActionZoomOut.data());
   mToolBarView->addAction(mActionZoomFit.data());
+  mToolBarView->addAction(mActionToggle3D.data());
   addToolBar(Qt::TopToolBarArea, mToolBarView.data());
 
   // Search.


### PR DESCRIPTION
I think for new users it's not so clear how to open the 3D mode (or that it even exists!) because the thin vertical buttons can easily be overlooked. Thus now also adding a toggle button to the toolbar, next to the zoom buttons (library editor & board editor).