### PR TITLE
Give GUI higher thread priority than background tasks

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -60,6 +60,10 @@ static int appExec() noexcept;
 int main(int argc, char* argv[]) {
   QApplication app(argc, argv);
 
+  // Give the main thread a higher priority than most other threads as GUI
+  // rendering and event processing are important for a smooth user experience.
+  QThread::currentThread()->setPriority(QThread::HighPriority);
+
   // Set the organization / application names must be done very early because
   // some other classes will use these values (for example QSettings, Debug)!
   setApplicationMetadata();

--- a/libs/librepcb/core/network/networkaccessmanager.cpp
+++ b/libs/librepcb/core/network/networkaccessmanager.cpp
@@ -56,8 +56,9 @@ NetworkAccessManager::NetworkAccessManager(const FilePath& cache) noexcept
   connect(qApp, &QCoreApplication::aboutToQuit, this,
           &NetworkAccessManager::stop, Qt::DirectConnection);
 
-  // start the thread and wait until the thread is started successfully
-  start();
+  // Start the thread and wait until the thread is started successfully.
+  // Use a lower priority to not risk blocking the GUI thread.
+  start(QThread::LowPriority);
   mThreadStartSemaphore.acquire();
 }
 

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -58,7 +58,11 @@ WorkspaceLibraryScanner::WorkspaceLibraryScanner(
       this, &WorkspaceLibraryScanner::scanProgressUpdate, this,
       [this](int percent) { mLastProgressPercent = percent; },
       Qt::QueuedConnection);
-  start();
+
+  // Run thread with the lowest priority to not risk blocking the GUI thread.
+  // In manual tests with Qt6Quick it was observed that any higher priority
+  // sometimes freezes the GUI significantly.
+  start(QThread::LowestPriority);
 }
 
 WorkspaceLibraryScanner::~WorkspaceLibraryScanner() noexcept {


### PR DESCRIPTION
In some experiments with QtQuick I observed significant lags in the GUI when the background library scanner was running, which seem to be fixed by giving the main thread (GUI) a higher priority than the library scanner. Though not sure if relevant with QtWidgets (not using QtQuick for now) and some systems might not support thread priorities, I think it makes sense anyway to assign thread priorities. Thus now also assigned the network thread a lower priority than the main thread.