### PR TITLE
Doxygen: Change ID naming convention from snake-case to kebab-case

### DIFF
--- a/dev/doxygen/pages/slint_style_guide.md
+++ b/dev/doxygen/pages/slint_style_guide.md
@@ -16,7 +16,7 @@ otherwise important for tests (e.g. a conditional `Image`, in contrast to
 a static `Image`). Typical non-functional elements are `Rectangle`,
 `VerticalLayout` etc, though sometimes you might give them an ID anyway.
 
-IDs shall be `snake-case` and must be unique within a Slint component.
+IDs shall be `kebab-case` and must be unique within a Slint component.
 They shall start with the most generic term, then more specific terms, and
 the last segment shall be a type specification of the element. Examples:
 


### PR DESCRIPTION
As far as I am aware, this isn't snake case. Snake case would look more like `snake_case`. This is [`kebab-case`](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case).