### PR TITLE
Linux: Ship the CLI in the same AppImage as the GUI app

### DIFF
--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -17,9 +17,12 @@ fi
 # Helper to extract and rebuild AppImages with appimagetool to get the static
 # runtime which doesn't need libfuse2 and thus also runs on Ubuntu 22.04, see
 # https://github.com/LibrePCB/LibrePCB/issues/980.
+# In addition, replace AppRun by a script which allows to run the CLI.
 patch_appimage () {
   ./LibrePCB-*-x86_64.AppImage --appimage-extract
   chmod -R 755 ./squashfs-root
+  rm ./squashfs-root/AppRun
+  cp ./dist/appimage/AppRun ./squashfs-root/
   rm ./LibrePCB-*-x86_64.AppImage
   appimagetool ./squashfs-root
   rm -rf ./squashfs-root
@@ -38,21 +41,13 @@ LINUXDEPLOYQT_FLAGS="-executable=./build/install/opt/lib/$(basename $LIBSSL)"
 LINUXDEPLOYQT_FLAGS+=" -executable=./build/install/opt/lib/$(basename $LIBCRYPTO)"
 LINUXDEPLOYQT_FLAGS+=" -bundle-non-qt-libs"
 
-# Build CLI AppImage.
-cp -r "./build/install" "./build/appimage-cli"
-mv -f "./build/appimage-cli/opt/bin/librepcb-cli" "./build/appimage-cli/opt/bin/librepcb"
-cp "./build/appimage-cli/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" \
-  "./build/appimage-cli/org.librepcb.LibrePCB.svg"
-linuxdeployqt "./build/appimage-cli/opt/share/applications/org.librepcb.LibrePCB.desktop" \
-  $LINUXDEPLOYQT_FLAGS -appimage
-patch_appimage
-mv ./LibrePCB-*-x86_64.AppImage ./artifacts/nightly_builds/librepcb-cli-nightly-linux-$ARCH.AppImage
-
-# Build LibrePCB AppImage.
+# Build AppImage.
 cp -r "./build/install" "./build/appimage"
 cp "./build/appimage/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" \
   "./build/appimage/org.librepcb.LibrePCB.svg"
 linuxdeployqt "./build/appimage/opt/share/applications/org.librepcb.LibrePCB.desktop" \
+  -executable="./build/appimage/opt/bin/librepcb" \
+  -executable="./build/appimage/opt/bin/librepcb-cli" \
   -qmldir="./build/appimage/opt/share/librepcb/qml" \
   $LINUXDEPLOYQT_FLAGS -appimage
 patch_appimage

--- a/dist/appimage/AppRun
+++ b/dist/appimage/AppRun
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+# Wrapper allowing to bundle both the GUI and the CLI in a single AppImage.
+# If the called AppImage has "cli" in its name, the CLI executable is invoked.
+# If not, the GUI executable is invoked.
+
+# See https://discourse.appimage.org/t/call-alternative-binary-from-appimage/93.
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+BINARY_NAME=$(basename "$ARGV0")
+
+case $BINARY_NAME in
+  *cli*) exec "$HERE/opt/bin/librepcb-cli" "$@";;
+  *CLI*) exec "$HERE/opt/bin/librepcb-cli" "$@";;
+  *) exec "$HERE/opt/bin/librepcb" "$@";;
+esac


### PR DESCRIPTION
Determine by `argv[0]` whether the CLI or the GUI shall be executed. This way we don't need to distribute two separate AppImages anymore, which simplifies deployment and even reduces disk usage and network traffic of release artifacts.

Downside is that for the CLI the AppImage either needs to be renamed (add "cli" to its filename) or a symlink (with "cli" in its name) needs to be created. But probably the CLI AppImage isn't used by many people anyway, so I think that's no problem at all (and of course will be documented accordingly in the user manual).

Similar to #1378 which was for macOS.