### PR TITLE
Set up code signing of Windows executables & installer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,10 @@ jobs:
         run: docker exec ci uv --directory ./tests/ui run --no-dev pytest -vvv --librepcb-executable="../../build/install/bin/librepcb.exe"
         env:
           SLINT_UI_TESTING_AUTH: ${{ secrets.SLINT_UI_TESTING_AUTH }}
+      - name: Tar Artifacts
+        run: docker exec ci bash ./ci/tar_artifacts.sh
       - name: Upload Artifacts
-        if: ${{ success() && (github.event_name == 'push') }}
+        if: ${{ success() && (github.event_name == 'push') && env.UPLOAD_URL }}
         run: >
           docker exec
           -e UPLOAD_URL="${{ secrets.UPLOAD_URL }}"
@@ -96,6 +98,8 @@ jobs:
           -e UPLOAD_PASS="${{ secrets.UPLOAD_PASS }}"
           -e UPLOAD_SIGN_KEY="${{ secrets.UPLOAD_SIGN_KEY }}"
           ci bash ./ci/upload_artifacts.sh
+        env:
+          UPLOAD_URL: ${{ secrets.UPLOAD_URL }}  # Required to use it in 'if' condition
       - name: Stop Container
         if: ${{ always() }}
         run: docker stop -t 30 ci
@@ -166,9 +170,11 @@ jobs:
         run: uv --directory ./tests/ui run --no-dev pytest -vvv --librepcb-executable="../../build/install/bin/librepcb.app/Contents/MacOS/librepcb"
         env:
           SLINT_UI_TESTING_AUTH: ${{ secrets.SLINT_UI_TESTING_AUTH }}
-      - name: Upload Artifacts
-        if: ${{ success() && (github.event_name == 'push') }}
-        run: ./ci/upload_artifacts.sh
+      - name: Tar & Upload Artifacts
+        if: ${{ success() && (github.event_name == 'push') && env.UPLOAD_URL }}
+        run: |
+          ./ci/tar_artifacts.sh
+          ./ci/upload_artifacts.sh
         env:
           UPLOAD_URL: ${{ secrets.UPLOAD_URL }}
           UPLOAD_USER: ${{ secrets.UPLOAD_USER }}

--- a/ci/azure-jobs-linux.yml
+++ b/ci/azure-jobs-linux.yml
@@ -70,9 +70,11 @@ jobs:
     condition: and(succeeded(), variables['SLINT_UI_TESTING_AUTH'])
     env:
       SLINT_UI_TESTING_AUTH: $(SLINT_UI_TESTING_AUTH)
-  - bash: ./ci/upload_artifacts.sh
-    displayName: Upload Artifacts
-    condition: and(succeeded(), eq(variables['DEPLOY'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+  - bash: |
+      ./ci/tar_artifacts.sh
+      ./ci/upload_artifacts.sh
+    displayName: Tar & Upload Artifacts
+    condition: and(succeeded(), eq(variables['DEPLOY'], 'true'), ne(variables.UPLOAD_URL, ''), ne(variables['Build.Reason'], 'PullRequest'))
     env:
       UPLOAD_URL: $(ARTIFACTS_UPLOAD_URL)
       UPLOAD_USER: $(ARTIFACTS_UPLOAD_USER)

--- a/ci/azure-jobs-macos.yml
+++ b/ci/azure-jobs-macos.yml
@@ -43,9 +43,11 @@ jobs:
     condition: and(succeeded(), variables['SLINT_UI_TESTING_AUTH'])
     env:
       SLINT_UI_TESTING_AUTH: $(SLINT_UI_TESTING_AUTH)
-  - bash: ./ci/upload_artifacts.sh
-    displayName: Upload Artifacts
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  - bash: |
+      ./ci/tar_artifacts.sh
+      ./ci/upload_artifacts.sh
+    displayName: Tar & Upload Artifacts
+    condition: and(succeeded(), ne(variables.UPLOAD_URL, ''), ne(variables['Build.Reason'], 'PullRequest'))
     env:
       UPLOAD_URL: $(ARTIFACTS_UPLOAD_URL)
       UPLOAD_USER: $(ARTIFACTS_UPLOAD_USER)

--- a/ci/azure-jobs-stylecheck-doxygen.yml
+++ b/ci/azure-jobs-stylecheck-doxygen.yml
@@ -19,9 +19,11 @@ jobs:
     displayName: Find unused code
   - bash: ./ci/build_doxygen.sh
     displayName: Build Doxygen Documentation
-  - bash: ./ci/upload_artifacts.sh
+  - bash: |
+      ./ci/tar_artifacts.sh
+      ./ci/upload_artifacts.sh
     displayName: Upload Artifacts
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), ne(variables.UPLOAD_URL, ''), ne(variables['Build.Reason'], 'PullRequest'))
     env:
       UPLOAD_URL: $(ARTIFACTS_UPLOAD_URL)
       UPLOAD_USER: $(ARTIFACTS_UPLOAD_USER)

--- a/ci/build_windows_archive.sh
+++ b/ci/build_windows_archive.sh
@@ -33,6 +33,14 @@ rm -rfv ./build/install/lib
 windeployqt --compiler-runtime --force ./build/install/bin/librepcb.exe
 windeployqt --compiler-runtime --force ./build/install/bin/librepcb-cli.exe
 
+# Print checksums of executables *before signing* to allow public verification.
+sha256sum ./build/install/bin/*.exe
+
+# Sign the executables (the conditional is in sign.ps1 to ensure by CI that
+# the call is correct even if signing is disabled for nightly builds).
+powershell.exe -File ci/sign.ps1 $(cygpath -aw ./build/install/bin/librepcb.exe)
+powershell.exe -File ci/sign.ps1 $(cygpath -aw ./build/install/bin/librepcb-cli.exe)
+
 # Test if the bundles are working (hopefully catching deployment issues).
 ./build/install/bin/librepcb-cli.exe --version
 ./build/install/bin/librepcb.exe --exit-after-startup

--- a/ci/build_windows_installer.sh
+++ b/ci/build_windows_installer.sh
@@ -8,13 +8,24 @@ set -euv -o pipefail
 # we adjust PATH.
 export PATH="/usr/bin:$PATH"
 
+# Enable code signing only when available (detected by AST_TENANT).
+if [[ -n "${AST_TENANT-}" ]]
+then
+  echo "Code signing is enabled"
+  SIGN_FLAG="//DSIGN"
+else
+  echo "Code signing is disabled"
+  SIGN_FLAG=""
+fi
+
 # Build the installer.
 OUTPUT_DIRECTORY=".\\artifacts\\nightly_builds"
 OUTPUT_BASENAME="librepcb-installer-nightly-$OS-$ARCH"
 cp -r ./dist/innosetup/* ./build/dist/innosetup/
 cp -r ./build/install/. ./build/dist/innosetup/files
 iscc ./build/dist/innosetup/installer.iss \
-  //O"$OUTPUT_DIRECTORY" //F"$OUTPUT_BASENAME"
+  //O"$OUTPUT_DIRECTORY" //F"$OUTPUT_BASENAME" \
+  $SIGN_FLAG //Ssigntool="powershell.exe -File $(cygpath -aw ci/sign.ps1) \$f"
 
 # Print checksum to allow fully transparent public verification.
 sha256sum "$OUTPUT_DIRECTORY\\$OUTPUT_BASENAME.exe"

--- a/ci/sign.ps1
+++ b/ci/sign.ps1
@@ -1,0 +1,15 @@
+$FILE=$args[0]
+
+if ($env:AST_TENANT) {
+    AzureSignTool.exe sign `
+        -kvu "$env:AST_VAULT" `
+        -kvc "$env:AST_CERT" `
+        -kvi "$env:AST_IDENT" `
+        -kvs "$env:AST_SECRET" `
+        --azure-key-vault-tenant-id "$env:AST_TENANT" `
+        -tr "$env:AST_TIMESTAMP" `
+        -td $env:AST_TD `
+        $FILE
+} else {
+    Write-Host "Skipped code signing of $FILE"
+}

--- a/ci/tar_artifacts.sh
+++ b/ci/tar_artifacts.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# set shell settings (see https://sipb.mit.edu/doc/safe-shell/)
+set -euv -o pipefail
+
+# Bash on Windows calls the Windows provided "tar" and "openssl" tool instead
+# of the one from MSYS, which is bullshit since it isn't compatible. As a
+# workaround, we adjust PATH.
+export PATH="/usr/bin:$PATH"
+
+# create tarball of all artifacts
+cd ./artifacts
+tar -cf artifacts.tar *

--- a/ci/upload_artifacts.sh
+++ b/ci/upload_artifacts.sh
@@ -11,18 +11,14 @@ export PATH="/usr/bin:$PATH"
 # get branch name from CI
 BRANCH_NAME="${CI_BRANCH_NAME#refs/heads/}"
 
-# upload build artifacts for all branches of the upstream repository
-if [ -n "${UPLOAD_URL-}" ]
-then
-  # create tarball of all artifacts
-  cd ./artifacts
-  tar -cf artifacts.tar *
-  # create digital signature of artifacts tarball
-  openssl dgst -sha256 -sign <(echo -e "$UPLOAD_SIGN_KEY") -out ./artifacts.tar.sha256 ./artifacts.tar
-  # create archive containing the artifacts and its digital signature
-  BASENAME=$(echo $BRANCH_NAME | sed -e 's/[^A-Za-z0-9_-]/_/g')
-  BASENAME+="~$(date +%s)"  # timestamp to avoid filename conflicts on server
-  tar -cjf "./$BASENAME.tbz2" ./artifacts.tar.sha256 ./artifacts.tar
-  # upload archive
-  curl --fail --basic -u "$UPLOAD_USER:$UPLOAD_PASS" -F "path=@$BASENAME.tbz2" "$UPLOAD_URL"
-fi
+# create digital signature of artifacts tarball
+cd ./artifacts
+openssl dgst -sha256 -sign <(echo -e "$UPLOAD_SIGN_KEY") -out ./artifacts.tar.sha256 ./artifacts.tar
+
+# create archive containing the artifacts and its digital signature
+BASENAME=$(echo $BRANCH_NAME | sed -e 's/[^A-Za-z0-9_-]/_/g')
+BASENAME+="~$(date +%s)"  # timestamp to avoid filename conflicts on server
+tar -cjf "./$BASENAME.tbz2" ./artifacts.tar.sha256 ./artifacts.tar
+
+# upload archive
+curl --fail --basic -u "$UPLOAD_USER:$UPLOAD_PASS" -F "path=@$BASENAME.tbz2" "$UPLOAD_URL"

--- a/dev/doxygen/pages/release_workflow.md
+++ b/dev/doxygen/pages/release_workflow.md
@@ -144,6 +144,8 @@ downloading translations from [Transifex].
    older releases!). If necessary, add tags to the submodule repositories to
    avoid garbage collection of these commits.
 4. Verify that translations are up-to-date, i.e. the auto-sync still works.
+5. Check that the code signing configuration is still up-to-date and set up
+   for all executables to be signed.
 
 ### Release
 
@@ -163,6 +165,7 @@ downloading translations from [Transifex].
      * 3D viewer (check OpenGL and OpenCASCADE)
      * Translations
      * Desktop services (e.g. opening keyboard shortcuts reference PDF)
+     * Code signing (TODO: Can we make a test run of code signing?)
 8. If everything looks good, merge the branch into `master` (either by merging
    the PR or locally with merge commit [preferred] or fast-forward).
 9. Important: Only proceed with the following steps if you have a lot of time

--- a/dist/innosetup/installer.iss
+++ b/dist/innosetup/installer.iss
@@ -32,6 +32,12 @@ WizardImageFile=watermark.bmp
 WizardSmallImageFile=logo.bmp
 WizardStyle=modern
 
+; Support conditional code signing by CLI flag "/DSIGN"
+#ifdef SIGN
+SignTool=signtool $f
+SignedUninstaller=yes
+#endif
+
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "armenian"; MessagesFile: "compiler:Languages\Armenian.isl"


### PR DESCRIPTION
This configures CI & Inno Setup to perform code signing if credentials for AzureSignTool are available on CI. If those are not available, code signing is disabled. The actual signing will be done in the repository https://github.com/OSSign/LibrePCB--LibrePCB.