### PR TITLE
OutputJobsDialog: Ask for discarding changes

### DIFF
--- a/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.cpp
+++ b/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.cpp
@@ -189,6 +189,24 @@ OutputJobsDialog::~OutputJobsDialog() noexcept {
 }
 
 /*******************************************************************************
+ *  Public Methods
+ ******************************************************************************/
+
+void OutputJobsDialog::reject() noexcept {
+  if (mJobs != mProject.getOutputJobs()) {
+    const int ret = QMessageBox::question(
+        this, tr("Discard Changes?"),
+        tr("You made changes to output jobs which will be lost when closing "
+           "the dialog. Are you sure to discard them?"),
+        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+    if (ret != QMessageBox::Yes) {
+      return;
+    }
+  }
+  QDialog::reject();
+}
+
+/*******************************************************************************
  *  Private Methods
  ******************************************************************************/
 

--- a/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.h
+++ b/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.h
@@ -63,6 +63,9 @@ public:
                             QWidget* parent = nullptr) noexcept;
   ~OutputJobsDialog() noexcept;
 
+  // General Methods
+  virtual void reject() noexcept override;
+
   // Operator Overloads
   OutputJobsDialog& operator=(const OutputJobsDialog& rhs) = delete;
 

--- a/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.ui
+++ b/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.ui
@@ -320,38 +320,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>librepcb::editor::OutputJobsDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>librepcb::editor::OutputJobsDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
It already happened several times to myself that I close the output jobs dialog with "Cancel" or Escape instead of clicking "OK" to get the changes saved, so the changes were lost. This PR adds a confirmation message box when canceling this dialog while there are unsaved changes.