### PR TITLE
Schematic editor: Fix polygons not being editable

### DIFF
--- a/libs/librepcb/editor/project/schematiceditor/schematicgraphicsscene.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/schematicgraphicsscene.cpp
@@ -401,6 +401,7 @@ void SchematicGraphicsScene::addPolygon(SI_Polygon& polygon) noexcept {
   std::shared_ptr<PolygonGraphicsItem> item =
       std::make_shared<PolygonGraphicsItem>(polygon.getPolygon(),
                                             mLayerProvider);
+  item->setEditable(true);
   addItem(*item);
   mPolygons.insert(&polygon, item);
 }


### PR DESCRIPTION
Unfortunately polygon vertices were not draggable with the cursor in the schematic editor due to a regression.