### PR TITLE
CI: Build AppImage with linuxdeploy instead of linuxdeployqt

### DIFF
--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -22,7 +22,7 @@ jobs:
         UNBUNDLE_GTEST: true
         UNBUNDLE_MUPARSER: true
         UNBUNDLE_POLYCLIPPING: true
-        LD_LIBRARY_PATH: $(Build.Repository.LocalPath)/build/install/opt/lib
+        LD_LIBRARY_PATH: $(Build.Repository.LocalPath)/build/install/lib
   container:
     image: $[ variables['IMAGE'] ]
   steps:
@@ -60,9 +60,9 @@ jobs:
     displayName: Run rust-core tests
   - bash: xvfb-run -a ./build/tests/unittests/librepcb-unittests
     displayName: Run LibrePCB Unittests
-  - bash: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -vvv --librepcb-executable="build/install/opt/bin/librepcb-cli" ./tests/cli
+  - bash: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -vvv --librepcb-executable="build/install/bin/librepcb-cli" ./tests/cli
     displayName: Run LibrePCB-CLI Functional Tests
-  - bash: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -vvv --librepcb-executable="build/install/opt/bin/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
+  - bash: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -vvv --librepcb-executable="build/install/bin/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
     displayName: Run LibrePCB Functional Tests
   - bash: ./ci/upload_artifacts.sh
     displayName: Upload Artifacts

--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -30,11 +30,11 @@ jobs:
     displayName: Run rust-core tests
   - bash: ./build/tests/unittests/librepcb-unittests
     displayName: Run LibrePCB Unittests
-  - bash: pytest -vvv --librepcb-executable="build/install/opt/LibrePCB.app/Contents/MacOS/librepcb-cli" ./tests/cli
+  - bash: pytest -vvv --librepcb-executable="build/install/LibrePCB.app/Contents/MacOS/librepcb-cli" ./tests/cli
     displayName: Run LibrePCB-CLI Functional Tests
   # Note: Functional tests need to be run with the non-bundled app,
   # otherwise we get errors due to multiple definitions of Qt symbols.
-  - bash: pytest -vvv --librepcb-executable="build/install/opt/bin/librepcb.app/Contents/MacOS/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
+  - bash: pytest -vvv --librepcb-executable="build/install/bin/librepcb.app/Contents/MacOS/librepcb" --reruns 5 --reruns-delay 10 ./tests/funq
     displayName: Run LibrePCB Functional Tests
   - bash: ./ci/upload_artifacts.sh
     displayName: Upload Artifacts

--- a/ci/azure-jobs-windows.yml
+++ b/ci/azure-jobs-windows.yml
@@ -31,9 +31,9 @@ jobs:
       displayName: Run rust-core tests
     - script: build\\tests\\unittests\\librepcb-unittests.exe
       displayName: Run LibrePCB Unittests
-    - script: pytest -vvv --librepcb-executable="build/install/opt/bin/librepcb-cli.exe" ./tests/cli
+    - script: pytest -vvv --librepcb-executable="build/install/bin/librepcb-cli.exe" ./tests/cli
       displayName: Run LibrePCB-CLI Functional Tests
-    - script: pytest -vvv --librepcb-executable="build/install/opt/bin/librepcb.exe" --reruns 5 --reruns-delay 10 ./tests/funq
+    - script: pytest -vvv --librepcb-executable="build/install/bin/librepcb.exe" --reruns 5 --reruns-delay 10 ./tests/funq
       displayName: Run LibrePCB Functional Tests
     - bash: ./ci/upload_artifacts.sh
       displayName: Upload Artifacts

--- a/ci/build_librepcb.sh
+++ b/ci/build_librepcb.sh
@@ -20,7 +20,7 @@ mkdir -p build && pushd build
 cmake \
   -G Ninja \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-  -DCMAKE_INSTALL_PREFIX=$(pwd)/install/opt \
+  -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
   -DBUILD_DISALLOW_WARNINGS=1 \
   -DLIBREPCB_ENABLE_DESKTOP_INTEGRATION=1 \
   -DLIBREPCB_BUILD_AUTHOR="$LIBREPCB_BUILD_AUTHOR" \

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -32,17 +32,17 @@ patch_appimage () {
 # be detected by linuxdeployqt.
 LIBSSL="/opt/openssl/lib/libssl.so.3"
 LIBCRYPTO="/opt/openssl/lib/libcrypto.so.3"
-mkdir -p "./build/install/opt/lib"
-cp -fv "$LIBSSL" "./build/install/opt/lib/"
-cp -fv "$LIBCRYPTO" "./build/install/opt/lib/"
+mkdir -p "./build/install/lib"
+cp -fv "$LIBSSL" "./build/install/lib/"
+cp -fv "$LIBCRYPTO" "./build/install/lib/"
 
 # Determine common linuxdeployqt flags
-LINUXDEPLOYQT_FLAGS="-executable=./build/install/opt/lib/$(basename $LIBSSL)"
-LINUXDEPLOYQT_FLAGS+=" -executable=./build/install/opt/lib/$(basename $LIBCRYPTO)"
+LINUXDEPLOYQT_FLAGS="-executable=./build/install/lib/$(basename $LIBSSL)"
+LINUXDEPLOYQT_FLAGS+=" -executable=./build/install/lib/$(basename $LIBCRYPTO)"
 LINUXDEPLOYQT_FLAGS+=" -bundle-non-qt-libs -no-copy-copyright-files"
 
 # Build AppImage.
-cp -r "./build/install" "./build/appimage"
+cp -r "./build/install" "./build/appimage/opt"
 cp "./build/appimage/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" \
   "./build/appimage/org.librepcb.LibrePCB.svg"
 linuxdeployqt "./build/appimage/opt/share/applications/org.librepcb.LibrePCB.desktop" \
@@ -53,13 +53,13 @@ patch_appimage
 mv ./LibrePCB-*-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH.AppImage
 
 # Run linuxdeployqt to bundle all libraries into the portable packages.
-linuxdeployqt "./build/install/opt/bin/librepcb-cli" $LINUXDEPLOYQT_FLAGS -always-overwrite
-linuxdeployqt "./build/install/opt/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite
+linuxdeployqt "./build/install/bin/librepcb-cli" $LINUXDEPLOYQT_FLAGS -always-overwrite
+linuxdeployqt "./build/install/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite
 
 # Test if the bundles are working (hopefully catching deployment issues).
 # Doesn't work for AppImages unfortunately because of missing fuse on CI.
-xvfb-run -a ./build/install/opt/bin/librepcb-cli --version
-xvfb-run -a ./build/install/opt/bin/librepcb --exit-after-startup
+xvfb-run -a ./build/install/bin/librepcb-cli --version
+xvfb-run -a ./build/install/bin/librepcb --exit-after-startup
 
 # Copy to artifacts.
-cp -r "./build/install/opt" "./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH"
+cp -r "./build/install" "./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH"

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -14,47 +14,23 @@ rm -f $QTDIR/plugins/sqldrivers/libqsqlmysql.so
 rm -f $QTDIR/plugins/sqldrivers/libqsqlodbc.so
 rm -f $QTDIR/plugins/sqldrivers/libqsqlpsql.so
 
-# Helper to extract and rebuild AppImages with appimagetool to get the static
-# runtime which doesn't need libfuse2 and thus also runs on Ubuntu 22.04, see
-# https://github.com/LibrePCB/LibrePCB/issues/980.
-# In addition, replace AppRun by a script which allows to run the CLI.
-patch_appimage () {
-  ./LibrePCB-*-x86_64.AppImage --appimage-extract
-  chmod -R 755 ./squashfs-root
-  rm ./squashfs-root/AppRun
-  cp ./dist/appimage/AppRun ./squashfs-root/
-  rm ./LibrePCB-*-x86_64.AppImage
-  appimagetool ./squashfs-root
-  rm -rf ./squashfs-root
-}
+# Prepare AppDir.
+mkdir -p "./build/AppDir"
+mv "./build/install" "./build/AppDir/usr"
 
-# Copy OpenSSL libraries manually since these runtime dependencies cannot
-# be detected by linuxdeployqt.
-LIBSSL="/opt/openssl/lib/libssl.so.3"
-LIBCRYPTO="/opt/openssl/lib/libcrypto.so.3"
-mkdir -p "./build/install/lib"
-cp -fv "$LIBSSL" "./build/install/lib/"
-cp -fv "$LIBCRYPTO" "./build/install/lib/"
+# Build AppImage, which will also make the AppDir portable.
+# Specify OpenSSL libraries manually since these runtime dependencies cannot
+# be detected by linuxdeploy.
+linuxdeploy-x86_64.AppImage --plugin qt \
+  --library /opt/openssl/lib/libssl.so.3 \
+  --library /opt/openssl/lib/libcrypto.so.3 \
+  --custom-apprun ./dist/appimage/AppRun \
+  --appdir ./build/AppDir \
+  --output appimage
+mv ./LibrePCB-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH.AppImage
 
-# Determine common linuxdeployqt flags
-LINUXDEPLOYQT_FLAGS="-executable=./build/install/lib/$(basename $LIBSSL)"
-LINUXDEPLOYQT_FLAGS+=" -executable=./build/install/lib/$(basename $LIBCRYPTO)"
-LINUXDEPLOYQT_FLAGS+=" -bundle-non-qt-libs -no-copy-copyright-files"
-
-# Build AppImage.
-cp -r "./build/install" "./build/appimage/opt"
-cp "./build/appimage/opt/share/icons/hicolor/scalable/apps/org.librepcb.LibrePCB.svg" \
-  "./build/appimage/org.librepcb.LibrePCB.svg"
-linuxdeployqt "./build/appimage/opt/share/applications/org.librepcb.LibrePCB.desktop" \
-  -executable="./build/appimage/opt/bin/librepcb" \
-  -executable="./build/appimage/opt/bin/librepcb-cli" \
-  $LINUXDEPLOYQT_FLAGS -appimage
-patch_appimage
-mv ./LibrePCB-*-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH.AppImage
-
-# Run linuxdeployqt to bundle all libraries into the portable packages.
-linuxdeployqt "./build/install/bin/librepcb-cli" $LINUXDEPLOYQT_FLAGS -always-overwrite
-linuxdeployqt "./build/install/bin/librepcb" $LINUXDEPLOYQT_FLAGS -always-overwrite
+# For the portable package, we only need the usr/ directory.
+mv "./build/AppDir/usr" "./build/install"
 
 # Test if the bundles are working (hopefully catching deployment issues).
 # Doesn't work for AppImages unfortunately because of missing fuse on CI.

--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -12,12 +12,12 @@ then
 fi
 
 # Merge GUI application and CLI (https://github.com/LibrePCB/LibrePCB/issues/1358)
-cp "./build/install/opt/bin/librepcb-cli.app/Contents/MacOS/librepcb-cli" \
-   "./build/install/opt/bin/librepcb.app/Contents/MacOS/"
+cp "./build/install/bin/librepcb-cli.app/Contents/MacOS/librepcb-cli" \
+   "./build/install/bin/librepcb.app/Contents/MacOS/"
 
 # Replace "bin" and "share" directories with the single *.app directory
-cp -r "./build/install/opt/bin/librepcb.app" "./build/install/opt/LibrePCB.app"
-cp -r "./build/install/opt/share" "./build/install/opt/LibrePCB.app/Contents/"
+cp -r "./build/install/bin/librepcb.app" "./build/install/LibrePCB.app"
+cp -r "./build/install/share" "./build/install/LibrePCB.app/Contents/"
 
 # Fix failure of macdeployqt according to
 # https://github.com/orgs/Homebrew/discussions/2823.
@@ -30,7 +30,7 @@ fix_macdeployqt () {
 }
 
 # Build bundle
-pushd "./build/install/opt/"  # Avoid having path in DMG name
+pushd "./build/install/"  # Avoid having path in DMG name
 dylibbundler -ns -od -b \
   -x LibrePCB.app/Contents/MacOS/librepcb \
   -x LibrePCB.app/Contents/MacOS/librepcb-cli \
@@ -46,7 +46,7 @@ then
   macdeployqt "LibrePCB.app" -always-overwrite \
     -executable="./LibrePCB.app/Contents/MacOS/librepcb" \
     -executable="./LibrePCB.app/Contents/MacOS/librepcb-cli" \
-    -qmldir="../../../ci"
+    -qmldir="../../ci"
   codesign --force --deep -s - ./LibrePCB.app/Contents/MacOS/librepcb
   codesign --force --deep -s - ./LibrePCB.app/Contents/MacOS/librepcb-cli
   create-dmg --skip-jenkins --volname "LibrePCB" \
@@ -61,7 +61,7 @@ else
       macdeployqt "LibrePCB.app" -dmg -always-overwrite \
         -executable="./LibrePCB.app/Contents/MacOS/librepcb" \
         -executable="./LibrePCB.app/Contents/MacOS/librepcb-cli" \
-        -qmldir="../../../ci"
+        -qmldir="../../ci"
       sleep 5
     fi
   done
@@ -69,8 +69,8 @@ fi
 popd
 
 # Test if the bundles are working (hopefully catching deployment issues).
-./build/install/opt/LibrePCB.app/Contents/MacOS/librepcb-cli --version
-./build/install/opt/LibrePCB.app/Contents/MacOS/librepcb --exit-after-startup
+./build/install/LibrePCB.app/Contents/MacOS/librepcb-cli --version
+./build/install/LibrePCB.app/Contents/MacOS/librepcb --exit-after-startup
 
 # Move bundles to artifacts directory
-mv ./build/install/opt/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-$ARCH.dmg
+mv ./build/install/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-$ARCH.dmg

--- a/ci/build_windows_archive.sh
+++ b/ci/build_windows_archive.sh
@@ -4,28 +4,28 @@
 set -euv -o pipefail
 
 # Copy VC Runtime DLLs (no idea what I'm doing here, but it seems to work...)
-cp -v C:/Windows/System32/vc*140.dll ./build/install/opt/bin/
-cp -v C:/Windows/System32/msvcp140*.dll ./build/install/opt/bin/
+cp -v C:/Windows/System32/vc*140.dll ./build/install/bin/
+cp -v C:/Windows/System32/msvcp140*.dll ./build/install/bin/
 
 # ZLib DLL
-cp -v $ZLIB_ROOT/bin/libzlib.dll ./build/install/opt/bin/
+cp -v $ZLIB_ROOT/bin/libzlib.dll ./build/install/bin/
 
 # Copy OpenSSL DLLs (required to get HTTPS working)
-cp -v $OPENSSL_ROOT/bin/lib*.dll ./build/install/opt/bin/
+cp -v $OPENSSL_ROOT/bin/lib*.dll ./build/install/bin/
 
 # Copy OpenCascade DLLs
-cp -v C:/OpenCascade/win64/gcc/bin/libTK*.dll ./build/install/opt/bin/
+cp -v C:/OpenCascade/win64/gcc/bin/libTK*.dll ./build/install/bin/
 
 # Copy MinGW DLLs
-cp -v "`qmake -query QT_INSTALL_PREFIX`"/bin/lib*.dll ./build/install/opt/bin/
+cp -v "`qmake -query QT_INSTALL_PREFIX`"/bin/lib*.dll ./build/install/bin/
 
 # Copy Qt DLLs
-windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb.exe
-windeployqt --compiler-runtime --force ./build/install/opt/bin/librepcb-cli.exe
+windeployqt --compiler-runtime --force ./build/install/bin/librepcb.exe
+windeployqt --compiler-runtime --force ./build/install/bin/librepcb-cli.exe
 
 # Test if the bundles are working (hopefully catching deployment issues).
-./build/install/opt/bin/librepcb-cli.exe --version
-./build/install/opt/bin/librepcb.exe --exit-after-startup
+./build/install/bin/librepcb-cli.exe --version
+./build/install/bin/librepcb.exe --exit-after-startup
 
 # Copy everything to artifacts directory for deployment
-cp -r ./build/install/opt/. ./artifacts/nightly_builds/librepcb-nightly-windows-$ARCH/
+cp -r ./build/install/. ./artifacts/nightly_builds/librepcb-nightly-windows-$ARCH/

--- a/ci/build_windows_installer.sh
+++ b/ci/build_windows_installer.sh
@@ -11,7 +11,7 @@ export PATH="/usr/bin:$PATH"
 TARGET="$OS-$ARCH"
 
 cp -r ./dist/innosetup/* ./build/dist/innosetup/
-cp -r ./build/install/opt/. ./build/dist/innosetup/files
+cp -r ./build/install/. ./build/dist/innosetup/files
 iscc ./build/dist/innosetup/installer.iss \
   //O".\\artifacts\\nightly_builds" \
   //F"librepcb-installer-nightly-$TARGET"

--- a/dist/appimage/AppRun
+++ b/dist/appimage/AppRun
@@ -10,7 +10,7 @@ HERE="$(dirname "$(readlink -f "${0}")")"
 BINARY_NAME=$(basename "$ARGV0")
 
 case $BINARY_NAME in
-  *cli*) exec "$HERE/opt/bin/librepcb-cli" "$@";;
-  *CLI*) exec "$HERE/opt/bin/librepcb-cli" "$@";;
-  *) exec "$HERE/opt/bin/librepcb" "$@";;
+  *cli*) exec "$HERE/usr/bin/librepcb-cli" "$@";;
+  *CLI*) exec "$HERE/usr/bin/librepcb-cli" "$@";;
+  *) exec "$HERE/usr/bin/librepcb" "$@";;
 esac


### PR DESCRIPTION
That tool feels more mature, maybe it causes less troubles...