### PR TITLE
Schematic editor: Support snap to grid

### DIFF
--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -83,6 +83,15 @@ bool Path::isZeroLength() const noexcept {
   return true;
 }
 
+bool Path::isOnGrid(const PositiveLength& gridInterval) const noexcept {
+  for (const auto& v : mVertices) {
+    if (!v.getPos().isOnGrid(gridInterval)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 UnsignedLength Path::getTotalStraightLength() const noexcept {
   UnsignedLength length(0);
   if (mVertices.count() >= 2) {

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -70,6 +70,7 @@ public:
   bool isClosed() const noexcept;
   bool isCurved() const noexcept;
   bool isZeroLength() const noexcept;
+  bool isOnGrid(const PositiveLength& gridInterval) const noexcept;
   QVector<Vertex>& getVertices() noexcept {
     invalidatePainterPath();
     return mVertices;

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
@@ -62,6 +62,7 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
     mDeltaPos(0, 0),
     mCenterPos(0, 0),
     mDeltaAngle(0),
+    mSnappedToGrid(false),
     mMirrored(false),
     mTextsReset(false) {
   // get all selected items
@@ -127,6 +128,26 @@ CmdDragSelectedSchematicItems::~CmdDragSelectedSchematicItems() noexcept {
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
+
+void CmdDragSelectedSchematicItems::snapToGrid() noexcept {
+  const PositiveLength grid = mScene.getSchematic().getGridInterval();
+  foreach (CmdSymbolInstanceEdit* cmd, mSymbolEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
+  foreach (CmdSchematicNetPointEdit* cmd, mNetPointEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
+  foreach (CmdSchematicNetLabelEdit* cmd, mNetLabelEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
+  foreach (CmdPolygonEdit* cmd, mPolygonEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
+  foreach (CmdTextEdit* cmd, mTextEditCmds) {
+    cmd->snapToGrid(grid, true);
+  }
+  mSnappedToGrid = true;
+}
 
 void CmdDragSelectedSchematicItems::resetAllTexts() noexcept {
   mTextsReset = true;
@@ -215,8 +236,8 @@ void CmdDragSelectedSchematicItems::mirror(
  ******************************************************************************/
 
 bool CmdDragSelectedSchematicItems::performExecute() {
-  if (mDeltaPos.isOrigin() && (mDeltaAngle == Angle::deg0()) && (!mMirrored) &&
-      (!mTextsReset)) {
+  if (mDeltaPos.isOrigin() && (mDeltaAngle == Angle::deg0()) &&
+      (!mSnappedToGrid) && (!mMirrored) && (!mTextsReset)) {
     // no movement required --> discard all move commands
     qDeleteAll(mSymbolEditCmds);
     mSymbolEditCmds.clear();

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
@@ -59,6 +59,7 @@ public:
   ~CmdDragSelectedSchematicItems() noexcept;
 
   // General Methods
+  void snapToGrid() noexcept;
   void resetAllTexts() noexcept;
   void setCurrentPosition(const Point& pos) noexcept;
   void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
@@ -80,6 +81,7 @@ private:
   Point mDeltaPos;
   Point mCenterPos;
   Angle mDeltaAngle;
+  bool mSnappedToGrid;
   bool mMirrored;
   bool mTextsReset;
 

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.cpp
@@ -75,6 +75,11 @@ void CmdSchematicNetLabelEdit::translate(const Point& deltaPos,
   if (immediate) mNetLabel.setPosition(mNewPos);
 }
 
+void CmdSchematicNetLabelEdit::snapToGrid(const PositiveLength& gridInterval,
+                                          bool immediate) noexcept {
+  setPosition(mNewPos.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdSchematicNetLabelEdit::setRotation(const Angle& angle,
                                            bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.h
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetlabeledit.h
@@ -56,6 +56,7 @@ public:
   // Setters
   void setPosition(const Point& position, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirror(Qt::Orientation orientation, const Point& center,

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetpointedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetpointedit.cpp
@@ -67,6 +67,11 @@ void CmdSchematicNetPointEdit::translate(const Point& deltaPos,
   if (immediate) mNetPoint.setPosition(mNewPos);
 }
 
+void CmdSchematicNetPointEdit::snapToGrid(const PositiveLength& gridInterval,
+                                          bool immediate) noexcept {
+  setPosition(mNewPos.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdSchematicNetPointEdit::rotate(const Angle& angle, const Point& center,
                                       bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetpointedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetpointedit.h
@@ -54,6 +54,7 @@ public:
   // Setters
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void mirror(Qt::Orientation orientation, const Point& center,
               bool immediate) noexcept;

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.cpp
@@ -73,6 +73,11 @@ void CmdSymbolInstanceEdit::translate(const Point& deltaPos,
   if (immediate) mSymbol.setPosition(mNewPos);
 }
 
+void CmdSymbolInstanceEdit::snapToGrid(const PositiveLength& gridInterval,
+                                       bool immediate) noexcept {
+  setPosition(mNewPos.mappedToGrid(gridInterval), immediate);
+}
+
 void CmdSymbolInstanceEdit::setRotation(const Angle& angle,
                                         bool immediate) noexcept {
   Q_ASSERT(!wasEverExecuted());

--- a/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdsymbolinstanceedit.h
@@ -55,6 +55,7 @@ public:
   // General Methods
   void setPosition(const Point& pos, bool immediate) noexcept;
   void translate(const Point& deltaPos, bool immediate) noexcept;
+  void snapToGrid(const PositiveLength& gridInterval, bool immediate) noexcept;
   void setRotation(const Angle& angle, bool immediate) noexcept;
   void rotate(const Angle& angle, const Point& center, bool immediate) noexcept;
   void setMirrored(bool mirrored, bool immediate) noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.cpp
@@ -206,6 +206,15 @@ bool SchematicEditorFsm::processMirror(Qt::Orientation orientation) noexcept {
   return false;
 }
 
+bool SchematicEditorFsm::processSnapToGrid() noexcept {
+  if (SchematicEditorState* state = getCurrentStateObj()) {
+    if (state->processSnapToGrid()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool SchematicEditorFsm::processResetAllTexts() noexcept {
   if (SchematicEditorState* state = getCurrentStateObj()) {
     if (state->processResetAllTexts()) {

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorfsm.h
@@ -115,6 +115,7 @@ public:
   bool processMove(const Point& delta) noexcept;
   bool processRotate(const Angle& rotation) noexcept;
   bool processMirror(Qt::Orientation orientation) noexcept;
+  bool processSnapToGrid() noexcept;
   bool processResetAllTexts() noexcept;
   bool processRemove() noexcept;
   bool processEditProperties() noexcept;

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate.h
@@ -121,6 +121,7 @@ public:
     Q_UNUSED(orientation);
     return false;
   }
+  virtual bool processSnapToGrid() noexcept { return false; }
   virtual bool processResetAllTexts() noexcept { return false; }
   virtual bool processRemove() noexcept { return false; }
   virtual bool processEditProperties() noexcept { return false; }

--- a/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/editor/project/schematiceditor/fsm/schematiceditorstate_select.h
@@ -81,6 +81,7 @@ public:
   virtual bool processMove(const Point& delta) noexcept override;
   virtual bool processRotate(const Angle& rotation) noexcept override;
   virtual bool processMirror(Qt::Orientation orientation) noexcept override;
+  virtual bool processSnapToGrid() noexcept override;
   virtual bool processResetAllTexts() noexcept override;
   virtual bool processRemove() noexcept override;
   virtual bool processEditProperties() noexcept override;
@@ -107,6 +108,7 @@ private:  // Methods
   bool moveSelectedItems(const Point& delta) noexcept;
   bool rotateSelectedItems(const Angle& angle) noexcept;
   bool mirrorSelectedItems(Qt::Orientation orientation) noexcept;
+  bool snapSelectedItemsToGrid() noexcept;
   bool resetAllTextsOfSelectedItems() noexcept;
   bool removeSelectedItems() noexcept;
   void removePolygonVertices(Polygon& polygon,

--- a/tests/unittests/core/geometry/pathtest.cpp
+++ b/tests/unittests/core/geometry/pathtest.cpp
@@ -116,6 +116,26 @@ TEST_F(PathTest, testIsZeroLengthFalse) {
                    .isZeroLength());
 }
 
+TEST_F(PathTest, testIsOnGrid) {
+  const PositiveLength grid(1000000);
+  EXPECT_TRUE(Path().isOnGrid(grid));  // Usually this is the good case.
+  EXPECT_TRUE(Path({
+                       Vertex(Point(0, 0), Angle::deg90()),
+                       Vertex(Point(1000000, 2000000)),
+                   })
+                  .isOnGrid(grid));
+  EXPECT_FALSE(Path({
+                        Vertex(Point(1, 0), Angle::deg90()),
+                        Vertex(Point(1000000, 2000000)),
+                    })
+                   .isOnGrid(grid));
+  EXPECT_FALSE(Path({
+                        Vertex(Point(0, 0), Angle::deg90()),
+                        Vertex(Point(1000000, 2000001)),
+                    })
+                   .isOnGrid(grid));
+}
+
 TEST_F(PathTest, testGetTotalStraightLength) {
   QVector<Vertex> vertices;
   EXPECT_EQ(UnsignedLength(0), Path(vertices).getTotalStraightLength());


### PR DESCRIPTION
Just like in the board editor, allow moving off-grid objects to the grid with a command.