### PR TITLE
Support specifying per-package copper clearance value

### DIFF
--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -90,6 +90,7 @@ Package::Package(const Uuid& uuid, const Version& version,
     mAlternativeNames(),
     mAssemblyType(assemblyType),
     mGridInterval(2540000),
+    mMinCopperClearance(200000),  // 200 µm
     mPads(),
     mModels(),
     mFootprints() {
@@ -103,6 +104,8 @@ Package::Package(std::unique_ptr<TransactionalDirectory> directory,
     mAssemblyType(deserialize<AssemblyType>(root.getChild("assembly_type/@0"))),
     mGridInterval(
         deserialize<PositiveLength>(root.getChild("grid_interval/@0"))),
+    mMinCopperClearance(
+        deserialize<UnsignedLength>(root.getChild("min_copper_clearance/@0"))),
     mPads(root),
     mModels(root),
     mFootprints(root) {
@@ -222,6 +225,8 @@ void Package::serialize(SExpression& root) const {
   root.appendChild("assembly_type", mAssemblyType);
   root.ensureLineBreak();
   root.appendChild("grid_interval", mGridInterval);
+  root.ensureLineBreak();
+  root.appendChild("min_copper_clearance", mMinCopperClearance);
   root.ensureLineBreak();
   mPads.serialize(root);
   root.ensureLineBreak();

--- a/libs/librepcb/core/library/pkg/package.h
+++ b/libs/librepcb/core/library/pkg/package.h
@@ -102,6 +102,9 @@ public:
   const PositiveLength& getGridInterval() const noexcept {
     return mGridInterval;
   }
+  const UnsignedLength& getMinCopperClearance() const noexcept {
+    return mMinCopperClearance;
+  }
   PackagePadList& getPads() noexcept { return mPads; }
   const PackagePadList& getPads() const noexcept { return mPads; }
   PackageModelList& getModels() noexcept { return mModels; }
@@ -115,6 +118,9 @@ public:
   void setAssemblyType(AssemblyType type) noexcept { mAssemblyType = type; }
   void setGridInterval(const PositiveLength& interval) noexcept {
     mGridInterval = interval;
+  }
+  void setMinCopperClearance(const UnsignedLength& value) noexcept {
+    mMinCopperClearance = value;
   }
 
   // General Methods
@@ -145,6 +151,7 @@ private:  // Data
   QList<AlternativeName> mAlternativeNames;  ///< Optional
   AssemblyType mAssemblyType;  ///< Package assembly type (metadata)
   PositiveLength mGridInterval;
+  UnsignedLength mMinCopperClearance;  ///< For the package checks
   PackagePadList mPads;  ///< empty list if the package has no pads
   PackageModelList mModels;  ///< 3D models (optional)
   FootprintList mFootprints;  ///< minimum one footprint

--- a/libs/librepcb/core/library/pkg/packagecheck.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheck.cpp
@@ -319,8 +319,8 @@ void PackageCheck::checkPadsPackagePadUuid(MsgList& msgs) const {
 }
 
 void PackageCheck::checkPadsClearanceToPads(MsgList& msgs) const {
-  Length clearance(200000);  // 200 µm
-  Length tolerance(10);  // 0.01 µm, to avoid rounding issues
+  const Length clearance = *mPackage.getMinCopperClearance();
+  const Length tolerance(10);  // 0.01 µm, to avoid rounding issues
 
   // Check all footprints.
   for (auto itFtp = mPackage.getFootprints().begin();

--- a/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
+++ b/libs/librepcb/core/library/pkg/packagecheckmessages.cpp
@@ -483,10 +483,10 @@ MsgPadClearanceViolation::MsgPadClearanceViolation(
         tr("Clearance of pad '%1' to pad '%2' in '%3'")
             .arg(pkgPad1Name, pkgPad2Name,
                  *footprint->getNames().getDefaultValue()),
-        tr("Pads should have at least %1 clearance between each other. In some "
-           "situations it might be needed to use smaller clearances but not "
-           "all PCB manufacturers are able to reliably produce such small "
-           "clearances, so usually this should be avoided.")
+        tr("Pads must have at least %1 clearance between each other, as "
+           "configured in the package. Either increase the clearance between "
+           "those pads, or reduce the configured minimum clearance value if "
+           "you are sure the PCB manufacturer can reliably handle it.")
             .arg(QString::number(clearance.toMm() * 1000) % "μm"),
         "small_pad_clearance"),
     mFootprint(footprint),

--- a/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationunstable.cpp
@@ -67,6 +67,15 @@ void FileFormatMigrationUnstable::upgradeSymbol(TransactionalDirectory& dir) {
 
 void FileFormatMigrationUnstable::upgradePackage(TransactionalDirectory& dir) {
   Q_UNUSED(dir);
+
+  // Content File.
+  {
+    const QString fp = "package.lp";
+    std::unique_ptr<SExpression> root =
+        SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
+    root->appendChild("min_copper_clearance", SExpression::createToken("0.2"));
+    dir.write(fp, root->toByteArray());
+  }
 }
 
 void FileFormatMigrationUnstable::upgradeComponent(

--- a/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
+++ b/libs/librepcb/core/serialization/fileformatmigrationv1.cpp
@@ -87,6 +87,7 @@ void FileFormatMigrationV1::upgradePackage(TransactionalDirectory& dir) {
     std::unique_ptr<SExpression> root =
         SExpression::parse(dir.read(fp), dir.getAbsPath(fp));
     root->appendChild("grid_interval", SExpression::createToken("2.54"));
+    root->appendChild("min_copper_clearance", SExpression::createToken("0.2"));
 
     // Footprints.
     for (SExpression* fptNode : root->getChildren("footprint")) {

--- a/libs/librepcb/editor/library/cmd/cmdpackageedit.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpackageedit.cpp
@@ -38,7 +38,9 @@ CmdPackageEdit::CmdPackageEdit(Package& package) noexcept
   : CmdLibraryElementEdit(package, tr("Edit Package Properties")),
     mPackage(package),
     mOldAssemblyType(package.getAssemblyType(false)),
-    mNewAssemblyType(mOldAssemblyType) {
+    mNewAssemblyType(mOldAssemblyType),
+    mOldMinCopperClearance(package.getMinCopperClearance()),
+    mNewMinCopperClearance(mOldMinCopperClearance) {
 }
 
 CmdPackageEdit::~CmdPackageEdit() noexcept {
@@ -53,6 +55,11 @@ void CmdPackageEdit::setAssemblyType(Package::AssemblyType type) noexcept {
   mNewAssemblyType = type;
 }
 
+void CmdPackageEdit::setMinCopperClearance(const UnsignedLength& clr) noexcept {
+  Q_ASSERT(!wasEverExecuted());
+  mNewMinCopperClearance = clr;
+}
+
 /*******************************************************************************
  *  Inherited from UndoCommand
  ******************************************************************************/
@@ -60,17 +67,20 @@ void CmdPackageEdit::setAssemblyType(Package::AssemblyType type) noexcept {
 bool CmdPackageEdit::performExecute() {
   if (CmdLibraryElementEdit::performExecute()) return true;  // can throw
   if (mNewAssemblyType != mOldAssemblyType) return true;
+  if (mNewMinCopperClearance != mOldMinCopperClearance) return true;
   return false;
 }
 
 void CmdPackageEdit::performUndo() {
   CmdLibraryElementEdit::performUndo();  // can throw
   mPackage.setAssemblyType(mOldAssemblyType);
+  mPackage.setMinCopperClearance(mOldMinCopperClearance);
 }
 
 void CmdPackageEdit::performRedo() {
   CmdLibraryElementEdit::performRedo();  // can throw
   mPackage.setAssemblyType(mNewAssemblyType);
+  mPackage.setMinCopperClearance(mNewMinCopperClearance);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/cmd/cmdpackageedit.h
+++ b/libs/librepcb/editor/library/cmd/cmdpackageedit.h
@@ -52,6 +52,7 @@ public:
 
   // Setters
   void setAssemblyType(Package::AssemblyType type) noexcept;
+  void setMinCopperClearance(const UnsignedLength& clr) noexcept;
 
   // Operator Overloadings
   CmdPackageEdit& operator=(const CmdPackageEdit& rhs) = delete;
@@ -71,6 +72,8 @@ private:  // Data
 
   Package::AssemblyType mOldAssemblyType;
   Package::AssemblyType mNewAssemblyType;
+  UnsignedLength mOldMinCopperClearance;
+  UnsignedLength mNewMinCopperClearance;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/pkg/packagetab.h
+++ b/libs/librepcb/editor/library/pkg/packagetab.h
@@ -251,6 +251,7 @@ private:
   std::shared_ptr<LibraryElementCategoriesModel> mCategories;
   std::shared_ptr<CategoryTreeModel> mCategoriesTree;
   Package::AssemblyType mAssemblyType;
+  LengthEditContext mMinCopperClearance;
   std::shared_ptr<PackagePadListModel> mPads;
   std::shared_ptr<slint::SortModel<ui::PackagePadData>> mPadsSorted;
   slint::SharedString mNewPadName;

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -1122,6 +1122,7 @@ void MainWindow::openPackageTab(LibraryEditor& editor, const FilePath& fp,
           pkg->setResources(src->getResources());
           pkg->setAssemblyType(src->getAssemblyType(false));
           pkg->setGridInterval(src->getGridInterval());
+          pkg->setMinCopperClearance(src->getMinCopperClearance());
           // Copy pads but generate new UUIDs.
           QHash<Uuid, std::optional<Uuid>> padUuidMap;
           for (const PackagePad& pad : src->getPads()) {

--- a/libs/librepcb/editor/ui/api/types.slint
+++ b/libs/librepcb/editor/ui/api/types.slint
@@ -962,6 +962,7 @@ export struct PackageTabData {
     categories-tree: [TreeViewItemData],
     choose-category: bool,  // If true, the dialog is shown
     assembly-type: int,
+    min-copper-clearance: LengthEditData,
     pads: [PackagePadData],
     new-pad-name: string,
     new-pad-name-error: string,

--- a/libs/librepcb/editor/ui/rulecheckpanel.slint
+++ b/libs/librepcb/editor/ui/rulecheckpanel.slint
@@ -1,20 +1,26 @@
 import { ListView } from "std-widgets.slint";
 import {
+    Button,
     IconButton,
+    LengthEdit,
     ListViewItemButton,
     Palette,
     PanelHeader,
 } from "widgets.slint";
 import {
+    Backend,
     BoardAction,
     Data,
     EditorCommandSet as Cmd,
+    FeatureState,
     Helpers,
+    PackageTabData,
     RuleCheckData,
     RuleCheckMessageAction,
     RuleCheckMessageData,
     RuleCheckState,
     RuleCheckType,
+    TabAction,
 } from "api.slint";
 
 component RuleCheckListItem inherits Rectangle {
@@ -124,6 +130,7 @@ export component RuleCheckPanel inherits Rectangle {
             Data.erc-zoom-to-location
         }
     };
+    property <bool> settings-expanded: false;
 
     function set-current-index(index: int, force-zoom: bool) {
         if ((index + 1) * item-height) > (view.height - view.viewport-y) {
@@ -208,6 +215,18 @@ export component RuleCheckPanel inherits Rectangle {
                     }
                 }
 
+                if check.type == RuleCheckType.package-check: settings-btn := IconButton {
+                    width: self.height;
+                    icon: @image-url("../../../font-awesome/svgs/solid/sliders.svg");
+                    icon-scale: 0.7;
+                    tooltip: @tr("Settings");
+                    enabled: check.state != RuleCheckState.running;
+
+                    clicked => {
+                        settings-expanded = !settings-expanded;
+                    }
+                }
+
                 if (check.type == RuleCheckType.erc) || (check.type == RuleCheckType.drc): zoom-to-location-btn := IconButton {
                     width: self.height;
                     icon: @image-url("../../../font-awesome/svgs/solid/location-crosshairs.svg");
@@ -221,6 +240,80 @@ export component RuleCheckPanel inherits Rectangle {
                             Data.drc-zoom-to-location = !Data.drc-zoom-to-location;
                         } else {
                             Data.erc-zoom-to-location = !Data.erc-zoom-to-location;
+                        }
+                    }
+                }
+            }
+
+            if (check.type == RuleCheckType.package-check) && settings-expanded: Rectangle {
+                property <int> section-index: Data.current-section-index;
+                property <[PackageTabData]> tabs: Data.current-section.package-tabs;
+                property <int> index: Data.current-section.current-tab-index;
+                property <bool> read-only: Data.current-section.tabs[index].features.save != FeatureState.enabled;
+
+                Rectangle {
+                    y: parent.height - self.height;
+                    height: 1px;
+                    background: #555555;
+                }
+
+                GridLayout {
+                    padding: 5px;
+                    spacing: 5px;
+
+                    Row {
+                        Text {
+                            colspan: 2;
+                            text: @tr("These settings are stored in the currently opened package and don't affect other packages.");
+                            font-size: 11px;
+                            font-italic: true;
+                            wrap: word-wrap;
+                        }
+                    }
+
+                    Row {
+                        min-copper-clearance-txt := Text {
+                            width: self.preferred-width;
+                            text: @tr("Min. Copper Clearance:");
+                            vertical-alignment: center;
+                            accessible-role: none;
+                        }
+
+                        LengthEdit {
+                            z: 100;
+                            height: self.preferred-height;
+                            data: tabs[index].min-copper-clearance;
+                            enabled: !read-only;
+                            tooltip: @tr("Recommended: {} (default)", "200μm") + "\n" + @tr("Reduce it for packages with very small pitch");
+                            accessible-label: min-copper-clearance-txt.text;
+
+                            value-changed(value) => {
+                                tabs[index].min-copper-clearance.value = value;
+                            }
+
+                            unit-changed(unit) => {
+                                tabs[index].min-copper-clearance.unit = unit;
+                            }
+
+                            increase-triggered() => {
+                                tabs[index].min-copper-clearance.increase = true;
+                            }
+
+                            decrease-triggered() => {
+                                tabs[index].min-copper-clearance.decrease = true;
+                            }
+                        }
+                    }
+
+                    Row {
+                        settings-apply-btn := Button {
+                            colspan: 2;
+                            text: @tr("Apply");
+                            primary: true;
+
+                            clicked => {
+                                Backend.trigger-tab(section-index, index, TabAction.apply);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The new package-specific copper clearance can be configured in the rule check panel.

Closes #1529