### PR TITLE
Fix detection of cohesive net segments

### DIFF
--- a/libs/librepcb/core/project/board/items/bi_netsegment.h
+++ b/libs/librepcb/core/project/board/items/bi_netsegment.h
@@ -132,10 +132,11 @@ signals:
 private:
   bool checkAttributesValidity() const noexcept;
   bool areAllNetPointsConnectedTogether() const noexcept;
-  void findAllConnectedNetPoints(
-      const BI_NetLineAnchor& p, QSet<const BI_Via*>& vias,
-      QSet<const BI_FootprintPad*>& pads,
-      QSet<const BI_NetPoint*>& points) const noexcept;
+  void findAllConnectedNetPoints(const BI_NetLineAnchor& p,
+                                 QSet<const BI_Via*>& vias,
+                                 QSet<const BI_FootprintPad*>& pads,
+                                 QSet<const BI_NetPoint*>& points,
+                                 QSet<const BI_NetLine*>& lines) const noexcept;
 
   // Attributes
   Uuid mUuid;

--- a/libs/librepcb/core/project/schematic/items/si_netsegment.h
+++ b/libs/librepcb/core/project/schematic/items/si_netsegment.h
@@ -121,9 +121,10 @@ signals:
 private:
   bool checkAttributesValidity() const noexcept;
   bool areAllNetPointsConnectedTogether() const noexcept;
-  void findAllConnectedNetPoints(
-      const SI_NetLineAnchor& p, QSet<const SI_SymbolPin*>& pins,
-      QSet<const SI_NetPoint*>& points) const noexcept;
+  void findAllConnectedNetPoints(const SI_NetLineAnchor& p,
+                                 QSet<const SI_SymbolPin*>& pins,
+                                 QSet<const SI_NetPoint*>& points,
+                                 QSet<const SI_NetLine*>& lines) const noexcept;
 
   // Attributes
   Uuid mUuid;


### PR DESCRIPTION
Net segments (either in schematics or in boards) which consist only of direct lines between pins or pads (i.e. contain no junctions or vias) were considered as valid even if those lines did not touch each other. I.e. this was a bug in the detection of non-cohesive segments.

Theoretically this change breaks loading existing projects if they contain such invalid segments. But generally the editors should have never created such invalid segments, therefore I consider this risk as very low. If anyone experiences this issue, please let me know. I put a "contact us" note into the corresponding error message.