### PR TITLE
Package editor: Add tool to move & align objects

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -123,6 +123,8 @@ Copyright: LibrePCB Developers, see AUTHORS.md
 License: CC0-1.0
 
 Files:
+ img/actions/align_horizontally.svg
+ img/actions/align_vertically.svg
  img/actions/donate_white.svg
 Copyright: Font Awesome
 License: CC-BY-4.0

--- a/img/actions/align_horizontally.svg
+++ b/img/actions/align_horizontally.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="#74C0FC" d="M8 256a56 56 0 1 1 112 0A56 56 0 1 1 8 256zm160 0a56 56 0 1 1 112 0 56 56 0 1 1 -112 0zm216-56a56 56 0 1 1 0 112 56 56 0 1 1 0-112z"/></svg>

--- a/img/actions/align_vertically.svg
+++ b/img/actions/align_vertically.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="#74C0FC" d="M64 360a56 56 0 1 0 0 112 56 56 0 1 0 0-112zm0-160a56 56 0 1 0 0 112 56 56 0 1 0 0-112zM120 96A56 56 0 1 0 8 96a56 56 0 1 0 112 0z"/></svg>

--- a/img/images.qrc
+++ b/img/images.qrc
@@ -14,6 +14,8 @@
         <file>actions/add_value.png</file>
         <file>actions/add_value_dark.png</file>
         <file>actions/add_via.png</file>
+        <file>actions/align_horizontally.svg</file>
+        <file>actions/align_vertically.svg</file>
         <file>actions/apply.png</file>
         <file>actions/board_editor.png</file>
         <file>actions/bookmark.png</file>

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -54,6 +54,9 @@ add_library(
   dialogs/holepropertiesdialog.cpp
   dialogs/holepropertiesdialog.h
   dialogs/holepropertiesdialog.ui
+  dialogs/movealigndialog.cpp
+  dialogs/movealigndialog.h
+  dialogs/movealigndialog.ui
   dialogs/polygonpropertiesdialog.cpp
   dialogs/polygonpropertiesdialog.h
   dialogs/polygonpropertiesdialog.ui

--- a/libs/librepcb/editor/cmd/cmdholeedit.cpp
+++ b/libs/librepcb/editor/cmd/cmdholeedit.cpp
@@ -61,6 +61,12 @@ void CmdHoleEdit::setPath(const NonEmptyPath& path, bool immediate) noexcept {
   if (immediate) mHole.setPath(mNewPath);
 }
 
+void CmdHoleEdit::setPositionOfFirstVertex(const Point& pos,
+                                           bool immediate) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  translate(pos - mNewPath->getVertices().first().getPos(), immediate);
+}
+
 void CmdHoleEdit::translate(const Point& deltaPos, bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());
   setPath(NonEmptyPath(mNewPath->translated(deltaPos)), immediate);

--- a/libs/librepcb/editor/cmd/cmdholeedit.h
+++ b/libs/librepcb/editor/cmd/cmdholeedit.h
@@ -60,6 +60,7 @@ public:
 
   // Setters
   void setPath(const NonEmptyPath& path, bool immediate) noexcept;
+  void setPositionOfFirstVertex(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
   void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;

--- a/libs/librepcb/editor/dialogs/movealigndialog.cpp
+++ b/libs/librepcb/editor/dialogs/movealigndialog.cpp
@@ -1,0 +1,280 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "movealigndialog.h"
+
+#include "ui_movealigndialog.h"
+
+#include <librepcb/core/utils/toolbox.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+MoveAlignDialog::MoveAlignDialog(const QList<Point>& positions,
+                                 const QString& settingsPrefix,
+                                 QWidget* parent) noexcept
+  : QDialog(parent),
+    mUi(new Ui::MoveAlignDialog),
+    mSettingsPrefix(settingsPrefix),
+    mPositions(positions),
+    mNewPositions(positions) {
+  mUi->setupUi(this);
+  connect(mUi->rbtnModeAbsolute, &QRadioButton::toggled, this, [&](bool c) {
+    if (c) {
+      const Point ref = mPositionsOrdered.value(0);
+      mUi->edtX->setValue(mUi->edtX->getValue() + ref.getX());
+      mUi->edtY->setValue(mUi->edtY->getValue() + ref.getY());
+    }
+  });
+  connect(mUi->rbtnModeRelative, &QRadioButton::toggled, this, [&](bool c) {
+    if (c) {
+      const Point ref = mPositionsOrdered.value(0);
+      mUi->edtX->setValue(mUi->edtX->getValue() - ref.getX());
+      mUi->edtY->setValue(mUi->edtY->getValue() - ref.getY());
+    }
+  });
+  connect(mUi->btnCenterHorizontally, &QToolButton::toggled, mUi->edtX,
+          &LengthEdit::setDisabled);
+  connect(mUi->btnCenterVertically, &QToolButton::toggled, mUi->edtY,
+          &LengthEdit::setDisabled);
+  connect(mUi->cbxIntervalX, &QCheckBox::toggled, mUi->edtIntervalX,
+          &LengthEdit::setEnabled);
+  connect(mUi->cbxIntervalY, &QCheckBox::toggled, mUi->edtIntervalY,
+          &LengthEdit::setEnabled);
+  connect(mUi->btnHorizontally, &QToolButton::clicked, this, [&]() {
+    mUi->edtIntervalY->setValue(Length(0));
+    mUi->cbxIntervalY->setChecked(true);
+  });
+  connect(mUi->btnVertically, &QToolButton::clicked, this, [&]() {
+    mUi->edtIntervalX->setValue(Length(0));
+    mUi->cbxIntervalX->setChecked(true);
+  });
+  connect(mUi->buttonBox, &QDialogButtonBox::accepted, this,
+          &MoveAlignDialog::accept);
+  connect(mUi->buttonBox, &QDialogButtonBox::rejected, this,
+          &MoveAlignDialog::reject);
+
+  // React on settings changed.
+  connect(mUi->edtX, &LengthEdit::valueChanged, this,
+          &MoveAlignDialog::updateNewPositions);
+  connect(mUi->edtY, &LengthEdit::valueChanged, this,
+          &MoveAlignDialog::updateNewPositions);
+  connect(mUi->btnCenterHorizontally, &QToolButton::toggled, this,
+          &MoveAlignDialog::updateNewPositions);
+  connect(mUi->btnCenterVertically, &QToolButton::toggled, this,
+          &MoveAlignDialog::updateNewPositions);
+  connect(mUi->cbxIntervalX, &QCheckBox::toggled, this,
+          &MoveAlignDialog::updateNewPositions);
+  connect(mUi->cbxIntervalY, &QCheckBox::toggled, this,
+          &MoveAlignDialog::updateNewPositions);
+  connect(mUi->edtIntervalX, &LengthEdit::valueChanged, this,
+          &MoveAlignDialog::updateNewPositions);
+  connect(mUi->edtIntervalY, &LengthEdit::valueChanged, this,
+          &MoveAlignDialog::updateNewPositions);
+
+  // Calculate spread in X- and Y-direction.
+  QList<Length> xVals, yVals;  // May be empty.
+  Length spreadX, spreadY;
+  for (const Point& p : mPositions) {
+    xVals.append(p.getX());
+    yVals.append(p.getY());
+  }
+  std::sort(xVals.begin(), xVals.end());
+  std::sort(yVals.begin(), yVals.end());
+  if (mPositions.count() >= 2) {
+    spreadX = xVals.last() - xVals.first();
+    spreadY = yVals.last() - yVals.first();
+  } else {
+    mUi->gbxInterval->setEnabled(false);
+  }
+
+  // Calculate order how to interpret the input positions.
+  mPositionsOrdered = Toolbox::toList(Toolbox::toSet(mPositions));
+  std::sort(mPositionsOrdered.begin(), mPositionsOrdered.end(),
+            [&](const Point& a, const Point& b) {
+              if (spreadX > spreadY) {
+                // Horizontal: Sort on X first, then on Y value.
+                if (a.getX() != b.getX()) {
+                  return a.getX() < b.getX();
+                } else {
+                  return a.getY() > b.getY();
+                }
+              } else {
+                // Vertical: Sort on Y first, then on X value.
+                if (a.getY() != b.getY()) {
+                  return a.getY() > b.getY();
+                } else {
+                  return a.getX() < b.getX();
+                }
+              }
+            });
+
+  // Determine reference position.
+  const Point refPos = mPositionsOrdered.value(0);
+  mUi->edtX->setValue(refPos.getX());
+  mUi->edtY->setValue(refPos.getY());
+
+  // Get steps in X- and Y-direction.
+  QList<Length> xSteps, ySteps;  // May be empty!
+  for (int i = 1; i < mPositionsOrdered.count(); ++i) {
+    const Point p = mPositionsOrdered.value(i);
+    const Point p0 = mPositionsOrdered.value(i - 1);
+    xSteps.append(p.getX() - p0.getX());
+    ySteps.append(p.getY() - p0.getY());
+  }
+  if (mPositionsOrdered.count() >= 2) {
+    mDefaultInterval.setX(xSteps.first());
+    mDefaultInterval.setY(-ySteps.first());
+  }
+  mUi->edtIntervalX->setValue(mDefaultInterval.getX());
+  mUi->edtIntervalY->setValue(mDefaultInterval.getY());
+
+  // Check if the interval is constant between each item.
+  mUi->cbxIntervalX->setChecked(Toolbox::toSet(xSteps).count() == 1);
+  mUi->cbxIntervalY->setChecked(Toolbox::toSet(ySteps).count() == 1);
+
+  // If only one object is selected, choose relative mode by default and
+  // don't support centering.
+  if (mPositions.count() == 1) {
+    mUi->rbtnModeRelative->setChecked(true);
+    mUi->btnCenterHorizontally->setEnabled(false);
+    mUi->btnCenterVertically->setEnabled(false);
+  }
+
+  // Move focus into X coordiante for to allow editing it immediately.
+  mUi->edtX->setFocus();
+
+  // Install event filter on group boxes to make the Return key working.
+  mUi->gbxRefPos->installEventFilter(this);
+  mUi->gbxInterval->installEventFilter(this);
+
+  // Load client settings.
+  QSettings cs;
+  QSize windowSize = cs.value(mSettingsPrefix % "/window_size").toSize();
+  if (!windowSize.isEmpty()) {
+    resize(windowSize);
+  }
+}
+
+MoveAlignDialog::~MoveAlignDialog() noexcept {
+  QSettings cs;
+  cs.setValue(mSettingsPrefix % "/window_size", size());
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+bool MoveAlignDialog::eventFilter(QObject* watched, QEvent* event) noexcept {
+  if (event->type() == QEvent::KeyPress) {
+    QKeyEvent* e = static_cast<QKeyEvent*>(event);
+    if (e->key() == Qt::Key_Return) {
+      accept();
+      return true;
+    }
+  }
+  return QDialog::eventFilter(watched, event);
+}
+
+void MoveAlignDialog::updateNewPositions() noexcept {
+  // Calculate movement for all positions.
+  const Point firstPosOld = mPositionsOrdered.value(0);
+  Point firstPosNew(mUi->edtX->getValue(), mUi->edtY->getValue());
+  if (mUi->rbtnModeRelative->isChecked()) {
+    firstPosNew += firstPosOld;
+  }
+  const Point deltaPos = firstPosNew - firstPosOld;
+
+  // Calculate new positions.
+  QList<Point> positions = mPositions;
+  for (Point& pos : positions) {
+    Q_ASSERT(mPositionsOrdered.contains(pos));
+    const int index = mPositionsOrdered.indexOf(pos);
+    pos += deltaPos;
+    if (mUi->cbxIntervalX->isChecked()) {
+      pos.setX(firstPosNew.getX() + mUi->edtIntervalX->getValue() * index);
+    }
+    if (mUi->cbxIntervalY->isChecked()) {
+      pos.setY(firstPosNew.getY() - mUi->edtIntervalY->getValue() * index);
+    }
+  }
+
+  // Apply centering.
+  if (!positions.isEmpty()) {
+    Point offset = calcCenter(positions);
+    if (!mUi->btnCenterHorizontally->isChecked()) {
+      offset.setX(0);
+    }
+    if (!mUi->btnCenterVertically->isChecked()) {
+      offset.setY(0);
+    }
+    for (Point& pos : positions) {
+      pos -= offset;
+    }
+  }
+
+  // Update UI.
+  mUi->btnVertically->setEnabled((!mUi->cbxIntervalX->isChecked()) ||
+                                 (mUi->edtIntervalX->getValue() != 0));
+  mUi->btnHorizontally->setEnabled((!mUi->cbxIntervalY->isChecked()) ||
+                                   (mUi->edtIntervalY->getValue() != 0));
+
+  // Memorize and notify about changes.
+  if (positions != mNewPositions) {
+    mNewPositions = positions;
+    emit positionsChanged(mNewPositions);
+  }
+}
+
+Point MoveAlignDialog::calcCenter(const QList<Point>& p) noexcept {
+  if (p.isEmpty()) {
+    return Point();
+  }
+  auto cmpX = [&](const Point& a, const Point& b) {
+    return a.getX() < b.getX();
+  };
+  auto cmpY = [&](const Point& a, const Point& b) {
+    return a.getY() < b.getY();
+  };
+  const Length minX = std::min_element(p.begin(), p.end(), cmpX)->getX();
+  const Length maxX = std::max_element(p.begin(), p.end(), cmpX)->getX();
+  const Length minY = std::min_element(p.begin(), p.end(), cmpY)->getY();
+  const Length maxY = std::max_element(p.begin(), p.end(), cmpY)->getY();
+  return Point((minX + maxX) / 2, ((minY + maxY) / 2));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/dialogs/movealigndialog.h
+++ b/libs/librepcb/editor/dialogs/movealigndialog.h
@@ -1,0 +1,92 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_MOVEALIGNDIALOG_H
+#define LIBREPCB_EDITOR_MOVEALIGNDIALOG_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <librepcb/core/types/point.h>
+#include <optional/tl/optional.hpp>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+namespace Ui {
+class MoveAlignDialog;
+}
+
+/*******************************************************************************
+ *  Class MoveAlignDialog
+ ******************************************************************************/
+
+/**
+ * @brief The MoveAlignDialog class
+ */
+class MoveAlignDialog final : public QDialog {
+  Q_OBJECT
+
+  typedef tl::optional<PositiveLength> Interval;
+
+public:
+  // Constructors / Destructor
+  MoveAlignDialog() = delete;
+  MoveAlignDialog(const MoveAlignDialog& other) = delete;
+  MoveAlignDialog(const QList<Point>& positions, const QString& settingsPrefix,
+                  QWidget* parent = nullptr) noexcept;
+  ~MoveAlignDialog() noexcept;
+
+  // Getters
+  const QList<Point>& getNewPositions() const noexcept { return mNewPositions; }
+
+  // Operator Overloadings
+  MoveAlignDialog& operator=(const MoveAlignDialog& rhs) = delete;
+
+signals:
+  void positionsChanged(const QList<Point>& positions);
+
+private:  // Methods
+  virtual bool eventFilter(QObject* watched, QEvent* event) noexcept override;
+  void updateNewPositions() noexcept;
+  static Point calcCenter(const QList<Point>& p) noexcept;
+
+private:  // Data
+  QScopedPointer<Ui::MoveAlignDialog> mUi;
+  const QString mSettingsPrefix;
+  const QList<Point> mPositions;
+  QList<Point> mPositionsOrdered;  ///< Unique; First item = reference position;
+  Point mDefaultInterval;
+  QList<Point> mNewPositions;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/dialogs/movealigndialog.ui
+++ b/libs/librepcb/editor/dialogs/movealigndialog.ui
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::editor::MoveAlignDialog</class>
+ <widget class="QDialog" name="librepcb::editor::MoveAlignDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>244</width>
+    <height>288</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Move/Align Elements</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="gbxRefPos">
+     <property name="title">
+      <string>Reference Position (Top Left)</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Mode:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QRadioButton" name="rbtnModeAbsolute">
+          <property name="text">
+           <string>Absolute</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rbtnModeRelative">
+          <property name="text">
+           <string>Relative</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>X:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="librepcb::editor::LengthEdit" name="edtX" native="true"/>
+        </item>
+        <item>
+         <widget class="QToolButton" name="btnCenterHorizontally">
+          <property name="toolTip">
+           <string>Center around Y-axis</string>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>:/img/command_toolbars/align_horizontal_center.png</normaloff>:/img/command_toolbars/align_horizontal_center.png</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Y:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="librepcb::editor::LengthEdit" name="edtY" native="true"/>
+        </item>
+        <item>
+         <widget class="QToolButton" name="btnCenterVertically">
+          <property name="toolTip">
+           <string>Center around X-axis</string>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>:/img/command_toolbars/align_vertical_center.png</normaloff>:/img/command_toolbars/align_vertical_center.png</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbxInterval">
+     <property name="title">
+      <string>Pitch</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="cbxIntervalX">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>ΔX:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="librepcb::editor::LengthEdit" name="edtIntervalX" native="true">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="btnVertically">
+          <property name="toolTip">
+           <string>Align vertically (ΔX=0)</string>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>:/img/actions/align_vertically.svg</normaloff>:/img/actions/align_vertically.svg</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="cbxIntervalY">
+        <property name="text">
+         <string>ΔY:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="librepcb::editor::LengthEdit" name="edtIntervalY" native="true">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="btnHorizontally">
+          <property name="toolTip">
+           <string>Align horizontally (ΔY=0)</string>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>:/img/actions/align_horizontally.svg</normaloff>:/img/actions/align_horizontally.svg</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::editor::LengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/lengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>rbtnModeAbsolute</tabstop>
+  <tabstop>rbtnModeRelative</tabstop>
+  <tabstop>edtX</tabstop>
+  <tabstop>btnCenterHorizontally</tabstop>
+  <tabstop>edtY</tabstop>
+  <tabstop>btnCenterVertically</tabstop>
+  <tabstop>cbxIntervalX</tabstop>
+  <tabstop>edtIntervalX</tabstop>
+  <tabstop>btnVertically</tabstop>
+  <tabstop>cbxIntervalY</tabstop>
+  <tabstop>edtIntervalY</tabstop>
+  <tabstop>btnHorizontally</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -724,6 +724,16 @@ public:
       {QKeySequence(Qt::SHIFT | Qt::Key_F)},
       &categoryModify,
   };
+  EditorCommand moveAlign{
+      "move_align",  // clang-format break
+      QT_TR_NOOP("Move/Align Objects"),
+      QT_TR_NOOP("Move and/or align the selected object(s) vertically or "
+                 "horizontally"),
+      ":/img/actions/move.png",
+      EditorCommand::Flags(),
+      {QKeySequence(Qt::Key_A)},
+      &categoryModify,
+  };
   EditorCommand snapToGrid{
       "snap_to_grid",  // clang-format break
       QT_TR_NOOP("Snap to Grid"),

--- a/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.h
+++ b/libs/librepcb/editor/library/cmd/cmddragselectedfootprintitems.h
@@ -64,10 +64,12 @@ public:
   // Getters
   int getSelectedItemsCount() const noexcept;
   bool hasOffTheGridElements() const noexcept { return mHasOffTheGridElements; }
+  const QList<Point>& getPositions() const noexcept { return mPositions; }
 
   // General Methods
   void snapToGrid() noexcept;
   void setDeltaToStartPos(const Point& delta) noexcept;
+  void setNewPositions(QList<Point> positions);
   void translate(const Point& deltaPos) noexcept;
   void rotate(const Angle& angle) noexcept;
   void mirrorGeometry(Qt::Orientation orientation) noexcept;
@@ -87,12 +89,14 @@ private:
 
   // Private Member Variables
   const PackageEditorState::Context& mContext;
+  QList<Point> mPositions;
   Point mCenterPos;
   Point mDeltaPos;
   Angle mDeltaRot;
   bool mMirroredGeometry;
   bool mMirroredLayer;
   bool mSnappedToGrid;
+  bool mNewPositionsSet;
   bool mHasOffTheGridElements;
 
   // Move commands

--- a/libs/librepcb/editor/library/editorwidgetbase.h
+++ b/libs/librepcb/editor/library/editorwidgetbase.h
@@ -114,6 +114,7 @@ public:
     Rotate,
     Mirror,
     Flip,
+    MoveAlign,
     SnapToGrid,
     Properties,
   };
@@ -164,6 +165,7 @@ public slots:
     Q_UNUSED(orientation);
     return false;
   }
+  virtual bool moveAlign() noexcept { return false; }
   virtual bool snapToGrid() noexcept { return false; }
   virtual bool remove() noexcept { return false; }
   virtual bool editProperties() noexcept { return false; }

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -640,6 +640,9 @@ void LibraryEditor::createActions() noexcept {
   mActionFlipVertical.reset(cmd.flipVertical.createAction(this, this, [this]() {
     if (mCurrentEditorWidget) mCurrentEditorWidget->flip(Qt::Vertical);
   }));
+  mActionMoveAlign.reset(cmd.moveAlign.createAction(this, this, [this]() {
+    if (mCurrentEditorWidget) mCurrentEditorWidget->moveAlign();
+  }));
   mActionSnapToGrid.reset(cmd.snapToGrid.createAction(this, this, [this]() {
     if (mCurrentEditorWidget) mCurrentEditorWidget->snapToGrid();
   }));
@@ -899,6 +902,7 @@ void LibraryEditor::createMenus() noexcept {
   mb.addAction(mActionMirrorVertical);
   mb.addAction(mActionFlipHorizontal);
   mb.addAction(mActionFlipVertical);
+  mb.addAction(mActionMoveAlign);
   mb.addAction(mActionSnapToGrid);
   mb.addSeparator();
   mb.addAction(mActionCopy);
@@ -1000,6 +1004,7 @@ void LibraryEditor::setAvailableFeatures(
   mActionMirrorVertical->setEnabled(features.contains(Feature::Mirror));
   mActionFlipHorizontal->setEnabled(features.contains(Feature::Flip));
   mActionFlipVertical->setEnabled(features.contains(Feature::Flip));
+  mActionMoveAlign->setEnabled(features.contains(Feature::MoveAlign));
   mActionGenerate->setEnabled(features.contains(Feature::GenerateOutline) ||
                               features.contains(Feature::GenerateCourtyard));
   mActionGenerateOutline->setEnabled(

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -223,6 +223,7 @@ private:  // Data
   QScopedPointer<QAction> mActionMirrorVertical;
   QScopedPointer<QAction> mActionFlipHorizontal;
   QScopedPointer<QAction> mActionFlipVertical;
+  QScopedPointer<QAction> mActionMoveAlign;
   QScopedPointer<QAction> mActionSnapToGrid;
   QScopedPointer<QAction> mActionProperties;
   QScopedPointer<QAction> mActionRemove;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
@@ -379,6 +379,14 @@ bool PackageEditorFsm::processFlip(Qt::Orientation orientation) noexcept {
   }
 }
 
+bool PackageEditorFsm::processMoveAlign() noexcept {
+  if (getCurrentState()) {
+    return getCurrentState()->processMoveAlign();
+  } else {
+    return false;
+  }
+}
+
 bool PackageEditorFsm::processSnapToGrid() noexcept {
   if (getCurrentState()) {
     return getCurrentState()->processSnapToGrid();

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -138,6 +138,7 @@ public:
   bool processRotate(const Angle& rotation) noexcept;
   bool processMirror(Qt::Orientation orientation) noexcept;
   bool processFlip(Qt::Orientation orientation) noexcept;
+  bool processMoveAlign() noexcept;
   bool processSnapToGrid() noexcept;
   bool processRemove() noexcept;
   bool processEditProperties() noexcept;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
@@ -117,6 +117,7 @@ public:
     Q_UNUSED(orientation);
     return false;
   }
+  virtual bool processMoveAlign() noexcept { return false; }
   virtual bool processSnapToGrid() noexcept { return false; }
   virtual bool processFlip(Qt::Orientation orientation) noexcept {
     Q_UNUSED(orientation);

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
@@ -99,6 +99,7 @@ public:
   bool processRotate(const Angle& rotation) noexcept override;
   bool processMirror(Qt::Orientation orientation) noexcept override;
   bool processFlip(Qt::Orientation orientation) noexcept override;
+  bool processMoveAlign() noexcept override;
   bool processSnapToGrid() noexcept override;
   bool processRemove() noexcept override;
   bool processEditProperties() noexcept override;
@@ -125,6 +126,7 @@ private:  // Methods
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems(Qt::Orientation orientation,
                            bool flipLayers) noexcept;
+  bool moveAlignSelectedItems() noexcept;
   bool snapSelectedItemsToGrid() noexcept;
   bool removeSelectedItems() noexcept;
   bool generateOutline() noexcept;

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -377,6 +377,10 @@ bool PackageEditorWidget::flip(Qt::Orientation orientation) noexcept {
   return mFsm->processFlip(orientation);
 }
 
+bool PackageEditorWidget::moveAlign() noexcept {
+  return mFsm->processMoveAlign();
+}
+
 bool PackageEditorWidget::snapToGrid() noexcept {
   return mFsm->processSnapToGrid();
 }

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.h
@@ -97,6 +97,7 @@ public slots:
   bool rotate(const librepcb::Angle& rotation) noexcept override;
   bool mirror(Qt::Orientation orientation) noexcept override;
   bool flip(Qt::Orientation orientation) noexcept override;
+  bool moveAlign() noexcept override;
   bool snapToGrid() noexcept override;
   bool remove() noexcept override;
   bool editProperties() noexcept override;


### PR DESCRIPTION
Finally a very handy tool to move and/or align objects (especially pads) in the package editor! Features:

- Move multiple objects together by specifying either relative or absolute coordinates for the first object
- Apply constant X and/or Y steps between selected objects
- Automatically center objects horizontally and/or vertically
- Live preview - every change in settings immediately shows how the result will look
- Works with pads, circles, holes and texts (but currently only in the package editor)
- Multiple objects at the exact same position are handled as a single object (e.g. to keep documentation circles around pads)

![librepcb-align-4](https://github.com/user-attachments/assets/463278d6-7048-4dbb-b61f-2dfa9c5c22cb)
