### PR TITLE
Fix accessing dangling reference in net segment splitters

### DIFF
--- a/libs/librepcb/core/project/board/boardnetsegmentsplitter.h
+++ b/libs/librepcb/core/project/board/boardnetsegmentsplitter.h
@@ -73,9 +73,9 @@ public:
 private:  // Methods
   TraceAnchor replaceAnchor(const TraceAnchor& anchor,
                             const Layer& layer) noexcept;
-  void findConnectedLinesAndPoints(const TraceAnchor& anchor,
-                                   ViaList& availableVias,
-                                   TraceList& availableTraces, Segment& segment)
+  void findConnectedLinesAndPoints(
+      const TraceAnchor& anchor, QList<std::shared_ptr<Via>>& availableVias,
+      QList<std::shared_ptr<Trace>>& availableTraces, Segment& segment)
 
       noexcept;
 

--- a/libs/librepcb/core/project/schematic/schematicnetsegmentsplitter.h
+++ b/libs/librepcb/core/project/schematic/schematicnetsegmentsplitter.h
@@ -71,9 +71,9 @@ public:
 
 private:  // Methods
   NetLineAnchor replacePinAnchor(const NetLineAnchor& anchor) noexcept;
-  void findConnectedLinesAndPoints(const NetLineAnchor& anchor,
-                                   NetLineList& availableNetLines,
-                                   Segment& segment)
+  void findConnectedLinesAndPoints(
+      const NetLineAnchor& anchor,
+      QList<std::shared_ptr<NetLine>>& availableNetLines, Segment& segment)
 
       noexcept;
   void addNetLabelToNearestNetSegment(const NetLabel& netlabel,


### PR DESCRIPTION
Fixes a segfault which was detected on Alpine Linux, see https://github.com/LibrePCB/LibrePCB/issues/1476#issuecomment-2529918400.