### PR TITLE
Fix broken links of architecture diagrams

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -6,6 +6,6 @@ This directory contains some cmake projects to build applications, like
 - the LibrePCB command line interface
 
 The dependencies between applications and static libraries are shown in the
-[architecture overview diagram](../dev/diagrams/svg/architecture_overview.drawio.svg):
+[architecture overview diagram](../dev/doxygen/images/architecture_overview.svg):
 
 ![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.svg)

--- a/apps/README.md
+++ b/apps/README.md
@@ -6,6 +6,6 @@ This directory contains some cmake projects to build applications, like
 - the LibrePCB command line interface
 
 The dependencies between applications and static libraries are shown in the
-[architecture overview diagram](../../dev/diagrams/architecture_overview.drawio.svg):
+[architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](../../dev/diagrams/architecture_overview.drawio.svg)
+![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)

--- a/apps/README.md
+++ b/apps/README.md
@@ -6,6 +6,6 @@ This directory contains some cmake projects to build applications, like
 - the LibrePCB command line interface
 
 The dependencies between applications and static libraries are shown in the
-[architecture overview diagram](../dev/doxygen/images/architecture_overview.svg):
+[architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.svg)
+![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)

--- a/apps/README.md
+++ b/apps/README.md
@@ -6,6 +6,6 @@ This directory contains some cmake projects to build applications, like
 - the LibrePCB command line interface
 
 The dependencies between applications and static libraries are shown in the
-[architecture overview diagram](../dev/diagrams/svg/architecture_overview.svg):
+[architecture overview diagram](../dev/diagrams/svg/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.png)
+![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.svg)

--- a/apps/README.md
+++ b/apps/README.md
@@ -9,3 +9,4 @@ The dependencies between applications and static libraries are shown in the
 [architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
 ![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)
+<h5><i>note: this link may not work on GitHub, but will work on local machines.</i></h5>

--- a/apps/README.md
+++ b/apps/README.md
@@ -9,4 +9,3 @@ The dependencies between applications and static libraries are shown in the
 [architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
 ![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)
-<h5><i>note: this link may not work on GitHub, but will work on local machines.</i></h5>

--- a/apps/README.md
+++ b/apps/README.md
@@ -6,6 +6,6 @@ This directory contains some cmake projects to build applications, like
 - the LibrePCB command line interface
 
 The dependencies between applications and static libraries are shown in the
-[architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
+[architecture overview diagram](../../dev/diagrams/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)
+![Architecture Overview Diagram](../../dev/diagrams/architecture_overview.drawio.svg)

--- a/apps/librepcb/README.md
+++ b/apps/librepcb/README.md
@@ -2,6 +2,6 @@
 
 This directory contains the cmake project of the LibrePCB application.
 
-The dependencies between application and static libraries are shown in the [architecture overview diagram](/dev/doxygen/images/architecture_overview.svg):
+The dependencies between application and static libraries are shown in the [architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](/dev/doxygen/images/architecture_overview.svg)
+![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)

--- a/apps/librepcb/README.md
+++ b/apps/librepcb/README.md
@@ -2,6 +2,6 @@
 
 This directory contains the cmake project of the LibrePCB application.
 
-The dependencies between application and static libraries are shown in the [architecture overview diagram](../dev/diagrams/svg/architecture_overview.drawio.svg):
+The dependencies between application and static libraries are shown in the [architecture overview diagram](/dev/doxygen/images/architecture_overview.svg):
 
-![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.svg)
+![Architecture Overview Diagram](/dev/doxygen/images/architecture_overview.svg)

--- a/apps/librepcb/README.md
+++ b/apps/librepcb/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the cmake project of the LibrePCB application.
 
-The dependencies between application and static libraries are shown in the [architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
+The dependencies between application and static libraries are shown in the
+[architecture overview diagram](../../dev/diagrams/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)
-<h5><i> note - this link will not work on GitHub but will work on local machines.</i></h5>
+![Architecture Overview Diagram](../../dev/diagrams/architecture_overview.drawio.svg)

--- a/apps/librepcb/README.md
+++ b/apps/librepcb/README.md
@@ -5,3 +5,4 @@ This directory contains the cmake project of the LibrePCB application.
 The dependencies between application and static libraries are shown in the [architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
 ![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)
+<!-- note - this link will not work on GitHub but will work on local machines.-->

--- a/apps/librepcb/README.md
+++ b/apps/librepcb/README.md
@@ -5,4 +5,4 @@ This directory contains the cmake project of the LibrePCB application.
 The dependencies between application and static libraries are shown in the [architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
 ![Architecture Overview Diagram](../dev/diagrams/architecture_overview.drawio.svg)
-<!-- note - this link will not work on GitHub but will work on local machines.-->
+<h5><i> note - this link will not work on GitHub but will work on local machines.</i></h5>

--- a/apps/librepcb/README.md
+++ b/apps/librepcb/README.md
@@ -2,6 +2,6 @@
 
 This directory contains the cmake project of the LibrePCB application.
 
-The dependencies between application and static libraries are shown in the [architecture overview diagram](../dev/diagrams/svg/architecture_overview.svg):
+The dependencies between application and static libraries are shown in the [architecture overview diagram](../dev/diagrams/svg/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.png)
+![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.svg)


### PR DESCRIPTION
There were several broken links in /apps/README.md and  /apps/librepcb/README.md. The fault was that file types were mixed up, such as .png was meant to be .svg, and .svg was meant to be .drawio.svg.