### PR TITLE
README: Fix broken links

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -2,6 +2,6 @@
 
 This directory contains all libraries (as cmake projects) required to build the LibrePCB application and other tools.
 
-The dependencies between these libraries are shown in the [architecture overview diagram](../dev/diagrams/svg/architecture_overview.svg):
+The dependencies between these libraries are shown in the [architecture overview diagram](../dev/diagrams/architecture_overview.drawio.svg):
 
-![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.png)
+![Architecture Overview Diagram](../dev/doxygen/images/architecture_overview.svg)


### PR DESCRIPTION
Fix links to point to existing SVG files for the architectural overview.

Shoutout to [Let's Read OSS](https://github.com/stoeckmann/lets-read-oss)