### PR TITLE
Planes: Support configuring clearance to board outline & holes

### DIFF
--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -825,7 +825,9 @@ void Board::copyFrom(const Board& other) {
         new BI_Plane(*this, Uuid::createRandom(), plane->getLayer(),
                      plane->getNetSignal(), plane->getOutline());
     copy->setMinWidth(plane->getMinWidth());
-    copy->setMinClearance(plane->getMinClearance());
+    copy->setMinClearanceToCopper(plane->getMinClearanceToCopper());
+    copy->setMinClearanceToBoard(plane->getMinClearanceToBoard());
+    copy->setMinClearanceToNpth(plane->getMinClearanceToNpth());
     copy->setKeepIslands(plane->getKeepIslands());
     copy->setPriority(plane->getPriority());
     copy->setConnectStyle(plane->getConnectStyle());

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -149,7 +149,9 @@ private:  // Methods
     std::optional<Uuid> netSignal;
     Path outline;
     UnsignedLength minWidth;
-    UnsignedLength minClearance;
+    UnsignedLength minClearanceToCopper;
+    std::optional<UnsignedLength> minClearanceToBoard;
+    std::optional<UnsignedLength> minClearanceToNpth;
     bool keepIslands;
     int priority;
     BI_Plane::ConnectStyle connectStyle;

--- a/libs/librepcb/core/project/board/items/bi_plane.cpp
+++ b/libs/librepcb/core/project/board/items/bi_plane.cpp
@@ -48,13 +48,15 @@ BI_Plane::BI_Plane(Board& board, const Uuid& uuid, const Layer& layer,
     mLayer(&layer),
     mNetSignal(netsignal),
     mOutline(outline),
-    mMinWidth(200000),
-    mMinClearance(300000),
+    mMinWidth(200000),  // 200um
+    mMinClearanceToCopper(250000),  // 250um
+    mMinClearanceToBoard(300000),  // 300um
+    mMinClearanceToNpth(300000),  // 300um
     mKeepIslands(false),
     mPriority(0),
     mConnectStyle(ConnectStyle::ThermalRelief),
-    mThermalGap(300000),
-    mThermalSpokeWidth(300000),
+    mThermalGap(300000),  // 300um
+    mThermalSpokeWidth(300000),  // 300um
     mLocked(false),
     mIsVisible(true),
     mFragments() {
@@ -112,9 +114,26 @@ void BI_Plane::setMinWidth(const UnsignedLength& minWidth) noexcept {
   }
 }
 
-void BI_Plane::setMinClearance(const UnsignedLength& minClearance) noexcept {
-  if (minClearance != mMinClearance) {
-    mMinClearance = minClearance;
+void BI_Plane::setMinClearanceToCopper(
+    const UnsignedLength& minClearance) noexcept {
+  if (minClearance != mMinClearanceToCopper) {
+    mMinClearanceToCopper = minClearance;
+    mBoard.invalidatePlanes(mLayer);
+  }
+}
+
+void BI_Plane::setMinClearanceToBoard(
+    const UnsignedLength& minClearance) noexcept {
+  if (minClearance != mMinClearanceToBoard) {
+    mMinClearanceToBoard = minClearance;
+    mBoard.invalidatePlanes(mLayer);
+  }
+}
+
+void BI_Plane::setMinClearanceToNpth(
+    const UnsignedLength& minClearance) noexcept {
+  if (minClearance != mMinClearanceToNpth) {
+    mMinClearanceToNpth = minClearance;
     mBoard.invalidatePlanes(mLayer);
   }
 }
@@ -218,13 +237,16 @@ void BI_Plane::serialize(SExpression& root) const {
       "net",
       mNetSignal ? std::make_optional(mNetSignal->getUuid()) : std::nullopt);
   root.appendChild("priority", mPriority);
-  root.ensureLineBreak();
   root.appendChild("min_width", mMinWidth);
-  root.appendChild("min_clearance", mMinClearance);
+  root.ensureLineBreak();
+  root.appendChild("min_copper_clearance", mMinClearanceToCopper);
+  root.appendChild("min_board_clearance", mMinClearanceToBoard);
+  root.appendChild("min_npth_clearance", mMinClearanceToNpth);
+  root.ensureLineBreak();
+  root.appendChild("connect_style", mConnectStyle);
   root.appendChild("thermal_gap", mThermalGap);
   root.appendChild("thermal_spoke", mThermalSpokeWidth);
   root.ensureLineBreak();
-  root.appendChild("connect_style", mConnectStyle);
   root.appendChild("keep_islands", mKeepIslands);
   root.appendChild("lock", mLocked);
   root.ensureLineBreak();

--- a/libs/librepcb/core/project/board/items/bi_plane.h
+++ b/libs/librepcb/core/project/board/items/bi_plane.h
@@ -83,8 +83,14 @@ public:
   const Layer& getLayer() const noexcept { return *mLayer; }
   NetSignal* getNetSignal() const noexcept { return mNetSignal; }
   const UnsignedLength& getMinWidth() const noexcept { return mMinWidth; }
-  const UnsignedLength& getMinClearance() const noexcept {
-    return mMinClearance;
+  const UnsignedLength& getMinClearanceToCopper() const noexcept {
+    return mMinClearanceToCopper;
+  }
+  const UnsignedLength& getMinClearanceToBoard() const noexcept {
+    return mMinClearanceToBoard;
+  }
+  const UnsignedLength& getMinClearanceToNpth() const noexcept {
+    return mMinClearanceToNpth;
   }
   bool getKeepIslands() const noexcept { return mKeepIslands; }
   int getPriority() const noexcept { return mPriority; }
@@ -103,7 +109,9 @@ public:
   void setLayer(const Layer& layer) noexcept;
   void setNetSignal(NetSignal* netsignal);
   void setMinWidth(const UnsignedLength& minWidth) noexcept;
-  void setMinClearance(const UnsignedLength& minClearance) noexcept;
+  void setMinClearanceToCopper(const UnsignedLength& minClearance) noexcept;
+  void setMinClearanceToBoard(const UnsignedLength& minClearance) noexcept;
+  void setMinClearanceToNpth(const UnsignedLength& minClearance) noexcept;
   void setConnectStyle(ConnectStyle style) noexcept;
   void setThermalGap(const PositiveLength& gap) noexcept;
   void setThermalSpokeWidth(const PositiveLength& width) noexcept;
@@ -133,7 +141,9 @@ private:  // Data
   NetSignal* mNetSignal;  ///< Optional (`nullptr` = no net)
   Path mOutline;
   UnsignedLength mMinWidth;
-  UnsignedLength mMinClearance;
+  UnsignedLength mMinClearanceToCopper;
+  UnsignedLength mMinClearanceToBoard;
+  UnsignedLength mMinClearanceToNpth;
   bool mKeepIslands;
   int mPriority;
   ConnectStyle mConnectStyle;

--- a/libs/librepcb/core/project/projectloader.cpp
+++ b/libs/librepcb/core/project/projectloader.cpp
@@ -815,8 +815,12 @@ void ProjectLoader::loadBoardPlane(Board& b, const SExpression& node) {
                    netSignal, Path(node));
   plane->setMinWidth(
       deserialize<UnsignedLength>(node.getChild("min_width/@0")));
-  plane->setMinClearance(
-      deserialize<UnsignedLength>(node.getChild("min_clearance/@0")));
+  plane->setMinClearanceToCopper(
+      deserialize<UnsignedLength>(node.getChild("min_copper_clearance/@0")));
+  plane->setMinClearanceToBoard(
+      deserialize<UnsignedLength>(node.getChild("min_board_clearance/@0")));
+  plane->setMinClearanceToNpth(
+      deserialize<UnsignedLength>(node.getChild("min_npth_clearance/@0")));
   plane->setKeepIslands(deserialize<bool>(node.getChild("keep_islands/@0")));
   plane->setPriority(deserialize<int>(node.getChild("priority/@0")));
   plane->setConnectStyle(

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -157,6 +157,19 @@ void FileFormatMigrationUnstable::upgradeBoard(SExpression& root) {
       }
     }
   }
+
+  // Planes
+  for (SExpression* planeNode : root.getChildren("plane")) {
+    if (SExpression* clrNode = planeNode->tryGetChild("min_clearance")) {
+      clrNode->setName("min_copper_clearance");
+      planeNode->appendChild(
+          "min_board_clearance",
+          std::make_unique<SExpression>(clrNode->getChild("@0")));
+      planeNode->appendChild(
+          "min_npth_clearance",
+          std::make_unique<SExpression>(clrNode->getChild("@0")));
+    }
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
@@ -452,6 +452,18 @@ void FileFormatMigrationV1::upgradeBoard(SExpression& root) {
       }
     }
   }
+
+  // Planes
+  for (SExpression* planeNode : root.getChildren("plane")) {
+    SExpression& clrNode = planeNode->getChild("min_clearance");
+    clrNode.setName("min_copper_clearance");
+    planeNode->appendChild(
+        "min_board_clearance",
+        std::make_unique<SExpression>(clrNode.getChild("@0")));
+    planeNode->appendChild(
+        "min_npth_clearance",
+        std::make_unique<SExpression>(clrNode.getChild("@0")));
+  }
 }
 
 void FileFormatMigrationV1::upgradeTexts(SExpression& node, bool allowLock) {

--- a/libs/librepcb/editor/project/board/boardclipboarddata.h
+++ b/libs/librepcb/editor/project/board/boardclipboarddata.h
@@ -202,7 +202,9 @@ public:
     std::optional<CircuitIdentifier> netSignalName;
     Path outline;
     UnsignedLength minWidth;
-    UnsignedLength minClearance;
+    UnsignedLength minClearanceToCopper;
+    UnsignedLength minClearanceToBoard;
+    UnsignedLength minClearanceToNpth;
     bool keepIslands;
     int priority;
     BI_Plane::ConnectStyle connectStyle;
@@ -214,15 +216,20 @@ public:
     Plane(const Uuid& uuid, const Layer& layer,
           const std::optional<CircuitIdentifier>& netSignalName,
           const Path& outline, const UnsignedLength& minWidth,
-          const UnsignedLength& minClearance, bool keepIslands, int priority,
-          BI_Plane::ConnectStyle connectStyle, const PositiveLength& thermalGap,
+          const UnsignedLength& minClearanceToCopper,
+          const UnsignedLength& minClearanceToBoard,
+          const UnsignedLength& minClearanceToNpth, bool keepIslands,
+          int priority, BI_Plane::ConnectStyle connectStyle,
+          const PositiveLength& thermalGap,
           const PositiveLength& thermalSpokeWidth, bool locked)
       : uuid(uuid),
         layer(&layer),
         netSignalName(netSignalName),
         outline(outline),
         minWidth(minWidth),
-        minClearance(minClearance),
+        minClearanceToCopper(minClearanceToCopper),
+        minClearanceToBoard(minClearanceToBoard),
+        minClearanceToNpth(minClearanceToNpth),
         keepIslands(keepIslands),
         priority(priority),
         connectStyle(connectStyle),
@@ -238,8 +245,12 @@ public:
             node.getChild("net/@0"))),
         outline(node),
         minWidth(deserialize<UnsignedLength>(node.getChild("min_width/@0"))),
-        minClearance(
-            deserialize<UnsignedLength>(node.getChild("min_clearance/@0"))),
+        minClearanceToCopper(deserialize<UnsignedLength>(
+            node.getChild("min_copper_clearance/@0"))),
+        minClearanceToBoard(deserialize<UnsignedLength>(
+            node.getChild("min_board_clearance/@0"))),
+        minClearanceToNpth(deserialize<UnsignedLength>(
+            node.getChild("min_npth_clearance/@0"))),
         keepIslands(deserialize<bool>(node.getChild("keep_islands/@0"))),
         priority(deserialize<int>(node.getChild("priority/@0"))),
         connectStyle(deserialize<BI_Plane::ConnectStyle>(
@@ -257,13 +268,16 @@ public:
       root.ensureLineBreak();
       root.appendChild("net", netSignalName);
       root.appendChild("priority", priority);
-      root.ensureLineBreak();
       root.appendChild("min_width", minWidth);
-      root.appendChild("min_clearance", minClearance);
+      root.ensureLineBreak();
+      root.appendChild("min_copper_clearance", minClearanceToCopper);
+      root.appendChild("min_board_clearance", minClearanceToBoard);
+      root.appendChild("min_npth_clearance", minClearanceToNpth);
+      root.ensureLineBreak();
+      root.appendChild("connect_style", connectStyle);
       root.appendChild("thermal_gap", thermalGap);
       root.appendChild("thermal_spoke", thermalSpokeWidth);
       root.ensureLineBreak();
-      root.appendChild("connect_style", connectStyle);
       root.appendChild("keep_islands", keepIslands);
       root.appendChild("lock", locked);
       root.ensureLineBreak();
@@ -274,7 +288,10 @@ public:
     bool operator!=(const Plane& rhs) noexcept {
       return (uuid != rhs.uuid) || (layer != rhs.layer) ||
           (netSignalName != rhs.netSignalName) || (outline != rhs.outline) ||
-          (minWidth != rhs.minWidth) || (minClearance != rhs.minClearance) ||
+          (minWidth != rhs.minWidth) ||
+          (minClearanceToCopper != rhs.minClearanceToCopper) ||
+          (minClearanceToBoard != rhs.minClearanceToBoard) ||
+          (minClearanceToNpth != rhs.minClearanceToNpth) ||
           (keepIslands != rhs.keepIslands) || (priority != rhs.priority) ||
           (connectStyle != rhs.connectStyle) ||
           (thermalGap != rhs.thermalGap) ||

--- a/libs/librepcb/editor/project/board/boardclipboarddatabuilder.cpp
+++ b/libs/librepcb/editor/project/board/boardclipboarddatabuilder.cpp
@@ -175,10 +175,12 @@ std::unique_ptr<BoardClipboardData> BoardClipboardDataBuilder::generate(
             plane->getNetSignal()
                 ? std::make_optional(plane->getNetSignal()->getName())
                 : std::nullopt,
-            plane->getOutline(), plane->getMinWidth(), plane->getMinClearance(),
-            plane->getKeepIslands(), plane->getPriority(),
-            plane->getConnectStyle(), plane->getThermalGap(),
-            plane->getThermalSpokeWidth(), plane->isLocked());
+            plane->getOutline(), plane->getMinWidth(),
+            plane->getMinClearanceToCopper(), plane->getMinClearanceToBoard(),
+            plane->getMinClearanceToNpth(), plane->getKeepIslands(),
+            plane->getPriority(), plane->getConnectStyle(),
+            plane->getThermalGap(), plane->getThermalSpokeWidth(),
+            plane->isLocked());
     data->getPlanes().append(newPlane);
   }
 

--- a/libs/librepcb/editor/project/board/boardplanepropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/board/boardplanepropertiesdialog.cpp
@@ -58,8 +58,15 @@ BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(
   mUi->setupUi(this);
   mUi->edtMinWidth->configure(lengthUnit, LengthEditBase::Steps::generic(),
                               settingsPrefix % "/min_width");
-  mUi->edtMinClearance->configure(lengthUnit, LengthEditBase::Steps::generic(),
-                                  settingsPrefix % "/min_clearance");
+  mUi->edtMinClearanceToCopper->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/min_copper_clearance");
+  mUi->edtMinClearanceToBoard->configure(
+      lengthUnit, LengthEditBase::Steps::generic(),
+      settingsPrefix % "/min_board_clearance");
+  mUi->edtMinClearanceToNpth->configure(lengthUnit,
+                                        LengthEditBase::Steps::generic(),
+                                        settingsPrefix % "/min_npth_clearance");
   mUi->edtThermalGap->configure(lengthUnit, LengthEditBase::Steps::generic(),
                                 settingsPrefix % "/thermal_gap");
   mUi->edtThermalSpokeWidth->configure(lengthUnit,
@@ -99,9 +106,11 @@ BoardPlanePropertiesDialog::BoardPlanePropertiesDialog(
   mUi->cbxLayer->setLayers(mPlane.getBoard().getCopperLayers());
   mUi->cbxLayer->setCurrentLayer(mPlane.getLayer());
 
-  // minimum width / clearance spinbox
+  // minimum width / clearance spinboxes
   mUi->edtMinWidth->setValue(mPlane.getMinWidth());
-  mUi->edtMinClearance->setValue(mPlane.getMinClearance());
+  mUi->edtMinClearanceToCopper->setValue(mPlane.getMinClearanceToCopper());
+  mUi->edtMinClearanceToBoard->setValue(mPlane.getMinClearanceToBoard());
+  mUi->edtMinClearanceToNpth->setValue(mPlane.getMinClearanceToNpth());
 
   // connect style combobox
   mUi->cbxConnectStyle->addItem(tr("None"),
@@ -190,9 +199,11 @@ bool BoardPlanePropertiesDialog::applyChanges() noexcept {
       cmd->setLayer(*layer, false);  // can throw
     }
 
-    // min width/clearance
+    // min width/clearances
     cmd->setMinWidth(mUi->edtMinWidth->getValue());
-    cmd->setMinClearance(mUi->edtMinClearance->getValue());
+    cmd->setMinClearanceToCopper(mUi->edtMinClearanceToCopper->getValue());
+    cmd->setMinClearanceToBoard(mUi->edtMinClearanceToBoard->getValue());
+    cmd->setMinClearanceToNpth(mUi->edtMinClearanceToNpth->getValue());
 
     // connect style
     cmd->setConnectStyle(static_cast<BI_Plane::ConnectStyle>(

--- a/libs/librepcb/editor/project/board/boardplanepropertiesdialog.ui
+++ b/libs/librepcb/editor/project/board/boardplanepropertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>478</height>
+    <height>544</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      <enum>QFormLayout::FieldGrowthPolicy::AllNonFixedFieldsGrow</enum>
      </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label_4">
@@ -46,31 +46,31 @@
      <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Min. Clearance:</string>
+        <string>Min. Copper Clearance:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Priority:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="6" column="1">
       <widget class="QSpinBox" name="spbPriority"/>
      </item>
-     <item row="5" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Connect Style:</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="7" column="1">
       <widget class="QComboBox" name="cbxConnectStyle"/>
      </item>
-     <item row="8" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
         <string>Options:</string>
@@ -81,9 +81,9 @@
       <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinWidth" native="true"/>
      </item>
      <item row="3" column="1">
-      <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinClearance" native="true"/>
+      <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinClearanceToCopper" native="true"/>
      </item>
-     <item row="8" column="1">
+     <item row="10" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QCheckBox" name="cbKeepIslands">
@@ -104,7 +104,7 @@
        </item>
       </layout>
      </item>
-     <item row="6" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="label_8">
        <property name="toolTip">
         <string>Clearance around thermal pads</string>
@@ -114,7 +114,7 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="label_9">
        <property name="toolTip">
         <string>Width of the thermal pad spokes</string>
@@ -124,14 +124,34 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="8" column="1">
       <widget class="librepcb::editor::PositiveLengthEdit" name="edtThermalGap" native="true"/>
      </item>
-     <item row="7" column="1">
+     <item row="9" column="1">
       <widget class="librepcb::editor::PositiveLengthEdit" name="edtThermalSpokeWidth" native="true"/>
      </item>
      <item row="1" column="1">
       <widget class="librepcb::editor::LayerComboBox" name="cbxLayer" native="true"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Min. Board Clearance:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_11">
+       <property name="text">
+        <string>Min. Hole Clearance:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinClearanceToBoard" native="true"/>
+     </item>
+     <item row="5" column="1">
+      <widget class="librepcb::editor::UnsignedLengthEdit" name="edtMinClearanceToNpth" native="true"/>
      </item>
     </layout>
    </item>
@@ -148,10 +168,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
@@ -186,7 +206,9 @@
  <tabstops>
   <tabstop>cbxNetSignal</tabstop>
   <tabstop>edtMinWidth</tabstop>
-  <tabstop>edtMinClearance</tabstop>
+  <tabstop>edtMinClearanceToCopper</tabstop>
+  <tabstop>edtMinClearanceToBoard</tabstop>
+  <tabstop>edtMinClearanceToNpth</tabstop>
   <tabstop>spbPriority</tabstop>
   <tabstop>cbxConnectStyle</tabstop>
   <tabstop>edtThermalGap</tabstop>

--- a/libs/librepcb/editor/project/cmd/cmdboardplaneedit.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardplaneedit.cpp
@@ -48,8 +48,12 @@ CmdBoardPlaneEdit::CmdBoardPlaneEdit(BI_Plane& plane) noexcept
     mNewNetSignal(mOldNetSignal),
     mOldMinWidth(plane.getMinWidth()),
     mNewMinWidth(mOldMinWidth),
-    mOldMinClearance(plane.getMinClearance()),
-    mNewMinClearance(mOldMinClearance),
+    mOldMinClearanceToCopper(plane.getMinClearanceToCopper()),
+    mNewMinClearanceToCopper(mOldMinClearanceToCopper),
+    mOldMinClearanceToBoard(plane.getMinClearanceToBoard()),
+    mNewMinClearanceToBoard(mOldMinClearanceToBoard),
+    mOldMinClearanceToNpth(plane.getMinClearanceToNpth()),
+    mNewMinClearanceToNpth(mOldMinClearanceToNpth),
     mOldConnectStyle(plane.getConnectStyle()),
     mNewConnectStyle(mOldConnectStyle),
     mOldThermalGap(plane.getThermalGap()),
@@ -123,10 +127,22 @@ void CmdBoardPlaneEdit::setMinWidth(const UnsignedLength& minWidth) noexcept {
   mNewMinWidth = minWidth;
 }
 
-void CmdBoardPlaneEdit::setMinClearance(
+void CmdBoardPlaneEdit::setMinClearanceToCopper(
     const UnsignedLength& minClearance) noexcept {
   Q_ASSERT(!wasEverExecuted());
-  mNewMinClearance = minClearance;
+  mNewMinClearanceToCopper = minClearance;
+}
+
+void CmdBoardPlaneEdit::setMinClearanceToBoard(
+    const UnsignedLength& minClearance) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewMinClearanceToBoard = minClearance;
+}
+
+void CmdBoardPlaneEdit::setMinClearanceToNpth(
+    const UnsignedLength& minClearance) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewMinClearanceToNpth = minClearance;
 }
 
 void CmdBoardPlaneEdit::setConnectStyle(BI_Plane::ConnectStyle style) noexcept {
@@ -170,7 +186,9 @@ bool CmdBoardPlaneEdit::performExecute() {
   if (mNewLayer != mOldLayer) return true;
   if (mNewNetSignal != mOldNetSignal) return true;
   if (mNewMinWidth != mOldMinWidth) return true;
-  if (mNewMinClearance != mOldMinClearance) return true;
+  if (mNewMinClearanceToCopper != mOldMinClearanceToCopper) return true;
+  if (mNewMinClearanceToBoard != mOldMinClearanceToBoard) return true;
+  if (mNewMinClearanceToNpth != mOldMinClearanceToNpth) return true;
   if (mNewConnectStyle != mOldConnectStyle) return true;
   if (mNewThermalGap != mOldThermalGap) return true;
   if (mNewThermalSpokeWidth != mOldThermalSpokeWidth) return true;
@@ -185,7 +203,9 @@ void CmdBoardPlaneEdit::performUndo() {
   mPlane.setOutline(mOldOutline);
   mPlane.setLayer(*mOldLayer);
   mPlane.setMinWidth(mOldMinWidth);
-  mPlane.setMinClearance(mOldMinClearance);
+  mPlane.setMinClearanceToCopper(mOldMinClearanceToCopper);
+  mPlane.setMinClearanceToBoard(mOldMinClearanceToBoard);
+  mPlane.setMinClearanceToNpth(mOldMinClearanceToNpth);
   mPlane.setConnectStyle(mOldConnectStyle);
   mPlane.setThermalGap(mOldThermalGap);
   mPlane.setThermalSpokeWidth(mOldThermalSpokeWidth);
@@ -199,7 +219,9 @@ void CmdBoardPlaneEdit::performRedo() {
   mPlane.setOutline(mNewOutline);
   mPlane.setLayer(*mNewLayer);
   mPlane.setMinWidth(mNewMinWidth);
-  mPlane.setMinClearance(mNewMinClearance);
+  mPlane.setMinClearanceToCopper(mNewMinClearanceToCopper);
+  mPlane.setMinClearanceToBoard(mNewMinClearanceToBoard);
+  mPlane.setMinClearanceToNpth(mNewMinClearanceToNpth);
   mPlane.setConnectStyle(mNewConnectStyle);
   mPlane.setThermalGap(mNewThermalGap);
   mPlane.setThermalSpokeWidth(mNewThermalSpokeWidth);

--- a/libs/librepcb/editor/project/cmd/cmdboardplaneedit.h
+++ b/libs/librepcb/editor/project/cmd/cmdboardplaneedit.h
@@ -63,7 +63,9 @@ public:
   void setLayer(const Layer& layer, bool immediate) noexcept;
   void setNetSignal(NetSignal* netsignal) noexcept;
   void setMinWidth(const UnsignedLength& minWidth) noexcept;
-  void setMinClearance(const UnsignedLength& minClearance) noexcept;
+  void setMinClearanceToCopper(const UnsignedLength& minClearance) noexcept;
+  void setMinClearanceToBoard(const UnsignedLength& minClearance) noexcept;
+  void setMinClearanceToNpth(const UnsignedLength& minClearance) noexcept;
   void setConnectStyle(BI_Plane::ConnectStyle style) noexcept;
   void setThermalGap(const PositiveLength& gap) noexcept;
   void setThermalSpokeWidth(const PositiveLength& width) noexcept;
@@ -97,8 +99,12 @@ private:
   NetSignal* mNewNetSignal;
   UnsignedLength mOldMinWidth;
   UnsignedLength mNewMinWidth;
-  UnsignedLength mOldMinClearance;
-  UnsignedLength mNewMinClearance;
+  UnsignedLength mOldMinClearanceToCopper;
+  UnsignedLength mNewMinClearanceToCopper;
+  UnsignedLength mOldMinClearanceToBoard;
+  UnsignedLength mNewMinClearanceToBoard;
+  UnsignedLength mOldMinClearanceToNpth;
+  UnsignedLength mNewMinClearanceToNpth;
   BI_Plane::ConnectStyle mOldConnectStyle;
   BI_Plane::ConnectStyle mNewConnectStyle;
   PositiveLength mOldThermalGap;

--- a/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteboarditems.cpp
@@ -304,7 +304,9 @@ bool CmdPasteBoardItems::performExecute() {
         plane.outline.translated(mPosOffset)  // move
     );
     copy->setMinWidth(plane.minWidth);
-    copy->setMinClearance(plane.minClearance);
+    copy->setMinClearanceToCopper(plane.minClearanceToCopper);
+    copy->setMinClearanceToBoard(plane.minClearanceToBoard);
+    copy->setMinClearanceToNpth(plane.minClearanceToNpth);
     copy->setKeepIslands(plane.keepIslands);
     copy->setPriority(plane.priority);
     copy->setConnectStyle(plane.connectStyle);

--- a/tests/unittests/editor/project/board/boardclipboarddatatest.cpp
+++ b/tests/unittests/editor/project/board/boardclipboarddatatest.cpp
@@ -175,18 +175,18 @@ TEST(BoardClipboardDataTest, testToFromMimeDataPopulated) {
       std::make_shared<BoardClipboardData::Plane>(
           Uuid::createRandom(), Layer::topCopper(), CircuitIdentifier("bar"),
           Path({Vertex(Point(1, 2), Angle(3)), Vertex(Point(4, 5), Angle(6))}),
-          UnsignedLength(1), UnsignedLength(2), false, 0,
-          BI_Plane::ConnectStyle::None, PositiveLength(7), PositiveLength(8),
-          true);
+          UnsignedLength(1), UnsignedLength(2), UnsignedLength(3),
+          UnsignedLength(4), false, 0, BI_Plane::ConnectStyle::None,
+          PositiveLength(7), PositiveLength(8), true);
 
   std::shared_ptr<BoardClipboardData::Plane> plane2 =
       std::make_shared<BoardClipboardData::Plane>(
           Uuid::createRandom(), Layer::botCopper(), CircuitIdentifier("foo"),
           Path({Vertex(Point(10, 20), Angle(30)),
                 Vertex(Point(40, 50), Angle(60))}),
-          UnsignedLength(10), UnsignedLength(20), true, 5,
-          BI_Plane::ConnectStyle::Solid, PositiveLength(70), PositiveLength(80),
-          false);
+          UnsignedLength(10), UnsignedLength(20), UnsignedLength(30),
+          UnsignedLength(40), true, 5, BI_Plane::ConnectStyle::Solid,
+          PositiveLength(70), PositiveLength(80), false);
 
   BoardZoneData zone1(
       Uuid::createRandom(), {&Layer::topCopper()}, Zone::Rule::NoCopper,


### PR DESCRIPTION
As explained in #1435, this PR adds two more properties to planes to allow specifying individual clearances to the board outline and holes:

<img width="637" height="719" alt="image" src="https://github.com/user-attachments/assets/a3d7c54b-5a22-4c13-a708-fd7c875323fe" />

The plane fragments calculation algorithm has been adjusted accordingly to respect these new properties. And a clearance value of 0 is now handled differently to disable clipping the plane area to the board outlines, i.e. the plane will always fill up to its own outline, completely ignoring the board outlines and holes.

During project file format upgrade from v1, these properties are initialized with the value of the copper clearance to not introduce any change for existing planes. For new planes, the default copper clearance is now reduced from 300um to 250um. The two new properties are initialized with 300um.

Closes #1435