### PR TITLE
Replace non-reproducible build date by Git commit date

### DIFF
--- a/apps/librepcb-cli/commandlineinterface.cpp
+++ b/apps/librepcb-cli/commandlineinterface.cpp
@@ -389,18 +389,20 @@ int CommandLineInterface::execute(const QStringList& args) noexcept {
   if (parser.isSet(versionOption)) {
     // Note: Do not translate this output as it probably looks ugly and this
     // way it is deterministic even if LANG/LC_ALL is not explicitly set.
+    QString revision = Application::getGitRevision();
+    const QDate date = Application::getGitCommitDate().date();
+    if (date.isValid()) {
+      revision += " (" + date.toString(Qt::ISODate) + ")";
+    }
     print(QString("LibrePCB CLI Version %1").arg(Application::getVersion()));
     print(QString("File Format %1")
               .arg(Application::getFileFormatVersion().toStr()) %
           " " %
           (Application::isFileFormatStable() ? "(stable)" : "(unstable)"));
-    print(QString("Git Revision %1").arg(Application::getGitRevision()));
+    print(QString("Git Revision %1").arg(revision));
     print(QString("Qt Version %1 (compiled against %2)")
               .arg(qVersion(), QT_VERSION_STR));
     print("OpenCascade " % OccModel::getOccVersionString());
-    print(QString("Built at %1")
-              .arg(QLocale().toString(Application::getBuildDate(),
-                                      QLocale::ShortFormat)));
     return 0;
   }
 

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -30,7 +30,6 @@ linuxdeploy-x86_64.AppImage --plugin qt \
   --custom-apprun ./dist/appimage/AppRun \
   --appdir ./build/AppDir \
   --output appimage
-mv ./LibrePCB-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH.AppImage
 
 # For the portable package, we only need the usr/ directory.
 mv "./build/AppDir/usr" "./build/install"
@@ -40,5 +39,10 @@ mv "./build/AppDir/usr" "./build/install"
 xvfb-run -a ./build/install/bin/librepcb-cli --version
 xvfb-run -a ./build/install/bin/librepcb --exit-after-startup
 
+# Print checksums to allow fully transparent public verification.
+sha256sum ./LibrePCB-x86_64.AppImage
+find ./build/install -type f -exec sha256sum {} \; | sort -k 2
+
 # Copy to artifacts.
+mv ./LibrePCB-x86_64.AppImage ./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH.AppImage
 cp -r "./build/install" "./artifacts/nightly_builds/librepcb-nightly-linux-$ARCH"

--- a/ci/build_mac_bundle.sh
+++ b/ci/build_mac_bundle.sh
@@ -80,5 +80,8 @@ popd
 ./build/install/LibrePCB.app/Contents/MacOS/librepcb-cli --version
 ./build/install/LibrePCB.app/Contents/MacOS/librepcb --exit-after-startup
 
-# Move bundles to artifacts directory
+# Print checksums to allow fully transparent public verification.
+shasum -a 256 ./build/install/LibrePCB.dmg
+
+# Move to artifacts.
 mv ./build/install/LibrePCB.dmg ./artifacts/nightly_builds/librepcb-nightly-mac-$ARCH.dmg

--- a/ci/build_windows_archive.sh
+++ b/ci/build_windows_archive.sh
@@ -3,6 +3,11 @@
 # set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
 set -euv -o pipefail
 
+# Bash on Windows calls the Windows provided "find" tool instead of the one
+# from MSYS, which is bullshit since it isn't compatible. As a workaround,
+# we adjust PATH.
+export PATH="/usr/bin:$PATH"
+
 # Copy VC Runtime DLLs (no idea what I'm doing here, but it seems to work...)
 cp -v C:/Windows/System32/vc*140.dll ./build/install/bin/
 cp -v C:/Windows/System32/msvcp140*.dll ./build/install/bin/
@@ -31,6 +36,9 @@ windeployqt --compiler-runtime --force ./build/install/bin/librepcb-cli.exe
 # Test if the bundles are working (hopefully catching deployment issues).
 ./build/install/bin/librepcb-cli.exe --version
 ./build/install/bin/librepcb.exe --exit-after-startup
+
+# Print checksums to allow fully transparent public verification.
+find ./build/install -type f -exec sha256sum {} \; | sort -k 2
 
 # Copy everything to artifacts directory for deployment
 cp -r ./build/install/. ./artifacts/nightly_builds/librepcb-nightly-windows-$ARCH/

--- a/ci/build_windows_installer.sh
+++ b/ci/build_windows_installer.sh
@@ -8,10 +8,13 @@ set -euv -o pipefail
 # we adjust PATH.
 export PATH="/usr/bin:$PATH"
 
-TARGET="$OS-$ARCH"
-
+# Build the installer.
+OUTPUT_DIRECTORY=".\\artifacts\\nightly_builds"
+OUTPUT_BASENAME="librepcb-installer-nightly-$OS-$ARCH"
 cp -r ./dist/innosetup/* ./build/dist/innosetup/
 cp -r ./build/install/. ./build/dist/innosetup/files
 iscc ./build/dist/innosetup/installer.iss \
-  //O".\\artifacts\\nightly_builds" \
-  //F"librepcb-installer-nightly-$TARGET"
+  //O"$OUTPUT_DIRECTORY" //F"$OUTPUT_BASENAME"
+
+# Print checksum to allow fully transparent public verification.
+sha256sum "$OUTPUT_DIRECTORY\\$OUTPUT_BASENAME.exe"

--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -36,6 +36,13 @@ else()
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     set(GIT_COMMIT_SHA ${SHORT_SHA})
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${CMAKE_SOURCE_DIR}" show -s --format=%ct
+              HEAD
+      OUTPUT_VARIABLE COMMIT_TIMESTAMP
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(GIT_COMMIT_TIMESTAMP ${COMMIT_TIMESTAMP})
   else()
     message(STATUS "Git not found, cannot set version info")
   endif()

--- a/libs/librepcb/core/application.h
+++ b/libs/librepcb/core/application.h
@@ -70,13 +70,13 @@ public:
   static QString getGitRevision() noexcept;
 
   /**
-   * @brief Get the date/time when the application was built
+   * @brief Get the commit datetime of the sources used to build the application
    *
    * @note This function is thread-safe.
    *
    * @return Date/time (might be invalid)
    */
-  static QDateTime getBuildDate() noexcept;
+  static QDateTime getGitCommitDate() noexcept;
 
   /**
    * @brief Get the author who has built the application

--- a/libs/librepcb/core/build_env.h.in
+++ b/libs/librepcb/core/build_env.h.in
@@ -31,6 +31,7 @@
 
 // Commit information
 #define GIT_COMMIT_SHA "@GIT_COMMIT_SHA@"
+#define GIT_COMMIT_TIMESTAMP @GIT_COMMIT_TIMESTAMP@
 
 // Build information
 #define LIBREPCB_BUILD_AUTHOR "@LIBREPCB_BUILD_AUTHOR@"

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -10,10 +10,9 @@ Test "--version"
 PATTERN = (
     "LibrePCB CLI Version \\d+\\.\\d+\\.\\d+(\\-\\w+)?\\n"
     "File Format [0-9]+(\\.[0-9]+)? \\((stable|unstable)\\)\\n"
-    "Git Revision [0-9a-f]+\\n"
+    "Git Revision [0-9a-f]+ \\([0-9-]+\\)\\n"
     "Qt Version [0-9\\.]+ \\(compiled against [0-9\\.]+\\)\\n"
     "OpenCascade [A-Z/]+( [0-9\\.]+)?\\n"
-    "Built at [0-9a-zA-Z\\.:/  ]+\\n"
 )
 
 


### PR DESCRIPTION
Currently the build datetime is compiled into the executable and shown in the app version section:

```
LibrePCB Version: 1.3.1-unstable
Git Revision:     158544617
Build Date:       2025-06-29T23:38:52
[...]
```

But of course this clearly breaks reproducible builds. I don't want to completely omit the datetime as it is helpful for users to see how old their installed version is. But I think it makes more sense to include the *commit* date rather than the *build* date as it leads to more reproducible builds. Also I removed the output of the time, I think the date is enough:

```
LibrePCB Version: 1.3.1-unstable
Git Revision:     7032e481c (2025-06-29)
[...]
```

In addition, this PR makes CI printing out the sha256 sum of all build artifacts to allow public verification that our official binary releases are actually built on CI (with the public build chain) rather than on anyone's personal computer.

Includes the commit from #1549 so this needs to be rebased before merging.