### PR TITLE
CMake: Fix compiler flags for muparser & kicadimport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,12 +131,6 @@ endif()
 # interest, so let's suppress them.
 target_compile_options(common INTERFACE -Wno-noexcept-type)
 
-# Clang emits some warnings within the muParser library when compiling with
-# -Wpedantic, so let's suppress these warnings when compiling with Clang.
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(common INTERFACE -Wno-nested-anon-types)
-endif()
-
 # Avoid "file too big" error for debug builds on Windows.
 if(WIN32)
   target_compile_options(common INTERFACE $<$<CONFIG:Debug>:-Wa,-mbig-obj>)

--- a/cmake/FindMuParser.cmake
+++ b/cmake/FindMuParser.cmake
@@ -25,8 +25,9 @@ if(EXISTS "${MUPARSER_SUBMODULE_BASEPATH}"
     EXCLUDE_FROM_ALL
   )
 
-  # Disable deprecation warnings since they are not under our control.
+  # Suppress compiler warnings since they are not under our control.
   target_compile_options(muparser PRIVATE -Wno-deprecated-declarations)
+  target_compile_options(muparser PUBLIC -Wno-nested-anon-types)
 
   # Alias lib to namespaced variant
   add_library(MuParser::MuParser ALIAS muparser)

--- a/libs/librepcb/kicadimport/CMakeLists.txt
+++ b/libs/librepcb/kicadimport/CMakeLists.txt
@@ -21,6 +21,10 @@ target_include_directories(
 )
 target_link_libraries(
   librepcb_kicadimport
+  PRIVATE common
+)
+target_link_libraries(
+  librepcb_kicadimport
   PUBLIC # LibrePCB
          LibrePCB::Core
          # Qt

--- a/libs/librepcb/kicadimport/kicadlibraryconverter.cpp
+++ b/libs/librepcb/kicadimport/kicadlibraryconverter.cpp
@@ -495,7 +495,7 @@ std::unique_ptr<Device> KiCadLibraryConverter::createDevice(
     const QList<std::pair<QString, QStringList>> pinNames =
         C::convertSymbolPinNames(gate.pins);
     for (const auto& pair : pinNames) {
-      for (const QString padNumber : pair.second) {
+      for (const QString& padNumber : pair.second) {
         if (!connectedPads.contains(padNumber)) {
           throw RuntimeError(__FILE__, __LINE__,
                              QString("Pad '%1' not found in imported package.")

--- a/libs/librepcb/kicadimport/kicadlibraryimport.h
+++ b/libs/librepcb/kicadimport/kicadlibraryimport.h
@@ -40,7 +40,7 @@ class WorkspaceLibraryDb;
 
 namespace kicadimport {
 
-class KiCadLibraryConverterSettings;
+struct KiCadLibraryConverterSettings;
 
 /*******************************************************************************
  *  Class KiCadLibraryImport

--- a/libs/librepcb/kicadimport/kicadtypes.cpp
+++ b/libs/librepcb/kicadimport/kicadtypes.cpp
@@ -388,6 +388,8 @@ static kicadimport::KiCadLayer deserializeLayer(const SExpression& node,
 
 KiCadProperty KiCadProperty::parse(const SExpression& node,
                                    MessageLogger& log) {
+  Q_UNUSED(log);
+
   KiCadProperty obj;
   obj.key = node.getChild(0).getValue();
   obj.value = node.getChild(1).getValue();
@@ -424,6 +426,8 @@ KiCadProperty KiCadProperty::parse(const SExpression& node,
 
 KiCadGraphicalLine KiCadGraphicalLine::parse(const SExpression& node,
                                              MessageLogger& log) {
+  Q_UNUSED(log);
+
   KiCadGraphicalLine obj;
   obj.start = deserialize<QPointF>(node.getChild("start"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
@@ -437,6 +441,8 @@ KiCadGraphicalLine KiCadGraphicalLine::parse(const SExpression& node,
 
 KiCadGraphicalArc KiCadGraphicalArc::parse(const SExpression& node,
                                            MessageLogger& log) {
+  Q_UNUSED(log);
+
   KiCadGraphicalArc obj;
   obj.start = deserialize<QPointF>(node.getChild("start"));
   obj.mid = deserialize<QPointF>(node.getChild("mid"));
@@ -451,6 +457,8 @@ KiCadGraphicalArc KiCadGraphicalArc::parse(const SExpression& node,
 
 KiCadGraphicalCircle KiCadGraphicalCircle::parse(const SExpression& node,
                                                  MessageLogger& log) {
+  Q_UNUSED(log);
+
   KiCadGraphicalCircle obj;
   obj.center = deserialize<QPointF>(node.getChild("center"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
@@ -467,6 +475,8 @@ KiCadGraphicalCircle KiCadGraphicalCircle::parse(const SExpression& node,
 
 KiCadGraphicalPolygon KiCadGraphicalPolygon::parse(const SExpression& node,
                                                    MessageLogger& log) {
+  Q_UNUSED(log);
+
   KiCadGraphicalPolygon obj;
   foreach (const SExpression* child, node.getChild("pts").getChildren("xy")) {
     obj.coordinates.append(deserialize<QPointF>(*child));
@@ -584,6 +594,8 @@ KiCadSymbolPolyline KiCadSymbolPolyline::parse(const SExpression& node,
 
 KiCadSymbolText KiCadSymbolText::parse(const SExpression& node,
                                        MessageLogger& log) {
+  Q_UNUSED(log);
+
   KiCadSymbolText obj;
   obj.text = node.getChild("@0").getValue();
   obj.position = deserialize<QPointF>(node.getChild("at"));
@@ -981,6 +993,8 @@ KiCadFootprintPad KiCadFootprintPad::parse(const SExpression& node,
 
 KiCadFootprintModel KiCadFootprintModel::parse(const SExpression& node,
                                                MessageLogger& log) {
+  Q_UNUSED(log);
+
   KiCadFootprintModel obj;
   obj.path = node.getChild(0).getValue();
   if (const SExpression* child = node.tryGetChild("at/xyz")) {


### PR DESCRIPTION
The CMake config for the muparser & kicadimport libraries were not correct, possibly leading to false-positive and false-negative compiler warnings in those libraries.