### PR TITLE
Drop support for Qt < 5.12 and CMake < 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,10 +150,10 @@ if(WIN32)
   add_definitions(-DUNICODE -D_UNICODE)
 endif()
 
-# Disable Qt functions which are deprecated in Qt <= 5.5 to enforce us
+# Disable Qt functions which are deprecated in Qt <= 5.12 to enforce us
 # migrating away from them. Always set this to the lowest Qt version we want
 # to support.
-add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0x050500)
+add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0x050C00)
 
 # Not sure what we should do with deprecation warnings. Better keeping
 # backwards compatibility with already existing & supported environments
@@ -188,7 +188,7 @@ if(BUILD_TESTS)
 endif()
 
 # Find Qt
-find_package(${QT} 5.5.0 REQUIRED COMPONENTS ${QT_COMPONENTS})
+find_package(${QT} 5.12.0 REQUIRED COMPONENTS ${QT_COMPONENTS})
 set(QT_VERSION "${${QT}_VERSION}")
 message(STATUS "Building LibrePCB with Qt ${QT_VERSION}")
 if(QT_MAJOR_VERSION EQUAL 5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 # CMake version configuration
-# (Note: The minimal version 3.5 is shipped with Ubuntu 16.04)
-cmake_minimum_required(VERSION 3.5...3.19)
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-endif()
+# (Note: The minimal version 3.16 is shipped with Ubuntu 20.04)
+cmake_minimum_required(VERSION 3.16...3.19)
 
 # Support older macOS versions. Needs to be set before calling project()!
 # https://github.com/LibrePCB/LibrePCB/issues/1091

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To compile and run LibrePCB, you need the following software components:
   GLU (optional)
 - [zlib](http://www.zlib.net/)
 - [OpenSSL](https://www.openssl.org/)
-- [CMake](https://cmake.org/) 3.5 or newer
+- [CMake](https://cmake.org/) 3.16 or newer
 
 #### Prepared Docker Image
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ productive use, please install an official release as described in the
 To compile and run LibrePCB, you need the following software components:
 
 - Compiler: g++, MinGW or Clang (any version with C++17 support should work)
-- [Qt](http://www.qt.io/download-open-source/) >= 6.2 or 5.5...5.15 (make
+- [Qt](http://www.qt.io/download-open-source/) >= 6.2 or 5.12...5.15 (make
   sure the [imageformats](https://doc.qt.io/qt-5/qtimageformats-index.html)
   plugin is installed too as it will be needed at runtime!).
 - [OpenCASCADE](https://www.opencascade.com/) OCCT or OCE (optional)
@@ -71,7 +71,7 @@ actually used for CI, but are also useful to build LibrePCB locally.
 
 #### Installation on Debian/Ubuntu/Mint
 
-##### Ubuntu 22.04
+##### Ubuntu >= 22.04
 
 ```bash
 sudo apt-get install build-essential git cmake openssl zlib1g zlib1g-dev \
@@ -82,7 +82,7 @@ sudo apt-get install build-essential git cmake openssl zlib1g zlib1g-dev \
 sudo apt-get install qtcreator # optional
 ```
 
-##### Older Ubuntu Versions
+##### Ubuntu 20.04
 
 ```bash
 sudo apt-get install build-essential git cmake openssl zlib1g zlib1g-dev \

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -108,9 +108,7 @@ static void setApplicationMetadata() noexcept {
   QApplication::setOrganizationDomain("librepcb.org");
   QApplication::setApplicationName("LibrePCB");
   QApplication::setApplicationVersion(Application::getVersion());
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
   QApplication::setDesktopFileName("org.librepcb.LibrePCB");
-#endif
 }
 
 /*******************************************************************************

--- a/dev/doxygen/pages/code_style_guide.md
+++ b/dev/doxygen/pages/code_style_guide.md
@@ -30,7 +30,7 @@ This page describes the code style guide for LibrePCB developers.
 
 # General {#doc_code_style_guide_general}
 
-- Qt >= 5.5
+- Qt >= 5.12
 - C++11
 - Use strongly typed enums (`enum class`, C++11) whenever reasonable
 - Use `nullptr` instead of `NULL` or `0`

--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -351,13 +351,7 @@ Path& Path::operator=(const Path& rhs) noexcept {
 }
 
 bool Path::operator<(const Path& rhs) const noexcept {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
   return mVertices < rhs.mVertices;
-#else
-  return std::lexicographical_compare(mVertices.begin(), mVertices.end(),
-                                      rhs.mVertices.begin(),
-                                      rhs.mVertices.end());
-#endif
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/network/orderpcbapirequest.cpp
+++ b/libs/librepcb/core/network/orderpcbapirequest.cpp
@@ -76,11 +76,7 @@ void OrderPcbApiRequest::startUpload(const QByteArray& lppz,
 
   // Check file size.
   if ((mMaxFileSize > 0) && (lppz.size() > mMaxFileSize)) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-    QString size = QLocale().formattedDataSize(lppz.size(), 0);
-#else
-    QString size = QString("%1 MB").arg(lppz.size() / (1024 * 1024));
-#endif
+    const QString size = QLocale().formattedDataSize(lppz.size(), 0);
     emit uploadFailed(
         tr("The project is too large (%1). If you manually added files to "
            "the project directory, you might need to move them out of the "

--- a/libs/librepcb/core/serialization/serializableobjectlist.h
+++ b/libs/librepcb/core/serialization/serializableobjectlist.h
@@ -514,10 +514,7 @@ protected:  // Data
  *would create a deep copy of the list! You should use C++11 range based for
  *loops instead.
  ******************************************************************************/
-
-#if (QT_VERSION > QT_VERSION_CHECK(5, 9, 0))
 namespace QtPrivate {
-#endif
 
 template <typename T, typename P, typename... OnEditedArgs>
 class QForeachContainer<
@@ -532,9 +529,7 @@ public:
   ~QForeachContainer() = delete;
 };
 
-#if (QT_VERSION > QT_VERSION_CHECK(5, 9, 0))
 }  // namespace QtPrivate
-#endif
 
 /*******************************************************************************
  *  End of File

--- a/libs/librepcb/editor/editorcommand.cpp
+++ b/libs/librepcb/editor/editorcommand.cpp
@@ -192,13 +192,8 @@ bool EditorCommand::eventFilter(QObject* obj, QEvent* event) noexcept {
                 });
       if (!candidates.empty()) {
         qDebug() << "Ambiguous shortcut resolved:" << se->key().toString();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QMetaObject::invokeMethod(candidates.first(), &QAction::trigger,
                                   Qt::QueuedConnection);
-#else
-        QMetaObject::invokeMethod(candidates.first(), "trigger",
-                                  Qt::QueuedConnection);
-#endif
         return true;
       }
     }

--- a/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.cpp
+++ b/libs/librepcb/editor/library/dev/padsignalmapeditorwidget.cpp
@@ -330,14 +330,9 @@ void PadSignalMapEditorWidget::keyPressEvent(QKeyEvent* e) noexcept {
  ******************************************************************************/
 
 void PadSignalMapEditorWidget::scheduleToolButtonPositionUpdate() noexcept {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
   QMetaObject::invokeMethod(this,
                             &PadSignalMapEditorWidget::updateToolButtonPosition,
                             Qt::QueuedConnection);
-#else
-  QMetaObject::invokeMethod(this, "updateToolButtonPosition",
-                            Qt::QueuedConnection);
-#endif
 }
 
 void PadSignalMapEditorWidget::updateToolButtonPosition() noexcept {

--- a/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematiceditor.cpp
@@ -788,7 +788,6 @@ void SchematicEditor::createDockWidgets() noexcept {
   addDockWidget(Qt::RightDockWidgetArea, mDockErc.data(), Qt::Vertical);
 
   // Set reasonable default dock size.
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
   resizeDocks(
       {
           mDockPages.data(),
@@ -799,7 +798,6 @@ void SchematicEditor::createDockWidgets() noexcept {
           150,
       },
       Qt::Horizontal);
-#endif
 }
 
 void SchematicEditor::createMenus() noexcept {

--- a/libs/librepcb/editor/utils/editortoolbox.cpp
+++ b/libs/librepcb/editor/utils/editortoolbox.cpp
@@ -112,9 +112,7 @@ bool EditorToolbox::removeFormLayoutRow(QLayout& layout,
       if ((labelItem) && (labelItem->widget() == &label) && (fieldItem)) {
         hideLayoutItem(*labelItem);
         hideLayoutItem(*fieldItem);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
         formLayout->takeRow(i);  // Avoid ugly space caused by the empty rows.
-#endif
         return true;
       }
     }

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -246,14 +246,7 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
     mKeyboardShortcutsFilterModel->setFilterCaseSensitivity(
         Qt::CaseInsensitive);
     mKeyboardShortcutsFilterModel->setFilterKeyColumn(-1);  // All columns.
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     mKeyboardShortcutsFilterModel->setRecursiveFilteringEnabled(true);
-#else
-    // Filtering would be more complicated with Qt < 5.10, not really worth
-    // the effort. Thus simply don't provide the filter feature.
-    mUi->line->hide();
-    mUi->edtCommandFilter->hide();
-#endif
     connect(mUi->edtCommandFilter, &QLineEdit::textChanged,
             mKeyboardShortcutsFilterModel.data(),
             &QSortFilterProxyModel::setFilterFixedString);

--- a/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
+++ b/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
@@ -114,8 +114,7 @@ protected:
     QTest::keyClick(&dlg, Qt::Key_Enter);
 
     // Wait until the dialog is hidden, which means the export has finished.
-    EXPECT_TRUE(
-        TestHelpers::waitFor([&]() { return !dlg.isVisible(); }, timeoutMs));
+    EXPECT_TRUE(QTest::qWaitFor([&]() { return !dlg.isVisible(); }, timeoutMs));
 
     // Make dialog ready again for further tests.
     dlg.show();
@@ -133,8 +132,7 @@ protected:
     btn.click();
 
     // Wait until the dialog is hidden, which means the export has finished.
-    EXPECT_TRUE(
-        TestHelpers::waitFor([&]() { return !dlg.isVisible(); }, timeoutMs));
+    EXPECT_TRUE(QTest::qWaitFor([&]() { return !dlg.isVisible(); }, timeoutMs));
 
     // Make dialog ready again for further tests.
     dlg.show();

--- a/tests/unittests/testhelpers.h
+++ b/tests/unittests/testhelpers.h
@@ -26,7 +26,6 @@
 #include <librepcb/core/exceptions.h>
 
 #include <QtCore>
-#include <QtTest>
 
 /*******************************************************************************
  *  Namespace
@@ -52,35 +51,6 @@ public:
   TestHelpers& operator=(const TestHelpers& rhs) = delete;
 
   // Static Methods
-
-  /**
-   * @brief Wait for a particular state
-   *
-   * Same as `QTest::qWaitFor()`, but with own implementation for Qt < 5.10.
-   *
-   * @param predicate   Function which must return `true` once the desired
-   *                    condition is met.
-   * @param timeoutMs   Timeout [ms].
-   * @retval true   If the condition is met within the timeout.
-   * @retval false  On timeout.
-   */
-  template <typename Functor>
-  static bool waitFor(Functor predicate, int timeoutMs = 5000) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-    return QTest::qWaitFor(predicate, timeoutMs);
-#else
-    QElapsedTimer timer;
-    timer.start();
-    do {
-      if (predicate()) {
-        return true;
-      }
-      QCoreApplication::processEvents(QEventLoop::AllEvents);
-      QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
-    } while (!timer.hasExpired(timeoutMs));
-    return predicate();
-#endif
-  }
 
   /**
    * @brief Get a child object of a given parent object by path specification


### PR DESCRIPTION
These old versions are not needed anymore and weren't tested on CI anyway so it's easy to get rid of them...

Qt5.12 and CMake 3.16 are the versions of the still supported Ubuntu 20.04 and are also still used on CI.