### PR TITLE
Schematic editor: Increase default text size to 2.5mm

### DIFF
--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addtext.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addtext.cpp
@@ -54,7 +54,7 @@ SchematicEditorState_AddText::SchematicEditorState_AddText(
         "{{PROJECT}}",  // Text
         Point(),  // Position is not relevant here
         Angle::deg0(),  // Rotation
-        PositiveLength(1500000),  // Height
+        PositiveLength(2500000),  // Height
         Alignment(HAlign::left(), VAlign::bottom()),  // Alignment
         false  // Locked
         ),


### PR DESCRIPTION
The default height of 1.5mm for new texts was really tiny...