### PR TITLE
Library editor: Automatically set gate suffixes

### DIFF
--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.h
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantitemlistmodel.h
@@ -27,6 +27,8 @@
 
 #include <QtCore>
 
+#include <memory>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -35,6 +37,7 @@ namespace editor {
 
 class LibraryElementCache;
 class UndoCommand;
+class UndoCommandGroup;
 class UndoStack;
 
 /*******************************************************************************
@@ -97,11 +100,12 @@ public:
       const ComponentSymbolVariantItemListModel& rhs) noexcept;
 
 private:
+  std::unique_ptr<UndoCommandGroup> createSuffixUpdateCmd();
   void itemListEdited(
       const ComponentSymbolVariantItemList& list, int index,
       const std::shared_ptr<const ComponentSymbolVariantItem>& item,
       ComponentSymbolVariantItemList::Event event) noexcept;
-  void execCmd(UndoCommand* cmd);
+  void execCmd(UndoCommand* cmd, bool updateSuffixes = true);
 
 private:  // Data
   ComponentSymbolVariantItemList* mItemList;


### PR DESCRIPTION
When creating or modifying a component, gate suffixes "A", "B", "C" etc. are now automatically added since it is a frequent source of confusion and it is not so intuitive that this should be done. For single-symbol components, no suffix is added.

Closes #1426