### PR TITLE
Package check: Warn about thin silkscreen lines

### DIFF
--- a/libs/librepcb/core/library/pkg/packagecheck.h
+++ b/libs/librepcb/core/library/pkg/packagecheck.h
@@ -74,6 +74,7 @@ protected:  // Methods
   void checkCopperClearanceOnPads(MsgList& msgs) const;
   void checkPadFunctions(MsgList& msgs) const;
   void checkHolesStopMask(MsgList& msgs) const;
+  void checkLineWidths(MsgList& msgs) const;
   void checkZones(MsgList& msgs) const;
   void checkFootprintModels(MsgList& msgs) const;
 

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
@@ -198,6 +198,84 @@ MsgInvalidPadConnection::MsgInvalidPadConnection(
 }
 
 /*******************************************************************************
+ *  MsgMinimumWidthViolation
+ ******************************************************************************/
+
+MsgMinimumWidthViolation::MsgMinimumWidthViolation(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const Polygon> polygon, const Length& minWidth) noexcept
+  : RuleCheckMessage(
+        Severity::Warning, getMessage(footprint, polygon->getLayer()),
+        tr("It is recommended that polygons on layer '%1' have a line width of "
+           "at least %2.")
+                .arg(polygon->getLayer().getNameTr())
+                .arg(QString::number(minWidth.toMm() * 1000) % "μm") %
+            " " % getDescriptionAppendix(),
+        "thin_line"),
+    mFootprint(footprint),
+    mPolygon(polygon) {
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("polygon", polygon->getUuid());
+  mApproval->ensureLineBreak();
+}
+
+MsgMinimumWidthViolation::MsgMinimumWidthViolation(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const Circle> circle, const Length& minWidth) noexcept
+  : RuleCheckMessage(
+        Severity::Warning, getMessage(footprint, circle->getLayer()),
+        tr("It is recommended that circles on layer '%1' have a line width of "
+           "at least %2.")
+                .arg(circle->getLayer().getNameTr())
+                .arg(QString::number(minWidth.toMm() * 1000) % "μm") %
+            " " % getDescriptionAppendix(),
+        "thin_line"),
+    mFootprint(footprint),
+    mCircle(circle) {
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("circle", circle->getUuid());
+  mApproval->ensureLineBreak();
+}
+
+MsgMinimumWidthViolation::MsgMinimumWidthViolation(
+    std::shared_ptr<const Footprint> footprint,
+    std::shared_ptr<const StrokeText> text, const Length& minWidth) noexcept
+  : RuleCheckMessage(
+        Severity::Warning, getMessage(footprint, text->getLayer()),
+        tr("It is recommended that stroke texts on layer '%1' have a stroke "
+           "width of at least %2.")
+                .arg(text->getLayer().getNameTr())
+                .arg(QString::number(minWidth.toMm() * 1000) % "μm") %
+            " " % getDescriptionAppendix(),
+        "thin_line"),
+    mFootprint(footprint),
+    mStrokeText(text) {
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("footprint", footprint->getUuid());
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("text", text->getUuid());
+  mApproval->ensureLineBreak();
+}
+
+QString MsgMinimumWidthViolation::getMessage(
+    std::shared_ptr<const Footprint> footprint, const Layer& layer) noexcept {
+  return tr("Minimum width of '%1' in '%2'")
+      .arg(layer.getNameTr())
+      .arg(*footprint->getNames().getDefaultValue());
+}
+
+QString MsgMinimumWidthViolation::getDescriptionAppendix() noexcept {
+  return tr(
+      "Otherwise it could lead to manufacturing problems in some cases "
+      "(depending on board settings and/or the capabilities of the PCB "
+      "manufacturer).");
+}
+
+/*******************************************************************************
  *  MsgMissingCourtyard
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.h
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.h
@@ -33,6 +33,7 @@
  ******************************************************************************/
 namespace librepcb {
 
+class Circle;
 class Footprint;
 class FootprintPad;
 class Hole;
@@ -250,6 +251,55 @@ public:
 private:
   std::shared_ptr<const Footprint> mFootprint;
   std::shared_ptr<const FootprintPad> mPad;
+};
+
+/*******************************************************************************
+ *  Class MsgMinimumWidthViolation
+ ******************************************************************************/
+
+/**
+ * @brief The MsgMinimumWidthViolation class
+ */
+class MsgMinimumWidthViolation final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgMinimumWidthViolation)
+
+public:
+  // Constructors / Destructor
+  MsgMinimumWidthViolation() = delete;
+  MsgMinimumWidthViolation(std::shared_ptr<const Footprint> footprint,
+                           std::shared_ptr<const Polygon> polygon,
+                           const Length& minWidth) noexcept;
+  MsgMinimumWidthViolation(std::shared_ptr<const Footprint> footprint,
+                           std::shared_ptr<const Circle> circle,
+                           const Length& minWidth) noexcept;
+  MsgMinimumWidthViolation(std::shared_ptr<const Footprint> footprint,
+                           std::shared_ptr<const StrokeText> text,
+                           const Length& minWidth) noexcept;
+  MsgMinimumWidthViolation(const MsgMinimumWidthViolation& other) noexcept
+    : RuleCheckMessage(other), mFootprint(other.mFootprint) {}
+  virtual ~MsgMinimumWidthViolation() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  std::shared_ptr<const Polygon> getPolygon() const noexcept {
+    return mPolygon;
+  }
+  std::shared_ptr<const Circle> getCircle() const noexcept { return mCircle; }
+  std::shared_ptr<const StrokeText> getStrokeText() const noexcept {
+    return mStrokeText;
+  }
+
+private:
+  static QString getMessage(std::shared_ptr<const Footprint> footprint,
+                            const Layer& layer) noexcept;
+  static QString getDescriptionAppendix() noexcept;
+
+  std::shared_ptr<const Footprint> mFootprint;
+  std::shared_ptr<const Polygon> mPolygon;
+  std::shared_ptr<const Circle> mCircle;
+  std::shared_ptr<const StrokeText> mStrokeText;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
Emit warnings in the package editor if any lines (potentionally) drawn on silkscreen have a width less than 0.15mm as this could lead to manufacturing problems.