### PR TITLE
UI: Automatically open the first schematic

### DIFF
--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -584,6 +584,14 @@ std::shared_ptr<ProjectEditor> GuiApplication::openProject(
     // Switch to documents tab.
     switchToProject(index);
 
+    // Open the first schematic page to get immediate feedback that the project
+    // had been opened. In future we should restore the tabs which were opened
+    // the last time, so this is just a temporary solution.
+    if (auto win = getCurrentWindow();
+        win && (!editor->getProject().getSchematics().isEmpty())) {
+      win->openSchematicTab(index, 0);
+    }
+
     // Delay updating the last opened project to avoid an issue when
     // double-clicking: https://github.com/LibrePCB/LibrePCB/issues/293
     QTimer::singleShot(
@@ -670,9 +678,9 @@ void GuiApplication::createNewWindow(int id, int projectIndex) noexcept {
   d.set_preview_mode(false);
   d.set_window_id(id);
   d.set_window_title(
-      QString("LibrePCB %1").arg(Application::getVersion()).toUtf8().data());
+      q2s(QString("LibrePCB %1").arg(Application::getVersion())));
   d.set_about_librepcb_details(q2s(Application::buildFullVersionDetails()));
-  d.set_workspace_path(mWorkspace.getPath().toNative().toUtf8().data());
+  d.set_workspace_path(q2s(mWorkspace.getPath().toNative()));
   d.set_notifications(mNotifications);
   d.set_quick_access_items(mQuickAccessModel);
   d.set_local_libraries(filteredLibs(mLocalLibraries));

--- a/libs/librepcb/editor/mainwindow.h
+++ b/libs/librepcb/editor/mainwindow.h
@@ -86,6 +86,8 @@ public:
                            bool zoomTo) noexcept;
   void setCurrentLibrary(int index) noexcept;
   void setCurrentProject(int index) noexcept;
+  std::shared_ptr<SchematicTab> openSchematicTab(int projectIndex,
+                                                 int index) noexcept;
 
   // Operator Overloadings
   MainWindow& operator=(const MainWindow& rhs) = delete;
@@ -120,8 +122,6 @@ private:
                      bool copyFrom) noexcept;
   void openOrganizationTab(LibraryEditor& editor, const FilePath& fp,
                            bool copyFrom) noexcept;
-  std::shared_ptr<SchematicTab> openSchematicTab(int projectIndex,
-                                                 int index) noexcept;
   void openBoard2dTab(int projectIndex, int index) noexcept;
   void openBoard3dTab(int projectIndex, int index) noexcept;
   void updateHomeTabSection() noexcept;

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -220,6 +220,21 @@ class ElementQuery:
                 )
             time.sleep(0.01)
 
+    def wait_for_item(self, test, timeout=10.0):
+        start = time.time()
+        while True:
+            self.refresh()
+            for result in self._results:
+                if test(result):
+                    return result
+            if time.time() - start > timeout:
+                self.save_screenshot()
+                raise TimeoutError(
+                    f"Waiting for item timed out: {self._query} "
+                    + "-- Screenshot saved."
+                )
+            time.sleep(0.01)
+
     def read(self, keys):
         """
         Read several element properties
@@ -414,6 +429,11 @@ class LibrePcbFixture(object):
         dest = self.get_workspace_libraries_path("local")
         dest = os.path.join(dest, os.path.basename(path))
         shutil.copytree(_long_path(path), _long_path(dest))
+
+    def add_project_to_workspace(self, project):
+        src = os.path.join(DATA_DIR, "projects", project)
+        dst = os.path.join(self.workspace_path, "projects", project)
+        shutil.copytree(_long_path(src), _long_path(dst))
 
     def open(self):
         self._create_application_config_file()

--- a/tests/ui/mainwindow/test_open_project.py
+++ b/tests/ui/mainwindow/test_open_project.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test opening projects
+"""
+
+
+def test_file_tree_dclick(librepcb, helpers):
+    librepcb.add_project_to_workspace("Empty Project")
+
+    with librepcb.open() as app:
+        # Open project
+        items = app.get("#HomePanel #WorkspaceFolderTreeView TreeView::item-ta *")
+        items.wait(1)
+        items[0].dclick()
+        items.wait_for_item(lambda x: x.label == "Empty Project.lpp").dclick()
+
+        # Verify that schematic tab has been opened
+        tabs = app.get("#TabButton *")
+        tabs.wait(2)
+        assert tabs[1].label == "Main"
+        assert tabs[1].checked
+
+        # Close project and wait until schematic tab has been closed
+        app.get("#DocumentsPanel ProjectSection::close-btn").click()
+        tabs.wait(1)


### PR DESCRIPTION
Open the first schematic as a tab when opening a project, to provide better UI feedback. It's a temporary solution until we are able to restore the tabs which were opened the last time.