### PR TITLE
DRC: Report vias as useless if connected on <2 layers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -48,3 +48,4 @@ yourself by creating a pull request (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 - David Lamparter ([@eqvinox](https://github.com/eqvinox))
 - Allan Nordhøy ([@comradekingu](https://github.com/comradekingu))
 - Alexander Wilms
+- Connor Slade ([@connorslade](https://github.com/connorslade))

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.h
@@ -146,6 +146,8 @@ private:  // Methods
                                                  const Layer& layer);
   static QVector<Path> getDeviceLocation(const Data::Device& device);
   static QVector<Path> getViaLocation(const Data::Via& via) noexcept;
+  static bool isViaUseless(const Data& data, const Data::Segment& ns,
+                           const Data::Via& via) noexcept;
   static QVector<Path> getTraceLocation(const Data::Trace& trace) noexcept;
   static QVector<Path> getHoleLocation(
       const Data::Hole& hole,

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.cpp
@@ -24,11 +24,12 @@
 
 #include "../../../geometry/hole.h"
 #include "../../../geometry/stroketext.h"
+#include "../../../geometry/via.h"
 #include "../../../library/cmp/component.h"
-#include "../../../library/dev/device.h"
 #include "../../../library/pkg/footprint.h"
 #include "../../../library/pkg/footprintpad.h"
 #include "../../../library/pkg/packagepad.h"
+#include "../../../utils/clipperhelpers.h"
 #include "../../circuit/circuit.h"
 #include "../../circuit/componentinstance.h"
 #include "../../circuit/netsignal.h"
@@ -86,14 +87,25 @@ BoardDesignRuleCheckData::BoardDesignRuleCheckData(
                               nl->getEndPoint().getPosition(), nl->getWidth(),
                               &nl->getLayer()});
     }
-    foreach (const BI_Via* via, ns->getVias()) {
+    foreach (const BI_Via* biVia, ns->getVias()) {
+      QSet<const Layer*> connectedLayers;
+
+      // Add all the layers of traces directly connected to the current via to
+      // the connectedLayers set. The via may be connected to more layers
+      // through other mechanisms like planes, but identifying those connections
+      // can be expensive, so it's not done here.
+      foreach (const BI_NetLine* nl, biVia->getNetLines()) {
+        connectedLayers.insert(&nl->getLayer());
+      }
+
+      const librepcb::Via& via = biVia->getVia();
       nsd.vias.insert(
-          via->getUuid(),
-          Via{via->getUuid(), via->getPosition(), via->getSize(),
-              via->getDrillDiameter(), &via->getVia().getStartLayer(),
-              &via->getVia().getEndLayer(), via->getDrillLayerSpan(),
-              via->getVia().isBuried(), via->getVia().isBlind(),
-              via->getStopMaskDiameterTop(), via->getStopMaskDiameterBottom()});
+          biVia->getUuid(),
+          Via{biVia->getUuid(), biVia->getPosition(), biVia->getSize(),
+              biVia->getDrillDiameter(), connectedLayers, &via.getStartLayer(),
+              &via.getEndLayer(), biVia->getDrillLayerSpan(), via.isBuried(),
+              via.isBlind(), biVia->getStopMaskDiameterTop(),
+              biVia->getStopMaskDiameterBottom()});
     }
     segments.insert(ns->getUuid(), nsd);
   }

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.h
@@ -63,6 +63,8 @@ struct BoardDesignRuleCheckData final {
     Point position;
     PositiveLength size;
     PositiveLength drillDiameter;
+    // Only filled with the layers of traces directly connected to the via.
+    QSet<const Layer*> connectedLayers;
     const Layer* startLayer;
     const Layer* endLayer;
     std::optional<std::pair<const Layer*, const Layer*>> drillLayerSpan;

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
@@ -1448,6 +1448,28 @@ QString DrcMsgForbiddenVia::determineDescription(
 }
 
 /*******************************************************************************
+ *  Class DrcMsgInvalidVia
+ ******************************************************************************/
+
+// The key `useless_via` is used for backwards compatibility and should be
+// replaced with `invalid_via` for the next major release.
+DrcMsgInvalidVia::DrcMsgInvalidVia(const BoardDesignRuleCheckData::Segment& ns,
+                                   const Data::Via& via,
+                                   const QVector<Path>& locations) noexcept
+  : RuleCheckMessage(Severity::Warning,
+                     tr("Invalid via in net '%1'", "Placeholders: Net name")
+                         .arg(netNameWithFallback(ns.netName)),
+                     tr("The via is only drilled between one layer and is "
+                        "therefore invalid."),
+                     "useless_via", locations) {
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("netsegment", ns.uuid);
+  mApproval->ensureLineBreak();
+  mApproval->appendChild("via", via.uuid);
+  mApproval->ensureLineBreak();
+}
+
+/*******************************************************************************
  *  Class DrcMsgSilkscreenClearanceViolation
  ******************************************************************************/
 
@@ -1495,6 +1517,10 @@ DrcMsgUselessZone::DrcMsgUselessZone(const Data::Zone& zone,
  *  DrcMsgUselessVia
  ******************************************************************************/
 
+// Because the key `useless_via` is used by the InvalidVia
+// message and can't be changed for backwards compatibility reasons,
+// `antennae_via` is used here. This can be changed to `useless_via` for the
+// next major release.
 DrcMsgUselessVia::DrcMsgUselessVia(const BoardDesignRuleCheckData::Segment& ns,
                                    const Data::Via& via,
                                    const QVector<Path>& locations) noexcept
@@ -1503,7 +1529,7 @@ DrcMsgUselessVia::DrcMsgUselessVia(const BoardDesignRuleCheckData::Segment& ns,
                          .arg(netNameWithFallback(ns.netName)),
                      tr("The via is connected on less than two layers, thus it "
                         "seems to be useless."),
-                     "useless_via", locations) {
+                     "antennae_via", locations) {
   mApproval->ensureLineBreak();
   mApproval->appendChild("netsegment", ns.uuid);
   mApproval->ensureLineBreak();

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
@@ -921,6 +921,28 @@ private:
 };
 
 /*******************************************************************************
+ *  Class DrcMsgInvalidVia
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgInvalidVia class
+ */
+class DrcMsgInvalidVia final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgInvalidVia)
+
+public:
+  using Data = BoardDesignRuleCheckData;
+
+  // Constructors / Destructor
+  DrcMsgInvalidVia() = delete;
+  DrcMsgInvalidVia(const Data::Segment& ns, const Data::Via& via,
+                   const QVector<Path>& locations) noexcept;
+  DrcMsgInvalidVia(const DrcMsgInvalidVia& other) noexcept
+    : RuleCheckMessage(other) {}
+  virtual ~DrcMsgInvalidVia() noexcept {}
+};
+
+/*******************************************************************************
  *  Class DrcMsgSilkscreenClearanceViolation
  ******************************************************************************/
 

--- a/tests/unittests/core/project/board/boarddesignrulechecktest.cpp
+++ b/tests/unittests/core/project/board/boarddesignrulechecktest.cpp
@@ -54,6 +54,7 @@ TEST(BoardDesignRuleCheckTest, testMessages) {
       {"missing_device", {"checkForUnplacedComponents"}},
       {"missing_connection", {"checkForMissingConnections"}},
       {"unused_layer", {"checkUsedLayers"}},
+      {"antennae_via", {"checkVias", "checkVias2", "checkVias3"}},
   };
 
   // Open project from test data directory.
@@ -67,6 +68,7 @@ TEST(BoardDesignRuleCheckTest, testMessages) {
                   projectFp.getFilename());  // can throw
 
   // Run DRC for each board.
+  QStringList summary;
   foreach (Board* board, project->getBoards()) {
     std::cout << "- Run DRC for board '" << board->getName()->toStdString()
               << "':\n";
@@ -115,11 +117,23 @@ TEST(BoardDesignRuleCheckTest, testMessages) {
     expected->ensureLineBreak();
 
     // Compare.
-    std::cout << "  * Emitted " << approvals.count() << " messages, "
-              << board->getDrcMessageApprovals().count() << " approved\n";
+    const QString msg = QString("Emitted %1 messages, %2 approved")
+                            .arg(approvals.count())
+                            .arg(board->getDrcMessageApprovals().count());
+    std::cout << "  * " << qPrintable(msg) << "\n";
+    summary.append(QString(" * %1: %2").arg(*board->getName()).arg(msg));
     EXPECT_EQ(expected->toByteArray().toStdString(),
               actual->toByteArray().toStdString());
     EXPECT_EQ(board->getDrcMessageApprovals().count(), approvals.count());
+  }
+
+  // The output in case of failures can be very verbose, so we print a more
+  // readable summary at the end.
+  if (::testing::Test::HasFailure()) {
+    std::cout << "Summary:\n";
+    for (const QString& s : summary) {
+      std::cout << qPrintable(s) << "\n";
+    }
   }
 }
 


### PR DESCRIPTION
The previous implementation only detected vias as useless if they had no `drillLayerSpan`. Now they are also detected if there are traces from less than two layers connected. This identifies situations like below, where you may mistakenly have left a via:

<details><summary>Screenshot</summary>
<p>

![Screenshot from 2025-01-21 at 22_50_14 807626492](https://github.com/user-attachments/assets/83925b1a-c872-4e5f-96ff-1f0d2153ac32)

</p>
</details> 
