### PR TITLE
Provide visual feedback on save & copy actions

### DIFF
--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -1011,6 +1011,7 @@ bool PackageEditorState_Select::copySelectedItemsToClipboard() noexcept {
     if (data.getItemCount() > 0) {
       qApp->clipboard()->setMimeData(
           data.toMimeData(mContext.editorContext.layerProvider).release());
+      emit statusBarMessageChanged(tr("Copied to clipboard!"), 2000);
     }
   } catch (const Exception& e) {
     QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -811,6 +811,7 @@ bool SymbolEditorState_Select::copySelectedItemsToClipboard() noexcept {
     if (data.getItemCount() > 0) {
       qApp->clipboard()->setMimeData(
           data.toMimeData(mContext.editorContext.layerProvider).release());
+      emit statusBarMessageChanged(tr("Copied to clipboard!"), 2000);
     }
   } catch (const Exception& e) {
     QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());

--- a/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardeditor.cpp
@@ -164,6 +164,8 @@ BoardEditor::BoardEditor(ProjectEditor& projectEditor, Project& project)
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);
   mUi->statusbar->setProgressBarPercent(
       mProjectEditor.getWorkspace().getLibraryDb().getScanProgressPercent());
+  connect(&mProjectEditor, &ProjectEditor::showTemporaryStatusBarMessage,
+          mUi->statusbar, &StatusBar::showMessage);
 
   // Set window title.
   QString filenameStr = mProject.getFilepath().getFilename();

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -1560,6 +1560,7 @@ bool BoardEditorState_Select::copySelectedItemsToClipboard() noexcept {
     BoardClipboardDataBuilder builder(*scene);
     std::unique_ptr<BoardClipboardData> data = builder.generate(cursorPos);
     qApp->clipboard()->setMimeData(data->toMimeData().release());
+    emit statusBarMessageChanged(tr("Copied to clipboard!"), 2000);
   } catch (const Exception& e) {
     QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
   }

--- a/libs/librepcb/editor/project/projecteditor.h
+++ b/libs/librepcb/editor/project/projecteditor.h
@@ -254,6 +254,7 @@ signals:
   void showControlPanelClicked();
   void openProjectLibraryUpdaterClicked(const FilePath& fp);
   void projectEditorClosed();
+  void showTemporaryStatusBarMessage(const QString& message, int timeoutMs);
 
 private:  // Methods
   void runErc() noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -794,6 +794,7 @@ bool SchematicEditorState_Select::copySelectedItemsToClipboard() noexcept {
     SchematicClipboardDataBuilder builder(*scene);
     std::unique_ptr<SchematicClipboardData> data = builder.generate(cursorPos);
     qApp->clipboard()->setMimeData(data->toMimeData().release());
+    emit statusBarMessageChanged(tr("Copied to clipboard!"), 2000);
   } catch (const Exception& e) {
     QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
   }

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -118,6 +118,8 @@ SchematicEditor::SchematicEditor(ProjectEditor& projectEditor, Project& project)
           &StatusBar::setProgressBarPercent, Qt::QueuedConnection);
   mUi->statusbar->setProgressBarPercent(
       mProjectEditor.getWorkspace().getLibraryDb().getScanProgressPercent());
+  connect(&mProjectEditor, &ProjectEditor::showTemporaryStatusBarMessage,
+          mUi->statusbar, &StatusBar::showMessage);
 
   // Set window title.
   QString filenameStr = mProject.getFilepath().getFilename();


### PR DESCRIPTION
- Saving a project can take a few seconds while the UI is not responsive. Now showing a waiting cursor during this operation to provide immediate feedback, making the user know when the operation starts and ends. Also print "Project saved!" in the status bar when the operation succeeded.
- Copying something to clipboard did not provide any visual feedback so far, thus now displaying "Copied to clipboard!" in the status bar to let the user know it worked.