### PR TITLE
Fix some list view text colors for dark theme

### DIFF
--- a/libs/librepcb/editor/project/outputjobsdialog/outputjoblistwidgetitem.cpp
+++ b/libs/librepcb/editor/project/outputjobsdialog/outputjoblistwidgetitem.cpp
@@ -89,6 +89,15 @@ QString OutputJobListWidgetItem::getTitle() const noexcept {
  *  General Methods
  ******************************************************************************/
 
+void OutputJobListWidgetItem::setSelected(bool selected) noexcept {
+  QString stylesheet;
+  if (selected) {
+    stylesheet = "color: palette(highlighted-text);";
+  }
+  mUi->lblName->setStyleSheet(stylesheet);
+  mUi->lblType->setStyleSheet(stylesheet);
+}
+
 void OutputJobListWidgetItem::updateJobInfo() noexcept {
   if (mJob) {
     mUi->lblIcon->setPixmap(mJob->getTypeIcon().pixmap(mUi->lblIcon->size()));

--- a/libs/librepcb/editor/project/outputjobsdialog/outputjoblistwidgetitem.h
+++ b/libs/librepcb/editor/project/outputjobsdialog/outputjoblistwidgetitem.h
@@ -65,6 +65,7 @@ public:
   std::shared_ptr<OutputJob> getJob() noexcept { return mJob; }
 
   // General Methods
+  void setSelected(bool selected) noexcept;
   void updateJobInfo() noexcept;
   void setStatusColor(const QColor& color) noexcept;
 

--- a/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.cpp
+++ b/libs/librepcb/editor/project/outputjobsdialog/outputjobsdialog.cpp
@@ -489,7 +489,16 @@ void OutputJobsDialog::runJob(std::shared_ptr<OutputJob> job,
 
 void OutputJobsDialog::currentItemChanged(QListWidgetItem* current,
                                           QListWidgetItem* previous) noexcept {
-  Q_UNUSED(previous);
+  // Update item selection state to ensure proper theme-aware text color.
+  if (OutputJobListWidgetItem* w = qobject_cast<OutputJobListWidgetItem*>(
+          mUi->lstJobs->itemWidget(previous))) {
+    w->setSelected(false);
+  }
+  if (OutputJobListWidgetItem* w = qobject_cast<OutputJobListWidgetItem*>(
+          mUi->lstJobs->itemWidget(current))) {
+    w->setSelected(true);
+  }
+
   if (!current) {
     return;
   }

--- a/libs/librepcb/editor/widgets/rulechecklistwidget.cpp
+++ b/libs/librepcb/editor/widgets/rulechecklistwidget.cpp
@@ -148,7 +148,16 @@ void RuleCheckListWidget::updateList() noexcept {
 
 void RuleCheckListWidget::currentItemChanged(
     QListWidgetItem* current, QListWidgetItem* previous) noexcept {
-  Q_UNUSED(previous);
+  // Update item selection state to ensure proper theme-aware text color.
+  if (RuleCheckListItemWidget* w = qobject_cast<RuleCheckListItemWidget*>(
+          mListWidget->itemWidget(previous))) {
+    w->setSelected(false);
+  }
+  if (RuleCheckListItemWidget* w = qobject_cast<RuleCheckListItemWidget*>(
+          mListWidget->itemWidget(current))) {
+    w->setSelected(true);
+  }
+
   std::shared_ptr<const RuleCheckMessage> msg =
       mDisplayedMessages.value(mListWidget->row(current));
   if (msg && mHandler) {

--- a/libs/librepcb/editor/widgets/rulechecklistwidget.h
+++ b/libs/librepcb/editor/widgets/rulechecklistwidget.h
@@ -142,6 +142,10 @@ public:
   RuleCheckListItemWidget(const RuleCheckListItemWidget& other) = delete;
   ~RuleCheckListItemWidget() noexcept {}
 
+  void setSelected(bool selected) noexcept {
+    setStyleSheet(selected ? "QLabel{color: palette(highlighted-text);}" : "");
+  }
+
   // Operator Overloadings
   RuleCheckListItemWidget& operator=(const RuleCheckListItemWidget& rhs) =
       delete;


### PR DESCRIPTION
List items in the output jobs dialog and rule check docks had a wrong (badly readable) text color for selected list items when using the dark theme. This PR makes the text color theme-aware to fix it.