### PR TITLE
UI: Hide schematic/board name if there's only one

### DIFF
--- a/libs/librepcb/editor/ui/documentspanel.slint
+++ b/libs/librepcb/editor/ui/documentspanel.slint
@@ -30,6 +30,7 @@ component DocumentsListItem inherits Rectangle {
     in property <string> text;
     in property <image> icon;
     in property <bool> selected: false;
+    in property <bool> can-rename: true;
     in property <length> scrollbar-width;
 
     callback clicked <=> ta.clicked;
@@ -75,7 +76,7 @@ component DocumentsListItem inherits Rectangle {
                 text: text;
             }
 
-            if (ta.has-hover || selected) && (type == ItemType.schematic): rename-btn := ListViewItemButton {
+            if (ta.has-hover || selected) && (type == ItemType.schematic) && can-rename: rename-btn := ListViewItemButton {
                 y: (parent.height - self.height) / 2;
                 height: 18px;
                 icon: Cmd.sheet-rename.icon;
@@ -222,7 +223,11 @@ component ProjectSection inherits Rectangle {
 
         for schematic[index] in project.schematics: schematic-item := DocumentsListItem {
             type: ItemType.schematic;
-            text: schematic.name;
+            // The default schematic name "Main" is not very meaningful,
+            // especially for beginners. Thus hide it if there's only one
+            // schematic as it is not relevant then anyway.
+            text: (project.schematics.length == 1) ? @tr("Schematic") : schematic.name;
+            can-rename: project.schematics.length > 1;  // Because default name is hidden.
             icon: @image-url("../../../font-awesome/svgs/regular/image.svg");
             selected: (Data.current-tab.type == TabType.schematic) && (Data.current-schematic-tab.project-index == project-index) && (Data.current-schematic-tab.schematic-index == index);
             scrollbar-width: scrollbar-width;
@@ -238,7 +243,10 @@ component ProjectSection inherits Rectangle {
 
         for board[index] in project.boards: board-item := DocumentsListItem {
             type: ItemType.board;
-            text: board.name;
+            // The default board name "default" is not very meaningful,
+            // especially for beginners. Thus hide it if there's only one
+            // board as it is not relevant then anyway.
+            text: (project.boards.length == 1) ? @tr("Board") : board.name;
             icon: @image-url("../../../bootstrap-icons/icons/motherboard.svg");
             selected: {
                 if Data.current-tab.type == TabType.board-2d {


### PR DESCRIPTION
By default, the documents panel is not very intuitive because especially for beginners it might not be clear what is meant with "Main" and "default":

<img width="351" height="89" alt="image" src="https://github.com/user-attachments/assets/4e68c384-f658-4dc0-81c3-adbada6bab5f" />

Therefore let's hide those names if there's only one of them anyway (which is the case for every new project). Instead, display the more descriptive and translated terms "Schematic" resp. "Board":

<img width="353" height="83" alt="image" src="https://github.com/user-attachments/assets/75f8f4c5-4bdb-4e41-8cb6-b32bf6b74948" />

Also the "rename" button on the schematic is now hidden if there's only one, because it would be confusing as it has no effect on that UI anymore - the rename functionality is still available from the main menu in that case.

If a project has more than 1 schematic or board, their actual names will be displayed instead of the hardcoded terms.