### PR TITLE
CI: Update to macOS 13

### DIFF
--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: macOS
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   timeoutInMinutes: 180
   variables:
     OS: 'mac'


### PR DESCRIPTION
Homebrew does not provide binaries for macOS 12 anymore, which broke CI. Thus we have to update to macOS 13. Even though macOS 12 is EOL now, probably many people still use it and won't be happy that our binary releases might not run there anymore, but there's not much we could do to avoid it... :slightly_frowning_face: 