### PR TITLE
Fix non-canonical file format of trace & netline anchors

### DIFF
--- a/libs/librepcb/core/geometry/netline.h
+++ b/libs/librepcb/core/geometry/netline.h
@@ -80,6 +80,7 @@ public:
   bool operator!=(const NetLineAnchor& rhs) const noexcept {
     return !(*this == rhs);
   }
+  bool operator<(const NetLineAnchor& rhs) const noexcept;
   NetLineAnchor& operator=(const NetLineAnchor& rhs) noexcept;
 
   // Static Methods
@@ -104,6 +105,10 @@ private:  // Data
  *
  * The main purpose of this class is to serialize and deserialize schematic
  * net lines.
+ *
+ * @note The order of anchors (P1 & P2) is deterministic (sorted) to ensure a
+ *       canonical file format & behavior. The constructor and #setAnchors()
+ *       will automatically swap the passed anchors if needed.
  */
 class NetLine final {
   Q_DECLARE_TR_FUNCTIONS(NetLine)
@@ -113,8 +118,7 @@ public:
   enum class Event {
     UuidChanged,
     WidthChanged,
-    StartPointChanged,
-    EndPointChanged,
+    AnchorsChanged,
   };
   Signal<NetLine, Event> onEdited;
   typedef Slot<NetLine, Event> OnEditedSlot;
@@ -123,22 +127,21 @@ public:
   NetLine() = delete;
   NetLine(const NetLine& other) noexcept;
   NetLine(const Uuid& uuid, const NetLine& other) noexcept;
-  NetLine(const Uuid& uuid, const UnsignedLength& width,
-          const NetLineAnchor& start, const NetLineAnchor& end) noexcept;
+  NetLine(const Uuid& uuid, const UnsignedLength& width, const NetLineAnchor& a,
+          const NetLineAnchor& b) noexcept;
   explicit NetLine(const SExpression& node);
   ~NetLine() noexcept;
 
   // Getters
   const Uuid& getUuid() const noexcept { return mUuid; }
   const UnsignedLength& getWidth() const noexcept { return mWidth; }
-  const NetLineAnchor& getStartPoint() const noexcept { return mStart; }
-  const NetLineAnchor& getEndPoint() const noexcept { return mEnd; }
+  const NetLineAnchor& getP1() const noexcept { return mP1; }
+  const NetLineAnchor& getP2() const noexcept { return mP2; }
 
   // Setters
   bool setUuid(const Uuid& uuid) noexcept;
   bool setWidth(const UnsignedLength& width) noexcept;
-  bool setStartPoint(const NetLineAnchor& start) noexcept;
-  bool setEndPoint(const NetLineAnchor& end) noexcept;
+  bool setAnchors(NetLineAnchor a, NetLineAnchor b) noexcept;
 
   // General Methods
 
@@ -154,11 +157,15 @@ public:
   bool operator!=(const NetLine& rhs) const noexcept { return !(*this == rhs); }
   NetLine& operator=(const NetLine& rhs) noexcept;
 
+private:  // Methods
+  static void normalizeAnchors(NetLineAnchor& start,
+                               NetLineAnchor& end) noexcept;
+
 private:  // Data
   Uuid mUuid;
   UnsignedLength mWidth;
-  NetLineAnchor mStart;
-  NetLineAnchor mEnd;
+  NetLineAnchor mP1;
+  NetLineAnchor mP2;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/geometry/trace.h
+++ b/libs/librepcb/core/geometry/trace.h
@@ -83,6 +83,7 @@ public:
   bool operator!=(const TraceAnchor& rhs) const noexcept {
     return !(*this == rhs);
   }
+  bool operator<(const TraceAnchor& rhs) const noexcept;
   TraceAnchor& operator=(const TraceAnchor& rhs) noexcept;
 
   // Static Methods
@@ -109,6 +110,10 @@ private:  // Data
  * @brief The Trace class represents a trace within a board
  *
  * The main purpose of this class is to serialize and deserialize traces.
+ *
+ * @note The order of anchors (P1 & P2) is deterministic (sorted) to ensure a
+ *       canonical file format & behavior. The constructor and #setAnchors()
+ *       will automatically swap the passed anchors if needed.
  */
 class Trace final {
   Q_DECLARE_TR_FUNCTIONS(Trace)
@@ -119,8 +124,7 @@ public:
     UuidChanged,
     LayerChanged,
     WidthChanged,
-    StartPointChanged,
-    EndPointChanged,
+    AnchorsChanged,
   };
   Signal<Trace, Event> onEdited;
   typedef Slot<Trace, Event> OnEditedSlot;
@@ -130,7 +134,7 @@ public:
   Trace(const Trace& other) noexcept;
   Trace(const Uuid& uuid, const Trace& other) noexcept;
   Trace(const Uuid& uuid, const Layer& layer, const PositiveLength& width,
-        const TraceAnchor& start, const TraceAnchor& end) noexcept;
+        const TraceAnchor& a, const TraceAnchor& b) noexcept;
   explicit Trace(const SExpression& node);
   ~Trace() noexcept;
 
@@ -138,15 +142,14 @@ public:
   const Uuid& getUuid() const noexcept { return mUuid; }
   const Layer& getLayer() const noexcept { return *mLayer; }
   const PositiveLength& getWidth() const noexcept { return mWidth; }
-  const TraceAnchor& getStartPoint() const noexcept { return mStart; }
-  const TraceAnchor& getEndPoint() const noexcept { return mEnd; }
+  const TraceAnchor& getP1() const noexcept { return mP1; }
+  const TraceAnchor& getP2() const noexcept { return mP2; }
 
   // Setters
   bool setUuid(const Uuid& uuid) noexcept;
   bool setLayer(const Layer& layer) noexcept;
   bool setWidth(const PositiveLength& width) noexcept;
-  bool setStartPoint(const TraceAnchor& start) noexcept;
-  bool setEndPoint(const TraceAnchor& end) noexcept;
+  bool setAnchors(TraceAnchor a, TraceAnchor b) noexcept;
 
   // General Methods
 
@@ -162,12 +165,15 @@ public:
   bool operator!=(const Trace& rhs) const noexcept { return !(*this == rhs); }
   Trace& operator=(const Trace& rhs) noexcept;
 
+private:  // Methods
+  static void normalizeAnchors(TraceAnchor& start, TraceAnchor& end) noexcept;
+
 private:  // Data
   Uuid mUuid;
   const Layer* mLayer;
   PositiveLength mWidth;
-  TraceAnchor mStart;
-  TraceAnchor mEnd;
+  TraceAnchor mP1;
+  TraceAnchor mP2;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -257,8 +257,8 @@ std::shared_ptr<SceneData3D> Board::buildScene3D(
     }
     foreach (const BI_NetLine* netLine, netSegment->getNetLines()) {
       data->addStroke(netLine->getLayer(),
-                      {Path({Vertex(netLine->getStartPoint().getPosition()),
-                             Vertex(netLine->getEndPoint().getPosition())})},
+                      {Path({Vertex(netLine->getP1().getPosition()),
+                             Vertex(netLine->getP2().getPosition())})},
                       *netLine->getWidth(), Transform());
     }
   }
@@ -781,12 +781,12 @@ void Board::copyFrom(const Board& other) {
     // Copy netlines.
     QList<BI_NetLine*> netLines;
     foreach (const BI_NetLine* netLine, netSegment->getNetLines()) {
-      BI_NetLineAnchor* start = anchorsMap.value(&netLine->getStartPoint());
-      Q_ASSERT(start);
-      BI_NetLineAnchor* end = anchorsMap.value(&netLine->getEndPoint());
-      Q_ASSERT(end);
+      BI_NetLineAnchor* p1 = anchorsMap.value(&netLine->getP1());
+      Q_ASSERT(p1);
+      BI_NetLineAnchor* p2 = anchorsMap.value(&netLine->getP2());
+      Q_ASSERT(p2);
       BI_NetLine* netLineCopy =
-          new BI_NetLine(*copy, Uuid::createRandom(), *start, *end,
+          new BI_NetLine(*copy, Uuid::createRandom(), *p1, *p2,
                          netLine->getLayer(), netLine->getWidth());
       netLines.append(netLineCopy);
     }

--- a/libs/librepcb/core/project/board/boardairwiresbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardairwiresbuilder.cpp
@@ -115,10 +115,10 @@ QVector<std::pair<const BI_NetLineAnchor*, const BI_NetLineAnchor*>>
     }
     foreach (const BI_NetLine* netline, netsegment->getNetLines()) {
       Q_ASSERT(netline);
-      Q_ASSERT(anchorMap.contains(&netline->getStartPoint()));
-      Q_ASSERT(anchorMap.contains(&netline->getEndPoint()));
-      builder.addEdge(anchorMap[&netline->getStartPoint()],
-                      anchorMap[&netline->getEndPoint()]);
+      Q_ASSERT(anchorMap.contains(&netline->getP1()));
+      Q_ASSERT(anchorMap.contains(&netline->getP2()));
+      builder.addEdge(anchorMap[&netline->getP1()],
+                      anchorMap[&netline->getP2()]);
     }
   }
 

--- a/libs/librepcb/core/project/board/boardgerberexport.cpp
+++ b/libs/librepcb/core/project/board/boardgerberexport.cpp
@@ -703,11 +703,10 @@ void BoardGerberExport::drawLayerExceptDevices(GerberGenerator& gen,
     foreach (const BI_NetLine* netline, netsegment->getNetLines()) {
       Q_ASSERT(netline);
       if (netline->getLayer() == layer) {
-        gen.drawLine(netline->getStartPoint().getPosition(),
-                     netline->getEndPoint().getPosition(),
-                     positiveToUnsigned(netline->getWidth()),
-                     GerberAttribute::ApertureFunction::Conductor, net,
-                     QString());
+        gen.drawLine(
+            netline->getP1().getPosition(), netline->getP2().getPosition(),
+            positiveToUnsigned(netline->getWidth()),
+            GerberAttribute::ApertureFunction::Conductor, net, QString());
       }
     }
   }

--- a/libs/librepcb/core/project/board/boardinteractivehtmlbomgenerator.cpp
+++ b/libs/librepcb/core/project/board/boardinteractivehtmlbomgenerator.cpp
@@ -172,9 +172,8 @@ std::shared_ptr<InteractiveHtmlBom> BoardInteractiveHtmlBomGenerator::generate(
         net ? std::make_optional(*net->getName()) : std::nullopt;
     for (const auto nl : seg->getNetLines()) {
       if (layerMap.contains(&nl->getLayer())) {
-        ibom->addTrack(
-            layerMap[&nl->getLayer()], nl->getStartPoint().getPosition(),
-            nl->getEndPoint().getPosition(), nl->getWidth(), netName);
+        ibom->addTrack(layerMap[&nl->getLayer()], nl->getP1().getPosition(),
+                       nl->getP2().getPosition(), nl->getWidth(), netName);
       }
     }
     for (const auto via : seg->getVias()) {

--- a/libs/librepcb/core/project/board/boardnetsegmentsplitter.cpp
+++ b/libs/librepcb/core/project/board/boardnetsegmentsplitter.cpp
@@ -67,8 +67,8 @@ void BoardNetSegmentSplitter::addVia(const Via& via,
 
 void BoardNetSegmentSplitter::addTrace(const Trace& trace) noexcept {
   std::shared_ptr<Trace> copy = std::make_shared<Trace>(trace);
-  copy->setStartPoint(replaceAnchor(copy->getStartPoint(), copy->getLayer()));
-  copy->setEndPoint(replaceAnchor(copy->getEndPoint(), copy->getLayer()));
+  copy->setAnchors(replaceAnchor(copy->getP1(), copy->getLayer()),
+                   replaceAnchor(copy->getP2(), copy->getLayer()));
   mTraces.append(copy);
 }
 
@@ -83,8 +83,8 @@ QList<BoardNetSegmentSplitter::Segment>
   QList<std::shared_ptr<Trace>> availableTraces = mTraces.values();
   while (!availableTraces.isEmpty()) {
     Segment segment;
-    findConnectedLinesAndPoints(availableTraces.first()->getStartPoint(),
-                                availableVias, availableTraces, segment);
+    findConnectedLinesAndPoints(availableTraces.first()->getP1(), availableVias,
+                                availableTraces, segment);
     segments.append(segment);
   }
   Q_ASSERT(availableTraces.isEmpty());
@@ -141,15 +141,14 @@ void BoardNetSegmentSplitter::findConnectedLinesAndPoints(
   }
   for (int i = 0; i < mTraces.count(); ++i) {
     std::shared_ptr<Trace> trace = mTraces.value(i);
-    if (((trace->getStartPoint() == anchor) ||
-         (trace->getEndPoint() == anchor)) &&
+    if (((trace->getP1() == anchor) || (trace->getP2() == anchor)) &&
         availableTraces.contains(trace) &&
         (!segment.traces.contains(trace.get()))) {
       segment.traces.append(trace);
       availableTraces.removeOne(trace);
-      findConnectedLinesAndPoints(trace->getStartPoint(), availableVias,
+      findConnectedLinesAndPoints(trace->getP1(), availableVias,
                                   availableTraces, segment);
-      findConnectedLinesAndPoints(trace->getEndPoint(), availableVias,
+      findConnectedLinesAndPoints(trace->getP2(), availableVias,
                                   availableTraces, segment);
     }
   }

--- a/libs/librepcb/core/project/board/boardpainter.cpp
+++ b/libs/librepcb/core/project/board/boardpainter.cpp
@@ -124,9 +124,9 @@ BoardPainter::BoardPainter(const Board& board)
           via->getStopMaskDiameterTop(), via->getStopMaskDiameterBottom()});
     }
     for (const BI_NetLine* netline : segment->getNetLines()) {
-      mTraces.append(
-          Trace{&netline->getLayer(), netline->getStartPoint().getPosition(),
-                netline->getEndPoint().getPosition(), netline->getWidth()});
+      mTraces.append(Trace{&netline->getLayer(), netline->getP1().getPosition(),
+                           netline->getP2().getPosition(),
+                           netline->getWidth()});
     }
   }
 }

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -268,10 +268,9 @@ std::shared_ptr<BoardPlaneFragmentsBuilder::JobData>
     }
     for (const BI_NetLine* netline : segment->getNetLines()) {
       if (layers.contains(&netline->getLayer())) {
-        data->traces.append(TraceData{&netline->getLayer(), netSignalUuid,
-                                      netline->getStartPoint().getPosition(),
-                                      netline->getEndPoint().getPosition(),
-                                      netline->getWidth()});
+        data->traces.append(TraceData{
+            &netline->getLayer(), netSignalUuid, netline->getP1().getPosition(),
+            netline->getP2().getPosition(), netline->getWidth()});
       }
     }
   }

--- a/libs/librepcb/core/project/board/boardspecctraexport.cpp
+++ b/libs/librepcb/core/project/board/boardspecctraexport.cpp
@@ -521,11 +521,11 @@ std::unique_ptr<SExpression> BoardSpecctraExport::genWiring() const {
     for (const auto& trace : segment->getNetLines()) {
       root->ensureLineBreak();
       auto& wireNode = root->appendList("wire");
-      wireNode.appendChild(toPath(
-          trace->getLayer().getId(), positiveToUnsigned(trace->getWidth()),
-          Path::line(trace->getStartPoint().getPosition(),
-                     trace->getEndPoint().getPosition()),
-          false));
+      wireNode.appendChild(toPath(trace->getLayer().getId(),
+                                  positiveToUnsigned(trace->getWidth()),
+                                  Path::line(trace->getP1().getPosition(),
+                                             trace->getP2().getPosition()),
+                                  false));
       wireNode.appendChild("net", getNetName(*segment));
       wireNode.appendChild("type", SExpression::createToken("route"));
     }

--- a/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
+++ b/libs/librepcb/core/project/board/drc/boardclipperpathgenerator.cpp
@@ -264,8 +264,8 @@ void BoardClipperPathGenerator::addTrace(const Data::Trace& trace,
                                          const Length& offset) {
   const Length width = trace.width + (offset * 2);
   if (width > 0) {
-    const Path sceneOutline = Path::obround(
-        trace.startPosition, trace.endPosition, PositiveLength(width));
+    const Path sceneOutline =
+        Path::obround(trace.p1, trace.p2, PositiveLength(width));
     ClipperHelpers::unite(
         mPaths, {ClipperHelpers::convert(sceneOutline, mMaxArcTolerance)},
         ClipperLib::pftEvenOdd, ClipperLib::pftEvenOdd);

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -1622,8 +1622,7 @@ RuleCheckMessageList BoardDesignRuleCheck::checkZones(const Data& data) {
       // Check traces.
       for (const Data::Trace& trace : ns.traces) {
         if (noCopperLayers.contains(trace.layer)) {
-          const Path area = Path::obround(trace.startPosition,
-                                          trace.endPosition, trace.width);
+          const Path area = Path::obround(trace.p1, trace.p2, trace.width);
           const QPainterPath areaPx = area.toQPainterPathPx();
           if (zoneAreaPx.intersects(areaPx)) {
             messages.append(std::make_shared<DrcMsgCopperInKeepoutZone>(
@@ -2390,7 +2389,7 @@ bool BoardDesignRuleCheck::isViaUseless(const Data& data,
 
 QVector<Path> BoardDesignRuleCheck::getTraceLocation(
     const Data::Trace& trace) noexcept {
-  return {Path::obround(trace.startPosition, trace.endPosition, trace.width)};
+  return {Path::obround(trace.p1, trace.p2, trace.width)};
 }
 
 QVector<Path> BoardDesignRuleCheck::getHoleLocation(

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.cpp
@@ -83,8 +83,8 @@ BoardDesignRuleCheckData::BoardDesignRuleCheckData(
                                     np->getNetLines().count()});
     }
     foreach (const BI_NetLine* nl, ns->getNetLines()) {
-      nsd.traces.append(Trace{nl->getUuid(), nl->getStartPoint().getPosition(),
-                              nl->getEndPoint().getPosition(), nl->getWidth(),
+      nsd.traces.append(Trace{nl->getUuid(), nl->getP1().getPosition(),
+                              nl->getP2().getPosition(), nl->getWidth(),
                               &nl->getLayer()});
     }
     foreach (const BI_Via* biVia, ns->getVias()) {

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckdata.h
@@ -53,8 +53,8 @@ struct BoardDesignRuleCheckData final {
   };
   struct Trace {
     Uuid uuid;
-    Point startPosition;
-    Point endPosition;
+    Point p1;
+    Point p2;
     PositiveLength width;
     const Layer* layer;
   };

--- a/libs/librepcb/core/project/board/items/bi_netline.h
+++ b/libs/librepcb/core/project/board/items/bi_netline.h
@@ -85,9 +85,9 @@ public:
   // Constructors / Destructor
   BI_NetLine() = delete;
   BI_NetLine(const BI_NetLine& other) = delete;
-  BI_NetLine(BI_NetSegment& segment, const Uuid& uuid,
-             BI_NetLineAnchor& startPoint, BI_NetLineAnchor& endPoint,
-             const Layer& layer, const PositiveLength& width);
+  BI_NetLine(BI_NetSegment& segment, const Uuid& uuid, BI_NetLineAnchor& a,
+             BI_NetLineAnchor& b, const Layer& layer,
+             const PositiveLength& width);
   ~BI_NetLine() noexcept;
 
   // Getters
@@ -96,8 +96,8 @@ public:
   const Uuid& getUuid() const noexcept { return mTrace.getUuid(); }
   const Layer& getLayer() const noexcept { return mTrace.getLayer(); }
   const PositiveLength& getWidth() const noexcept { return mTrace.getWidth(); }
-  BI_NetLineAnchor& getStartPoint() const noexcept { return *mStartPoint; }
-  BI_NetLineAnchor& getEndPoint() const noexcept { return *mEndPoint; }
+  BI_NetLineAnchor& getP1() const noexcept { return *mP1; }
+  BI_NetLineAnchor& getP2() const noexcept { return *mP2; }
   BI_NetLineAnchor* getOtherPoint(
       const BI_NetLineAnchor& firstPoint) const noexcept;
   Path getSceneOutline(const Length& expansion = Length(0)) const noexcept;
@@ -124,8 +124,8 @@ private:
   QMetaObject::Connection mNetSignalNameChangedConnection;
 
   // References
-  BI_NetLineAnchor* mStartPoint;
-  BI_NetLineAnchor* mEndPoint;
+  BI_NetLineAnchor* mP1;
+  BI_NetLineAnchor* mP2;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/board/items/bi_netsegment.cpp
+++ b/libs/librepcb/core/project/board/items/bi_netsegment.cpp
@@ -347,7 +347,7 @@ bool BI_NetSegment::areAllNetPointsConnectedTogether() const noexcept {
   } else if (mNetPoints.count() > 0) {
     p = mNetPoints.first();
   } else if (mNetLines.count() > 0) {
-    p = &mNetLines.first()->getStartPoint();
+    p = &mNetLines.first()->getP1();
   } else {
     return true;  // Empty net segment is considered as valid.
   }
@@ -370,16 +370,13 @@ void BI_NetSegment::findAllConnectedNetPoints(
     if (vias.contains(via)) return;
     vias.insert(via);
     foreach (const BI_NetLine* netline, mNetLines) {
-      if (&netline->getStartPoint() == via) {
-        findAllConnectedNetPoints(netline->getEndPoint(), vias, pads, points,
-                                  lines);
+      if (&netline->getP1() == via) {
+        findAllConnectedNetPoints(netline->getP2(), vias, pads, points, lines);
       }
-      if (&netline->getEndPoint() == via) {
-        findAllConnectedNetPoints(netline->getStartPoint(), vias, pads, points,
-                                  lines);
+      if (&netline->getP2() == via) {
+        findAllConnectedNetPoints(netline->getP1(), vias, pads, points, lines);
       }
-      if ((&netline->getStartPoint() == via) ||
-          (&netline->getEndPoint() == via)) {
+      if ((&netline->getP1() == via) || (&netline->getP2() == via)) {
         lines.insert(netline);
       }
     }
@@ -388,16 +385,13 @@ void BI_NetSegment::findAllConnectedNetPoints(
     if (pads.contains(pad)) return;
     pads.insert(pad);
     foreach (const BI_NetLine* netline, mNetLines) {
-      if (&netline->getStartPoint() == pad) {
-        findAllConnectedNetPoints(netline->getEndPoint(), vias, pads, points,
-                                  lines);
+      if (&netline->getP1() == pad) {
+        findAllConnectedNetPoints(netline->getP2(), vias, pads, points, lines);
       }
-      if (&netline->getEndPoint() == pad) {
-        findAllConnectedNetPoints(netline->getStartPoint(), vias, pads, points,
-                                  lines);
+      if (&netline->getP2() == pad) {
+        findAllConnectedNetPoints(netline->getP1(), vias, pads, points, lines);
       }
-      if ((&netline->getStartPoint() == pad) ||
-          (&netline->getEndPoint() == pad)) {
+      if ((&netline->getP1() == pad) || (&netline->getP2() == pad)) {
         lines.insert(netline);
       }
     }
@@ -405,16 +399,13 @@ void BI_NetSegment::findAllConnectedNetPoints(
     if (points.contains(np)) return;
     points.insert(np);
     foreach (const BI_NetLine* netline, mNetLines) {
-      if (&netline->getStartPoint() == np) {
-        findAllConnectedNetPoints(netline->getEndPoint(), vias, pads, points,
-                                  lines);
+      if (&netline->getP1() == np) {
+        findAllConnectedNetPoints(netline->getP2(), vias, pads, points, lines);
       }
-      if (&netline->getEndPoint() == np) {
-        findAllConnectedNetPoints(netline->getStartPoint(), vias, pads, points,
-                                  lines);
+      if (&netline->getP2() == np) {
+        findAllConnectedNetPoints(netline->getP1(), vias, pads, points, lines);
       }
-      if ((&netline->getStartPoint() == np) ||
-          (&netline->getEndPoint() == np)) {
+      if ((&netline->getP1() == np) || (&netline->getP2() == np)) {
         lines.insert(netline);
       }
     }

--- a/libs/librepcb/core/project/erc/electricalrulecheck.cpp
+++ b/libs/librepcb/core/project/erc/electricalrulecheck.cpp
@@ -178,8 +178,7 @@ void ElectricalRuleCheck::checkNetSegments(const Schematic& schematic,
     if (netSegment->getNetLabels().isEmpty() &&
         (!mOpenNetSignals.contains(&netSegment->getNetSignal()))) {
       foreach (const SI_NetLine* netLine, netSegment->getNetLines()) {
-        if (netLine->getStartPoint().isOpen() ||
-            netLine->getEndPoint().isOpen()) {
+        if (netLine->getP1().isOpen() || netLine->getP2().isOpen()) {
           msgs.append(
               std::make_shared<ErcMsgOpenWireInSegment>(*netSegment, *netLine));
           break;

--- a/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
@@ -88,8 +88,8 @@ void ErcMsgBase::setLocation(const SI_SymbolPin& pin) noexcept {
 
 bool ErcMsgBase::setLocation(const SI_NetSegment& segment) noexcept {
   for (const SI_NetLine* nl : segment.getNetLines()) {
-    mLocations.append(Path::obround(nl->getStartPoint().getPosition(),
-                                    nl->getEndPoint().getPosition(),
+    mLocations.append(Path::obround(nl->getP1().getPosition(),
+                                    nl->getP2().getPosition(),
                                     PositiveLength(nl->getWidth() + 1)));
   }
   if (!segment.getNetLines().isEmpty()) {
@@ -107,8 +107,8 @@ void ErcMsgBase::setLocation(const SI_NetPoint& netPoint) noexcept {
 
 void ErcMsgBase::setLocation(const SI_NetLine& netLine) noexcept {
   mSchematic = netLine.getSchematic().getUuid();
-  mLocations.append(Path::obround(netLine.getStartPoint().getPosition(),
-                                  netLine.getEndPoint().getPosition(),
+  mLocations.append(Path::obround(netLine.getP1().getPosition(),
+                                  netLine.getP2().getPosition(),
                                   PositiveLength(netLine.getWidth() + 1)));
 }
 

--- a/libs/librepcb/core/project/schematic/items/si_netline.h
+++ b/libs/librepcb/core/project/schematic/items/si_netline.h
@@ -77,9 +77,8 @@ public:
   // Constructors / Destructor
   SI_NetLine() = delete;
   SI_NetLine(const SI_NetLine& other) = delete;
-  SI_NetLine(SI_NetSegment& segment, const Uuid& uuid,
-             SI_NetLineAnchor& startPoint, SI_NetLineAnchor& endPoint,
-             const UnsignedLength& width);
+  SI_NetLine(SI_NetSegment& segment, const Uuid& uuid, SI_NetLineAnchor& a,
+             SI_NetLineAnchor& b, const UnsignedLength& width);
   ~SI_NetLine() noexcept;
 
   // Getters
@@ -89,8 +88,8 @@ public:
   const UnsignedLength& getWidth() const noexcept {
     return mNetLine.getWidth();
   }
-  SI_NetLineAnchor& getStartPoint() const noexcept { return *mStartPoint; }
-  SI_NetLineAnchor& getEndPoint() const noexcept { return *mEndPoint; }
+  SI_NetLineAnchor& getP1() const noexcept { return *mP1; }
+  SI_NetLineAnchor& getP2() const noexcept { return *mP2; }
   SI_NetLineAnchor* getOtherPoint(
       const SI_NetLineAnchor& firstPoint) const noexcept;
   NetSignal& getNetSignalOfNetSegment() const noexcept;
@@ -111,8 +110,8 @@ private:  // Data
   NetLine mNetLine;
 
   // References
-  SI_NetLineAnchor* mStartPoint;
-  SI_NetLineAnchor* mEndPoint;
+  SI_NetLineAnchor* mP1;
+  SI_NetLineAnchor* mP2;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
@@ -73,8 +73,8 @@ bool SI_NetSegment::isUsed() const noexcept {
 QSet<QString> SI_NetSegment::getForcedNetNames() const noexcept {
   QSet<QString> names;
   foreach (SI_NetLine* netline, mNetLines) {
-    SI_SymbolPin* pin1 = dynamic_cast<SI_SymbolPin*>(&netline->getStartPoint());
-    SI_SymbolPin* pin2 = dynamic_cast<SI_SymbolPin*>(&netline->getEndPoint());
+    SI_SymbolPin* pin1 = dynamic_cast<SI_SymbolPin*>(&netline->getP1());
+    SI_SymbolPin* pin2 = dynamic_cast<SI_SymbolPin*>(&netline->getP2());
     ComponentSignalInstance* sig1 =
         pin1 ? pin1->getComponentSignalInstance() : nullptr;
     ComponentSignalInstance* sig2 =
@@ -102,8 +102,8 @@ Point SI_NetSegment::calcNearestPoint(const Point& p) const noexcept {
   for (auto it = mNetLines.begin(); it != mNetLines.end(); it++) {
     Point lp;
     UnsignedLength ld = Toolbox::shortestDistanceBetweenPointAndLine(
-        p, it.value()->getStartPoint().getPosition(),
-        it.value()->getEndPoint().getPosition(), &lp);
+        p, it.value()->getP1().getPosition(), it.value()->getP2().getPosition(),
+        &lp);
     if ((it == mNetLines.begin()) || (ld < dist)) {
       dist = *ld;
       pos = lp;
@@ -116,8 +116,8 @@ QSet<SI_SymbolPin*> SI_NetSegment::getAllConnectedPins() const noexcept {
   Q_ASSERT(isAddedToSchematic());
   QSet<SI_SymbolPin*> pins;
   foreach (const SI_NetLine* netline, mNetLines) {
-    SI_SymbolPin* p1 = dynamic_cast<SI_SymbolPin*>(&netline->getStartPoint());
-    SI_SymbolPin* p2 = dynamic_cast<SI_SymbolPin*>(&netline->getEndPoint());
+    SI_SymbolPin* p1 = dynamic_cast<SI_SymbolPin*>(&netline->getP1());
+    SI_SymbolPin* p2 = dynamic_cast<SI_SymbolPin*>(&netline->getP2());
     if (p1) {
       pins.insert(p1);
       Q_ASSERT(p1->getCompSigInstNetSignal() == mNetSignal);
@@ -391,7 +391,7 @@ bool SI_NetSegment::areAllNetPointsConnectedTogether() const noexcept {
   if (mNetPoints.count() > 0) {
     p = mNetPoints.first();
   } else if (mNetLines.count() > 0) {
-    p = &mNetLines.first()->getStartPoint();
+    p = &mNetLines.first()->getP1();
   } else {
     return true;  // Empty net segment is considered as valid.
   }
@@ -412,15 +412,13 @@ void SI_NetSegment::findAllConnectedNetPoints(
     if (pins.contains(pin)) return;
     pins.insert(pin);
     foreach (const SI_NetLine* netline, mNetLines) {
-      if (&netline->getStartPoint() == pin) {
-        findAllConnectedNetPoints(netline->getEndPoint(), pins, points, lines);
+      if (&netline->getP1() == pin) {
+        findAllConnectedNetPoints(netline->getP2(), pins, points, lines);
       }
-      if (&netline->getEndPoint() == pin) {
-        findAllConnectedNetPoints(netline->getStartPoint(), pins, points,
-                                  lines);
+      if (&netline->getP2() == pin) {
+        findAllConnectedNetPoints(netline->getP1(), pins, points, lines);
       }
-      if ((&netline->getStartPoint() == pin) ||
-          (&netline->getEndPoint() == pin)) {
+      if ((&netline->getP1() == pin) || (&netline->getP2() == pin)) {
         lines.insert(netline);
       }
     }
@@ -428,15 +426,13 @@ void SI_NetSegment::findAllConnectedNetPoints(
     if (points.contains(np)) return;
     points.insert(np);
     foreach (const SI_NetLine* netline, mNetLines) {
-      if (&netline->getStartPoint() == np) {
-        findAllConnectedNetPoints(netline->getEndPoint(), pins, points, lines);
+      if (&netline->getP1() == np) {
+        findAllConnectedNetPoints(netline->getP2(), pins, points, lines);
       }
-      if (&netline->getEndPoint() == np) {
-        findAllConnectedNetPoints(netline->getStartPoint(), pins, points,
-                                  lines);
+      if (&netline->getP2() == np) {
+        findAllConnectedNetPoints(netline->getP1(), pins, points, lines);
       }
-      if ((&netline->getStartPoint() == np) ||
-          (&netline->getEndPoint() == np)) {
+      if ((&netline->getP1() == np) || (&netline->getP2() == np)) {
         lines.insert(netline);
       }
     }

--- a/libs/librepcb/core/project/schematic/schematicpainter.cpp
+++ b/libs/librepcb/core/project/schematic/schematicpainter.cpp
@@ -162,8 +162,8 @@ SchematicPainter::SchematicPainter(const Schematic& schematic,
       }
     }
     for (const SI_NetLine* netline : segment->getNetLines()) {
-      mNetLines.append(Line{netline->getStartPoint().getPosition(),
-                            netline->getEndPoint().getPosition(),
+      mNetLines.append(Line{netline->getP1().getPosition(),
+                            netline->getP2().getPosition(),
                             netline->getWidth()});
     }
   }

--- a/libs/librepcb/eagleimport/eagleprojectimport.cpp
+++ b/libs/librepcb/eagleimport/eagleprojectimport.cpp
@@ -1134,11 +1134,11 @@ void EagleProjectImport::importBoard(Project& project,
                            .arg(eagleWire.getLayer()));
           continue;
         }
-        const TraceAnchor startAnchor =
+        const TraceAnchor p1 =
             getOrCreateAnchor(*layer, C::convertPoint(eagleWire.getP1()));
-        const TraceAnchor endAnchor =
+        const TraceAnchor p2 =
             getOrCreateAnchor(*layer, C::convertPoint(eagleWire.getP2()));
-        if (startAnchor == endAnchor) {
+        if (p1 == p2) {
           log.info("Attaching a trace to a pad removed a short trace segment.");
           continue;
         }
@@ -1155,10 +1155,9 @@ void EagleProjectImport::importBoard(Project& project,
           log.critical(
               tr("Curved trace is not supported, converting to straight."));
         }
-        splitter.addTrace(
-            Trace(Uuid::createRandom(), *layer,
-                  PositiveLength(C::convertLength(eagleWire.getWidth())),
-                  startAnchor, endAnchor));
+        splitter.addTrace(Trace(
+            Uuid::createRandom(), *layer,
+            PositiveLength(C::convertLength(eagleWire.getWidth())), p1, p2));
       }
 
       // Determine segments and add them to the board.
@@ -1199,10 +1198,9 @@ void EagleProjectImport::importBoard(Project& project,
           netPoints.append(np);
         }
         for (const Trace& trace : segment.traces) {
-          netLines.append(new BI_NetLine(*netSegment, trace.getUuid(),
-                                         *getAnchor(trace.getStartPoint()),
-                                         *getAnchor(trace.getEndPoint()),
-                                         trace.getLayer(), trace.getWidth()));
+          netLines.append(new BI_NetLine(
+              *netSegment, trace.getUuid(), *getAnchor(trace.getP1()),
+              *getAnchor(trace.getP2()), trace.getLayer(), trace.getWidth()));
         }
         netSegment->addElements(vias, netPoints, netLines);
       }

--- a/libs/librepcb/eagleimport/eagleprojectimport.cpp
+++ b/libs/librepcb/eagleimport/eagleprojectimport.cpp
@@ -660,8 +660,8 @@ void EagleProjectImport::importSchematic(Project& project,
         }
         for (const NetLine& line : segment.netlines) {
           netLines.append(new SI_NetLine(
-              *netSegment, line.getUuid(), *getAnchor(line.getStartPoint()),
-              *getAnchor(line.getEndPoint()), line.getWidth()));
+              *netSegment, line.getUuid(), *getAnchor(line.getP1()),
+              *getAnchor(line.getP2()), line.getWidth()));
         }
         netSegment->addNetPointsAndNetLines(netPoints, netLines);
         for (const NetLabel& label : segment.netlabels) {

--- a/libs/librepcb/editor/project/board/boardselectionquery.cpp
+++ b/libs/librepcb/editor/project/board/boardselectionquery.cpp
@@ -197,8 +197,8 @@ void BoardSelectionQuery::addSelectedHoles() noexcept {
 void BoardSelectionQuery::addNetPointsOfNetLines(
     bool onlyIfAllNetLinesSelected) noexcept {
   foreach (BI_NetLine* netline, mResultNetLines) {
-    BI_NetPoint* p1 = dynamic_cast<BI_NetPoint*>(&netline->getStartPoint());
-    BI_NetPoint* p2 = dynamic_cast<BI_NetPoint*>(&netline->getEndPoint());
+    BI_NetPoint* p1 = dynamic_cast<BI_NetPoint*>(&netline->getP1());
+    BI_NetPoint* p2 = dynamic_cast<BI_NetPoint*>(&netline->getP2());
     if (p1 &&
         ((!onlyIfAllNetLinesSelected) ||
          (mResultNetLines.contains(p1->getNetLines())))) {

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate.cpp
@@ -320,12 +320,12 @@ QList<std::shared_ptr<QGraphicsItem>> BoardEditorState::findItemsAtPos(
           netsignals.contains(it.key()->getNetSegment().getNetSignal())) {
         const Layer& layer = it.key()->getLayer();
         if ((!cuLayer) || (*cuLayer == layer)) {
-          processItem(it.value(), it.value(),
-                      Toolbox::nearestPointOnLine(
-                          pos.mappedToGrid(getGridInterval()),
-                          it.key()->getStartPoint().getPosition(),
-                          it.key()->getEndPoint().getPosition()),
-                      20 + priorityFromLayer(layer), false);
+          processItem(
+              it.value(), it.value(),
+              Toolbox::nearestPointOnLine(pos.mappedToGrid(getGridInterval()),
+                                          it.key()->getP1().getPosition(),
+                                          it.key()->getP2().getPosition()),
+              20 + priorityFromLayer(layer), false);
         }
       }
     }

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_addvia.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_addvia.cpp
@@ -288,9 +288,9 @@ bool BoardEditorState_AddVia::fixPosition(const Point& pos) noexcept {
     // Split net lines.
     foreach (BI_NetLine* netline, otherNetLines) {
       if (!otherNetPoints.contains(
-              dynamic_cast<BI_NetPoint*>(&netline->getStartPoint())) &&
+              dynamic_cast<BI_NetPoint*>(&netline->getP1())) &&
           !otherNetPoints.contains(
-              dynamic_cast<BI_NetPoint*>(&netline->getEndPoint()))) {
+              dynamic_cast<BI_NetPoint*>(&netline->getP2()))) {
         // TODO(5n8ke) is this the best way to check whtether the NetLine
         // should be split?
         std::unique_ptr<CmdBoardSplitNetLine> cmdSplit(

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawtrace.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawtrace.cpp
@@ -426,8 +426,8 @@ bool BoardEditorState_DrawTrace::startPositioning(
       layer = &netline->getNetLine().getLayer();
       // get closest point on the netline
       Point posOnNetline = Toolbox::nearestPointOnLine(
-          posOnGrid, netline->getNetLine().getStartPoint().getPosition(),
-          netline->getNetLine().getEndPoint().getPosition());
+          posOnGrid, netline->getNetLine().getP1().getPosition(),
+          netline->getNetLine().getP2().getPosition());
       std::unique_ptr<CmdBoardSplitNetLine> cmdSplit(
           new CmdBoardSplitNetLine(netline->getNetLine(), posOnNetline));
       mFixedStartAnchor = cmdSplit->getSplitPoint();
@@ -556,8 +556,8 @@ bool BoardEditorState_DrawTrace::addNextNetPoint(
     }
     foreach (auto item, items) {
       if (auto netLine = std::dynamic_pointer_cast<BGI_NetLine>(item)) {
-        if (otherAnchors.contains(&netLine->getNetLine().getStartPoint()) ||
-            otherAnchors.contains(&netLine->getNetLine().getEndPoint())) {
+        if (otherAnchors.contains(&netLine->getNetLine().getP1()) ||
+            otherAnchors.contains(&netLine->getNetLine().getP2())) {
           continue;
         }
         // TODO(5n8ke): does snapping need to be handled?
@@ -743,8 +743,8 @@ void BoardEditorState_DrawTrace::updateNetpointPositions() noexcept {
     } else if (auto netline = std::dynamic_pointer_cast<BGI_NetLine>(item)) {
       // Get closest point on the netline.
       mTargetPos = Toolbox::nearestPointOnLine(
-          mTargetPos, netline->getNetLine().getStartPoint().getPosition(),
-          netline->getNetLine().getEndPoint().getPosition());
+          mTargetPos, netline->getNetLine().getP1().getPosition(),
+          netline->getNetLine().getP2().getPosition());
     }
   }
 

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
@@ -1779,7 +1779,7 @@ void BoardEditorState_Select::measureLengthInDirection(
     const BI_NetLine& netline, QSet<Uuid>& visitedNetLines,
     UnsignedLength& totalLength) {
   const BI_NetLineAnchor* currentAnchor =
-      directionBackwards ? &netline.getStartPoint() : &netline.getEndPoint();
+      directionBackwards ? &netline.getP1() : &netline.getP2();
 
   for (;;) {
     const BI_NetLine* nextNetline = nullptr;

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.cpp
@@ -144,15 +144,15 @@ void BGI_NetLine::layerEdited(const GraphicsLayer& layer,
 
 void BGI_NetLine::updateLine() noexcept {
   prepareGeometryChange();
-  mLineF.setP1(mNetLine.getStartPoint().getPosition().toPxQPointF());
-  mLineF.setP2(mNetLine.getEndPoint().getPosition().toPxQPointF());
+  mLineF.setP1(mNetLine.getP1().getPosition().toPxQPointF());
+  mLineF.setP2(mNetLine.getP2().getPosition().toPxQPointF());
   mBoundingRect = QRectF(mLineF.p1(), mLineF.p2()).normalized();
   mBoundingRect.adjust(
       -mNetLine.getWidth()->toPx() / 2, -mNetLine.getWidth()->toPx() / 2,
       mNetLine.getWidth()->toPx() / 2, mNetLine.getWidth()->toPx() / 2);
   mShape = QPainterPath();
-  mShape.moveTo(mNetLine.getStartPoint().getPosition().toPxQPointF());
-  mShape.lineTo(mNetLine.getEndPoint().getPosition().toPxQPointF());
+  mShape.moveTo(mNetLine.getP1().getPosition().toPxQPointF());
+  mShape.lineTo(mNetLine.getP2().getPosition().toPxQPointF());
   mShape = Toolbox::shapeFromPath(mShape, QPen(Qt::SolidPattern, 0), QBrush(),
                                   positiveToUnsigned(mNetLine.getWidth()));
   update();

--- a/libs/librepcb/editor/project/cmd/cmdboardnetsegmentaddelements.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardnetsegmentaddelements.cpp
@@ -77,11 +77,11 @@ BI_NetLine* CmdBoardNetSegmentAddElements::addNetLine(BI_NetLine& netline) {
 }
 
 BI_NetLine* CmdBoardNetSegmentAddElements::addNetLine(
-    BI_NetLineAnchor& startPoint, BI_NetLineAnchor& endPoint,
-    const Layer& layer, const PositiveLength& width) {
-  BI_NetLine* netline = new BI_NetLine(mNetSegment, Uuid::createRandom(),
-                                       startPoint, endPoint, layer,
-                                       width);  // can throw
+    BI_NetLineAnchor& a, BI_NetLineAnchor& b, const Layer& layer,
+    const PositiveLength& width) {
+  BI_NetLine* netline =
+      new BI_NetLine(mNetSegment, Uuid::createRandom(), a, b, layer,
+                     width);  // can throw
   return addNetLine(*netline);
 }
 

--- a/libs/librepcb/editor/project/cmd/cmdboardnetsegmentaddelements.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardnetsegmentaddelements.h
@@ -62,9 +62,8 @@ public:
   BI_NetPoint* addNetPoint(BI_NetPoint& netpoint);
   BI_NetPoint* addNetPoint(const Point& position);
   BI_NetLine* addNetLine(BI_NetLine& netline);
-  BI_NetLine* addNetLine(BI_NetLineAnchor& startPoint,
-                         BI_NetLineAnchor& endPoint, const Layer& layer,
-                         const PositiveLength& width);
+  BI_NetLine* addNetLine(BI_NetLineAnchor& a, BI_NetLineAnchor& b,
+                         const Layer& layer, const PositiveLength& width);
 
 private:
   // Private Methods

--- a/libs/librepcb/editor/project/cmd/cmdboardsplitnetline.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardsplitnetline.cpp
@@ -56,10 +56,10 @@ bool CmdBoardSplitNetLine::performExecute() {
   std::unique_ptr<CmdBoardNetSegmentAddElements> cmdAdd(
       new CmdBoardNetSegmentAddElements(mOldNetLine.getNetSegment()));
   cmdAdd->addNetPoint(*mSplitPoint);
-  cmdAdd->addNetLine(*mSplitPoint, mOldNetLine.getStartPoint(),
-                     mOldNetLine.getLayer(), mOldNetLine.getWidth());
-  cmdAdd->addNetLine(*mSplitPoint, mOldNetLine.getEndPoint(),
-                     mOldNetLine.getLayer(), mOldNetLine.getWidth());
+  cmdAdd->addNetLine(*mSplitPoint, mOldNetLine.getP1(), mOldNetLine.getLayer(),
+                     mOldNetLine.getWidth());
+  cmdAdd->addNetLine(*mSplitPoint, mOldNetLine.getP2(), mOldNetLine.getLayer(),
+                     mOldNetLine.getWidth());
   std::unique_ptr<CmdBoardNetSegmentRemoveElements> cmdRemove(
       new CmdBoardNetSegmentRemoveElements(mOldNetLine.getNetSegment()));
   cmdRemove->removeNetLine(mOldNetLine);

--- a/libs/librepcb/editor/project/cmd/cmdcombineboardnetsegments.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdcombineboardnetsegments.cpp
@@ -93,14 +93,14 @@ bool CmdCombineBoardNetSegments::performExecute() {
     }
   }
   foreach (BI_NetLine* netline, mOldSegment.getNetLines()) {
-    BI_NetLineAnchor* startPoint =
-        anchorMap.value(&netline->getStartPoint(), &netline->getStartPoint());
-    Q_ASSERT(startPoint);
-    BI_NetLineAnchor* endPoint =
-        anchorMap.value(&netline->getEndPoint(), &netline->getEndPoint());
-    Q_ASSERT(endPoint);
-    BI_NetLine* newNetLine = cmdAdd->addNetLine(
-        *startPoint, *endPoint, netline->getLayer(), netline->getWidth());
+    BI_NetLineAnchor* p1 =
+        anchorMap.value(&netline->getP1(), &netline->getP1());
+    Q_ASSERT(p1);
+    BI_NetLineAnchor* p2 =
+        anchorMap.value(&netline->getP2(), &netline->getP2());
+    Q_ASSERT(p2);
+    BI_NetLine* newNetLine =
+        cmdAdd->addNetLine(*p1, *p2, netline->getLayer(), netline->getWidth());
     Q_ASSERT(newNetLine);
   }
   execNewChildCmd(new CmdBoardNetSegmentRemove(mOldSegment));  // can throw

--- a/libs/librepcb/editor/project/cmd/cmdcombineschematicnetsegments.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdcombineschematicnetsegments.cpp
@@ -88,13 +88,13 @@ bool CmdCombineSchematicNetSegments::performExecute() {
     }
   }
   foreach (SI_NetLine* netline, mOldSegment.getNetLines()) {
-    SI_NetLineAnchor* startPoint =
-        anchorMap.value(&netline->getStartPoint(), &netline->getStartPoint());
-    Q_ASSERT(startPoint);
-    SI_NetLineAnchor* endPoint =
-        anchorMap.value(&netline->getEndPoint(), &netline->getEndPoint());
-    Q_ASSERT(endPoint);
-    SI_NetLine* newNetLine = cmdAdd->addNetLine(*startPoint, *endPoint);
+    SI_NetLineAnchor* p1 =
+        anchorMap.value(&netline->getP1(), &netline->getP1());
+    Q_ASSERT(p1);
+    SI_NetLineAnchor* p2 =
+        anchorMap.value(&netline->getP2(), &netline->getP2());
+    Q_ASSERT(p2);
+    SI_NetLine* newNetLine = cmdAdd->addNetLine(*p1, *p2);
     Q_ASSERT(newNetLine);
   }
   execNewChildCmd(new CmdSchematicNetSegmentRemove(mOldSegment));  // can throw

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
@@ -114,8 +114,8 @@ CmdDragSelectedBoardItems::CmdDragSelectedBoardItems(
   }
   foreach (BI_NetLine* netline, query.getNetLines()) {
     Q_ASSERT(netline);
-    mCenterPos += netline->getStartPoint().getPosition();
-    mCenterPos += netline->getEndPoint().getPosition();
+    mCenterPos += netline->getP1().getPosition();
+    mCenterPos += netline->getP2().getPosition();
     mItemCount += 2;
     CmdBoardNetLineEdit* cmd = new CmdBoardNetLineEdit(*netline);
     mNetLineEditCmds.append(cmd);

--- a/libs/librepcb/editor/project/cmd/cmdflipselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdflipselectedboarditems.cpp
@@ -107,8 +107,8 @@ bool CmdFlipSelectedBoardItems::performExecute() {
     ++count;
   }
   foreach (BI_NetLine* netline, query.getNetLines()) {
-    center += netline->getStartPoint().getPosition();
-    center += netline->getEndPoint().getPosition();
+    center += netline->getP1().getPosition();
+    center += netline->getP2().getPosition();
     count += 2;
   }
   foreach (BI_NetPoint* netpoint, query.getNetPoints()) {

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -219,37 +219,34 @@ bool CmdPasteBoardItems::performExecute() {
         netPointMap.insert(junction.getUuid(), netpoint);
       }
       for (const Trace& trace : segment.traces) {
-        BI_NetLineAnchor* start = nullptr;
-        if (std::optional<Uuid> anchor =
-                trace.getStartPoint().tryGetJunction()) {
-          start = netPointMap[*anchor];
-        } else if (std::optional<Uuid> anchor =
-                       trace.getStartPoint().tryGetVia()) {
-          start = viaMap[*anchor];
+        BI_NetLineAnchor* p1 = nullptr;
+        if (std::optional<Uuid> anchor = trace.getP1().tryGetJunction()) {
+          p1 = netPointMap[*anchor];
+        } else if (std::optional<Uuid> anchor = trace.getP1().tryGetVia()) {
+          p1 = viaMap[*anchor];
         } else if (std::optional<TraceAnchor::PadAnchor> anchor =
-                       trace.getStartPoint().tryGetPad()) {
+                       trace.getP1().tryGetPad()) {
           Q_ASSERT(pastedDevices.contains(anchor->device));
           BI_Device* device =
               mBoard.getDeviceInstanceByComponentUuid(anchor->device);
-          start = device ? device->getPad(anchor->pad) : nullptr;
+          p1 = device ? device->getPad(anchor->pad) : nullptr;
         }
-        BI_NetLineAnchor* end = nullptr;
-        if (std::optional<Uuid> anchor = trace.getEndPoint().tryGetJunction()) {
-          end = netPointMap[*anchor];
-        } else if (std::optional<Uuid> anchor =
-                       trace.getEndPoint().tryGetVia()) {
-          end = viaMap[*anchor];
+        BI_NetLineAnchor* p2 = nullptr;
+        if (std::optional<Uuid> anchor = trace.getP2().tryGetJunction()) {
+          p2 = netPointMap[*anchor];
+        } else if (std::optional<Uuid> anchor = trace.getP2().tryGetVia()) {
+          p2 = viaMap[*anchor];
         } else if (std::optional<TraceAnchor::PadAnchor> anchor =
-                       trace.getEndPoint().tryGetPad()) {
+                       trace.getP2().tryGetPad()) {
           Q_ASSERT(pastedDevices.contains(anchor->device));
           BI_Device* device =
               mBoard.getDeviceInstanceByComponentUuid(anchor->device);
-          end = device ? device->getPad(anchor->pad) : nullptr;
+          p2 = device ? device->getPad(anchor->pad) : nullptr;
         }
-        if ((!start) || (!end)) {
+        if ((!p1) || (!p2)) {
           throw LogicError(__FILE__, __LINE__);
         }
-        cmdAddElements->addNetLine(*start, *end, trace.getLayer(),
+        cmdAddElements->addNetLine(*p1, *p2, trace.getLayer(),
                                    trace.getWidth());
       }
       execNewChildCmd(cmdAddElements.release());

--- a/libs/librepcb/editor/project/cmd/cmdpasteschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteschematicitems.cpp
@@ -263,18 +263,18 @@ bool CmdPasteSchematicItems::performExecute() {
       netPointMap.insert(junction.getUuid(), netpoint);
     }
     for (const NetLine& nl : seg.lines) {
-      SI_NetLineAnchor* start = nullptr;
-      if (std::optional<Uuid> anchor = nl.getStartPoint().tryGetJunction()) {
-        start = netPointMap[*anchor];
-        Q_ASSERT(start);
+      SI_NetLineAnchor* p1 = nullptr;
+      if (std::optional<Uuid> anchor = nl.getP1().tryGetJunction()) {
+        p1 = netPointMap[*anchor];
+        Q_ASSERT(p1);
       } else if (std::optional<NetLineAnchor::PinAnchor> anchor =
-                     nl.getStartPoint().tryGetPin()) {
+                     nl.getP1().tryGetPin()) {
         SI_Symbol* symbol = mSchematic.getSymbols().value(
             symbolMap.value(anchor->symbol, Uuid::createRandom()));
         Q_ASSERT(symbol);
         SI_SymbolPin* pin = symbol->getPin(anchor->pin);
         Q_ASSERT(pin);
-        start = pin;
+        p1 = pin;
         ComponentSignalInstance* sigInst = pin->getComponentSignalInstance();
         if (sigInst && (sigInst->getNetSignal() != netSignal)) {
           execNewChildCmd(new CmdCompSigInstSetNetSignal(*sigInst, netSignal));
@@ -285,18 +285,18 @@ bool CmdPasteSchematicItems::performExecute() {
       } else {
         throw LogicError(__FILE__, __LINE__);
       }
-      SI_NetLineAnchor* end = nullptr;
-      if (std::optional<Uuid> anchor = nl.getEndPoint().tryGetJunction()) {
-        end = netPointMap[*anchor];
-        Q_ASSERT(end);
+      SI_NetLineAnchor* p2 = nullptr;
+      if (std::optional<Uuid> anchor = nl.getP2().tryGetJunction()) {
+        p2 = netPointMap[*anchor];
+        Q_ASSERT(p2);
       } else if (std::optional<NetLineAnchor::PinAnchor> anchor =
-                     nl.getEndPoint().tryGetPin()) {
+                     nl.getP2().tryGetPin()) {
         SI_Symbol* symbol = mSchematic.getSymbols().value(
             symbolMap.value(anchor->symbol, Uuid::createRandom()));
         Q_ASSERT(symbol);
         SI_SymbolPin* pin = symbol->getPin(anchor->pin);
         Q_ASSERT(pin);
-        end = pin;
+        p2 = pin;
         ComponentSignalInstance* sigInst = pin->getComponentSignalInstance();
         if (sigInst && (sigInst->getNetSignal() != netSignal)) {
           execNewChildCmd(new CmdCompSigInstSetNetSignal(*sigInst, netSignal));
@@ -307,7 +307,7 @@ bool CmdPasteSchematicItems::performExecute() {
       } else {
         throw LogicError(__FILE__, __LINE__);
       }
-      cmdAddElements->addNetLine(*start, *end);
+      cmdAddElements->addNetLine(*p1, *p2);
     }
     execNewChildCmd(cmdAddElements.release());
 

--- a/libs/librepcb/editor/project/cmd/cmdremoveboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveboarditems.cpp
@@ -219,34 +219,33 @@ void CmdRemoveBoardItems::removeNetSegmentItems(
       junctionMap.insert(junction.getUuid(), newNetPoint);
     }
     for (const Trace& trace : segment.traces) {
-      BI_NetLineAnchor* start = nullptr;
-      if (std::optional<Uuid> anchor = trace.getStartPoint().tryGetJunction()) {
-        start = junctionMap[*anchor];
-      } else if (std::optional<Uuid> anchor =
-                     trace.getStartPoint().tryGetVia()) {
-        start = viaMap[*anchor];
+      BI_NetLineAnchor* p1 = nullptr;
+      if (std::optional<Uuid> anchor = trace.getP1().tryGetJunction()) {
+        p1 = junctionMap[*anchor];
+      } else if (std::optional<Uuid> anchor = trace.getP1().tryGetVia()) {
+        p1 = viaMap[*anchor];
       } else if (std::optional<TraceAnchor::PadAnchor> anchor =
-                     trace.getStartPoint().tryGetPad()) {
+                     trace.getP1().tryGetPad()) {
         BI_Device* device =
             mBoard.getDeviceInstanceByComponentUuid(anchor->device);
-        start = device ? device->getPad(anchor->pad) : nullptr;
+        p1 = device ? device->getPad(anchor->pad) : nullptr;
       }
-      BI_NetLineAnchor* end = nullptr;
-      if (std::optional<Uuid> anchor = trace.getEndPoint().tryGetJunction()) {
-        end = junctionMap[*anchor];
-      } else if (std::optional<Uuid> anchor = trace.getEndPoint().tryGetVia()) {
-        end = viaMap[*anchor];
+      BI_NetLineAnchor* p2 = nullptr;
+      if (std::optional<Uuid> anchor = trace.getP2().tryGetJunction()) {
+        p2 = junctionMap[*anchor];
+      } else if (std::optional<Uuid> anchor = trace.getP2().tryGetVia()) {
+        p2 = viaMap[*anchor];
       } else if (std::optional<TraceAnchor::PadAnchor> anchor =
-                     trace.getEndPoint().tryGetPad()) {
+                     trace.getP2().tryGetPad()) {
         BI_Device* device =
             mBoard.getDeviceInstanceByComponentUuid(anchor->device);
-        end = device ? device->getPad(anchor->pad) : nullptr;
+        p2 = device ? device->getPad(anchor->pad) : nullptr;
       }
-      if ((!start) || (!end)) {
+      if ((!p1) || (!p2)) {
         throw LogicError(__FILE__, __LINE__);
       }
       BI_NetLine* newNetLine = cmdAddElements->addNetLine(
-          *start, *end, trace.getLayer(), trace.getWidth());
+          *p1, *p2, trace.getLayer(), trace.getWidth());
       Q_ASSERT(newNetLine);
     }
     execNewChildCmd(cmdAddElements);  // can throw

--- a/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
@@ -231,29 +231,28 @@ void CmdRemoveSelectedSchematicItems::removeNetSegmentItems(
       junctionMap.insert(junction.getUuid(), newNetPoint);
     }
     for (const NetLine& netline : segment.netlines) {
-      SI_NetLineAnchor* start = nullptr;
-      if (std::optional<Uuid> anchor =
-              netline.getStartPoint().tryGetJunction()) {
-        start = junctionMap[*anchor];
+      SI_NetLineAnchor* p1 = nullptr;
+      if (std::optional<Uuid> anchor = netline.getP1().tryGetJunction()) {
+        p1 = junctionMap[*anchor];
       } else if (std::optional<NetLineAnchor::PinAnchor> anchor =
-                     netline.getStartPoint().tryGetPin()) {
+                     netline.getP1().tryGetPin()) {
         SI_Symbol* symbol =
             mScene.getSchematic().getSymbols().value(anchor->symbol);
-        start = symbol ? symbol->getPin(anchor->pin) : nullptr;
+        p1 = symbol ? symbol->getPin(anchor->pin) : nullptr;
       }
-      SI_NetLineAnchor* end = nullptr;
-      if (std::optional<Uuid> anchor = netline.getEndPoint().tryGetJunction()) {
-        end = junctionMap[*anchor];
+      SI_NetLineAnchor* p2 = nullptr;
+      if (std::optional<Uuid> anchor = netline.getP2().tryGetJunction()) {
+        p2 = junctionMap[*anchor];
       } else if (std::optional<NetLineAnchor::PinAnchor> anchor =
-                     netline.getEndPoint().tryGetPin()) {
+                     netline.getP2().tryGetPin()) {
         SI_Symbol* symbol =
             mScene.getSchematic().getSymbols().value(anchor->symbol);
-        end = symbol ? symbol->getPin(anchor->pin) : nullptr;
+        p2 = symbol ? symbol->getPin(anchor->pin) : nullptr;
       }
-      if ((!start) || (!end)) {
+      if ((!p1) || (!p2)) {
         throw LogicError(__FILE__, __LINE__);
       }
-      SI_NetLine* newNetLine = cmdAddElements->addNetLine(*start, *end);
+      SI_NetLine* newNetLine = cmdAddElements->addNetLine(*p1, *p2);
       Q_ASSERT(newNetLine);
     }
     execNewChildCmd(cmdAddElements);  // can throw

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetsegmentaddelements.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetsegmentaddelements.cpp
@@ -69,11 +69,10 @@ SI_NetLine* CmdSchematicNetSegmentAddElements::addNetLine(SI_NetLine& netline) {
   return &netline;
 }
 
-SI_NetLine* CmdSchematicNetSegmentAddElements::addNetLine(
-    SI_NetLineAnchor& startPoint, SI_NetLineAnchor& endPoint) {
-  SI_NetLine* netline =
-      new SI_NetLine(mNetSegment, Uuid::createRandom(), startPoint, endPoint,
-                     UnsignedLength(158750));  // can throw
+SI_NetLine* CmdSchematicNetSegmentAddElements::addNetLine(SI_NetLineAnchor& a,
+                                                          SI_NetLineAnchor& b) {
+  SI_NetLine* netline = new SI_NetLine(mNetSegment, Uuid::createRandom(), a, b,
+                                       UnsignedLength(158750));  // can throw
   return addNetLine(*netline);
 }
 

--- a/libs/librepcb/editor/project/cmd/cmdschematicnetsegmentaddelements.h
+++ b/libs/librepcb/editor/project/cmd/cmdschematicnetsegmentaddelements.h
@@ -58,8 +58,7 @@ public:
   SI_NetPoint* addNetPoint(SI_NetPoint& netpoint);
   SI_NetPoint* addNetPoint(const Point& position);
   SI_NetLine* addNetLine(SI_NetLine& netline);
-  SI_NetLine* addNetLine(SI_NetLineAnchor& startPoint,
-                         SI_NetLineAnchor& endPoint);
+  SI_NetLine* addNetLine(SI_NetLineAnchor& a, SI_NetLineAnchor& b);
 
 private:
   // Private Methods

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.cpp
@@ -236,8 +236,8 @@ QList<std::shared_ptr<QGraphicsItem>> SchematicEditorState::findItemsAtPos(
       processItem(
           it.value(), it.value(),
           Toolbox::nearestPointOnLine(pos.mappedToGrid(getGridInterval()),
-                                      it.key()->getStartPoint().getPosition(),
-                                      it.key()->getEndPoint().getPosition()),
+                                      it.key()->getP1().getPosition(),
+                                      it.key()->getP2().getPosition()),
           20, true, std::nullopt);  // Large grab area, better usability!
     }
   }

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_netline.cpp
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_netline.cpp
@@ -115,15 +115,15 @@ void SGI_NetLine::netLineEdited(const SI_NetLine& obj,
 
 void SGI_NetLine::updatePositions() noexcept {
   prepareGeometryChange();
-  mLineF.setP1(mNetLine.getStartPoint().getPosition().toPxQPointF());
-  mLineF.setP2(mNetLine.getEndPoint().getPosition().toPxQPointF());
+  mLineF.setP1(mNetLine.getP1().getPosition().toPxQPointF());
+  mLineF.setP2(mNetLine.getP2().getPosition().toPxQPointF());
   mBoundingRect = QRectF(mLineF.p1(), mLineF.p2()).normalized();
   mBoundingRect.adjust(
       -mNetLine.getWidth()->toPx() / 2, -mNetLine.getWidth()->toPx() / 2,
       mNetLine.getWidth()->toPx() / 2, mNetLine.getWidth()->toPx() / 2);
   mShape = QPainterPath();
-  mShape.moveTo(mNetLine.getStartPoint().getPosition().toPxQPointF());
-  mShape.lineTo(mNetLine.getEndPoint().getPosition().toPxQPointF());
+  mShape.moveTo(mNetLine.getP1().getPosition().toPxQPointF());
+  mShape.lineTo(mNetLine.getP2().getPosition().toPxQPointF());
   mShape = Toolbox::shapeFromPath(mShape, QPen(Qt::SolidPattern, 0), QBrush(),
                                   mNetLine.getWidth());
   update();

--- a/libs/librepcb/editor/project/schematic/schematicselectionquery.cpp
+++ b/libs/librepcb/editor/project/schematic/schematicselectionquery.cpp
@@ -167,8 +167,8 @@ void SchematicSelectionQuery::addSelectedImages() noexcept {
 void SchematicSelectionQuery::addNetPointsOfNetLines(
     bool onlyIfAllNetLinesSelected) noexcept {
   foreach (SI_NetLine* netline, mResultNetLines) {
-    SI_NetPoint* p1 = dynamic_cast<SI_NetPoint*>(&netline->getStartPoint());
-    SI_NetPoint* p2 = dynamic_cast<SI_NetPoint*>(&netline->getEndPoint());
+    SI_NetPoint* p1 = dynamic_cast<SI_NetPoint*>(&netline->getP1());
+    SI_NetPoint* p2 = dynamic_cast<SI_NetPoint*>(&netline->getP2());
     if (p1 &&
         ((!onlyIfAllNetLinesSelected) ||
          (mResultNetLines.contains(p1->getNetLines())))) {

--- a/tests/unittests/core/geometry/tracetest.cpp
+++ b/tests/unittests/core/geometry/tracetest.cpp
@@ -41,12 +41,58 @@ class TraceTest : public ::testing::Test {};
  *  Test Methods
  ******************************************************************************/
 
+TEST_F(TraceTest, testAnchorLessThan) {
+  // The comparison operator is relevant for the file format.
+  const QVector<TraceAnchor> input = {
+      TraceAnchor::junction(
+          Uuid::fromString("5bed2074-1b02-4db5-9b0e-293c42d8728f")),
+      TraceAnchor::pad(
+          Uuid::fromString("d14141ff-651f-40f0-87be-b4f86831375a"),
+          Uuid::fromString("65ab6c75-b264-4fed-b445-d3d98c956008")),
+      TraceAnchor::via(
+          Uuid::fromString("c893f5a0-3fec-498b-99d6-467d5d69825d")),
+      TraceAnchor::pad(
+          Uuid::fromString("94ca7c55-bf86-43e0-8399-d713ce1f1929"),
+          Uuid::fromString("65ab6c75-b264-4fed-b445-d3d98c956008")),
+      TraceAnchor::junction(
+          Uuid::fromString("0d8f2ef9-34f4-4400-a313-f17cdcdfe924")),
+      TraceAnchor::via(
+          Uuid::fromString("1e80206f-158b-48e6-9cb4-6e368af7b7d7")),
+      TraceAnchor::pad(
+          Uuid::fromString("94ca7c55-bf86-43e0-8399-d713ce1f1929"),
+          Uuid::fromString("04bb6ac3-34d7-4fb3-b274-44f845f8d3b5")),
+  };
+  const QVector<TraceAnchor> expected = {
+      TraceAnchor::pad(
+          Uuid::fromString("94ca7c55-bf86-43e0-8399-d713ce1f1929"),
+          Uuid::fromString("04bb6ac3-34d7-4fb3-b274-44f845f8d3b5")),
+      TraceAnchor::pad(
+          Uuid::fromString("94ca7c55-bf86-43e0-8399-d713ce1f1929"),
+          Uuid::fromString("65ab6c75-b264-4fed-b445-d3d98c956008")),
+      TraceAnchor::pad(
+          Uuid::fromString("d14141ff-651f-40f0-87be-b4f86831375a"),
+          Uuid::fromString("65ab6c75-b264-4fed-b445-d3d98c956008")),
+      TraceAnchor::via(
+          Uuid::fromString("1e80206f-158b-48e6-9cb4-6e368af7b7d7")),
+      TraceAnchor::via(
+          Uuid::fromString("c893f5a0-3fec-498b-99d6-467d5d69825d")),
+      TraceAnchor::junction(
+          Uuid::fromString("0d8f2ef9-34f4-4400-a313-f17cdcdfe924")),
+      TraceAnchor::junction(
+          Uuid::fromString("5bed2074-1b02-4db5-9b0e-293c42d8728f")),
+  };
+
+  QVector<TraceAnchor> actual = input;
+  std::sort(actual.begin(), actual.end());
+  EXPECT_EQ(expected, actual);
+}
+
 TEST_F(TraceTest, testConstructFromSExpression) {
   std::unique_ptr<SExpression> sexpr = SExpression::parse(
       "(trace c893f5a0-3fec-498b-99d6-467d5d69825d (layer bot_cu) (width 0.5) "
-      "(from (device 0d8f2ef9-34f4-4400-a313-f17cdcdfe924) "
-      "(pad 65ab6c75-b264-4fed-b445-d3d98c956008)) "
-      "(to (via 1e80206f-158b-48e6-9cb4-6e368af7b7d7)))",
+      "(from (via 1e80206f-158b-48e6-9cb4-6e368af7b7d7)) "
+      "(to (device 0d8f2ef9-34f4-4400-a313-f17cdcdfe924) "
+      "(pad 65ab6c75-b264-4fed-b445-d3d98c956008)))",
       FilePath());
   Trace obj(*sexpr);
   EXPECT_EQ(Uuid::fromString("c893f5a0-3fec-498b-99d6-467d5d69825d"),
@@ -56,10 +102,10 @@ TEST_F(TraceTest, testConstructFromSExpression) {
   EXPECT_EQ(TraceAnchor::pad(
                 Uuid::fromString("0d8f2ef9-34f4-4400-a313-f17cdcdfe924"),
                 Uuid::fromString("65ab6c75-b264-4fed-b445-d3d98c956008")),
-            obj.getStartPoint());
+            obj.getP1());
   EXPECT_EQ(TraceAnchor::via(
                 Uuid::fromString("1e80206f-158b-48e6-9cb4-6e368af7b7d7")),
-            obj.getEndPoint());
+            obj.getP2());
 }
 
 TEST_F(TraceTest, testSerializeAndDeserialize) {


### PR DESCRIPTION
No functional change, just fix an ambiguity in the file format of boards & schematics by sorting any trace & netline anchors (swapping start- & end position of lines) since the direction of lines (A->B vs. B->A) is not relevant for LibrePCB. This also makes data exports (e.g. Gerber) more deterministic.