### PR TITLE
Auto-open board when opening project

### DIFF
--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -584,12 +584,18 @@ std::shared_ptr<ProjectEditor> GuiApplication::openProject(
     // Switch to documents tab.
     switchToProject(index);
 
-    // Open the first schematic page to get immediate feedback that the project
-    // had been opened. In future we should restore the tabs which were opened
-    // the last time, so this is just a temporary solution.
-    if (auto win = getCurrentWindow();
-        win && (!editor->getProject().getSchematics().isEmpty())) {
-      win->openSchematicTab(index, 0);
+    // Open the first schematic and board to get immediate feedback that the
+    // project has been opened. In future we should restore the tabs which were
+    // opened the last time, so this is just a temporary solution.
+    if (auto win = getCurrentWindow()) {
+      bool tabOpened = false;
+      if (!editor->getProject().getSchematics().isEmpty()) {
+        win->openSchematicTab(index, 0);
+        tabOpened = true;
+      }
+      if (!editor->getProject().getBoards().isEmpty()) {
+        win->openBoard2dTab(index, 0, !tabOpened);
+      }
     }
 
     // Delay updating the last opened project to avoid an issue when

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -1458,11 +1458,13 @@ std::shared_ptr<SchematicTab> MainWindow::openSchematicTab(int projectIndex,
   return nullptr;
 }
 
-void MainWindow::openBoard2dTab(int projectIndex, int index) noexcept {
+void MainWindow::openBoard2dTab(int projectIndex, int index,
+                                bool switchToTab) noexcept {
   if (!switchToProjectTab<Board2dTab>(projectIndex, index)) {
     if (auto prjEditor = mApp.getProjects().value(projectIndex)) {
       if (auto brdEditor = prjEditor->getBoards().value(index)) {
-        addTab(std::make_shared<Board2dTab>(mApp, *brdEditor));
+        addTab(std::make_shared<Board2dTab>(mApp, *brdEditor), -1, -1,
+               switchToTab, switchToTab);
       }
     }
   }

--- a/libs/librepcb/editor/mainwindow.h
+++ b/libs/librepcb/editor/mainwindow.h
@@ -88,6 +88,8 @@ public:
   void setCurrentProject(int index) noexcept;
   std::shared_ptr<SchematicTab> openSchematicTab(int projectIndex,
                                                  int index) noexcept;
+  void openBoard2dTab(int projectIndex, int index,
+                      bool switchToTab = true) noexcept;
 
   // Operator Overloadings
   MainWindow& operator=(const MainWindow& rhs) = delete;
@@ -122,7 +124,6 @@ private:
                      bool copyFrom) noexcept;
   void openOrganizationTab(LibraryEditor& editor, const FilePath& fp,
                            bool copyFrom) noexcept;
-  void openBoard2dTab(int projectIndex, int index) noexcept;
   void openBoard3dTab(int projectIndex, int index) noexcept;
   void updateHomeTabSection() noexcept;
   template <typename T>

--- a/tests/ui/mainwindow/test_open_project.py
+++ b/tests/ui/mainwindow/test_open_project.py
@@ -16,12 +16,14 @@ def test_file_tree_dclick(librepcb, helpers):
         items[0].dclick()
         items.wait_for_item(lambda x: x.label == "Empty Project.lpp").dclick()
 
-        # Verify that schematic tab has been opened
+        # Verify that schematic- and board tabs have been opened
         tabs = app.get("#TabButton *")
-        tabs.wait(2)
+        tabs.wait(3)
         assert tabs[1].label == "Main"
         assert tabs[1].checked
+        assert tabs[2].label == "default"
+        assert not tabs[2].checked
 
-        # Close project and wait until schematic tab has been closed
+        # Close project and wait until tabs have been closed
         app.get("#DocumentsPanel ProjectSection::close-btn").click()
         tabs.wait(1)


### PR DESCRIPTION
Not just open the schematic, but also the board. I think most of the time this is better than opening only the schematic. And especially for projects which have only a board but no schematic, this ensures that at least *something* is opened.