### PR TITLE
Fix possibly wrong colors after STEP minification

### DIFF
--- a/libs/librepcb/core/3d/occmodel.cpp
+++ b/libs/librepcb/core/3d/occmodel.cpp
@@ -641,7 +641,7 @@ std::unique_ptr<OccModel> OccModel::loadStep(const QByteArray content) {
 
     if (!stepReader.Transfer(doc)) {
       doc->Close();
-      throw RuntimeError(__FILE__, __LINE__);
+      throw RuntimeError(__FILE__, __LINE__, "Failed to transfer STEP model.");
     }
     result.reset(
         new OccModel(std::unique_ptr<Data>(new Data{doc, TDF_Label()})));
@@ -730,8 +730,9 @@ QByteArray OccModel::minifyStep(const QByteArray& content) {
     // identical. When merged, the STEP model won't be rendered anymore
     // and FreeCAD displays a wrong shape object tree. We add a unique
     // number to these entries to ensure they are left untouched.
+    // See also https://github.com/LibrePCB/LibrePCB/issues/1286.
     if (valueStr.contains("PRODUCT_DEFINITION") ||
-        valueStr.contains("SHAPE_REPRESENTATION")) {
+        valueStr.contains("REPRESENTATION")) {
       value.second.append(data.count() + 1);
     } else {
       value.second.append(0);

--- a/tests/cli/open_step/test_minify.py
+++ b/tests/cli/open_step/test_minify.py
@@ -17,7 +17,7 @@ def test_valid_file(cli):
     assert stdout == \
         "Open STEP file '{path}'...\n" \
         "Perform minify...\n" \
-        " - Minified from 28,521 bytes to 11,716 bytes (-59%)\n" \
+        " - Minified from 28,521 bytes to 18,336 bytes (-36%)\n" \
         "Load model...\n" \
         "SUCCESS\n".format(path=fp)
     assert code == 0
@@ -47,7 +47,7 @@ def test_on_save_to_output(cli):
     assert stdout == \
         "Open STEP file '{path}'...\n" \
         "Perform minify...\n" \
-        " - Minified from 28,521 bytes to 11,716 bytes (-59%)\n" \
+        " - Minified from 28,521 bytes to 18,336 bytes (-36%)\n" \
         "Save to '{outpath}'...\n" \
         "Load model...\n" \
         "SUCCESS\n".format(path=fp, outpath=fp_out)


### PR DESCRIPTION
Seems that too many STEP nodes were merged, thus now blacklisting all nodes containing the term "REPRESENTATION". Slightly increases the size of the resulting STEP models, but I think there's no way to avoid that...

Also added a unit test to avoid regression.

Fixes #1286