### PR TITLE
Board editor: Fix missing inner layers in dropdowns

### DIFF
--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.cpp
@@ -104,9 +104,8 @@ const LengthUnit& BoardEditorState::getLengthUnit() const noexcept {
   }
 }
 
-const QSet<const Layer*>&
-    BoardEditorState::getAllowedGeometryLayers() noexcept {
-  static const QSet<const Layer*> layers = {
+QSet<const Layer*> BoardEditorState::getAllowedGeometryLayers() noexcept {
+  static const QSet<const Layer*> commonLayers = {
       &Layer::boardSheetFrames(),
       &Layer::boardOutlines(),
       &Layer::boardCutouts(),
@@ -139,6 +138,10 @@ const QSet<const Layer*>&
       &Layer::botSolderPaste(),
       &Layer::botStopMask(),
   };
+  QSet<const Layer*> layers = commonLayers;
+  if (const Board* board = getActiveBoard()) {
+    layers |= board->getCopperLayers();
+  }
   return layers;
 }
 

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate.h
@@ -193,7 +193,7 @@ protected:  // Methods
   bool getIgnoreLocks() const noexcept;
   PositiveLength getGridInterval() const noexcept;
   const LengthUnit& getLengthUnit() const noexcept;
-  static const QSet<const Layer*>& getAllowedGeometryLayers() noexcept;
+  QSet<const Layer*> getAllowedGeometryLayers() noexcept;
   void makeLayerVisible(const QString& layer) noexcept;
   void abortBlockingToolsInOtherEditors() noexcept;
   bool execCmd(UndoCommand* cmd);


### PR DESCRIPTION
Currently it was not possible to add polygons or texts on inner copper layers because these layers didn't show up in the layer dropdown, although this is totally valid. Fixed by adding inner copper layers to the dropdowns.