### PR TITLE
UI: Disable slide animation in library editor tabs

### DIFF
--- a/libs/librepcb/editor/ui/library/cmp/componenttab.slint
+++ b/libs/librepcb/editor/ui/library/cmp/componenttab.slint
@@ -582,6 +582,7 @@ export component ComponentTab inherits Tab {
                 { title: @tr("Variants & Gates") },
             ];
             current-index: tabs[index].page-index;
+            duration: 0;  // Temporary, needs proper refactoring.
 
             metadata-tab-2 := ComponentMetadataTab {
                 width: parent.width;

--- a/libs/librepcb/editor/ui/library/dev/devicetab.slint
+++ b/libs/librepcb/editor/ui/library/dev/devicetab.slint
@@ -525,6 +525,7 @@ export component DeviceTab inherits Tab {
                 { title: @tr("Pinout & Parts") },
             ];
             current-index: tabs[index].page-index;
+            duration: 0;  // Temporary, needs proper refactoring.
 
             metadata-tab-2 := DeviceMetadataTab {
                 width: parent.width;

--- a/libs/librepcb/editor/ui/library/lib/librarytab.slint
+++ b/libs/librepcb/editor/ui/library/lib/librarytab.slint
@@ -897,6 +897,7 @@ export component LibraryTab inherits Tab {
             { title: @tr("Library Content") },
         ];
         current-index: tabs[index].page-index;
+        duration: 0;  // Temporary, needs proper refactoring.
 
         LibraryMetadataTab {
             width: parent.width;

--- a/libs/librepcb/editor/ui/library/pkg/packagetab.slint
+++ b/libs/librepcb/editor/ui/library/pkg/packagetab.slint
@@ -1,6 +1,8 @@
 import { AddFootprintHoleToolBar } from "addfootprintholetoolbar.slint";
 import { AddFootprintPadToolBar } from "addfootprintpadtoolbar.slint";
-import { AddFootprintStrokeTextToolBar } from "addfootprintstroketexttoolbar.slint";
+import {
+    AddFootprintStrokeTextToolBar,
+} from "addfootprintstroketexttoolbar.slint";
 import { DrawFootprintPolygonToolBar } from "drawfootprintpolygontoolbar.slint";
 import { DrawFootprintZoneToolBar } from "drawfootprintzonetoolbar.slint";
 import { ReNumberPadsToolBar } from "renumberpadstoolbar.slint";
@@ -1059,6 +1061,7 @@ export component PackageTab inherits Tab {
                     tabs[index].page-index
                 }
             };
+            duration: 0;  // Temporary, needs proper refactoring.
 
             metadata-tab-2 := PackageMetadataTab {
                 width: parent.width;

--- a/libs/librepcb/editor/ui/library/sym/symboltab.slint
+++ b/libs/librepcb/editor/ui/library/sym/symboltab.slint
@@ -684,6 +684,7 @@ export component SymbolTab inherits Tab {
                 { title: @tr("Graphics") },
             ];
             current-index: tabs[index].page-index;
+            duration: 0;  // Temporary, needs proper refactoring.
 
             SymbolMetadataTab {
                 width: parent.width;

--- a/libs/librepcb/editor/ui/widgets/slideview.slint
+++ b/libs/librepcb/editor/ui/widgets/slideview.slint
@@ -4,6 +4,7 @@ export component SlideView inherits VerticalLayout {
     in property <[NavBarItemData]> pages;
     in-out property <int> current-index: 0;
     in-out property <int> current-navbar-index: current-index;
+    in property <duration> duration: 200ms;
 
     callback page-clicked(index: int);
     page-clicked(index) => {
@@ -29,7 +30,7 @@ export component SlideView inherits VerticalLayout {
     Rectangle {
         property <float> animated-index: max(min(current-index, pages.length - 1), 0);
 
-        animate animated-index { duration: 200ms; }
+        animate animated-index { duration: duration; }
 
         clip: true;
 


### PR DESCRIPTION
I think those animations are rather annoying, let's try disabling them for now. Code should be refactored once we decide to definitively remove the animations.