### PR TITLE
CI: Update Windows docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,11 @@ jobs:
   windows-x64:
     name: Windows x86_64
     runs-on: windows-2025
+    env:
+      # Docker image tag: windowsservercore-ltsc2025-qt6.6-64bit-2
+      # Using digest for easier verification of the transparent build chain.
+      # https://github.com/LibrePCB/docker-librepcb-dev/actions/runs/16144496203/job/45559638212
+      IMAGE_DIGEST: d1ad2916b9cc865c22b6bba1471e8f784c89cb51c07e0f25dac9274db846572a
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,7 +38,7 @@ jobs:
           -e CARGO_HOME="C:/work/build/.cargo-home"
           -e CARGO_INCREMENTAL="${{ env.CARGO_INCREMENTAL }}"
           -e LIBREPCB_BUILD_AUTHOR="${{ env.LIBREPCB_BUILD_AUTHOR }}"
-          librepcb/librepcb-dev:windowsservercore-ltsc2025-qt6.6-64bit-1
+          "ghcr.io/librepcb/docker-librepcb-dev@sha256:${{ env.IMAGE_DIGEST }}"
       - name: Print Environment
         run: docker exec ci bash ./ci/print_environment.sh
       - name: Install Dependencies
@@ -93,7 +98,7 @@ jobs:
           ci bash ./ci/upload_artifacts.sh
       - name: Stop Container
         if: ${{ always() }}
-        run: docker stop ci
+        run: docker stop -t 30 ci
 
   macos-arm64:
     name: MacOS ARM64


### PR DESCRIPTION
Now pulling the new image from GitHub container registry since the image is now built on CI, see https://github.com/LibrePCB/docker-librepcb-dev/pull/70.

And added a flag to `docker stop` to make it terminate the container if necessary.