### PR TITLE
Delete old temporary files at application startup

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -32,6 +32,7 @@
 #include <librepcb/editor/workspace/controlpanel/controlpanel.h>
 #include <librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard.h>
 
+#include <QtConcurrent>
 #include <QtCore>
 #include <QtWidgets>
 
@@ -83,6 +84,10 @@ int main(int argc, char* argv[]) {
   // shown.
   Application::loadBundledFonts();
   Application::setTranslationLocale(QLocale::system());
+
+  // Clean up old temporary files since at least on Windows this is not done
+  // automatically. Let's do it in a thread to avoid delaying application start.
+  std::ignore = QtConcurrent::run(&Application::cleanTemporaryDirectory);
 
   // This is to remove the ugly frames around widgets in all status bars...
   // (from http://www.qtcentre.org/threads/1904)

--- a/libs/librepcb/core/application.h
+++ b/libs/librepcb/core/application.h
@@ -197,6 +197,17 @@ public:
    */
   static void setTranslationLocale(const QLocale& locale) noexcept;
 
+  /**
+   * @brief Clean up old files & folders in the temporary directory
+   *
+   * To be called from time to time (e.g. once on application startup) to
+   * keep the temporary directory clean, i.e. avoid filling the disk with
+   * data no longer used.
+   *
+   * @note This function is safe to be called from a thread.
+   */
+  static void cleanTemporaryDirectory() noexcept;
+
   // Operator Overloadings
   Application& operator=(const Application& rhs) = delete;
 };

--- a/libs/librepcb/core/fileio/filepath.cpp
+++ b/libs/librepcb/core/fileio/filepath.cpp
@@ -228,6 +228,8 @@ FilePath FilePath::getApplicationTempPath() noexcept {
 }
 
 FilePath FilePath::getRandomTempPath() noexcept {
+  // Attention: This pattern is assumed by
+  // Application::cleanTemporaryDirectory() to detect the age of tmp files!
   QString random = QString("%1_%2")
                        .arg(QDateTime::currentMSecsSinceEpoch())
                        .arg(QRandomGenerator::global()->generate());

--- a/libs/librepcb/core/fileio/filepath.h
+++ b/libs/librepcb/core/fileio/filepath.h
@@ -99,7 +99,7 @@ namespace librepcb {
  * @code
  *    FilePath fp("C:\\foo\\bar.txt"); // a file
  *    qDebug(fp.toStr());      // "C:/foo/bar.txt"
- *    qDebug(fp.toNative());   // "C:/foo/bar.txt" ("C:\\foo\\bar.txt" on Windows)
+ *    qDebug(fp.toNative());   // "C:/foo/bar.txt"; Windows: "C:\\foo\\bar.txt"
  *    fp.setPath("/foo/bar/"); // a directory
  *    qDebug(fp.toStr());      // "/foo/bar" (trailing slash removed!)
  *    qDebug(fp.toNative());   // "/foo/bar" ("\\foo\\bar" on Windows)
@@ -375,6 +375,9 @@ public:  // Methods
   /**
    * @brief Get the path to the temporary directory (e.g. "/tmp" on Unix/Linux)
    *
+   * @attention Do not use this to store any files in it!
+   *            Use #getRandomTempPath() instead.
+   *
    * @return The filepath (in case of an error, the path can be invalid!)
    */
   static FilePath getTempPath() noexcept;
@@ -382,6 +385,9 @@ public:  // Methods
   /**
    * @brief Get the path to the temporary application directory (e.g.
    * "/tmp/librepcb")
+   *
+   * @attention Do not use this to store any files in it!
+   *            Use #getRandomTempPath() instead.
    *
    * @return The filepath (in case of an error, the path can be invalid!)
    */

--- a/tests/unittests/core/fileio/directorylocktest.cpp
+++ b/tests/unittests/core/fileio/directorylocktest.cpp
@@ -43,8 +43,7 @@ class DirectoryLockTest : public ::testing::Test {
 protected:
   virtual void SetUp() override {
     // create temporary, empty directory
-    mTempDir =
-        FilePath::getApplicationTempPath().getPathTo("DirectoryLockTest");
+    mTempDir = FilePath::getRandomTempPath();
     mTempLockFilePath = FilePath(mTempDir.toStr() % "/.lock");
     if (mTempDir.isExistingDir()) {
       FileUtils::removeDirRecursively(mTempDir);  // can throw

--- a/tests/unittests/core/network/filedownloadtest.cpp
+++ b/tests/unittests/core/network/filedownloadtest.cpp
@@ -52,26 +52,30 @@ typedef struct {
  ******************************************************************************/
 
 class FileDownloadTest : public ::testing::TestWithParam<FileDownloadTestData> {
-public:
-  static void SetUpTestCase() { sDownloadManager = new NetworkAccessManager(); }
+protected:
+  FilePath mTmpDir;
+  NetworkRequestBaseSignalReceiver mSignalReceiver;
+  static NetworkAccessManager* sDownloadManager;
 
-  static void TearDownTestCase() { delete sDownloadManager; }
+  FileDownloadTest() : mTmpDir(FilePath::getRandomTempPath()) {}
 
-  static FilePath getDestination(const FileDownloadTestData& data) {
-    return FilePath::getApplicationTempPath().getPathTo(data.destFilename);
+  ~FileDownloadTest() { QDir(mTmpDir.toStr()).removeRecursively(); }
+
+  FilePath getDestination(const FileDownloadTestData& data) {
+    return mTmpDir.getPathTo(data.destFilename);
   }
 
-  static FilePath getExtractToDir(const FileDownloadTestData& data) {
+  FilePath getExtractToDir(const FileDownloadTestData& data) {
     if (!data.extractDirname.isEmpty()) {
-      return FilePath::getApplicationTempPath().getPathTo(data.extractDirname);
+      return mTmpDir.getPathTo(data.extractDirname);
     } else {
       return FilePath();
     }
   }
 
-protected:
-  NetworkRequestBaseSignalReceiver mSignalReceiver;
-  static NetworkAccessManager* sDownloadManager;
+  static void SetUpTestCase() { sDownloadManager = new NetworkAccessManager(); }
+
+  static void TearDownTestCase() { delete sDownloadManager; }
 };
 
 NetworkAccessManager* FileDownloadTest::sDownloadManager = nullptr;

--- a/tests/unittests/core/sqlitedatabasetest.cpp
+++ b/tests/unittests/core/sqlitedatabasetest.cpp
@@ -43,8 +43,7 @@ class SQLiteDatabaseTest : public ::testing::Test {
 protected:
   virtual void SetUp() override {
     // create temporary, empty directory
-    mTempDir =
-        FilePath::getApplicationTempPath().getPathTo("SQLiteDatabaseTest");
+    mTempDir = FilePath::getRandomTempPath();
     mTempDbFilePath = mTempDir.getPathTo("db.sqlite");
     if (mTempDir.isExistingDir()) {
       FileUtils::removeDirRecursively(mTempDir);  // can throw


### PR DESCRIPTION
AFAIK the temporary directory on Windows is not cleaned automatically at reboot, thus might get bigger and bigger if LibrePCB does not clean it up either. So let's scan the temporary directory of LibrePCB during application startup and delete files older than 60 days. This is done in a thread to avoid delaying application startup.