### PR TITLE
MacOS: Ship the CLI in the same bundle as the GUI app

### DIFF
--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -32,7 +32,7 @@ jobs:
     displayName: Build Bundle
   - bash: ./build/tests/unittests/librepcb-unittests
     displayName: Run LibrePCB Unittests
-  - bash: pytest -vvv --librepcb-executable="build/install/opt/librepcb-cli.app/Contents/MacOS/librepcb-cli" ./tests/cli
+  - bash: pytest -vvv --librepcb-executable="build/install/opt/LibrePCB.app/Contents/MacOS/librepcb-cli" ./tests/cli
     displayName: Run LibrePCB-CLI Functional Tests
   # Note: Functional tests need to be run with the non-bundled app, otherwise
   # we get the error "Cannot add multiple registrations for QtQml.Models 2".

--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -11,21 +11,20 @@ then
   while pgrep XProtect; do sleep 3; done;
 fi
 
-# replace "bin" and "share" directories with the single *.app directory
+# Merge GUI application and CLI (https://github.com/LibrePCB/LibrePCB/issues/1358)
+cp "./build/install/opt/bin/librepcb-cli.app/Contents/MacOS/librepcb-cli" \
+   "./build/install/opt/bin/librepcb.app/Contents/MacOS/"
+
+# Replace "bin" and "share" directories with the single *.app directory
 cp -r "./build/install/opt/bin/librepcb.app" "./build/install/opt/LibrePCB.app"
 cp -r "./build/install/opt/share" "./build/install/opt/LibrePCB.app/Contents/"
-cp -r "./build/install/opt/bin/librepcb-cli.app" "./build/install/opt/LibrePCB-CLI.app"
-cp -r "./build/install/opt/share" "./build/install/opt/LibrePCB-CLI.app/Contents/"
 
-# Build bundles
+# Build bundle
 pushd "./build/install/opt/"  # Avoid having path in DMG name
 dylibbundler -ns -od -b \
   -x LibrePCB.app/Contents/MacOS/librepcb \
+  -x LibrePCB.app/Contents/MacOS/librepcb-cli \
   -d LibrePCB.app/Contents/Frameworks/ \
-  -p @executable_path/../Frameworks/
-dylibbundler -ns -od -b \
-  -x LibrePCB-CLI.app/Contents/MacOS/librepcb-cli \
-  -d LibrePCB-CLI.app/Contents/Frameworks/ \
   -p @executable_path/../Frameworks/
 if [ "$ARCH" = "arm64" ]
 then
@@ -34,32 +33,26 @@ then
   # somehow macdeployqt fails on that so we have to do it manually.
   # Requirement: brew install create-dmg
   ln -s /opt/homebrew/lib ./lib  # https://github.com/orgs/Homebrew/discussions/2823
-  macdeployqt "LibrePCB.app" -always-overwrite
-  macdeployqt "LibrePCB-CLI.app" -always-overwrite
+  macdeployqt "LibrePCB.app" -always-overwrite \
+    -executable="./LibrePCB.app/Contents/MacOS/librepcb" \
+    -executable="./LibrePCB.app/Contents/MacOS/librepcb-cli"
   codesign --force --deep -s - ./LibrePCB.app/Contents/MacOS/librepcb
-  codesign --force --deep -s - ./LibrePCB-CLI.app/Contents/MacOS/librepcb-cli
+  codesign --force --deep -s - ./LibrePCB.app/Contents/MacOS/librepcb-cli
   create-dmg --skip-jenkins --volname "LibrePCB" \
     --volicon ./LibrePCB.app/Contents/Resources/librepcb.icns \
     ./LibrePCB.dmg ./LibrePCB.app
-  create-dmg --skip-jenkins --volname "LibrePCB-CLI" \
-    --volicon ./LibrePCB-CLI.app/Contents/Resources/librepcb.icns \
-    ./LibrePCB-CLI.dmg ./LibrePCB-CLI.app
 else
   # On x86_64, directly create the *.dmg with macdeployqt.
   ln -s /usr/local/lib ./lib  # https://github.com/orgs/Homebrew/discussions/2823
-  macdeployqt "LibrePCB.app" -dmg -always-overwrite
-  macdeployqt "LibrePCB-CLI.app" -dmg -always-overwrite
+  macdeployqt "LibrePCB.app" -dmg -always-overwrite \
+    -executable="./LibrePCB.app/Contents/MacOS/librepcb" \
+    -executable="./LibrePCB.app/Contents/MacOS/librepcb-cli"
 fi
 popd
 
-# Restore lowercase app names for backwards compatibility with installers
-mv "./build/install/opt/LibrePCB.app" "./build/install/opt/librepcb.app"
-mv "./build/install/opt/LibrePCB-CLI.app" "./build/install/opt/librepcb-cli.app"
-
 # Test if the bundles are working (hopefully catching deployment issues).
-./build/install/opt/librepcb-cli.app/Contents/MacOS/librepcb-cli --version
-./build/install/opt/librepcb.app/Contents/MacOS/librepcb --exit-after-startup
+./build/install/opt/LibrePCB.app/Contents/MacOS/librepcb-cli --version
+./build/install/opt/LibrePCB.app/Contents/MacOS/librepcb --exit-after-startup
 
 # Move bundles to artifacts directory
 mv ./build/install/opt/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-$ARCH.dmg
-mv ./build/install/opt/LibrePCB-CLI.dmg ./artifacts/nightly_builds/librepcb-cli-nightly-mac-$ARCH.dmg


### PR DESCRIPTION
Avoid deploying two separate *.app bundles in separate *.dmg images - just include the `librepcb-cli` executable in the normal GUI application bundle.

Closes #1358