### PR TITLE
UI: Fix background color of gates preview

### DIFF
--- a/libs/librepcb/editor/library/cmp/componentgateeditor.cpp
+++ b/libs/librepcb/editor/library/cmp/componentgateeditor.cpp
@@ -211,7 +211,18 @@ void ComponentGateEditor::reloadSymbol() noexcept {
 
   if (mSymbol) {
     mScene.reset(new GraphicsScene());
+    const Theme& theme = mWorkspace.getSettings().themes.getActive();
     mScene->setOriginCrossVisible(false);  // It's rather disruptive.
+    mScene->setBackgroundColors(
+        theme.getColor(Theme::Color::sSchematicBackground).getPrimaryColor(),
+        theme.getColor(Theme::Color::sSchematicBackground).getSecondaryColor());
+    mScene->setOverlayColors(
+        theme.getColor(Theme::Color::sSchematicOverlays).getPrimaryColor(),
+        theme.getColor(Theme::Color::sSchematicOverlays).getSecondaryColor());
+    mScene->setSelectionRectColors(
+        theme.getColor(Theme::Color::sSchematicSelection).getPrimaryColor(),
+        theme.getColor(Theme::Color::sSchematicSelection).getSecondaryColor());
+    mScene->setGridStyle(Theme::GridStyle::None);
     mGraphicsItem.reset(new SymbolGraphicsItem(
         const_cast<Symbol&>(*mSymbol), mLayers, mComponent, mGate,
         mWorkspace.getSettings().libraryLocaleOrder.get(), false));

--- a/libs/librepcb/editor/library/cmp/componentvarianteditor.cpp
+++ b/libs/librepcb/editor/library/cmp/componentvarianteditor.cpp
@@ -72,14 +72,29 @@ ComponentVariantEditor::ComponentVariantEditor(
     mFrameIndex(0),
     mGates(new ComponentGateListModel(ws, layers, cache)),
     mHasUnassignedSignals(false) {
-  mGates->setReferences(&mVariant->getSymbolItems(), component, mScene.get(),
-                        sigs, mUndoStack, mWizardMode);
-  connect(sigs.get(), &ComponentSignalNameListModel::modified, this,
-          &ComponentVariantEditor::updateUnassignedSignals);
+  // Setup preview scene.
+  const Theme& theme = mWorkspace.getSettings().themes.getActive();
+  mScene->setOriginCrossVisible(true);  // Required for positioning.
+  mScene->setBackgroundColors(
+      theme.getColor(Theme::Color::sSchematicBackground).getPrimaryColor(),
+      theme.getColor(Theme::Color::sSchematicBackground).getSecondaryColor());
+  mScene->setOverlayColors(
+      theme.getColor(Theme::Color::sSchematicOverlays).getPrimaryColor(),
+      theme.getColor(Theme::Color::sSchematicOverlays).getSecondaryColor());
+  mScene->setSelectionRectColors(
+      theme.getColor(Theme::Color::sSchematicSelection).getPrimaryColor(),
+      theme.getColor(Theme::Color::sSchematicSelection).getSecondaryColor());
+  mScene->setGridStyle(Theme::GridStyle::Lines);  // Required for positioning.
   connect(mScene.get(), &GraphicsScene::changed, this, [this]() {
     ++mFrameIndex;
     emit uiDataChanged();
   });
+
+  // Connect models.
+  mGates->setReferences(&mVariant->getSymbolItems(), component, mScene.get(),
+                        sigs, mUndoStack, mWizardMode);
+  connect(sigs.get(), &ComponentSignalNameListModel::modified, this,
+          &ComponentVariantEditor::updateUnassignedSignals);
   updateUnassignedSignals();
 }
 

--- a/libs/librepcb/editor/ui/library/cmp/componentvariantlistview.slint
+++ b/libs/librepcb/editor/ui/library/cmp/componentvariantlistview.slint
@@ -507,14 +507,17 @@ component ComponentVariantListItem inherits Rectangle {
             placement-l := HorizontalLayout {
                 height: expanded ? self.preferred-height : 0;
                 spacing: 10px;
-                visible: self.height > 0;
+
+                // To avoid unnecessary overhead, do not render during animation.
+                // https://github.com/LibrePCB/LibrePCB/issues/1652
+                visible: self.height == self.preferred-height;
 
                 animate height { duration: 150ms; }
 
                 Rectangle {
                     max-width: 500px;  // Only to ensure some alignment across gates on a large screen
                     min-height: 250px;  // Vertically aligned symbols require a lot of space
-                    background: white;  // For the preview
+                    background: Data.preview-mode ? white : transparent;  // For the preview
                     border-radius: 10px;
                     clip: true;  // For the rounded corners
 


### PR DESCRIPTION
The background color of the gates graphics scenes in the component tab did not respect the theme colors configured in the workspace.

Also fixes slow rendering during animation (#1652).