### PR TITLE
Always accept decimal point as separator in input fields

### DIFF
--- a/libs/librepcb/core/utils/mathparser.cpp
+++ b/libs/librepcb/core/utils/mathparser.cpp
@@ -47,12 +47,19 @@ void MathParser::setLocale(const QLocale& locale) noexcept {
   mLocale = locale;
 }
 
-MathParser::Result MathParser::parse(const QString& expression) const noexcept {
+MathParser::Result MathParser::parse(QString expression) const noexcept {
   MathParser::Result result;
 
   try {
     const QString decimalPoint(mLocale.decimalPoint());
     const QString groupSeparator(mLocale.groupSeparator());
+
+    // Always support '.' as decimal separator in addition to the
+    // locale-dependent separator, especially for German people
+    // (https://github.com/LibrePCB/LibrePCB/issues/1367).
+    if (decimalPoint != ".") {
+      expression.replace(".", decimalPoint);
+    }
 
     mu::Parser parser;
     parser.SetArgSep(';');  // avoid conflict with other separators

--- a/libs/librepcb/core/utils/mathparser.h
+++ b/libs/librepcb/core/utils/mathparser.h
@@ -79,7 +79,7 @@ public:
    * @return  The result, either valid with a value, or invalid with an error
    *          message.
    */
-  Result parse(const QString& expression) const noexcept;
+  Result parse(QString expression) const noexcept;
 
   // Operator Overloadings
   MathParser& operator=(const MathParser& rhs) = delete;

--- a/tests/unittests/core/utils/mathparsertest.cpp
+++ b/tests/unittests/core/utils/mathparsertest.cpp
@@ -82,8 +82,13 @@ INSTANTIATE_TEST_SUITE_P(MathParserTest, MathParserTest, ::testing::Values(
     MathParserTestData({"en_US", "2+3", 5}),
     MathParserTestData({"en_US", "(1+2)/2", 1.5}),
     MathParserTestData({"en_US", " 2 * (1.1 + 2.2) / 3.3 ", 2*(1.1+2.2)/3.3}),
-    MathParserTestData({"en_US", "5,000", 5000}), // thousand separator
-    MathParserTestData({"de_DE", "5,000", 5}), // decimal point
+    MathParserTestData({"en_US", "5,123", 5123}), // thousand separator
+    MathParserTestData({"en_US", "5,123.456", 5123.456}), // both separators
+
+    // https://github.com/LibrePCB/LibrePCB/issues/1367
+    MathParserTestData({"de_DE", "5,123", 5.123}), // decimal point
+    MathParserTestData({"de_DE", "5.123", 5.123}), // support '.' in any locale
+    MathParserTestData({"de_DE", "5.123,456", std::nullopt}), // downside :-/
 
     // invalid cases
     MathParserTestData({"en_US", "", std::nullopt}),


### PR DESCRIPTION
Especially in Germany one would expect the decimal point "." should be usable as the decimal separator even though officially it would be the comma. Thus now always accepting the decimal point *in addition* to the locale-dependent decimal separator.

As a downside, for locales with the decimal point as the *thousands* separator you can no longer enter thousands separators, e.g. "1.000,5" with de_DE is no longer a valid input because both separators are considered as the decimal separator. But I think this is an acceptable downside as probably nobody inserts thousands separator and we rarely have to write large numbers anyway.

Closes #1367.