### PR TITLE
Automatically switch to 10x grid when zooming out

### DIFF
--- a/libs/librepcb/editor/graphics/graphicsscene.cpp
+++ b/libs/librepcb/editor/graphics/graphicsscene.cpp
@@ -214,25 +214,55 @@ void GraphicsScene::drawBackground(QPainter* painter,
   right = rect.right();
   top = rect.top();
   bottom = qFloor(rect.bottom() / gridIntervalPixels) * gridIntervalPixels;
+  int xIndex = qFloor(rect.left() / gridIntervalPixels);
+  int yIndex = -qFloor(rect.bottom() / gridIntervalPixels);
   switch (mGridStyle) {
     case Theme::GridStyle::Lines: {
-      QVarLengthArray<QLineF, 500> lines;
-      for (qreal x = left; x < right; x += gridIntervalPixels)
-        lines.append(QLineF(x, rect.top(), x, rect.bottom()));
-      for (qreal y = bottom; y > top; y -= gridIntervalPixels)
-        lines.append(QLineF(rect.left(), y, rect.right(), y));
-      painter->setOpacity(0.5);
-      painter->drawLines(lines.data(), lines.size());
+      QVarLengthArray<QLineF, 450> minorLines;
+      QVarLengthArray<QLineF, 50> majorLines;
+      for (qreal x = left; x < right; x += gridIntervalPixels) {
+        if (xIndex % 10) {
+          minorLines.append(QLineF(x, rect.top(), x, rect.bottom()));
+        } else {
+          majorLines.append(QLineF(x, rect.top(), x, rect.bottom()));
+        }
+        ++xIndex;
+      }
+      for (qreal y = bottom; y > top; y -= gridIntervalPixels) {
+        if (yIndex % 10) {
+          minorLines.append(QLineF(rect.left(), y, rect.right(), y));
+        } else {
+          majorLines.append(QLineF(rect.left(), y, rect.right(), y));
+        }
+        ++yIndex;
+      }
+      painter->setOpacity(0.4);
+      painter->drawLines(minorLines.data(), minorLines.size());
+      painter->setOpacity(0.7);
+      painter->drawLines(majorLines.data(), majorLines.size());
       painter->setOpacity(1);
       break;
     }
 
     case Theme::GridStyle::Dots: {
-      QVarLengthArray<QPointF, 2000> dots;
-      for (qreal x = left; x < right; x += gridIntervalPixels)
-        for (qreal y = bottom; y > top; y -= gridIntervalPixels)
-          dots.append(QPointF(x, y));
-      painter->drawPoints(dots.data(), dots.size());
+      QVarLengthArray<QPointF, 1800> minorDots;
+      QVarLengthArray<QPointF, 200> majorDots;
+      for (qreal x = left; x < right; x += gridIntervalPixels) {
+        yIndex = -qFloor(rect.bottom() / gridIntervalPixels);
+        for (qreal y = bottom; y > top; y -= gridIntervalPixels) {
+          if ((xIndex % 10) || (yIndex % 10)) {
+            minorDots.append(QPointF(x, y));
+          } else {
+            majorDots.append(QPointF(x, y));
+          }
+          ++yIndex;
+        }
+        ++xIndex;
+      }
+      painter->setOpacity(0.6);
+      painter->drawPoints(minorDots.data(), minorDots.size());
+      painter->setOpacity(1);
+      painter->drawPoints(majorDots.data(), majorDots.size());
       break;
     }
 


### PR DESCRIPTION
When zooming out in editors, the grid is now no longer hidden completely, but switches automatically to 10x/100x/1000x of the configured grid interval. This ensures there is always a grid shown. However, the snap grid still remains at the configured grid interval.

In addition, every 10th grid line is now highlighted a bit to get a better visual overview of the dimensions and to help aligning objects.

![librepcb-10x-grid](https://github.com/user-attachments/assets/5012ab3d-1b3a-4e6d-b453-f7faad00d642)

Sometimes there are some minor rendering issues which make it hard to distinguish between thicker and thinner grid lines. Maybe it even depends on the platform, I need to investigate it further some day. But I'll merge this anyway because the improvement clearly outweighs the minor rendering issues.

Closes #604