### PR TITLE
TransactionalFileSystem: Reject access outside root dir

### DIFF
--- a/libs/librepcb/core/fileio/transactionalfilesystem.h
+++ b/libs/librepcb/core/fileio/transactionalfilesystem.h
@@ -212,6 +212,8 @@ private:  // Methods
   void saveDiff(const QString& type) const;
   void loadDiff(const FilePath& fp);
   void removeDiff(const QString& type);
+  void sanitizePathOrThrow(const QString& cleanedPath) const;
+  bool checkIfPathIsSafe(const QString& cleanedPath) const noexcept;
 
 private:  // Data
   const FilePath mFilePath;


### PR DESCRIPTION
In a few cases, relative file paths are loaded from files to load dynamic content (e.g. projects contain a list of file paths to each schematic file). So those file paths are basically untrusted user input and shall be sanitized. This PR makes `TransactionalFileSystem` validating each access and rejecting access to outside its root directory (e.g. a project directory, library directory etc.) so no files outside the "sandbox" can be accessed, fixing potential attack vectors.