### PR TITLE
Fix approvals not updated after sym/pkg reload

### DIFF
--- a/libs/librepcb/editor/library/cmd/cmdpackagereload.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdpackagereload.cpp
@@ -42,6 +42,8 @@ CmdPackageReload::CmdPackageReload(Package& element) noexcept
     mElement(element),
     mOldFiles(mElement.getDirectory().getFileSystem()->saveState()),
     mNewFiles(),
+    mOldApprovals(element.getMessageApprovals()),
+    mNewApprovals(mOldApprovals),
     mOldGridInterval(mElement.getGridInterval()),
     mNewGridInterval(mOldGridInterval),
     mOldPads(mElement.getPads()),
@@ -87,6 +89,7 @@ bool CmdPackageReload::performExecute() {
   setResources(newElement->getResources());
   setAlternativeNames(newElement->getAlternativeNames());
   setAssemblyType(newElement->getAssemblyType(false));
+  mNewApprovals = newElement->getMessageApprovals();
   mNewGridInterval = newElement->getGridInterval();
   setMinCopperClearance(newElement->getMinCopperClearance());
   mNewPads = newElement->getPads();
@@ -95,6 +98,7 @@ bool CmdPackageReload::performExecute() {
 
   // And apply the modifications.
   if (CmdPackageEdit::performExecute()) return true;  // can throw
+  if (mNewApprovals != mOldApprovals) return true;
   if (mNewGridInterval != mOldGridInterval) return true;
   if (mNewPads != mOldPads) return true;
   if (mNewModels != mOldModels) return true;
@@ -105,6 +109,7 @@ bool CmdPackageReload::performExecute() {
 void CmdPackageReload::performUndo() {
   CmdPackageEdit::performUndo();  // can throw
   mElement.getDirectory().getFileSystem()->restoreState(mOldFiles);
+  mElement.setMessageApprovals(mOldApprovals);
   mElement.setGridInterval(mOldGridInterval);
   mElement.getPads() = mOldPads;
   mElement.getModels() = mOldModels;
@@ -114,6 +119,7 @@ void CmdPackageReload::performUndo() {
 void CmdPackageReload::performRedo() {
   CmdPackageEdit::performRedo();  // can throw
   mElement.getDirectory().getFileSystem()->restoreState(mNewFiles);
+  mElement.setMessageApprovals(mNewApprovals);
   mElement.setGridInterval(mNewGridInterval);
   mElement.getPads() = mNewPads;
   mElement.getModels() = mNewModels;

--- a/libs/librepcb/editor/library/cmd/cmdpackagereload.h
+++ b/libs/librepcb/editor/library/cmd/cmdpackagereload.h
@@ -71,6 +71,8 @@ private:  // Data
 
   TransactionalFileSystem::State mOldFiles;
   TransactionalFileSystem::State mNewFiles;
+  QSet<SExpression> mOldApprovals;
+  QSet<SExpression> mNewApprovals;
 
   PositiveLength mOldGridInterval;
   PositiveLength mNewGridInterval;

--- a/libs/librepcb/editor/library/cmd/cmdsymbolreload.cpp
+++ b/libs/librepcb/editor/library/cmd/cmdsymbolreload.cpp
@@ -42,6 +42,8 @@ CmdSymbolReload::CmdSymbolReload(Symbol& element) noexcept
     mElement(element),
     mOldFiles(mElement.getDirectory().getFileSystem()->saveState()),
     mNewFiles(),
+    mOldApprovals(element.getMessageApprovals()),
+    mNewApprovals(mOldApprovals),
     mOldGridInterval(mElement.getGridInterval()),
     mNewGridInterval(mOldGridInterval),
     mOldPins(mElement.getPins()),
@@ -88,6 +90,7 @@ bool CmdSymbolReload::performExecute() {
   setGeneratedBy(newElement->getGeneratedBy());
   setCategories(newElement->getCategories());
   setResources(newElement->getResources());
+  mNewApprovals = newElement->getMessageApprovals();
   mNewGridInterval = newElement->getGridInterval();
   mNewPins = newElement->getPins();
   mNewPolygons = newElement->getPolygons();
@@ -97,6 +100,7 @@ bool CmdSymbolReload::performExecute() {
 
   // And apply the modifications.
   if (CmdLibraryElementEdit::performExecute()) return true;  // can throw
+  if (mNewApprovals != mOldApprovals) return true;
   if (mNewGridInterval != mOldGridInterval) return true;
   if (mNewPins != mOldPins) return true;
   if (mNewPolygons != mOldPolygons) return true;
@@ -109,6 +113,7 @@ bool CmdSymbolReload::performExecute() {
 void CmdSymbolReload::performUndo() {
   CmdLibraryElementEdit::performUndo();  // can throw
   mElement.getDirectory().getFileSystem()->restoreState(mOldFiles);
+  mElement.setMessageApprovals(mOldApprovals);
   mElement.setGridInterval(mOldGridInterval);
   mElement.getPins() = mOldPins;
   mElement.getPolygons() = mOldPolygons;
@@ -120,6 +125,7 @@ void CmdSymbolReload::performUndo() {
 void CmdSymbolReload::performRedo() {
   CmdLibraryElementEdit::performRedo();  // can throw
   mElement.getDirectory().getFileSystem()->restoreState(mNewFiles);
+  mElement.setMessageApprovals(mNewApprovals);
   mElement.setGridInterval(mNewGridInterval);
   mElement.getPins() = mNewPins;
   mElement.getPolygons() = mNewPolygons;

--- a/libs/librepcb/editor/library/cmd/cmdsymbolreload.h
+++ b/libs/librepcb/editor/library/cmd/cmdsymbolreload.h
@@ -72,6 +72,8 @@ private:  // Data
 
   TransactionalFileSystem::State mOldFiles;
   TransactionalFileSystem::State mNewFiles;
+  QSet<SExpression> mOldApprovals;
+  QSet<SExpression> mNewApprovals;
 
   PositiveLength mOldGridInterval;
   PositiveLength mNewGridInterval;

--- a/tests/unittests/editor/library/cmd/cmdpackagereloadtest.cpp
+++ b/tests/unittests/editor/library/cmd/cmdpackagereloadtest.cpp
@@ -91,6 +91,7 @@ TEST_F(CmdPackageReloadTest, test) {
    (auto_rotate true) (mirror false) (value "{{NAME}}")
   )
  )
+ (approved ambiguous_footprint_tags)
 )
 )";
 

--- a/tests/unittests/editor/library/cmd/cmdsymbolreloadtest.cpp
+++ b/tests/unittests/editor/library/cmd/cmdsymbolreloadtest.cpp
@@ -85,6 +85,7 @@ TEST_F(CmdSymbolReloadTest, test) {
   (position 1.1 2.2) (rotation 1.0) (width 10.0) (height 11.0)
   (border 0.5)
  )
+ (approved missing_value_text)
 )
 )";
 


### PR DESCRIPTION
Symbol/package approvals were not reloaded from file during the auto-reload after file modifications.