### PR TITLE
Fix OpenGL 3D viewers for Qt > 6.6

### DIFF
--- a/libs/librepcb/editor/widgets/openglview.cpp
+++ b/libs/librepcb/editor/widgets/openglview.cpp
@@ -278,6 +278,11 @@ void OpenGlView::paintGL() {
   // Clear color and depth buffer.
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+  // Bind the shader program.
+  if (!mProgram.bind()) {
+    qCritical() << "Failed to bind OpenGL shader program.";
+  }
+
   // Set modelview-projection matrix.
   const qreal zNear = 0.1;
   const qreal zFar = 100.0;


### PR DESCRIPTION
Seems the shader program needs to be bound, though it worked without this call in older Qt versions...