### PR TITLE
Schematic editor: Automatically simplify net segments

### DIFF
--- a/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
@@ -158,10 +158,6 @@ void SI_NetSegment::setNetSignal(NetSignal& netsignal) {
 
 void SI_NetSegment::addNetPointsAndNetLines(
     const QList<SI_NetPoint*>& netpoints, const QList<SI_NetLine*>& netlines) {
-  if (!isAddedToSchematic()) {
-    throw LogicError(__FILE__, __LINE__);
-  }
-
   ScopeGuardList sgl(netpoints.count() + netlines.count());
   foreach (SI_NetPoint* netpoint, netpoints) {
     if ((mNetPoints.values().contains(netpoint)) ||
@@ -174,10 +170,14 @@ void SI_NetSegment::addNetPointsAndNetLines(
           QString("There is already a netpoint with the UUID \"%1\"!")
               .arg(netpoint->getUuid().toStr()));
     }
-    netpoint->addToSchematic();  // can throw
+    if (isAddedToSchematic()) {
+      netpoint->addToSchematic();  // can throw
+    }
     mNetPoints.insert(netpoint->getUuid(), netpoint);
     sgl.add([this, netpoint]() {
-      netpoint->removeFromSchematic();
+      if (isAddedToSchematic()) {
+        netpoint->removeFromSchematic();
+      }
       mNetPoints.remove(netpoint->getUuid());
     });
   }
@@ -192,10 +192,14 @@ void SI_NetSegment::addNetPointsAndNetLines(
           QString("There is already a netline with the UUID \"%1\"!")
               .arg(netline->getUuid().toStr()));
     }
-    netline->addToSchematic();  // can throw
+    if (isAddedToSchematic()) {
+      netline->addToSchematic();  // can throw
+    }
     mNetLines.insert(netline->getUuid(), netline);
     sgl.add([this, netline]() {
-      netline->removeFromSchematic();
+      if (isAddedToSchematic()) {
+        netline->removeFromSchematic();
+      }
       mNetLines.remove(netline->getUuid());
     });
   }

--- a/libs/librepcb/editor/CMakeLists.txt
+++ b/libs/librepcb/editor/CMakeLists.txt
@@ -673,6 +673,8 @@ add_library(
   project/cmd/cmdschematictextremove.h
   project/cmd/cmdsimplifyboardnetsegments.cpp
   project/cmd/cmdsimplifyboardnetsegments.h
+  project/cmd/cmdsimplifyschematicnetsegments.cpp
+  project/cmd/cmdsimplifyschematicnetsegments.h
   project/cmd/cmdsymbolinstanceadd.cpp
   project/cmd/cmdsymbolinstanceadd.h
   project/cmd/cmdsymbolinstanceedit.cpp

--- a/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
@@ -85,6 +85,15 @@ CmdRemoveSelectedSchematicItems::~CmdRemoveSelectedSchematicItems() noexcept {
 }
 
 /*******************************************************************************
+ *  Public Methods
+ ******************************************************************************/
+
+QList<SI_NetSegment*> CmdRemoveSelectedSchematicItems::getModifiedNetSegments()
+    const noexcept {
+  return mModifiedNetSegments;
+}
+
+/*******************************************************************************
  *  Inherited from UndoCommand
  ******************************************************************************/
 
@@ -220,6 +229,7 @@ void CmdRemoveSelectedSchematicItems::removeNetSegmentItems(
     SI_NetSegment* newNetSegment = cmdAddNetSegment->getNetSegment();
     Q_ASSERT(newNetSegment);
     newNetSegments.append(newNetSegment);
+    mModifiedNetSegments.append(newNetSegment);
 
     // Add new netpoints and netlines
     CmdSchematicNetSegmentAddElements* cmdAddElements =

--- a/libs/librepcb/editor/project/cmd/cmdsimplifyschematicnetsegments.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsimplifyschematicnetsegments.cpp
@@ -1,0 +1,164 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "cmdsimplifyschematicnetsegments.h"
+
+#include "../../project/cmd/cmdschematicnetsegmentadd.h"
+#include "../../project/cmd/cmdschematicnetsegmentremove.h"
+
+#include <librepcb/core/algorithm/netsegmentsimplifier.h>
+#include <librepcb/core/project/schematic/items/si_netline.h>
+#include <librepcb/core/project/schematic/items/si_netpoint.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
+#include <librepcb/core/project/schematic/items/si_symbolpin.h>
+#include <librepcb/core/project/schematic/schematic.h>
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+
+/*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+CmdSimplifySchematicNetSegments::CmdSimplifySchematicNetSegments(
+    const QList<SI_NetSegment*>& segments) noexcept
+  : UndoCommandGroup(tr("Simplify Schematic Net Segments")),
+    mSegments(segments) {
+}
+
+CmdSimplifySchematicNetSegments::~CmdSimplifySchematicNetSegments() noexcept {
+}
+
+/*******************************************************************************
+ *  Inherited from UndoCommand
+ ******************************************************************************/
+
+bool CmdSimplifySchematicNetSegments::performExecute() {
+  for (SI_NetSegment* seg : mSegments) {
+    simplifySegment(*seg);
+  }
+  return UndoCommandGroup::performExecute();
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void CmdSimplifySchematicNetSegments::simplifySegment(SI_NetSegment& segment) {
+  // A segment which contains no lines can entirely be removed.
+  if (segment.getNetLines().isEmpty()) {
+    appendChild(new CmdSchematicNetSegmentRemove(segment));
+    return;
+  }
+
+  // Collect anchors & lines for the simplification.
+  NetSegmentSimplifier simplifier;
+  QHash<SI_NetLineAnchor*, int> anchors;
+  QHash<const SI_NetLine*, int> lines;
+  auto addAnchor = [&](SI_NetLineAnchor& anchor) {
+    auto it = anchors.find(&anchor);
+    if (it != anchors.end()) {
+      return *it;
+    }
+    std::optional<int> id;
+    if (auto pin = dynamic_cast<const SI_SymbolPin*>(&anchor)) {
+      id = simplifier.addAnchor(NetSegmentSimplifier::AnchorType::PinOrPad,
+                                pin->getPosition(), nullptr, nullptr);
+    } else if (auto np = dynamic_cast<const SI_NetPoint*>(&anchor)) {
+      id = simplifier.addAnchor(NetSegmentSimplifier::AnchorType::Junction,
+                                np->getPosition(), nullptr, nullptr);
+    }
+    if (!id) {
+      throw LogicError(__FILE__, __LINE__, "Unhandled anchor type.");
+    }
+    anchors.insert(&anchor, *id);
+    return *id;
+  };
+  foreach (SI_NetLine* netline, segment.getNetLines()) {
+    const int p1 = addAnchor(netline->getP1());
+    const int p2 = addAnchor(netline->getP2());
+    const int id = simplifier.addLine(p1, p2, nullptr, *netline->getWidth());
+    lines.insert(netline, id);
+  }
+
+  // Perform the simplification. If nothing was modified, abort here.
+  const NetSegmentSimplifier::Result result = simplifier.simplify();
+  if (!result.modified) {
+    return;
+  }
+
+  // Remove old segment.
+  appendChild(new CmdSchematicNetSegmentRemove(segment));
+
+  // Add new segment, if there is anything to add.
+  std::unique_ptr<SI_NetSegment> newSegment(new SI_NetSegment(
+      segment.getSchematic(), segment.getUuid(), segment.getNetSignal()));
+  QHash<int, SI_NetPoint*> newPoints;
+  auto getOrCreateAnchor = [&](int anchorId) {
+    if (auto np = newPoints.value(anchorId)) {
+      return static_cast<SI_NetLineAnchor*>(np);
+    }
+    SI_NetLineAnchor* oldAnchor = anchors.key(anchorId, nullptr);  // can be 0
+    if (auto pin = dynamic_cast<SI_SymbolPin*>(oldAnchor)) {
+      return static_cast<SI_NetLineAnchor*>(pin);
+    } else if (auto oldNp = dynamic_cast<SI_NetPoint*>(oldAnchor)) {
+      SI_NetPoint* newNp =
+          new SI_NetPoint(*newSegment, oldNp->getUuid(), oldNp->getPosition());
+      newPoints.insert(anchorId, newNp);
+      return static_cast<SI_NetLineAnchor*>(newNp);
+    } else if (result.newJunctions.contains(anchorId)) {
+      SI_NetPoint* newNp = new SI_NetPoint(*newSegment, Uuid::createRandom(),
+                                           result.newJunctions.value(anchorId));
+      newPoints.insert(anchorId, newNp);
+      return static_cast<SI_NetLineAnchor*>(newNp);
+    }
+    return static_cast<SI_NetLineAnchor*>(nullptr);
+  };
+  QList<SI_NetLine*> newLines;
+  for (const NetSegmentSimplifier::Line& line : result.lines) {
+    SI_NetLineAnchor* p1 = getOrCreateAnchor(line.p1);
+    SI_NetLineAnchor* p2 = getOrCreateAnchor(line.p2);
+    const SI_NetLine* oldNetLine = lines.key(line.id, nullptr);  // can be null
+    if ((!p1) || (!p2) || (line.width < 0)) {
+      throw LogicError(__FILE__, __LINE__);
+    }
+    const Uuid uuid = oldNetLine ? oldNetLine->getUuid() : Uuid::createRandom();
+    newLines.append(new SI_NetLine(*newSegment, uuid, *p1, *p2,
+                                   UnsignedLength(line.width)));
+  }
+  if (!newLines.isEmpty()) {
+    newSegment->addNetPointsAndNetLines(newPoints.values(), newLines);
+    appendChild(new CmdSchematicNetSegmentAdd(*newSegment.release()));
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace editor
+}  // namespace librepcb

--- a/libs/librepcb/editor/project/cmd/cmdsimplifyschematicnetsegments.h
+++ b/libs/librepcb/editor/project/cmd/cmdsimplifyschematicnetsegments.h
@@ -17,13 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBREPCB_EDITOR_CMDREMOVESELECTEDSCHEMATICITEMS_H
-#define LIBREPCB_EDITOR_CMDREMOVESELECTEDSCHEMATICITEMS_H
+#ifndef LIBREPCB_EDITOR_CMDSIMPLIFYSCHEMATICNETSEGMENTS_H
+#define LIBREPCB_EDITOR_CMDSIMPLIFYSCHEMATICNETSEGMENTS_H
 
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
 #include "../../undocommandgroup.h"
+
+#include <librepcb/core/geometry/netline.h>
 
 #include <QtCore>
 
@@ -32,52 +34,42 @@
  ******************************************************************************/
 namespace librepcb {
 
-class ComponentSignalInstance;
-class SI_NetLabel;
-class SI_NetLine;
-class SI_NetPoint;
+class Point;
+class SI_NetLineAnchor;
 class SI_NetSegment;
-class SI_Symbol;
 
 namespace editor {
 
-class SchematicGraphicsScene;
-
 /*******************************************************************************
- *  Class CmdRemoveSelectedSchematicItems
+ *  Class CmdSimplifySchematicNetSegments
  ******************************************************************************/
 
 /**
- * @brief The CmdRemoveSelectedSchematicItems class
+ * @brief Undo command which runs ::librepcb::NetSegmentSimplifier on a
+ *        ::librepcb::SI_NetSegment
  */
-class CmdRemoveSelectedSchematicItems final : public UndoCommandGroup {
+class CmdSimplifySchematicNetSegments final : public UndoCommandGroup {
 public:
   // Constructors / Destructor
-  explicit CmdRemoveSelectedSchematicItems(
-      SchematicGraphicsScene& scene) noexcept;
-  ~CmdRemoveSelectedSchematicItems() noexcept;
+  CmdSimplifySchematicNetSegments() = delete;
+  CmdSimplifySchematicNetSegments(
+      const CmdSimplifySchematicNetSegments& other) = delete;
+  explicit CmdSimplifySchematicNetSegments(
+      const QList<SI_NetSegment*>& segments) noexcept;
+  ~CmdSimplifySchematicNetSegments() noexcept;
 
-  // Output
-  QList<SI_NetSegment*> getModifiedNetSegments() const noexcept;
+  // Operator Overloadings
+  CmdSimplifySchematicNetSegments& operator=(
+      const CmdSimplifySchematicNetSegments& rhs) = delete;
 
-private:
-  // Private Methods
-
+private:  // Methods
   /// @copydoc ::librepcb::editor::UndoCommand::performExecute()
   bool performExecute() override;
 
-  void removeNetSegmentItems(SI_NetSegment& netsegment,
-                             const QSet<SI_NetPoint*>& netpointsToRemove,
-                             const QSet<SI_NetLine*>& netlinesToRemove,
-                             const QSet<SI_NetLabel*>& netlabelsToRemove);
-  void removeSymbol(SI_Symbol& symbol);
-  void disconnectComponentSignalInstance(ComponentSignalInstance& signal);
+  void simplifySegment(SI_NetSegment& segment);
 
-  // Attributes from the constructor
-  SchematicGraphicsScene& mScene;
-
-  // Output
-  QList<SI_NetSegment*> mModifiedNetSegments;
+private:  // Data
+  QList<SI_NetSegment*> mSegments;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.h
@@ -38,6 +38,7 @@ class Circuit;
 class SI_NetLine;
 class SI_NetLineAnchor;
 class SI_NetPoint;
+class SI_NetSegment;
 class SI_SymbolPin;
 
 namespace editor {
@@ -112,7 +113,7 @@ private:  //  Methods
   bool startPositioning(SchematicGraphicsScene& scene, bool snap,
                         SI_NetPoint* fixedPoint = nullptr) noexcept;
   bool addNextNetPoint(SchematicGraphicsScene& scene, bool snap) noexcept;
-  bool abortPositioning(bool showErrMsgBox) noexcept;
+  bool abortPositioning(bool showErrMsgBox, bool simplifySegment) noexcept;
   std::shared_ptr<QGraphicsItem> findItem(
       const Point& pos,
       const QVector<std::shared_ptr<QGraphicsItem>>& except = {}) noexcept;
@@ -125,8 +126,10 @@ private:  // Data
   SubState mSubState;  ///< the current substate
   WireMode mCurrentWireMode;  ///< the current wire mode
   Point mCursorPos;  ///< the current cursor position
-  SI_NetLineAnchor*
-      mFixedStartAnchor;  ///< the fixed anchor (start point of the line)
+  SI_NetLineAnchor* mFixedStartAnchor;  ///< the fixed anchor (start point of
+                                        ///< the line)
+  SI_NetSegment* mCurrentNetSegment;  ///< the net segment that is currently
+                                      ///< edited
   SI_NetLine* mPositioningNetLine1;  ///< line between fixed point and p1
   SI_NetPoint* mPositioningNetPoint1;  ///< the first netpoint to place
   SI_NetLine* mPositioningNetLine2;  ///< line between p1 and p2

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
@@ -37,6 +37,7 @@
 #include "../../cmd/cmddragselectedschematicitems.h"
 #include "../../cmd/cmdpasteschematicitems.h"
 #include "../../cmd/cmdremoveselectedschematicitems.h"
+#include "../../cmd/cmdsimplifyschematicnetsegments.h"
 #include "../graphicsitems/sgi_netlabel.h"
 #include "../graphicsitems/sgi_symbol.h"
 #include "../graphicsitems/sgi_text.h"
@@ -861,7 +862,9 @@ bool SchematicEditorState_Select::removeSelectedItems() noexcept {
   try {
     CmdRemoveSelectedSchematicItems* cmd =
         new CmdRemoveSelectedSchematicItems(*scene);
-    execCmd(cmd);
+    execCmd(cmd);  // can throw
+    execCmd(new CmdSimplifySchematicNetSegments(
+        cmd->getModifiedNetSegments()));  // can throw
     return true;
   } catch (const Exception& e) {
     QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());


### PR DESCRIPTION
Exactly the same as #1591, but now for the schematic editor to simplify net lines.