### PR TITLE
Board editor: Link "no device or package found" message to FAQ

### DIFF
--- a/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
+++ b/libs/librepcb/editor/project/boardeditor/unplacedcomponentsdock.cpp
@@ -28,6 +28,7 @@
 #include "../../project/cmd/cmdcomponentinstanceedit.h"
 #include "../../undostack.h"
 #include "../../widgets/graphicsview.h"
+#include "../../workspace/desktopservices.h"
 #include "../cmd/cmdadddevicetoboard.h"
 #include "../projecteditor.h"
 #include "ui_unplacedcomponentsdock.h"
@@ -87,6 +88,19 @@ UnplacedComponentsDock::UnplacedComponentsDock(ProjectEditor& editor,
     mPreviewGraphicsScene(new GraphicsScene()),
     mPreviewGraphicsItem(nullptr) {
   mUi->setupUi(this);
+
+  // Setup "no devices found" label.
+  mUi->lblNoDeviceFound->setText(
+      mUi->lblNoDeviceFound->text() % " " %
+      tr("See details <a href=\"%1\">here</a>.")
+          .arg("https://librepcb.org/_branches/develop/faq/"
+               "#error-no-dev-or-pkg-found"));
+  connect(mUi->lblNoDeviceFound, &QLabel::linkActivated, this,
+          [this](const QString& url) {
+            DesktopServices ds(mProjectEditor.getWorkspace().getSettings(),
+                               this);
+            ds.openWebUrl(QUrl(url));
+          });
 
   // Setup graphics view.
   const Theme& theme =


### PR DESCRIPTION
It seems a common problem that the message "No device or package for the selected component found in the library! Please add a suitable device and package to your workspace library." in the board editor confuses users, making them opening issues or forum threads explaining there's a problem with the software. So I appended a "See details here." note which points to a FAQ item I just created: https://librepcb.org/faq/#error-no-dev-or-pkg-found

Hope this makes it more clear for users what the message means and what they have to do.