### PR TITLE
CI: Update Docker images, fix OpenSSL deployment on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,14 @@ if(BUILD_DISALLOW_WARNINGS)
   target_compile_options(common INTERFACE -Werror)
 endif()
 
+# GCC 13.x emits a false-positive (?) warning.
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0
+)
+  target_compile_options(common INTERFACE -Wno-maybe-uninitialized)
+endif()
+
 # The TypeSafe library causes some compiler warnings which are not of
 # interest, so let's suppress them.
 target_compile_options(common INTERFACE -Wno-noexcept-type)

--- a/ci/azure-jobs-doxygen.yml
+++ b/ci/azure-jobs-doxygen.yml
@@ -2,7 +2,7 @@ jobs:
 - job: Doxygen
   pool:
     vmImage: 'ubuntu-22.04'
-  container: librepcb/librepcb-dev:devtools-4
+  container: librepcb/librepcb-dev:devtools-5
   steps:
   - bash: ./ci/print_environment.sh
     displayName: Print Environment

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -9,15 +9,15 @@ jobs:
   strategy:
     matrix:
       Ubuntu_2004_Qt_6_6_GCC:
-        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-qt6.6-2
+        IMAGE: librepcb/librepcb-dev:ubuntu-20.04-qt6.6-3
         DEPLOY: true
         NO_HOEDOWN: true
       Ubuntu_2204_Clang:
-        IMAGE: librepcb/librepcb-dev:ubuntu-22.04-3
+        IMAGE: librepcb/librepcb-dev:ubuntu-22.04-4
         CC: clang
         CXX: clang++
       Ubuntu_2404_Unbundled:
-        IMAGE: librepcb/librepcb-dev:ubuntu-24.04-1
+        IMAGE: librepcb/librepcb-dev:ubuntu-24.04-2
         UNBUNDLE_DXFLIB: true
         UNBUNDLE_GTEST: true
         UNBUNDLE_MUPARSER: true

--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -8,7 +8,6 @@ jobs:
     ARCH: 'x86_64'
     COPYFILE_DISABLE: 1 # Stop creating shit files (https://superuser.com/questions/259703/get-mac-tar-to-stop-putting-filenames-in-tar-archives)
     HOMEBREW_NO_INSTALL_CLEANUP: 1 # Might speed up homebrew commands(?)
-    CMAKE_CXX_COMPILER_LAUNCHER: ccache
   steps:
   - checkout: self
     clean: true

--- a/ci/azure-jobs-stylecheck.yml
+++ b/ci/azure-jobs-stylecheck.yml
@@ -2,7 +2,7 @@ jobs:
 - job: Stylecheck
   pool:
     vmImage: 'ubuntu-22.04'
-  container: librepcb/librepcb-dev:devtools-4
+  container: librepcb/librepcb-dev:devtools-5
   steps:
   - bash: ./ci/print_environment.sh
     displayName: Print Environment

--- a/ci/azure-jobs-windows.yml
+++ b/ci/azure-jobs-windows.yml
@@ -7,7 +7,6 @@ jobs:
     variables:
       OS: 'windows'
       ARCH: 'x86_64'
-      CMAKE_CXX_COMPILER_LAUNCHER: ccache
       DEPLOY: true
     steps:
     - checkout: self

--- a/ci/azure-jobs-windows.yml
+++ b/ci/azure-jobs-windows.yml
@@ -8,8 +8,6 @@ jobs:
       OS: 'windows'
       ARCH: 'x86_64'
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CMAKE_GENERATOR: 'Ninja'
-      FUNQ_MAKE_PATH: 'ninja'
       DEPLOY: true
     steps:
     - checkout: self

--- a/ci/build_librepcb.sh
+++ b/ci/build_librepcb.sh
@@ -19,6 +19,7 @@ echo "Using CC=$CC"
 mkdir -p build && pushd build
 cmake \
   -G Ninja \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCMAKE_INSTALL_PREFIX=$(pwd)/install/opt \
   -DBUILD_DISALLOW_WARNINGS=1 \
   -DLIBREPCB_ENABLE_DESKTOP_INTEGRATION=1 \

--- a/ci/build_librepcb.sh
+++ b/ci/build_librepcb.sh
@@ -3,14 +3,6 @@
 # set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
 set -euv -o pipefail
 
-# use Ninja on Windows
-if [ "$OS" = "windows" ]
-then
-  MAKE="ninja"
-else
-  MAKE="make -j8"
-fi
-
 # default compiler
 if [ -z "${CC-}" ]; then CC="gcc"; fi
 if [ -z "${CXX-}" ]; then CXX="g++"; fi
@@ -25,14 +17,15 @@ git -C ./i18n checkout master && git -C ./i18n pull origin master
 echo "Using CXX=$CXX"
 echo "Using CC=$CC"
 mkdir -p build && pushd build
-cmake .. \
+cmake \
+  -G Ninja \
   -DCMAKE_INSTALL_PREFIX=$(pwd)/install/opt \
   -DBUILD_DISALLOW_WARNINGS=1 \
   -DLIBREPCB_ENABLE_DESKTOP_INTEGRATION=1 \
   -DLIBREPCB_BUILD_AUTHOR="$LIBREPCB_BUILD_AUTHOR" \
-  ${CMAKE_OPTIONS-}
-VERBOSE=1 $MAKE
-$MAKE install
+  ..
+ninja
+ninja install
 popd
 
 # Prepare artifacts directory

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -8,11 +8,11 @@ export LANG="C.UTF-8"
 
 # Remove unneeded SQL plugins to fix deployment issue:
 # https://forum.qt.io/topic/151452/what-qt-specific-files-exactly-do-i-need-to-add-when-deploying
-if command -v qmake6 &> /dev/null
-then
-  rm -f $QTDIR/plugins/sqldrivers/libqsqlmimer.so
-  rm -f $QTDIR/plugins/sqldrivers/libqsqlmysql.so
-fi
+# Also this removes the OpenSSL 1.x dependency which we don't want to deploy.
+rm -f $QTDIR/plugins/sqldrivers/libqsqlmimer.so
+rm -f $QTDIR/plugins/sqldrivers/libqsqlmysql.so
+rm -f $QTDIR/plugins/sqldrivers/libqsqlodbc.so
+rm -f $QTDIR/plugins/sqldrivers/libqsqlpsql.so
 
 # Helper to extract and rebuild AppImages with appimagetool to get the static
 # runtime which doesn't need libfuse2 and thus also runs on Ubuntu 22.04, see
@@ -39,7 +39,7 @@ cp -fv "$LIBCRYPTO" "./build/install/opt/lib/"
 # Determine common linuxdeployqt flags
 LINUXDEPLOYQT_FLAGS="-executable=./build/install/opt/lib/$(basename $LIBSSL)"
 LINUXDEPLOYQT_FLAGS+=" -executable=./build/install/opt/lib/$(basename $LIBCRYPTO)"
-LINUXDEPLOYQT_FLAGS+=" -bundle-non-qt-libs"
+LINUXDEPLOYQT_FLAGS+=" -bundle-non-qt-libs -no-copy-copyright-files"
 
 # Build AppImage.
 cp -r "./build/install" "./build/appimage"

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -30,8 +30,8 @@ patch_appimage () {
 
 # Copy OpenSSL libraries manually since these runtime dependencies cannot
 # be detected by linuxdeployqt.
-LIBSSL=(/usr/lib/libssl.so.*)
-LIBCRYPTO=(/usr/lib/libcrypto.so.*)
+LIBSSL="/opt/openssl/lib/libssl.so.3"
+LIBCRYPTO="/opt/openssl/lib/libcrypto.so.3"
 mkdir -p "./build/install/opt/lib"
 cp -fv "$LIBSSL" "./build/install/opt/lib/"
 cp -fv "$LIBCRYPTO" "./build/install/opt/lib/"

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -46,6 +46,10 @@ then
   echo "Installing dylibbundler..."
   brew install --force-bottle dylibbundler
 
+  # Install Ninja
+  echo "Installing ninja..."
+  brew install --force-bottle ninja
+
   # Install Rust toolchain
   echo "Installing Rust toolchain..."
   brew install --force-bottle rust
@@ -73,5 +77,7 @@ fi
 
 # Install Python packages
 export PIP_BREAK_SYSTEM_PACKAGES=1
+export CMAKE_GENERATOR=Ninja
+export FUNQ_MAKE_PATH=ninja
 pip install $PIP_USER_INSTALL -r "$DIR/../tests/cli/requirements.txt"
 pip install $PIP_USER_INSTALL -r "$DIR/../tests/funq/requirements.txt"

--- a/ci/stylecheck.sh
+++ b/ci/stylecheck.sh
@@ -31,3 +31,6 @@ done
 # check formatting of .reuse/dep5
 (debian-copyright-sorter --iml -s casefold -o ".reuse/dep5" ".reuse/dep5") || exit 1
 (git diff --exit-code -- ".reuse/dep5") || exit 1
+
+# validate AppStream files
+appstream-util validate share/metainfo/org.librepcb.LibrePCB.metainfo.xml


### PR DESCRIPTION
Use new Docker images with the following updates:

- https://github.com/LibrePCB/docker-librepcb-dev/pull/56
- https://github.com/LibrePCB/docker-librepcb-dev/pull/57
- https://github.com/LibrePCB/docker-librepcb-dev/pull/58
- https://github.com/LibrePCB/docker-librepcb-dev/pull/59
- https://github.com/LibrePCB/docker-librepcb-dev/pull/60
- https://github.com/LibrePCB/docker-librepcb-dev/pull/63

In addition:
- Now build with Ninja on Linux and MacOS too, not using GNU Make anymore at all
- Enable ccache also for all Linux jobs
- Stop deploying unnecessary OpenSSL 1.x libs in Linux releases
- Run `appstream-util validate` on AppStream XML file

Fixes https://github.com/LibrePCB/LibrePCB/issues/1480