### PR TITLE
Board editor: Fix rejecting planes if project has no nets

### DIFF
--- a/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.h
+++ b/libs/librepcb/editor/project/boardeditor/fsm/boardeditorstate_drawplane.h
@@ -92,6 +92,7 @@ private:  // Methods
 private:  // Data
   // State
   bool mIsUndoCmdActive;
+  bool mAutoNetSignal;
   NetSignal* mLastNetSignal;
   const Layer* mLastLayer;
   Point mLastVertexPos;


### PR DESCRIPTION
There was a leftover from old LibrePCB versions which didn't allow to add planes without a net, still rejecting adding planes if the project contains no nets (i.e. the schematic is empty). Removed that conditional since planes without a net are now allowed.

Also slightly improved the logic for preselecting the default net when adding a new plane.