### PR TITLE
Ignore stale schematics/boards during file format upgrade

### DIFF
--- a/libs/librepcb/editor/project/projecteditor.cpp
+++ b/libs/librepcb/editor/project/projecteditor.cpp
@@ -680,10 +680,12 @@ void ProjectEditor::showUpgradeMessages() noexcept {
   std::sort(mUpgradeMessages->begin(), mUpgradeMessages->end(),
             [](const FileFormatMigration::Message& a,
                const FileFormatMigration::Message& b) {
-              if (a.severity > b.severity) return true;
-              if (a.toVersion < b.toVersion) return true;
-              if (a.message < b.message) return true;
-              return false;
+              // It is most intuitive to have the oldest messages at top, and
+              // the newest messages at bottom since they might "depend" on
+              // each other.
+              if (a.toVersion != b.toVersion) return a.toVersion < b.toVersion;
+              if (a.severity != b.severity) return a.severity > b.severity;
+              return a.message < b.message;
             });
 
   QDialog dialog(qApp->activeWindow());


### PR DESCRIPTION
Stale files in a project can lead to fatal upgrade errors (e.g. `schematic.lp` or `board.lp` which have actually been removed from the project, but still exist on the file system), therefore now ignoring them, i.e. no longer upgrade them.

In addition, change the sort order of upgrade messages to oldest at top, newest at bottom for a natural reading flow.
