### PR TITLE
Hide unused symbol pins in schematics

### DIFF
--- a/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
@@ -280,7 +280,7 @@ ErcMsgConnectedPinWithoutWire::ErcMsgConnectedPinWithoutWire(
   mApproval->ensureLineBreak();
   mApproval->appendChild("symbol", pin.getSymbol().getUuid());
   mApproval->ensureLineBreak();
-  mApproval->appendChild("pin", pin.getLibPinUuid());
+  mApproval->appendChild("pin", pin.getLibPin().getUuid());
   mApproval->ensureLineBreak();
 
   setLocation(pin);

--- a/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
+++ b/libs/librepcb/core/project/schematic/items/si_netsegment.cpp
@@ -76,9 +76,9 @@ QSet<QString> SI_NetSegment::getForcedNetNames() const noexcept {
     SI_SymbolPin* pin1 = dynamic_cast<SI_SymbolPin*>(&netline->getP1());
     SI_SymbolPin* pin2 = dynamic_cast<SI_SymbolPin*>(&netline->getP2());
     ComponentSignalInstance* sig1 =
-        pin1 ? pin1->getComponentSignalInstance() : nullptr;
+        pin1 ? &pin1->getComponentSignalInstance() : nullptr;
     ComponentSignalInstance* sig2 =
-        pin2 ? pin2->getComponentSignalInstance() : nullptr;
+        pin2 ? &pin2->getComponentSignalInstance() : nullptr;
     if (sig1 && sig1->isNetSignalNameForced())
       names.insert(sig1->getForcedNetSignalName());
     if (sig2 && sig2->isNetSignalNameForced())

--- a/libs/librepcb/core/project/schematic/items/si_symbolpin.h
+++ b/libs/librepcb/core/project/schematic/items/si_symbolpin.h
@@ -70,7 +70,8 @@ public:
   // Constructors / Destructor
   SI_SymbolPin() = delete;
   SI_SymbolPin(const SI_SymbolPin& other) = delete;
-  explicit SI_SymbolPin(SI_Symbol& symbol, const Uuid& pinUuid);
+  explicit SI_SymbolPin(SI_Symbol& symbol, const SymbolPin& pin,
+                        const ComponentPinSignalMapItem& item);
   ~SI_SymbolPin();
 
   // Getters
@@ -103,10 +104,9 @@ public:
     return mNumbersAlignment;
   }
 
-  const Uuid& getLibPinUuid() const noexcept;
   SI_Symbol& getSymbol() const noexcept { return mSymbol; }
-  const SymbolPin& getLibPin() const noexcept { return *mSymbolPin; }
-  ComponentSignalInstance* getComponentSignalInstance() const noexcept {
+  const SymbolPin& getLibPin() const noexcept { return mSymbolPin; }
+  ComponentSignalInstance& getComponentSignalInstance() const noexcept {
     return mComponentSignalInstance;
   }
   NetSignal* getCompSigInstNetSignal() const noexcept;
@@ -143,14 +143,13 @@ private:
   void updateNumbers() noexcept;
   void updateNumbersTransform() noexcept;
   QString getLibraryComponentName() const noexcept;
-  QString getComponentSignalNameOrPinUuid() const noexcept;
   QString getNetSignalName() const noexcept;
 
   // General
   SI_Symbol& mSymbol;
-  const SymbolPin* mSymbolPin;
-  const ComponentPinSignalMapItem* mPinSignalMapItem;
-  ComponentSignalInstance* mComponentSignalInstance;
+  const SymbolPin& mSymbolPin;
+  const ComponentPinSignalMapItem& mPinSignalMapItem;
+  ComponentSignalInstance& mComponentSignalInstance;
 
   // Cached Properties
   Point mPosition;

--- a/libs/librepcb/eagleimport/eagleprojectimport.cpp
+++ b/libs/librepcb/eagleimport/eagleprojectimport.cpp
@@ -570,10 +570,11 @@ void EagleProjectImport::importSchematic(Project& project,
           }
           auto symbolPin = cmpSigInst->getRegisteredSymbolPins().first();
           pinMap.insert(std::make_pair(symbolPin->getSymbol().getUuid(),
-                                       symbolPin->getLibPinUuid()),
+                                       symbolPin->getLibPin().getUuid()),
                         symbolPin);
-          const NetLineAnchor pinAnchor = NetLineAnchor::pin(
-              symbolPin->getSymbol().getUuid(), symbolPin->getLibPinUuid());
+          const NetLineAnchor pinAnchor =
+              NetLineAnchor::pin(symbolPin->getSymbol().getUuid(),
+                                 symbolPin->getLibPin().getUuid());
           splitter.addSymbolPin(pinAnchor, symbolPin->getPosition());
           auto it = anchorMap.find(symbolPin->getPosition());
           if (it != anchorMap.end()) {

--- a/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
+++ b/libs/librepcb/editor/library/cmp/componentchooserdialog.cpp
@@ -262,8 +262,8 @@ void ComponentChooserDialog::updatePreview(const FilePath& fp) noexcept {
             std::shared_ptr<SymbolGraphicsItem> graphicsItem =
                 std::make_shared<SymbolGraphicsItem>(
                     *sym, *mLayers, mComponent.get(),
-                    symbVar.getSymbolItems().get(item.getUuid()),
-                    localeOrder());
+                    symbVar.getSymbolItems().get(item.getUuid()), localeOrder(),
+                    true);
             graphicsItem->setPosition(item.getSymbolPosition());
             graphicsItem->setRotation(item.getSymbolRotation());
             mGraphicsScene->addItem(*graphicsItem);

--- a/libs/librepcb/editor/library/cmp/componentgateeditor.cpp
+++ b/libs/librepcb/editor/library/cmp/componentgateeditor.cpp
@@ -211,11 +211,13 @@ void ComponentGateEditor::reloadSymbol() noexcept {
   if (mSymbol) {
     mScene.reset(new GraphicsScene());
     mScene->setOriginCrossVisible(false);  // It's rather disruptive.
-    mGraphicsItem.reset(new SymbolGraphicsItem(const_cast<Symbol&>(*mSymbol),
-                                               mLayers, mComponent, mGate));
+    mGraphicsItem.reset(new SymbolGraphicsItem(
+        const_cast<Symbol&>(*mSymbol), mLayers, mComponent, mGate,
+        mWorkspace.getSettings().libraryLocaleOrder.get(), false));
     mScene->addItem(*mGraphicsItem);
     mComponentGraphicsItem.reset(new SymbolGraphicsItem(
-        const_cast<Symbol&>(*mSymbol), mLayers, mComponent, mGate));
+        const_cast<Symbol&>(*mSymbol), mLayers, mComponent, mGate,
+        mWorkspace.getSettings().libraryLocaleOrder.get(), false));
     mComponentGraphicsItem->setPosition(mGate->getSymbolPosition());
     mComponentGraphicsItem->setRotation(mGate->getSymbolRotation());
     if (mComponentScene) {

--- a/libs/librepcb/editor/library/dev/devicetab.cpp
+++ b/libs/librepcb/editor/library/dev/devicetab.cpp
@@ -685,7 +685,8 @@ void DeviceTab::refreshDependentElements() noexcept {
           mSymbols.append(symbol);
           auto graphicsItem = std::make_shared<SymbolGraphicsItem>(
               const_cast<Symbol&>(*symbol), mApp.getPreviewLayers(),
-              mComponent.get(), gate);
+              mComponent.get(), gate,
+              mApp.getWorkspace().getSettings().libraryLocaleOrder.get(), true);
           graphicsItem->setPosition(gate->getSymbolPosition());
           graphicsItem->setRotation(gate->getSymbolRotation());
           mComponentScene->addItem(*graphicsItem);

--- a/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
+++ b/libs/librepcb/editor/library/sym/symbolchooserdialog.cpp
@@ -244,7 +244,8 @@ void SymbolChooserDialog::setSelectedSymbol(const FilePath& fp) noexcept {
           *mSelectedSymbol->getNames().value(localeOrder()));
       mUi->lblSymbolDescription->setText(
           mSelectedSymbol->getDescriptions().value(localeOrder()));
-      mGraphicsItem.reset(new SymbolGraphicsItem(*mSelectedSymbol, mLayers));
+      mGraphicsItem.reset(new SymbolGraphicsItem(*mSelectedSymbol, mLayers,
+                                                 nullptr, nullptr, {}, false));
       mPreviewScene->addItem(*mGraphicsItem);
       mUi->graphicsView->zoomAll();
     } catch (const Exception& e) {

--- a/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
+++ b/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
@@ -155,7 +155,8 @@ QPixmap SymbolClipboardData::generatePixmap() noexcept {
   GraphicsScene scene;
   QVector<std::shared_ptr<QGraphicsItem>> items;
   for (auto ptr : mPins.values()) {
-    items.append(std::make_shared<SymbolPinGraphicsItem>(ptr, *layers));
+    items.append(std::make_shared<SymbolPinGraphicsItem>(ptr, *layers, nullptr,
+                                                         nullptr, false));
   }
   for (Polygon& polygon : mPolygons) {
     items.append(std::make_shared<PolygonGraphicsItem>(polygon, *layers));

--- a/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolgraphicsitem.cpp
@@ -50,13 +50,14 @@ SymbolGraphicsItem::SymbolGraphicsItem(
     Symbol& symbol, const GraphicsLayerList& layers,
     QPointer<const Component> cmp,
     std::shared_ptr<const ComponentSymbolVariantItem> cmpItem,
-    const QStringList& localeOrder) noexcept
+    const QStringList& localeOrder, bool hideUnusedPins) noexcept
   : QGraphicsItemGroup(nullptr),
     mSymbol(symbol),
     mLayers(layers),
     mComponent(cmp),
     mItem(cmpItem),
     mLocaleOrder(localeOrder),
+    mHideUnusedPins(hideUnusedPins),
     mOnEditedSlot(*this, &SymbolGraphicsItem::symbolEdited) {
   syncPins();
   syncCircles();
@@ -270,8 +271,8 @@ void SymbolGraphicsItem::syncPins() noexcept {
   for (auto& obj : mSymbol.getPins().values()) {
     if (!mPinGraphicsItems.contains(obj)) {
       Q_ASSERT(obj);
-      auto i = std::make_shared<SymbolPinGraphicsItem>(obj, mLayers, mComponent,
-                                                       mItem, this);
+      auto i = std::make_shared<SymbolPinGraphicsItem>(
+          obj, mLayers, mComponent, mItem, mHideUnusedPins, this);
       mPinGraphicsItems.insert(obj, i);
     }
   }

--- a/libs/librepcb/editor/library/sym/symbolgraphicsitem.h
+++ b/libs/librepcb/editor/library/sym/symbolgraphicsitem.h
@@ -71,11 +71,11 @@ public:
   // Constructors / Destructor
   SymbolGraphicsItem() = delete;
   SymbolGraphicsItem(const SymbolGraphicsItem& other) = delete;
-  SymbolGraphicsItem(
-      Symbol& symbol, const GraphicsLayerList& layers,
-      QPointer<const Component> cmp = nullptr,
-      std::shared_ptr<const ComponentSymbolVariantItem> cmpItem = nullptr,
-      const QStringList& localeOrder = {}) noexcept;
+  SymbolGraphicsItem(Symbol& symbol, const GraphicsLayerList& layers,
+                     QPointer<const Component> cmp,
+                     std::shared_ptr<const ComponentSymbolVariantItem> cmpItem,
+                     const QStringList& localeOrder,
+                     bool hideUnusedPins) noexcept;
   ~SymbolGraphicsItem() noexcept;
 
   // Getters
@@ -133,7 +133,8 @@ private:  // Data
   const GraphicsLayerList& mLayers;
   QPointer<const Component> mComponent;  // Can be nullptr.
   std::shared_ptr<const ComponentSymbolVariantItem> mItem;  // Can be nullptr.
-  QStringList mLocaleOrder;
+  const QStringList mLocaleOrder;
+  const bool mHideUnusedPins;
   QMap<std::shared_ptr<SymbolPin>, std::shared_ptr<SymbolPinGraphicsItem>>
       mPinGraphicsItems;
   QMap<std::shared_ptr<Circle>, std::shared_ptr<CircleGraphicsItem>>

--- a/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
+++ b/libs/librepcb/editor/library/sym/symbolpingraphicsitem.cpp
@@ -50,12 +50,13 @@ SymbolPinGraphicsItem::SymbolPinGraphicsItem(
     std::shared_ptr<SymbolPin> pin, const GraphicsLayerList& layers,
     QPointer<const Component> cmp,
     std::shared_ptr<const ComponentSymbolVariantItem> cmpItem,
-    QGraphicsItem* parent) noexcept
+    bool hideIfUnused, QGraphicsItem* parent) noexcept
   : QGraphicsItemGroup(parent),
     mPin(pin),
     mLayers(layers),
     mComponent(cmp),
     mItem(cmpItem),
+    mHideIfUnused(hideIfUnused),
     mCircleGraphicsItem(new PrimitiveCircleGraphicsItem(this)),
     mLineGraphicsItem(new LineGraphicsItem(this)),
     mNameGraphicsItem(new PrimitiveTextGraphicsItem(this)),
@@ -115,8 +116,10 @@ SymbolPinGraphicsItem::~SymbolPinGraphicsItem() noexcept {
 
 void SymbolPinGraphicsItem::updateText() noexcept {
   QString text;
+  bool isConnected = false;
   if (mItem) {
     if (auto i = mItem->getPinSignalMap().find(mPin->getUuid())) {
+      isConnected = i->getSignalUuid().has_value();
       auto signal = (mComponent && i->getSignalUuid())
           ? mComponent->getSignals().find(*i->getSignalUuid())
           : nullptr;
@@ -155,6 +158,9 @@ void SymbolPinGraphicsItem::updateText() noexcept {
   }
   setToolTip(text);
   mNameGraphicsItem->setText(text, true);
+
+  // Also update the pin's visibility, despite the misleading method name o_o
+  setVisible(isConnected || (!mItem) || (!mHideIfUnused));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/sym/symbolpingraphicsitem.h
+++ b/libs/librepcb/editor/library/sym/symbolpingraphicsitem.h
@@ -54,9 +54,9 @@ public:
   SymbolPinGraphicsItem(const SymbolPinGraphicsItem& other) = delete;
   SymbolPinGraphicsItem(
       std::shared_ptr<SymbolPin> pin, const GraphicsLayerList& layers,
-      QPointer<const Component> cmp = nullptr,
-      std::shared_ptr<const ComponentSymbolVariantItem> cmpItem = nullptr,
-      QGraphicsItem* parent = nullptr) noexcept;
+      QPointer<const Component> cmp,
+      std::shared_ptr<const ComponentSymbolVariantItem> cmpItem,
+      bool hideIfUnused, QGraphicsItem* parent = nullptr) noexcept;
   ~SymbolPinGraphicsItem() noexcept;
 
   // Getters
@@ -85,6 +85,7 @@ private:  // Data
   const GraphicsLayerList& mLayers;
   QPointer<const Component> mComponent;  // Can be nullptr.
   std::shared_ptr<const ComponentSymbolVariantItem> mItem;  // Can be nullptr.
+  const bool mHideIfUnused;
   QScopedPointer<PrimitiveCircleGraphicsItem> mCircleGraphicsItem;
   QScopedPointer<LineGraphicsItem> mLineGraphicsItem;
   QScopedPointer<PrimitiveTextGraphicsItem> mNameGraphicsItem;

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -392,7 +392,8 @@ void SymbolTab::activate() noexcept {
   connect(mScene.get(), &GraphicsScene::changed, this,
           &SymbolTab::requestRepaint);
 
-  mGraphicsItem.reset(new SymbolGraphicsItem(*mSymbol, *mLayers));
+  mGraphicsItem.reset(
+      new SymbolGraphicsItem(*mSymbol, *mLayers, nullptr, nullptr, {}, false));
   mScene->addItem(*mGraphicsItem);
 
   applyTheme();

--- a/libs/librepcb/editor/project/addcomponentdialog.cpp
+++ b/libs/librepcb/editor/project/addcomponentdialog.cpp
@@ -840,7 +840,8 @@ void AddComponentDialog::setSelectedSymbVar(
 
       auto graphicsItem = std::make_shared<SymbolGraphicsItem>(
           *symbol, *mLayers, mSelectedComponent.get(),
-          mSelectedSymbVar->getSymbolItems().get(item.getUuid()), mLocaleOrder);
+          mSelectedSymbVar->getSymbolItems().get(item.getUuid()), mLocaleOrder,
+          true);
       graphicsItem->setPosition(item.getSymbolPosition());
       graphicsItem->setRotation(item.getSymbolRotation());
       mPreviewSymbolGraphicsItems.append(graphicsItem);

--- a/libs/librepcb/editor/project/cmd/cmdchangenetsignalofschematicnetsegment.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdchangenetsignalofschematicnetsegment.cpp
@@ -107,10 +107,7 @@ void CmdChangeNetSignalOfSchematicNetSegment::changeNetSignalOfNetSegment() {
   // signals)
   foreach (SI_SymbolPin* pin, pins) {
     Q_ASSERT(pin);
-    ComponentSignalInstance* sig = pin->getComponentSignalInstance();
-    if (sig) {
-      updateCompSigInstNetSignal(*sig);
-    }
+    updateCompSigInstNetSignal(pin->getComponentSignalInstance());
   }
 
   // re-add netsegment

--- a/libs/librepcb/editor/project/cmd/cmdpasteschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdpasteschematicitems.cpp
@@ -275,12 +275,12 @@ bool CmdPasteSchematicItems::performExecute() {
         SI_SymbolPin* pin = symbol->getPin(anchor->pin);
         Q_ASSERT(pin);
         p1 = pin;
-        ComponentSignalInstance* sigInst = pin->getComponentSignalInstance();
-        if (sigInst && (sigInst->getNetSignal() != netSignal)) {
-          execNewChildCmd(new CmdCompSigInstSetNetSignal(*sigInst, netSignal));
+        ComponentSignalInstance& sigInst = pin->getComponentSignalInstance();
+        if (sigInst.getNetSignal() != netSignal) {
+          execNewChildCmd(new CmdCompSigInstSetNetSignal(sigInst, netSignal));
         }
-        if (sigInst && (sigInst->isNetSignalNameForced()) && (!forcedNetName)) {
-          forcedNetName = CircuitIdentifier(sigInst->getForcedNetSignalName());
+        if (sigInst.isNetSignalNameForced() && (!forcedNetName)) {
+          forcedNetName = CircuitIdentifier(sigInst.getForcedNetSignalName());
         }
       } else {
         throw LogicError(__FILE__, __LINE__);
@@ -297,12 +297,12 @@ bool CmdPasteSchematicItems::performExecute() {
         SI_SymbolPin* pin = symbol->getPin(anchor->pin);
         Q_ASSERT(pin);
         p2 = pin;
-        ComponentSignalInstance* sigInst = pin->getComponentSignalInstance();
-        if (sigInst && (sigInst->getNetSignal() != netSignal)) {
-          execNewChildCmd(new CmdCompSigInstSetNetSignal(*sigInst, netSignal));
+        ComponentSignalInstance& sigInst = pin->getComponentSignalInstance();
+        if (sigInst.getNetSignal() != netSignal) {
+          execNewChildCmd(new CmdCompSigInstSetNetSignal(sigInst, netSignal));
         }
-        if (sigInst && (sigInst->isNetSignalNameForced()) && (!forcedNetName)) {
-          forcedNetName = CircuitIdentifier(sigInst->getForcedNetSignalName());
+        if (sigInst.isNetSignalNameForced() && (!forcedNetName)) {
+          forcedNetName = CircuitIdentifier(sigInst.getForcedNetSignalName());
         }
       } else {
         throw LogicError(__FILE__, __LINE__);

--- a/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdremoveselectedschematicitems.cpp
@@ -202,11 +202,10 @@ void CmdRemoveSelectedSchematicItems::removeNetSegmentItems(
   }
   QSet<ComponentSignalInstance*> cmpSigsToBeDisconnected;
   foreach (SI_SymbolPin* pin, pinsToBeDisconnected) {
-    ComponentSignalInstance* cmpSig = pin->getComponentSignalInstance();
-    Q_ASSERT(cmpSig);
+    ComponentSignalInstance& cmpSig = pin->getComponentSignalInstance();
     if (pinsToBeDisconnected.contains(
-            Toolbox::toSet(cmpSig->getRegisteredSymbolPins()))) {
-      cmpSigsToBeDisconnected.insert(cmpSig);
+            Toolbox::toSet(cmpSig.getRegisteredSymbolPins()))) {
+      cmpSigsToBeDisconnected.insert(&cmpSig);
     }
   }
 

--- a/libs/librepcb/editor/project/cmd/cmdsimplifyschematicnetsegments.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdsimplifyschematicnetsegments.cpp
@@ -122,12 +122,12 @@ void CmdSimplifySchematicNetSegments::simplifySegment(SI_NetSegment& segment) {
   // (i.e. their net line have been removed by the simplification).
   for (auto id : result.disconnectedPinsOrPads) {
     if (auto* pin = dynamic_cast<SI_SymbolPin*>(anchors.key(id, nullptr))) {
-      ComponentSignalInstance* sig = pin->getComponentSignalInstance();
-      if (sig && (sig->getRegisteredSymbolPins().count() <= 1)) {
+      ComponentSignalInstance& sig = pin->getComponentSignalInstance();
+      if (sig.getRegisteredSymbolPins().count() <= 1) {
         // Last pin has been disconnected, thus deleting all traces from pads
         // in boards and disconnect the component signal from the net signal.
         QHash<Board*, QSet<BI_NetLine*>> boardNetLinesToRemove;
-        foreach (BI_Pad* pad, sig->getRegisteredFootprintPads()) {
+        foreach (BI_Pad* pad, sig.getRegisteredFootprintPads()) {
           boardNetLinesToRemove[&pad->getBoard()] += pad->getNetLines();
         }
         for (auto it = boardNetLinesToRemove.constBegin();
@@ -137,7 +137,7 @@ void CmdSimplifySchematicNetSegments::simplifySegment(SI_NetSegment& segment) {
           cmd->removeNetLines(it.value());
           appendChild(cmd.release());
         }
-        appendChild(new CmdCompSigInstSetNetSignal(*sig, nullptr));
+        appendChild(new CmdCompSigInstSetNetSignal(sig, nullptr));
       }
     } else {
       throw LogicError(__FILE__, __LINE__, "ID does not correspond to a pin.");

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.cpp
@@ -263,15 +263,11 @@ QList<std::shared_ptr<QGraphicsItem>> SchematicEditorState::findItemsAtPos(
     }
   }
 
-  if (flags &
-      (FindFlag::SymbolPins | FindFlag::SymbolPinsWithComponentSignal)) {
+  if (flags.testFlag(FindFlag::SymbolPins)) {
     for (auto it = scene->getSymbolPins().begin();
          it != scene->getSymbolPins().end(); it++) {
-      if (flags.testFlag(FindFlag::SymbolPins) ||
-          (it.key()->getComponentSignalInstance())) {
-        processItem(it.value(), it.value(), it.key()->getPosition(), 40, false,
-                    std::nullopt);
-      }
+      processItem(it.value(), it.value(), it.key()->getPosition(), 40, false,
+                  std::nullopt);
     }
   }
 

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
@@ -68,10 +68,9 @@ public:
     NetLabels = (1 << 2),
     Symbols = (1 << 3),
     SymbolPins = (1 << 4),
-    SymbolPinsWithComponentSignal = (1 << 5),  // Subset of SymbolPins.
-    Polygons = (1 << 6),
-    Texts = (1 << 7),
-    Images = (1 << 8),
+    Polygons = (1 << 5),
+    Texts = (1 << 6),
+    Images = (1 << 7),
     All = NetPoints | NetLines | NetLabels | Symbols | SymbolPins | Polygons |
         Texts | Images,
 

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_symbolpin.cpp
@@ -268,11 +268,7 @@ void SGI_SymbolPin::updateToolTip() noexcept {
   Q_ASSERT(mCircleGraphicsItem && mNameGraphicsItem && mNumbersGraphicsItem);
   QString s;
   s += "<b>" % tr("Signal:") % " ";
-  if (const ComponentSignalInstance* sig = mPin.getComponentSignalInstance()) {
-    s += *sig->getCompSignal().getName();
-  } else {
-    s += "✖";
-  }
+  s += *mPin.getComponentSignalInstance().getCompSignal().getName();
   s += "</b><br>" % tr("Net:") % " ";
   if (const NetSignal* net = mPin.getCompSigInstNetSignal()) {
     s += *net->getName();


### PR DESCRIPTION
Hide symbol pins in schematics which have no connection made in the component. It was not possible already to attach wires to those pads, so they were useless anyway. And hiding them allows to reuse more symbols - e.g. a symbol with 8 pins can now also be used for a component that needs only 7 pins, since the last pin will now simply be hidden.