### PR TITLE
OutputJobsDialog: Show hint allowing to add a default job set

### DIFF
--- a/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.ui
+++ b/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.ui
@@ -73,6 +73,9 @@
       </widget>
      </item>
      <item>
+      <widget class="librepcb::editor::MessageWidget" name="msgAddDefaultJobs" native="true"/>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="spacing">
         <number>0</number>
@@ -308,6 +311,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::editor::MessageWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/messagewidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Especially for beginners, output jobs might be a bit overwhelming and not clear what needs to be done in this dialog. But also for experienced users it's simply cumbersome to manually add several jobs one by one. So this PR provides a hint in the GUI telling the user to add output jobs and even allowing to generate a standard set of output jobs with a single click:

![librepcb-default-output-jobs](https://github.com/LibrePCB/LibrePCB/assets/5374821/a0139a42-7578-4dc2-b23a-4719dccc0b9d)

I think some day this default set should be configurable in the workspace settings, but for now this hardcoded set is already a big improvement.