### PR TITLE
Windows: Use NetUserGetInfo() to get full user name

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -543,6 +543,8 @@ target_link_libraries(
          # Link with -lproc on SunOS / Solaris / Illumos
          # This is required for proc_get_psinfo
          $<$<STREQUAL:$<PLATFORM_ID>,SunOS>:proc>
+         # On Windows, NetUserGetInfo() requires to link with netapi32.dll.
+         $<$<STREQUAL:$<PLATFORM_ID>,Windows>:netapi32>
 )
 
 # Alias to namespaced variant


### PR DESCRIPTION
This Windows API function seems to be handling encoding correctly, in contrast to the previously used "net user" command. For now the old way is still used as fallback in case `NetUserGetInfo()` does not work.

Fixes #1365