### PR TITLE
Package editor: Support copying properties to other objects

### DIFF
--- a/libs/librepcb/editor/graphics/circlegraphicsitem.h
+++ b/libs/librepcb/editor/graphics/circlegraphicsitem.h
@@ -55,7 +55,7 @@ public:
   virtual ~CircleGraphicsItem() noexcept;
 
   // Getters
-  Circle& getCircle() noexcept { return mCircle; }
+  Circle& getObj() noexcept { return mCircle; }
 
   // Operator Overloadings
   CircleGraphicsItem& operator=(const CircleGraphicsItem& rhs) = delete;

--- a/libs/librepcb/editor/graphics/holegraphicsitem.h
+++ b/libs/librepcb/editor/graphics/holegraphicsitem.h
@@ -56,7 +56,7 @@ public:
   virtual ~HoleGraphicsItem() noexcept;
 
   // Getters
-  Hole& getHole() noexcept { return mHole; }
+  Hole& getObj() noexcept { return mHole; }
 
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;

--- a/libs/librepcb/editor/graphics/polygongraphicsitem.h
+++ b/libs/librepcb/editor/graphics/polygongraphicsitem.h
@@ -55,7 +55,7 @@ public:
   virtual ~PolygonGraphicsItem() noexcept;
 
   // Getters
-  Polygon& getPolygon() noexcept { return mPolygon; }
+  Polygon& getObj() noexcept { return mPolygon; }
 
   /// Get the line segment at a specific position
   ///

--- a/libs/librepcb/editor/graphics/stroketextgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/stroketextgraphicsitem.h
@@ -57,7 +57,7 @@ public:
   virtual ~StrokeTextGraphicsItem() noexcept;
 
   // Getters
-  StrokeText& getText() noexcept { return mText; }
+  StrokeText& getObj() noexcept { return mText; }
 
   // General Methods
   void setTextOverride(const tl::optional<QString>& text) noexcept;

--- a/libs/librepcb/editor/graphics/textgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/textgraphicsitem.h
@@ -56,7 +56,7 @@ public:
   virtual ~TextGraphicsItem() noexcept;
 
   // Getters
-  Text& getText() noexcept { return mText; }
+  Text& getObj() noexcept { return mText; }
 
   // Setters
   void setTextOverride(const tl::optional<QString>& text) noexcept;

--- a/libs/librepcb/editor/graphics/zonegraphicsitem.h
+++ b/libs/librepcb/editor/graphics/zonegraphicsitem.h
@@ -55,7 +55,7 @@ public:
   virtual ~ZoneGraphicsItem() noexcept;
 
   // Getters
-  Zone& getZone() noexcept { return mZone; }
+  Zone& getObj() noexcept { return mZone; }
 
   // Operator Overloadings
   ZoneGraphicsItem& operator=(const ZoneGraphicsItem& rhs) = delete;

--- a/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.cpp
@@ -69,9 +69,9 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
       context.currentGraphicsItem->getSelectedPads();
   foreach (const std::shared_ptr<FootprintPadGraphicsItem>& pad, pads) {
     Q_ASSERT(pad);
-    mPadEditCmds.append(new CmdFootprintPadEdit(*pad->getPad()));
-    mCenterPos += pad->getPad()->getPosition();
-    if (!pad->getPad()->getPosition().isOnGrid(grid)) {
+    mPadEditCmds.append(new CmdFootprintPadEdit(pad->getObj()));
+    mCenterPos += pad->getObj().getPosition();
+    if (!pad->getObj().getPosition().isOnGrid(grid)) {
       mHasOffTheGridElements = true;
     }
     ++count;
@@ -81,9 +81,9 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
       context.currentGraphicsItem->getSelectedCircles();
   foreach (const std::shared_ptr<CircleGraphicsItem>& circle, circles) {
     Q_ASSERT(circle);
-    mCircleEditCmds.append(new CmdCircleEdit(circle->getCircle()));
-    mCenterPos += circle->getCircle().getCenter();
-    if (!circle->getCircle().getCenter().isOnGrid(grid)) {
+    mCircleEditCmds.append(new CmdCircleEdit(circle->getObj()));
+    mCenterPos += circle->getObj().getCenter();
+    if (!circle->getObj().getCenter().isOnGrid(grid)) {
       mHasOffTheGridElements = true;
     }
     ++count;
@@ -93,9 +93,8 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
       context.currentGraphicsItem->getSelectedPolygons();
   foreach (const std::shared_ptr<PolygonGraphicsItem>& polygon, polygons) {
     Q_ASSERT(polygon);
-    mPolygonEditCmds.append(new CmdPolygonEdit(polygon->getPolygon()));
-    foreach (const Vertex& vertex,
-             polygon->getPolygon().getPath().getVertices()) {
+    mPolygonEditCmds.append(new CmdPolygonEdit(polygon->getObj()));
+    foreach (const Vertex& vertex, polygon->getObj().getPath().getVertices()) {
       mCenterPos += vertex.getPos();
       if (!vertex.getPos().isOnGrid(grid)) {
         mHasOffTheGridElements = true;
@@ -108,9 +107,9 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
       context.currentGraphicsItem->getSelectedStrokeTexts();
   foreach (const std::shared_ptr<StrokeTextGraphicsItem>& text, texts) {
     Q_ASSERT(text);
-    mTextEditCmds.append(new CmdStrokeTextEdit(text->getText()));
-    mCenterPos += text->getText().getPosition();
-    if (!text->getText().getPosition().isOnGrid(grid)) {
+    mTextEditCmds.append(new CmdStrokeTextEdit(text->getObj()));
+    mCenterPos += text->getObj().getPosition();
+    if (!text->getObj().getPosition().isOnGrid(grid)) {
       mHasOffTheGridElements = true;
     }
     ++count;
@@ -120,8 +119,8 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
       context.currentGraphicsItem->getSelectedZones();
   foreach (const std::shared_ptr<ZoneGraphicsItem>& zone, zones) {
     Q_ASSERT(zone);
-    mZoneEditCmds.append(new CmdZoneEdit(zone->getZone()));
-    foreach (const Vertex& vertex, zone->getZone().getOutline().getVertices()) {
+    mZoneEditCmds.append(new CmdZoneEdit(zone->getObj()));
+    foreach (const Vertex& vertex, zone->getObj().getOutline().getVertices()) {
       mCenterPos += vertex.getPos();
       if (!vertex.getPos().isOnGrid(grid)) {
         mHasOffTheGridElements = true;
@@ -136,8 +135,8 @@ CmdDragSelectedFootprintItems::CmdDragSelectedFootprintItems(
     Q_ASSERT(hole);
     // Note: The const_cast<> is a bit ugly, but it was by far the easiest
     // way and is safe since here we know that we're allowed to modify the hole.
-    mHoleEditCmds.append(new CmdHoleEdit(const_cast<Hole&>(hole->getHole())));
-    const Point pos = hole->getHole().getPath()->getVertices().first().getPos();
+    mHoleEditCmds.append(new CmdHoleEdit(hole->getObj()));
+    const Point pos = hole->getObj().getPath()->getVertices().first().getPos();
     mCenterPos += pos;
     if (!pos.isOnGrid(grid)) {
       mHasOffTheGridElements = true;

--- a/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedsymbolitems.cpp
@@ -62,9 +62,9 @@ CmdDragSelectedSymbolItems::CmdDragSelectedSymbolItems(
       context.symbolGraphicsItem.getSelectedPins();
   foreach (const std::shared_ptr<SymbolPinGraphicsItem>& pin, pins) {
     Q_ASSERT(pin);
-    mPinEditCmds.append(new CmdSymbolPinEdit(pin->getPin()));
-    mCenterPos += pin->getPin()->getPosition();
-    if (!pin->getPin()->getPosition().isOnGrid(grid)) {
+    mPinEditCmds.append(new CmdSymbolPinEdit(pin->getPtr()));
+    mCenterPos += pin->getObj().getPosition();
+    if (!pin->getObj().getPosition().isOnGrid(grid)) {
       mHasOffTheGridElements = true;
     }
     ++count;
@@ -74,9 +74,9 @@ CmdDragSelectedSymbolItems::CmdDragSelectedSymbolItems(
       context.symbolGraphicsItem.getSelectedCircles();
   foreach (const std::shared_ptr<CircleGraphicsItem>& circle, circles) {
     Q_ASSERT(circle);
-    mCircleEditCmds.append(new CmdCircleEdit(circle->getCircle()));
-    mCenterPos += circle->getCircle().getCenter();
-    if (!circle->getCircle().getCenter().isOnGrid(grid)) {
+    mCircleEditCmds.append(new CmdCircleEdit(circle->getObj()));
+    mCenterPos += circle->getObj().getCenter();
+    if (!circle->getObj().getCenter().isOnGrid(grid)) {
       mHasOffTheGridElements = true;
     }
     ++count;
@@ -86,9 +86,8 @@ CmdDragSelectedSymbolItems::CmdDragSelectedSymbolItems(
       context.symbolGraphicsItem.getSelectedPolygons();
   foreach (const std::shared_ptr<PolygonGraphicsItem>& polygon, polygons) {
     Q_ASSERT(polygon);
-    mPolygonEditCmds.append(new CmdPolygonEdit(polygon->getPolygon()));
-    foreach (const Vertex& vertex,
-             polygon->getPolygon().getPath().getVertices()) {
+    mPolygonEditCmds.append(new CmdPolygonEdit(polygon->getObj()));
+    foreach (const Vertex& vertex, polygon->getObj().getPath().getVertices()) {
       mCenterPos += vertex.getPos();
       if (!vertex.getPos().isOnGrid(grid)) {
         mHasOffTheGridElements = true;
@@ -101,9 +100,9 @@ CmdDragSelectedSymbolItems::CmdDragSelectedSymbolItems(
       context.symbolGraphicsItem.getSelectedTexts();
   foreach (const std::shared_ptr<TextGraphicsItem>& text, texts) {
     Q_ASSERT(text);
-    mTextEditCmds.append(new CmdTextEdit(text->getText()));
-    mCenterPos += text->getText().getPosition();
-    if (!text->getText().getPosition().isOnGrid(grid)) {
+    mTextEditCmds.append(new CmdTextEdit(text->getObj()));
+    mCenterPos += text->getObj().getPosition();
+    if (!text->getObj().getPosition().isOnGrid(grid)) {
       mHasOffTheGridElements = true;
     }
     ++count;

--- a/libs/librepcb/editor/library/cmd/cmdremoveselectedfootprintitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdremoveselectedfootprintitems.cpp
@@ -67,40 +67,40 @@ bool CmdRemoveSelectedFootprintItems::performExecute() {
   // remove pins
   foreach (const auto& pad, mContext.currentGraphicsItem->getSelectedPads()) {
     appendChild(new CmdFootprintPadRemove(mContext.currentFootprint->getPads(),
-                                          pad->getPad().get()));
+                                          &pad->getObj()));
   }
 
   // remove circles
   foreach (const auto& circle,
            mContext.currentGraphicsItem->getSelectedCircles()) {
     appendChild(new CmdCircleRemove(mContext.currentFootprint->getCircles(),
-                                    &circle->getCircle()));
+                                    &circle->getObj()));
   }
 
   // remove polygons
   foreach (const auto& polygon,
            mContext.currentGraphicsItem->getSelectedPolygons()) {
     appendChild(new CmdPolygonRemove(mContext.currentFootprint->getPolygons(),
-                                     &polygon->getPolygon()));
+                                     &polygon->getObj()));
   }
 
   // remove texts
   foreach (const auto& text,
            mContext.currentGraphicsItem->getSelectedStrokeTexts()) {
     appendChild(new CmdStrokeTextRemove(
-        mContext.currentFootprint->getStrokeTexts(), &text->getText()));
+        mContext.currentFootprint->getStrokeTexts(), &text->getObj()));
   }
 
   // remove zones
   foreach (const auto& zone, mContext.currentGraphicsItem->getSelectedZones()) {
     appendChild(new CmdZoneRemove(mContext.currentFootprint->getZones(),
-                                  &zone->getZone()));
+                                  &zone->getObj()));
   }
 
   // remove holes
   foreach (const auto& hole, mContext.currentGraphicsItem->getSelectedHoles()) {
     appendChild(new CmdHoleRemove(mContext.currentFootprint->getHoles(),
-                                  &hole->getHole()));
+                                  &hole->getObj()));
   }
 
   // execute all child commands

--- a/libs/librepcb/editor/library/cmd/cmdremoveselectedsymbolitems.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdremoveselectedsymbolitems.cpp
@@ -62,27 +62,26 @@ bool CmdRemoveSelectedSymbolItems::performExecute() {
   // remove pins
   foreach (const auto& pin, mContext.symbolGraphicsItem.getSelectedPins()) {
     appendChild(
-        new CmdSymbolPinRemove(mContext.symbol.getPins(), pin->getPin().get()));
+        new CmdSymbolPinRemove(mContext.symbol.getPins(), &pin->getObj()));
   }
 
   // remove circles
   foreach (const auto& circle,
            mContext.symbolGraphicsItem.getSelectedCircles()) {
-    appendChild(new CmdCircleRemove(mContext.symbol.getCircles(),
-                                    &circle->getCircle()));
+    appendChild(
+        new CmdCircleRemove(mContext.symbol.getCircles(), &circle->getObj()));
   }
 
   // remove polygons
   foreach (const auto& polygon,
            mContext.symbolGraphicsItem.getSelectedPolygons()) {
     appendChild(new CmdPolygonRemove(mContext.symbol.getPolygons(),
-                                     &polygon->getPolygon()));
+                                     &polygon->getObj()));
   }
 
   // remove texts
   foreach (const auto& text, mContext.symbolGraphicsItem.getSelectedTexts()) {
-    appendChild(
-        new CmdTextRemove(mContext.symbol.getTexts(), &text->getText()));
+    appendChild(new CmdTextRemove(mContext.symbol.getTexts(), &text->getObj()));
   }
 
   // execute all child commands

--- a/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintgraphicsitem.cpp
@@ -219,8 +219,8 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
   if (flags.testFlag(FindFlag::Pads)) {
     foreach (auto ptr, mPadGraphicsItems) {
       int priority = 10;
-      if (!ptr->getPad()->isTht()) {
-        priority += priorityFromLayer(ptr->getPad()->getSmtLayer());
+      if (!ptr->getObj().isTht()) {
+        priority += priorityFromLayer(ptr->getObj().getSmtLayer());
       }
       processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
                   false);
@@ -230,13 +230,13 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
   if (flags.testFlag(FindFlag::StrokeTexts)) {
     foreach (auto ptr, mStrokeTextGraphicsItems) {
       processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr),
-                  20 + priorityFromLayer(ptr->getText().getLayer()), false);
+                  20 + priorityFromLayer(ptr->getObj().getLayer()), false);
     }
   }
 
   if (flags.testFlag(FindFlag::Circles)) {
     foreach (auto ptr, mCircleGraphicsItems) {
-      int priority = 30 + priorityFromLayer(ptr->getCircle().getLayer());
+      int priority = 30 + priorityFromLayer(ptr->getObj().getLayer());
       if (ptr->zValue() > 0) priority -= 1;
       if (ptr->zValue() < 0) priority += 1;
       processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
@@ -246,7 +246,7 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
 
   if (flags.testFlag(FindFlag::Polygons)) {
     foreach (auto ptr, mPolygonGraphicsItems) {
-      int priority = 30 + priorityFromLayer(ptr->getPolygon().getLayer());
+      int priority = 30 + priorityFromLayer(ptr->getObj().getLayer());
       if (ptr->zValue() > 0) priority -= 1;
       if (ptr->zValue() < 0) priority += 1;
       processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
@@ -257,11 +257,11 @@ QList<std::shared_ptr<QGraphicsItem>> FootprintGraphicsItem::findItemsAtPos(
   if (flags.testFlag(FindFlag::Zones)) {
     foreach (auto ptr, mZoneGraphicsItems) {
       int priority = 40;
-      if (ptr->getZone().getLayers().testFlag(Zone::Layer::Top)) {
+      if (ptr->getObj().getLayers().testFlag(Zone::Layer::Top)) {
         priority += 100;
-      } else if (ptr->getZone().getLayers().testFlag(Zone::Layer::Inner)) {
+      } else if (ptr->getObj().getLayers().testFlag(Zone::Layer::Inner)) {
         priority += 200;
-      } else if (ptr->getZone().getLayers().testFlag(Zone::Layer::Bottom)) {
+      } else if (ptr->getObj().getLayers().testFlag(Zone::Layer::Bottom)) {
         priority += 300;
       }
       processItem(std::dynamic_pointer_cast<QGraphicsItem>(ptr), priority,
@@ -514,7 +514,7 @@ void FootprintGraphicsItem::substituteText(
       }
     };
     text.setTextOverride(
-        AttributeSubstitutor::substitute(text.getText().getText(), lookup));
+        AttributeSubstitutor::substitute(text.getObj().getText(), lookup));
   }
 }
 

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.h
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.h
@@ -59,7 +59,7 @@ public:
   ~FootprintPadGraphicsItem() noexcept;
 
   // Getters
-  const std::shared_ptr<FootprintPad>& getPad() noexcept { return mPad; }
+  FootprintPad& getObj() noexcept { return *mPad; }
 
   // General Methods
   void updateText() noexcept;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -780,7 +780,7 @@ bool PackageEditorState_Select::openContextMenuAtPos(
   if (auto i = std::dynamic_pointer_cast<PolygonGraphicsItem>(selectedItem)) {
     if (mContext.currentFootprint) {
       if (auto polygon =
-              mContext.currentFootprint->getPolygons().find(&i->getPolygon())) {
+              mContext.currentFootprint->getPolygons().find(&i->getObj())) {
         QVector<int> vertices = i->getVertexIndicesAtPosition(pos);
         if (!vertices.isEmpty()) {
           QAction* aRemove = cmd.vertexRemove.createAction(
@@ -814,7 +814,7 @@ bool PackageEditorState_Select::openContextMenuAtPos(
   if (auto i = std::dynamic_pointer_cast<ZoneGraphicsItem>(selectedItem)) {
     if (mContext.currentFootprint) {
       if (auto zone =
-              mContext.currentFootprint->getZones().find(&i->getZone())) {
+              mContext.currentFootprint->getZones().find(&i->getObj())) {
         QVector<int> vertices = i->getVertexIndicesAtPosition(pos);
         if (!vertices.isEmpty()) {
           QAction* aRemove = cmd.vertexRemove.createAction(
@@ -903,7 +903,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
 
   if (auto i = std::dynamic_pointer_cast<FootprintPadGraphicsItem>(item)) {
     FootprintPadPropertiesDialog dialog(
-        mContext.package, *i->getPad(), mContext.undoStack, getLengthUnit(),
+        mContext.package, i->getObj(), mContext.undoStack, getLengthUnit(),
         "package_editor/footprint_pad_properties_dialog",
         &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
@@ -911,7 +911,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (auto i = std::dynamic_pointer_cast<StrokeTextGraphicsItem>(item)) {
     StrokeTextPropertiesDialog dialog(
-        i->getText(), mContext.undoStack, getAllowedTextLayers(),
+        i->getObj(), mContext.undoStack, getAllowedTextLayers(),
         getLengthUnit(), "package_editor/stroke_text_properties_dialog",
         &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
@@ -919,7 +919,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (auto i = std::dynamic_pointer_cast<PolygonGraphicsItem>(item)) {
     PolygonPropertiesDialog dialog(
-        i->getPolygon(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
+        i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "package_editor/polygon_properties_dialog",
         &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
@@ -927,7 +927,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (auto i = std::dynamic_pointer_cast<CircleGraphicsItem>(item)) {
     CirclePropertiesDialog dialog(
-        i->getCircle(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
+        i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "package_editor/circle_properties_dialog",
         &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
@@ -935,7 +935,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (auto i = std::dynamic_pointer_cast<ZoneGraphicsItem>(item)) {
     ZonePropertiesDialog dialog(
-        i->getZone(), mContext.undoStack, getLengthUnit(),
+        i->getObj(), mContext.undoStack, getLengthUnit(),
         mContext.editorContext.layerProvider,
         "package_editor/zone_properties_dialog", &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
@@ -945,7 +945,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     // Note: The const_cast<> is a bit ugly, but it was by far the easiest
     // way and is safe since here we know that we're allowed to modify the hole.
     HolePropertiesDialog dialog(
-        const_cast<Hole&>(i->getHole()), mContext.undoStack, getLengthUnit(),
+        const_cast<Hole&>(i->getObj()), mContext.undoStack, getLengthUnit(),
         "package_editor/hole_properties_dialog", &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
     dialog.exec();
@@ -979,34 +979,33 @@ bool PackageEditorState_Select::copySelectedItemsToClipboard() noexcept {
              mContext.currentGraphicsItem->getSelectedPads()) {
       Q_ASSERT(pad);
       data.getFootprintPads().append(
-          std::make_shared<FootprintPad>(*pad->getPad()));
+          std::make_shared<FootprintPad>(pad->getObj()));
     }
     foreach (const std::shared_ptr<CircleGraphicsItem>& circle,
              mContext.currentGraphicsItem->getSelectedCircles()) {
       Q_ASSERT(circle);
-      data.getCircles().append(std::make_shared<Circle>(circle->getCircle()));
+      data.getCircles().append(std::make_shared<Circle>(circle->getObj()));
     }
     foreach (const std::shared_ptr<PolygonGraphicsItem>& polygon,
              mContext.currentGraphicsItem->getSelectedPolygons()) {
       Q_ASSERT(polygon);
-      data.getPolygons().append(
-          std::make_shared<Polygon>(polygon->getPolygon()));
+      data.getPolygons().append(std::make_shared<Polygon>(polygon->getObj()));
     }
     foreach (const std::shared_ptr<StrokeTextGraphicsItem>& text,
              mContext.currentGraphicsItem->getSelectedStrokeTexts()) {
       Q_ASSERT(text);
       data.getStrokeTexts().append(
-          std::make_shared<StrokeText>(text->getText()));
+          std::make_shared<StrokeText>(text->getObj()));
     }
     foreach (const std::shared_ptr<ZoneGraphicsItem>& zone,
              mContext.currentGraphicsItem->getSelectedZones()) {
       Q_ASSERT(zone);
-      data.getZones().append(std::make_shared<Zone>(zone->getZone()));
+      data.getZones().append(std::make_shared<Zone>(zone->getObj()));
     }
     foreach (const std::shared_ptr<HoleGraphicsItem>& hole,
              mContext.currentGraphicsItem->getSelectedHoles()) {
       Q_ASSERT(hole);
-      data.getHoles().append(std::make_shared<Hole>(hole->getHole()));
+      data.getHoles().append(std::make_shared<Hole>(hole->getObj()));
     }
     if (data.getItemCount() > 0) {
       qApp->clipboard()->setMimeData(

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -23,7 +23,9 @@
 #include "packageeditorstate_select.h"
 
 #include "../../../cmd/cmdcircleedit.h"
+#include "../../../cmd/cmdholeedit.h"
 #include "../../../cmd/cmdpolygonedit.h"
+#include "../../../cmd/cmdstroketextedit.h"
 #include "../../../cmd/cmdzoneedit.h"
 #include "../../../dialogs/circlepropertiesdialog.h"
 #include "../../../dialogs/dxfimportdialog.h"
@@ -43,6 +45,7 @@
 #include "../../../widgets/graphicsview.h"
 #include "../../../widgets/positivelengthedit.h"
 #include "../../cmd/cmddragselectedfootprintitems.h"
+#include "../../cmd/cmdfootprintpadedit.h"
 #include "../../cmd/cmdpastefootprintitems.h"
 #include "../../cmd/cmdremoveselectedfootprintitems.h"
 #include "../footprintclipboarddata.h"
@@ -430,7 +433,14 @@ bool PackageEditorState_Select::processPaste() noexcept {
             FootprintClipboardData::fromMimeData(
                 qApp->clipboard()->mimeData());  // can throw
         if (data) {
-          return startPaste(std::move(data), tl::nullopt);
+          if (canPasteGeometry(data)) {
+            // Only one object in clipboard and objects of same type selected,
+            // thus only paste the geometry to the selected pads (not inserting
+            // the copied object).
+            return pasteGeometryFromClipboard(std::move(data));
+          } else {
+            return startPaste(std::move(data), tl::nullopt);
+          }
         }
       } catch (const Exception& e) {
         QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
@@ -853,6 +863,28 @@ bool PackageEditorState_Select::openContextMenuAtPos(
       &menu, this, [this]() { copySelectedItemsToClipboard(); });
   aCopy->setEnabled(features.contains(EditorWidgetBase::Feature::Copy));
   mb.addAction(aCopy);
+
+  // If exactly one object is in the clipboard and objects of the same type are
+  // selected, provide the "paste geometry" action.
+  std::unique_ptr<FootprintClipboardData> clipboardData;
+  try {
+    clipboardData = FootprintClipboardData::fromMimeData(
+        qApp->clipboard()->mimeData());  // can throw
+    if (canPasteGeometry(clipboardData)) {
+      QAction* aPaste = cmd.clipboardPaste.createAction(
+          &menu, this, [this, &clipboardData]() {
+            pasteGeometryFromClipboard(std::move(clipboardData));
+          });
+      aPaste->setText(tr("Paste Geometry"));
+      aPaste->setToolTip(
+          tr("Apply the same geometry as the object in the clipboard"));
+      aPaste->setEnabled(features.contains(EditorWidgetBase::Feature::Paste));
+      mb.addAction(aPaste);
+    }
+  } catch (const Exception& e) {
+    qCritical() << e.getMsg();
+  }
+
   QAction* aRemove =
       cmd.remove.createAction(&menu, this, [this]() { removeSelectedItems(); });
   aRemove->setEnabled(features.contains(EditorWidgetBase::Feature::Remove));
@@ -1016,6 +1048,145 @@ bool PackageEditorState_Select::copySelectedItemsToClipboard() noexcept {
     QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
   }
   return true;
+}
+
+template <typename TCpy, typename TSel>
+static bool hasSelectedObjects(const TCpy& copied,
+                               const TSel& selected) noexcept {
+  if (auto copiedObj = copied.value(0)) {
+    foreach (const auto& sel, selected) {
+      if (sel && (sel->getObj().getUuid() != copiedObj->getUuid())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool PackageEditorState_Select::canPasteGeometry(
+    const std::unique_ptr<FootprintClipboardData>& data) const noexcept {
+  if ((!data) || (!mContext.currentFootprint) ||
+      (!mContext.currentGraphicsItem)) {
+    return false;
+  }
+
+  // Can paste only if there is exactly one object in clipboard.
+  if (data->getFootprintPads().count() + data->getPolygons().count() +
+          data->getCircles().count() + data->getStrokeTexts().count() +
+          data->getZones().count() + data->getHoles().count() !=
+      1) {
+    return false;
+  }
+
+  // Can paste only if there is at least one object selected of the same type
+  // as the object in clipboard. But don't count the object in clipboard since
+  // it would not allow to copy&paste a single object!
+  auto g = mContext.currentGraphicsItem;
+  return hasSelectedObjects(data->getFootprintPads(), g->getSelectedPads()) ||
+      hasSelectedObjects(data->getPolygons(), g->getSelectedPolygons()) ||
+      hasSelectedObjects(data->getCircles(), g->getSelectedCircles()) ||
+      hasSelectedObjects(data->getStrokeTexts(), g->getSelectedStrokeTexts()) ||
+      hasSelectedObjects(data->getZones(), g->getSelectedZones()) ||
+      hasSelectedObjects(data->getHoles(), g->getSelectedHoles());
+}
+
+bool PackageEditorState_Select::pasteGeometryFromClipboard(
+    std::unique_ptr<FootprintClipboardData> data) noexcept {
+  Q_ASSERT(data);
+
+  // Abort if no footprint is selected or the clipboard data is invalid.
+  if ((!mContext.currentFootprint) || (!mContext.currentGraphicsItem) ||
+      (!canPasteGeometry(data))) {
+    return false;
+  }
+
+  // Paste geometry.
+  try {
+    UndoStackTransaction transaction(mContext.undoStack, tr("Paste Geometry"));
+    if (auto src = data->getFootprintPads().value(0)) {
+      foreach (const auto& dst,
+               mContext.currentGraphicsItem->getSelectedPads()) {
+        Q_ASSERT(dst);
+        QScopedPointer<CmdFootprintPadEdit> cmd(
+            new CmdFootprintPadEdit(dst->getObj()));
+        cmd->setComponentSide(src->getComponentSide(), false);
+        cmd->setFunction(src->getFunction(), false);
+        cmd->setShape(src->getShape(), false);
+        cmd->setWidth(src->getWidth(), false);
+        cmd->setHeight(src->getHeight(), false);
+        cmd->setRadius(src->getRadius(), false);
+        cmd->setCustomShapeOutline(src->getCustomShapeOutline());
+        cmd->setStopMaskConfig(src->getStopMaskConfig(), false);
+        cmd->setSolderPasteConfig(src->getSolderPasteConfig());
+        cmd->setCopperClearance(src->getCopperClearance());
+        cmd->setHoles(src->getHoles(), false);
+        transaction.append(cmd.take());
+      }
+    }
+    if (auto src = data->getPolygons().value(0)) {
+      foreach (const auto& dst,
+               mContext.currentGraphicsItem->getSelectedPolygons()) {
+        Q_ASSERT(dst);
+        QScopedPointer<CmdPolygonEdit> cmd(new CmdPolygonEdit(dst->getObj()));
+        cmd->setLayer(src->getLayer(), false);
+        cmd->setLineWidth(src->getLineWidth(), false);
+        cmd->setIsFilled(src->isFilled(), false);
+        cmd->setIsGrabArea(src->isGrabArea(), false);
+        transaction.append(cmd.take());
+      }
+    }
+    if (auto src = data->getCircles().value(0)) {
+      foreach (const auto& dst,
+               mContext.currentGraphicsItem->getSelectedCircles()) {
+        Q_ASSERT(dst);
+        QScopedPointer<CmdCircleEdit> cmd(new CmdCircleEdit(dst->getObj()));
+        cmd->setLayer(src->getLayer(), false);
+        cmd->setLineWidth(src->getLineWidth(), false);
+        cmd->setIsFilled(src->isFilled(), false);
+        cmd->setIsGrabArea(src->isGrabArea(), false);
+        cmd->setDiameter(src->getDiameter(), false);
+        transaction.append(cmd.take());
+      }
+    }
+    if (auto src = data->getStrokeTexts().value(0)) {
+      foreach (const auto& dst,
+               mContext.currentGraphicsItem->getSelectedStrokeTexts()) {
+        Q_ASSERT(dst);
+        QScopedPointer<CmdStrokeTextEdit> cmd(
+            new CmdStrokeTextEdit(dst->getObj()));
+        cmd->setLayer(src->getLayer(), false);
+        cmd->setHeight(src->getHeight(), false);
+        cmd->setStrokeWidth(src->getStrokeWidth(), false);
+        cmd->setLetterSpacing(src->getLetterSpacing(), false);
+        cmd->setLineSpacing(src->getLineSpacing(), false);
+        transaction.append(cmd.take());
+      }
+    }
+    if (auto src = data->getZones().value(0)) {
+      foreach (const auto& dst,
+               mContext.currentGraphicsItem->getSelectedZones()) {
+        Q_ASSERT(dst);
+        QScopedPointer<CmdZoneEdit> cmd(new CmdZoneEdit(dst->getObj()));
+        cmd->setLayers(src->getLayers(), false);
+        cmd->setRules(src->getRules(), false);
+        transaction.append(cmd.take());
+      }
+    }
+    if (auto src = data->getHoles().value(0)) {
+      foreach (const auto& dst,
+               mContext.currentGraphicsItem->getSelectedHoles()) {
+        Q_ASSERT(dst);
+        QScopedPointer<CmdHoleEdit> cmd(new CmdHoleEdit(dst->getObj()));
+        cmd->setDiameter(src->getDiameter(), false);
+        cmd->setStopMaskConfig(src->getStopMaskConfig());
+        transaction.append(cmd.take());
+      }
+    }
+    return transaction.commit();  // can throw
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+    return false;
+  }
 }
 
 bool PackageEditorState_Select::startPaste(

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
@@ -116,6 +116,10 @@ private:  // Methods
   bool openPropertiesDialogOfItem(std::shared_ptr<QGraphicsItem> item) noexcept;
   bool openPropertiesDialogOfItemAtPos(const Point& pos) noexcept;
   bool copySelectedItemsToClipboard() noexcept;
+  bool canPasteGeometry(
+      const std::unique_ptr<FootprintClipboardData>& data) const noexcept;
+  bool pasteGeometryFromClipboard(
+      std::unique_ptr<FootprintClipboardData> data) noexcept;
   bool startPaste(std::unique_ptr<FootprintClipboardData> data,
                   const tl::optional<Point>& fixedPosition);
   bool rotateSelectedItems(const Angle& angle) noexcept;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -658,7 +658,7 @@ bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
 
   // If a polygon line is under the cursor, add vertex menu items
   if (auto i = std::dynamic_pointer_cast<PolygonGraphicsItem>(selectedItem)) {
-    if (auto polygon = mContext.symbol.getPolygons().find(&i->getPolygon())) {
+    if (auto polygon = mContext.symbol.getPolygons().find(&i->getObj())) {
       QVector<int> vertices = i->getVertexIndicesAtPosition(pos);
       if (!vertices.isEmpty()) {
         QAction* aRemoveVertex = cmd.vertexRemove.createAction(
@@ -738,13 +738,13 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
 
   if (auto i = std::dynamic_pointer_cast<SymbolPinGraphicsItem>(item)) {
     SymbolPinPropertiesDialog dialog(
-        i->getPin(), mContext.undoStack, getLengthUnit(),
+        i->getPtr(), mContext.undoStack, getLengthUnit(),
         "symbol_editor/pin_properties_dialog", &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<TextGraphicsItem>(item)) {
-    TextPropertiesDialog dialog(i->getText(), mContext.undoStack,
+    TextPropertiesDialog dialog(i->getObj(), mContext.undoStack,
                                 getAllowedTextLayers(), getLengthUnit(),
                                 "symbol_editor/text_properties_dialog",
                                 &mContext.editorWidget);
@@ -753,7 +753,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (auto i = std::dynamic_pointer_cast<PolygonGraphicsItem>(item)) {
     PolygonPropertiesDialog dialog(
-        i->getPolygon(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
+        i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "symbol_editor/polygon_properties_dialog",
         &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
@@ -761,7 +761,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     return true;
   } else if (auto i = std::dynamic_pointer_cast<CircleGraphicsItem>(item)) {
     CirclePropertiesDialog dialog(
-        i->getCircle(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
+        i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "symbol_editor/circle_properties_dialog",
         &mContext.editorWidget);
     dialog.setReadOnly(mContext.editorContext.readOnly);
@@ -790,23 +790,22 @@ bool SymbolEditorState_Select::copySelectedItemsToClipboard() noexcept {
     foreach (const std::shared_ptr<SymbolPinGraphicsItem>& pin,
              mContext.symbolGraphicsItem.getSelectedPins()) {
       Q_ASSERT(pin);
-      data.getPins().append(std::make_shared<SymbolPin>(*pin->getPin()));
+      data.getPins().append(std::make_shared<SymbolPin>(pin->getObj()));
     }
     foreach (const std::shared_ptr<CircleGraphicsItem>& circle,
              mContext.symbolGraphicsItem.getSelectedCircles()) {
       Q_ASSERT(circle);
-      data.getCircles().append(std::make_shared<Circle>(circle->getCircle()));
+      data.getCircles().append(std::make_shared<Circle>(circle->getObj()));
     }
     foreach (const std::shared_ptr<PolygonGraphicsItem>& polygon,
              mContext.symbolGraphicsItem.getSelectedPolygons()) {
       Q_ASSERT(polygon);
-      data.getPolygons().append(
-          std::make_shared<Polygon>(polygon->getPolygon()));
+      data.getPolygons().append(std::make_shared<Polygon>(polygon->getObj()));
     }
     foreach (const std::shared_ptr<TextGraphicsItem>& text,
              mContext.symbolGraphicsItem.getSelectedTexts()) {
       Q_ASSERT(text);
-      data.getTexts().append(std::make_shared<Text>(text->getText()));
+      data.getTexts().append(std::make_shared<Text>(text->getObj()));
     }
     if (data.getItemCount() > 0) {
       qApp->clipboard()->setMimeData(

--- a/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
@@ -365,7 +365,7 @@ void SymbolGraphicsItem::substituteText(TextGraphicsItem& text) noexcept {
       }
     };
     text.setTextOverride(
-        AttributeSubstitutor::substitute(text.getText().getText(), lookup));
+        AttributeSubstitutor::substitute(text.getObj().getText(), lookup));
   }
 }
 

--- a/libs/librepcb/editor/library/sym/symbolpingraphicsitem.h
+++ b/libs/librepcb/editor/library/sym/symbolpingraphicsitem.h
@@ -63,7 +63,8 @@ public:
   ~SymbolPinGraphicsItem() noexcept;
 
   // Getters
-  const std::shared_ptr<SymbolPin>& getPin() noexcept { return mPin; }
+  SymbolPin& getObj() noexcept { return *mPin; }
+  const std::shared_ptr<SymbolPin>& getPtr() noexcept { return mPin; }
 
   // General Methods
   void updateText() noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -549,7 +549,7 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
   } else if (auto item =
                  std::dynamic_pointer_cast<PolygonGraphicsItem>(selectedItem)) {
     SI_Polygon* polygon =
-        scene->getSchematic().getPolygons().value(item->getPolygon().getUuid());
+        scene->getSchematic().getPolygons().value(item->getObj().getUuid());
     if (!polygon) return false;
 
     int lineIndex = item->getLineIndexAtPosition(pos);
@@ -883,7 +883,7 @@ bool SchematicEditorState_Select::openPropertiesDialog(
     return true;
   } else if (auto polygon =
                  std::dynamic_pointer_cast<PolygonGraphicsItem>(item)) {
-    openPolygonPropertiesDialog(polygon->getPolygon());
+    openPolygonPropertiesDialog(polygon->getObj());
     return true;
   } else if (auto text = std::dynamic_pointer_cast<SGI_Text>(item)) {
     openTextPropertiesDialog(text->getText().getTextObj());


### PR DESCRIPTION
In the package editor it is a common task to modify pad geometries (e.g. width, height or drill diameter) of already added pads. But for packages with a lot of pads, this is *very* annoying because each pad has to be edited individually. So it would be very helpful to allow modifying many pads at once.

I implemented this as a quite generic feature. After copying a single object of any type (pad, polygon, hole, ...) to the clipboard as usual, the context menu contains a new item "Paste Geometry" which applies only the geometry from the copied object to the selected objects. The usual keyboard shortcuts Ctrl+C and Ctrl+V work as well since Ctrl+V automatically detects whether only the geometry shall be applied or the normal paste operation takes place. With this feature, it is now very efficient to apply changes to many objects at once - just modify one object and then copy it to the others.

![librepcb-paste-geometry](https://github.com/LibrePCB/LibrePCB/assets/5374821/afac2853-391d-4e41-b757-c44af89c8e6a)

Note that it is not possible to choose *which* properties will be copy&pasted. Basically everything except placement (X/Y/ROT; and for pads, the package pad assignment) are copied. Btw, the copy&paste works even across tabs/windows, so you can copy the pad geometry of any package in any library to another one.

Unfortunately this new powerful feature is not really promoted in the UI so maybe it is not so intuitive to find it - the (conditional) context menu item is the only visible part of the feature. However, I didn't find a better solution yet :thinking: 