### PR TITLE
Component check: Warn about missing pin-signal connections

### DIFF
--- a/libs/librepcb/core/library/cmp/componentcheck.h
+++ b/libs/librepcb/core/library/cmp/componentcheck.h
@@ -62,6 +62,7 @@ protected:  // Methods
   void checkSignalNamesInversionSign(MsgList& msgs) const;
   void checkMissingSymbolVariants(MsgList& msgs) const;
   void checkMissingSymbolVariantItems(MsgList& msgs) const;
+  void checkNoPinsConnected(MsgList& msgs) const;
 
 private:  // Data
   const Component& mComponent;

--- a/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
+++ b/libs/librepcb/core/library/cmp/componentcheckmessages.cpp
@@ -137,6 +137,28 @@ MsgNonFunctionalComponentSignalInversionSign::
 }
 
 /*******************************************************************************
+ *  MsgNoPinsInSymbolVariantConnected
+ ******************************************************************************/
+
+MsgNoPinsInSymbolVariantConnected::MsgNoPinsInSymbolVariantConnected(
+    std::shared_ptr<const ComponentSymbolVariant> symbVar) noexcept
+  : RuleCheckMessage(
+        Severity::Error,
+        tr("No pins connected in '%1'")
+            .arg(*symbVar->getNames().getDefaultValue()),
+        tr("The chosen symbols contain pins, but none of them are connected "
+           "to component signals. So when adding this component to a "
+           "schematic, no wires can be attached to them.\n\nTo fix this "
+           "issue, connect the symbol pins to their corresponding component "
+           "signals in the symbol variant editor dialog."),
+        "no_pins_connected"),
+    mSymbVar(symbVar) {
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("variant", symbVar->getUuid());
+  mApproval->ensureLineBreak();
+}
+
+/*******************************************************************************
  *  End of File
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/cmp/componentcheckmessages.h
+++ b/libs/librepcb/core/library/cmp/componentcheckmessages.h
@@ -121,7 +121,7 @@ class MsgMissingSymbolVariantItem final : public RuleCheckMessage {
 
 public:
   // Constructors / Destructor
-  MsgMissingSymbolVariantItem() noexcept;
+  MsgMissingSymbolVariantItem() = delete;
   explicit MsgMissingSymbolVariantItem(
       std::shared_ptr<const ComponentSymbolVariant> symbVar) noexcept;
   MsgMissingSymbolVariantItem(const MsgMissingSymbolVariantItem& other) noexcept
@@ -165,6 +165,35 @@ public:
 
 private:
   std::shared_ptr<const ComponentSignal> mSignal;
+};
+
+/*******************************************************************************
+ *  Class MsgNoPinsInSymbolVariantConnected
+ ******************************************************************************/
+
+/**
+ * @brief The MsgNoPinsInSymbolVariantConnected class
+ */
+class MsgNoPinsInSymbolVariantConnected final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgNoPinsInSymbolVariantConnected)
+
+public:
+  // Constructors / Destructor
+  MsgNoPinsInSymbolVariantConnected() = delete;
+  explicit MsgNoPinsInSymbolVariantConnected(
+      std::shared_ptr<const ComponentSymbolVariant> symbVar) noexcept;
+  MsgNoPinsInSymbolVariantConnected(
+      const MsgNoPinsInSymbolVariantConnected& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~MsgNoPinsInSymbolVariantConnected() noexcept {}
+
+  // Getters
+  std::shared_ptr<const ComponentSymbolVariant> getSymbVar() const noexcept {
+    return mSymbVar;
+  }
+
+private:
+  std::shared_ptr<const ComponentSymbolVariant> mSymbVar;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componenteditorwidget.cpp
@@ -384,6 +384,12 @@ void ComponentEditorWidget::fixMsg(
   mUndoStack->execCmd(cmd.take());
 }
 
+template <>
+void ComponentEditorWidget::fixMsg(
+    const MsgNoPinsInSymbolVariantConnected& msg) {
+  mUi->symbolVariantsEditorWidget->openEditor(msg.getSymbVar()->getUuid());
+}
+
 template <typename MessageType>
 bool ComponentEditorWidget::fixMsgHelper(
     std::shared_ptr<const RuleCheckMessage> msg, bool applyFix) {
@@ -404,6 +410,8 @@ bool ComponentEditorWidget::processRuleCheckMessage(
   if (fixMsgHelper<MsgMissingComponentDefaultValue>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgMissingSymbolVariant>(msg, applyFix)) return true;
   if (fixMsgHelper<MsgNonFunctionalComponentSignalInversionSign>(msg, applyFix))
+    return true;
+  if (fixMsgHelper<MsgNoPinsInSymbolVariantConnected>(msg, applyFix))
     return true;
   return false;
 }

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.cpp
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.cpp
@@ -89,7 +89,7 @@ ComponentSymbolVariantListWidget::~ComponentSymbolVariantListWidget() noexcept {
 }
 
 /*******************************************************************************
- *  Setters
+ *  General Methods
  ******************************************************************************/
 
 void ComponentSymbolVariantListWidget::setFrameStyle(int style) noexcept {
@@ -108,6 +108,12 @@ void ComponentSymbolVariantListWidget::setReferences(
   mSymbolVariantList = list;
   mUndoStack = undoStack;
   mEditorProvider = editorProvider;
+}
+
+void ComponentSymbolVariantListWidget::openEditor(const Uuid& uuid) noexcept {
+  if (mSymbolVariantList && mUndoStack && mEditorProvider) {
+    editVariant(uuid);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.h
+++ b/libs/librepcb/editor/library/cmp/componentsymbolvariantlistwidget.h
@@ -57,12 +57,13 @@ public:
       const ComponentSymbolVariantListWidget& other) = delete;
   ~ComponentSymbolVariantListWidget() noexcept;
 
-  // Setters
+  // General Methods
   void setFrameStyle(int style) noexcept;
   void setReadOnly(bool readOnly) noexcept;
   void setReferences(
       UndoStack* undoStack, ComponentSymbolVariantList* list,
       IF_ComponentSymbolVariantEditorProvider* editorProvider) noexcept;
+  void openEditor(const Uuid& uuid) noexcept;
 
   // Operator Overloadings
   ComponentSymbolVariantListWidget& operator=(


### PR DESCRIPTION
It seems to be a frequent issue that users forget to connect pins to their corresponding component signals in the component editor. The UI is also not so clear about this since the corresponding editor is located in a dialog.

Now the component editor warns clearly (error severity) if a component contains signals and pins, but no connections exist at all. And the "fix" button directly opens the dialog where the connections need to be made.