### PR TITLE
Fix flaky global cursor position transform in editors

### DIFF
--- a/libs/librepcb/editor/library/cat/componentcategorytab.cpp
+++ b/libs/librepcb/editor/library/cat/componentcategorytab.cpp
@@ -203,7 +203,7 @@ void ComponentCategoryTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -212,7 +212,7 @@ void ComponentCategoryTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -237,7 +237,7 @@ bool ComponentCategoryTab::requestClose() noexcept {
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
-      qApp->activeWindow(), tr("Save Changes?"),
+      getWindow(), tr("Save Changes?"),
       tr("The component category '%1' contains unsaved changes.\n"
          "Do you want to save them before closing it?")
           .arg(*mCategory->getNames().getDefaultValue()),
@@ -377,7 +377,7 @@ void ComponentCategoryTab::commitUiData() noexcept {
     cmd->setParentUuid(mParent);
     mUndoStack->execCmd(cmd.release());
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -409,7 +409,7 @@ bool ComponentCategoryTab::save() noexcept {
     refreshUiData();
     return true;
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     refreshUiData();
     return false;
   }

--- a/libs/librepcb/editor/library/cat/packagecategorytab.cpp
+++ b/libs/librepcb/editor/library/cat/packagecategorytab.cpp
@@ -203,7 +203,7 @@ void PackageCategoryTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -212,7 +212,7 @@ void PackageCategoryTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -237,7 +237,7 @@ bool PackageCategoryTab::requestClose() noexcept {
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
-      qApp->activeWindow(), tr("Save Changes?"),
+      getWindow(), tr("Save Changes?"),
       tr("The package category '%1' contains unsaved changes.\n"
          "Do you want to save them before closing it?")
           .arg(*mCategory->getNames().getDefaultValue()),
@@ -377,7 +377,7 @@ void PackageCategoryTab::commitUiData() noexcept {
     cmd->setParentUuid(mParent);
     mUndoStack->execCmd(cmd.release());
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -409,7 +409,7 @@ bool PackageCategoryTab::save() noexcept {
     refreshUiData();
     return true;
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     refreshUiData();
     return false;
   }

--- a/libs/librepcb/editor/library/cmp/componenttab.cpp
+++ b/libs/librepcb/editor/library/cmp/componenttab.cpp
@@ -315,7 +315,7 @@ void ComponentTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -324,7 +324,7 @@ void ComponentTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -339,7 +339,7 @@ void ComponentTab::trigger(ui::TabAction a) noexcept {
       if (auto dbRes = mComponent->getResources().value(0)) {
         DesktopServices::downloadAndOpenResourceAsync(
             mApp.getWorkspace().getSettings(), *dbRes->getName(),
-            dbRes->getMediaType(), dbRes->getUrl(), qApp->activeWindow());
+            dbRes->getMediaType(), dbRes->getUrl(), getWindow());
       }
       break;
     }
@@ -377,7 +377,7 @@ bool ComponentTab::requestClose() noexcept {
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
-      qApp->activeWindow(), tr("Save Changes?"),
+      getWindow(), tr("Save Changes?"),
       tr("The component '%1' contains unsaved changes.\n"
          "Do you want to save them before closing it?")
           .arg(*mComponent->getNames().getDefaultValue()),
@@ -492,7 +492,7 @@ bool ComponentTab::autoFix(const MsgMissingComponentDefaultValue& msg) {
       tr("Is this rather a (manufacturer-)specific component than a generic "
          "component?");
   const int answer = QMessageBox::question(
-      qApp->activeWindow(), title, question,
+      getWindow(), title, question,
       QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No |
           QMessageBox::StandardButton::Cancel,
       QMessageBox::StandardButton::Cancel);
@@ -679,7 +679,7 @@ void ComponentTab::commitUiData() noexcept {
     mAttributes->apply();
     mSignals->apply();
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -718,7 +718,7 @@ bool ComponentTab::save() noexcept {
     refreshUiData();
     return true;
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     refreshUiData();
     return false;
   }

--- a/libs/librepcb/editor/library/dev/devicetab.cpp
+++ b/libs/librepcb/editor/library/dev/devicetab.cpp
@@ -426,7 +426,7 @@ void DeviceTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -435,7 +435,7 @@ void DeviceTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -450,7 +450,7 @@ void DeviceTab::trigger(ui::TabAction a) noexcept {
       if (auto dbRes = mDevice->getResources().value(0)) {
         DesktopServices::downloadAndOpenResourceAsync(
             mApp.getWorkspace().getSettings(), *dbRes->getName(),
-            dbRes->getMediaType(), dbRes->getUrl(), qApp->activeWindow());
+            dbRes->getMediaType(), dbRes->getUrl(), getWindow());
       }
       break;
     }
@@ -514,7 +514,7 @@ bool DeviceTab::requestClose() noexcept {
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
-      qApp->activeWindow(), tr("Save Changes?"),
+      getWindow(), tr("Save Changes?"),
       tr("The device '%1' contains unsaved changes.\n"
          "Do you want to save them before closing it?")
           .arg(*mDevice->getNames().getDefaultValue()),
@@ -782,7 +782,7 @@ void DeviceTab::commitUiData() noexcept {
     mAttributes->apply();
     mParts->apply();
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -817,7 +817,7 @@ bool DeviceTab::save() noexcept {
     refreshUiData();
     return true;
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     refreshUiData();
     return false;
   }
@@ -825,7 +825,7 @@ bool DeviceTab::save() noexcept {
 
 void DeviceTab::selectComponent() noexcept {
   ComponentChooserDialog dialog(mApp.getWorkspace(), &mApp.getPreviewLayers(),
-                                qApp->activeWindow());
+                                getWindow());
   if (dialog.exec() != QDialog::Accepted) return;
 
   std::optional<Uuid> cmpUuid = dialog.getSelectedComponentUuid();
@@ -854,14 +854,14 @@ void DeviceTab::selectComponent() noexcept {
       }
       mUndoStack->execCmd(cmdGroup.release());
     } catch (const Exception& e) {
-      QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+      QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     }
   }
 }
 
 void DeviceTab::selectPackage() noexcept {
   PackageChooserDialog dialog(mApp.getWorkspace(), &mApp.getPreviewLayers(),
-                              qApp->activeWindow());
+                              getWindow());
   if (dialog.exec() != QDialog::Accepted) return;
 
   std::optional<Uuid> pkgUuid = dialog.getSelectedPackageUuid();
@@ -895,7 +895,7 @@ void DeviceTab::selectPackage() noexcept {
       mUndoStack->execCmd(cmdGroup.release());
       Q_ASSERT(mDevice->getPadSignalMap().getUuidSet() == pads);
     } catch (const Exception& e) {
-      QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+      QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     }
   }
 }

--- a/libs/librepcb/editor/library/lib/librarytab.cpp
+++ b/libs/librepcb/editor/library/lib/librarytab.cpp
@@ -342,7 +342,7 @@ void LibraryTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mEditor.getUndoStack().undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -351,13 +351,13 @@ void LibraryTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mEditor.getUndoStack().redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
     case ui::TabAction::LibraryChooseIcon: {
       const QString fp = FileDialog::getOpenFileName(
-          qApp->activeWindow(), tr("Choose Library Icon"),
+          getWindow(), tr("Choose Library Icon"),
           mLibrary.getDirectory().getAbsPath().toNative(),
           tr("Portable Network Graphics (*.png)"));
       if (!fp.isEmpty()) {
@@ -365,7 +365,7 @@ void LibraryTab::trigger(ui::TabAction a) noexcept {
           mIcon = FileUtils::readFile(FilePath(fp));  // can throw
           commitUiData();
         } catch (const Exception& e) {
-          QMessageBox::critical(qApp->activeWindow(), tr("Could not open file"),
+          QMessageBox::critical(getWindow(), tr("Could not open file"),
                                 e.getMsg());
         }
       }
@@ -515,7 +515,7 @@ void LibraryTab::commitUiData() noexcept {
     }
     mEditor.getUndoStack().execCmd(cmd.release());
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -1019,7 +1019,7 @@ void LibraryTab::moveOrCopyElementsTo(
 
   // Show confirmation dialog.
   const int ret = QMessageBox::warning(
-      qApp->activeWindow(), tr("Move %1 Elements").arg(items.count()), msg,
+      getWindow(), tr("Move %1 Elements").arg(items.count()), msg,
       QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
   if (ret != QMessageBox::Yes) {
     return;
@@ -1044,7 +1044,7 @@ void LibraryTab::moveOrCopyElementsTo(
         FileUtils::copyDirRecursively(fp, destination);
       }
     } catch (const Exception& e) {
-      QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+      QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     }
   }
 
@@ -1086,7 +1086,7 @@ void LibraryTab::deleteElements(
 
   // Show message box
   const int ret = QMessageBox::warning(
-      qApp->activeWindow(), tr("Remove %1 Elements").arg(items.count()), msg,
+      getWindow(), tr("Remove %1 Elements").arg(items.count()), msg,
       QMessageBox::Yes, QMessageBox::Cancel);
   if (ret == QMessageBox::Yes) {
     // Close opened tabs of elements to be deleted.
@@ -1095,7 +1095,7 @@ void LibraryTab::deleteElements(
       try {
         FileUtils::removeDirRecursively(fp);
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
     }
     mEditor.getWorkspace().getLibraryDb().startLibraryRescan();

--- a/libs/librepcb/editor/library/libraryeditortab.cpp
+++ b/libs/librepcb/editor/library/libraryeditortab.cpp
@@ -176,7 +176,7 @@ QString LibraryEditorTab::getWorkspaceSettingsUserName() const noexcept {
   QString u = mEditor.getWorkspace().getSettings().userName.get();
   if (u.isEmpty()) {
     QMessageBox::warning(
-        qApp->activeWindow(), tr("User name not set"),
+        getWindow(), tr("User name not set"),
         tr("No user name is defined in the workspace settings. Please open "
            "the workspace settings to set a default user name."));
   }
@@ -194,7 +194,7 @@ bool LibraryEditorTab::autoFixHandler(
     return autoFixImpl(msg, checkOnly);  // can throw
   } catch (const Exception& e) {
     if (!checkOnly) {
-      QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+      QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     }
   }
   return false;

--- a/libs/librepcb/editor/library/org/organizationtab.cpp
+++ b/libs/librepcb/editor/library/org/organizationtab.cpp
@@ -225,7 +225,7 @@ void OrganizationTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -234,7 +234,7 @@ void OrganizationTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -246,14 +246,14 @@ void OrganizationTab::trigger(ui::TabAction a) noexcept {
     }
     case ui::TabAction::LibraryChooseIcon: {
       const QString fp = FileDialog::getOpenFileName(
-          qApp->activeWindow(), tr("Choose Organization Logo"), QString(),
+          getWindow(), tr("Choose Organization Logo"), QString(),
           tr("Portable Network Graphics (*.png)"));
       if (!fp.isEmpty()) {
         try {
           mLogo = FileUtils::readFile(FilePath(fp));  // can throw
           commitUiData();
         } catch (const Exception& e) {
-          QMessageBox::critical(qApp->activeWindow(), tr("Could not open file"),
+          QMessageBox::critical(getWindow(), tr("Could not open file"),
                                 e.getMsg());
         }
       }
@@ -288,7 +288,7 @@ bool OrganizationTab::requestClose() noexcept {
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
-      qApp->activeWindow(), tr("Save Changes?"),
+      getWindow(), tr("Save Changes?"),
       tr("The organization '%1' contains unsaved changes.\n"
          "Do you want to save them before closing it?")
           .arg(*mOrganization->getNames().getDefaultValue()),
@@ -423,7 +423,7 @@ void OrganizationTab::commitUiData() noexcept {
     cmd->setPriority(mPriority);
     mUndoStack->execCmd(cmd.release());
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -455,7 +455,7 @@ bool OrganizationTab::save() noexcept {
     refreshUiData();
     return true;
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     refreshUiData();
     return false;
   }
@@ -476,7 +476,7 @@ void OrganizationTab::execOutputJobsDialog(
     ((*cmd).*setter)(prj.getOutputJobs());
     mUndoStack->execCmd(cmd.release());
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), "Error", e.getMsg());
+    QMessageBox::critical(getWindow(), "Error", e.getMsg());
   }
 }
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsmadapter.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsmadapter.h
@@ -79,6 +79,7 @@ public:
   };
   Q_DECLARE_FLAGS(Features, Feature)
 
+  virtual QWidget* fsmGetParentWidget() noexcept = 0;
   virtual GraphicsScene* fsmGetGraphicsScene() noexcept = 0;
   virtual PositiveLength fsmGetGridInterval() const noexcept = 0;
   virtual void fsmSetViewCursor(

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate.cpp
@@ -60,7 +60,7 @@ const LengthUnit& PackageEditorState::getLengthUnit() const noexcept {
 }
 
 QWidget* PackageEditorState::parentWidget() noexcept {
-  return qApp->activeWindow();
+  return mAdapter.fsmGetParentWidget();
 }
 
 const QSet<const Layer*>& PackageEditorState::getAllowedTextLayers() noexcept {

--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -679,7 +679,7 @@ void PackageTab::trigger(ui::TabAction a) noexcept {
       try {
         reloadFromDisk();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -688,7 +688,7 @@ void PackageTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -697,7 +697,7 @@ void PackageTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -1001,7 +1001,7 @@ bool PackageTab::requestClose() noexcept {
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
-      qApp->activeWindow(), tr("Save Changes?"),
+      getWindow(), tr("Save Changes?"),
       tr("The package '%1' contains unsaved changes.\n"
          "Do you want to save them before closing it?")
           .arg(*mPackage->getNames().getDefaultValue()),
@@ -1060,6 +1060,10 @@ bool PackageTab::graphicsSceneRightMouseButtonReleased(
  *  PackageEditorFsmAdapter
  ******************************************************************************/
 
+QWidget* PackageTab::fsmGetParentWidget() noexcept {
+  return getWindow();
+}
+
 GraphicsScene* PackageTab::fsmGetGraphicsScene() noexcept {
   return mScene.get();
 }
@@ -1117,7 +1121,7 @@ QPainterPath PackageTab::fsmCalcPosWithTolerance(
 }
 
 Point PackageTab::fsmMapGlobalPosToScenePos(const QPoint& pos) const noexcept {
-  if (QWidget* win = qApp->activeWindow()) {
+  if (QWidget* win = getWindow()) {
     return mView->mapToScenePos(win->mapFromGlobal(pos) - mSceneImagePos);
   } else {
     qWarning() << "Failed to map global position to scene position.";
@@ -2054,7 +2058,7 @@ bool PackageTab::autoFix(const MsgMinimumWidthViolation& msg) {
       mPackage->getFootprints().get(msg.getFootprint().get());
   setCurrentFootprintIndex(mPackage->getFootprints().indexOf(footprint.get()));
 
-  QDialog dlg(qApp->activeWindow());
+  QDialog dlg(getWindow());
   dlg.setWindowTitle(tr("New Line Width"));
   QVBoxLayout* vLayout = new QVBoxLayout(&dlg);
   UnsignedLengthEdit* edtWidth = new UnsignedLengthEdit(&dlg);
@@ -2277,7 +2281,7 @@ bool PackageTab::autoFix(const MsgSuspiciousPadFunction& msg) {
 
 template <typename MessageType>
 bool PackageTab::fixPadFunction(const MessageType& msg) {
-  QMenu menu(qApp->activeWindow());
+  QMenu menu(getWindow());
   QAction* aAll = menu.addAction(tr("Apply to all unspecified pads"));
   aAll->setCheckable(true);
   menu.addSeparator();
@@ -2476,7 +2480,7 @@ void PackageTab::commitUiData() noexcept {
     mPads->apply();  // can throw
     mFootprints->apply();  // can throw
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -2514,7 +2518,7 @@ bool PackageTab::save() noexcept {
     refreshUiData();
     return true;
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     refreshUiData();
     return false;
   }
@@ -2573,7 +2577,7 @@ bool PackageTab::execGraphicsExportDialog(GraphicsExportDialog::Output output,
         GraphicsExportDialog::Mode::Board, output, pages, 0,
         *mPackage->getNames().getDefaultValue(), 0, defaultFilePath, mUnit,
         mApp.getWorkspace().getSettings().themes.getActive(),
-        "package_editor/" % settingsKey, qApp->activeWindow());
+        "package_editor/" % settingsKey, getWindow());
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
               DesktopServices ds(mApp.getWorkspace().getSettings());
@@ -2581,7 +2585,7 @@ bool PackageTab::execGraphicsExportDialog(GraphicsExportDialog::Output output,
             });
     dialog.exec();
   } catch (const Exception& e) {
-    QMessageBox::warning(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::warning(getWindow(), tr("Error"), e.getMsg());
   }
   return true;
 }
@@ -2670,7 +2674,7 @@ bool PackageTab::toggleBackgroundImage() noexcept {
     mBackgroundImageSettings.enabled = false;
   } else {
     // Show dialog.
-    BackgroundImageSetupDialog dlg("package_editor", qApp->activeWindow());
+    BackgroundImageSetupDialog dlg("package_editor", getWindow());
     if (!mBackgroundImageSettings.image.isNull()) {
       dlg.setData(mBackgroundImageSettings.image,
                   mBackgroundImageSettings.rotation,

--- a/libs/librepcb/editor/library/pkg/packagetab.h
+++ b/libs/librepcb/editor/library/pkg/packagetab.h
@@ -129,6 +129,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
 
   // PackageEditorFsmAdapter
+  QWidget* fsmGetParentWidget() noexcept override;
   GraphicsScene* fsmGetGraphicsScene() noexcept override;
   PositiveLength fsmGetGridInterval() const noexcept override;
   void fsmSetViewCursor(

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsmadapter.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsmadapter.h
@@ -75,6 +75,7 @@ public:
   };
   Q_DECLARE_FLAGS(Features, Feature)
 
+  virtual QWidget* fsmGetParentWidget() noexcept = 0;
   virtual GraphicsScene* fsmGetGraphicsScene() noexcept = 0;
   virtual SymbolGraphicsItem* fsmGetGraphicsItem() noexcept = 0;
   virtual PositiveLength fsmGetGridInterval() const noexcept = 0;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate.cpp
@@ -82,7 +82,7 @@ const LengthUnit& SymbolEditorState::getLengthUnit() const noexcept {
 }
 
 QWidget* SymbolEditorState::parentWidget() noexcept {
-  return qApp->activeWindow();
+  return mAdapter.fsmGetParentWidget();
 }
 
 const QSet<const Layer*>& SymbolEditorState::getAllowedTextLayers() noexcept {

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -431,7 +431,7 @@ void SymbolTab::trigger(ui::TabAction a) noexcept {
       try {
         reloadFromDisk();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -440,7 +440,7 @@ void SymbolTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->undo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -449,7 +449,7 @@ void SymbolTab::trigger(ui::TabAction a) noexcept {
         commitUiData();
         mUndoStack->redo();
       } catch (const Exception& e) {
-        QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+        QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
       break;
     }
@@ -668,7 +668,7 @@ bool SymbolTab::requestClose() noexcept {
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
-      qApp->activeWindow(), tr("Save Changes?"),
+      getWindow(), tr("Save Changes?"),
       tr("The symbol '%1' contains unsaved changes.\n"
          "Do you want to save them before closing it?")
           .arg(*mSymbol->getNames().getDefaultValue()),
@@ -726,6 +726,10 @@ bool SymbolTab::graphicsSceneRightMouseButtonReleased(
 /*******************************************************************************
  *  SymbolEditorFsmAdapter
  ******************************************************************************/
+
+QWidget* SymbolTab::fsmGetParentWidget() noexcept {
+  return getWindow();
+}
 
 GraphicsScene* SymbolTab::fsmGetGraphicsScene() noexcept {
   return mScene.get();
@@ -788,7 +792,7 @@ QPainterPath SymbolTab::fsmCalcPosWithTolerance(
 }
 
 Point SymbolTab::fsmMapGlobalPosToScenePos(const QPoint& pos) const noexcept {
-  if (QWidget* win = qApp->activeWindow()) {
+  if (QWidget* win = getWindow()) {
     return mView->mapToScenePos(win->mapFromGlobal(pos) - mSceneImagePos);
   } else {
     qWarning() << "Failed to map global position to scene position.";
@@ -1517,7 +1521,7 @@ void SymbolTab::commitUiData() noexcept {
     cmd->setCategories(mCategories->getCategories());
     mUndoStack->execCmd(cmd.release());
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -1556,7 +1560,7 @@ bool SymbolTab::save() noexcept {
     refreshUiData();
     return true;
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
     refreshUiData();
     return false;
   }
@@ -1606,7 +1610,7 @@ bool SymbolTab::execGraphicsExportDialog(GraphicsExportDialog::Output output,
         GraphicsExportDialog::Mode::Schematic, output, pages, 0,
         *mSymbol->getNames().getDefaultValue(), 0, defaultFilePath, mUnit,
         mApp.getWorkspace().getSettings().themes.getActive(),
-        "symbol_editor/" % settingsKey, qApp->activeWindow());
+        "symbol_editor/" % settingsKey, getWindow());
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
               DesktopServices ds(mApp.getWorkspace().getSettings());
@@ -1614,7 +1618,7 @@ bool SymbolTab::execGraphicsExportDialog(GraphicsExportDialog::Output output,
             });
     dialog.exec();
   } catch (const Exception& e) {
-    QMessageBox::warning(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::warning(getWindow(), tr("Error"), e.getMsg());
   }
   return true;
 }

--- a/libs/librepcb/editor/library/sym/symboltab.h
+++ b/libs/librepcb/editor/library/sym/symboltab.h
@@ -119,6 +119,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
 
   // SymbolEditorFsmAdapter
+  QWidget* fsmGetParentWidget() noexcept override;
   GraphicsScene* fsmGetGraphicsScene() noexcept override;
   SymbolGraphicsItem* fsmGetGraphicsItem() noexcept override;
   PositiveLength fsmGetGridInterval() const noexcept override;

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -374,7 +374,8 @@ void MainWindow::makeCurrentWindow() noexcept {
 
 void MainWindow::addSection(int newIndex, bool makeCurrent) noexcept {
   newIndex = qBound(0, newIndex, mSections->count());
-  std::shared_ptr<WindowSection> s = std::make_shared<WindowSection>(mApp);
+  std::shared_ptr<WindowSection> s =
+      std::make_shared<WindowSection>(mApp, *this);
   connect(s.get(), &WindowSection::currentTabChanged, this, [this]() {
     const ui::Data& d = mWindow->global<ui::Data>();
     d.fn_current_tab_changed();
@@ -792,16 +793,14 @@ void MainWindow::triggerLibraryElement(slint::SharedString path,
     }
     case ui::LibraryElementAction::ImportEagleLibrary: {
       if (mApp.getLibrary(fp)) {
-        EagleLibraryImportWizard wiz(mApp.getWorkspace(), fp,
-                                     qApp->activeWindow());
+        EagleLibraryImportWizard wiz(mApp.getWorkspace(), fp, mWidget);
         wiz.exec();
       }
       break;
     }
     case ui::LibraryElementAction::ImportKicadLibrary: {
       if (mApp.getLibrary(fp)) {
-        KiCadLibraryImportWizard wiz(mApp.getWorkspace(), fp,
-                                     qApp->activeWindow());
+        KiCadLibraryImportWizard wiz(mApp.getWorkspace(), fp, mWidget);
         wiz.exec();
       }
       break;

--- a/libs/librepcb/editor/mainwindow.h
+++ b/libs/librepcb/editor/mainwindow.h
@@ -72,6 +72,7 @@ public:
   int getId() const noexcept { return mId; }
   bool isCurrentWindow() const noexcept;
   void makeCurrentWindow() noexcept;
+  QWidget& getWidget() noexcept { return *mWidget; }
   void addSection(int newIndex, bool makeCurrent) noexcept;
   void addTab(std::shared_ptr<WindowTab> tab, int section = -1, int index = -1,
               bool switchToTab = true, bool switchToSection = true) noexcept;

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -1087,6 +1087,10 @@ bool Board2dTab::graphicsSceneRightMouseButtonReleased(
  *  BoardEditorFsmAdapter Methods
  ******************************************************************************/
 
+QWidget* Board2dTab::fsmGetParentWidget() noexcept {
+  return getWindow();
+}
+
 BoardGraphicsScene* Board2dTab::fsmGetGraphicsScene() noexcept {
   return mScene.get();
 }
@@ -1144,7 +1148,7 @@ QPainterPath Board2dTab::fsmCalcPosWithTolerance(
 }
 
 Point Board2dTab::fsmMapGlobalPosToScenePos(const QPoint& pos) const noexcept {
-  if (QWidget* win = qApp->activeWindow()) {
+  if (QWidget* win = getWindow()) {
     return mView->mapToScenePos(win->mapFromGlobal(pos) - mSceneImagePos);
   } else {
     qWarning() << "Failed to map global position to scene position.";
@@ -1877,7 +1881,7 @@ void Board2dTab::loadDesignRules(const QString& uiKey) noexcept {
     // Make sure to hide the "setup design rules" message in the UI.
     mMsgSetupDesignRules.dismiss();
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), "Error", e.getMsg());
+    QMessageBox::critical(getWindow(), "Error", e.getMsg());
   }
 }
 
@@ -2352,7 +2356,7 @@ void Board2dTab::addUnplacedComponentsToBoard(
   try {
     mProjectEditor.getUndoStack().execCmd(cmd.release());
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -2371,7 +2375,7 @@ void Board2dTab::execGraphicsExportDialog(GraphicsExportDialog::Output output,
     // Copy board to allow processing it in worker threads.
     // Also rebuild outdated planes to avoid exporting wrong data.
     QProgressDialog progress(tr("Preparing board..."), tr("Cancel"), 0, 1,
-                             qApp->activeWindow());
+                             getWindow());
     progress.setWindowModality(Qt::WindowModal);
     progress.setMinimumDuration(100);
     const auto layers = mBoard.getCopperLayers();
@@ -2396,7 +2400,7 @@ void Board2dTab::execGraphicsExportDialog(GraphicsExportDialog::Output output,
         *mProject.getName(), mBoard.getInnerLayerCount(), defaultFilePath,
         mApp.getWorkspace().getSettings().defaultLengthUnit.get(),
         mApp.getWorkspace().getSettings().themes.getActive(),
-        "board_editor/" % settingsKey, qApp->activeWindow());
+        "board_editor/" % settingsKey, getWindow());
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
               DesktopServices ds(mApp.getWorkspace().getSettings());
@@ -2404,7 +2408,7 @@ void Board2dTab::execGraphicsExportDialog(GraphicsExportDialog::Output output,
             });
     dialog.exec();
   } catch (const Exception& e) {
-    QMessageBox::warning(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::warning(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -2423,7 +2427,7 @@ void Board2dTab::execD356NetlistExportDialog() noexcept {
               str, FilePath::ReplaceSpaces | FilePath::KeepCase);
         });
     path = FileDialog::getSaveFileName(
-        qApp->activeWindow(), tr("Export IPC D-356A Netlist"),
+        getWindow(), tr("Export IPC D-356A Netlist"),
         mProject.getPath().getPathTo(path).toStr(), "*.d356");
     if (path.isEmpty()) return;
     if (!path.contains(".")) path.append(".d356");
@@ -2435,7 +2439,7 @@ void Board2dTab::execD356NetlistExportDialog() noexcept {
     FileUtils::writeFile(fp, exp.generate());  // can throw
     qDebug() << "Successfully exported netlist.";
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -2469,7 +2473,7 @@ void Board2dTab::execSpecctraExportDialog() noexcept {
 
     // Choose file path.
     path = FileDialog::getSaveFileName(
-        qApp->activeWindow(),
+        getWindow(),
         EditorCommandSet::instance().exportSpecctraDsn.getDisplayText(), path,
         "*.dsn");
     if (path.isEmpty()) return;
@@ -2489,7 +2493,7 @@ void Board2dTab::execSpecctraExportDialog() noexcept {
     qDebug() << "Successfully exported Specctra DSN.";
     emit statusBarMessageChanged(tr("Success!"), 3000);
   } catch (const Exception& e) {
-    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
   }
 }
 
@@ -2518,7 +2522,7 @@ void Board2dTab::execSpecctraImportDialog() noexcept {
 
     // Choose file path.
     path = FileDialog::getOpenFileName(
-        qApp->activeWindow(),
+        getWindow(),
         EditorCommandSet::instance().importSpecctraSes.getDisplayText(), path,
         "*.ses;;*");
     if (path.isEmpty()) return;
@@ -2547,7 +2551,7 @@ void Board2dTab::execSpecctraImportDialog() noexcept {
   }
 
   // Display messages.
-  QDialog dlg(qApp->activeWindow());
+  QDialog dlg(getWindow());
   dlg.setWindowTitle(tr("Specctra SES Import"));
   dlg.setMinimumSize(600, 400);
   QVBoxLayout* layout = new QVBoxLayout(&dlg);
@@ -2610,7 +2614,7 @@ bool Board2dTab::toggleBackgroundImage() noexcept {
     mBackgroundImageSettings.enabled = false;
   } else {
     // Show dialog.
-    BackgroundImageSetupDialog dlg("board_editor", qApp->activeWindow());
+    BackgroundImageSetupDialog dlg("board_editor", getWindow());
     if (!mBackgroundImageSettings.image.isNull()) {
       dlg.setData(mBackgroundImageSettings.image,
                   mBackgroundImageSettings.rotation,

--- a/libs/librepcb/editor/project/board/board2dtab.h
+++ b/libs/librepcb/editor/project/board/board2dtab.h
@@ -143,6 +143,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
 
   // BoardEditorFsmAdapter
+  QWidget* fsmGetParentWidget() noexcept override;
   BoardGraphicsScene* fsmGetGraphicsScene() noexcept override;
   bool fsmGetIgnoreLocks() const noexcept override;
   void fsmSetViewCursor(

--- a/libs/librepcb/editor/project/board/fsm/boardeditorfsmadapter.h
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorfsmadapter.h
@@ -82,6 +82,7 @@ public:
   };
   Q_DECLARE_FLAGS(Features, Feature)
 
+  virtual QWidget* fsmGetParentWidget() noexcept = 0;
   virtual BoardGraphicsScene* fsmGetGraphicsScene() noexcept = 0;
   virtual bool fsmGetIgnoreLocks() const noexcept = 0;
   virtual void fsmSetViewCursor(

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate.cpp
@@ -149,7 +149,7 @@ bool BoardEditorState::execCmd(UndoCommand* cmd) {
 }
 
 QWidget* BoardEditorState::parentWidget() noexcept {
-  return qApp->activeWindow();
+  return mAdapter.fsmGetParentWidget();
 }
 
 QList<std::shared_ptr<QGraphicsItem>> BoardEditorState::findItemsAtPos(

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsmadapter.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsmadapter.h
@@ -75,6 +75,7 @@ public:
   };
   Q_DECLARE_FLAGS(Features, Feature)
 
+  virtual QWidget* fsmGetParentWidget() noexcept = 0;
   virtual SchematicGraphicsScene* fsmGetGraphicsScene() noexcept = 0;
   virtual bool fsmGetIgnoreLocks() const noexcept = 0;
   virtual void fsmSetViewCursor(

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.cpp
@@ -118,7 +118,7 @@ bool SchematicEditorState::execCmd(UndoCommand* cmd) {
 }
 
 QWidget* SchematicEditorState::parentWidget() noexcept {
-  return qApp->activeWindow();
+  return mAdapter.fsmGetParentWidget();
 }
 
 QList<std::shared_ptr<QGraphicsItem>> SchematicEditorState::findItemsAtPos(

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -779,6 +779,10 @@ bool SchematicTab::graphicsSceneRightMouseButtonReleased(
  *  SchematicEditorFsmAdapter Methods
  ******************************************************************************/
 
+QWidget* SchematicTab::fsmGetParentWidget() noexcept {
+  return getWindow();
+}
+
 SchematicGraphicsScene* SchematicTab::fsmGetGraphicsScene() noexcept {
   return mScene.get();
 }
@@ -837,7 +841,7 @@ QPainterPath SchematicTab::fsmCalcPosWithTolerance(
 
 Point SchematicTab::fsmMapGlobalPosToScenePos(
     const QPoint& pos) const noexcept {
-  if (QWidget* win = qApp->activeWindow()) {
+  if (QWidget* win = getWindow()) {
     return mView->mapToScenePos(win->mapFromGlobal(pos) - mSceneImagePos);
   } else {
     qWarning() << "Failed to map global position to scene position.";
@@ -1178,7 +1182,7 @@ void SchematicTab::execGraphicsExportDialog(
     // Copy all schematic pages to allow processing them in worker threads.
     const int count = mProject.getSchematics().count();
     QProgressDialog progress(tr("Preparing schematics..."), tr("Cancel"), 0,
-                             count, qApp->activeWindow());
+                             count, getWindow());
     progress.setWindowModality(Qt::WindowModal);
     progress.setMinimumDuration(100);
     QList<std::shared_ptr<GraphicsPagePainter>> pages;
@@ -1198,7 +1202,7 @@ void SchematicTab::execGraphicsExportDialog(
         defaultFilePath,
         mApp.getWorkspace().getSettings().defaultLengthUnit.get(),
         mApp.getWorkspace().getSettings().themes.getActive(),
-        "schematic_editor/" % settingsKey, qApp->activeWindow());
+        "schematic_editor/" % settingsKey, getWindow());
     connect(&dialog, &GraphicsExportDialog::requestOpenFile, this,
             [this](const FilePath& fp) {
               DesktopServices ds(mApp.getWorkspace().getSettings());
@@ -1206,7 +1210,7 @@ void SchematicTab::execGraphicsExportDialog(
             });
     dialog.exec();
   } catch (const Exception& e) {
-    QMessageBox::warning(qApp->activeWindow(), tr("Error"), e.getMsg());
+    QMessageBox::warning(getWindow(), tr("Error"), e.getMsg());
   }
 }
 

--- a/libs/librepcb/editor/project/schematic/schematictab.h
+++ b/libs/librepcb/editor/project/schematic/schematictab.h
@@ -113,6 +113,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
 
   // SchematicEditorFsmAdapter
+  QWidget* fsmGetParentWidget() noexcept override;
   SchematicGraphicsScene* fsmGetGraphicsScene() noexcept override;
   bool fsmGetIgnoreLocks() const noexcept override;
   void fsmSetViewCursor(

--- a/libs/librepcb/editor/windowsection.cpp
+++ b/libs/librepcb/editor/windowsection.cpp
@@ -51,10 +51,12 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-WindowSection::WindowSection(GuiApplication& app, QObject* parent) noexcept
+WindowSection::WindowSection(GuiApplication& app, MainWindow& win,
+                             QObject* parent) noexcept
   : QObject(parent),
     onUiDataChanged(*this),
     mApp(app),
+    mWindow(win),
     mTabs(new UiObjectList<WindowTab, ui::TabData>()),
     mUiData{
         mTabs,  // Tabs
@@ -143,6 +145,7 @@ void WindowSection::addTab(std::shared_ptr<WindowTab> tab, int index,
   if ((!mTabs->isEmpty()) && (index <= currentIndex)) {
     ++currentIndex;
   }
+  tab->setWindow(&mWindow);
   mTabs->insert(index, tab);
   setCurrentTab(switchToTab ? index : currentIndex, forceUpdate);
 }
@@ -160,6 +163,7 @@ std::shared_ptr<WindowTab> WindowSection::removeTab(int index,
       --currentIndex;
     }
     tab->deactivate();  // setCurrentTab() doesn't do it because tab is removed.
+    tab->setWindow(nullptr);
     setCurrentTab(std::min(currentIndex, mTabs->count() - 1), forceUpdate);
     disconnect(tab.get(), &WindowTab::closeRequested, this,
                &WindowSection::tabCloseRequested);

--- a/libs/librepcb/editor/windowsection.h
+++ b/libs/librepcb/editor/windowsection.h
@@ -44,6 +44,7 @@ class Point;
 namespace editor {
 
 class GuiApplication;
+class MainWindow;
 class WindowTab;
 
 /*******************************************************************************
@@ -63,7 +64,7 @@ public:
   // Constructors / Destructor
   WindowSection() = delete;
   WindowSection(const WindowSection& other) = delete;
-  explicit WindowSection(GuiApplication& app,
+  explicit WindowSection(GuiApplication& app, MainWindow& win,
                          QObject* parent = nullptr) noexcept;
   ~WindowSection() noexcept;
 
@@ -157,6 +158,7 @@ private:
   typedef UiObjectList<WindowTab, ui::TabData> TabList;
 
   GuiApplication& mApp;
+  MainWindow& mWindow;
   std::shared_ptr<TabList> mTabs;
   ui::WindowSectionData mUiData;
 };

--- a/libs/librepcb/editor/windowtab.cpp
+++ b/libs/librepcb/editor/windowtab.cpp
@@ -22,6 +22,8 @@
  ******************************************************************************/
 #include "windowtab.h"
 
+#include "mainwindow.h"
+
 #include <QtCore>
 
 /*******************************************************************************
@@ -35,7 +37,7 @@ namespace editor {
  ******************************************************************************/
 
 WindowTab::WindowTab(GuiApplication& app, QObject* parent) noexcept
-  : QObject(parent), onUiDataChanged(*this), mApp(app) {
+  : QObject(parent), onUiDataChanged(*this), mApp(app), mWindow(nullptr) {
 }
 
 WindowTab::~WindowTab() noexcept {
@@ -89,6 +91,14 @@ bool WindowTab::processSceneKeyEvent(
     const slint::private_api::KeyEvent& e) noexcept {
   Q_UNUSED(e);
   return false;
+}
+
+/*******************************************************************************
+ *  Protected Methods
+ ******************************************************************************/
+
+QWidget* WindowTab::getWindow() const noexcept {
+  return mWindow ? &mWindow->getWidget() : nullptr;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/windowtab.h
+++ b/libs/librepcb/editor/windowtab.h
@@ -40,6 +40,7 @@ class Point;
 namespace editor {
 
 class GuiApplication;
+class MainWindow;
 
 /*******************************************************************************
  *  Class WindowTab
@@ -62,6 +63,7 @@ public:
   virtual ~WindowTab() noexcept;
 
   // General Methods
+  virtual void setWindow(MainWindow* w) noexcept { mWindow = w; }
   virtual ui::TabData getUiData() const noexcept = 0;
   virtual void setUiData(const ui::TabData& data) noexcept;
   virtual void activate() noexcept {}
@@ -101,7 +103,11 @@ signals:
   void cursorCoordinatesChanged(const Point& pos, const LengthUnit& unit);
 
 protected:
+  QWidget* getWindow() const noexcept;
+
+protected:
   GuiApplication& mApp;
+  MainWindow* mWindow;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
Fixes for example in the schematic editor that new components may not be moved immediately to the cursor position after closing the Add Component dialog.
