### PR TITLE
Library manager: Add button to manually check for updates

### DIFF
--- a/libs/librepcb/core/network/apiendpoint.h
+++ b/libs/librepcb/core/network/apiendpoint.h
@@ -75,7 +75,7 @@ public:
   const QUrl& getUrl() const noexcept { return mUrl; }
 
   // General Methods
-  void requestLibraryList() const noexcept;
+  void requestLibraryList(bool forceNoCache = false) noexcept;
   void requestPartsInformationStatus() const noexcept;
   void requestPartsInformation(const QUrl& url,
                                const QVector<Part>& parts) const noexcept;
@@ -92,8 +92,9 @@ signals:
   void errorWhileFetchingPartsInformation(const QString& errorMsg);
 
 private:  // Methods
-  void requestLibraryList(const QUrl& url) const noexcept;
-  void libraryListResponseReceived(const QByteArray& data) noexcept;
+  void requestLibraryList(const QUrl& url, bool forceNoCache) noexcept;
+  void libraryListResponseReceived(const QByteArray& data,
+                                   bool forceNoCache) noexcept;
   void partsInformationStatusResponseReceived(const QByteArray& data) noexcept;
   void partsInformationResponseReceived(const QByteArray& data) noexcept;
 

--- a/libs/librepcb/editor/library/librariesmodel.cpp
+++ b/libs/librepcb/editor/library/librariesmodel.cpp
@@ -146,7 +146,7 @@ void LibrariesModel::ensurePopulated(bool withIcons) noexcept {
   if ((mMode == Mode::RemoteLibs) &&
       (mApiEndpointsInProgress.isEmpty() &&
        (mOnlineLibs.isEmpty() || (!mOnlineLibsErrors.isEmpty())))) {
-    requestOnlineLibraries();
+    requestOnlineLibraries(false);
   }
   if (mRequestIcons) {
     requestMissingOnlineIcons();
@@ -155,6 +155,20 @@ void LibrariesModel::ensurePopulated(bool withIcons) noexcept {
 
 void LibrariesModel::highlightLibraryOnNextRescan(const FilePath& fp) noexcept {
   mHighlightedLib = fp;
+}
+
+void LibrariesModel::checkForUpdates() noexcept {
+  if (mMode != Mode::RemoteLibs) return;
+
+  requestOnlineLibraries(true);
+}
+
+void LibrariesModel::cancelUpdateCheck() noexcept {
+  if (mMode != Mode::RemoteLibs) return;
+
+  mApiEndpointsInProgress.clear();  // Should cancel the network requests.
+  mOnlineLibsErrors.clear();
+  emit uiDataChanged(getUiData());
 }
 
 void LibrariesModel::applyChanges() noexcept {
@@ -354,7 +368,7 @@ void LibrariesModel::updateLibraries(bool resetHighlight) noexcept {
   }
 }
 
-void LibrariesModel::requestOnlineLibraries() noexcept {
+void LibrariesModel::requestOnlineLibraries(bool forceNoCache) noexcept {
   mApiEndpointsInProgress.clear();  // Disconnects all signal/slot connections.
   mOnlineLibs.clear();
   mOnlineLibsErrors.clear();
@@ -367,7 +381,7 @@ void LibrariesModel::requestOnlineLibraries() noexcept {
       connect(repo.get(), &ApiEndpoint::errorWhileFetchingLibraryList, this,
               &LibrariesModel::errorWhileFetchingLibraryList);
       mApiEndpointsInProgress.append(repo);
-      repo->requestLibraryList();
+      repo->requestLibraryList(forceNoCache);
     }
   }
   if (!mApiEndpointsInProgress.isEmpty()) {

--- a/libs/librepcb/editor/library/librariesmodel.h
+++ b/libs/librepcb/editor/library/librariesmodel.h
@@ -71,6 +71,8 @@ public:
   void setOnlineVersions(const QHash<Uuid, Version>& versions) noexcept;
   void ensurePopulated(bool withIcons) noexcept;
   void highlightLibraryOnNextRescan(const FilePath& fp) noexcept;
+  void checkForUpdates() noexcept;
+  void cancelUpdateCheck() noexcept;
   void applyChanges() noexcept;
   void cancel() noexcept;
 
@@ -90,7 +92,7 @@ signals:
 
 private:
   void updateLibraries(bool resetHighlight = true) noexcept;
-  void requestOnlineLibraries() noexcept;
+  void requestOnlineLibraries(bool forceNoCache) noexcept;
   void onlineLibraryListReceived(QList<ApiEndpoint::Library> libs) noexcept;
   void requestMissingOnlineIcons() noexcept;
   void onlineIconReceived(const Uuid& uuid, const QByteArray& data) noexcept;

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -590,6 +590,14 @@ void MainWindow::trigger(ui::Action a) noexcept {
       mApp.getRemoteLibraries().ensurePopulated(true);
       break;
     }
+    case ui::Action::LibraryPanelCheckForUpdates: {
+      mApp.getRemoteLibraries().checkForUpdates();
+      break;
+    }
+    case ui::Action::LibraryPanelCancelUpdateCheck: {
+      mApp.getRemoteLibraries().cancelUpdateCheck();
+      break;
+    }
     case ui::Action::LibraryPanelApply: {
       mApp.getRemoteLibraries().applyChanges();
       break;

--- a/libs/librepcb/editor/ui/api/types.slint
+++ b/libs/librepcb/editor/ui/api/types.slint
@@ -22,6 +22,8 @@ export enum Action {
     library-create,
     library-download,
     library-panel-ensure-populated,
+    library-panel-check-for-updates,  // Reload remote libs without cache
+    library-panel-cancel-update-check,  // Abort fetching remote libraries
     library-panel-apply,
     library-panel-cancel,
 

--- a/libs/librepcb/editor/ui/library/librariespanel.slint
+++ b/libs/librepcb/editor/ui/library/librariespanel.slint
@@ -303,6 +303,35 @@ component LibrariesPanelSection inherits FocusScope {
             highlight: root.has-focus;
             show-spinner: data.refreshing;
 
+            if remote && (!data.refreshing): LinkText {
+                width: self.preferred-width + 2px;
+                horizontal-alignment: left;
+                vertical-alignment: center;
+                font-size: 10px;
+                text-color: #c0c0c0;
+                text: @tr("Toggle All");
+                enabled: root.enabled;
+
+                clicked => {
+                    check-all = !check-all;
+                }
+            }
+
+            if remote: Rectangle {
+                width: 2px;
+            }
+
+            if !data.refreshing-error.is-empty: IconButton {
+                width: self.height;
+                style: read-only;
+                icon: @image-url("../../../../font-awesome/svgs/solid/triangle-exclamation.svg");
+                icon-scale: 0.7;
+                color-disabled: yellow.darker(1);
+                color-enabled: yellow;
+                tooltip: data.refreshing-error;
+                enabled: root.enabled;
+            }
+
             if !remote: download-by-url-btn := IconButton {
                 width: self.height;
                 icon: @image-url("../../../../bootstrap-icons/icons/cloud-arrow-down-fill.svg");
@@ -326,33 +355,29 @@ component LibrariesPanelSection inherits FocusScope {
                 }
             }
 
-            if remote: LinkText {
-                width: self.preferred-width + view.scrollbar-width + 2px;
-                horizontal-alignment: left;
-                vertical-alignment: center;
-                font-size: 10px;
-                text-color: #c0c0c0;
-                text: @tr("Toggle All");
-                enabled: root.enabled;
+            property <bool> check-for-updates-enabled: true;
+            if remote && (!data.refreshing): check-for-updates-btn := IconButton {
+                width: self.height;
+                icon: @image-url("../../../../font-awesome/svgs/solid/rotate.svg");
+                icon-scale: 0.7;
+                tooltip: @tr("Check For Updates");
+                enabled: root.enabled && check-for-updates-enabled;
 
                 clicked => {
-                    check-all = !check-all;
+                    check-for-updates-enabled = false;  // DoS attack prevention ;-)
+                    Backend.trigger(Action.library-panel-check-for-updates);
                 }
             }
 
-            if remote: Rectangle {
-                width: 5px;
-            }
-
-            if !data.refreshing-error.is-empty: IconButton {
+            if remote && data.refreshing: cancel-update-check-btn := IconButton {
                 width: self.height;
-                style: read-only;
-                icon: @image-url("../../../../font-awesome/svgs/solid/triangle-exclamation.svg");
+                icon: @image-url("../../../../font-awesome/svgs/solid/ban.svg");
                 icon-scale: 0.7;
-                color-disabled: yellow.darker(1);
-                color-enabled: yellow;
-                tooltip: data.refreshing-error;
-                enabled: root.enabled;
+                tooltip: @tr("Cancel Update Check");
+
+                clicked => {
+                    Backend.trigger(Action.library-panel-cancel-update-check);
+                }
             }
         }
 


### PR DESCRIPTION
The button fetches the remote libraries **bypassing the HTTP cache**. This is very handy when a library update was just published to allow users getting that update without waiting for the HTTP cache to become outdated.