### PR TITLE
Library editor: Warn about non-centered symbols/packages

### DIFF
--- a/libs/librepcb/core/library/pkg/packagecheck.h
+++ b/libs/librepcb/core/library/pkg/packagecheck.h
@@ -63,6 +63,7 @@ protected:  // Methods
   void checkWrongTextLayers(MsgList& msgs) const;
   void checkPackageOutlines(MsgList& msgs) const;
   void checkCourtyards(MsgList& msgs) const;
+  void checkOriginInCenter(MsgList& msgs) const;
   void checkPadsPackagePadUuid(MsgList& msgs) const;
   void checkPadsClearanceToPads(MsgList& msgs) const;
   void checkPadsClearanceToLegend(MsgList& msgs) const;

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
@@ -398,6 +398,28 @@ MsgMissingPackageOutline::MsgMissingPackageOutline(
 }
 
 /*******************************************************************************
+ *  MsgFootprintOriginNotInCenter
+ ******************************************************************************/
+
+MsgFootprintOriginNotInCenter::MsgFootprintOriginNotInCenter(
+    std::shared_ptr<const Footprint> footprint, const Point& center) noexcept
+  : RuleCheckMessage(
+        Severity::Hint,
+        tr("Origin of '%1' not in center")
+            .arg(*footprint->getNames().getDefaultValue()),
+        tr("Generally the origin (0, 0) should be at the coordinate used for "
+           "pick&place which is typically in the center of the package body. "
+           "It should even be (more or less) <b>exactly</b> in the center, not "
+           "aligned to a grid (off-grid pads are fine).\n\nIt looks like this "
+           "rule is not followed in this footprint. However, for irregular "
+           "package shapes or other special cases this warning may not be "
+           "justified. In such cases, just approve it."),
+        "origin_not_in_center"),
+    mFootprint(footprint),
+    mCenter(center) {
+}
+
+/*******************************************************************************
  *  MsgOverlappingPads
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.h
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.h
@@ -452,6 +452,39 @@ private:
 };
 
 /*******************************************************************************
+ *  Class MsgFootprintOriginNotInCenter
+ ******************************************************************************/
+
+/**
+ * @brief The MsgFootprintOriginNotInCenter class
+ */
+class MsgFootprintOriginNotInCenter final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgFootprintOriginNotInCenter)
+
+public:
+  // Constructors / Destructor
+  MsgFootprintOriginNotInCenter() = delete;
+  MsgFootprintOriginNotInCenter(std::shared_ptr<const Footprint> footprint,
+                                const Point& center) noexcept;
+  MsgFootprintOriginNotInCenter(
+      const MsgFootprintOriginNotInCenter& other) noexcept
+    : RuleCheckMessage(other),
+      mFootprint(other.mFootprint),
+      mCenter(other.mCenter) {}
+  virtual ~MsgFootprintOriginNotInCenter() noexcept {}
+
+  // Getters
+  std::shared_ptr<const Footprint> getFootprint() const noexcept {
+    return mFootprint;
+  }
+  const Point& getCenter() const noexcept { return mCenter; }
+
+private:
+  std::shared_ptr<const Footprint> mFootprint;
+  const Point mCenter;
+};
+
+/*******************************************************************************
  *  Class MsgOverlappingPads
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/sym/symbolcheck.h
+++ b/libs/librepcb/core/library/sym/symbolcheck.h
@@ -62,6 +62,7 @@ protected:  // Methods
   void checkOverlappingPins(MsgList& msgs) const;
   void checkMissingTexts(MsgList& msgs) const;
   void checkWrongTextLayers(MsgList& msgs) const;
+  void checkOriginInCenter(MsgList& msgs) const;
 
 private:  // Data
   const Symbol& mSymbol;

--- a/libs/librepcb/core/library/sym/symbolcheckmessages.cpp
+++ b/libs/librepcb/core/library/sym/symbolcheckmessages.cpp
@@ -98,6 +98,24 @@ MsgNonFunctionalSymbolPinInversionSign::MsgNonFunctionalSymbolPinInversionSign(
 }
 
 /*******************************************************************************
+ *  MsgSymbolOriginNotInCenter
+ ******************************************************************************/
+
+MsgSymbolOriginNotInCenter::MsgSymbolOriginNotInCenter(
+    const Point& center) noexcept
+  : RuleCheckMessage(
+        Severity::Hint, tr("Origin not in center"),
+        tr("Generally the origin (0, 0) should be in the center of the symbol "
+           "body (roughly, mapped to grid). It's not recommended to have it at "
+           "pin-1 coordinate, top-left or something like that.\n\nIt looks "
+           "like this rule is not followed in this symbol. However, for "
+           "irregular symbol shapes this warning may not be justified. In such "
+           "cases, just approve it."),
+        "origin_not_in_center"),
+    mCenter(center) {
+}
+
+/*******************************************************************************
  *  MsgOverlappingSymbolPins
  ******************************************************************************/
 

--- a/libs/librepcb/core/library/sym/symbolcheckmessages.h
+++ b/libs/librepcb/core/library/sym/symbolcheckmessages.h
@@ -122,6 +122,31 @@ private:
 };
 
 /*******************************************************************************
+ *  Class MsgSymbolOriginNotInCenter
+ ******************************************************************************/
+
+/**
+ * @brief The MsgSymbolOriginNotInCenter class
+ */
+class MsgSymbolOriginNotInCenter final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(MsgSymbolOriginNotInCenter)
+
+public:
+  // Constructors / Destructor
+  MsgSymbolOriginNotInCenter() = delete;
+  explicit MsgSymbolOriginNotInCenter(const Point& center) noexcept;
+  MsgSymbolOriginNotInCenter(const MsgSymbolOriginNotInCenter& other) noexcept
+    : RuleCheckMessage(other), mCenter(other.mCenter) {}
+  virtual ~MsgSymbolOriginNotInCenter() noexcept {}
+
+  // Getters
+  const Point& getCenter() const noexcept { return mCenter; }
+
+private:
+  const Point mCenter;
+};
+
+/*******************************************************************************
  *  Class MsgOverlappingSymbolPins
  ******************************************************************************/
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
@@ -348,10 +348,10 @@ bool PackageEditorFsm::processPaste() noexcept {
   }
 }
 
-bool PackageEditorFsm::processMove(Qt::ArrowType direction) noexcept {
+bool PackageEditorFsm::processMove(const Point& delta) noexcept {
   if (getCurrentState() && mContext.currentFootprint &&
       mContext.currentGraphicsItem) {
-    return getCurrentState()->processMove(direction);
+    return getCurrentState()->processMove(delta);
   } else {
     return false;
   }

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -135,7 +135,7 @@ public:
   bool processCut() noexcept;
   bool processCopy() noexcept;
   bool processPaste() noexcept;
-  bool processMove(Qt::ArrowType direction) noexcept;
+  bool processMove(const Point& delta) noexcept;
   bool processRotate(const Angle& rotation) noexcept;
   bool processMirror(Qt::Orientation orientation) noexcept;
   bool processFlip(Qt::Orientation orientation) noexcept;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
@@ -105,8 +105,8 @@ public:
   virtual bool processCut() noexcept { return false; }
   virtual bool processCopy() noexcept { return false; }
   virtual bool processPaste() noexcept { return false; }
-  virtual bool processMove(Qt::ArrowType direction) {
-    Q_UNUSED(direction);
+  virtual bool processMove(const Point& delta) {
+    Q_UNUSED(delta);
     return false;
   }
   virtual bool processRotate(const Angle& rotation) noexcept {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -460,7 +460,7 @@ bool PackageEditorState_Select::processPaste() noexcept {
   return false;
 }
 
-bool PackageEditorState_Select::processMove(Qt::ArrowType direction) noexcept {
+bool PackageEditorState_Select::processMove(const Point& delta) noexcept {
   if ((!mContext.currentFootprint) || (!mContext.currentGraphicsItem)) {
     return false;
   }
@@ -468,31 +468,6 @@ bool PackageEditorState_Select::processMove(Qt::ArrowType direction) noexcept {
   switch (mState) {
     case SubState::IDLE: {
       try {
-        Point delta;
-        switch (direction) {
-          case Qt::LeftArrow: {
-            delta.setX(-getGridInterval());
-            break;
-          }
-          case Qt::RightArrow: {
-            delta.setX(*getGridInterval());
-            break;
-          }
-          case Qt::UpArrow: {
-            delta.setY(*getGridInterval());
-            break;
-          }
-          case Qt::DownArrow: {
-            delta.setY(-getGridInterval());
-            break;
-          }
-          default: {
-            qWarning() << "Unhandled switch-case in "
-                          "PackageEditorState_Select::processMove():"
-                       << direction;
-            break;
-          }
-        }
         QScopedPointer<CmdDragSelectedFootprintItems> cmd(
             new CmdDragSelectedFootprintItems(mContext));
         cmd->translate(delta);

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
@@ -95,7 +95,7 @@ public:
   bool processCut() noexcept override;
   bool processCopy() noexcept override;
   bool processPaste() noexcept override;
-  bool processMove(Qt::ArrowType direction) noexcept override;
+  bool processMove(const Point& delta) noexcept override;
   bool processRotate(const Angle& rotation) noexcept override;
   bool processMirror(Qt::Orientation orientation) noexcept override;
   bool processFlip(Qt::Orientation orientation) noexcept override;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.cpp
@@ -233,9 +233,9 @@ bool SymbolEditorFsm::processPaste() noexcept {
   }
 }
 
-bool SymbolEditorFsm::processMove(Qt::ArrowType direction) noexcept {
+bool SymbolEditorFsm::processMove(const Point& delta) noexcept {
   if (getCurrentState()) {
-    return getCurrentState()->processMove(direction);
+    return getCurrentState()->processMove(delta);
   } else {
     return false;
   }

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
@@ -117,7 +117,7 @@ public:
   bool processCut() noexcept;
   bool processCopy() noexcept;
   bool processPaste() noexcept;
-  bool processMove(Qt::ArrowType direction) noexcept;
+  bool processMove(const Point& delta) noexcept;
   bool processRotate(const Angle& rotation) noexcept;
   bool processMirror(Qt::Orientation orientation) noexcept;
   bool processSnapToGrid() noexcept;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
@@ -112,8 +112,8 @@ public:
     Q_UNUSED(data);
     return false;
   }
-  virtual bool processMove(Qt::ArrowType direction) {
-    Q_UNUSED(direction);
+  virtual bool processMove(const Point& delta) {
+    Q_UNUSED(delta);
     return false;
   }
   virtual bool processRotate(const Angle& rotation) noexcept {

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -398,35 +398,10 @@ bool SymbolEditorState_Select::processPaste(
   return false;
 }
 
-bool SymbolEditorState_Select::processMove(Qt::ArrowType direction) noexcept {
+bool SymbolEditorState_Select::processMove(const Point& delta) noexcept {
   switch (mState) {
     case SubState::IDLE: {
       try {
-        Point delta;
-        switch (direction) {
-          case Qt::LeftArrow: {
-            delta.setX(-getGridInterval());
-            break;
-          }
-          case Qt::RightArrow: {
-            delta.setX(*getGridInterval());
-            break;
-          }
-          case Qt::UpArrow: {
-            delta.setY(*getGridInterval());
-            break;
-          }
-          case Qt::DownArrow: {
-            delta.setY(-getGridInterval());
-            break;
-          }
-          default: {
-            qWarning() << "Unhandled switch-case in "
-                          "SymbolEditorState_Select::processMove():"
-                       << direction;
-            break;
-          }
-        }
         QScopedPointer<CmdDragSelectedSymbolItems> cmd(
             new CmdDragSelectedSymbolItems(mContext));
         cmd->translate(delta);

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.h
@@ -93,7 +93,7 @@ public:
   bool processCopy() noexcept override;
   bool processPaste(
       std::unique_ptr<SymbolClipboardData> data = nullptr) noexcept override;
-  bool processMove(Qt::ArrowType direction) noexcept override;
+  bool processMove(const Point& delta) noexcept override;
   bool processRotate(const Angle& rotation) noexcept override;
   bool processMirror(Qt::Orientation orientation) noexcept override;
   bool processSnapToGrid() noexcept override;


### PR DESCRIPTION
Our guidelines clearly say that symbols should be centered around the origin (0, 0). This is mainly for a consistent look&feel, but also because symbols can be grabbed at (0, 0) so it's important for usability that every symbol can be grabbed at the same position.

For packages, out guidelines also clearly say the body center must be at (0, 0) because this is the position where pick&place machines will pick the part. So it's really important to have it in the body center.

However, I saw many users do not follow these guidelines. Possibly because many symbols & packages in other EDA tools do not follow them either or have other guidelines. Especially in KiCad, many footprints have pin-1 at (0, 0).

To enforce this rule more strictly for LibrePCB users, the symbol- & package editors try to detect the center and warn if it's not close to (0, 0). Some tolerance is allowed of course to avoid being too picky, leading to many false-positives.

The "fix" button automatically moves the auto-detected center to the origin (0, 0).

![image](https://github.com/user-attachments/assets/29be7894-b221-4544-8ab4-dee2b9c8a8a4)
