### PR TITLE
Update to Slint 1.11.0

### DIFF
--- a/ci/azure-jobs-stylecheck-doxygen.yml
+++ b/ci/azure-jobs-stylecheck-doxygen.yml
@@ -2,7 +2,7 @@ jobs:
 - job: Stylecheck_Doxygen
   pool:
     vmImage: 'ubuntu-22.04'
-  container: librepcb/librepcb-dev:devtools-5
+  container: librepcb/librepcb-dev:devtools-6
   steps:
   - checkout: self
     clean: true

--- a/dev/format_code.sh
+++ b/dev/format_code.sh
@@ -28,7 +28,7 @@ set -eufo pipefail
 
 DOCKER=""
 DOCKER_CMD="docker"
-DOCKER_IMAGE="librepcb/librepcb-dev:devtools-5"
+DOCKER_IMAGE="librepcb/librepcb-dev:devtools-6"
 CLANGFORMAT=${CLANGFORMAT:-clang-format}
 RUSTFMT=${RUSTFMT:-rustfmt}
 BASE="master"
@@ -178,7 +178,7 @@ slintlsp_failed() {
 echo "Formatting Slint sources with slint-lsp..."
 for dir in apps/ libs/librepcb/; do
   for file in $(search_files "${dir}**.slint"); do
-    slint-lsp format "$file" | update_file "$file" || slintlsp_failed
+    slint-lsp format "$file" | "$REPO_ROOT/dev/format_code_helper.py" "$file" | update_file "$file" || slintlsp_failed
   done
 done
 

--- a/dev/format_code_helper.py
+++ b/dev/format_code_helper.py
@@ -58,6 +58,18 @@ def format_ui(content):
     return content
 
 
+def format_slint(content):
+    # Sort import statements
+    matches = list(re.finditer(r'(import|export) \{\n([^\}]*)', content, re.MULTILINE))
+    matches.reverse()
+    for m in matches:
+        imports = [s.strip() for s in m.group(2).split(',') if s.strip()]
+        sorted_imports = sorted(list(set(imports)))
+        new_content = ',\n'.join(['    ' + s for s in sorted_imports]) + ',\n'
+        content = content[:m.start(2)] + new_content + content[m.end(2):]
+    return content
+
+
 if __name__ == '__main__':
     # Get relative file path.
     path = sys.argv[1]
@@ -71,6 +83,8 @@ if __name__ == '__main__':
         content = format_cxx(path, extension, content)
     elif extension == 'ui':
         content = format_ui(content)
+    elif extension == 'slint':
+        content = format_slint(content)
 
     # Write file content to stdout.
     sys.stdout.write(content)

--- a/libs/librepcb/editor/library/librariesmodel.cpp
+++ b/libs/librepcb/editor/library/librariesmodel.cpp
@@ -114,7 +114,7 @@ void LibrariesModel::setOnlineVersions(
         mMergedLibs.at(i).online_version = versionStr;
         mMergedLibs.at(i).outdated = Version::fromString(s2q(versionStr)) >
             Version::fromString(s2q(mMergedLibs.at(i).installed_version));
-        row_changed(i);
+        notify_row_changed(i);
       }
     }
   }
@@ -178,7 +178,7 @@ void LibrariesModel::applyChanges() noexcept {
           [this, uuid](int percent) {
             if (auto i = indexOf(*uuid)) {
               mMergedLibs.at(*i).progress = percent;
-              row_changed(*i);
+              notify_row_changed(*i);
             }
           },
           Qt::QueuedConnection);
@@ -425,7 +425,7 @@ void LibrariesModel::onlineIconReceived(const Uuid& uuid,
   for (std::size_t i = 0; i < mMergedLibs.size(); ++i) {
     if (mMergedLibs.at(i).uuid == uuid.toStr()) {
       mMergedLibs.at(i).icon = q2s(pixmap);
-      row_changed(i);
+      notify_row_changed(i);
     }
   }
 }
@@ -493,7 +493,7 @@ void LibrariesModel::updateMergedLibraries() noexcept {
   checkMissingDependenciesOfLibs();
   updateCheckStates(false);
 
-  reset();
+  notify_reset();
 
   emit uiDataChanged(getUiData());
 }
@@ -505,7 +505,7 @@ void LibrariesModel::updateCheckStates(bool notify) noexcept {
     if (lib.checked != checked) {
       lib.checked = checked;
       if (notify) {
-        row_changed(i);
+        notify_row_changed(i);
       }
     }
   }

--- a/libs/librepcb/editor/notificationsmodel.cpp
+++ b/libs/librepcb/editor/notificationsmodel.cpp
@@ -48,7 +48,7 @@ NotificationsModel::NotificationsModel(Workspace& ws, QObject* parent) noexcept
       &mWorkspace.getSettings().dismissedMessages,
       &WorkspaceSettingsItem::edited, this,
       [this]() {
-        reset();
+        notify_reset();
         updateUnreadNotificationsCount();
         updateCurrentProgressIndex();
       },
@@ -78,7 +78,7 @@ void NotificationsModel::push(
   const QString dismissKey = notification->getDismissKey();
   if (dismissKey.isEmpty() ||
       (!mWorkspace.getSettings().dismissedMessages.contains(dismissKey))) {
-    row_added(0, 1);
+    notify_row_added(0, 1);
     updateUnreadNotificationsCount();
     updateCurrentProgressIndex();
     if (notification->getAutoPopUp()) {
@@ -118,7 +118,7 @@ void NotificationsModel::set_row_data(
   const int itemIndex = mapIndex(i);
   if ((itemIndex >= 0) && (itemIndex < static_cast<int>(mItems.size()))) {
     mItems[itemIndex]->setUiData(obj);
-    row_changed(i);
+    notify_row_changed(i);
 
     // Handle "don't show again".
     const QString dismissKey = mItems[itemIndex]->getDismissKey();
@@ -170,7 +170,7 @@ void NotificationsModel::itemChanged(bool dismissed) noexcept {
       if (dismissed) {
         removeItem(logicalIndex, i);
       } else {
-        row_changed(logicalIndex);
+        notify_row_changed(logicalIndex);
       }
       return;
     }
@@ -186,7 +186,7 @@ void NotificationsModel::removeItem(std::size_t i, int itemIndex) noexcept {
   disconnect(mItems[itemIndex].get(), &Notification::changed, this,
              &NotificationsModel::itemChanged);
   mItems.erase(mItems.begin() + itemIndex);
-  row_removed(i, 1);
+  notify_row_removed(i, 1);
 }
 
 void NotificationsModel::updateUnreadNotificationsCount() noexcept {

--- a/libs/librepcb/editor/ui/aboutpanel.slint
+++ b/libs/librepcb/editor/ui/aboutpanel.slint
@@ -2,14 +2,14 @@ import { ScrollView } from "std-widgets.slint";
 import {
     Button,
     IconButton,
-    PanelHeader
+    PanelHeader,
 } from "widgets.slint";
 import {
     Action,
     Backend,
     Constants,
     Data,
-    EditorCommandSet as Cmd
+    EditorCommandSet as Cmd,
 } from "api.slint";
 
 export component AboutPanel inherits Rectangle {

--- a/libs/librepcb/editor/ui/api/data.slint
+++ b/libs/librepcb/editor/ui/api/data.slint
@@ -7,7 +7,7 @@ import {
     TabData,
     TabType,
     TreeViewItemData,
-    WindowSectionData
+    WindowSectionData,
 } from "types.slint";
 
 export global Data {

--- a/libs/librepcb/editor/ui/api/helpers.slint
+++ b/libs/librepcb/editor/ui/api/helpers.slint
@@ -2,7 +2,7 @@ import {
     Action,
     EditorCommand,
     NotificationType,
-    TabType
+    TabType,
 } from "types.slint";
 import { Backend } from "backend.slint";
 

--- a/libs/librepcb/editor/ui/appwindow.slint
+++ b/libs/librepcb/editor/ui/appwindow.slint
@@ -15,7 +15,7 @@ import {
     Data,
     EditorCommandSet as Cmd,
     Helpers,
-    PanelPage
+    PanelPage,
 } from "api.slint";
 
 export { Backend, Data, Cmd as EditorCommandSet }

--- a/libs/librepcb/editor/ui/homepanel.slint
+++ b/libs/librepcb/editor/ui/homepanel.slint
@@ -5,7 +5,7 @@ import {
     MenuPopup,
     Palette,
     PanelHeader,
-    TreeView
+    TreeView,
 } from "widgets.slint";
 import {
     Action,
@@ -14,7 +14,7 @@ import {
     Data,
     EditorCommandSet as Cmd,
     Helpers,
-    TreeViewItemData
+    TreeViewItemData,
 } from "api.slint";
 
 component QuickAccessListView inherits TreeView {

--- a/libs/librepcb/editor/ui/hometab.slint
+++ b/libs/librepcb/editor/ui/hometab.slint
@@ -5,7 +5,7 @@ import {
     Backend,
     Constants,
     Data,
-    EditorCommandSet as Cmd
+    EditorCommandSet as Cmd,
 } from "api.slint";
 
 component DonateButton inherits Button {

--- a/libs/librepcb/editor/ui/library/createlibrarytab.slint
+++ b/libs/librepcb/editor/ui/library/createlibrarytab.slint
@@ -3,14 +3,14 @@ import {
     IconButton,
     LineEdit,
     LinkText,
-    Switch
+    Switch,
 } from "../widgets.slint";
 import { Tab } from "../tab.slint";
 import {
     Action,
     Backend,
     CreateLibraryTabData,
-    WindowSectionData
+    WindowSectionData,
 } from "../api.slint";
 
 export component CreateLibraryTab inherits Tab {

--- a/libs/librepcb/editor/ui/library/downloadlibrarytab.slint
+++ b/libs/librepcb/editor/ui/library/downloadlibrarytab.slint
@@ -2,13 +2,13 @@ import {
     Button,
     LineEdit,
     LinkText,
-    ProgressBar
+    ProgressBar,
 } from "../widgets.slint";
 import { Tab } from "../tab.slint";
 import {
     Action,
     DownloadLibraryTabData,
-    WindowSectionData
+    WindowSectionData,
 } from "../api.slint";
 
 export component DownloadLibraryTab inherits Tab {

--- a/libs/librepcb/editor/ui/library/librariespanel.slint
+++ b/libs/librepcb/editor/ui/library/librariespanel.slint
@@ -8,7 +8,7 @@ import {
     MessagePopup,
     PanelHeader,
     ProgressBar,
-    Switch
+    Switch,
 } from "../widgets.slint";
 import {
     Action,
@@ -16,7 +16,7 @@ import {
     Constants,
     Data,
     LibraryData,
-    LibraryListData
+    LibraryListData,
 } from "../api.slint";
 
 component LibraryUninstallPopup inherits MessagePopup {

--- a/libs/librepcb/editor/ui/mainmenubar.slint
+++ b/libs/librepcb/editor/ui/mainmenubar.slint
@@ -5,7 +5,7 @@ import {
     Constants,
     Data,
     EditorCommandSet as Cmd,
-    PanelPage
+    PanelPage,
 } from "api.slint";
 
 component MainMenuItem inherits Rectangle {

--- a/libs/librepcb/editor/ui/notificationspopup.slint
+++ b/libs/librepcb/editor/ui/notificationspopup.slint
@@ -4,7 +4,7 @@ import {
     Data,
     Helpers,
     NotificationData,
-    NotificationType
+    NotificationType,
 } from "api.slint";
 
 component NotificationItem inherits Rectangle {

--- a/libs/librepcb/editor/ui/sidebar.slint
+++ b/libs/librepcb/editor/ui/sidebar.slint
@@ -5,7 +5,7 @@ import {
     Constants,
     Data,
     EditorCommandSet as Cmd,
-    PanelPage
+    PanelPage,
 } from "api.slint";
 
 enum Emblem {

--- a/libs/librepcb/editor/ui/statusbar.slint
+++ b/libs/librepcb/editor/ui/statusbar.slint
@@ -3,7 +3,7 @@ import { NotificationsPopup } from "notificationspopup.slint";
 import {
     Constants,
     Data,
-    NotificationType
+    NotificationType,
 } from "api.slint";
 
 export component StatusBar inherits Rectangle {

--- a/libs/librepcb/editor/ui/widgets/treeview.slint
+++ b/libs/librepcb/editor/ui/widgets/treeview.slint
@@ -6,7 +6,7 @@ import {
     Constants,
     EditorCommandSet as Cmd,
     Helpers,
-    TreeViewItemData
+    TreeViewItemData,
 } from "../api.slint";
 
 export component TreeView inherits Rectangle {

--- a/libs/librepcb/editor/ui/windowsection.slint
+++ b/libs/librepcb/editor/ui/windowsection.slint
@@ -10,7 +10,7 @@ import {
     Helpers,
     TabData,
     TabType,
-    WindowSectionData
+    WindowSectionData,
 } from "api.slint";
 
 component TabButton inherits Rectangle {

--- a/libs/librepcb/editor/utils/deriveduiobjectlistview.h
+++ b/libs/librepcb/editor/utils/deriveduiobjectlistview.h
@@ -89,7 +89,7 @@ private:
     Q_UNUSED(obj);
     switch (event) {
       case TList::Event::ElementAdded: {
-        slint::Model<TDerivedUiData>::row_added(index, 1);
+        slint::Model<TDerivedUiData>::notify_row_added(index, 1);
         if (auto o = std::dynamic_pointer_cast<TDerived>(mList->value(index))) {
           Q_ASSERT(o == obj);
           o->onDerivedUiDataChanged.attach(mOnDerivedUiDataChangedSlot);
@@ -97,7 +97,7 @@ private:
         break;
       }
       case TList::Event::ElementRemoved: {
-        slint::Model<TDerivedUiData>::row_removed(index, 1);
+        slint::Model<TDerivedUiData>::notify_row_removed(index, 1);
         if (auto o = std::dynamic_pointer_cast<TDerived>(mList->value(index))) {
           Q_ASSERT(o == obj);
           o->onDerivedUiDataChanged.detach(mOnDerivedUiDataChangedSlot);
@@ -112,7 +112,7 @@ private:
   void elementDerivedUiDataChangedHandler(const TDerived& obj) noexcept {
     if (auto index =
             mList->indexOf(static_cast<const typename TList::Element*>(&obj))) {
-      slint::Model<TDerivedUiData>::row_changed(*index);
+      slint::Model<TDerivedUiData>::notify_row_changed(*index);
     }
   }
 

--- a/libs/librepcb/editor/utils/uiobjectlist.h
+++ b/libs/librepcb/editor/utils/uiobjectlist.h
@@ -85,7 +85,7 @@ public:
     Q_ASSERT(obj);
     index = qBound(0, index, mObjects.count() + 1);
     mObjects.insert(index, obj);
-    slint::Model<TUiData>::row_added(index, 1);
+    slint::Model<TUiData>::notify_row_added(index, 1);
     obj->onUiDataChanged.attach(mOnUiDataChangedSlot);
     onEdited.notify(index, obj, Event::ElementAdded);
   }
@@ -99,7 +99,7 @@ public:
   }
   std::shared_ptr<TObj> takeAt(int index) noexcept {
     if (auto obj = mObjects.takeAt(index)) {
-      slint::Model<TUiData>::row_removed(index, 1);
+      slint::Model<TUiData>::notify_row_removed(index, 1);
       obj->onUiDataChanged.detach(mOnUiDataChangedSlot);
       onEdited.notify(index, obj, Event::ElementRemoved);
       return obj;
@@ -140,7 +140,7 @@ public:
 private:
   void elementUiDataChangedHandler(const TObj& obj) noexcept {
     if (auto index = indexOf(&obj)) {
-      slint::Model<TUiData>::row_changed(*index);
+      slint::Model<TUiData>::notify_row_changed(*index);
       onEdited.notify(*index, at(*index), Event::ElementUiDataChanged);
     }
   }

--- a/libs/librepcb/editor/workspace/filesystemmodel.cpp
+++ b/libs/librepcb/editor/workspace/filesystemmodel.cpp
@@ -129,7 +129,7 @@ void FileSystemModel::set_row_data(std::size_t i,
     }
     mItems.at(i) = data;
     mItems.at(i).action = ui::Action::None;
-    row_changed(i);
+    notify_row_changed(i);
   }
 }
 
@@ -185,7 +185,7 @@ void FileSystemModel::expandDir(const FilePath& fp, std::size_t index,
             isPinnable && mQuickAccess->isFavoriteProject(itemFp),  // Pinned
             ui::Action::None,  // Action
         });
-    row_added(index, 1);
+    notify_row_added(index, 1);
     ++index;
   }
   if (!mWatcher.addPath(fp.toStr())) {
@@ -221,7 +221,7 @@ void FileSystemModel::collapseDir(const FilePath& fp, std::size_t index,
   }
   if (childCount > 0) {
     mItems.erase(mItems.begin() + index, mItems.begin() + index + childCount);
-    row_removed(index, childCount);
+    notify_row_removed(index, childCount);
   }
   if (fp != mRoot) {
     mExpandedDirs.remove(fp);
@@ -255,7 +255,7 @@ void FileSystemModel::favoriteProjectChanged(const FilePath& fp,
         (FilePath(s2q(mItems.at(i).user_data)) == fp) &&
         (mItems.at(i).pinned != favorite)) {
       mItems.at(i).pinned = favorite;
-      row_changed(i);
+      notify_row_changed(i);
       break;
     }
   }

--- a/libs/librepcb/editor/workspace/quickaccessmodel.cpp
+++ b/libs/librepcb/editor/workspace/quickaccessmodel.cpp
@@ -231,14 +231,14 @@ void QuickAccessModel::refreshItems() noexcept {
 
   const std::size_t oldCount = mItems.size();
   if (items.size() < oldCount) {
-    row_removed(items.size(), oldCount - items.size());
+    notify_row_removed(items.size(), oldCount - items.size());
   }
   mItems = items;
   if (items.size() > oldCount) {
-    row_added(oldCount, items.size() - oldCount);
+    notify_row_added(oldCount, items.size() - oldCount);
   }
   for (std::size_t i = 0; i < std::min(items.size(), oldCount); ++i) {
-    row_changed(i);
+    notify_row_changed(i);
   }
 }
 


### PR DESCRIPTION
Fixing deprecation warnings & make use of trailing commas in import statements, enforced by our own code formatter script.