### PR TITLE
Package editor: Add tool to interactively re-number pads

### DIFF
--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -326,6 +326,8 @@ add_library(
   library/pkg/fsm/packageeditorstate_drawzone.h
   library/pkg/fsm/packageeditorstate_measure.cpp
   library/pkg/fsm/packageeditorstate_measure.h
+  library/pkg/fsm/packageeditorstate_renumberpads.cpp
+  library/pkg/fsm/packageeditorstate_renumberpads.h
   library/pkg/fsm/packageeditorstate_select.cpp
   library/pkg/fsm/packageeditorstate_select.h
   library/pkg/packagechooserdialog.cpp

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -1138,6 +1138,15 @@ public:
       {},
       &categoryTools,
   };
+  EditorCommand toolReNumberPads{
+      "tool_renumber_pads",  // clang-format break
+      QT_TR_NOOP("Re-Number Pads"),
+      QT_TR_NOOP("Helper tool to interactively change pad numbers"),
+      ":/img/actions/wizard.png",
+      EditorCommand::Flag::OpensPopup,
+      {},
+      &categoryTools,
+  };
   EditorCommand toolMeasure{
       "tool_measure",  // clang-format break
       QT_TR_NOOP("Measure Distance"),
@@ -1753,11 +1762,11 @@ public:
       {},
       &categoryContextMenu,
   };
-  EditorCommand generateContent{
+  EditorCommand helperTools{
       // Actually not really for the context menu :-/
-      "generate_content",  // clang-format break
+      "helper_tools",  // clang-format break
       QT_TR_NOOP("Generate Content"),
-      QT_TR_NOOP("Automatically generate some content"),
+      QT_TR_NOOP("Various helper tools to generate or modify objects"),
       ":/img/actions/wizard.png",
       EditorCommand::Flag::OpensPopup,
       {},

--- a/libs/librepcb/editor/library/editorwidgetbase.h
+++ b/libs/librepcb/editor/library/editorwidgetbase.h
@@ -90,6 +90,7 @@ public:
     ADD_SMT_PADS,
     ADD_HOLES,
     MEASURE,
+    RENUMBER_PADS,
   };
 
   enum class Feature {
@@ -101,6 +102,7 @@ public:
     ExportGraphics,
     GenerateOutline,
     GenerateCourtyard,
+    ReNumberPads,
 
     // Handled by FSM states (dynamic).
     SelectGraphics,

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -652,7 +652,7 @@ void LibraryEditor::createActions() noexcept {
   mActionRemove.reset(cmd.remove.createAction(this, this, [this]() {
     if (mCurrentEditorWidget) mCurrentEditorWidget->remove();
   }));
-  mActionGenerate.reset(cmd.generateContent.createAction(this));
+  mActionHelperTools.reset(cmd.helperTools.createAction(this));
   mActionGenerateOutline.reset(
       cmd.toolGenerateOutline.createAction(this, this, [this]() {
         if (mCurrentEditorWidget)
@@ -690,6 +690,7 @@ void LibraryEditor::createActions() noexcept {
   mActionToolZone.reset(cmd.toolZone.createAction(this));
   mActionToolHole.reset(cmd.toolHole.createAction(this));
   mActionToolMeasure.reset(cmd.toolMeasure.createAction(this));
+  mActionReNumberPads.reset(cmd.toolReNumberPads.createAction(this));
 
   // Undo stack action group.
   mUndoStackActionGroup.reset(new UndoStackActionGroup(
@@ -749,6 +750,8 @@ void LibraryEditor::createActions() noexcept {
                                EditorWidgetBase::Tool::ADD_HOLES);
   mToolsActionGroup->addAction(mActionToolMeasure.data(),
                                EditorWidgetBase::Tool::MEASURE);
+  mToolsActionGroup->addAction(mActionReNumberPads.data(),
+                               EditorWidgetBase::Tool::RENUMBER_PADS);
   mToolsActionGroup->setEnabled(false);
 }
 
@@ -845,12 +848,13 @@ void LibraryEditor::createToolBars() noexcept {
   mToolBarTools->addAction(mActionToolZone.data());
   mToolBarTools->addAction(mActionToolHole.data());
   mToolBarTools->addSeparator();
-  mToolBarTools->addAction(mActionGenerate.data());
+  mToolBarTools->addAction(mActionHelperTools.data());
   if (auto btn = qobject_cast<QToolButton*>(
-          mToolBarTools->widgetForAction(mActionGenerate.data()))) {
+          mToolBarTools->widgetForAction(mActionHelperTools.data()))) {
     QMenu* menu = new QMenu(mToolBarTools.data());
     menu->addAction(mActionGenerateOutline.data());
     menu->addAction(mActionGenerateCourtyard.data());
+    menu->addAction(mActionReNumberPads.data());
     btn->setMenu(menu);
     btn->setPopupMode(QToolButton::InstantPopup);
   }
@@ -953,6 +957,7 @@ void LibraryEditor::createMenus() noexcept {
   mb.addSeparator();
   mb.addAction(mActionGenerateOutline);
   mb.addAction(mActionGenerateCourtyard);
+  mb.addAction(mActionReNumberPads);
   mb.addSeparator();
   mb.addAction(mActionToolMeasure);
 
@@ -1005,12 +1010,13 @@ void LibraryEditor::setAvailableFeatures(
   mActionFlipHorizontal->setEnabled(features.contains(Feature::Flip));
   mActionFlipVertical->setEnabled(features.contains(Feature::Flip));
   mActionMoveAlign->setEnabled(features.contains(Feature::MoveAlign));
-  mActionGenerate->setEnabled(features.contains(Feature::GenerateOutline) ||
-                              features.contains(Feature::GenerateCourtyard));
+  mActionHelperTools->setEnabled(features.contains(Feature::GenerateOutline) ||
+                                 features.contains(Feature::GenerateCourtyard));
   mActionGenerateOutline->setEnabled(
       features.contains(Feature::GenerateOutline));
   mActionGenerateCourtyard->setEnabled(
       features.contains(Feature::GenerateCourtyard));
+  mActionReNumberPads->setEnabled(features.contains(Feature::ReNumberPads));
   mActionImportDxf->setEnabled(features.contains(Feature::ImportGraphics));
   mActionSnapToGrid->setEnabled(features.contains(Feature::SnapToGrid));
   mActionProperties->setEnabled(features.contains(Feature::Properties));

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -227,7 +227,7 @@ private:  // Data
   QScopedPointer<QAction> mActionSnapToGrid;
   QScopedPointer<QAction> mActionProperties;
   QScopedPointer<QAction> mActionRemove;
-  QScopedPointer<QAction> mActionGenerate;
+  QScopedPointer<QAction> mActionHelperTools;
   QScopedPointer<QAction> mActionGenerateOutline;
   QScopedPointer<QAction> mActionGenerateCourtyard;
   QScopedPointer<QAction> mActionAbort;
@@ -252,6 +252,7 @@ private:  // Data
   QScopedPointer<QAction> mActionToolZone;
   QScopedPointer<QAction> mActionToolHole;
   QScopedPointer<QAction> mActionToolMeasure;
+  QScopedPointer<QAction> mActionReNumberPads;
 
   // Action groups
   QScopedPointer<UndoStackActionGroup> mUndoStackActionGroup;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -83,6 +83,7 @@ private:  // Types
     DRAW_ZONE,
     ADD_HOLES,
     MEASURE,
+    RENUMBER_PADS,
   };
 
 public:  // Types
@@ -161,6 +162,7 @@ public:
   bool processStartAddingHoles() noexcept;
   bool processStartDxfImport() noexcept;
   bool processStartMeasure() noexcept;
+  bool processStartReNumberPads() noexcept;
 
   // Operator Overloadings
   PackageEditorFsm& operator=(const PackageEditorFsm& rhs) = delete;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
@@ -134,6 +134,7 @@ public:
   PackageEditorState& operator=(const PackageEditorState& rhs) = delete;
 
 signals:
+  void abortRequested();
   void availableFeaturesChanged();
   void statusBarMessageChanged(const QString& message, int timeoutMs = -1);
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.cpp
@@ -1,0 +1,383 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "packageeditorstate_renumberpads.h"
+
+#include "../../../graphics/graphicsscene.h"
+#include "../../../undocommandgroup.h"
+#include "../../../undostack.h"
+#include "../../../widgets/graphicsview.h"
+#include "../../cmd/cmdfootprintpadedit.h"
+#include "../footprintgraphicsitem.h"
+#include "../footprintpadgraphicsitem.h"
+#include "../packageeditorwidget.h"
+
+#include <librepcb/core/library/pkg/footprint.h>
+#include <librepcb/core/library/pkg/footprintpad.h>
+#include <librepcb/core/library/pkg/package.h>
+#include <librepcb/core/utils/toolbox.h>
+
+#include <QtCore>
+
+#include <algorithm>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+PackageEditorState_ReNumberPads::PackageEditorState_ReNumberPads(
+    Context& context) noexcept
+  : PackageEditorState(context) {
+}
+
+PackageEditorState_ReNumberPads::~PackageEditorState_ReNumberPads() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+bool PackageEditorState_ReNumberPads::entry() noexcept {
+  // Populate command toolbar.
+  std::unique_ptr<QToolButton> btnFinish(new QToolButton());
+  btnFinish->setIcon(QIcon(":/img/actions/apply.png"));
+  btnFinish->setText(tr("Finish"));
+  btnFinish->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+  connect(btnFinish.get(), &QToolButton::clicked, this,
+          &PackageEditorState_ReNumberPads::finish);
+  mContext.commandToolBar.addWidget(std::move(btnFinish));
+
+  // Start undo command.
+  if (!start()) {
+    mContext.commandToolBar.clear();
+    return false;
+  }
+
+  const QString note = " " %
+      tr("(press %1 for single-selection, %2 to change numbering mode, %3 to "
+         "finish)")
+          .arg(QCoreApplication::translate("QShortcut", "Ctrl"))
+          .arg(QCoreApplication::translate("QShortcut", "Shift"))
+          .arg(QCoreApplication::translate("QShortcut", "Return"));
+  emit statusBarMessageChanged(tr("Click on the next pad") % note);
+  mContext.graphicsScene.setSelectionArea(QPainterPath());
+  mContext.graphicsView.setCursor(Qt::PointingHandCursor);
+  return true;
+}
+
+bool PackageEditorState_ReNumberPads::exit() noexcept {
+  // Abort command.
+  try {
+    mPreviousPad.reset();
+    mCurrentPad.reset();
+    mTmpCmd.reset();
+    if (mUndoCmdActive) {
+      mContext.undoStack.abortCmdGroup();
+      mUndoCmdActive = false;
+    }
+  } catch (const Exception& e) {
+    qCritical() << "Could not abort command:" << e.getMsg();
+  }
+
+  mPackagePads.clear();
+
+  // Cleanup command toolbar.
+  mContext.commandToolBar.clear();
+
+  mContext.graphicsView.unsetCursor();
+  mContext.graphicsScene.setSelectionArea(QPainterPath());
+  emit statusBarMessageChanged(QString());
+  return true;
+}
+
+QSet<EditorWidgetBase::Feature>
+    PackageEditorState_ReNumberPads::getAvailableFeatures() const noexcept {
+  return {
+      EditorWidgetBase::Feature::Abort,
+  };
+}
+
+/*******************************************************************************
+ *  Event Handlers
+ ******************************************************************************/
+
+bool PackageEditorState_ReNumberPads::processKeyPressed(
+    const QKeyEvent& e) noexcept {
+  if (e.key() == Qt::Key_Return) {
+    finish();
+    return true;
+  } else if (mCurrentModifiers != e.modifiers()) {
+    mCurrentModifiers = e.modifiers();
+    updateCurrentPad(true);
+    return true;
+  }
+
+  return false;
+}
+
+bool PackageEditorState_ReNumberPads::processKeyReleased(
+    const QKeyEvent& e) noexcept {
+  return processKeyPressed(e);
+}
+
+bool PackageEditorState_ReNumberPads::processGraphicsSceneMouseMoved(
+    QGraphicsSceneMouseEvent& e) noexcept {
+  mCurrentPos = Point::fromPx(e.scenePos());
+  const bool force = (mCurrentModifiers != e.modifiers());
+  mCurrentModifiers = e.modifiers();
+  updateCurrentPad(force);
+  return true;
+}
+
+bool PackageEditorState_ReNumberPads::
+    processGraphicsSceneLeftMouseButtonPressed(
+        QGraphicsSceneMouseEvent& e) noexcept {
+  mCurrentPos = Point::fromPx(e.scenePos());
+  const bool force = (mCurrentModifiers != e.modifiers());
+  mCurrentModifiers = e.modifiers();
+
+  commitCurrentPad();
+  if (mContext.currentFootprint &&
+      (mAssignedFootprintPadCount ==
+       mContext.currentFootprint->getPads().count())) {
+    finish();
+  } else {
+    updateCurrentPad(force);
+  }
+  return true;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+bool PackageEditorState_ReNumberPads::start() noexcept {
+  try {
+    if (!mContext.currentFootprint) {
+      return false;
+    }
+
+    // Memorize package pads, sorted by name.
+    mPackagePads = mContext.package.getPads().values();
+    Toolbox::sortNumeric(
+        mPackagePads,
+        [](const QCollator& cmp, const std::shared_ptr<PackagePad>& a,
+           const std::shared_ptr<PackagePad>& b) {
+          return cmp(*a->getName(), *b->getName());
+        },
+        Qt::CaseInsensitive, false);
+
+    // Reset state.
+    mUndoCmdActive = false;
+    mAssignedFootprintPadCount = 0;
+    mPreviousPad.reset();
+    mCurrentPad.reset();
+    mTmpCmd.reset();
+    mCurrentPos = mContext.graphicsView.mapGlobalPosToScenePos(QCursor::pos(),
+                                                               true, false);
+    mCurrentModifiers = Qt::KeyboardModifiers();
+
+    // Start undo command group.
+    mContext.undoStack.beginCmdGroup(tr("Re-number pads"));
+    mUndoCmdActive = true;
+
+    // Clear all pad numbers.
+    for (auto& pad : mContext.currentFootprint->getPads()) {
+      QScopedPointer<CmdFootprintPadEdit> cmd(new CmdFootprintPadEdit(pad));
+      cmd->setPackagePadUuid(tl::nullopt, true);
+      mContext.undoStack.appendToCmdGroup(cmd.take());
+    }
+    return true;
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+    return false;
+  }
+}
+
+void PackageEditorState_ReNumberPads::updateCurrentPad(bool force) noexcept {
+  try {
+    if ((!mUndoCmdActive) || (!mContext.currentFootprint) ||
+        (!mContext.currentGraphicsItem)) {
+      return;
+    }
+
+    // Find pad under cursor.
+    QList<std::shared_ptr<QGraphicsItem>> items =
+        mContext.currentGraphicsItem->findItemsAtPos(
+            mContext.graphicsView.calcPosWithTolerance(mCurrentPos),
+            mContext.graphicsView.calcPosWithTolerance(mCurrentPos, 2),
+            FootprintGraphicsItem::FindFlag::Pads |
+                FootprintGraphicsItem::FindFlag::AcceptNearMatch);
+    std::shared_ptr<FootprintPadGraphicsItem> pad =
+        std::dynamic_pointer_cast<FootprintPadGraphicsItem>(items.value(0));
+
+    // If no change, return.
+    if ((pad == mCurrentPad) && (!force)) {
+      return;
+    }
+
+    // Discard temporary changes.
+    mTmpCmd.reset();
+    mCurrentPad = pad;
+    mContext.graphicsScene.setSelectionArea(QPainterPath());
+
+    // If no pad selected, return.
+    if ((!pad) || (pad->getObj().getPackagePadUuid())) {
+      return;
+    }
+
+    // Determine area between last pad and current pad.
+    const Point curPos = pad->getObj().getPosition();
+    const Point prevPos =
+        mPreviousPad ? mPreviousPad->getObj().getPosition() : curPos;
+    const Length minX = std::min(prevPos.getX(), curPos.getX());
+    const Length maxX = std::max(prevPos.getX(), curPos.getX());
+    const Length minY = std::min(prevPos.getY(), curPos.getY());
+    const Length maxY = std::max(prevPos.getY(), curPos.getY());
+
+    // Find all unconnected pads in the area, sorted by their position.
+    QVector<std::shared_ptr<FootprintPad>> pads =
+        mContext.currentFootprint->getPads().values();
+    pads.erase(
+        std::remove_if(
+            pads.begin(), pads.end(),
+            [&](const std::shared_ptr<FootprintPad>& p) {
+              const Point pos = p->getPosition();
+              if (p->getPackagePadUuid()) {
+                return true;
+              } else if (!mPreviousPad) {
+                return p.get() != &pad->getObj();
+              } else if (mCurrentModifiers.testFlag(Qt::ControlModifier) &&
+                         (p.get() != &pad->getObj())) {
+                return true;
+              } else if ((pos.getX() >= minX) && (pos.getX() <= maxX) &&
+                         (pos.getY() >= minY) && (pos.getY() <= maxY)) {
+                return false;
+              } else {
+                return true;
+              }
+            }),
+        pads.end());
+    std::sort(pads.begin(), pads.end(),
+              [&](const std::shared_ptr<FootprintPad>& a,
+                  const std::shared_ptr<FootprintPad>& b) {
+                const Point pA = a->getPosition();
+                const Point pB = b->getPosition();
+                const bool invX = (prevPos.getX() > curPos.getX());
+                const bool invY = (prevPos.getY() < curPos.getY());
+                if (mCurrentModifiers.testFlag(Qt::ShiftModifier)) {
+                  if (pA.getY() != pB.getY()) {
+                    return (pA.getY() > pB.getY()) != invY;
+                  } else {
+                    return (pA.getX() < pB.getX()) != invX;
+                  }
+                } else {
+                  if (pA.getX() != pB.getX()) {
+                    return (pA.getX() < pB.getX()) != invX;
+                  } else {
+                    return (pA.getY() > pB.getY()) != invY;
+                  }
+                }
+              });
+
+    // Determine next unused pad number.
+    int pkgPadIndex = 0;
+    if ((mPreviousPad) && (mPreviousPad->getObj().getPackagePadUuid())) {
+      pkgPadIndex = findIndexOfPad(*mPreviousPad->getObj().getPackagePadUuid());
+      const bool keepLastIndex = mCurrentModifiers.testFlag(Qt::ShiftModifier);
+      if ((pads.count() > 1) || (!keepLastIndex)) {
+        ++pkgPadIndex;
+      }
+    }
+
+    // Assign new pad numbers.
+    mTmpCmd.reset(new UndoCommandGroup("group"));
+    for (auto padPtr : pads) {
+      if (std::shared_ptr<PackagePad> pkgPad =
+              mPackagePads.value(pkgPadIndex)) {
+        QScopedPointer<CmdFootprintPadEdit> cmd(
+            new CmdFootprintPadEdit(*padPtr));
+        cmd->setPackagePadUuid(pkgPad->getUuid(), true);
+        mTmpCmd->appendChild(cmd.take());
+      }
+      if (auto i = mContext.currentGraphicsItem->getGraphicsItem(padPtr)) {
+        i->setSelected(true);
+      }
+      ++pkgPadIndex;
+    }
+
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+  }
+}
+
+bool PackageEditorState_ReNumberPads::commitCurrentPad() noexcept {
+  try {
+    if (mCurrentPad && mTmpCmd) {
+      const int count = mTmpCmd->getChildCount();
+      mContext.graphicsScene.setSelectionArea(QPainterPath());
+      mContext.undoStack.appendToCmdGroup(mTmpCmd.take());
+      mPreviousPad = mCurrentPad;
+      mCurrentPad = nullptr;
+      mAssignedFootprintPadCount += count;
+    }
+    return true;
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+    return false;
+  }
+}
+
+void PackageEditorState_ReNumberPads::finish() noexcept {
+  try {
+    if (mUndoCmdActive) {
+      mContext.undoStack.commitCmdGroup();
+      mUndoCmdActive = false;
+      emit abortRequested();
+    }
+  } catch (const Exception& e) {
+    QMessageBox::critical(&mContext.editorWidget, tr("Error"), e.getMsg());
+  }
+}
+
+int PackageEditorState_ReNumberPads::findIndexOfPad(
+    const Uuid& uuid) const noexcept {
+  for (int i = 0; i < mPackagePads.count(); ++i) {
+    if (mPackagePads.at(i)->getUuid() == uuid) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.h
@@ -1,0 +1,108 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_PACKAGEEDITORSTATE_RENUMBERPADS_H
+#define LIBREPCB_EDITOR_PACKAGEEDITORSTATE_RENUMBERPADS_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "packageeditorstate.h"
+
+#include <QtCore>
+#include <QtWidgets>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class PackagePad;
+
+namespace editor {
+
+class FootprintPadGraphicsItem;
+
+/*******************************************************************************
+ *  Class PackageEditorState_ReNumberPads
+ ******************************************************************************/
+
+/**
+ * @brief The PackageEditorState_ReNumberPads class
+ */
+class PackageEditorState_ReNumberPads final : public PackageEditorState {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  PackageEditorState_ReNumberPads() = delete;
+  PackageEditorState_ReNumberPads(
+      const PackageEditorState_ReNumberPads& other) = delete;
+  explicit PackageEditorState_ReNumberPads(Context& context) noexcept;
+  ~PackageEditorState_ReNumberPads() noexcept;
+
+  // General Methods
+  bool entry() noexcept override;
+  bool exit() noexcept override;
+  QSet<EditorWidgetBase::Feature> getAvailableFeatures()
+      const noexcept override;
+
+  // Event Handlers
+  bool processKeyPressed(const QKeyEvent& e) noexcept override;
+  bool processKeyReleased(const QKeyEvent& e) noexcept override;
+  bool processGraphicsSceneMouseMoved(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+  bool processGraphicsSceneLeftMouseButtonPressed(
+      QGraphicsSceneMouseEvent& e) noexcept override;
+
+  // Operator Overloadings
+  PackageEditorState_ReNumberPads& operator=(
+      const PackageEditorState_ReNumberPads& rhs) = delete;
+
+private:  // Methods
+  bool start() noexcept;
+  void updateCurrentPad(bool force = false) noexcept;
+  bool commitCurrentPad() noexcept;
+  void finish() noexcept;
+  int findIndexOfPad(const Uuid& uuid) const noexcept;
+
+private:  // Data
+  bool mUndoCmdActive;
+  int mAssignedFootprintPadCount;
+
+  QVector<std::shared_ptr<PackagePad>> mPackagePads;
+
+  std::shared_ptr<FootprintPadGraphicsItem> mPreviousPad;
+  std::shared_ptr<FootprintPadGraphicsItem> mCurrentPad;
+  QScopedPointer<UndoCommandGroup> mTmpCmd;
+
+  Point mCurrentPos;
+  Qt::KeyboardModifiers mCurrentModifiers;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.cpp
@@ -266,6 +266,7 @@ QSet<EditorWidgetBase::Feature> PackageEditorWidget::getAvailableFeatures()
       EditorWidgetBase::Feature::ExportGraphics,
       EditorWidgetBase::Feature::GenerateOutline,
       EditorWidgetBase::Feature::GenerateCourtyard,
+      EditorWidgetBase::Feature::ReNumberPads,
   };
   return features + mFsm->getAvailableFeatures();
 }
@@ -296,6 +297,7 @@ void PackageEditorWidget::connectEditor(
   mToolsActionGroup->setActionEnabled(Tool::DRAW_ZONE, enabled);
   mToolsActionGroup->setActionEnabled(Tool::ADD_HOLES, enabled);
   mToolsActionGroup->setActionEnabled(Tool::MEASURE, true);
+  mToolsActionGroup->setActionEnabled(Tool::RENUMBER_PADS, enabled);
   mToolsActionGroup->setCurrentAction(mFsm->getCurrentTool());
   connect(mFsm.data(), &PackageEditorFsm::toolChanged, mToolsActionGroup,
           &ExclusiveActionGroup::setCurrentAction);
@@ -611,6 +613,8 @@ bool PackageEditorWidget::toolChangeRequested(Tool newTool,
       return mFsm->processStartAddingHoles();
     case Tool::MEASURE:
       return mFsm->processStartMeasure();
+    case Tool::RENUMBER_PADS:
+      return mFsm->processStartReNumberPads();
     default:
       return false;
   }


### PR DESCRIPTION
Especially after copy&pasting pads, one has to manually assign each of the pasted pads to the corresponding package pad. For many pads, this can be very cumbersome. This this PR adds a new tool to re-number all pads in a footprint:

![librepcb-renumber-pads](https://github.com/user-attachments/assets/d7be5858-06a0-44bb-b7f7-4e90a8b26346)

Behavior:
- When starting the tool, all pad numbers are cleared
- Pads are assigned one-by-one by clicks on pads in the desired order
- When pressing SHIFT, auto-increment is disabled to allow assigning multiple pads to the same package pad
- If multiple pads are in the area between the last assigned pad and the currently highlighted, each of the pads in this area will be assigned at once
  - The numbering direction X->Y vs. Y->X can be toggled by pressing SHIFT
  - This multi-mode can be disabled by pressing CTRL to allow single selection
- The tool is left (and the pinout stored) once all pads are assigned, or by pressing the Return key
- Leaving the tool in any other way (e.g. Escape) discards all changes and restores the original pinout