### PR TITLE
Refactor & speed up plane rebuilds & DRC with multithreading

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -641,7 +641,7 @@ bool CommandLineInterface::openProject(
         qInfo().nospace().noquote() << "Rebuilding all planes of board '"
                                     << *board->getName() << "'...";
         BoardPlaneFragmentsBuilder builder;
-        builder.runSynchronously(*board);  // can throw
+        builder.runAndApply(*board);  // can throw
       }
     } else {
       qInfo() << "No need to rebuild planes, thus skipped.";

--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -710,13 +710,18 @@ bool CommandLineInterface::openProject(
       }
       foreach (Board* board, boardsToCheck) {
         print("  " % tr("Board '%1':").arg(*board->getName()));
-        BoardDesignRuleCheck drc(
-            *board, customSettings ? *customSettings : board->getDrcSettings());
-        drc.execute(false);
+        BoardDesignRuleCheck drc;
+        drc.start(*board,
+                  customSettings ? *customSettings : board->getDrcSettings(),
+                  false);
+        const BoardDesignRuleCheck::Result result = drc.waitForFinished();
+        for (const QString& msg : result.errors) {
+          printErr("FATAL ERROR: " % msg);
+          success = false;
+        }
         int approvedMsgCount = 0;
         const QStringList nonApproved = prepareRuleCheckMessages(
-            drc.getMessages(), board->getDrcMessageApprovals(),
-            approvedMsgCount);
+            result.messages, board->getDrcMessageApprovals(), approvedMsgCount);
         print("    " % tr("Approved messages: %1").arg(approvedMsgCount));
         print("    " %
               tr("Non-approved messages: %1").arg(nonApproved.count()));

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -331,6 +331,8 @@ add_library(
   project/board/drc/boardclipperpathgenerator.h
   project/board/drc/boarddesignrulecheck.cpp
   project/board/drc/boarddesignrulecheck.h
+  project/board/drc/boarddesignrulecheckdata.cpp
+  project/board/drc/boarddesignrulecheckdata.h
   project/board/drc/boarddesignrulecheckmessages.cpp
   project/board/drc/boarddesignrulecheckmessages.h
   project/board/drc/boarddesignrulechecksettings.cpp

--- a/libs/librepcb/core/geometry/via.cpp
+++ b/libs/librepcb/core/geometry/via.cpp
@@ -116,12 +116,7 @@ bool Via::isOnLayer(const Layer& layer) const noexcept {
 }
 
 bool Via::isOnAnyLayer(const QSet<const Layer*>& layers) const noexcept {
-  foreach (const Layer* layer, layers) {
-    if (layer && isOnLayer(*layer)) {
-      return true;
-    }
-  }
-  return false;
+  return isOnAnyLayer(layers, *mStartLayer, *mEndLayer);
 }
 
 QPainterPath Via::toQPainterPathPx(const Length& expansion) const noexcept {
@@ -259,6 +254,16 @@ bool Via::isOnLayer(const Layer& layer, const Layer& from,
                     const Layer& to) noexcept {
   const int nbr = layer.getCopperNumber();
   return ((nbr >= from.getCopperNumber()) && (nbr <= to.getCopperNumber()));
+}
+
+bool Via::isOnAnyLayer(const QSet<const Layer*>& layers, const Layer& from,
+                       const Layer& to) noexcept {
+  foreach (const Layer* layer, layers) {
+    if (layer && isOnLayer(*layer, from, to)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 QPainterPath Via::toQPainterPathPx(const PositiveLength& size,

--- a/libs/librepcb/core/geometry/via.h
+++ b/libs/librepcb/core/geometry/via.h
@@ -125,6 +125,8 @@ public:
                          const Length& expansion = Length(0)) noexcept;
   static bool isOnLayer(const Layer& layer, const Layer& from,
                         const Layer& to) noexcept;
+  static bool isOnAnyLayer(const QSet<const Layer*>& layers, const Layer& from,
+                           const Layer& to) noexcept;
   static QPainterPath toQPainterPathPx(
       const PositiveLength& size, const PositiveLength& drillDiameter,
       const Length& expansion = Length(0)) noexcept;

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.h
@@ -26,6 +26,7 @@
 #include "../../../geometry/path.h"
 #include "../../../types/length.h"
 #include "../../../utils/transform.h"
+#include "boarddesignrulecheckdata.h"
 
 #include <polyclipping/clipper.hpp>
 
@@ -36,30 +37,20 @@
  ******************************************************************************/
 namespace librepcb {
 
-class BI_FootprintPad;
-class BI_NetLine;
-class BI_Plane;
-class BI_StrokeText;
-class BI_Via;
-class Board;
-class Circle;
-class Hole;
-class Layer;
-class NetSignal;
-
 /*******************************************************************************
  *  Class BoardClipperPathGenerator
  ******************************************************************************/
 
 /**
- * @brief The BoardClipperPathGenerator class creates a Clipper path from
- *        a ::librepcb::Board
+ * @brief Helper to create Clipper paths for ::librepcb::BoardDesignRuleCheck
  */
 class BoardClipperPathGenerator final {
 public:
+  using Data = BoardDesignRuleCheckData;
+
   // Constructors / Destructor
   explicit BoardClipperPathGenerator(
-      Board& board, const PositiveLength& maxArcTolerance) noexcept;
+      const PositiveLength& maxArcTolerance) noexcept;
   ~BoardClipperPathGenerator() noexcept;
 
   // Getters
@@ -67,27 +58,27 @@ public:
   void takePathsTo(ClipperLib::Paths& out) noexcept;
 
   // General Methods
-  void addCopper(const Layer& layer, const QSet<const NetSignal*>& netsignals,
+  void addCopper(const Data& data, const Layer& layer,
+                 const QSet<tl::optional<Uuid>>& netsignals,
                  bool ignorePlanes = false);
-  void addStopMaskOpenings(const Layer& layer,
+  void addStopMaskOpenings(const Data& data, const Layer& layer,
                            const Length& offset = Length(0));
-  void addVia(const BI_Via& via, const Length& offset = Length(0));
-  void addNetLine(const BI_NetLine& netLine, const Length& offset = Length(0));
-  void addPlane(const BI_Plane& plane);
+  void addVia(const Data::Via& via, const Length& offset = Length(0));
+  void addTrace(const Data::Trace& trace, const Length& offset = Length(0));
+  void addPlane(const QVector<Path>& fragments);
   void addPolygon(const Path& path, const UnsignedLength& lineWidth,
                   bool filled, const Length& offset = Length(0));
-  void addCircle(const Circle& circle, const Transform& transform,
+  void addCircle(const Data::Circle& circle, const Transform& transform,
                  const Length& offset = Length(0));
-  void addStrokeText(const BI_StrokeText& strokeText,
+  void addStrokeText(const Data::StrokeText& strokeText,
                      const Length& offset = Length(0));
   void addHole(const PositiveLength& diameter, const NonEmptyPath& path,
                const Transform& transform = Transform(),
                const Length& offset = Length(0));
-  void addPad(const BI_FootprintPad& pad, const Layer& layer,
+  void addPad(const Data::Pad& pad, const Layer& layer,
               const Length& offset = Length(0));
 
 private:  // Data
-  Board& mBoard;
   PositiveLength mMaxArcTolerance;
   ClipperLib::Paths mPaths;
 };

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -137,7 +137,7 @@ void BoardDesignRuleCheck::execute(bool quick) {
 void BoardDesignRuleCheck::rebuildPlanes(int progressEnd) {
   emitStatus(tr("Rebuild planes..."));
   BoardPlaneFragmentsBuilder builder;
-  builder.runSynchronously(mBoard);  // can throw
+  builder.runAndApply(mBoard);  // can throw
   emitProgress(progressEnd);
 }
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.cpp
@@ -1,0 +1,242 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "boarddesignrulecheckdata.h"
+
+#include "../../../geometry/hole.h"
+#include "../../../geometry/stroketext.h"
+#include "../../../library/cmp/component.h"
+#include "../../../library/dev/device.h"
+#include "../../../library/pkg/footprint.h"
+#include "../../../library/pkg/footprintpad.h"
+#include "../../../library/pkg/packagepad.h"
+#include "../../circuit/circuit.h"
+#include "../../circuit/componentinstance.h"
+#include "../../circuit/netsignal.h"
+#include "../../project.h"
+#include "../board.h"
+#include "../items/bi_airwire.h"
+#include "../items/bi_device.h"
+#include "../items/bi_footprintpad.h"
+#include "../items/bi_hole.h"
+#include "../items/bi_netline.h"
+#include "../items/bi_netpoint.h"
+#include "../items/bi_netsegment.h"
+#include "../items/bi_plane.h"
+#include "../items/bi_polygon.h"
+#include "../items/bi_stroketext.h"
+#include "../items/bi_via.h"
+#include "../items/bi_zone.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+BoardDesignRuleCheckData::BoardDesignRuleCheckData(
+    const Board& board, const BoardDesignRuleCheckSettings& drcSettings,
+    bool quickCheck) noexcept {
+  settings = drcSettings;
+  quick = quickCheck;
+  copperLayers = board.getCopperLayers();
+  silkscreenLayersTop = board.getSilkscreenLayersTop();
+  silkscreenLayersBot = board.getSilkscreenLayersBot();
+  foreach (const BI_NetSegment* ns, board.getNetSegments()) {
+    const NetSignal* net = ns->getNetSignal();
+    Segment nsd{
+        ns->getUuid(),
+        net ? net->getUuid() : tl::optional<Uuid>(),
+        net ? *net->getName() : QString(),
+        {},
+        {},
+        {},
+    };
+    foreach (const BI_NetPoint* np, ns->getNetPoints()) {
+      nsd.junctions.insert(np->getUuid(),
+                           Junction{np->getUuid(), np->getPosition(),
+                                    np->getNetLines().count()});
+    }
+    foreach (const BI_NetLine* nl, ns->getNetLines()) {
+      nsd.traces.append(Trace{nl->getUuid(), nl->getStartPoint().getPosition(),
+                              nl->getEndPoint().getPosition(), nl->getWidth(),
+                              &nl->getLayer()});
+    }
+    foreach (const BI_Via* via, ns->getVias()) {
+      nsd.vias.insert(
+          via->getUuid(),
+          Via{via->getUuid(), via->getPosition(), via->getSize(),
+              via->getDrillDiameter(), &via->getVia().getStartLayer(),
+              &via->getVia().getEndLayer(), via->getDrillLayerSpan(),
+              via->getVia().isBuried(), via->getVia().isBlind(),
+              via->getStopMaskDiameterTop(), via->getStopMaskDiameterBottom()});
+    }
+    segments.insert(ns->getUuid(), nsd);
+  }
+  foreach (const BI_Plane* plane, board.getPlanes()) {
+    const NetSignal* net = plane->getNetSignal();
+    planes.append(Plane{
+        plane->getUuid(),
+        net ? tl::make_optional(net->getUuid()) : tl::optional<Uuid>(),
+        net ? *net->getName() : QString(), &plane->getLayer(),
+        plane->getMinWidth(), plane->getOutline(), plane->getFragments()});
+  }
+  foreach (const BI_Polygon* polygon, board.getPolygons()) {
+    polygons.append(
+        Polygon{polygon->getData().getUuid(), &polygon->getData().getLayer(),
+                polygon->getData().getLineWidth(),
+                polygon->getData().isFilled(), polygon->getData().getPath()});
+  }
+  foreach (const BI_StrokeText* strokeText, board.getStrokeTexts()) {
+    strokeTexts.append(StrokeText{
+        strokeText->getData().getUuid(), strokeText->getData().getPosition(),
+        strokeText->getData().getRotation(),
+        strokeText->getData().getMirrored(), &strokeText->getData().getLayer(),
+        strokeText->getData().getStrokeWidth(),
+        strokeText->getData().getHeight(), strokeText->getPaths()});
+  }
+  foreach (const BI_Hole* hole, board.getHoles()) {
+    holes.append(Hole{hole->getData().getUuid(), hole->getData().getDiameter(),
+                      hole->getData().getPath(), hole->getStopMaskOffset()});
+  }
+  foreach (const BI_Zone* zone, board.getZones()) {
+    zones.append(Zone{zone->getData().getUuid(), zone->getData().getLayers(),
+                      librepcb::Zone::Layers(), zone->getData().getRules(),
+                      zone->getData().getOutline()});
+  }
+  foreach (const BI_Device* dev, board.getDeviceInstances()) {
+    Device dd{
+        dev->getComponentInstanceUuid(),
+        *dev->getComponentInstance().getName(),
+        dev->getPosition(),
+        dev->getRotation(),
+        dev->getMirrored(),
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+    };
+    foreach (const BI_FootprintPad* pad, dev->getPads()) {
+      QSet<const Layer*> layersWithTraces;
+      foreach (const BI_NetLine* netLine, pad->getNetLines()) {
+        layersWithTraces.insert(&netLine->getLayer());
+      }
+      const NetSignal* net = pad->getCompSigInstNetSignal();
+      Pad pd{
+          pad->getLibPadUuid(),
+          pad->getLibPackagePad() ? *pad->getLibPackagePad()->getName()
+                                  : QString(),
+          pad->getPosition(),
+          pad->getRotation(),
+          pad->getMirrored(),
+          {},
+          pad->getGeometries(),
+          layersWithTraces,
+          pad->getLibPad().getCopperClearance(),
+          net ? tl::make_optional(net->getUuid()) : tl::optional<Uuid>(),
+          net ? *net->getName() : QString(),
+      };
+      for (const PadHole& hole : pad->getLibPad().getHoles()) {
+        pd.holes.append(Hole{hole.getUuid(), hole.getDiameter(), hole.getPath(),
+                             tl::optional<Length>()});
+      }
+      dd.pads.insert(pad->getLibPadUuid(), pd);
+    }
+    for (const librepcb::Polygon& polygon :
+         dev->getLibFootprint().getPolygons()) {
+      dd.polygons.append(Polygon{polygon.getUuid(), &polygon.getLayer(),
+                                 polygon.getLineWidth(), polygon.isFilled(),
+                                 polygon.getPath()});
+    }
+    for (const librepcb::Circle& circle : dev->getLibFootprint().getCircles()) {
+      dd.circles.append(Circle{circle.getUuid(), circle.getCenter(),
+                               circle.getDiameter(), &circle.getLayer(),
+                               circle.getLineWidth(), circle.isFilled()});
+    }
+    foreach (const BI_StrokeText* strokeText, dev->getStrokeTexts()) {
+      dd.strokeTexts.append(StrokeText{
+          strokeText->getData().getUuid(), strokeText->getData().getPosition(),
+          strokeText->getData().getRotation(),
+          strokeText->getData().getMirrored(),
+          &strokeText->getData().getLayer(),
+          strokeText->getData().getStrokeWidth(),
+          strokeText->getData().getHeight(), strokeText->getPaths()});
+    }
+    for (const librepcb::Hole& hole : dev->getLibFootprint().getHoles()) {
+      dd.holes.append(Hole{hole.getUuid(), hole.getDiameter(), hole.getPath(),
+                           dev->getHoleStopMasks().value(hole.getUuid())});
+    }
+    for (const librepcb::Zone& zone : dev->getLibFootprint().getZones()) {
+      dd.zones.append(Zone{zone.getUuid(),
+                           {},
+                           zone.getLayers(),
+                           zone.getRules(),
+                           zone.getOutline()});
+    }
+    devices.insert(dev->getComponentInstanceUuid(), dd);
+  }
+  auto convertAnchor = [](const BI_NetLineAnchor& a) {
+    AirWireAnchor ret;
+    ret.position = a.getPosition();
+    if (const BI_FootprintPad* pad = dynamic_cast<const BI_FootprintPad*>(&a)) {
+      ret.device = pad->getDevice().getComponentInstanceUuid();
+      ret.pad = pad->getLibPadUuid();
+    } else if (const BI_NetPoint* np = dynamic_cast<const BI_NetPoint*>(&a)) {
+      ret.segment = np->getNetSegment().getUuid();
+      ret.junction = np->getUuid();
+    } else if (const BI_Via* via = dynamic_cast<const BI_Via*>(&a)) {
+      ret.segment = via->getNetSegment().getUuid();
+      ret.via = via->getUuid();
+    } else {
+      qCritical() << "Unknown anchor type, DRC will fail later.";
+    }
+    return ret;
+  };
+  foreach (const BI_AirWire* aw, board.getAirWires()) {
+    airWires.append(AirWire{convertAnchor(aw->getP1()),
+                            convertAnchor(aw->getP2()),
+                            *aw->getNetSignal().getName()});
+  }
+  foreach (const ComponentInstance* cmp,
+           board.getProject().getCircuit().getComponentInstances()) {
+    // A bit unusual, but the actual check is already done here to avoid
+    // copying lots of data for such a lightweight check.
+    const BI_Device* dev =
+        board.getDeviceInstanceByComponentUuid(cmp->getUuid());
+    if ((!dev) && (!cmp->getLibComponent().isSchematicOnly())) {
+      unplacedComponents.insert(cmp->getUuid(), *cmp->getName());
+    }
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.h
@@ -1,0 +1,199 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_BOARDDESIGNRULECHECKDATA_H
+#define LIBREPCB_CORE_BOARDDESIGNRULECHECKDATA_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../../../geometry/padgeometry.h"
+#include "../../../geometry/zone.h"
+#include "../../../types/uuid.h"
+#include "boarddesignrulechecksettings.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class Board;
+class Layer;
+
+/*******************************************************************************
+ *  Class BoardDesignRuleCheckData
+ ******************************************************************************/
+
+/**
+ * @brief Input data structure for ::librepcb::BoardDesignRuleCheck
+ */
+struct BoardDesignRuleCheckData final {
+  struct Junction {
+    Uuid uuid;
+    Point position;
+    qsizetype traces;
+  };
+  struct Trace {
+    Uuid uuid;
+    Point startPosition;
+    Point endPosition;
+    PositiveLength width;
+    const Layer* layer;
+  };
+  struct Via {
+    Uuid uuid;
+    Point position;
+    PositiveLength size;
+    PositiveLength drillDiameter;
+    const Layer* startLayer;
+    const Layer* endLayer;
+    tl::optional<std::pair<const Layer*, const Layer*>> drillLayerSpan;
+    bool isBuried;
+    bool isBlind;
+    tl::optional<PositiveLength> stopMaskDiameterTop;
+    tl::optional<PositiveLength> stopMaskDiameterBot;
+  };
+  struct Segment {
+    Uuid uuid;
+    tl::optional<Uuid> net;
+    QString netName;  // Empty if no net.
+    QHash<Uuid, Junction> junctions;
+    QList<Trace> traces;
+    QHash<Uuid, Via> vias;
+  };
+  struct AirWireAnchor {
+    Point position;
+    tl::optional<Uuid> device;  // If it's a pad.
+    tl::optional<Uuid> pad;  // If it's a pad.
+    tl::optional<Uuid> segment;  // If it's a junction or via.
+    tl::optional<Uuid> junction;  // If it's a junction.
+    tl::optional<Uuid> via;  // If it's a via.
+  };
+  struct AirWire {
+    AirWireAnchor p1;
+    AirWireAnchor p2;
+    QString netName;  // Always valid.
+  };
+  struct Plane {
+    Uuid uuid;
+    tl::optional<Uuid> net;
+    QString netName;  // Empty if no net.
+    const Layer* layer;
+    UnsignedLength minWidth;
+    Path outline;
+    QVector<Path> fragments;
+  };
+  struct Polygon {
+    Uuid uuid;
+    const Layer* layer;
+    UnsignedLength lineWidth;
+    bool filled;
+    Path path;
+  };
+  struct Circle {
+    Uuid uuid;
+    Point center;
+    PositiveLength diameter;
+    const Layer* layer;
+    UnsignedLength lineWidth;
+    bool filled;
+  };
+  struct StrokeText {
+    Uuid uuid;
+    Point position;
+    Angle rotation;
+    bool mirror;
+    const Layer* layer;
+    UnsignedLength strokeWidth;
+    PositiveLength height;
+    QVector<Path> paths;
+  };
+  struct Hole {
+    Uuid uuid;
+    PositiveLength diameter;
+    NonEmptyPath path;
+    tl::optional<Length> stopMaskOffset;
+  };
+  struct Zone {
+    Uuid uuid;
+    QSet<const Layer*> boardLayers;  // Only set for board zones!
+    librepcb::Zone::Layers footprintLayers;  // Only set for device zones!
+    librepcb::Zone::Rules rules;
+    Path outline;
+  };
+  struct Pad {
+    Uuid uuid;
+    QString libPkgPadName;  // Empty if not connected to a package pad.
+    Point position;  // Absolute transform.
+    Angle rotation;  // Absolute transform.
+    bool mirror;  // Absolute transform.
+    QList<Hole> holes;
+    QHash<const Layer*, QList<PadGeometry>> geometries;
+    QSet<const Layer*> layersWithTraces;  // Layers where traces are connected.
+    UnsignedLength copperClearance;
+    tl::optional<Uuid> net;
+    QString netName;  // Empty if no net.
+  };
+  struct Device {
+    Uuid uuid;
+    QString cmpInstanceName;
+    Point position;
+    Angle rotation;
+    bool mirror;
+    QHash<Uuid, Pad> pads;  // With absolute transform.
+    QList<Polygon> polygons;  // From library footprint.
+    QList<Circle> circles;  // From library footprint.
+    QList<StrokeText> strokeTexts;  // With absolute transform.
+    QList<Hole> holes;  // From library footprint.
+    QList<Zone> zones;  // From library footprint.
+  };
+
+  // NOTE: We create a `const` copy of this structure for each thread to
+  // ensure thread-safety. For the implicitly shared Qt containers this is
+  // a lightweight operation.
+  BoardDesignRuleCheckSettings settings;
+  bool quick = false;
+  QSet<const Layer*> copperLayers;  // All board copper layers.
+  QVector<const Layer*> silkscreenLayersTop;
+  QVector<const Layer*> silkscreenLayersBot;
+  QHash<Uuid, Segment> segments;
+  QList<Plane> planes;
+  QList<Polygon> polygons;
+  QList<StrokeText> strokeTexts;
+  QList<Hole> holes;
+  QList<Zone> zones;
+  QHash<Uuid, Device> devices;
+  QList<AirWire> airWires;
+  QMap<Uuid, QString> unplacedComponents;  // UUID and name.
+
+  // Constructors / Destructor
+  BoardDesignRuleCheckData(const Board& board,
+                           const BoardDesignRuleCheckSettings& drcSettings,
+                           bool quickCheck) noexcept;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/core/types/layer.h
+++ b/libs/librepcb/core/types/layer.h
@@ -36,6 +36,8 @@ namespace librepcb {
 
 /**
  * @brief The Layer class provides all supported geometry layers
+ *
+ * @note All methods of this class are thread-safe.
  */
 class Layer final {
   Q_DECLARE_TR_FUNCTIONS(Layer)

--- a/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fabricationoutputdialog.cpp
@@ -191,7 +191,7 @@ void FabricationOutputDialog::btnGenerateClicked() {
 
     // rebuild planes because they may be outdated!
     BoardPlaneFragmentsBuilder builder;
-    builder.runSynchronously(mBoard);  // can throw
+    builder.runAndApply(mBoard);  // can throw
 
     // update fabrication output settings if modified
     BoardFabricationOutputSettings s = mBoard.getFabricationOutputSettings();

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(
   core/network/networkrequestbasesignalreceiver.h
   core/network/networkrequesttest.cpp
   core/project/board/boardd356netlistexporttest.cpp
+  core/project/board/boarddesignrulechecktest.cpp
   core/project/board/boarddesignrulestest.cpp
   core/project/board/boardfabricationoutputsettingstest.cpp
   core/project/board/boardgerberexporttest.cpp

--- a/tests/unittests/core/project/board/boarddesignrulechecktest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulechecktest.cpp
@@ -1,0 +1,163 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/application.h>
+#include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/project/board/board.h>
+#include <librepcb/core/project/board/drc/boarddesignrulecheck.h>
+#include <librepcb/core/project/project.h>
+#include <librepcb/core/project/projectloader.h>
+#include <librepcb/core/serialization/sexpression.h>
+#include <librepcb/core/utils/toolbox.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class BoardDesignRuleCheckTest : public ::testing::Test {};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST(BoardDesignRuleCheckTest, testMessages) {
+  // Ignore certain messages in all boards, except on whitelisted ones.
+  QHash<QString, QStringList> whitelist = {
+      {"missing_device", {"checkForUnplacedComponents"}},
+      {"missing_connection", {"checkForMissingConnections"}},
+      {"unused_layer", {"checkUsedLayers"}},
+  };
+
+  // Open project from test data directory.
+  FilePath projectFp(TEST_DATA_DIR "/projects/DRC/project.lpp");
+  std::shared_ptr<TransactionalFileSystem> projectFs =
+      TransactionalFileSystem::openRO(projectFp.getParentDir());
+  ProjectLoader loader;
+  std::unique_ptr<Project> project =
+      loader.open(std::unique_ptr<TransactionalDirectory>(
+                      new TransactionalDirectory(projectFs)),
+                  projectFp.getFilename());  // can throw
+
+  // Run DRC for each board.
+  foreach (Board* board, project->getBoards()) {
+    std::cout << "- Run DRC for board '" << board->getName()->toStdString()
+              << "':\n";
+
+    BoardDesignRuleCheck drc;
+    drc.start(*board, board->getDrcSettings(), false);
+    const BoardDesignRuleCheck::Result result = drc.waitForFinished();
+
+    // Filter messages, get approvals and check uniqueness of their approval.
+    QSet<SExpression> approvals;
+    for (const auto& msg : result.messages) {
+      // Skip some messages.
+      const QString msgType = msg->getApproval().getChild("@0").getValue();
+      if (whitelist.contains(msgType)) {
+        if (!whitelist[msgType].contains(*board->getName())) {
+          continue;
+        }
+      }
+
+      // Check for ambiguous approvals.
+      if (approvals.contains(msg->getApproval())) {
+        std::cout << "  * Ambiguous approval for message '"
+                  << msg->getMessage().toStdString() << "':\n"
+                  << msg->getApproval().toByteArray().toStdString() << "\n";
+        ADD_FAILURE();
+      }
+
+      approvals.insert(msg->getApproval());
+    }
+
+    // Build actual approvals.
+    std::unique_ptr<SExpression> actual = SExpression::createList("node");
+    foreach (const SExpression& node, Toolbox::sortedQSet(approvals)) {
+      actual->ensureLineBreak();
+      actual->appendChild(node);
+    }
+    actual->ensureLineBreak();
+
+    // Build expected approvals.
+    std::unique_ptr<SExpression> expected = SExpression::createList("node");
+    foreach (const SExpression& node,
+             Toolbox::sortedQSet(board->getDrcMessageApprovals())) {
+      expected->ensureLineBreak();
+      expected->appendChild(node);
+    }
+    expected->ensureLineBreak();
+
+    // Compare.
+    std::cout << "  * Emitted " << approvals.count() << " messages, "
+              << board->getDrcMessageApprovals().count() << " approved\n";
+    EXPECT_EQ(expected->toByteArray().toStdString(),
+              actual->toByteArray().toStdString());
+    EXPECT_EQ(board->getDrcMessageApprovals().count(), approvals.count());
+  }
+}
+
+TEST(BoardDesignRuleCheckTest, testMultithreading) {
+  // open project from test data directory
+  FilePath projectFp(TEST_DATA_DIR "/projects/Gerber Test/project.lpp");
+  std::shared_ptr<TransactionalFileSystem> projectFs =
+      TransactionalFileSystem::openRO(projectFp.getParentDir());
+  ProjectLoader loader;
+  std::unique_ptr<Project> project =
+      loader.open(std::unique_ptr<TransactionalDirectory>(
+                      new TransactionalDirectory(projectFs)),
+                  projectFp.getFilename());  // can throw
+  Board* board = project->getBoards().first();
+
+  // Run several times to heavily test multithreading.
+  const int runs = qBound(10, QThread::idealThreadCount() * 8, 50);
+  qreal totalTimeMs = 0;
+  BoardDesignRuleCheck drc;
+  for (int i = 0; i < runs; ++i) {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start =
+        std::chrono::high_resolution_clock::now();
+    drc.start(*board, board->getDrcSettings(), false);
+    const BoardDesignRuleCheck::Result result = drc.waitForFinished();
+    std::chrono::duration<double> elapsed =
+        std::chrono::high_resolution_clock::now() - start;
+    totalTimeMs += elapsed.count() * 1000;
+
+    // Check result.
+    EXPECT_EQ(0, result.errors.count());
+  }
+  std::cout << "Average time over " << runs << " runs: " << (totalTimeMs / runs)
+            << " ms\n";
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb

--- a/tests/unittests/core/project/board/boardgerberexporttest.cpp
+++ b/tests/unittests/core/project/board/boardgerberexporttest.cpp
@@ -80,7 +80,7 @@ TEST(BoardGerberExportTest, test) {
 
   // force planes rebuild
   BoardPlaneFragmentsBuilder builder;
-  builder.runSynchronously(*board);  // can throw
+  builder.runAndApply(*board);  // can throw
 
   // export fabrication data
   BoardFabricationOutputSettings config = board->getFabricationOutputSettings();


### PR DESCRIPTION
This PR refactors two CPU intensive operations to run them now with multiple threads:
- Plane fragment building
- Design rule check

Planes are now using a separate thread for each layer. So the more layers, the more time is saved now. In a real project with planes on 4 layers, I measured an improvement from ~170ms to ~95ms (44%), and with a complex 2-layer board I measured an improvement from 490ms to 330ms (33%). This makes the UI feeling more responsive while drawing traces etc.

For the DRC, it is more complicated since there are many different kinds of checks and some checks depend on CPU-intensive precalculated data. The concept is documented in the source code:

```
  // - A subset of jobs, called "stage 1", is run in parallel to calculate data
  //   which other jobs depend on (e.g. copper areas on each layer).
  // - Jobs depending on this data, called "stage 2", are started after all
  //   jobs of stage 1 completed. Stage 2 jobs are run in parallel then too.
  // - A third set of jobs, called "independent", does not depend on stage 1
  //   jobs output data and is thus run in parallel to stage 1 & 2 jobs.
  // - Very trivial (CPU inexpensive) jobs are run sequentially in this thread
  //   to avoid spawning a large amount of threads. They are run sequentially,
  //   but in parallel to stage 2 jobs since this thread has no other work to
  //   do then.
  //
  //        ▲                           ┌────────────────────────────────┐
  //        │                         ┌►│        Independent jobs        │
  //        │                         │ └────────────────────────────────┤
  // Threads│                         │                                  │
  //  2..n  │                         │ ┌────────────┐   ┌───────────────┤
  //        │                         ├►│Stage 1 jobs│ ┌►│ Stage 2 jobs  │
  //        │                         │ └────────────┤ │ └───────────────┤
  //        │                         │              ▼ │                 │
  //        │              ┌──────────┤              ┌─┤ ┌───────────────┤
  //  run() │            ┌►│Spawn jobs│--------------│ ├►│Sequential jobs│
  // Thread │            │ └──────────┘              └─┘ └───────────────┤
  //        │            │                                               ▼
  //        │ ┌──────────┤                                               ┌───┐
  //  Main  │ │Copy board│-----------------------------------------------│End│
  // Thread │ └──────────┘                                               └───┘
  //        └────────────────────────────────────────────────────────────────► t
```

For a complex 2-layer board, I measured an improvement from 14.2s to 7.5s (47%), which is very nice since the DRC is an operation the user needs to wait for its result.

In addition to the speedup, the refactoring also fixes a few minor DRC bugs and adds initial unit tests for the DRC.