### PR TITLE
Fix colors of BOM/PnP table rows with dark theme

### DIFF
--- a/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/boardpickplacegeneratordialog.cpp
@@ -209,7 +209,10 @@ void BoardPickPlaceGeneratorDialog::updateData() noexcept {
         QTableWidgetItem* item = new QTableWidgetItem(text);
         if ((row >= mData->getItems().count()) ||
             (!mData->getItems().at(row).isMount())) {
-          item->setBackground(Qt::gray);
+          // Don't use hardcoded colors because of light/dark theme support.
+          item->setBackground(
+              palette().color(QPalette::Disabled, QPalette::Base));
+          item->setForeground(palette().color(QPalette::PlaceholderText));
         }
         mUi->tableWidget->setItem(row, column, item);
       }

--- a/libs/librepcb/editor/project/bomgeneratordialog.cpp
+++ b/libs/librepcb/editor/project/bomgeneratordialog.cpp
@@ -325,7 +325,10 @@ void BomGeneratorDialog::updateTable() noexcept {
         text.replace("\n", " ");
         QTableWidgetItem* item = new QTableWidgetItem(text);
         if (csv->getValues()[row][0] == "0") {
-          item->setBackground(Qt::gray);
+          // Don't use hardcoded colors because of light/dark theme support.
+          item->setBackground(
+              palette().color(QPalette::Disabled, QPalette::Base));
+          item->setForeground(palette().color(QPalette::PlaceholderText));
         }
         mUi->tableWidget->setItem(row, column, item);
       }


### PR DESCRIPTION
Rows of do-not-mount components were not readable well with dark theme, which is fixed by using the theme-dependent colors from QPalette.