### PR TITLE
Provide "clear cache" option after failed libraries rescan

### DIFF
--- a/libs/librepcb/core/workspace/workspacelibrarydb.h
+++ b/libs/librepcb/core/workspace/workspacelibrarydb.h
@@ -506,6 +506,11 @@ public:
   // General Methods
 
   /**
+   * @brief Re-initialize database and start new rescan
+   */
+  void resetAndRescan() noexcept;
+
+  /**
    * @brief Rescan the whole library directory and update the SQLite database
    */
   void startLibraryRescan() noexcept;
@@ -524,6 +529,7 @@ signals:
 
 private:
   // Private Methods
+  void reset();
   QMultiMap<Version, FilePath> getAll(const QString& elementsTable,
                                       const std::optional<Uuid>& uuid,
                                       const FilePath& lib) const;

--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -259,7 +259,10 @@ GuiApplication::GuiApplication(Workspace& ws, bool fileFormatIsOutdated,
           [this](const QString& err) {
             std::shared_ptr<Notification> n = std::make_shared<Notification>(
                 ui::NotificationType::Critical, tr("Scanning Libraries Failed"),
-                err, QString(), QString(), true);
+                err, tr("Clear Cache"), QString(), true);
+            connect(n.get(), &Notification::buttonClicked,
+                    &mWorkspace.getLibraryDb(),
+                    &WorkspaceLibraryDb::resetAndRescan);
             connect(&mWorkspace.getLibraryDb(),
                     &WorkspaceLibraryDb::scanStarted, n.get(),
                     &Notification::dismiss);


### PR DESCRIPTION
In case there's something messed up with the SQLite database (especially during development), provide a "Clear Cache" button in the corresponding notification, to allow recovering from that error.