### PR TITLE
Fix license identifier in AppStream Metainfo XML

### DIFF
--- a/share/metainfo/org.librepcb.LibrePCB.metainfo.xml
+++ b/share/metainfo/org.librepcb.LibrePCB.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>org.librepcb.LibrePCB</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
   <name>LibrePCB</name>
   <summary>Design Schematics and PCBs</summary>
   <developer_name>The LibrePCB Developers</developer_name>


### PR DESCRIPTION
Saw on Flathub that the "or later" is missing :see_no_evil: 