### PR TITLE
Fix deserialization of pressfit pads

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -426,6 +426,8 @@ add_library(
   serialization/fileformatmigrationunstable.h
   serialization/fileformatmigrationv01.cpp
   serialization/fileformatmigrationv01.h
+  serialization/fileformatmigrationv1.cpp
+  serialization/fileformatmigrationv1.h
   serialization/serializablekeyvaluemap.h
   serialization/serializableobjectlist.h
   serialization/sexpression.cpp

--- a/libs/librepcb/core/library/pkg/footprintpad.cpp
+++ b/libs/librepcb/core/library/pkg/footprintpad.cpp
@@ -123,7 +123,10 @@ inline FootprintPad::Function deserialize(const SExpression& node) {
     return FootprintPad::Function::Unspecified;
   } else if (str == QLatin1String("standard")) {
     return FootprintPad::Function::StandardPad;
-  } else if (str == QLatin1String("press_fit")) {
+  } else if ((str == QLatin1String("pressfit")) ||
+             (str == QLatin1String("press_fit"))) {
+    // NOTE: Remove press_fit in LibrePCB 2.x since it will be renamed during
+    // file format upgrade.
     return FootprintPad::Function::PressFitPad;
   } else if (str == QLatin1String("thermal")) {
     return FootprintPad::Function::ThermalPad;

--- a/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
@@ -1,0 +1,177 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "fileformatmigrationv1.h"
+
+#include "../fileio/transactionaldirectory.h"
+#include "../fileio/versionfile.h"
+#include "sexpression.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+FileFormatMigrationV1::FileFormatMigrationV1(QObject* parent) noexcept
+  : FileFormatMigration(Version::fromString("1"), Version::fromString("2"),
+                        parent) {
+}
+
+FileFormatMigrationV1::~FileFormatMigrationV1() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void FileFormatMigrationV1::upgradeComponentCategory(
+    TransactionalDirectory& dir) {
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-cmpcat");
+}
+
+void FileFormatMigrationV1::upgradePackageCategory(
+    TransactionalDirectory& dir) {
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-pkgcat");
+}
+
+void FileFormatMigrationV1::upgradeSymbol(TransactionalDirectory& dir) {
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-sym");
+}
+
+void FileFormatMigrationV1::upgradePackage(TransactionalDirectory& dir) {
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-pkg");
+
+  // Content File.
+  {
+    const QString fp = "package.lp";
+    std::unique_ptr<SExpression> root =
+        SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+
+    // Footprints.
+    for (SExpression* fptNode : root->getChildren("footprint")) {
+      // Pads.
+      for (SExpression* padNode : fptNode->getChildren("pad")) {
+        // Revert possibly made manual change as a workaround for bug, see
+        // https://librepcb.discourse.group/t/migrating-libraries-from-old-version-1-0-pressfit-problem/810
+        SExpression& padFunction = padNode->getChild("function/@0");
+        if (padFunction.getValue() == "press_fit") {
+          padFunction.setValue("pressfit");
+        }
+      }
+    }
+
+    dir.write(fp, root->toByteArray());
+  }
+}
+
+void FileFormatMigrationV1::upgradeComponent(TransactionalDirectory& dir) {
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-cmp");
+}
+
+void FileFormatMigrationV1::upgradeDevice(TransactionalDirectory& dir) {
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-dev");
+}
+
+void FileFormatMigrationV1::upgradeLibrary(TransactionalDirectory& dir) {
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-lib");
+}
+
+void FileFormatMigrationV1::upgradeProject(TransactionalDirectory& dir,
+                                           QList<Message>& messages) {
+  // ATTENTION: Do not actually perform any upgrade in this method! Instead,
+  // just call virtual protected methods which do the upgrade. This allows
+  // FileFormatMigrationUnstable to override them with partial upgrades.
+  Q_UNUSED(messages);
+
+  // Version File.
+  upgradeVersionFile(dir, ".librepcb-project");
+
+  // Symbols.
+  foreach (const QString& dirName, dir.getDirs("library/sym")) {
+    TransactionalDirectory subDir(dir, "library/sym/" % dirName);
+    if (subDir.fileExists(".librepcb-sym")) {
+      upgradeSymbol(subDir);
+    }
+  }
+
+  // Packages.
+  foreach (const QString& dirName, dir.getDirs("library/pkg")) {
+    TransactionalDirectory subDir(dir, "library/pkg/" % dirName);
+    if (subDir.fileExists(".librepcb-pkg")) {
+      upgradePackage(subDir);
+    }
+  }
+
+  // Components.
+  foreach (const QString& dirName, dir.getDirs("library/cmp")) {
+    TransactionalDirectory subDir(dir, "library/cmp/" % dirName);
+    if (subDir.fileExists(".librepcb-cmp")) {
+      upgradeComponent(subDir);
+    }
+  }
+
+  // Devices.
+  foreach (const QString& dirName, dir.getDirs("library/dev")) {
+    TransactionalDirectory subDir(dir, "library/dev/" % dirName);
+    if (subDir.fileExists(".librepcb-dev")) {
+      upgradeDevice(subDir);
+    }
+  }
+}
+
+void FileFormatMigrationV1::upgradeWorkspaceData(TransactionalDirectory& dir) {
+  // Create version file.
+  dir.write(".librepcb-data", VersionFile(mToVersion).toByteArray());
+
+  // Remove legacy files.
+  const QStringList filesToRemove = {
+      "cache_v3",
+      "cache_v4",
+  };
+  TransactionalDirectory librariesDir(dir, "libraries");
+  foreach (const QString fileName, librariesDir.getFiles()) {
+    if (filesToRemove.contains(fileName.split(".").first())) {
+      qInfo() << "Removing legacy file:"
+              << librariesDir.getAbsPath(fileName).toNative();
+      librariesDir.removeFile(fileName);
+    }
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/serialization/fileformatmigrationv1.h
+++ b/libs/librepcb/core/serialization/fileformatmigrationv1.h
@@ -1,0 +1,75 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_FILEFORMATMIGRATIONV1_H
+#define LIBREPCB_CORE_FILEFORMATMIGRATIONV1_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "fileformatmigration.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class SExpression;
+
+/*******************************************************************************
+ *  Class FileFormatMigrationV1
+ ******************************************************************************/
+
+/**
+ * @brief Migration to upgrade file format v1.0
+ */
+class FileFormatMigrationV1 : public FileFormatMigration {
+  Q_OBJECT
+
+public:
+  // Constructors / Destructor
+  explicit FileFormatMigrationV1(QObject* parent = nullptr) noexcept;
+  FileFormatMigrationV1(const FileFormatMigrationV1& other) = delete;
+  virtual ~FileFormatMigrationV1() noexcept;
+
+  // General Methods
+  virtual void upgradeComponentCategory(TransactionalDirectory& dir) override;
+  virtual void upgradePackageCategory(TransactionalDirectory& dir) override;
+  virtual void upgradeSymbol(TransactionalDirectory& dir) override;
+  virtual void upgradePackage(TransactionalDirectory& dir) override;
+  virtual void upgradeComponent(TransactionalDirectory& dir) override;
+  virtual void upgradeDevice(TransactionalDirectory& dir) override;
+  virtual void upgradeLibrary(TransactionalDirectory& dir) override;
+  virtual void upgradeProject(TransactionalDirectory& dir,
+                              QList<Message>& messages) override;
+  virtual void upgradeWorkspaceData(TransactionalDirectory& dir) override;
+
+  // Operator Overloadings
+  FileFormatMigrationV1& operator=(const FileFormatMigrationV1& rhs) = delete;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif


### PR DESCRIPTION
Press-fit pads were incorrectly deserialized, leading in an error when opening the package :-/ Now support loading the incorrect value (to avoid the error) and make the v1->v2 file format migration restoring the correct value in files.