### PR TITLE
SlintGraphicsView: Support rendering with OpenGL

### DIFF
--- a/libs/librepcb/editor/graphics/slintgraphicsview.h
+++ b/libs/librepcb/editor/graphics/slintgraphicsview.h
@@ -29,6 +29,7 @@
 
 #include <QtCore>
 #include <QtGui>
+#include <QtOpenGL>
 
 #include <slint.h>
 
@@ -87,6 +88,7 @@ public:
   Point mapToScenePos(const QPointF& pos) const noexcept;
 
   // General Methods
+  void setUseOpenGl(bool use) noexcept;
   void setEventHandler(IF_GraphicsViewEventHandler* obj) noexcept;
   slint::Image render(GraphicsScene& scene, float width, float height) noexcept;
   bool pointerEvent(const QPointF& pos,
@@ -125,6 +127,10 @@ private:  // Methods
 private:  // Data
   const QRectF mDefaultSceneRect;
   IF_GraphicsViewEventHandler* mEventHandler;
+  std::unique_ptr<QOffscreenSurface> mGlSurface;
+  std::unique_ptr<QOpenGLContext> mGlContext;
+  std::unique_ptr<QOpenGLFramebufferObject> mGlFbo;
+  QString mGlError;
   Projection mProjection;
   QSizeF mViewSize;
 

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -118,7 +118,13 @@ SymbolTab::SymbolTab(LibraryEditor& editor, std::unique_ptr<Symbol> sym,
     mIsInterfaceBroken(false),
     mOriginalSymbolPinUuids(mSymbol->getPins().getUuidSet()) {
   // Setup graphics view.
+  mView->setUseOpenGl(mApp.getWorkspace().getSettings().useOpenGl.get());
   mView->setEventHandler(this);
+  connect(
+      &mApp.getWorkspace().getSettings().useOpenGl,
+      &WorkspaceSettingsItem_GenericValue<bool>::edited, this, [this]() {
+        mView->setUseOpenGl(mApp.getWorkspace().getSettings().useOpenGl.get());
+      });
   connect(mView.get(), &SlintGraphicsView::transformChanged, this,
           &SymbolTab::requestRepaint);
   connect(mView.get(), &SlintGraphicsView::stateChanged, this,

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -174,7 +174,13 @@ Board2dTab::Board2dTab(GuiApplication& app, BoardEditor& editor,
           &Board2dTab::storeLayersVisibility);
 
   // Setup graphics view.
+  mView->setUseOpenGl(mApp.getWorkspace().getSettings().useOpenGl.get());
   mView->setEventHandler(this);
+  connect(
+      &mApp.getWorkspace().getSettings().useOpenGl,
+      &WorkspaceSettingsItem_GenericValue<bool>::edited, this, [this]() {
+        mView->setUseOpenGl(mApp.getWorkspace().getSettings().useOpenGl.get());
+      });
   connect(mView.get(), &SlintGraphicsView::transformChanged, this,
           &Board2dTab::requestRepaint);
   connect(mView.get(), &SlintGraphicsView::stateChanged, this,
@@ -829,6 +835,7 @@ slint::Image Board2dTab::renderScene(float width, float height,
   if (scene == 1) {
     if (mUnplacedComponentGraphicsScene) {
       SlintGraphicsView view(SlintGraphicsView::defaultFootprintSceneRect());
+      view.setUseOpenGl(mApp.getWorkspace().getSettings().useOpenGl.get());
       return view.render(*mUnplacedComponentGraphicsScene, width, height);
     } else {
       QPixmap pix(width, height);

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -135,7 +135,13 @@ SchematicTab::SchematicTab(GuiApplication& app, SchematicEditor& editor,
   Q_ASSERT(&mSchematic.getProject() == &mProject);
 
   // Setup graphics view.
+  mView->setUseOpenGl(mApp.getWorkspace().getSettings().useOpenGl.get());
   mView->setEventHandler(this);
+  connect(
+      &mApp.getWorkspace().getSettings().useOpenGl,
+      &WorkspaceSettingsItem_GenericValue<bool>::edited, this, [this]() {
+        mView->setUseOpenGl(mApp.getWorkspace().getSettings().useOpenGl.get());
+      });
   connect(mView.get(), &SlintGraphicsView::transformChanged, this,
           &SchematicTab::requestRepaint);
   connect(mView.get(), &SlintGraphicsView::stateChanged, this,


### PR DESCRIPTION
Support OpenGL 2D rendering, depending on workspace settings. We already had it in previous versions but it was dropped during the Slint migration because the 2D graphics view needed to be re-implemented in a different way.