### PR TITLE
DRC: Add checks for unused or disabled layers

### DIFF
--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -98,6 +98,7 @@ private:  // Methods
   void checkInvalidPadConnections(int progressEnd);
   void checkDeviceClearances(int progressEnd);
   void checkBoardOutline(int progressEnd);
+  void checkUsedLayers(int progressEnd);
   void checkForUnplacedComponents(int progressEnd);
   void checkForMissingConnections(int progressEnd);
   void checkForStaleObjects(int progressEnd);

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
@@ -1701,6 +1701,45 @@ DrcMsgUselessVia::DrcMsgUselessVia(const BI_Via& via,
 }
 
 /*******************************************************************************
+ *  DrcMsgDisabledLayer
+ ******************************************************************************/
+
+DrcMsgDisabledLayer::DrcMsgDisabledLayer(const Layer& layer) noexcept
+  : RuleCheckMessage(
+        Severity::Warning,
+        tr("Objects on disabled layer: '%1'").arg(layer.getNameTr()),
+        tr("The layer contains copper objects, but it is disabled in the board "
+           "setup dialog and thus will be ignored in any production data "
+           "exports. Either increase the layer count to get this layer "
+           "exported, or remove all objects on this layer (by temporarily "
+           "enabling this layer to see them)."),
+        "disabled_layer") {
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("layer", layer.getId());
+  mApproval->ensureLineBreak();
+}
+
+/*******************************************************************************
+ *  DrcMsgUnusedLayer
+ ******************************************************************************/
+
+DrcMsgUnusedLayer::DrcMsgUnusedLayer(const Layer& layer) noexcept
+  : RuleCheckMessage(
+        Severity::Hint, tr("Unused layer: '%1'").arg(layer.getNameTr()),
+        tr("The layer contains no copper objects (except the automatically "
+           "generated through-hole annular rings, if any) so it is useless. "
+           "This is not critical, but if your intention is to flood it with "
+           "copper, you need to add a plane manually. Or if you don't need "
+           "this layer, you might want to reduce the layer count in the board "
+           "setup dialog to avoid unnecessary production costs. Also some PCB "
+           "manufacturers might be confused by empty layers."),
+        "unused_layer") {
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("layer", layer.getId());
+  mApproval->ensureLineBreak();
+}
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
@@ -845,6 +845,44 @@ public:
 };
 
 /*******************************************************************************
+ *  Class DrcMsgDisabledLayer
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgDisabledLayer class
+ */
+class DrcMsgDisabledLayer final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgDisabledLayer)
+
+public:
+  // Constructors / Destructor
+  DrcMsgDisabledLayer() = delete;
+  explicit DrcMsgDisabledLayer(const Layer& layer) noexcept;
+  DrcMsgDisabledLayer(const DrcMsgDisabledLayer& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgDisabledLayer() noexcept {}
+};
+
+/*******************************************************************************
+ *  Class DrcMsgUnusedLayer
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgUnusedLayer class
+ */
+class DrcMsgUnusedLayer final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgUnusedLayer)
+
+public:
+  // Constructors / Destructor
+  DrcMsgUnusedLayer() = delete;
+  explicit DrcMsgUnusedLayer(const Layer& layer) noexcept;
+  DrcMsgUnusedLayer(const DrcMsgUnusedLayer& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgUnusedLayer() noexcept {}
+};
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 


### PR DESCRIPTION
Add two new DRC warnings:
- Inner copper layers which are enabled, but contain no copper objects. Especially useful if users think that inner layers act as planes, i.e. are automatically filled with copper which is not the case. Also PCB manufacturers might be confused about empty layers (got a report that PCBWay asked the user which polarity the layer has).
- Inner copper layers which are disabled, but contain copper objects, as this looks like a wrong board setup.