### PR TITLE
Board editor: Automatically simplify net segments

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -75,6 +75,8 @@ add_library(
   3d/stepexport.h
   algorithm/airwiresbuilder.cpp
   algorithm/airwiresbuilder.h
+  algorithm/netsegmentsimplifier.cpp
+  algorithm/netsegmentsimplifier.h
   application.cpp
   application.h
   attribute/attribute.cpp

--- a/libs/librepcb/core/algorithm/netsegmentsimplifier.cpp
+++ b/libs/librepcb/core/algorithm/netsegmentsimplifier.cpp
@@ -1,0 +1,407 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "netsegmentsimplifier.h"
+
+#include "../types/layer.h"
+#include "../utils/toolbox.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+NetSegmentSimplifier::NetSegmentSimplifier() noexcept
+  : mNextFreeLineId(0), mModified(false) {
+}
+
+NetSegmentSimplifier::~NetSegmentSimplifier() noexcept {
+}
+
+/*******************************************************************************
+ *  Public Methods
+ ******************************************************************************/
+
+int NetSegmentSimplifier::addAnchor(AnchorType type, const Point& pos,
+                                    const Layer* start,
+                                    const Layer* end) noexcept {
+  const int id = mAnchors.count();
+  mAnchors.append(Anchor{id, type, pos, start, end, false});
+  return id;
+}
+
+int NetSegmentSimplifier::addLine(int p1, int p2, const Layer* layer,
+                                  const Length& width) noexcept {
+  Q_ASSERT((p1 >= 0) && (p1 < mAnchors.count()) && (p2 >= 0) &&
+           (p2 < mAnchors.count()));
+
+  const int id = mLines.count();
+  mLines.insert(id, Line{id, p1, p2, layer, width, false});
+  return id;
+}
+
+NetSegmentSimplifier::Result NetSegmentSimplifier::simplify() noexcept {
+  // Clear state.
+  mAnchorMap.clear();
+  mNextFreeLineId = mLines.count();
+  mModified = false;
+
+  // First, group all anchors by position.
+  // Important: Fixed anchors (pads & vias) must appear first, and non-fixed
+  // anchors (junctions) last! Thus we sort the anchors by type.
+  for (const Anchor& anchor : mAnchors) {
+    mAnchorMap[anchor.pos].append(anchor);
+  }
+  for (auto it = mAnchorMap.begin(); it != mAnchorMap.end(); it++) {
+    std::sort(it->begin(), it->end(), [](const Anchor& a, const Anchor& b) {
+      return static_cast<int>(a.type) < static_cast<int>(b.type);
+    });
+  }
+
+  // Add junctions where lines are intersecting each other. Those lines will
+  // then be split in the next step to connect with the new anchors.
+  addJunctionsAtLineIntersections();
+
+  // Split netlines by junctions intersecting them.
+  splitLinesAtAnchors();
+
+  // Replace unnecessary junctions by the first suitable anchor from the
+  // anchors map. Pads and vias will have priority, junctions are only
+  // used if they are not redundant with any pad or via. Redundant junctions
+  // will not be used anymore (they appear multiple times in the anchors map,
+  // but we will use only the first of them).
+  removeDuplicateJunctions();
+
+  // Remove redundant lines. If there are redundant lines with different
+  // widths, keep the thickest of them.
+  removeRedundantLines();
+
+  // Remove unnecessary junctions in the middle of straight lines.
+  // This needs to be done in a loop (trace by trace) until no more lines
+  // can be merged.
+  while (mergeNextLines()) {
+    mModified = true;
+  }
+
+  Result result{mLines.values(), {}, mModified};
+  for (const Anchor& anchor : mAnchors) {
+    if (anchor.isNew) {
+      result.newJunctions.insert(anchor.id, anchor.pos);
+    }
+  }
+  mAnchors.clear();
+  mLines.clear();
+  return result;
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void NetSegmentSimplifier::addJunctionsAtLineIntersections() noexcept {
+  auto intersectsHorizontalVertical = [](const Point& a1, const Point& a2,
+                                         const Point& b1, const Point& b2) {
+    // Line 'a' must be horizontal and line 'b' vertical.
+    const Length ay = a1.getY();
+    const Length ax0 = std::min(a1.getX(), a2.getX());
+    const Length ax1 = std::max(a1.getX(), a2.getX());
+    const Length bx = b1.getX();
+    const Length by0 = std::min(b1.getY(), b2.getY());
+    const Length by1 = std::max(b1.getY(), b2.getY());
+    return (ax0 < bx) && (bx < ax1) && (by0 < ay) && (ay < by1);
+  };
+
+  // For now we only detect orthogonal intersections, not arbitrary-angle
+  // intersections. Maybe it's better anyway to split only those lines?
+  auto getIntersectionPos = [&](const Point& a1, const Point& a2,
+                                const Point& b1, const Point& b2) {
+    if ((a1.getY() == a2.getY()) && (b1.getX() == b2.getX()) &&
+        intersectsHorizontalVertical(a1, a2, b1, b2)) {
+      // Line 'a' is horizontal, line 'b' is vertical.
+      return std::make_optional(Point(b1.getX(), a1.getY()));
+    } else if ((a1.getX() == a2.getX()) && (b1.getY() == b2.getY()) &&
+               intersectsHorizontalVertical(b1, b2, a1, a2)) {
+      // Line 'a' is vertical, line 'b' is horizontal.
+      return std::make_optional(Point(a1.getX(), b1.getY()));
+    } else {
+      return std::optional<Point>();
+    }
+  };
+
+  const QList<Line> lines = mLines.values();
+  for (int i = 0; i < lines.count(); ++i) {
+    const Line& line0 = lines.at(i);
+    const Point a1 = mAnchors.at(line0.p1).pos;
+    const Point a2 = mAnchors.at(line0.p2).pos;
+    for (int k = i + 1; k < lines.count(); ++k) {
+      const Line& line1 = lines.at(k);
+      if (line0.layer != line1.layer) {
+        continue;
+      }
+      const Point b1 = mAnchors.at(line1.p1).pos;
+      const Point b2 = mAnchors.at(line1.p2).pos;
+      if (const std::optional<Point> pos = getIntersectionPos(a1, a2, b1, b2)) {
+        if (!findAnchor(*pos, line0.layer)) {
+          const Anchor anchor{
+              static_cast<int>(mAnchors.count()),  // ID
+              AnchorType::Junction,  // Type
+              *pos,  // Position
+              line0.layer,  // Start layer
+              line0.layer,  // End layer
+              true,  // Is new
+          };
+          mAnchors.append(anchor);
+          mAnchorMap[*pos].append(anchor);
+        }
+      }
+    }
+  }
+}
+
+void NetSegmentSimplifier::splitLinesAtAnchors() noexcept {
+  auto findIntersectingAnchor = [&](const Line& line) {
+    const Point p1 = mAnchors.at(line.p1).pos;
+    const Point p2 = mAnchors.at(line.p2).pos;
+    if (p1 != p2) {
+      for (const Anchor& anchor : mAnchors) {
+        if ((anchor.pos != p1) && (anchor.pos != p2) &&
+            isAnchorOnLayer(anchor, line.layer) &&
+            isStraightLine(p1, anchor.pos, p2)) {
+          return &anchor;
+        }
+      }
+    }
+    return static_cast<const Anchor*>(nullptr);
+  };
+
+  QMap<int, Line> lines = mLines;
+  QSet<int> finishedLineIds;
+  auto splitNextLine = [&]() {
+    for (Line& line : lines) {
+      if (finishedLineIds.contains(line.id)) continue;  // Already processed.
+      if (const Anchor* anchor = findIntersectingAnchor(line)) {
+        // Add new line.
+        lines.insert(mNextFreeLineId,
+                     Line{mNextFreeLineId, anchor->id, line.p2, line.layer,
+                          line.width, true});
+        ++mNextFreeLineId;
+        // Split existing line.
+        line.p2 = anchor->id;
+        line.modified = true;
+        return true;
+      } else {
+        finishedLineIds.insert(line.id);
+      }
+    }
+    return false;
+  };
+
+  // We have to do this iterative because the same line may need to be split
+  // multiple times. This causes some risk that to end up in an endless loop.
+  // To recover from such a situation, we set a maximum number of new lines
+  // allowed to be created and apply the result only if we didn't reach that
+  // limit.
+  const int maxLinesCount = (mLines.count() * 2) + 10;
+  bool modified = false;
+  while (splitNextLine()) {
+    modified = true;
+
+    // Check abort condition to prevent endless loop.
+    if (lines.count() >= maxLinesCount) {
+      qWarning() << "Aborted net segment simplification of initially"
+                 << mLines.count() << "lines after" << lines.count()
+                 << "lines.";
+      return;  // Discard all changes.
+    }
+  }
+
+  // Apply result only on success.
+  if (modified) {
+    mLines = lines;
+    mModified = true;
+  }
+}
+
+void NetSegmentSimplifier::removeDuplicateJunctions() noexcept {
+  auto convertLineAnchor = [&](const Anchor& anchor, const Layer* lineLayer) {
+    if (anchor.type == AnchorType::Junction) {
+      if (const Anchor* existingAnchor = findAnchor(anchor.pos, lineLayer)) {
+        return existingAnchor;
+      }
+    }
+    return &anchor;
+  };
+  for (int i = mLines.count() - 1; i >= 0; --i) {
+    auto& line = mLines[i];
+    auto p1 = convertLineAnchor(mAnchors.at(line.p1), line.layer);
+    auto p2 = convertLineAnchor(mAnchors.at(line.p2), line.layer);
+    if (p1->id == p2->id) {
+      // Start and end anchor of the trace are now the same, which is invalid
+      // and would lead to a zero-length trace anyway, so we just remove it.
+      mLines.remove(i);
+      mModified = true;
+    } else if (QSet<int>{line.p1, line.p2} != QSet<int>{p1->id, p2->id}) {
+      line.p1 = p1->id;
+      line.p2 = p2->id;
+      line.modified = true;
+      mModified = true;
+    }
+  }
+}
+
+void NetSegmentSimplifier::removeRedundantLines() noexcept {
+  auto isDuplicateLine = [&](const Line& line) {
+    for (const Line& other : mLines) {
+      if ((other.id != line.id) && (other.layer == line.layer) &&
+          (other.width >= line.width) &&
+          (QSet<int>{other.p1, other.p2} == QSet<int>{line.p1, line.p2})) {
+        return true;
+      }
+    }
+    return false;
+  };
+  for (int id : mLines.keys()) {
+    if (isDuplicateLine(mLines.value(id))) {
+      mLines.remove(id);
+      mModified = true;
+    }
+  }
+}
+
+bool NetSegmentSimplifier::mergeNextLines() noexcept {
+  // Collect all junctions (no vias and no pads!!!) and their connected traces.
+  QHash<int, QVector<Line*>> junctionLines;
+  auto addLineAnchor = [&](Line& line, const Anchor& anchor) {
+    if (anchor.type == AnchorType::Junction) {
+      junctionLines[anchor.id].append(&line);
+    }
+  };
+  for (Line& line : mLines) {
+    addLineAnchor(line, mAnchors.at(line.p1));
+    addLineAnchor(line, mAnchors.at(line.p2));
+  }
+
+  // Check if a junction is located exactly between two trace anchors, i.e.
+  // can be removed.
+  auto isStraight = [&](int anchor0, int junction, int anchor1) {
+    const Point p0 = mAnchors.at(anchor0).pos;
+    const Point p1 = mAnchors.at(junction).pos;
+    const Point p2 = mAnchors.at(anchor1).pos;
+    if ((p0 == p1) || (p0 == p2) || (p1 == p2)) {
+      // Redundant junctions should have been removed already?!
+      qWarning() << "Unexpected state during net segment simplification.";
+      return false;
+    }
+    return isStraightLine(p0, p1, p2);
+  };
+
+  // Helper to find an existing line between two given anchors.
+  auto findExistingDirectLine = [&](const Layer* layer,
+                                    const QSet<int>& anchors) {
+    for (Line& line : mLines) {
+      if ((line.layer == layer) && (QSet<int>{line.p1, line.p2} == anchors)) {
+        return &line;
+      }
+    }
+    return static_cast<Line*>(nullptr);
+  };
+
+  // Now find the next two traces which can be merged.
+  for (auto it = junctionLines.begin(); it != junctionLines.end(); it++) {
+    if ((it->count() == 2)) {
+      Line& trace0 = *it->at(0);
+      Line& trace1 = *it->at(1);
+      const int junction = it.key();
+      const int anchor0 = (trace0.p1 == junction) ? trace0.p2 : trace0.p1;
+      const int anchor1 = (trace1.p1 == junction) ? trace1.p2 : trace1.p1;
+      if ((trace0.layer == trace1.layer) && (trace0.width == trace1.width) &&
+          isStraight(anchor0, junction, anchor1)) {
+        // Merge these two traces! But check first if such a direct trace
+        // already exists. In that case, just remove the redundant traces
+        // and keep the thicker trace width.
+        if (Line* trace = findExistingDirectLine(trace0.layer,
+                                                 QSet<int>{anchor0, anchor1})) {
+          if (trace->width < trace0.width) {
+            trace->width = trace0.width;
+            trace->modified = true;
+          }
+          mLines.remove(trace0.id);
+          mLines.remove(trace1.id);
+        } else {
+          // Merge two traces.
+          trace0.p1 = anchor0;
+          trace0.p2 = anchor1;
+          trace0.modified = true;
+          mLines.remove(trace1.id);
+        }
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+const NetSegmentSimplifier::Anchor* NetSegmentSimplifier::findAnchor(
+    const Point& pos, const Layer* layer) noexcept {
+  for (const Anchor& anchor : mAnchorMap[pos]) {
+    if (isAnchorOnLayer(anchor, layer)) {
+      return &anchor;
+    }
+  }
+  return nullptr;
+}
+
+bool NetSegmentSimplifier::isAnchorOnLayer(const Anchor& anchor,
+                                           const Layer* layer) noexcept {
+  return (!layer) || (!anchor.startLayer) || (!anchor.endLayer) ||
+      ((layer->getCopperNumber() >= anchor.startLayer->getCopperNumber()) &&
+       (layer->getCopperNumber() <= anchor.endLayer->getCopperNumber()));
+}
+
+bool NetSegmentSimplifier::isStraightLine(const Point& p0, const Point& p1,
+                                          const Point& p2) noexcept {
+  if (p0.getX() == p1.getX()) {
+    return (p2.getX() == p1.getX()) &&
+        ((p0.getY() < p1.getY()) == (p1.getY() < p2.getY()));
+  } else if (p0.getY() == p1.getY()) {
+    return (p2.getY() == p1.getY()) &&
+        ((p0.getX() < p1.getX()) == (p1.getX() < p2.getX()));
+  } else {
+    // Not sure what tolerance we should allow for non-90° lines...
+    const UnsignedLength length = (p2 - p0).getLength();
+    const Length tolerance = std::min(length / 100, Length(50));
+    return Toolbox::shortestDistanceBetweenPointAndLine(p1, p0, p2) < tolerance;
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/algorithm/netsegmentsimplifier.h
+++ b/libs/librepcb/core/algorithm/netsegmentsimplifier.h
@@ -1,0 +1,183 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_NETSEGMENTSIMPLIFIER_H
+#define LIBREPCB_CORE_NETSEGMENTSIMPLIFIER_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "../types/point.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+class Layer;
+
+/*******************************************************************************
+ *  Class NetSegmentSimplifier
+ ******************************************************************************/
+
+/**
+ * @brief Algorithm to clean/simplify net segment lines
+ *
+ * Performed operations:
+ *  - Remove redundant junctions (same position, same layer)
+ *  - Remove redundant lines (same anchors, same layer), keeping the thickest
+ *  - Remove zero-length lines
+ *  - Remove useless junctions within straight line segments (join line
+ *    segments into the same direction to a single line)
+ *  - Split lines to connect with junctions on the path between start and end
+ *    points
+ *  - Split intersecting lines, placing a new junction to connect them (only
+ *    orthogonal intersections for now)
+ */
+class NetSegmentSimplifier final {
+  Q_DECLARE_TR_FUNCTIONS(NetSegmentSimplifier)
+
+public:
+  // Types
+  enum class AnchorType : int {
+    // Value is important for the sort algorithm, do not change!
+    Via = 0,
+    PinOrPad = 1,
+    Junction = 2,
+  };
+  struct Line {
+    int id = 0;
+    int p1 = 0;
+    int p2 = 0;
+    const Layer* layer = nullptr;
+    Length width;
+    bool modified = false;
+  };
+  struct Result {
+    QList<Line> lines;
+    QMap<int, Point> newJunctions;
+    bool modified = false;
+  };
+
+  // Constructors / Destructor
+
+  /**
+   * @brief Default constructor
+   */
+  NetSegmentSimplifier() noexcept;
+
+  /**
+   * @brief Copy constructor
+   *
+   * @param other     Another ::librepcb::NetSegmentSimplifier object
+   */
+  NetSegmentSimplifier(const NetSegmentSimplifier& other) = delete;
+
+  /**
+   * Destructor
+   */
+  ~NetSegmentSimplifier() noexcept;
+
+  /**
+   * @brief Add a line anchor
+   *
+   * @param type     Type of the anchor.
+   * @param pos      Position.
+   * @param start    Start (most upper) layer of the anchors or `nullptr`
+   *                 for schematic netsegment simplifications
+   * @param end      End (most lower) layer of the anchors or `nullptr`
+   *                 for schematic netsegment simplifications
+   *
+   * @return The ID of the added anchors.
+   */
+  int addAnchor(AnchorType type, const Point& pos, const Layer* start,
+                const Layer* end) noexcept;
+
+  /**
+   * @brief Add a line between two anchors
+   *
+   * @param p1      ID of first anchors.
+   * @param p2      ID of second anchors.
+   * @param layer   Layer of the line (`nullptr` for schematic netsegment
+   *                simplification).
+   * @param width   Line width.
+   *
+   * @return The ID of the added line.
+   */
+  int addLine(int p1, int p2, const Layer* layer, const Length& width) noexcept;
+
+  /**
+   * @brief Perform the simplification
+   *
+   * @note  This method also resets the state, so the object can be reused for
+   *        the next net segment.
+   *
+   * @attention When lines are split, new anchor- and line IDs will be
+   *            generated on the fly! So the returned lines may contain IDs
+   *            which you didn't know yet from #addAnchor() and #addLine()!.
+   *
+   * @return   Any remaining lines after the simplification.
+   */
+  Result simplify() noexcept;
+
+  // Operator overloadings
+  NetSegmentSimplifier& operator=(const NetSegmentSimplifier& rhs) = delete;
+
+private:
+  // Types
+  struct Anchor {
+    int id = 0;
+    AnchorType type = AnchorType::Junction;
+    Point pos;
+    const Layer* startLayer = nullptr;
+    const Layer* endLayer = nullptr;
+    bool isNew = false;
+  };
+
+  // Methods
+  void addJunctionsAtLineIntersections() noexcept;
+  void splitLinesAtAnchors() noexcept;
+  void removeDuplicateJunctions() noexcept;
+  void removeRedundantLines() noexcept;
+  bool mergeNextLines() noexcept;
+  const Anchor* findAnchor(const Point& pos, const Layer* layer) noexcept;
+  static bool isAnchorOnLayer(const Anchor& anchor,
+                              const Layer* layer) noexcept;
+  static bool isStraightLine(const Point& p0, const Point& p1,
+                             const Point& p2) noexcept;
+
+  // Data input
+  QList<Anchor> mAnchors;
+  QMap<int, Line> mLines;
+  int mNextFreeLineId;
+
+  // State
+  QHash<Point, QVector<Anchor>> mAnchorMap;
+  bool mModified;
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+#endif

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -671,6 +671,8 @@ add_library(
   project/cmd/cmdschematictextadd.h
   project/cmd/cmdschematictextremove.cpp
   project/cmd/cmdschematictextremove.h
+  project/cmd/cmdsimplifyboardnetsegments.cpp
+  project/cmd/cmdsimplifyboardnetsegments.h
   project/cmd/cmdsymbolinstanceadd.cpp
   project/cmd/cmdsymbolinstanceadd.h
   project/cmd/cmdsymbolinstanceedit.cpp

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawtrace.h
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawtrace.h
@@ -163,9 +163,11 @@ private:
 
   /**
    * @brief Abort or cancel the current drawing of the trace.
+   *
    * @param showErrMsgBox When true, show an error message in a pop-up box.
+   * @param simplifySegment If true, the segment will be simplified afterwards.
    */
-  bool abortPositioning(bool showErrMsgBox) noexcept;
+  bool abortPositioning(bool showErrMsgBox, bool simplifySegment) noexcept;
 
   /**
    * @brief Update the currently active traces according

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
@@ -46,6 +46,7 @@
 #include "../../cmd/cmdpasteboarditems.h"
 #include "../../cmd/cmdremoveselectedboarditems.h"
 #include "../../cmd/cmdreplacedevice.h"
+#include "../../cmd/cmdsimplifyboardnetsegments.h"
 #include "../boardclipboarddatabuilder.h"
 #include "../boardgraphicsscene.h"
 #include "../boardplanepropertiesdialog.h"
@@ -1436,7 +1437,9 @@ bool BoardEditorState_Select::removeSelectedItems() noexcept {
   try {
     CmdRemoveSelectedBoardItems* cmd =
         new CmdRemoveSelectedBoardItems(*scene, getIgnoreLocks());
-    mContext.undoStack.execCmd(cmd);
+    mContext.undoStack.execCmd(cmd);  // can throw
+    mContext.undoStack.execCmd(new CmdSimplifyBoardNetSegments(
+        cmd->getModifiedNetSegments()));  // can throw
     return true;
   } catch (const Exception& e) {
     QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());

--- a/libs/librepcb/editor/project/cmd/cmdremoveboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveboarditems.cpp
@@ -249,6 +249,7 @@ void CmdRemoveBoardItems::removeNetSegmentItems(
       Q_ASSERT(newNetLine);
     }
     execNewChildCmd(cmdAddElements);  // can throw
+    mModifiedNetSegments.append(newNetSegment);
   }
 }
 

--- a/libs/librepcb/editor/project/cmd/cmdremoveboarditems.h
+++ b/libs/librepcb/editor/project/cmd/cmdremoveboarditems.h
@@ -114,6 +114,11 @@ public:
     mHoles += set;
   }
 
+  // Output
+  const QList<BI_NetSegment*>& getModifiedNetSegments() const noexcept {
+    return mModifiedNetSegments;
+  }
+
   // Operator Overloadings
   CmdRemoveBoardItems& operator=(const CmdRemoveBoardItems& other) = delete;
 
@@ -141,6 +146,9 @@ private:  // Data
   QSet<BI_Polygon*> mPolygons;
   QSet<BI_StrokeText*> mStrokeTexts;
   QSet<BI_Hole*> mHoles;
+
+  // Output
+  QList<BI_NetSegment*> mModifiedNetSegments;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/cmd/cmdremoveselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveselectedboarditems.cpp
@@ -53,6 +53,16 @@ CmdRemoveSelectedBoardItems::~CmdRemoveSelectedBoardItems() noexcept {
 }
 
 /*******************************************************************************
+ *  Public Methods
+ ******************************************************************************/
+
+QList<BI_NetSegment*> CmdRemoveSelectedBoardItems::getModifiedNetSegments()
+    const noexcept {
+  return mWrappedCommand ? mWrappedCommand->getModifiedNetSegments()
+                         : QList<BI_NetSegment*>{};
+}
+
+/*******************************************************************************
  *  Inherited from UndoCommand
  ******************************************************************************/
 

--- a/libs/librepcb/editor/project/cmd/cmdsimplifyboardnetsegments.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsimplifyboardnetsegments.cpp
@@ -1,0 +1,187 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdsimplifyboardnetsegments.h"
+
+#include "../../project/cmd/cmdboardnetsegmentadd.h"
+#include "../../project/cmd/cmdboardnetsegmentremove.h"
+
+#include <librepcb/core/algorithm/netsegmentsimplifier.h>
+#include <librepcb/core/project/board/board.h>
+#include <librepcb/core/project/board/items/bi_device.h>
+#include <librepcb/core/project/board/items/bi_footprintpad.h>
+#include <librepcb/core/project/board/items/bi_netline.h>
+#include <librepcb/core/project/board/items/bi_netpoint.h>
+#include <librepcb/core/project/board/items/bi_netsegment.h>
+#include <librepcb/core/types/layer.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdSimplifyBoardNetSegments::CmdSimplifyBoardNetSegments(
+    const QList<BI_NetSegment*>& segments) noexcept
+  : UndoCommandGroup(tr("Simplify Board Net Segments")), mSegments(segments) {
+}
+
+CmdSimplifyBoardNetSegments::~CmdSimplifyBoardNetSegments() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdSimplifyBoardNetSegments::performExecute() {
+  for (BI_NetSegment* seg : mSegments) {
+    simplifySegment(*seg);
+  }
+  return UndoCommandGroup::performExecute();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void CmdSimplifyBoardNetSegments::simplifySegment(BI_NetSegment& segment) {
+  // A segment which contains no traces and no vias can entirely be removed.
+  if (segment.getVias().isEmpty() && segment.getNetLines().isEmpty()) {
+    appendChild(new CmdBoardNetSegmentRemove(segment));
+    return;
+  }
+
+  // A segment which contains no traces cannot be simplified.
+  if (segment.getNetLines().isEmpty()) {
+    return;
+  }
+
+  // Collect anchors & lines for the simplification.
+  NetSegmentSimplifier simplifier;
+  QHash<BI_NetLineAnchor*, int> anchors;
+  QHash<const BI_NetLine*, int> lines;
+  auto addAnchor = [&](BI_NetLineAnchor& anchor) {
+    auto it = anchors.find(&anchor);
+    if (it != anchors.end()) {
+      return *it;
+    }
+    std::optional<int> id;
+    if (auto pad = dynamic_cast<const BI_FootprintPad*>(&anchor)) {
+      const bool isTht = pad->getLibPad().isTht();
+      id = simplifier.addAnchor(
+          NetSegmentSimplifier::AnchorType::PinOrPad, pad->getPosition(),
+          isTht ? &Layer::topCopper() : &pad->getSolderLayer(),
+          isTht ? &Layer::botCopper() : &pad->getSolderLayer());
+    } else if (auto via = dynamic_cast<const BI_Via*>(&anchor)) {
+      id = simplifier.addAnchor(
+          NetSegmentSimplifier::AnchorType::Via, via->getPosition(),
+          &via->getVia().getStartLayer(), &via->getVia().getEndLayer());
+    } else if (auto np = dynamic_cast<const BI_NetPoint*>(&anchor)) {
+      if (const Layer* layer = np->getLayerOfTraces()) {
+        id = simplifier.addAnchor(NetSegmentSimplifier::AnchorType::Junction,
+                                  np->getPosition(), layer, layer);
+      }
+    }
+    if (!id) {
+      throw LogicError(__FILE__, __LINE__, "Unhandled anchor type.");
+    }
+    anchors.insert(&anchor, *id);
+    return *id;
+  };
+  foreach (BI_NetLine* netline, segment.getNetLines()) {
+    const int p1 = addAnchor(netline->getP1());
+    const int p2 = addAnchor(netline->getP2());
+    const int id =
+        simplifier.addLine(p1, p2, &netline->getLayer(), *netline->getWidth());
+    lines.insert(netline, id);
+  }
+
+  // Perform the simplification. If nothing was modified, abort here.
+  const NetSegmentSimplifier::Result result = simplifier.simplify();
+  if (!result.modified) {
+    return;
+  }
+
+  // Remove old segment.
+  appendChild(new CmdBoardNetSegmentRemove(segment));
+
+  // Add new segment, if there is anything to add.
+  std::unique_ptr<BI_NetSegment> newSegment(new BI_NetSegment(
+      segment.getBoard(), segment.getUuid(), segment.getNetSignal()));
+  QHash<int, BI_Via*> newVias;
+  foreach (BI_Via* via, segment.getVias()) {
+    newVias.insert(anchors.value(via), new BI_Via(*newSegment, via->getVia()));
+  }
+  QHash<int, BI_NetPoint*> newPoints;
+  auto getOrCreateAnchor = [&](int anchorId) {
+    if (auto np = newPoints.value(anchorId)) {
+      return static_cast<BI_NetLineAnchor*>(np);
+    }
+    if (auto via = newVias.value(anchorId)) {
+      return static_cast<BI_NetLineAnchor*>(via);
+    }
+    BI_NetLineAnchor* oldAnchor = anchors.key(anchorId, nullptr);  // can be 0
+    if (auto pad = dynamic_cast<BI_FootprintPad*>(oldAnchor)) {
+      return static_cast<BI_NetLineAnchor*>(pad);
+    } else if (auto oldNp = dynamic_cast<BI_NetPoint*>(oldAnchor)) {
+      BI_NetPoint* newNp =
+          new BI_NetPoint(*newSegment, oldNp->getUuid(), oldNp->getPosition());
+      newPoints.insert(anchorId, newNp);
+      return static_cast<BI_NetLineAnchor*>(newNp);
+    } else if (result.newJunctions.contains(anchorId)) {
+      BI_NetPoint* newNp = new BI_NetPoint(*newSegment, Uuid::createRandom(),
+                                           result.newJunctions.value(anchorId));
+      newPoints.insert(anchorId, newNp);
+      return static_cast<BI_NetLineAnchor*>(newNp);
+    }
+    return static_cast<BI_NetLineAnchor*>(nullptr);
+  };
+  QList<BI_NetLine*> newLines;
+  for (const NetSegmentSimplifier::Line& line : result.lines) {
+    BI_NetLineAnchor* p1 = getOrCreateAnchor(line.p1);
+    BI_NetLineAnchor* p2 = getOrCreateAnchor(line.p2);
+    const BI_NetLine* oldNetLine = lines.key(line.id, nullptr);  // can be null
+    if ((!p1) || (!p2) || (!line.layer) || (line.width <= 0)) {
+      throw LogicError(__FILE__, __LINE__);
+    }
+    const Uuid uuid = oldNetLine ? oldNetLine->getUuid() : Uuid::createRandom();
+    newLines.append(new BI_NetLine(*newSegment, uuid, *p1, *p2, *line.layer,
+                                   PositiveLength(line.width)));
+  }
+  if ((!newVias.isEmpty()) || (!newLines.isEmpty())) {
+    newSegment->addElements(newVias.values(), newPoints.values(), newLines);
+    appendChild(new CmdBoardNetSegmentAdd(*newSegment.release()));
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/cmd/cmdsimplifyboardnetsegments.h
+++ b/libs/librepcb/editor/project/cmd/cmdsimplifyboardnetsegments.h
@@ -17,64 +17,59 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_CMDREMOVESELECTEDBOARDITEMS_H
-#define LIBREPCB_EDITOR_CMDREMOVESELECTEDBOARDITEMS_H
+#ifndef LIBREPCB_EDITOR_CMDSIMPLIFYBOARDNETSEGMENTS_H
+#define LIBREPCB_EDITOR_CMDSIMPLIFYBOARDNETSEGMENTS_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include "../../undocommand.h"
+#include "../../undocommandgroup.h"
+
+#include <librepcb/core/geometry/trace.h>
 
 #include <QtCore>
-
-#include <memory>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
 namespace librepcb {
 
-class BI_NetLine;
-class BI_NetPoint;
+class BI_NetLineAnchor;
 class BI_NetSegment;
-class BI_Via;
+class Point;
 
 namespace editor {
 
-class BoardGraphicsScene;
-class CmdRemoveBoardItems;
-
 /*******************************************************************************
- *  Class CmdRemoveSelectedBoardItems
+ *  Class CmdSimplifyBoardNetSegments
  ******************************************************************************/
 
 /**
- * @brief The CmdRemoveSelectedBoardItems class
+ * @brief Undo command which runs ::librepcb::NetSegmentSimplifier on a
+ *        ::librepcb::BI_NetSegment
  */
-class CmdRemoveSelectedBoardItems final : public UndoCommand {
+class CmdSimplifyBoardNetSegments final : public UndoCommandGroup {
 public:
   // Constructors / Destructor
-  explicit CmdRemoveSelectedBoardItems(BoardGraphicsScene& scene,
-                                       bool includeLockedItems) noexcept;
-  ~CmdRemoveSelectedBoardItems() noexcept;
+  CmdSimplifyBoardNetSegments() = delete;
+  CmdSimplifyBoardNetSegments(const CmdSimplifyBoardNetSegments& other) =
+      delete;
+  explicit CmdSimplifyBoardNetSegments(
+      const QList<BI_NetSegment*>& segments) noexcept;
+  ~CmdSimplifyBoardNetSegments() noexcept;
 
-  // Output
-  QList<BI_NetSegment*> getModifiedNetSegments() const noexcept;
+  // Operator Overloadings
+  CmdSimplifyBoardNetSegments& operator=(
+      const CmdSimplifyBoardNetSegments& rhs) = delete;
 
 private:  // Methods
   /// @copydoc ::librepcb::editor::UndoCommand::performExecute()
   bool performExecute() override;
 
-  /// @copydoc ::librepcb::editor::UndoCommand::performUndo()
-  void performUndo() override;
-
-  /// @copydoc ::librepcb::editor::UndoCommand::performRedo()
-  void performRedo() override;
+  void simplifySegment(BI_NetSegment& segment);
 
 private:  // Data
-  BoardGraphicsScene& mScene;
-  bool mIncludeLockedItems;
-  std::unique_ptr<CmdRemoveBoardItems> mWrappedCommand;
+  QList<BI_NetSegment*> mSegments;
 };
 
 /*******************************************************************************

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   librepcb_unittests
   core/3d/occmodeltest.cpp
   core/algorithm/airwiresbuildertest.cpp
+  core/algorithm/netsegmentsimplifiertest.cpp
   core/applicationtest.cpp
   core/attribute/attributekeytest.cpp
   core/attribute/attributesubstitutortest.cpp

--- a/tests/unittests/core/algorithm/netsegmentsimplifiertest.cpp
+++ b/tests/unittests/core/algorithm/netsegmentsimplifiertest.cpp
@@ -1,0 +1,329 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <librepcb/core/algorithm/netsegmentsimplifier.h>
+#include <librepcb/core/types/layer.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class NetSegmentSimplifierTest : public ::testing::Test {
+protected:
+  using AnchorType = NetSegmentSimplifier::AnchorType;
+  using Line = NetSegmentSimplifier::Line;
+  using Result = NetSegmentSimplifier::Result;
+
+  static std::string str(const Result& result) noexcept {
+    QStringList s;
+    for (const auto& line : result.lines) {
+      s.append(QString("line id=%1 p1=%2 p2=%3 layer=%4 width=%5 modified=%6")
+                   .arg(line.id)
+                   .arg(line.p1)
+                   .arg(line.p2)
+                   .arg(line.layer ? line.layer->getId() : "nullptr")
+                   .arg(line.width.toMmString())
+                   .arg(line.modified ? "true" : "false"));
+    }
+    for (auto it = result.newJunctions.begin(); it != result.newJunctions.end();
+         it++) {
+      s.append(QString("new junction id=%1 x=%2 y=%3")
+                   .arg(it.key())
+                   .arg(it->getX().toMmString())
+                   .arg(it->getY().toMmString()));
+    }
+    s.append(QString("modified=%1").arg(result.modified ? "true" : "false"));
+    return s.join("\n").toStdString();
+  }
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(NetSegmentSimplifierTest, testEmpty) {
+  NetSegmentSimplifier obj;
+  const Result actual = obj.simplify();
+
+  const Result expected{{}, {}, false};
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testIncrementingIdsAndResetState) {
+  NetSegmentSimplifier obj;
+  for (int i = 0; i < 2; ++i) {
+    const int p0 =
+        obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+    EXPECT_EQ(0, p0);
+    const int p1 =
+        obj.addAnchor(AnchorType::Via, Point(1000, 1000), nullptr, nullptr);
+    EXPECT_EQ(1, p1);
+    const int p2 =
+        obj.addAnchor(AnchorType::Via, Point(1000, 1000), nullptr, nullptr);
+    EXPECT_EQ(2, p2);
+    const int l0 = obj.addLine(p0, p1, nullptr, Length(1));
+    EXPECT_EQ(0, l0);
+    const int l1 = obj.addLine(p1, p2, nullptr, Length(1));
+    EXPECT_EQ(1, l1);
+    obj.simplify();  // Must reset the state, i.e. reuse IDs.
+  }
+}
+
+TEST_F(NetSegmentSimplifierTest, testOnlyAnchors) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Via, Point(1000, 1000), nullptr, nullptr);
+  const Result actual = obj.simplify();
+
+  const Result expected{{}, {}, false};
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testOneLine) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Via, Point(1000, 1000), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  const Result actual = obj.simplify();
+
+  const Result expected{{Line{0, 0, 1, nullptr, Length(1), false}}, {}, false};
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testDuplicateJunctions) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(10, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(10, 10), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(-10, 0), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  obj.addLine(1, 2, nullptr, Length(2));
+  obj.addLine(2, 3, nullptr, Length(3));
+  obj.addLine(3, 4, nullptr, Length(4));
+  const Result actual = obj.simplify();
+
+  const Result expected{{
+                            Line{0, 0, 1, nullptr, Length(1), false},
+                            Line{1, 1, 2, nullptr, Length(2), false},
+                            Line{2, 2, 0, nullptr, Length(3), true},
+                            Line{3, 0, 4, nullptr, Length(4), true},
+                        },
+                        {},
+                        true};
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testTwoRedundantLines) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 1000), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  obj.addLine(1, 0, nullptr, Length(2));
+  const Result actual = obj.simplify();
+
+  const Result expected{{Line{1, 1, 0, nullptr, Length(2), false}}, {}, true};
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testOneZeroLengthLineBetweenJunctions) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  const Result actual = obj.simplify();
+
+  const Result expected{{}, {}, true};
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testKeepZeroLengthLineBetweenPins) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::PinOrPad, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::PinOrPad, Point(0, 0), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  const Result actual = obj.simplify();
+
+  const Result expected{{Line{0, 0, 1, nullptr, Length(1), false}}, {}, false};
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testMergeStraightLines) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(2000, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(3000, 100), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  obj.addLine(1, 2, nullptr, Length(1));
+  obj.addLine(2, 3, nullptr, Length(3));
+  const Result actual = obj.simplify();
+
+  const Result expected{
+      {
+          Line{0, 0, 2, nullptr, Length(1), true},
+          Line{2, 2, 3, nullptr, Length(3), false},
+      },
+      {},
+      true,
+  };
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testKeepStraightLinesWithDifferentWidth) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(2000, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(3000, 100), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  obj.addLine(1, 2, nullptr, Length(2));  // different width
+  obj.addLine(2, 3, nullptr, Length(3));
+  const Result actual = obj.simplify();
+
+  const Result expected{
+      {
+          Line{0, 0, 1, nullptr, Length(1), false},
+          Line{1, 1, 2, nullptr, Length(2), false},
+          Line{2, 2, 3, nullptr, Length(3), false},
+      },
+      {},
+      false,
+  };
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testSplitLineAtExistingAnchor) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(200, 0), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  obj.addLine(1, 2, nullptr, Length(2));
+  obj.addLine(2, 3, nullptr, Length(3));
+  const Result actual = obj.simplify();
+
+  const Result expected{
+      {
+          Line{0, 0, 3, nullptr, Length(1), true},
+          Line{1, 1, 2, nullptr, Length(2), false},
+          Line{2, 2, 3, nullptr, Length(3), false},
+          Line{3, 3, 1, nullptr, Length(1), true},  // new
+      },
+      {},
+      true,
+  };
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testSplitIntersectingLines) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(700, 1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(700, -1000), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  obj.addLine(1, 2, nullptr, Length(2));
+  obj.addLine(2, 3, nullptr, Length(3));
+  const Result actual = obj.simplify();
+
+  const Result expected{
+      {
+          Line{0, 0, 4, nullptr, Length(1), true},  // split
+          Line{1, 1, 2, nullptr, Length(2), false},
+          Line{2, 2, 4, nullptr, Length(3), true},  // split
+          Line{3, 4, 1, nullptr, Length(1), true},  // new
+          Line{4, 4, 3, nullptr, Length(3), true},  // new
+      },
+      {
+          {4, Point(700, 0)},
+      },
+      true,
+  };
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+TEST_F(NetSegmentSimplifierTest, testSplitMultipleIntersectingLines) {
+  NetSegmentSimplifier obj;
+  obj.addAnchor(AnchorType::Junction, Point(0, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 0), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(1000, 1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(800, 1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(800, -1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(600, -1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(600, 1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(400, 1000), nullptr, nullptr);
+  obj.addAnchor(AnchorType::Junction, Point(400, -1000), nullptr, nullptr);
+  obj.addLine(0, 1, nullptr, Length(1));
+  obj.addLine(1, 2, nullptr, Length(1));
+  obj.addLine(2, 3, nullptr, Length(1));
+  obj.addLine(3, 4, nullptr, Length(1));
+  obj.addLine(4, 5, nullptr, Length(1));
+  obj.addLine(5, 6, nullptr, Length(1));
+  obj.addLine(6, 7, nullptr, Length(1));
+  obj.addLine(7, 8, nullptr, Length(1));
+  const Result actual = obj.simplify();
+
+  const Result expected{
+      {
+          Line{0, 0, 11, nullptr, Length(1), true},  // split
+          Line{1, 1, 2, nullptr, Length(1), false},
+          Line{2, 2, 3, nullptr, Length(1), false},
+          Line{3, 3, 9, nullptr, Length(1), true},  // split
+          Line{4, 4, 5, nullptr, Length(1), false},
+          Line{5, 5, 10, nullptr, Length(1), true},  // split
+          Line{6, 6, 7, nullptr, Length(1), false},
+          Line{7, 7, 11, nullptr, Length(1), true},  // split
+          Line{8, 9, 1, nullptr, Length(1), true},  // new
+          Line{9, 10, 9, nullptr, Length(1), true},  // new
+          Line{10, 11, 10, nullptr, Length(1), true},  // new
+          Line{11, 9, 4, nullptr, Length(1), true},  // new
+          Line{12, 10, 6, nullptr, Length(1), true},  // new
+          Line{13, 11, 8, nullptr, Length(1), true},  // new
+      },
+      {
+          {9, Point(800, 0)},
+          {10, Point(600, 0)},
+          {11, Point(400, 0)},
+      },
+      true,
+  };
+  EXPECT_EQ(str(expected), str(actual));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace librepcb


### PR DESCRIPTION
When drawing traces or deleting traces/vias in the board editor, the modified net segments will be automatically simplified in the following ways:

- Remove redundant junctions (same position, same layer)
- Remove redundant traces (same anchors, same layer), keeping only the thickest of them
- Remove zero-length traces
- Remove useless junctions within straight trace segments (join line segments into the same direction to a single trace)
- Split traces to connect with junctions on the path between start and end points
- Split intersecting traces, placing a new junction to connect them (only orthogonal intersections for now)

The simplification is added as a separate operation to the undo stack. If for any reason the user doesn't want the simplified result, just press Ctrl+Z and you'll have your modifications applied without the simplification.

The algorithm is implemented in a generic way so we can reuse it later for the schematic editor.

![librepcb-simplify-board](https://github.com/user-attachments/assets/e45bddea-0b3d-4a50-b9eb-73a7c475da84)

Replaces #737
Closes #710