### PR TITLE
Library editor: Fix conflicting component signal names

### DIFF
--- a/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentsignals.h
+++ b/libs/librepcb/editor/library/newelementwizard/newelementwizardpage_componentsignals.h
@@ -66,9 +66,11 @@ public:
   NewElementWizardPage_ComponentSignals& operator=(
       const NewElementWizardPage_ComponentSignals& rhs) = delete;
 
+  // Static Methods
+  static QString appendNumberToSignalName(QString name, int number) noexcept;
+
 private:  // Methods
-  QHash<Uuid, CircuitIdentifier> getPinNames(
-      const Uuid& symbol, const QString& suffix) const noexcept;
+  QHash<Uuid, CircuitIdentifier> getPinNames(const Uuid& symbol) const noexcept;
   void initializePage() noexcept override;
   void cleanupPage() noexcept override;
 


### PR DESCRIPTION
When creating a new component in the library editor which consists of multiple gates, the automatically added component signals may have conflicting names (e.g. 2x "OUT" for a dual opamp). This change appends an incrementing number in this case (e.g. "OUT1" & "OUT2").

The "Automatically assign all signals by name" also takes this suffix into account to get a successful auto-assignment, no matter if the suffix is there or not.

Fixes #1425