### PR TITLE
Store grid interval in symbols & packages

### DIFF
--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -89,6 +89,7 @@ Package::Package(const Uuid& uuid, const Version& version,
                    author, name_en_US, description_en_US, keywords_en_US),
     mAlternativeNames(),
     mAssemblyType(assemblyType),
+    mGridInterval(2540000),
     mPads(),
     mModels(),
     mFootprints() {
@@ -100,6 +101,8 @@ Package::Package(std::unique_ptr<TransactionalDirectory> directory,
                    std::move(directory), root),
     mAlternativeNames(),
     mAssemblyType(deserialize<AssemblyType>(root.getChild("assembly_type/@0"))),
+    mGridInterval(
+        deserialize<PositiveLength>(root.getChild("grid_interval/@0"))),
     mPads(root),
     mModels(root),
     mFootprints(root) {
@@ -217,6 +220,8 @@ void Package::serialize(SExpression& root) const {
   }
   root.ensureLineBreak();
   root.appendChild("assembly_type", mAssemblyType);
+  root.ensureLineBreak();
+  root.appendChild("grid_interval", mGridInterval);
   root.ensureLineBreak();
   mPads.serialize(root);
   root.ensureLineBreak();

--- a/libs/librepcb/core/library/pkg/package.h
+++ b/libs/librepcb/core/library/pkg/package.h
@@ -99,6 +99,9 @@ public:
   }
   AssemblyType getAssemblyType(bool resolveAuto) const noexcept;
   AssemblyType guessAssemblyType() const noexcept;
+  const PositiveLength& getGridInterval() const noexcept {
+    return mGridInterval;
+  }
   PackagePadList& getPads() noexcept { return mPads; }
   const PackagePadList& getPads() const noexcept { return mPads; }
   PackageModelList& getModels() noexcept { return mModels; }
@@ -110,6 +113,9 @@ public:
 
   // Setters
   void setAssemblyType(AssemblyType type) noexcept { mAssemblyType = type; }
+  void setGridInterval(const PositiveLength& interval) noexcept {
+    mGridInterval = interval;
+  }
 
   // General Methods
   virtual RuleCheckMessageList runChecks() const override;
@@ -138,6 +144,7 @@ private:  // Methods
 private:  // Data
   QList<AlternativeName> mAlternativeNames;  ///< Optional
   AssemblyType mAssemblyType;  ///< Package assembly type (metadata)
+  PositiveLength mGridInterval;
   PackagePadList mPads;  ///< empty list if the package has no pads
   PackageModelList mModels;  ///< 3D models (optional)
   FootprintList mFootprints;  ///< minimum one footprint

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -42,6 +42,7 @@ Symbol::Symbol(const Uuid& uuid, const Version& version, const QString& author,
   : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
                    author, name_en_US, description_en_US, keywords_en_US),
     onEdited(*this),
+    mGridInterval(2540000),
     mPins(),
     mPolygons(),
     mCircles(),
@@ -61,6 +62,8 @@ Symbol::Symbol(std::unique_ptr<TransactionalDirectory> directory,
   : LibraryElement(getShortElementName(), getLongElementName(), true,
                    std::move(directory), root),
     onEdited(*this),
+    mGridInterval(
+        deserialize<PositiveLength>(root.getChild("grid_interval/@0"))),
     mPins(root),
     mPolygons(root),
     mCircles(root),
@@ -126,6 +129,8 @@ std::unique_ptr<Symbol> Symbol::open(
 
 void Symbol::serialize(SExpression& root) const {
   LibraryElement::serialize(root);
+  root.ensureLineBreak();
+  root.appendChild("grid_interval", mGridInterval);
   root.ensureLineBreak();
   mPins.serialize(root);
   root.ensureLineBreak();

--- a/libs/librepcb/core/library/sym/symbol.h
+++ b/libs/librepcb/core/library/sym/symbol.h
@@ -74,6 +74,16 @@ public:
          const QString& keywords_en_US);
   ~Symbol() noexcept;
 
+  // Getters: Attributes
+  const PositiveLength& getGridInterval() const noexcept {
+    return mGridInterval;
+  }
+
+  // Setters: Attributes
+  void setGridInterval(const PositiveLength& interval) noexcept {
+    mGridInterval = interval;
+  }
+
   // Getters: Geometry
   bool isEmpty() const noexcept;
   SymbolPinList& getPins() noexcept { return mPins; }
@@ -122,6 +132,8 @@ private:  // Methods
                    TextList::Event event) noexcept;
 
 private:  // Data
+  PositiveLength mGridInterval;
+
   SymbolPinList mPins;
   PolygonList mPolygons;
   CircleList mCircles;

--- a/libs/librepcb/core/project/schematic/schematic.h
+++ b/libs/librepcb/core/project/schematic/schematic.h
@@ -100,10 +100,7 @@ public:
   // Setters: Attributes
   void setName(const ElementName& name) noexcept;
   void setGridInterval(const PositiveLength& interval) noexcept {
-    if (interval != mGridInterval) {
-      mGridInterval = interval;
-      emit gridIntervalChanged(mGridInterval);
-    }
+    mGridInterval = interval;
   }
   void setGridUnit(const LengthUnit& unit) noexcept { mGridUnit = unit; }
 
@@ -148,7 +145,6 @@ public:
 
 signals:
   void nameChanged(const ElementName& name);
-  void gridIntervalChanged(const PositiveLength& interval);
   void symbolAdded(SI_Symbol& symbol);
   void symbolRemoved(SI_Symbol& symbol);
   void netSegmentAdded(SI_NetSegment& netSegment);

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -63,10 +63,32 @@ void FileFormatMigrationUnstable::upgradePackageCategory(
 
 void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  // Content File.
+  {
+    const QString fp = "symbol.lp";
+    std::unique_ptr<SExpression> root =
+        SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    if (!root->tryGetChild("grid_interval")) {
+      root->appendChild("grid_interval", SExpression::createToken("2.54"));
+    }
+    dir.write(fp, root->toByteArray());
+  }
 }
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  // Content File.
+  {
+    const QString fp = "package.lp";
+    std::unique_ptr<SExpression> root =
+        SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    if (!root->tryGetChild("grid_interval")) {
+      root->appendChild("grid_interval", SExpression::createToken("2.54"));
+    }
+    dir.write(fp, root->toByteArray());
+  }
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(

--- a/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
@@ -64,6 +64,15 @@ void FileFormatMigrationV1::upgradePackageCategory(
 void FileFormatMigrationV1::upgradeSymbol(TransactionalDirectory& dir) {
   // Version File.
   upgradeVersionFile(dir, ".librepcb-sym");
+
+  // Content File.
+  {
+    const QString fp = "symbol.lp";
+    std::unique_ptr<SExpression> root =
+        SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root->appendChild("grid_interval", SExpression::createToken("2.54"));
+    dir.write(fp, root->toByteArray());
+  }
 }
 
 void FileFormatMigrationV1::upgradePackage(TransactionalDirectory& dir) {
@@ -75,6 +84,7 @@ void FileFormatMigrationV1::upgradePackage(TransactionalDirectory& dir) {
     const QString fp = "package.lp";
     std::unique_ptr<SExpression> root =
         SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root->appendChild("grid_interval", SExpression::createToken("2.54"));
 
     // Footprints.
     for (SExpression* fptNode : root->getChildren("footprint")) {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.cpp
@@ -447,9 +447,9 @@ bool PackageEditorFsm::processStartReNumberPads() noexcept {
 }
 
 bool PackageEditorFsm::processGridIntervalChanged(
-    const PositiveLength& inverval) noexcept {
+    const PositiveLength& interval) noexcept {
   if (PackageEditorState* state = getCurrentState()) {
-    if (state->processGridIntervalChanged(inverval)) {
+    if (state->processGridIntervalChanged(interval)) {
       return true;
     }
   }

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -160,7 +160,7 @@ public:
   bool processStartDxfImport() noexcept;
   bool processStartMeasure() noexcept;
   bool processStartReNumberPads() noexcept;
-  bool processGridIntervalChanged(const PositiveLength& inverval) noexcept;
+  bool processGridIntervalChanged(const PositiveLength& interval) noexcept;
 
   // Operator Overloadings
   PackageEditorFsm& operator=(const PackageEditorFsm& rhs) = delete;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.h
@@ -129,8 +129,8 @@ public:
   virtual bool processAcceptCommand() noexcept { return false; }
   virtual bool processAbortCommand() noexcept { return false; }
   virtual bool processGridIntervalChanged(
-      const PositiveLength& inverval) noexcept {
-    Q_UNUSED(inverval);
+      const PositiveLength& interval) noexcept {
+    Q_UNUSED(interval);
     return false;
   }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -706,8 +706,8 @@ bool PackageEditorState_Select::processAbortCommand() noexcept {
 }
 
 bool PackageEditorState_Select::processGridIntervalChanged(
-    const PositiveLength& inverval) noexcept {
-  Q_UNUSED(inverval);
+    const PositiveLength& interval) noexcept {
+  Q_UNUSED(interval);
   scheduleUpdateAvailableFeatures();
   return true;
 }

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.h
@@ -106,7 +106,7 @@ public:
   bool processImportDxf() noexcept override;
   bool processAbortCommand() noexcept override;
   bool processGridIntervalChanged(
-      const PositiveLength& inverval) noexcept override;
+      const PositiveLength& interval) noexcept override;
 
   // Operator Overloadings
   PackageEditorState_Select& operator=(const PackageEditorState_Select& rhs) =

--- a/libs/librepcb/editor/library/pkg/packagetab.h
+++ b/libs/librepcb/editor/library/pkg/packagetab.h
@@ -242,7 +242,6 @@ private:
   int mCurrentPageIndex;
   bool mView3d;
   Theme::GridStyle mGridStyle;
-  PositiveLength mGridInterval;
   LengthUnit mUnit;
   bool mChooseCategory;
   std::shared_ptr<PackageModel> mCurrentModel;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.cpp
@@ -297,9 +297,9 @@ bool SymbolEditorFsm::processStartMeasure() noexcept {
 }
 
 bool SymbolEditorFsm::processGridIntervalChanged(
-    const PositiveLength& inverval) noexcept {
+    const PositiveLength& interval) noexcept {
   if (SymbolEditorState* state = getCurrentState()) {
-    if (state->processGridIntervalChanged(inverval)) {
+    if (state->processGridIntervalChanged(interval)) {
       return true;
     }
   }

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
@@ -126,7 +126,7 @@ public:
   bool processStartDrawTexts() noexcept;
   bool processStartDxfImport() noexcept;
   bool processStartMeasure() noexcept;
-  bool processGridIntervalChanged(const PositiveLength& inverval) noexcept;
+  bool processGridIntervalChanged(const PositiveLength& interval) noexcept;
 
   // Operator Overloadings
   SymbolEditorState& operator=(const SymbolEditorState& rhs) = delete;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate.h
@@ -131,8 +131,8 @@ public:
   virtual bool processImportDxf() noexcept { return false; }
   virtual bool processAbortCommand() noexcept { return false; }
   virtual bool processGridIntervalChanged(
-      const PositiveLength& inverval) noexcept {
-    Q_UNUSED(inverval);
+      const PositiveLength& interval) noexcept {
+    Q_UNUSED(interval);
     return false;
   }
 

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -588,8 +588,8 @@ bool SymbolEditorState_Select::processAbortCommand() noexcept {
 }
 
 bool SymbolEditorState_Select::processGridIntervalChanged(
-    const PositiveLength& inverval) noexcept {
-  Q_UNUSED(inverval);
+    const PositiveLength& interval) noexcept {
+  Q_UNUSED(interval);
   scheduleUpdateAvailableFeatures();
   return true;
 }

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.h
@@ -100,7 +100,7 @@ public:
   bool processImportDxf() noexcept override;
   bool processAbortCommand() noexcept override;
   bool processGridIntervalChanged(
-      const PositiveLength& inverval) noexcept override;
+      const PositiveLength& interval) noexcept override;
 
   // Operator Overloadings
   SymbolEditorState_Select& operator=(const SymbolEditorState_Select& rhs) =

--- a/libs/librepcb/editor/library/sym/symboltab.h
+++ b/libs/librepcb/editor/library/sym/symboltab.h
@@ -200,7 +200,6 @@ private:
   bool mWizardMode;
   int mCurrentPageIndex;
   Theme::GridStyle mGridStyle;
-  PositiveLength mGridInterval;
   LengthUnit mUnit;
   bool mChooseCategory;
   bool mCompactLayout;

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -1003,6 +1003,7 @@ void MainWindow::openSymbolTab(LibraryEditor& editor, const FilePath& fp,
           sym->setDescriptions(src->getDescriptions());
           sym->setKeywords(src->getKeywords());
           sym->setCategories(src->getCategories());
+          sym->setGridInterval(src->getGridInterval());
           // Copy pins but generate new UUIDs.
           for (const SymbolPin& pin : src->getPins()) {
             sym->getPins().append(std::make_shared<SymbolPin>(
@@ -1070,6 +1071,7 @@ void MainWindow::openPackageTab(LibraryEditor& editor, const FilePath& fp,
           pkg->setKeywords(src->getKeywords());
           pkg->setCategories(src->getCategories());
           pkg->setAssemblyType(src->getAssemblyType(false));
+          pkg->setGridInterval(src->getGridInterval());
           // Copy pads but generate new UUIDs.
           QHash<Uuid, std::optional<Uuid>> padUuidMap;
           for (const PackagePad& pad : src->getPads()) {

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.cpp
@@ -328,6 +328,16 @@ bool SchematicEditorFsm::processGraphicsSceneRightMouseButtonReleased(
   return false;
 }
 
+bool SchematicEditorFsm::processGridIntervalChanged(
+    const PositiveLength& interval) noexcept {
+  if (SchematicEditorState* state = getCurrentStateObj()) {
+    if (state->processGridIntervalChanged(interval)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.h
@@ -127,6 +127,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept;
   bool processGraphicsSceneRightMouseButtonReleased(
       const GraphicsSceneMouseEvent& e) noexcept;
+  bool processGridIntervalChanged(const PositiveLength& interval) noexcept;
 
   // Operator Overloadings
   SchematicEditorFsm& operator=(const SchematicEditorFsm& rhs) = delete;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
@@ -160,6 +160,11 @@ public:
     Q_UNUSED(e);
     return false;
   }
+  virtual bool processGridIntervalChanged(
+      const PositiveLength& interval) noexcept {
+    Q_UNUSED(interval);
+    return false;
+  }
 
   // Operator Overloadings
   SchematicEditorState& operator=(const SchematicEditorState& rhs) = delete;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
@@ -95,9 +95,6 @@ bool SchematicEditorState_Select::entry() noexcept {
       connect(&mContext.undoStack, &UndoStack::stateModified, this,
               &SchematicEditorState_Select::scheduleUpdateAvailableFeatures));
   mConnections.append(
-      connect(&mContext.schematic, &Schematic::gridIntervalChanged, this,
-              &SchematicEditorState_Select::scheduleUpdateAvailableFeatures));
-  mConnections.append(
       connect(qApp->clipboard(), &QClipboard::dataChanged, this,
               &SchematicEditorState_Select::scheduleUpdateAvailableFeatures));
 
@@ -691,6 +688,13 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
 
   // execute the context menu
   menu.exec(QCursor::pos());
+  return true;
+}
+
+bool SchematicEditorState_Select::processGridIntervalChanged(
+    const PositiveLength& interval) noexcept {
+  Q_UNUSED(interval);
+  scheduleUpdateAvailableFeatures();
   return true;
 }
 

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.h
@@ -95,6 +95,8 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
   virtual bool processGraphicsSceneRightMouseButtonReleased(
       const GraphicsSceneMouseEvent& e) noexcept override;
+  virtual bool processGridIntervalChanged(
+      const PositiveLength& interval) noexcept override;
 
   // Operator Overloadings
   SchematicEditorState_Select& operator=(


### PR DESCRIPTION
See ##1366. This PR will store the grid interval from the UI in the symbol & package files so that it is restored the next time you open those elements.

I'm not 100% sure this is a good idea. It does make sense for many cases for sure, but it might also lead to additional "noise" in version control of libraries when the grid interval is changed. However, I think if this happens, we could consider not storing the grid interval automatically on save, but only on request (like a "save grid interval" command). And in very worst case, we could revert this change in file format v3 :see_no_evil: 

Note that in contrast to schematics & boards, the grid *unit* is not stored as it is more a personal preference than a property of the library element.

Closes #1366