### PR TITLE
Support specifying & opening datasheets in editors

### DIFF
--- a/libs/librepcb/core/network/networkrequestbase.cpp
+++ b/libs/librepcb/core/network/networkrequestbase.cpp
@@ -109,6 +109,14 @@ void NetworkRequestBase::setMinimumCacheTime(int seconds) noexcept {
   mMinimumCacheTime = seconds;
 }
 
+void NetworkRequestBase::useBrowserUserAgent() noexcept {
+  Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
+  Q_ASSERT(!mStarted);
+  mRequest.setHeader(QNetworkRequest::UserAgentHeader,
+                     "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:131.0) "
+                     "Gecko/20100101 Firefox/131.0");
+}
+
 void NetworkRequestBase::start() noexcept {
   Q_ASSERT(QThread::currentThread() != NetworkAccessManager::instance());
 

--- a/libs/librepcb/core/network/networkrequestbase.h
+++ b/libs/librepcb/core/network/networkrequestbase.h
@@ -107,6 +107,16 @@ public:
    */
   void setMinimumCacheTime(int seconds) noexcept;
 
+  /**
+   * @brief Use a typical browser user agent for this request
+   *
+   * It turned out at least st.com blocks downloading files if the request
+   * is not coming from a browser. For downloading datasheets we don't care
+   * about the user agent so let's just work arount this issue by using
+   * a well-known user agent.
+   */
+  void useBrowserUserAgent() noexcept;
+
   // Operator Overloadings
   NetworkRequestBase& operator=(const NetworkRequestBase& rhs) = delete;
 

--- a/libs/librepcb/core/workspace/workspacelibrarydb.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.h
@@ -26,6 +26,7 @@
 #include "../attribute/attribute.h"
 #include "../attribute/attributetype.h"
 #include "../fileio/filepath.h"
+#include "../library/resource.h"
 #include "../types/uuid.h"
 #include "../types/version.h"
 
@@ -364,6 +365,23 @@ public:
   }
 
   /**
+   * @brief Get resources of a specific library element
+   *
+   * @tparam ElementType  Type of the library element.
+   *
+   *  @param elemDir       Library element directory.
+   *
+   * @return Element resources (empty if element doesn't exist).
+   */
+  template <typename ElementType>
+  ResourceList getResources(const FilePath elemDir) const {
+    static_assert(std::is_same<ElementType, Component>::value ||
+                      std::is_same<ElementType, Device>::value,
+                  "Unsupported ElementType");
+    return getResources(getTable<ElementType>(), elemDir);
+  }
+
+  /**
    * @brief Get all devices of a specific component
    *
    * @param component   Component UUID to get the devices of.
@@ -421,6 +439,8 @@ private:
   QSet<Uuid> getByCategory(const QString& elementsTable,
                            const QString& categoryTable,
                            const tl::optional<Uuid>& category, int limit) const;
+  ResourceList getResources(const QString& elementsTable,
+                            const FilePath& elemDir) const;
   static QSet<Uuid> getUuidSet(QSqlQuery& query);
   int getDbVersion() const noexcept;
   template <typename ElementType>
@@ -435,7 +455,7 @@ private:
   QScopedPointer<WorkspaceLibraryScanner> mLibraryScanner;
 
   // Constants
-  static const int sCurrentDbVersion = 5;
+  static const int sCurrentDbVersion = 6;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.cpp
@@ -240,6 +240,15 @@ void WorkspaceLibraryDbWriter::createAllTables() {
       "`category_uuid` TEXT NOT NULL, "
       "UNIQUE(element_id, category_uuid)"
       ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS components_res ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`element_id` INTEGER "
+      "REFERENCES components(id) ON DELETE CASCADE NOT NULL, "
+      "`name` TEXT NOT NULL, "
+      "`media_type` TEXT NOT NULL, "
+      "`url` TEXT"
+      ")");
 
   // devices
   queries << QString(
@@ -271,6 +280,15 @@ void WorkspaceLibraryDbWriter::createAllTables() {
       "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
       "`category_uuid` TEXT NOT NULL, "
       "UNIQUE(element_id, category_uuid)"
+      ")");
+  queries << QString(
+      "CREATE TABLE IF NOT EXISTS devices_res ("
+      "`id` INTEGER PRIMARY KEY NOT NULL, "
+      "`element_id` INTEGER "
+      "REFERENCES devices(id) ON DELETE CASCADE NOT NULL, "
+      "`name` TEXT NOT NULL, "
+      "`media_type` TEXT NOT NULL, "
+      "`url` TEXT"
       ")");
 
   // parts
@@ -565,6 +583,24 @@ int WorkspaceLibraryDbWriter::addToCategory(const QString& elementsTable,
       });
   query.bindValue(":element_id", elementId);
   query.bindValue(":category_uuid", category.toStr());
+  return mDb.insert(query);
+}
+
+int WorkspaceLibraryDbWriter::addResource(const QString& elementsTable,
+                                          int elementId, const QString& name,
+                                          const QString& mediaType,
+                                          const QUrl& url) {
+  QSqlQuery query = mDb.prepareQuery(
+      "INSERT INTO %elements_res "
+      "(element_id, name, media_type, url) VALUES "
+      "(:element_id, :name, :media_type, :url)",
+      {
+          {"%elements", elementsTable},
+      });
+  query.bindValue(":element_id", elementId);
+  query.bindValue(":name", nonNull(name));
+  query.bindValue(":media_type", nonNull(mediaType));
+  query.bindValue(":url", url);
   return mDb.insert(query);
 }
 

--- a/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydbwriter.h
@@ -264,6 +264,26 @@ public:
   }
 
   /**
+   * @brief Add a resource for a library element
+   *
+   * @tparam ElementType  Type of element of the resource.
+   * @param elementId     ID of the element of the resource.
+   * @param name          Resource name
+   * @param mediaType     Resource media type.
+   * @param url           Resource URL.
+   * @return ID of the added resource.
+   */
+  template <typename ElementType>
+  int addResource(int elementId, const QString& name, const QString& mediaType,
+                  const QUrl& url) {
+    static_assert(std::is_same<ElementType, Component>::value ||
+                      std::is_same<ElementType, Device>::value,
+                  "Unsupported ElementType");
+    return addResource(getElementTable<ElementType>(), elementId, name,
+                       mediaType, url);
+  }
+
+  /**
    * @brief Add an alternative name to a previously added package
    *
    * @param pkgId         ID of the package for this alternative name.
@@ -315,6 +335,9 @@ private:  // Methods
   void removeAllTranslations(const QString& elementsTable);
   int addToCategory(const QString& elementsTable, int elementId,
                     const Uuid& category);
+  int addResource(const QString& elementsTable, int elementId,
+                  const QString& name, const QString& mediaType,
+                  const QUrl& url);
   QString filePathToString(const FilePath& fp) const noexcept;
   static QString nonNull(const QString& s) noexcept;
 

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.cpp
@@ -335,6 +335,17 @@ int WorkspaceLibraryScanner::addElementToDb<Package>(
 }
 
 template <>
+int WorkspaceLibraryScanner::addElementToDb<Component>(
+    WorkspaceLibraryDbWriter& writer, int libId, const Component& element) {
+  const int id = writer.addElement<Component>(
+      libId, element.getDirectory().getAbsPath(), element.getUuid(),
+      element.getVersion(), element.isDeprecated());
+  addToCategories(writer, id, element);
+  addResourcesToDb(writer, id, element);
+  return id;
+}
+
+template <>
 int WorkspaceLibraryScanner::addElementToDb<Device>(
     WorkspaceLibraryDbWriter& writer, int libId, const Device& element) {
   const int id = writer.addDevice(
@@ -342,6 +353,7 @@ int WorkspaceLibraryScanner::addElementToDb<Device>(
       element.getVersion(), element.isDeprecated(), element.getComponentUuid(),
       element.getPackageUuid());
   addToCategories(writer, id, element);
+  addResourcesToDb(writer, id, element);
   for (const Part& part : element.getParts()) {
     if (!part.isEmpty()) {
       const int partId =
@@ -372,6 +384,16 @@ void WorkspaceLibraryScanner::addToCategories(WorkspaceLibraryDbWriter& writer,
                                               const ElementType& element) {
   foreach (const Uuid& category, element.getCategories()) {
     writer.addToCategory<ElementType>(elementId, category);
+  }
+}
+
+template <typename ElementType>
+void WorkspaceLibraryScanner::addResourcesToDb(WorkspaceLibraryDbWriter& writer,
+                                               int elementId,
+                                               const ElementType& element) {
+  for (const Resource& res : element.getResources()) {
+    writer.addResource<ElementType>(elementId, *res.getName(),
+                                    res.getMediaType(), res.getUrl());
   }
 }
 

--- a/libs/librepcb/core/workspace/workspacelibraryscanner.h
+++ b/libs/librepcb/core/workspace/workspacelibraryscanner.h
@@ -99,6 +99,9 @@ private:  // Methods
   void addToCategories(WorkspaceLibraryDbWriter& writer, int elementId,
                        const ElementType& element);
   template <typename ElementType>
+  void addResourcesToDb(WorkspaceLibraryDbWriter& writer, int elementId,
+                        const ElementType& element);
+  template <typename ElementType>
   std::unique_ptr<ElementType> openAndMigrate(const FilePath& fp);
 
 private:  // Data

--- a/libs/librepcb/editor/library/cmd/cmdlibraryelementedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdlibraryelementedit.cpp
@@ -39,7 +39,9 @@ CmdLibraryElementEdit::CmdLibraryElementEdit(LibraryElement& element,
   : CmdLibraryBaseElementEdit(element, text),
     mElement(element),
     mOldCategories(element.getCategories()),
-    mNewCategories(mOldCategories) {
+    mNewCategories(mOldCategories),
+    mOldResources(element.getResources()),
+    mNewResources(mOldResources) {
 }
 
 CmdLibraryElementEdit::~CmdLibraryElementEdit() noexcept {
@@ -54,6 +56,12 @@ void CmdLibraryElementEdit::setCategories(const QSet<Uuid>& uuids) noexcept {
   mNewCategories = uuids;
 }
 
+void CmdLibraryElementEdit::setResources(
+    const ResourceList& resources) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewResources = resources;
+}
+
 /*******************************************************************************
  *  Inherited from UndoCommand
  ******************************************************************************/
@@ -61,17 +69,20 @@ void CmdLibraryElementEdit::setCategories(const QSet<Uuid>& uuids) noexcept {
 bool CmdLibraryElementEdit::performExecute() {
   if (CmdLibraryBaseElementEdit::performExecute()) return true;  // can throw
   if (mNewCategories != mOldCategories) return true;
+  if (mNewResources != mOldResources) return true;
   return false;
 }
 
 void CmdLibraryElementEdit::performUndo() {
   CmdLibraryBaseElementEdit::performUndo();  // can throw
   mElement.setCategories(mOldCategories);
+  mElement.setResources(mOldResources);
 }
 
 void CmdLibraryElementEdit::performRedo() {
   CmdLibraryBaseElementEdit::performRedo();  // can throw
   mElement.setCategories(mNewCategories);
+  mElement.setResources(mNewResources);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdlibraryelementedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdlibraryelementedit.h
@@ -53,6 +53,7 @@ public:
 
   // Setters
   void setCategories(const QSet<Uuid>& uuids) noexcept;
+  void setResources(const ResourceList& resources) noexcept;
 
   // Operator Overloadings
   CmdLibraryElementEdit& operator=(const CmdLibraryElementEdit& rhs) = delete;
@@ -72,6 +73,8 @@ private:  // Data
 
   QSet<Uuid> mOldCategories;
   QSet<Uuid> mNewCategories;
+  ResourceList mOldResources;
+  ResourceList mNewResources;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
@@ -23,6 +23,7 @@
 #include "componenteditorwidget.h"
 
 #include "../../widgets/signalrolecombobox.h"
+#include "../../workspace/desktopservices.h"
 #include "../cmd/cmdcomponentedit.h"
 #include "../cmd/cmdcomponentsignaledit.h"
 #include "../cmd/cmdcomponentsymbolvariantedit.h"
@@ -33,6 +34,7 @@
 #include <librepcb/core/library/cmp/componentcheckmessages.h>
 #include <librepcb/core/library/librarybaseelementcheckmessages.h>
 #include <librepcb/core/library/libraryelementcheckmessages.h>
+#include <librepcb/core/workspace/workspace.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -60,6 +62,14 @@ ComponentEditorWidget::ComponentEditorWidget(const Context& context,
   mUi->edtAuthor->setReadOnly(mContext.readOnly);
   mUi->edtVersion->setReadOnly(mContext.readOnly);
   mUi->cbxDeprecated->setCheckable(!mContext.readOnly);
+  mUi->edtDatasheet->setReadOnly(mContext.readOnly);
+  connect(mUi->btnDownloadDatasheet, &QToolButton::clicked, this, [this]() {
+    if (auto dbRes = mComponent->getResources().value(0)) {
+      DesktopServices::downloadAndOpenResourceAsync(
+          mContext.workspace.getSettings(), *dbRes->getName(),
+          dbRes->getMediaType(), dbRes->getUrl(), this);
+    }
+  });
   mUi->cbxSchematicOnly->setCheckable(!mContext.readOnly);
   mUi->edtPrefix->setReadOnly(mContext.readOnly);
   mUi->edtDefaultValue->setReadOnly(mContext.readOnly);
@@ -120,6 +130,8 @@ ComponentEditorWidget::ComponentEditorWidget(const Context& context,
   connect(mUi->edtVersion, &QLineEdit::editingFinished, this,
           &ComponentEditorWidget::commitMetadata);
   connect(mUi->cbxDeprecated, &QCheckBox::clicked, this,
+          &ComponentEditorWidget::commitMetadata);
+  connect(mUi->edtDatasheet, &QLineEdit::editingFinished, this,
           &ComponentEditorWidget::commitMetadata);
   connect(mCategoriesEditorWidget.data(), &CategoryListEditorWidget::edited,
           this, &ComponentEditorWidget::commitMetadata);
@@ -189,6 +201,12 @@ void ComponentEditorWidget::updateMetadata() noexcept {
   mUi->edtAuthor->setText(mComponent->getAuthor());
   mUi->edtVersion->setText(mComponent->getVersion().toStr());
   mUi->cbxDeprecated->setChecked(mComponent->isDeprecated());
+  if (auto dbRes = mComponent->getResources().value(0)) {
+    mUi->edtDatasheet->setText(dbRes->getUrl().toDisplayString());
+  } else {
+    mUi->edtDatasheet->clear();
+  }
+  mUi->btnDownloadDatasheet->setEnabled(!mUi->edtDatasheet->text().isEmpty());
   mUi->lstMessages->setApprovals(mComponent->getMessageApprovals());
   mCategoriesEditorWidget->setUuids(mComponent->getCategories());
   mUi->cbxSchematicOnly->setChecked(mComponent->isSchematicOnly());
@@ -214,6 +232,26 @@ QString ComponentEditorWidget::commitMetadata() noexcept {
     cmd->setAuthor(mUi->edtAuthor->text().trimmed());
     cmd->setDeprecated(mUi->cbxDeprecated->isChecked());
     cmd->setCategories(mCategoriesEditorWidget->getUuids());
+    try {
+      ResourceList resources = mComponent->getResources();
+      const ElementName name(
+          cleanElementName("Datasheet " % mUi->edtName->text().trimmed()));
+      const QString dbUrlStr = mUi->edtDatasheet->text().trimmed();
+      const QUrl dbUrl = QUrl::fromUserInput(dbUrlStr);
+      std::shared_ptr<Resource> res = resources.value(0);
+      if ((dbUrl.isValid()) && (!res)) {
+        resources.append(
+            std::make_shared<Resource>(name, "application/pdf", dbUrl));
+      } else if ((!dbUrl.isValid()) && res) {
+        resources.remove(res.get());
+      } else if ((dbUrl.isValid()) && res &&
+                 (dbUrlStr != res->getUrl().toDisplayString())) {
+        res->setName(name);
+        res->setUrl(dbUrl);
+      }
+      cmd->setResources(resources);
+    } catch (const Exception& e) {
+    }
     cmd->setIsSchematicOnly(mUi->cbxSchematicOnly->isChecked());
     try {
       // throws on invalid prefix

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.ui
@@ -278,42 +278,77 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0" colspan="2">
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Datasheet:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="edtDatasheet">
+           <property name="maxLength">
+            <number>255</number>
+           </property>
+           <property name="placeholderText">
+            <string>Direct URL to online PDF</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnDownloadDatasheet">
+           <property name="toolTip">
+            <string>Download &amp; open</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/download.png</normaloff>:/img/actions/download.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="8" column="0" colspan="2">
         <widget class="Line" name="line">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Schematic-Only:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QCheckBox" name="cbxSchematicOnly">
          <property name="text">
           <string>Component cannot be used in devices.</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_11">
          <property name="text">
           <string>Prefix:</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QLineEdit" name="edtPrefix">
          <property name="maxLength">
           <number>10</number>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Default Value:</string>
@@ -323,28 +358,34 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="librepcb::editor::PlainTextEdit" name="edtDefaultValue">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>100</height>
+          </size>
+         </property>
          <property name="tabChangesFocus">
           <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Messages:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0" colspan="2">
+       <item row="12" column="0" colspan="2">
         <widget class="Line" name="line_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Messages:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1">
         <widget class="librepcb::editor::RuleCheckListWidget" name="lstMessages" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">

--- a/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
+++ b/libs/librepcb/editor/library/dev/deviceeditorwidget.ui
@@ -508,7 +508,21 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="7" column="0">
+        <widget class="Line" name="line_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Messages:</string>
@@ -518,14 +532,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0" colspan="2">
-        <widget class="Line" name="line_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
+       <item row="10" column="1">
         <widget class="librepcb::editor::RuleCheckListWidget" name="lstMessages" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -535,6 +542,41 @@
          </property>
         </widget>
        </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Datasheet</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="edtDatasheet">
+           <property name="maxLength">
+            <number>255</number>
+           </property>
+           <property name="placeholderText">
+            <string>Direct URL to online PDF</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnDownloadDatasheet">
+           <property name="toolTip">
+            <string>Download &amp; open</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/img/actions/download.png</normaloff>:/img/actions/download.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
     </layout>
@@ -543,26 +585,26 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>librepcb::editor::AttributeListEditorWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/attributelisteditorwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>librepcb::editor::PlainTextEdit</class>
    <extends>QPlainTextEdit</extends>
    <header location="global">librepcb/editor/widgets/plaintextedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::editor::GraphicsView</class>
-   <extends>QGraphicsView</extends>
-   <header location="global">librepcb/editor/widgets/graphicsview.h</header>
   </customwidget>
   <customwidget>
    <class>librepcb::editor::RuleCheckListWidget</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/rulechecklistwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::AttributeListEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/attributelisteditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>librepcb::editor::GraphicsView</class>
+   <extends>QGraphicsView</extends>
+   <header location="global">librepcb/editor/widgets/graphicsview.h</header>
   </customwidget>
   <customwidget>
    <class>librepcb::editor::PadSignalMapEditorWidget</class>

--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_select.cpp
@@ -45,6 +45,7 @@
 #include "../../cmd/cmdpasteboarditems.h"
 #include "../../cmd/cmdremoveselectedboarditems.h"
 #include "../../cmd/cmdreplacedevice.h"
+#include "../../projecteditor.h"
 #include "../boardclipboarddatabuilder.h"
 #include "../boardeditor.h"
 #include "../boardgraphicsscene.h"
@@ -864,6 +865,11 @@ bool BoardEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
         }
       }
       modMenu->setEnabled(!modMenu->isEmpty());
+
+      mContext.editor.getProjectEditor().addResourcesToMenu(
+          mb, device->getDevice().getComponentInstance(),
+          device->getDevice().getLibDevice().getUuid(), &mContext.editor,
+          &menu);
     } else if (auto netline =
                    std::dynamic_pointer_cast<BGI_NetLine>(selectedItem)) {
       mb.addAction(cmd.setLineWidth.createAction(

--- a/libs/librepcb/editor/project/partinformationprovider.h
+++ b/libs/librepcb/editor/project/partinformationprovider.h
@@ -124,8 +124,10 @@ public:
   void setApiEndpoint(const QUrl& url) noexcept;
 
   // General Methods
-  void startOperation() noexcept;
+  bool startOperation(int timeoutMs = 0) noexcept;
   std::shared_ptr<PartInformation> getPartInfo(const Part& part) noexcept;
+  std::shared_ptr<PartInformation> waitForPartInfo(const Part& part,
+                                                   int timeoutMs) noexcept;
   bool isOngoing(const Part& part) const noexcept;
   void scheduleRequest(const Part& part) noexcept;
   void requestScheduledParts() noexcept;

--- a/libs/librepcb/editor/project/projecteditor.h
+++ b/libs/librepcb/editor/project/projecteditor.h
@@ -23,12 +23,14 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/core/library/resource.h>
 #include <librepcb/core/project/circuit/netsignal.h>
 #include <librepcb/core/rulecheck/rulecheckmessage.h>
 #include <librepcb/core/serialization/fileformatmigration.h>
 #include <optional/tl/optional.hpp>
 
 #include <QtCore>
+#include <QtWidgets>
 
 #include <memory>
 
@@ -41,6 +43,7 @@ class QMainWindow;
 namespace librepcb {
 
 class Board;
+class ComponentInstance;
 class FilePath;
 class LengthUnit;
 class Project;
@@ -49,6 +52,7 @@ class Workspace;
 namespace editor {
 
 class BoardEditor;
+class MenuBuilder;
 class SchematicEditor;
 class UndoStack;
 
@@ -95,7 +99,15 @@ public:
    */
   UndoStack& getUndoStack() const noexcept { return *mUndoStack; }
 
+  ResourceList getComponentResources(
+      const ComponentInstance& cmp,
+      const tl::optional<Uuid>& filterDev = tl::nullopt) const noexcept;
+
   // General Methods
+
+  void addResourcesToMenu(MenuBuilder& mb, const ComponentInstance& cmp,
+                          const tl::optional<Uuid>& filterDev,
+                          QPointer<QWidget> editor, QMenu* root) const noexcept;
 
   /**
    * @brief Abort any active (blocking) tools in other editors
@@ -260,6 +272,8 @@ private:  // Methods
   void runErc() noexcept;
   void saveErcMessageApprovals(const QSet<SExpression>& approvals) noexcept;
   int getCountOfVisibleEditorWindows() const noexcept;
+  void searchAndOpenDatasheet(const QString& mpn, const QString& manufacturer,
+                              QPointer<QWidget> parent) const noexcept;
 
 private:  // Data
   Workspace& mWorkspace;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.cpp
@@ -33,11 +33,13 @@
 #include "../../cmd/cmddragselectedschematicitems.h"
 #include "../../cmd/cmdpasteschematicitems.h"
 #include "../../cmd/cmdremoveselectedschematicitems.h"
+#include "../../projecteditor.h"
 #include "../graphicsitems/sgi_netlabel.h"
 #include "../graphicsitems/sgi_symbol.h"
 #include "../graphicsitems/sgi_text.h"
 #include "../renamenetsegmentdialog.h"
 #include "../schematicclipboarddatabuilder.h"
+#include "../schematiceditor.h"
 #include "../schematicgraphicsscene.h"
 #include "../schematicselectionquery.h"
 #include "../symbolinstancepropertiesdialog.h"
@@ -500,7 +502,7 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
   QMenu menu;
   MenuBuilder mb(&menu);
   const EditorCommandSet& cmd = EditorCommandSet::instance();
-  if (std::dynamic_pointer_cast<SGI_Symbol>(selectedItem)) {
+  if (auto sym = std::dynamic_pointer_cast<SGI_Symbol>(selectedItem)) {
     mb.addAction(
         cmd.properties.createAction(
             &menu, this,
@@ -528,6 +530,10 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
     mb.addAction(cmd.deviceResetTextAll.createAction(
         &menu, this,
         &SchematicEditorState_Select::resetAllTextsOfSelectedItems));
+    mContext.editor.getProjectEditor().addResourcesToMenu(
+        mb, sym->getSymbol().getComponentInstance(), tl::nullopt,
+        &mContext.editor, &menu);
+
   } else if (std::dynamic_pointer_cast<SGI_NetLabel>(selectedItem)) {
     mb.addAction(
         cmd.properties.createAction(

--- a/libs/librepcb/editor/utils/menubuilder.cpp
+++ b/libs/librepcb/editor/utils/menubuilder.cpp
@@ -194,6 +194,10 @@ QMenu* MenuBuilder::createMoveToOtherLibraryMenu(QWidget* parent) noexcept {
   return menu;
 }
 
+QMenu* MenuBuilder::createMoreResourcesMenu(QWidget* parent) noexcept {
+  return createMenu("menuMoreResources", tr("More Resources"), QIcon(), parent);
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/

--- a/libs/librepcb/editor/utils/menubuilder.h
+++ b/libs/librepcb/editor/utils/menubuilder.h
@@ -92,6 +92,7 @@ public:
   static QMenu* createChangeFootprintMenu(QWidget* parent) noexcept;
   static QMenu* createChangeModelMenu(QWidget* parent) noexcept;
   static QMenu* createMoveToOtherLibraryMenu(QWidget* parent) noexcept;
+  static QMenu* createMoreResourcesMenu(QWidget* parent) noexcept;
 
 private:  // Methods
   static QMenu* createMenu(const QString& objectName, const QString& text,

--- a/libs/librepcb/editor/workspace/desktopservices.h
+++ b/libs/librepcb/editor/workspace/desktopservices.h
@@ -64,6 +64,13 @@ public:
   bool openWebUrl(const QUrl& url) const noexcept;
   bool openLocalPath(const FilePath& filePath) const noexcept;
 
+  // Static Methods
+  static void downloadAndOpenResourceAsync(const WorkspaceSettings& settings,
+                                           const QString& name,
+                                           const QString& mediaType,
+                                           const QUrl& url,
+                                           QPointer<QWidget> parent) noexcept;
+
   // Operator Overloadings
   DesktopServices& operator=(const DesktopServices& rhs) = delete;
 


### PR DESCRIPTION
The support for storing datasheet URLs in components and devices has already been implemented in the LibrePCB 1.0 file format (#1181), but it has not been not implemented in the UI yet. This PR implements the missing UI integration, consisting of several parts:

### Library Editor

A new text field for components and devices in the library editor allows to enter a datasheet URL:

![image](https://github.com/user-attachments/assets/4cd9e98f-bff1-43bf-a4c7-a218be48100d)

If a datasheet URL is set, the button next to the text field opens it. Useful for testing URLs but also when working on a library element to quickly access the datasheet.

Note that the file format actually allows to store multiple URLs, not just one. But to keep the UI simple, for now it only displays & modifies the first URL if there are multiple.

### SQLite Library Cache

The background library scan now also stores any URLs on components and devices in the SQLite database so they can be accessed quickly from the schematic- & board editors.

### Schematic- & Board Editors

The context menu of components in the schematic- and board editors now provide quick access to the stored resources:

![image](https://github.com/user-attachments/assets/115c7878-606d-49dd-af20-e0cb8f19f171)

The first item here is the datasheet URL fetched from the SQLite library cache (or from the project's library element, if not found in the cache). When clicked, the datasheet is downloaded & opened.

The second item here is shown only if an MPN is set on the component. Instead of relying on URLs stored in the library, it requests live part information on demand through the [LibrePCB API](https://developers.librepcb.org/d1/dcb/doc_server_api.html#doc_server_api_resources_parts). If the response contains a datasheet URL, it will be downloaded & opened.

### Download & Caching

When requesting to open a datasheet, the following steps are performed:

1. Download the resource from its URL (if not in cache)
2. Store the downloaded file in the user's cache directory (e.g. `~/.cache/LibrePCB`) so the next time, no download is needed (identified by the URL's MD5 hash)
3. Open the cached file with the local PDF reader

If the download fails (e.g. because it's not a direct URL, which is currently the case for our API responses), the URL will be opened in the web browser. This way even indirect URLs or URLs with a cloudflare wall etc. should work.