### PR TITLE
KiCad Library Import: Add compatibility with KiCad v9 & Ultra Librarian

### DIFF
--- a/libs/librepcb/kicadimport/kicadlibraryconverter.h
+++ b/libs/librepcb/kicadimport/kicadlibraryconverter.h
@@ -106,7 +106,7 @@ public:
                                        const QList<KiCadSymbolGate>& kiGates,
                                        const QString& generatedBy,
                                        const QString& cmpGeneratedBy,
-                                       const QString& pkgGeneratedBy,
+                                       QString pkgGeneratedBy,
                                        MessageLogger& log);
 
   // Operator Overloadings
@@ -114,10 +114,10 @@ public:
 
 private:  // Methods
   void loadAlreadyImportedSymbol(const QString& generatedBy);
-  void loadAlreadyImportedPackage(const QString& generatedBy);
+  QString loadAlreadyImportedPackage(const QStringList& generatedBy);
   void loadAlreadyImportedComponent(const QString& generatedBy);
   template <typename T>
-  FilePath getAlreadyImportedFp(const QString& generatedBy) const;
+  FilePath getAlreadyImportedFp(const QStringList& generatedBy) const;
   void tryOrLogError(std::function<void()> func, MessageLogger& log);
 
 private:  // Data

--- a/libs/librepcb/kicadimport/kicadtypes.cpp
+++ b/libs/librepcb/kicadimport/kicadtypes.cpp
@@ -395,7 +395,11 @@ KiCadProperty KiCadProperty::parse(const SExpression& node,
   obj.value = node.getChild(1).getValue();
   obj.position = deserialize<QPointF>(node.getChild("at"));
   if (const SExpression* child = node.tryGetChild("at/@2")) {
-    obj.rotation = deserialize<qreal>(*child);
+    if (child->getValue() == "unlocked") {
+      obj.unlocked = true;  // KiCad v6 compatibility.
+    } else {
+      obj.rotation = deserialize<qreal>(*child);
+    }
   }
   if (const SExpression* child = node.tryGetChild("layer/@0")) {
     obj.layer = child->getValue();
@@ -536,8 +540,14 @@ KiCadSymbolArc KiCadSymbolArc::parse(const SExpression& node,
   obj.start = deserialize<QPointF>(node.getChild("start"));
   obj.mid = deserialize<QPointF>(node.getChild("mid"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   obj.fillType = deserializeSymbolFillType(node.getChild("fill/type/@0"), log);
   return obj;
 }
@@ -551,8 +561,14 @@ KiCadSymbolCircle KiCadSymbolCircle::parse(const SExpression& node,
   KiCadSymbolCircle obj;
   obj.center = deserialize<QPointF>(node.getChild("center"));
   obj.radius = deserialize<qreal>(node.getChild("radius/@0"));
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   obj.fillType = deserializeSymbolFillType(node.getChild("fill/type/@0"), log);
   return obj;
 }
@@ -566,8 +582,14 @@ KiCadSymbolRectangle KiCadSymbolRectangle::parse(const SExpression& node,
   KiCadSymbolRectangle obj;
   obj.start = deserialize<QPointF>(node.getChild("start"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   obj.fillType = deserializeSymbolFillType(node.getChild("fill/type/@0"), log);
   return obj;
 }
@@ -582,8 +604,14 @@ KiCadSymbolPolyline KiCadSymbolPolyline::parse(const SExpression& node,
   foreach (const SExpression* child, node.getChild("pts").getChildren("xy")) {
     obj.coordinates.append(deserialize<QPointF>(*child));
   }
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   obj.fillType = deserializeSymbolFillType(node.getChild("fill/type/@0"), log);
   return obj;
 }
@@ -756,8 +784,14 @@ KiCadFootprintLine KiCadFootprintLine::parse(const SExpression& node,
   KiCadFootprintLine obj;
   obj.start = deserialize<QPointF>(node.getChild("start"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   obj.layer = deserializeLayer(node.getChild("layer/@0"), log);
   return obj;
 }
@@ -772,8 +806,14 @@ KiCadFootprintArc KiCadFootprintArc::parse(const SExpression& node,
   obj.start = deserialize<QPointF>(node.getChild("start"));
   obj.mid = deserialize<QPointF>(node.getChild("mid"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   obj.layer = deserializeLayer(node.getChild("layer/@0"), log);
   return obj;
 }
@@ -788,8 +828,14 @@ KiCadFootprintCircle KiCadFootprintCircle::parse(const SExpression& node,
   obj.center = deserialize<QPointF>(node.getChild("center"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
   obj.layer = deserializeLayer(node.getChild("layer/@0"), log);
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   if (const SExpression* child = node.tryGetChild("fill/@0")) {
     obj.fillType = deserializeFootprintFillType(*child, log);
   }
@@ -806,8 +852,14 @@ KiCadFootprintRectangle KiCadFootprintRectangle::parse(const SExpression& node,
   obj.start = deserialize<QPointF>(node.getChild("start"));
   obj.end = deserialize<QPointF>(node.getChild("end"));
   obj.layer = deserializeLayer(node.getChild("layer/@0"), log);
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   if (const SExpression* child = node.tryGetChild("fill/@0")) {
     obj.fillType = deserializeFootprintFillType(*child, log);
   }
@@ -825,8 +877,14 @@ KiCadFootprintPolygon KiCadFootprintPolygon::parse(const SExpression& node,
     obj.coordinates.append(deserialize<QPointF>(*child));
   }
   obj.layer = deserializeLayer(node.getChild("layer/@0"), log);
-  obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
-  obj.strokeType = deserializeStrokeType(node.getChild("stroke/type/@0"), log);
+  if (const SExpression* child = node.tryGetChild("width/@0")) {
+    obj.strokeWidth = deserialize<qreal>(*child);  // KiCad v6 compatibility.
+  } else {
+    obj.strokeWidth = deserialize<qreal>(node.getChild("stroke/width/@0"));
+  }
+  if (const SExpression* child = node.tryGetChild("stroke/type/@0")) {
+    obj.strokeType = deserializeStrokeType(*child, log);
+  }
   if (const SExpression* child = node.tryGetChild("fill/@0")) {
     obj.fillType = deserializeFootprintFillType(*child, log);
   }
@@ -844,7 +902,11 @@ KiCadFootprintText KiCadFootprintText::parse(const SExpression& node,
   obj.text = node.getChild("@1").getValue();
   obj.position = deserialize<QPointF>(node.getChild("at"));
   if (const SExpression* child = node.tryGetChild("at/@2")) {
-    obj.rotation = deserialize<qreal>(*child);
+    if (child->getValue() == "unlocked") {  // KiCad v6 compatibility.
+      obj.unlocked = true;
+    } else {
+      obj.rotation = deserialize<qreal>(*child);
+    }
   }
   obj.layer = deserializeLayer(node.getChild("layer/@0"), log);
   if (const SExpression* child = node.tryGetChild("effects/font/size")) {
@@ -905,8 +967,11 @@ KiCadFootprintPad KiCadFootprintPad::parse(const SExpression& node,
         obj.offset = deserialize<QPointF>(*offset);
       }
     } else if (child->getName() == "layers") {
+      // KiCad v6 seems to had no quotes in some cases, thus we also need to
+      // take tokens into account.
       foreach (const SExpression* layer,
-               child->getChildren(SExpression::Type::String)) {
+               child->getChildren(SExpression::Type::String) +
+                   child->getChildren(SExpression::Type::Token)) {
         obj.layers.append(deserializeLayer(*layer, log));
       }
     } else if (child->getName() == "property") {

--- a/libs/librepcb/kicadimport/kicadtypes.cpp
+++ b/libs/librepcb/kicadimport/kicadtypes.cpp
@@ -208,9 +208,10 @@ static kicadimport::KiCadPinStyle deserializePinStyle(const SExpression& node,
 
 static kicadimport::KiCadFootprintFillType deserializeFootprintFillType(
     const SExpression& node, MessageLogger& log) {
-  if (node.getValue() == "none") {
+  // Just yes/no since KiCad v9.
+  if ((node.getValue() == "no") || (node.getValue() == "none")) {
     return kicadimport::KiCadFootprintFillType::None;
-  } else if (node.getValue() == "solid") {
+  } else if ((node.getValue() == "yes") || (node.getValue() == "solid")) {
     return kicadimport::KiCadFootprintFillType::Solid;
   } else {
     log.warning("Unknown footprint fill type: " + node.getValue());
@@ -740,6 +741,8 @@ KiCadSymbol KiCadSymbol::parse(const SExpression& node, MessageLogger& log) {
       obj.properties.append(KiCadProperty::parse(*child, log));
     } else if (child->getName() == "symbol") {
       obj.gates.append(KiCadSymbolGate::parse(*child, log));
+    } else if (child->getName() == "embedded_fonts") {
+      // New in KiCad v9, ignoring for now.
     } else {
       log.warning(tr("Unsupported symbol child: '%1'").arg(child->getName()));
     }
@@ -1157,6 +1160,8 @@ KiCadFootprint KiCadFootprint::parse(const SExpression& node,
       obj.pads.append(KiCadFootprintPad::parse(*child, log));
     } else if (child->getName() == "group") {
       // Ignore.
+    } else if (child->getName() == "embedded_fonts") {
+      // New in KiCad v9, ignoring for now.
     } else if (child->getName() == "model") {
       obj.models.append(KiCadFootprintModel::parse(*child, log));
     } else {

--- a/tests/unittests/kicadimport/kicadlibraryimporttest.cpp
+++ b/tests/unittests/kicadimport/kicadlibraryimporttest.cpp
@@ -52,6 +52,30 @@ protected:
   virtual ~KiCadLibraryImportTest() {
     QDir(mWsDir.toStr()).removeRecursively();
   }
+
+  int getTotalSymbolsCount(const KiCadLibraryImport::Result& result) const {
+    int count = 0;
+    for (const KiCadLibraryImport::SymbolLibrary& lib : result.symbolLibs) {
+      count += lib.symbols.count();
+    }
+    return count;
+  }
+
+  int getTotalFootprintFilesCount(const KiCadLibraryImport::Result& result) const {
+    int count = 0;
+    for (const KiCadLibraryImport::FootprintLibrary& lib : result.footprintLibs) {
+      count += lib.files.count();
+    }
+    return count;
+  }
+
+  int getTotalFootprintsCount(const KiCadLibraryImport::Result& result) const {
+    int count = 0;
+    for (const KiCadLibraryImport::FootprintLibrary& lib : result.footprintLibs) {
+      count += lib.footprints.count();
+    }
+    return count;
+  }
 };
 
 /*******************************************************************************
@@ -80,11 +104,11 @@ TEST_F(KiCadLibraryImportTest, testImport) {
   std::shared_ptr<KiCadLibraryImport::Result> result = import.getResult();
   EXPECT_EQ(1, signalFinished);
   EXPECT_GE(log->getMessages().count(), 1);
-  ASSERT_EQ(1, result->symbolLibs.count());
-  ASSERT_EQ(0, result->symbolLibs.first().symbols.count());
-  ASSERT_EQ(1, result->footprintLibs.count());
-  ASSERT_EQ(1, result->footprintLibs.first().files.count());
-  ASSERT_EQ(0, result->footprintLibs.first().footprints.count());
+  EXPECT_EQ(3, result->symbolLibs.count());
+  EXPECT_EQ(0, getTotalSymbolsCount(*result));
+  EXPECT_EQ(2, result->footprintLibs.count());
+  EXPECT_EQ(3, getTotalFootprintFilesCount(*result));
+  EXPECT_EQ(0, getTotalFootprintsCount(*result));
   log->clear();
   signalFinished = 0;
 
@@ -94,15 +118,15 @@ TEST_F(KiCadLibraryImportTest, testImport) {
   result = import.getResult();
   EXPECT_EQ(1, signalFinished);
   EXPECT_GE(log->getMessages().count(), 1);
-  ASSERT_EQ(1, result->symbolLibs.count());
-  ASSERT_EQ(1, result->symbolLibs.first().symbols.count());
-  ASSERT_EQ(1, result->footprintLibs.count());
-  ASSERT_EQ(1, result->footprintLibs.first().files.count());
-  ASSERT_EQ(1, result->footprintLibs.first().footprints.count());
+  EXPECT_EQ(3, result->symbolLibs.count());
+  EXPECT_EQ(3, getTotalSymbolsCount(*result));
+  EXPECT_EQ(2, result->footprintLibs.count());
+  EXPECT_EQ(3, getTotalFootprintFilesCount(*result));
+  EXPECT_EQ(3, getTotalFootprintsCount(*result));
   log->clear();
   signalFinished = 0;
 
-  // Verify nothing is exported yet.
+  // Verify nothing is imported yet.
   EXPECT_FALSE(dst.isExistingDir());
 
   // Import.
@@ -117,7 +141,7 @@ TEST_F(KiCadLibraryImportTest, testImport) {
   // Verify that files have been written (2 files per element).
   const QList<FilePath> dstFiles =
       FileUtils::getFilesInDirectory(dst, QStringList(), true, false);
-  EXPECT_EQ(6, dstFiles.count());
+  EXPECT_EQ(22, dstFiles.count());
 }
 
 /*******************************************************************************


### PR DESCRIPTION
KiCad v9 was released, with some small changes in the library file format. This PR adds compatibility with that format.

In addition, the KiCad libraries provided by Ultra Librarian seem to have an old format (KiCad v6) and also have a strange/invalid structure (footprints are in `footprints.pretty`, but symbols do not reference it properly with that namespace). This PR adds basic compatibility with the v6 format and an ugly hack that the illegal structure is supported anyway, for a better user experience if libraries from Ultra Librarian are imported.