### PR TITLE
Remove QtQuick test window & dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ option(BUILD_TESTS "Build unit tests." ON)
 option(BUILD_DISALLOW_WARNINGS
        "Disallow compiler warnings during build (build with -Werror)." OFF
 )
-option(BUILD_QTQUICK_TEST "Build the QML test window." ON)
 option(UNBUNDLE_DXFLIB "Don't use vendored dxflib library." OFF)
 option(UNBUNDLE_FONTOBENE_QT "Don't use vendored FontoBeneQt library." OFF)
 option(UNBUNDLE_GTEST "Don't use vendored GoogleTest library." OFF)
@@ -140,9 +139,6 @@ set(QT_COMPONENTS
     Svg
     Widgets
 )
-if(BUILD_QTQUICK_TEST)
-  list(APPEND QT_COMPONENTS Quick QuickControls2)
-endif()
 if(BUILD_TESTS)
   list(APPEND QT_COMPONENTS Test)
 endif()

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ actually used for CI, but are also useful to build LibrePCB locally.
 ```bash
 sudo apt-get install build-essential git cmake openssl zlib1g zlib1g-dev \
      qt6-base-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
-     libqt6core5compat6-dev qt6-declarative-dev libqt6opengl6-dev libqt6svg6-dev \
+     libqt6core5compat6-dev libqt6opengl6-dev libqt6svg6-dev \
      qt6-image-formats-plugins libglu1-mesa-dev libtbb-dev libxi-dev \
      occt-misc libocct-*-dev rustc cargo
 sudo apt-get install qtcreator # optional
@@ -88,9 +88,9 @@ sudo apt-get install qtcreator # optional
 
 ```bash
 sudo apt-get install build-essential git cmake openssl zlib1g zlib1g-dev \
-     qt5-default qtdeclarative5-dev qttools5-dev-tools qttools5-dev \
-     qtquickcontrols2-5-dev libqt5opengl5-dev libqt5svg5-dev \
-     qt5-image-formats-plugins libglu1-mesa-dev liboce-*-dev rustc cargo
+     qt5-default qttools5-dev-tools qttools5-dev libqt5opengl5-dev \
+     libqt5svg5-dev qt5-image-formats-plugins libglu1-mesa-dev \
+     liboce-*-dev rustc cargo
 sudo apt-get install qt5-doc qtcreator # optional
 ```
 
@@ -98,7 +98,7 @@ sudo apt-get install qt5-doc qtcreator # optional
 
 ```bash
 sudo pacman -S base-devel git cmake openssl zlib desktop-file-utils \
-     shared-mime-info qt6-base qt6-5compat qt6-declarative qt6-svg qt6-tools \
+     shared-mime-info qt6-base qt6-5compat qt6-svg qt6-tools \
      qt6-imageformats opencascade rust
 sudo pacman -S qt6-doc qtcreator # optional
 ```

--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -32,8 +32,8 @@ jobs:
     displayName: Run LibrePCB Unittests
   - bash: pytest -vvv --librepcb-executable="build/install/opt/LibrePCB.app/Contents/MacOS/librepcb-cli" ./tests/cli
     displayName: Run LibrePCB-CLI Functional Tests
-  # Note: Functional tests need to be run with the non-bundled app, otherwise
-  # we get the error "Cannot add multiple registrations for QtQml.Models 2".
+  # Note: Functional tests need to be run with the non-bundled app,
+  # otherwise we get errors due to multiple definitions of Qt symbols.
   - bash: pytest -vvv --librepcb-executable="build/install/opt/bin/librepcb.app/Contents/MacOS/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
     displayName: Run LibrePCB Functional Tests
   - bash: ./ci/upload_artifacts.sh

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -48,15 +48,13 @@ cp "./build/appimage/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB
 linuxdeployqt "./build/appimage/opt/share/applications/org.librepcb.LibrePCB.desktop" \
   -executable="./build/appimage/opt/bin/librepcb" \
   -executable="./build/appimage/opt/bin/librepcb-cli" \
-  -qmldir="./build/appimage/opt/share/librepcb/qml" \
   $LINUXDEPLOYQT_FLAGS -appimage
 patch_appimage
 mv ./LibrePCB-*-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH.AppImage
 
 # Run linuxdeployqt to bundle all libraries into the portable packages.
 linuxdeployqt "./build/install/opt/bin/librepcb-cli" $LINUXDEPLOYQT_FLAGS -always-overwrite
-linuxdeployqt "./build/install/opt/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite \
-  -qmldir="./build/install/opt/share/librepcb/qml"
+linuxdeployqt "./build/install/opt/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite
 
 # Test if the bundles are working (hopefully catching deployment issues).
 # Doesn't work for AppImages unfortunately because of missing fuse on CI.

--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -46,7 +46,7 @@ then
   macdeployqt "LibrePCB.app" -always-overwrite \
     -executable="./LibrePCB.app/Contents/MacOS/librepcb" \
     -executable="./LibrePCB.app/Contents/MacOS/librepcb-cli" \
-    -qmldir="./LibrePCB.app/Contents/share/librepcb/qml"
+    -qmldir="../../../ci"
   codesign --force --deep -s - ./LibrePCB.app/Contents/MacOS/librepcb
   codesign --force --deep -s - ./LibrePCB.app/Contents/MacOS/librepcb-cli
   create-dmg --skip-jenkins --volname "LibrePCB" \
@@ -61,7 +61,7 @@ else
       macdeployqt "LibrePCB.app" -dmg -always-overwrite \
         -executable="./LibrePCB.app/Contents/MacOS/librepcb" \
         -executable="./LibrePCB.app/Contents/MacOS/librepcb-cli" \
-        -qmldir="./LibrePCB.app/Contents/share/librepcb/qml"
+        -qmldir="../../../ci"
       sleep 5
     fi
   done

--- a/ci/build_windows_archive.sh
+++ b/ci/build_windows_archive.sh
@@ -20,9 +20,7 @@ cp -v C:/OpenCascade/win64/gcc/bin/libTK*.dll ./build/install/opt/bin/
 cp -v "`qmake -query QT_INSTALL_PREFIX`"/bin/lib*.dll ./build/install/opt/bin/
 
 # Copy Qt DLLs
-windeployqt --compiler-runtime --force \
-    --qmldir=./build/install/opt/share/librepcb/qml \
-    ./build/install/opt/bin/librepcb.exe
+windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb.exe
 windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb-cli.exe
 
 # Test if the bundles are working (hopefully catching deployment issues).

--- a/ci/macdeployqt-dummy.qml
+++ b/ci/macdeployqt-dummy.qml
@@ -1,4 +1,7 @@
-// Note: These dependencies require at least Qt 5.7 to run.
+// Dummy QML because macdeployqt fails to bundle QtDBus if the application
+// doesn't depend on QtQuick. Crap!!! And the following workaround doesn't work:
+// https://stackoverflow.com/questions/73108273/building-and-distributing-a-macos-application-using-cmake/73126397
+
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.2

--- a/dev/doxygen/pages/building.md
+++ b/dev/doxygen/pages/building.md
@@ -153,23 +153,6 @@ LibrePCB should also work with the Community Edition (OCE). CMake should
 automatically detect the availability of both variants.
 
 
-# QtQuick / Qt Declarative / QML Dependency
-
-Starting with version 1.0, LibrePCB depends on the QtQuick / Qt Declarative
-component for evaluation purposes. In future QML might be used for the GUI,
-but we first need to do some evaluation and testing. To catch potential issues
-as early as possible, the dependency has been added already but is not used
-yet for productive features. If this dependency causes any issues during
-packaging or during runtime, LibrePCB can currently be built without it:
-
-    cmake .. -DBUILD_QTQUICK_TEST=0
-
-**IMPORTANT**: Please report any problems in our
-[issue tracker](https://github.com/LibrePCB/LibrePCB/issues)! Otherwise,
-sooner or later the dependency might be mandatory without having a workaround
-anymore for your issue!
-
-
 # Dynamic Linking / Unbundling {#doc_building_unbundling}
 
 By default, all dependencies except Qt and OpenCascade will be linked

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -209,30 +209,6 @@ for file in $(search_files "**.qrc"); do
   xmlsort -r "RCC/qresource/file" -i -s "$file" | tr "'" '"' | update_file "$file" || xmlsort_failed
 done
 
-# Format qml source files with qmlformat.
-qml_format_failed() {
-  echo "" >&2
-  echo "ERROR: qmlformat failed!" >&2
-  echo "  On Linux, you can also run this script in a docker" >&2
-  echo "  container by using the '--docker' argument." >&2
-  exit 7
-}
-QMLFORMAT=$(which qmlformat || true)
-if [ -z "${QMLFORMAT}" -o ! -x ${QMLFORMAT} ]; then
-  QMLFORMAT="/usr/lib/qt5/bin/qmlformat"  # For qtdeclarative5-dev-tools package
-fi
-if [ -x ${QMLFORMAT} ]; then
-  echo "Formatting QML sources with qmlformat..."
-  for file in $(search_files "**.qml"); do
-    ${QMLFORMAT} "$file" | update_file "$file" || qml_format_failed
-  done
-else
-  echo "Formatting QML sources with qmlformat DISABLED ..."
-  echo "  Make sure that qmlformat (qtdeclarative5-dev-tools) are installed."
-  echo "  On Linux, you can also run this script in a docker"
-  echo "  container by using the '--docker' argument."
-fi
-
 # Format .reuse/dep5 files with debian-copyright-sorter.
 dcs_failed() {
   echo "" >&2

--- a/libs/librepcb/core/build_env.h.in
+++ b/libs/librepcb/core/build_env.h.in
@@ -41,7 +41,6 @@
 #cmakedefine LIBREPCB_BINARY_DIR "@LIBREPCB_BINARY_DIR@"
 
 // Features
-#cmakedefine01 BUILD_QTQUICK_TEST
 #cmakedefine01 LIBREPCB_ENABLE_DESKTOP_INTEGRATION
 #cmakedefine01 USE_GLU
 #cmakedefine01 USE_OPENCASCADE

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -1023,11 +1023,6 @@ target_link_libraries(
          ${QT}::Network
          ${QT}::Widgets
 )
-if(BUILD_QTQUICK_TEST)
-  target_link_libraries(
-    librepcb_editor PUBLIC ${QT}::Quick ${QT}::QuickControls2
-  )
-endif()
 
 # Alias to namespaced variant
 add_library(LibrePCB::Editor ALIAS librepcb_editor)

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.cpp
@@ -56,12 +56,6 @@
 #include <QtCore>
 #include <QtWidgets>
 
-#if BUILD_QTQUICK_TEST
-#include <QQmlContext>
-#include <QQmlEngine>
-#include <QQuickView>
-#endif
-
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -306,24 +300,6 @@ void ControlPanel::createActions() noexcept {
   mActionWebsite.reset(
       cmd.website.createAction(this, mStandardCommandHandler.data(),
                                &StandardEditorCommandHandler::website));
-  mActionQtQuickTest.reset(new QAction("QtQuick Test Window", this));
-  connect(mActionQtQuickTest.data(), &QAction::triggered, this, [this]() {
-#if BUILD_QTQUICK_TEST
-    Q_UNUSED(this);
-    QQuickView* view = new QQuickView;
-    view->setTitle("QtQuick Test");
-    view->setResizeMode(QQuickView::SizeRootObjectToView);
-    view->resize(350, 150);
-    view->engine()->rootContext()->setContextProperty("view", view);
-    view->setSource(Application::getResourcesDir()
-                        .getPathTo("qml/testwindow.qml")
-                        .toQUrl());
-    view->show();
-#else
-    QMessageBox::warning(this, "QtQuick Test",
-                         "LibrePCB was built without QtQuick support!");
-#endif
-  });
   mActionQuit.reset(cmd.applicationQuit.createAction(
       this, qApp, &QApplication::closeAllWindows,
       EditorCommand::ActionFlag::QueuedConnection));
@@ -375,8 +351,6 @@ void ControlPanel::createMenus() noexcept {
   mb.addAction(mActionOnlineDocumentation);
   mb.addAction(mActionKeyboardShortcutsReference);
   mb.addAction(mActionWebsite);
-  mb.addSeparator();
-  mb.addAction(mActionQtQuickTest);
   mb.addSeparator();
   mb.addAction(mActionAboutLibrePcb);
   mb.addAction(mActionAboutQt);

--- a/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
+++ b/libs/librepcb/editor/workspace/controlpanel/controlpanel.h
@@ -229,7 +229,6 @@ private:
   QScopedPointer<QAction> mActionOnlineDocumentation;
   QScopedPointer<QAction> mActionKeyboardShortcutsReference;
   QScopedPointer<QAction> mActionWebsite;
-  QScopedPointer<QAction> mActionQtQuickTest;
   QScopedPointer<QAction> mActionQuit;
 };
 


### PR DESCRIPTION
It's pretty clear now we'll go with Slint, not QtQuick so we don't need this evaluation dependency anymore...