### PR TITLE
Eagle import: Fix unreadable log messages with dark theme

### DIFF
--- a/libs/librepcb/core/utils/messagelogger.cpp
+++ b/libs/librepcb/core/utils/messagelogger.cpp
@@ -31,24 +31,26 @@ namespace librepcb {
  *  Class MessageLogger::Message
  ******************************************************************************/
 
-QString MessageLogger::Message::toRichText(bool colored,
+QString MessageLogger::Message::toRichText(ColorTheme theme,
                                            bool bulletPoint) const noexcept {
-  static const QHash<QtMsgType, QString> colorMap = {
-      {QtDebugMsg, "blue"},
-      {QtInfoMsg, "darkblue"},
-      {QtWarningMsg, "orangered"},
-      {QtCriticalMsg, "red"},
+  static const QHash<QtMsgType, std::pair<QString, QString>> colorMap = {
+      {QtDebugMsg, {"blue", "gray"}},
+      {QtInfoMsg, {"darkblue", "white"}},
+      {QtWarningMsg, {"orangered", "yellow"}},
+      {QtCriticalMsg, {"red", "red"}},
   };
 
   QString s;
-  if (colored && colorMap.contains(type)) {
-    s += QString("<font color=\"%1\">").arg(colorMap[type]);
+  if ((theme != ColorTheme::None) && colorMap.contains(type)) {
+    s += QString("<font color=\"%1\">")
+             .arg((theme == ColorTheme::Dark) ? colorMap[type].second
+                                              : colorMap[type].first);
   }
   if (bulletPoint) {
     s += "&#x2022; ";
   }
   s += QString(message).replace("\n", "<br>");
-  if (colored && colorMap.contains(type)) {
+  if ((theme != ColorTheme::None) && colorMap.contains(type)) {
     s += "</font>";
   }
   return s;
@@ -113,10 +115,10 @@ QStringList MessageLogger::getMessagesPlain() const noexcept {
   return l;
 }
 
-QString MessageLogger::getMessagesRichText() const noexcept {
+QString MessageLogger::getMessagesRichText(ColorTheme theme) const noexcept {
   QStringList l;
   foreach (const Message& msg, getMessages()) {
-    l.append(msg.toRichText());
+    l.append(msg.toRichText(theme));
   }
   return l.join("<br>");
 }

--- a/libs/librepcb/core/utils/messagelogger.h
+++ b/libs/librepcb/core/utils/messagelogger.h
@@ -44,11 +44,13 @@ class MessageLogger final : public QObject {
   Q_OBJECT
 
 public:
+  enum class ColorTheme { None, Light, Dark };
+
   struct Message {
     QtMsgType type;
     QString message;
 
-    QString toRichText(bool colored = true,
+    QString toRichText(ColorTheme theme,
                        bool bulletPoint = false) const noexcept;
   };
 
@@ -81,7 +83,7 @@ public:
   bool hasMessages() const noexcept;
   QList<Message> getMessages() const noexcept;
   QStringList getMessagesPlain() const noexcept;
-  QString getMessagesRichText() const noexcept;
+  QString getMessagesRichText(ColorTheme theme) const noexcept;
 
   // General Methods
   void clear() noexcept;

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "eaglelibraryimportwizardpage_result.h"
 
+#include "../../utils/editortoolbox.h"
 #include "eaglelibraryimportwizardcontext.h"
 #include "ui_eaglelibraryimportwizardpage_result.h"
 
@@ -110,7 +111,10 @@ void EagleLibraryImportWizardPage_Result::importFinished() noexcept {
               &QProgressBar::setValue, Qt::QueuedConnection));
 
   const auto log = mContext->getImport().getLogger();
-  mUi->lblMessages->setText(log->getMessagesRichText());
+  mUi->lblMessages->setText(
+      log->getMessagesRichText(EditorToolbox::isWindowBackgroundDark()
+                                   ? MessageLogger::ColorTheme::Dark
+                                   : MessageLogger::ColorTheme::Light));
   mUi->prgImport->setFormat(tr("Scanning libraries") % " (%p%)");
   mUi->gbxErrors->setVisible(!log->getMessages().isEmpty());
   if (QWizard* wiz = wizard()) {

--- a/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.cpp
+++ b/libs/librepcb/editor/project/newprojectwizard/newprojectwizardpage_eagleimport.cpp
@@ -24,6 +24,7 @@
 
 #include "../../dialogs/filedialog.h"
 #include "../../editorcommandset.h"
+#include "../../utils/editortoolbox.h"
 #include "../../widgets/waitingspinnerwidget.h"
 #include "../../workspace/desktopservices.h"
 #include "ui_newprojectwizardpage_eagleimport.h"
@@ -148,9 +149,12 @@ void NewProjectWizardPage_EagleImport::import(Project& project) {
     DesktopServices ds(ws->getSettings(), nullptr);
     ds.openUrl(url);
   });
+  const auto msgColors = EditorToolbox::isWindowBackgroundDark()
+      ? MessageLogger::ColorTheme::Dark
+      : MessageLogger::ColorTheme::Light;
   connect(mImport->getLogger().get(), &MessageLogger::msgEmitted, browser,
-          [browser](const MessageLogger::Message& msg) {
-            browser->append(msg.toRichText(true, true));
+          [browser, msgColors](const MessageLogger::Message& msg) {
+            browser->append(msg.toRichText(msgColors, true));
             browser->verticalScrollBar()->setValue(
                 browser->verticalScrollBar()->maximum());
             qApp->processEvents();


### PR DESCRIPTION
Text colors were only suitable for light window background - now using better colors for dark windows.