### PR TITLE
Package editor: Support displaying datasheet image overlay

### DIFF
--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -31,6 +31,9 @@ add_library(
   dialogs/aboutdialog.cpp
   dialogs/aboutdialog.h
   dialogs/aboutdialog.ui
+  dialogs/backgroundimagesetupdialog.cpp
+  dialogs/backgroundimagesetupdialog.h
+  dialogs/backgroundimagesetupdialog.ui
   dialogs/circlepropertiesdialog.cpp
   dialogs/circlepropertiesdialog.h
   dialogs/circlepropertiesdialog.ui

--- a/libs/librepcb/editor/dialogs/backgroundimagesetupdialog.cpp
+++ b/libs/librepcb/editor/dialogs/backgroundimagesetupdialog.cpp
@@ -1,0 +1,631 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "backgroundimagesetupdialog.h"
+
+#include "../widgets/lengthedit.h"
+#include "filedialog.h"
+#include "ui_backgroundimagesetupdialog.h"
+
+#include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/fileio/fileutils.h>
+#include <librepcb/core/serialization/sexpression.h>
+#include <librepcb/core/utils/toolbox.h>
+#include <librepcb/editor/graphics/graphicsscene.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+static std::shared_ptr<QGraphicsPathItem> createCrossGraphicsItem(bool cursor) {
+  auto i = std::make_shared<QGraphicsPathItem>();
+  i->setFlag(QGraphicsItem::ItemIgnoresTransformations, true);
+  i->setPen(QPen(Qt::blue, 0));
+  const qreal len = cursor ? 2000 : 30;
+  QPainterPath p;
+  p.moveTo(-len, 0);
+  p.lineTo(len, 0);
+  p.moveTo(0, -len);
+  p.lineTo(0, len);
+  if (!cursor) {
+    p.addEllipse(QPointF(0, 0), 15, 15);
+  }
+  i->setPath(p);
+  return i;
+}
+
+static std::shared_ptr<QGraphicsLineItem> createRefLineGraphicsItem() {
+  auto i = std::make_shared<QGraphicsLineItem>();
+  i->setPen(QPen(Qt::blue, 0));
+  return i;
+}
+
+static std::shared_ptr<QWidget> createReferenceWidget(
+    int index, QWidget* parent, QList<std::pair<QPointF, Point>>* refs,
+    std::function<void()> cb) {
+  auto w = std::make_shared<QWidget>(parent);
+  w->setLayout(new QHBoxLayout());
+  w->layout()->setContentsMargins(3, 3, 3, 3);
+  w->layout()->setSpacing(3);
+  LengthEdit* edtX = new LengthEdit(w.get());
+  edtX->setValue(refs->value(index).second.getX());
+  QObject::connect(edtX, &LengthEdit::valueChanged,
+                   [index, refs, cb](const Length& v) {
+                     if (index < refs->count()) {
+                       std::get<1>((*refs)[index]).setX(v);
+                       cb();
+                     }
+                   });
+  w->layout()->addWidget(edtX);
+  LengthEdit* edtY = new LengthEdit(w.get());
+  edtY->setValue(refs->value(index).second.getY());
+  QObject::connect(edtY, &LengthEdit::valueChanged,
+                   [index, refs, cb](const Length& v) {
+                     if (index < refs->count()) {
+                       std::get<1>((*refs)[index]).setY(v);
+                       cb();
+                     }
+                   });
+  w->layout()->addWidget(edtY);
+  w->setFocusProxy(edtX);
+  w->adjustSize();
+  w->move(0, index * w->height());
+  w->show();
+  return w;
+}
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BackgroundImageSetupDialog::BackgroundImageSetupDialog(
+    const QString& settingsPrefix, QWidget* parent) noexcept
+  : QDialog(parent),
+    mUi(new Ui::BackgroundImageSetupDialog),
+    mSettingsPrefix(settingsPrefix % "/background_image_dialog"),
+    mState(State::Idle),
+    mImage(),
+    mRotation(),
+    mLoadedReferences(),
+    mReferences(),
+    mScreen(),
+    mCountdownSecs(0),
+    mRotateWidget(),
+    mImageGraphicsItem(new QGraphicsPixmapItem()),
+    mCursorGraphicsItem(createCrossGraphicsItem(true)),
+    mCropGraphicsItem(new QGraphicsPathItem()) {
+  mUi->setupUi(this);
+  mUi->graphicsView->setOriginCrossVisible(false);
+  mUi->graphicsView->setBackgroundColors(Qt::transparent, Qt::transparent);
+  mUi->graphicsView->setScene(new GraphicsScene(this));
+  mUi->graphicsView->setEventHandlerObject(this);
+  mUi->graphicsView->scene()->addItem(mImageGraphicsItem.get());
+  mUi->graphicsView->scene()->addItem(mCursorGraphicsItem.get());
+  mUi->graphicsView->scene()->addItem(mCropGraphicsItem.get());
+  mImageGraphicsItem->setTransformationMode(Qt::SmoothTransformation);
+  mCropGraphicsItem->setPen(QPen(Qt::blue, 0));
+
+  // Create widget for rotating.
+  {
+    mRotateWidget.reset(new QWidget(mUi->graphicsView));
+    mRotateWidget->setAutoFillBackground(true);
+    mRotateWidget->setLayout(new QHBoxLayout());
+    mRotateWidget->layout()->setContentsMargins(3, 3, 3, 3);
+    mRotateWidget->layout()->setSpacing(3);
+
+    QToolButton* btnRotateCcw = new QToolButton(mRotateWidget.get());
+    btnRotateCcw->setIcon(QIcon(":/img/actions/rotate_left.png"));
+    connect(btnRotateCcw, &QToolButton::clicked, this, [this]() {
+      mRotation += Angle::deg45();
+      updateUi();
+    });
+    mRotateWidget->layout()->addWidget(btnRotateCcw);
+
+    QToolButton* btnRotateCw = new QToolButton(mRotateWidget.get());
+    btnRotateCw->setIcon(QIcon(":/img/actions/rotate_right.png"));
+    connect(btnRotateCw, &QToolButton::clicked, this, [this]() {
+      mRotation -= Angle::deg45();
+      updateUi();
+    });
+    mRotateWidget->layout()->addWidget(btnRotateCw);
+
+    QToolButton* btnMirror = new QToolButton(mRotateWidget.get());
+    btnMirror->setIcon(QIcon(":/img/actions/mirror_horizontal.png"));
+    btnMirror->setCheckable(true);
+    connect(btnMirror, &QToolButton::toggled, this, [this]() {
+      mImage = mImage.mirrored(true, false);
+      updateUi();
+    });
+    mRotateWidget->layout()->addWidget(btnMirror);
+
+    QToolButton* btnApply = new QToolButton(mRotateWidget.get());
+    btnApply->setIcon(QIcon(":/img/actions/apply.png"));
+    connect(btnApply, &QToolButton::clicked, this, [this]() {
+      mState = State::SelectRef1;
+      updateUi();
+    });
+    mRotateWidget->layout()->addWidget(btnApply);
+
+    QToolButton* btnCancel = new QToolButton(mRotateWidget.get());
+    btnCancel->setIcon(QIcon(":/img/actions/cancel.png"));
+    connect(btnCancel, &QToolButton::clicked, this, [this]() {
+      mState = State::Idle;
+      updateUi();
+    });
+    mRotateWidget->layout()->addWidget(btnCancel);
+
+    mRotateWidget->adjustSize();
+  }
+
+  // Set minimum side bar width to avoid dynamic resizing.
+  if (auto w = createReferenceWidget(0, this, &mReferences, nullptr)) {
+    mUi->hLine->setMinimumWidth(w->width());
+  }
+
+  // UI Handlers.
+  connect(mUi->buttonBox, &QDialogButtonBox::accepted, this,
+          &BackgroundImageSetupDialog::accept);
+  connect(mUi->buttonBox, &QDialogButtonBox::rejected, this,
+          &BackgroundImageSetupDialog::reject);
+  connect(mUi->btnScreenshot, &QPushButton::clicked, this,
+          &BackgroundImageSetupDialog::startScreenshot);
+  connect(mUi->btnPaste, &QPushButton::clicked, this,
+          &BackgroundImageSetupDialog::pasteFromClipboard);
+  connect(mUi->btnOpen, &QPushButton::clicked, this,
+          &BackgroundImageSetupDialog::loadFromFile);
+  connect(mUi->btnReset, &QToolButton::clicked, this, [this]() {
+    mImage = QImage();
+    mRotation = Angle::deg0();
+    mReferences.clear();
+    mCropGraphicsItem->setPath(QPainterPath());
+    mState = State::Idle;
+    updateUi();
+  });
+
+  // Load initial values and window geometry.
+  QSettings cs;
+  restoreGeometry(cs.value(mSettingsPrefix % "/window_geometry").toByteArray());
+
+  // Try to load image from clipboard.
+  pasteFromClipboard();
+  updateUi();  // Clear error message if no image in clipboard.
+}
+
+BackgroundImageSetupDialog::~BackgroundImageSetupDialog() noexcept {
+  mUi->graphicsView->setEventHandlerObject(nullptr);
+
+  // Save the values and window geometry.
+  QSettings cs;
+  cs.setValue(mSettingsPrefix % "/window_geometry", saveGeometry());
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BackgroundImageSetupDialog::setData(
+    const QImage& image, const Angle& rotation,
+    const QList<std::pair<QPointF, Point>>& references) noexcept {
+  mImage = image;
+  mRotation = rotation;
+  mLoadedReferences = references;
+  mReferences = references;
+  updateUi();
+  fitImageInView();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void BackgroundImageSetupDialog::keyPressEvent(QKeyEvent* event) noexcept {
+  if ((event->key() == Qt::Key_Escape) &&
+      (mCropGraphicsItem->path().elementCount())) {
+    mCropGraphicsItem->setPath(QPainterPath());
+    updateUi();
+    event->accept();
+    return;
+  } else if (mScreen) {
+    mScreen = nullptr;
+    screenshotCountdownTick();
+    return;
+  }
+
+  QDialog::keyPressEvent(event);
+}
+
+bool BackgroundImageSetupDialog::graphicsViewEventHandler(
+    QEvent* event) noexcept {
+  if (event->type() == QEvent::GraphicsSceneMousePress) {
+    QGraphicsSceneMouseEvent* e = static_cast<QGraphicsSceneMouseEvent*>(event);
+    if (e->button() != Qt::LeftButton) return false;
+    if (mState == State::Crop) {
+      QPainterPath p;
+      p.moveTo(e->scenePos());
+      mCropGraphicsItem->setPath(p);
+    } else if (mState == State::Rotate) {
+      mState = State::SelectRef1;
+      updateUi();
+    } else if (mState == State::SelectRef1) {
+      auto ref = mLoadedReferences.value(0);
+      ref.first = mImageGraphicsItem->mapFromScene(e->scenePos());
+      mReferences.append(ref);
+      mState = State::SelectRef2;
+      updateUi();
+    } else if (mState == State::SelectRef2) {
+      auto ref = mLoadedReferences.value(1);
+      ref.first = mImageGraphicsItem->mapFromScene(e->scenePos());
+      mReferences.append(ref);
+      mState = State::Idle;
+      updateUi();
+      if (auto w = mReferenceWidgets.value(0)) {
+        w->setFocus(Qt::TabFocusReason);
+      }
+    }
+  } else if (event->type() == QEvent::GraphicsSceneMouseRelease) {
+    QGraphicsSceneMouseEvent* e = static_cast<QGraphicsSceneMouseEvent*>(event);
+    if (e->button() != Qt::LeftButton) return false;
+    if (mState == State::Crop) {
+      QPainterPath path = mCropGraphicsItem->path();
+      mCropGraphicsItem->setPath(QPainterPath());
+      path.closeSubpath();
+      path.translate(-mImageGraphicsItem->pos());
+      if (path.elementCount() > 10) {
+        mImage = cropImage(mImage, path);
+      }
+      mState = State::Rotate;
+      updateUi();
+      fitImageInView();
+    }
+  } else if (event->type() == QEvent::GraphicsSceneMouseMove) {
+    QGraphicsSceneMouseEvent* e = static_cast<QGraphicsSceneMouseEvent*>(event);
+    mCursorGraphicsItem->setPos(e->scenePos());
+    if ((mState == State::Crop) &&
+        (mCropGraphicsItem->path().elementCount() > 0)) {
+      QPainterPath p = mCropGraphicsItem->path();
+      p.lineTo(e->scenePos());
+      mCropGraphicsItem->setPath(p);
+    }
+    updateAnchors();
+  }
+  return false;
+}
+
+void BackgroundImageSetupDialog::startScreenshot() noexcept {
+  QList<QScreen*> screens = QGuiApplication::screens();
+  mScreen = screens.value(0);
+  if (screens.count() > 1) {
+    QMenu menu;
+    QHash<QAction*, QScreen*> screenMap;
+    for (QScreen* screen : screens) {
+      QString name = tr("Screen %1").arg(screenMap.count() + 1);
+      QString type = (screen->manufacturer() + " " + screen->model()).trimmed();
+      if (!type.isEmpty()) {
+        name += QString(" (%1)").arg(type);
+      }
+      screenMap.insert(menu.addAction(name), screen);
+    }
+    mScreen = screenMap.value(menu.exec(QCursor::pos()));
+    if (!mScreen) return;
+  }
+
+  mUi->btnReset->click();
+  mCountdownSecs = 4;
+  screenshotCountdownTick();
+}
+
+void BackgroundImageSetupDialog::screenshotCountdownTick() noexcept {
+  --mCountdownSecs;
+  if (!mScreen) {
+    // Screen disappeared or screenshot aborted.
+    updateUi();
+  } else if (mCountdownSecs <= 0) {
+    takeScreenshot();
+  } else {
+    updateUi(QString::number(mCountdownSecs));
+    QTimer::singleShot(1000, this,
+                       &BackgroundImageSetupDialog::screenshotCountdownTick);
+  }
+}
+
+void BackgroundImageSetupDialog::takeScreenshot() noexcept {
+  if (!mScreen) return;
+
+  mImage = mScreen->grabWindow(0).toImage();
+  mScreen = nullptr;
+  if (mImage.isNull()) {
+    mState = State::Idle;
+    updateUi(
+        tr("Could not take a screenshot. Note that this feature does not "
+           "work on some systems due to security mechanisms."));
+  } else {
+    mState = State::Crop;
+    updateUi();
+  }
+  fitImageInView();
+  raise();
+  activateWindow();
+}
+
+void BackgroundImageSetupDialog::pasteFromClipboard() noexcept {
+  mUi->btnReset->click();
+
+  mImage = qApp->clipboard()->image();
+  if (mImage.isNull()) {
+    updateUi(tr("No image found in the clipboard."));
+  } else {
+    mState = State::Crop;
+    updateUi();
+  }
+  fitImageInView();
+}
+
+void BackgroundImageSetupDialog::loadFromFile() noexcept {
+  QString extensionsStr;
+  foreach (const QString& ext, QImageReader::supportedImageFormats()) {
+    extensionsStr += "*." % ext % " ";
+  }
+
+  QSettings cs;
+  QString key = mSettingsPrefix % "/file";
+  QString fp = cs.value(key, QDir::homePath()).toString();
+  fp = FileDialog::getOpenFileName(this, tr("Choose image"), fp, extensionsStr);
+  if (fp.isEmpty()) {
+    return;  // Aborted.
+  }
+  cs.setValue(key, fp);
+  mUi->btnReset->click();
+  if (!mImage.load(fp)) {
+    updateUi(tr("Failed to open the selected image file."));
+  } else {
+    mState = State::Crop;
+    updateUi();
+  }
+  fitImageInView();
+}
+
+void BackgroundImageSetupDialog::updateUi(QString msg) noexcept {
+  const bool valid = (!mImage.isNull()) && mImage.width() && mImage.height();
+  if (valid &&
+      ((mState == State::SelectRef1) || (mState == State::SelectRef2))) {
+    mUi->graphicsView->setCursor(Qt::BlankCursor);
+  } else if (valid && (mState == State::Crop)) {
+    mUi->graphicsView->setCursor(Qt::CrossCursor);
+  } else {
+    mUi->graphicsView->unsetCursor();
+  }
+
+  // Update widgets & graphics items.
+  mRotateWidget->setVisible(mState == State::Rotate);
+  if (mRotateWidget->isVisible()) {
+    mRotateWidget->move(mUi->graphicsView->rect().center() -
+                        mRotateWidget->rect().center());
+  }
+  mImageGraphicsItem->setTransformOriginPoint(mImage.rect().center());
+  mImageGraphicsItem->setRotation(-mRotation.toDeg());
+  mImageGraphicsItem->setPos(-mImage.rect().center());
+  mCursorGraphicsItem->setVisible((mState == State::SelectRef1) ||
+                                  (mState == State::SelectRef2));
+  while (mReferenceGraphicsItems.count() > mReferences.count()) {
+    mReferenceGraphicsItems.takeLast();
+    mReferenceLineGraphicsItems.takeLast();
+    mReferenceWidgets.takeLast();
+  }
+  while (mReferenceGraphicsItems.count() < mReferences.count()) {
+    auto c = createCrossGraphicsItem(false);
+    mUi->graphicsView->scene()->addItem(c.get());
+    mReferenceGraphicsItems.append(c);
+    auto l = createRefLineGraphicsItem();
+    mUi->graphicsView->scene()->addItem(l.get());
+    mReferenceLineGraphicsItems.append(l);
+    auto w = createReferenceWidget(
+        mReferenceWidgets.count(), this, &mReferences,
+        std::bind(&BackgroundImageSetupDialog::updateStatusMsg, this));
+    mUi->widgetsLayout->addWidget(w.get());
+    mReferenceWidgets.append(w);
+  }
+  for (int i = 0; i < mReferenceGraphicsItems.count(); ++i) {
+    mReferenceGraphicsItems.at(i)->setPos(
+        mImageGraphicsItem->mapToScene(mReferences.value(i).first));
+  }
+  mUi->lblCoordinates->setVisible(mReferences.count() > 0);
+  QTimer::singleShot(10, this, &BackgroundImageSetupDialog::updateAnchors);
+
+  // Show message if no image available to display.
+  if (msg.isEmpty() && (!valid)) {
+    msg = "<p>" %
+        tr("This tool allows you to set a background image (typically a "
+           "datasheet drawing) in the footprint editor to easily verify the "
+           "size &amp; position of footprint pads etc. Note that the image "
+           "won't appear on the board, it's only visible in the footprint "
+           "editor.") %
+        "</p>";
+    msg += "<ol>";
+    QStringList lines;
+    lines.append(tr("Load an image with one of the buttons on the left side."));
+    lines.append(
+        tr("Draw a line around the footprint to cut out the relevant area."));
+    lines.append(tr("Rotate/mirror the image."));
+    lines.append(
+        tr("Specify two reference points to calculate X/Y scale & offset."));
+    for (const QString& line : lines) {
+      msg += QString("<li>%1</li>").arg(line);
+    }
+    msg += "</ol>";
+    msg += "<p><b>" %
+        tr("Important: Make sure to zoom in as much as possible when taking "
+           "the screenshot, to get a reasonably high resolution!") %
+        "</b></p>";
+  }
+
+  if (msg.isEmpty()) {
+    // Show image.
+    mUi->lblMessage->hide();
+    mImageGraphicsItem->setPixmap(QPixmap::fromImage(mImage));
+    mUi->graphicsView->show();
+  } else {
+    // Show text.
+    const bool multiline = msg.contains("<p>");
+    QFont f = mUi->lblMessage->font();
+    f.setPointSize((msg.length() == 1) ? 40 : (multiline ? 12 : 20));
+    mUi->lblMessage->setFont(f);
+
+    mUi->graphicsView->hide();
+    mUi->lblMessage->setAlignment(multiline ? (Qt::AlignLeft | Qt::AlignVCenter)
+                                            : Qt::AlignCenter);
+    mUi->lblMessage->setText(msg);
+    mUi->lblMessage->show();
+  }
+
+  // Update status text.
+  updateStatusMsg();
+}
+
+void BackgroundImageSetupDialog::fitImageInView() noexcept {
+  QTimer::singleShot(10, this, [this]() {
+    mUi->graphicsView->setVisibleSceneRect(
+        mImageGraphicsItem->mapToScene(mImageGraphicsItem->boundingRect())
+            .boundingRect());
+    updateAnchors();
+  });
+}
+
+void BackgroundImageSetupDialog::updateAnchors() noexcept {
+  for (int i = 0; i < mReferenceGraphicsItems.count(); ++i) {
+    const QPoint widget = mReferenceWidgets.at(i)->geometry().center();
+    const QPoint anchor(0, mUi->graphicsView->mapFrom(this, widget).y());
+    const QPointF anchorScene = mUi->graphicsView->mapToScene(anchor);
+    mReferenceLineGraphicsItems.at(i)->setLine(
+        QLineF(anchorScene,
+               mImageGraphicsItem->mapToScene(mReferences.value(i).first)));
+  }
+}
+
+void BackgroundImageSetupDialog::updateStatusMsg() noexcept {
+  QStringList lines;
+  auto addStep = [&lines](int step) { lines.append(tr("Step %1:").arg(step)); };
+  const QString note =
+      tr("Note that the two points must be located diagonally to get a large "
+         "distance in both X- and Y-direction.");
+
+  if (mState == State::Crop) {
+    addStep(1);
+    lines.append(
+        tr("Crop the image by drawing a line with the cursor around the "
+           "footprint (single click to skip)."));
+  } else if (mState == State::Rotate) {
+    addStep(2);
+    lines.append(tr(
+        "Rotate/mirror the image to match the orientation of the footprint."));
+  } else if (mState == State::SelectRef1) {
+    addStep(3);
+    lines.append(
+        tr("Click into the image to select the first reference point with "
+           "known X/Y coordinates."));
+    lines.append(note);
+  } else if (mState == State::SelectRef2) {
+    addStep(4);
+    lines.append(
+        tr("Click into the image to select the second reference point with "
+           "known X/Y coordinates."));
+    lines.append(note);
+  } else if (!mImage.isNull()) {
+    QString err;
+    if (mReferences.count() < 2) {
+      err = tr("Too few reference points (2 required).");
+    } else if (mReferences.last().second.isOrigin()) {
+      addStep(5);
+      lines.append(tr(
+          "Specify the target coordinates for the chosen reference points."));
+    } else {
+      const int minPixels = std::min(mImage.width(), mImage.height()) / 5;
+      const Length minLength(100000);
+      const QPointF dPx = mReferences[1].first - mReferences[0].first;
+      const Point dMm = mReferences[1].second - mReferences[0].second;
+      const qreal scaleX = std::abs(dPx.x() / dMm.toMmQPointF().x());
+      const qreal scaleY = std::abs(dPx.y() / dMm.toMmQPointF().y());
+      if ((std::abs(dPx.x()) < minPixels) || (std::abs(dPx.y()) < minPixels) ||
+          (dMm.getX().abs() < minLength) || (dMm.getY().abs() < minLength)) {
+        err = tr(
+            "There's not enough distance in either X- or Y direction. Choose "
+            "reference points with a large distance in both directions.");
+      } else if ((std::abs(scaleX - scaleY) / std::min(scaleX, scaleY)) > 0.5) {
+        err = tr(
+            "There is a high deviation between X- and Y scale factor. Please "
+            "check the reference points.");
+      }
+    }
+    if (!err.isEmpty()) {
+      lines.append("<span style=\"color:red\">" % err % "</span>");
+    }
+  }
+
+  QString s;
+  for (const QString& l : lines) {
+    s += "<p>" % l % "</p>";
+  }
+  mUi->lblStatus->setText(s);
+}
+
+QImage BackgroundImageSetupDialog::cropImage(const QImage& img,
+                                             const QPainterPath& p) noexcept {
+  // Determine background color.
+  QHash<QRgb, int> histogram;
+  for (int i = 0; i <= 100; ++i) {
+    QPoint pos = p.pointAtPercent(i / qreal(100)).toPoint();
+    if (pos.x() < 0) pos.setX(0);
+    if (pos.y() < 0) pos.setY(0);
+    if (pos.x() >= img.width()) pos.setX(img.width() - 1);
+    if (pos.x() >= img.height()) pos.setY(img.height() - 1);
+    histogram[img.pixel(pos)]++;
+  }
+  const int maxHistogramCount = Toolbox::sorted(histogram.values()).last();
+  const QRgb bgColor = histogram.key(maxHistogramCount);
+
+  // Create new empty pixmap.
+  QPixmap pixmap(img.width(), img.height());
+  pixmap.fill(bgColor);
+
+  // Paste cropped image content.
+  {
+    QPainter painter(&pixmap);
+    painter.setClipPath(p);
+    painter.drawImage(0, 0, img);
+  }
+
+  // Auto-crop to content.
+  QRect rect = p.boundingRect().toRect();
+  const int m = std::min(rect.width(), rect.height()) / 20;
+  rect = rect.adjusted(-m, -m, m, m);
+  return pixmap.copy(rect).toImage();
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/dialogs/backgroundimagesetupdialog.h
+++ b/libs/librepcb/editor/dialogs/backgroundimagesetupdialog.h
@@ -1,0 +1,130 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_EDITOR_BACKGROUNDIMAGESETUPDIALOG_H
+#define LIBREPCB_EDITOR_BACKGROUNDIMAGESETUPDIALOG_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../widgets/if_graphicsvieweventhandler.h"
+
+#include <librepcb/core/types/angle.h>
+#include <librepcb/core/types/point.h>
+
+#include <QtCore>
+#include <QtWidgets>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+namespace Ui {
+class BackgroundImageSetupDialog;
+}
+
+/*******************************************************************************
+ *  Class BackgroundImageSetupDialog
+ ******************************************************************************/
+
+/**
+ * @brief Dialog (GUI) to configure the background image of a 2D view
+ */
+class BackgroundImageSetupDialog final : public QDialog,
+                                         private IF_GraphicsViewEventHandler {
+  Q_OBJECT
+
+public:
+  // Types
+  enum class State {
+    Idle,
+    Crop,
+    Rotate,
+    SelectRef1,
+    SelectRef2,
+  };
+
+  // Constructors / Destructor
+  BackgroundImageSetupDialog() = delete;
+  BackgroundImageSetupDialog(const BackgroundImageSetupDialog& other) = delete;
+  explicit BackgroundImageSetupDialog(const QString& settingsPrefix,
+                                      QWidget* parent = nullptr) noexcept;
+  ~BackgroundImageSetupDialog() noexcept;
+
+  // General Methods
+  const QImage& getImage() const noexcept { return mImage; }
+  const Angle& getRotation() const noexcept { return mRotation; }
+  const QList<std::pair<QPointF, Point>>& getReferences() const noexcept {
+    return mReferences;
+  }
+  void setData(const QImage& image, const Angle& rotation,
+               const QList<std::pair<QPointF, Point>>& references) noexcept;
+
+  // Operator Overloadings
+  BackgroundImageSetupDialog& operator=(const BackgroundImageSetupDialog& rhs) =
+      delete;
+
+private:
+  void keyPressEvent(QKeyEvent* event) noexcept override;
+  bool graphicsViewEventHandler(QEvent* event) noexcept override;
+  void startScreenshot() noexcept;
+  void screenshotCountdownTick() noexcept;
+  void takeScreenshot() noexcept;
+  void pasteFromClipboard() noexcept;
+  void loadFromFile() noexcept;
+  void updateUi(QString msg = QString()) noexcept;
+  void fitImageInView() noexcept;
+  void updateAnchors() noexcept;
+  void updateStatusMsg() noexcept;
+  static QImage cropImage(const QImage& img, const QPainterPath& p) noexcept;
+
+  QScopedPointer<Ui::BackgroundImageSetupDialog> mUi;
+  const QString mSettingsPrefix;
+
+  // State
+  State mState;
+  QImage mImage;
+  Angle mRotation;
+  QList<std::pair<QPointF, Point>> mLoadedReferences;
+  QList<std::pair<QPointF, Point>> mReferences;
+  QPointer<QScreen> mScreen;
+  int mCountdownSecs;
+
+  // Widgets & graphics items
+  QScopedPointer<QWidget> mRotateWidget;
+  QScopedPointer<QGraphicsPixmapItem> mImageGraphicsItem;
+  std::shared_ptr<QGraphicsPathItem> mCursorGraphicsItem;
+  QScopedPointer<QGraphicsPathItem> mCropGraphicsItem;
+
+  // Always in sync with #mReferences
+  QList<std::shared_ptr<QGraphicsPathItem>> mReferenceGraphicsItems;
+  QList<std::shared_ptr<QGraphicsLineItem>> mReferenceLineGraphicsItems;
+  QList<std::shared_ptr<QWidget>> mReferenceWidgets;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/dialogs/backgroundimagesetupdialog.ui
+++ b/libs/librepcb/editor/dialogs/backgroundimagesetupdialog.ui
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>librepcb::editor::BackgroundImageSetupDialog</class>
+ <widget class="QDialog" name="librepcb::editor::BackgroundImageSetupDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>699</width>
+    <height>435</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Set Background Image</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QPushButton" name="btnScreenshot">
+           <property name="text">
+            <string>Take Screenshot</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/export_pixmap.png</normaloff>:/img/actions/export_pixmap.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QPushButton" name="btnPaste">
+           <property name="text">
+            <string>Paste From Clipboard</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/paste.png</normaloff>:/img/actions/paste.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QPushButton" name="btnOpen">
+           <property name="text">
+            <string>Load From File</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/open.png</normaloff>:/img/actions/open.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1" rowspan="3">
+          <widget class="QPushButton" name="btnReset">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Discard image</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/clean.png</normaloff>:/img/actions/clean.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="hLine">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblCoordinates">
+         <property name="text">
+          <string>Specify coordinates of reference points:</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="widgetsLayout"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblStatus">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QFrame" name="frame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="lblMessage">
+          <property name="styleSheet">
+           <string notr="true">color: gray;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="margin">
+           <number>30</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="librepcb::editor::GraphicsView" name="graphicsView"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>librepcb::editor::GraphicsView</class>
+   <extends>QGraphicsView</extends>
+   <header location="global">librepcb/editor/widgets/graphicsview.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -873,6 +873,15 @@ public:
       {QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_L)},
       &categoryView,
   };
+  EditorCommand toggleBackgroundImage{
+      "toggle_background_image",  // clang-format break
+      QT_TR_NOOP("Set/Unset Background Image"),
+      QT_TR_NOOP("Use a datasheet drawing as the background for verification"),
+      ":/img/actions/export_pixmap.png",
+      EditorCommand::Flag::OpensPopup,
+      {},
+      &categoryView,
+  };
   EditorCommand toggle3d{
       "toggle_3d",  // clang-format break
       QT_TR_NOOP("Toggle 2D/3D Mode"),

--- a/libs/librepcb/editor/library/editorwidgetbase.h
+++ b/libs/librepcb/editor/library/editorwidgetbase.h
@@ -99,6 +99,7 @@ public:
     Filter,
     GraphicsView,
     OpenGlView,
+    BackgroundImage,
     ExportGraphics,
     GenerateOutline,
     GenerateCourtyard,
@@ -133,6 +134,7 @@ public:
   bool isDirty() const noexcept {
     return mManualModificationsMade || (!mUndoStack->isClean());
   }
+  virtual bool isBackgroundImageSet() const noexcept { return false; }
   virtual QSet<Feature> getAvailableFeatures() const noexcept = 0;
 
   // Setters
@@ -185,6 +187,7 @@ public slots:
   virtual bool editGridProperties() noexcept { return false; }
   virtual bool increaseGridInterval() noexcept { return false; }
   virtual bool decreaseGridInterval() noexcept { return false; }
+  virtual bool toggleBackgroundImage() noexcept { return false; }
 
 protected:  // Methods
   void setupInterfaceBrokenWarningWidget(QWidget& widget) noexcept;

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -580,6 +580,14 @@ void LibraryEditor::createActions() noexcept {
   mActionGridDecrease.reset(cmd.gridDecrease.createAction(this, this, [this]() {
     if (mCurrentEditorWidget) mCurrentEditorWidget->decreaseGridInterval();
   }));
+  mActionToggleBgImage.reset(
+      cmd.toggleBackgroundImage.createAction(this, this, [this]() {
+        if (mCurrentEditorWidget) {
+          const bool enabled = mCurrentEditorWidget->toggleBackgroundImage();
+          mActionToggleBgImage->setCheckable(enabled);
+          mActionToggleBgImage->setChecked(enabled);
+        }
+      }));
   mActionZoomFit.reset(cmd.zoomFitContent.createAction(this, this, [this]() {
     if (mCurrentEditorWidget) mCurrentEditorWidget->zoomAll();
   }));
@@ -785,6 +793,7 @@ void LibraryEditor::createToolBars() noexcept {
   mToolBarView.reset(new QToolBar(tr("View"), this));
   mToolBarView->setObjectName("toolBarView");
   mToolBarView->addAction(mActionGridProperties.data());
+  mToolBarView->addAction(mActionToggleBgImage.data());
   mToolBarView->addAction(mActionZoomIn.data());
   mToolBarView->addAction(mActionZoomOut.data());
   mToolBarView->addAction(mActionZoomFit.data());
@@ -923,6 +932,7 @@ void LibraryEditor::createMenus() noexcept {
   mb.addAction(mActionGridProperties);
   mb.addAction(mActionGridIncrease.data());
   mb.addAction(mActionGridDecrease.data());
+  mb.addAction(mActionToggleBgImage);
   mb.addSeparator();
   mb.addAction(mActionZoomIn);
   mb.addAction(mActionZoomOut);
@@ -1001,6 +1011,7 @@ void LibraryEditor::setAvailableFeatures(
   mActionRotateCcw->setEnabled(features.contains(Feature::Rotate));
   mActionRotateCw->setEnabled(features.contains(Feature::Rotate));
   mActionSelectAll->setEnabled(features.contains(Feature::SelectGraphics));
+  mActionToggleBgImage->setEnabled(features.contains(Feature::BackgroundImage));
   mActionZoomFit->setEnabled(features.contains(Feature::GraphicsView));
   mActionZoomIn->setEnabled(features.contains(Feature::GraphicsView));
   mActionZoomOut->setEnabled(features.contains(Feature::GraphicsView));
@@ -1037,10 +1048,14 @@ void LibraryEditor::setActiveEditorWidget(EditorWidgetBase* widget) {
     mCurrentEditorWidget->connectEditor(*mUndoStackActionGroup,
                                         *mToolsActionGroup, *mToolBarCommand,
                                         *mUi->statusBar);
+    const bool bgImageSet = mCurrentEditorWidget->isBackgroundImageSet();
+    mActionToggleBgImage->setCheckable(bgImageSet);
+    mActionToggleBgImage->setChecked(bgImageSet);
     setAvailableFeatures(mCurrentEditorWidget->getAvailableFeatures());
     connect(mCurrentEditorWidget, &EditorWidgetBase::availableFeaturesChanged,
             this, &LibraryEditor::setAvailableFeatures);
   } else {
+    mActionToggleBgImage->setChecked(false);
     setAvailableFeatures({});
   }
   updateTabTitles();  // force updating the "Save" action title

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -204,6 +204,7 @@ private:  // Data
   QScopedPointer<QAction> mActionGridProperties;
   QScopedPointer<QAction> mActionGridIncrease;
   QScopedPointer<QAction> mActionGridDecrease;
+  QScopedPointer<QAction> mActionToggleBgImage;
   QScopedPointer<QAction> mActionZoomFit;
   QScopedPointer<QAction> mActionZoomIn;
   QScopedPointer<QAction> mActionZoomOut;

--- a/libs/librepcb/editor/library/pkg/packageeditorwidget.h
+++ b/libs/librepcb/editor/library/pkg/packageeditorwidget.h
@@ -56,6 +56,21 @@ class PackageEditorWidget;
 }
 
 /*******************************************************************************
+ *  Class BackgroundImageSettings
+ ******************************************************************************/
+
+struct BackgroundImageSettings {
+  bool enabled = true;  ///< Whether the background is enabled or not
+  QImage image;  ///< The original loaded image
+  Angle rotation;  ///< Rotation in scene
+  QList<std::pair<QPointF, Point>> references;  ///< References in #image
+
+  bool tryLoadFromDir(const FilePath& dir) noexcept;
+  void saveToDir(const FilePath& dir) noexcept;
+  QPixmap buildPixmap(const QColor& bgColor) const noexcept;
+};
+
+/*******************************************************************************
  *  Class PackageEditorWidget
  ******************************************************************************/
 
@@ -75,6 +90,7 @@ public:
   ~PackageEditorWidget() noexcept;
 
   // Getters
+  bool isBackgroundImageSet() const noexcept override;
   QSet<Feature> getAvailableFeatures() const noexcept override;
 
   // Setters
@@ -112,6 +128,7 @@ public slots:
   bool editGridProperties() noexcept override;
   bool increaseGridInterval() noexcept override;
   bool decreaseGridInterval() noexcept override;
+  bool toggleBackgroundImage() noexcept override;
 
 private:  // Methods
   void updateMetadata() noexcept;
@@ -141,6 +158,8 @@ private:  // Methods
                                 const QString& settingsKey) noexcept override;
   void setGridProperties(const PositiveLength& interval, const LengthUnit& unit,
                          Theme::GridStyle style) noexcept;
+  void applyBackgroundImageSettings() noexcept;
+  FilePath getBackgroundImageCacheDir() const noexcept;
   void toggle3DMode(bool enable) noexcept;
   bool is3DModeEnabled() const noexcept;
 
@@ -155,6 +174,10 @@ private:  // Data
   std::unique_ptr<Package> mPackage;
   std::shared_ptr<Footprint> mCurrentFootprint;
   std::shared_ptr<PackageModel> mCurrentModel;
+
+  // Background image
+  BackgroundImageSettings mBackgroundImageSettings;
+  std::shared_ptr<QGraphicsPixmapItem> mBackgroundImageGraphicsItem;
 
   // broken interface detection
   QSet<Uuid> mOriginalPadUuids;

--- a/libs/librepcb/editor/utils/shortcutsreferencegenerator.cpp
+++ b/libs/librepcb/editor/utils/shortcutsreferencegenerator.cpp
@@ -76,16 +76,16 @@ bool ShortcutsReferenceGenerator::generatePdf(const FilePath& fp) {
                        "Failed to start PDF export - invalid output file?");
   }
 
-  QRect imageRect(mmToPx(writer, 0), mmToPx(writer, 4), mmToPx(writer, 15),
+  QRect imageRect(mmToPx(writer, 0), mmToPx(writer, 0), mmToPx(writer, 15),
                   mmToPx(writer, 15));
   painter.drawImage(imageRect, QImage(":/img/app/librepcb.png"));
-  drawText(writer, painter, 17, 8.5, 12, 0, "LibrePCB");
-  drawText(writer, painter, 17.5, 17, 3.5, 0, "Keyboard Shortcuts Reference");
+  drawText(writer, painter, 17, 4.5, 12, 0, "LibrePCB");
+  drawText(writer, painter, 17.5, 13, 3.5, 0, "Keyboard Shortcuts Reference");
 
   qreal x = sPageWidth - 2 * sColumnWidth - sColumnSpacing;
   qreal shortcutsWidth = sColumnWidth;
-  qreal y = 6;
-  drawSectionTitle(writer, painter, x, sPageWidth, 1.5, "Built-In");
+  qreal y = 5.5;
+  drawSectionTitle(writer, painter, x, sPageWidth, 1.2, "Built-In");
   drawRow(writer, painter, x, y, sPageWidth - x, shortcutsWidth,
           "Switch Back to Last Used Tool", "Right Click", true);
   y += sRowHeight;
@@ -95,7 +95,7 @@ bool ShortcutsReferenceGenerator::generatePdf(const FilePath& fp) {
   drawRow(writer, painter, x, y, sPageWidth - x, shortcutsWidth, "Zoom View",
           "Scroll Wheel", true);
 
-  drawSectionTitle(writer, painter, 0, sPageWidth, 25.5,
+  drawSectionTitle(writer, painter, 0, sPageWidth, 19,
                    "Configured in Workspace Settings");
 
   // Use manual order of categories to get a compact page layout.
@@ -119,7 +119,7 @@ bool ShortcutsReferenceGenerator::generatePdf(const FilePath& fp) {
         "Editor command category not added to shortcuts reference export.");
   }
   x = 0;
-  y = 32;
+  y = 25;
   bool layoutOverflow = false;
   for (int i = 0; i < categories.count(); ++i) {
     if (!categories.at(i)->isConfigurable()) {
@@ -129,7 +129,7 @@ bool ShortcutsReferenceGenerator::generatePdf(const FilePath& fp) {
         mCommands.getCommands(categories.at(i)).count() * sRowHeight;
     if ((y + categoryHeight) > sPageHeight) {
       x += sColumnWidth + sColumnSpacing;
-      y = 32;
+      y = 25;
       if (((y + categoryHeight) > sPageHeight) ||
           ((x + sColumnWidth) > sPageWidth)) {
         layoutOverflow = true;


### PR DESCRIPTION
This PR allows to set an image as a semi-transparent overlay in the footprint editor, to verify the footprint geometry with a package drawing (e.g. from a datasheet). Images can be loaded from several sources:

- Take screenshot directly from within LibrePCB (with 3 seconds delay to allow window switching)
- Paste from clipboard
- Load from file

Then the transform of the image needs to be set by a few steps:

1. Crop the image (optional)
2. Mirror & rotate the image, if required
3. Specify two points in the image with their corresponding target coordinates in the footprint. LibrePCB will then calculate X- and Y scale factors and offset for the actual image placement. A sanity check warns e.g. in case the distance in one direction is not large enough, thus would lead in inaccurate scaling.

The image together with all the settings is stored in the user's cache directory (`~/.cache` on Linux) - not in the library element! - and automatically displayed again when opening the package the next time.

For display, the image colors get inverted depending on the window's background color and the image's background color is made transparent so only the drawing should be visible. And actually it's not an overlay but in the background, to avoid hiding footprint geometry in case the automatic transparency doesn't work.

![librepcb-bg-image](https://github.com/user-attachments/assets/98bbb8c6-6b5c-49a9-9513-ffcce1f04a19)

Closes #909 