### PR TITLE
Library editor: Refactor "copy to other library"

### DIFF
--- a/libs/librepcb/editor/library/lib/libraryoverviewwidget.h
+++ b/libs/librepcb/editor/library/lib/libraryoverviewwidget.h
@@ -132,8 +132,7 @@ private:  // Methods
       const QHash<QListWidgetItem*, FilePath>& selectedItemPaths) noexcept;
   void copyElementsToOtherLibrary(
       const QHash<QListWidgetItem*, FilePath>& selectedItemPaths,
-      const FilePath& libFp, const QString& libName,
-      bool removeFromSource) noexcept;
+      const FilePath& libFp, const QString& libName) noexcept;
   QList<LibraryMenuItem> getLocalLibraries() const noexcept;
 
   // Event Handlers

--- a/libs/librepcb/editor/utils/menubuilder.cpp
+++ b/libs/librepcb/editor/utils/menubuilder.cpp
@@ -186,15 +186,6 @@ QMenu* MenuBuilder::createChangeModelMenu(QWidget* parent) noexcept {
                     QIcon(":/img/library/3d_model.png"), parent);
 }
 
-QMenu* MenuBuilder::createCopyToOtherLibraryMenu(QWidget* parent) noexcept {
-  QMenu* menu =
-      createMenu("menuCopyToOtherLibrary", tr("Copy to Other Library"),
-                 QIcon(":/img/actions/copy.png"), parent);
-  menu->setStatusTip(tr(
-      "Create a copy of this element (preserving UUIDs) in another library"));
-  return menu;
-}
-
 QMenu* MenuBuilder::createMoveToOtherLibraryMenu(QWidget* parent) noexcept {
   QMenu* menu =
       createMenu("menuMoveToOtherLibrary", tr("Move to Other Library"),

--- a/libs/librepcb/editor/utils/menubuilder.h
+++ b/libs/librepcb/editor/utils/menubuilder.h
@@ -91,7 +91,6 @@ public:
   static QMenu* createChangeDeviceMenu(QWidget* parent) noexcept;
   static QMenu* createChangeFootprintMenu(QWidget* parent) noexcept;
   static QMenu* createChangeModelMenu(QWidget* parent) noexcept;
-  static QMenu* createCopyToOtherLibraryMenu(QWidget* parent) noexcept;
   static QMenu* createMoveToOtherLibraryMenu(QWidget* parent) noexcept;
 
 private:  // Methods


### PR DESCRIPTION
Remove the "Copy to other library" context menu item because it was misleading (users could think this feature allows to create a new library element which will cause serious trouble, see #1321). Now only the "Move to other library" option is available in the context menu, but its confirmation dialog contains a checkbox to keep the elements in the current library (effectively making a copy):

![image](https://github.com/LibrePCB/LibrePCB/assets/5374821/8ed051de-6e63-42e5-b76f-52cbab77f848)

It might still not be a perfect solution but I didn't find a better one and I think this should now be much less "dangerous".

Note that this checkbox will be checked but read-only for remote libraries as their filesystem is read-only.

Closes #1321