### PR TITLE
Board editor: Display component signal names in pads

### DIFF
--- a/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
+++ b/libs/librepcb/core/project/board/items/bi_footprintpad.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "bi_footprintpad.h"
 
+#include "../../../library/cmp/componentsignal.h"
 #include "../../../library/dev/device.h"
 #include "../../../library/pkg/footprint.h"
 #include "../../../library/pkg/package.h"
@@ -290,8 +291,24 @@ void BI_FootprintPad::updateText() noexcept {
   if (mPackagePad) {
     text += *mPackagePad->getName();
   }
+  // Show the component signal name too if it differs from the pad name,
+  // because it is much more expressive. To avoid long texts, only display the
+  // text up to the first "/" as it is usually unique already for the device.
+  if (const ComponentSignalInstance* signal = getComponentSignalInstance()) {
+    const QString fullName = *signal->getCompSignal().getName();
+    const int sepPos = fullName.indexOf("/", 1);  // Ignore leading slash.
+    const QString shortName = (sepPos != -1) ? fullName.left(sepPos) : fullName;
+    if ((fullName != text) && (shortName != text)) {
+      text += ":" % shortName;
+    }
+  }
+  // To avoid too small text size, truncate text.
+  if (text.count() > 8) {
+    text = text.left(6) % "…";
+  }
+  // Show the net name on the next line to avoid too long texts.
   if (NetSignal* signal = getCompSigInstNetSignal()) {
-    text += ": " % *signal->getName();
+    text += "\n" % *signal->getName();
   }
   if (text != mText) {
     mText = text;

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
@@ -114,14 +114,17 @@ void PrimitiveFootprintPadGraphicsItem::setText(const QString& text) noexcept {
       Application::getDefaultStrokeFont(), StrokeTextSpacing(),
       StrokeTextSpacing(), PositiveLength(1000000), UnsignedLength(100000),
       Alignment(HAlign::center(), VAlign::center()), Angle(0), false, text);
+  mTextGraphicsItem->setPath(Path::toQPainterPathPx(paths, false));
+  updateTextHeight();
+}
 
+void PrimitiveFootprintPadGraphicsItem::setToolTipText(
+    const QString& text) noexcept {
   setToolTip(text);
   mOriginCrossGraphicsItem->setToolTip(text);
-  mTextGraphicsItem->setPath(Path::toQPainterPathPx(paths, false));
   foreach (auto& item, mPathGraphicsItems) {
     item.item->setToolTip(text);
   }
-  updateTextHeight();
 }
 
 void PrimitiveFootprintPadGraphicsItem::setLayer(

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
@@ -69,6 +69,7 @@ public:
   void setRotation(const Angle& rotation) noexcept;
   void setMirrored(bool mirrored) noexcept;
   void setText(const QString& text) noexcept;
+  void setToolTipText(const QString& text) noexcept;
   void setLayer(const QString& layerName) noexcept;
   void setGeometries(const QHash<const Layer*, QList<PadGeometry>>& geometries,
                      const Length& clearance) noexcept;

--- a/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadgraphicsitem.cpp
@@ -85,6 +85,7 @@ void FootprintPadGraphicsItem::updateText() noexcept {
     }
   }
   mGraphicsItem->setText(text);
+  mGraphicsItem->setToolTipText(text);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.h
+++ b/libs/librepcb/editor/project/boardeditor/graphicsitems/bgi_footprintpad.h
@@ -52,6 +52,8 @@ class PrimitiveFootprintPadGraphicsItem;
  * @brief The BGI_FootprintPad class
  */
 class BGI_FootprintPad final : public QGraphicsItemGroup {
+  Q_DECLARE_TR_FUNCTIONS(BGI_FootprintPad)
+
 public:
   // Constructors / Destructor
   BGI_FootprintPad() = delete;
@@ -83,6 +85,7 @@ private:  // Methods
   virtual QVariant itemChange(GraphicsItemChange change,
                               const QVariant& value) noexcept override;
   void updateLayer() noexcept;
+  void updateToolTip() noexcept;
   void updateHightlighted(bool selected) noexcept;
 
 private:  // Data


### PR DESCRIPTION
So far, the board editor displayed the pad name and (if connected) the net name in the footprint pads. However, often both values are not very expressive (e.g. pad name is just a number, and net name is auto-generated "N#"). So, often the function of a pad is not clear. 

Since the component signal is always something expressive, it will now be displayed in pads too. In addition, the tooltip now contains the component signal name and the net name too.

![image](https://github.com/user-attachments/assets/dbde1833-ff00-4d69-8432-bfdc78980a07)
