### PR TITLE
Package editor: Support uppercase STEP file suffixes

### DIFF
--- a/libs/librepcb/editor/library/pkg/packagemodellistmodel.cpp
+++ b/libs/librepcb/editor/library/pkg/packagemodellistmodel.cpp
@@ -459,9 +459,9 @@ bool PackageModelListModel::chooseStepFile(QByteArray& content,
   QSettings clientSettings;
   QString key = "library_editor/package_editor/step_file";
   QString initialFp = clientSettings.value(key, QDir::homePath()).toString();
-  FilePath fp(FileDialog::getOpenFileName(qobject_cast<QWidget*>(parent()),
-                                          tr("Choose STEP Model"), initialFp,
-                                          "STEP Models (*.step *.stp)"));
+  FilePath fp(FileDialog::getOpenFileName(
+      qobject_cast<QWidget*>(parent()), tr("Choose STEP Model"), initialFp,
+      "STEP Models (*.step *.stp *.STEP *.STP *.Step *.Stp)"));
   if (selectedFile) {
     *selectedFile = fp;
   }


### PR DESCRIPTION
Many STEP files downloaded from the internet have suffixes `STEP`, `STP` or even `Step` or `Stp`. But the "Select STEP file" dialog in the package editor did only allow selecting files with lowercase suffix `step` and `stp`, at least on some systems. Looks like a bug in Qt (or the desktop environment?) to me as the file suffix capitalization should not be relevant - anyway, it's easy to fix by explicitly accepting the uppercase variants.