### PR TITLE
Support changing opacity of 2D background image

### DIFF
--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -367,6 +367,7 @@ ui::PackageTabData PackageTab::getDerivedUiData() const noexcept {
       l2s(*mPackage->getGridInterval()),  // Grid interval
       l2s(mUnit),  // Unit
       mBackgroundImageGraphicsItem->isVisible(),  // Background image set
+      static_cast<float>(mBackgroundImageGraphicsItem->opacity()),  // BG alpha
       mAlpha.value(OpenGlObject::Type::SolderResist, 1),  // Solder resist alpha
       mAlpha.value(OpenGlObject::Type::Silkscreen, 1),  // Silkscreen alpha
       mAlpha.value(OpenGlObject::Type::SolderPaste, 1),  // Solder paste alpha
@@ -514,6 +515,7 @@ void PackageTab::setDerivedUiData(const ui::PackageTabData& data) noexcept {
   if (unit != mUnit) {
     mUnit = unit;
   }
+  mBackgroundImageGraphicsItem->setOpacity(data.background_image_alpha);
   mAlpha[OpenGlObject::Type::SolderResist] =
       qBound(0.0f, data.solderresist_alpha, 1.0f);
   mAlpha[OpenGlObject::Type::Silkscreen] =
@@ -2691,11 +2693,18 @@ bool PackageTab::toggleBackgroundImage() noexcept {
     mBackgroundImageSettings.enabled =
         (!mBackgroundImageSettings.image.isNull()) &&
         (mBackgroundImageSettings.references.count() >= 2);
+
+    // Make sure the loaded image is actually visible.
+    if (mBackgroundImageSettings.enabled &&
+        (mBackgroundImageGraphicsItem->opacity() < 0.1)) {
+      mBackgroundImageGraphicsItem->setOpacity(0.8);
+    }
   }
 
   // Store & apply new settings.
   mBackgroundImageSettings.saveToDir(getBackgroundImageCacheDir());
   applyBackgroundImageSettings();
+  onDerivedUiDataChanged.notify();
   return mBackgroundImageGraphicsItem->isVisible();
 }
 

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -368,6 +368,7 @@ ui::Board2dTabData Board2dTab::getDerivedUiData() const noexcept {
       l2s(*mBoard.getGridInterval()),  // Grid interval
       l2s(mBoard.getGridUnit()),  // Length unit
       mBackgroundImageGraphicsItem->isVisible(),  // Background image set
+      static_cast<float>(mBackgroundImageGraphicsItem->opacity()),  // BG alpha
       mIgnorePlacementLocks,  // Ignore placement locks
       mBoardEditor.isRebuildingPlanes(),  // Refreshing
       mMsgEmptySchematics.getUiData(),  // Message "empty schematics"
@@ -450,6 +451,9 @@ void Board2dTab::setDerivedUiData(const ui::Board2dTabData& data) noexcept {
     mBoard.setGridUnit(unit);
     mProjectEditor.setManualModificationsMade();
   }
+
+  // Background image
+  mBackgroundImageGraphicsItem->setOpacity(data.background_image_alpha);
 
   // Placement locks
   mIgnorePlacementLocks = data.ignore_placement_locks;
@@ -2631,11 +2635,18 @@ bool Board2dTab::toggleBackgroundImage() noexcept {
     mBackgroundImageSettings.enabled =
         (!mBackgroundImageSettings.image.isNull()) &&
         (mBackgroundImageSettings.references.count() >= 2);
+
+    // Make sure the loaded image is actually visible.
+    if (mBackgroundImageSettings.enabled &&
+        (mBackgroundImageGraphicsItem->opacity() < 0.1)) {
+      mBackgroundImageGraphicsItem->setOpacity(0.8);
+    }
   }
 
   // Store & apply new settings.
   mBackgroundImageSettings.saveToDir(getBackgroundImageCacheDir());
   applyBackgroundImageSettings();
+  onDerivedUiDataChanged.notify();
   return mBackgroundImageGraphicsItem->isVisible();
 }
 

--- a/libs/librepcb/ui/api/types.slint
+++ b/libs/librepcb/ui/api/types.slint
@@ -1056,6 +1056,7 @@ export struct PackageTabData {
     grid-interval: Int64,
     unit: LengthUnit,
     background-image-set: bool,
+    background-image-alpha: float,
     solderresist-alpha: float,  // 3D view
     silkscreen-alpha: float,  // 3D view
     solderpaste-alpha: float,  // 3D view
@@ -1281,6 +1282,7 @@ export struct Board2dTabData {
     grid-interval: Int64,
     unit: LengthUnit,
     background-image-set: bool,
+    background-image-alpha: float,
     ignore-placement-locks: bool,
     refreshing: bool,
 

--- a/libs/librepcb/ui/library/pkg/packagetab.slint
+++ b/libs/librepcb/ui/library/pkg/packagetab.slint
@@ -836,19 +836,24 @@ component PackageEditorTab inherits TouchArea {
             }
         }
 
-        if !view-3d: toggle-background-image-btn := SceneButton {
+        if !view-3d: background-image-btn := SliderSceneButton {
             x: parent.width - self.width;
-            style: self.checked ? checkbox : button;
-            icon-scale: self.checked ? 0.8 : 0.9;
+            style: self.slider-enabled ? checkbox : button;
+            icon-scale: self.slider-enabled ? 0.8 : 0.9;
             icon: Cmd.toggle-background-image.icon;
-            tooltip: Cmd.toggle-background-image.text;
+            tooltip: self.slider-enabled ? @tr("Background Image") : Cmd.toggle-background-image.text;
             bg-color: tabs[index].background-color;
             fg-color: tabs[index].foreground-color;
-            checked: tabs[index].background-image-set;
+            value: tabs[index].background-image-alpha;
+            slider-enabled: tabs[index].background-image-set;
             enabled: footprint-selected;
 
-            clicked => {
+            button-clicked => {
                 Backend.trigger-tab(section-index, index, TabAction.toggle-background-image);
+            }
+
+            value-changed(value) => {
+                tabs[index].background-image-alpha = value;
             }
         }
 

--- a/libs/librepcb/ui/project/board/board2dtab.slint
+++ b/libs/librepcb/ui/project/board/board2dtab.slint
@@ -14,6 +14,7 @@ import {
     MenuPopup,
     MessageBox,
     SceneButton,
+    SliderSceneButton,
     Spinner,
     ToolButton,
 } from "../../widgets.slint";
@@ -576,6 +577,7 @@ export component Board2dTab inherits Tab {
             width: self.preferred-width;
 
             zoom-fit-btn := SceneButton {
+                x: parent.width - self.width;
                 icon: @image-url("../../../../font-awesome/svgs/solid/expand.svg");
                 icon-scale: 0.9;
                 bg-color: tabs[index].background-color;
@@ -587,6 +589,7 @@ export component Board2dTab inherits Tab {
             }
 
             zoom-in-btn := SceneButton {
+                x: parent.width - self.width;
                 icon: @image-url("../../../../bootstrap-icons/icons/zoom-in.svg");
                 bg-color: tabs[index].background-color;
                 fg-color: tabs[index].foreground-color;
@@ -597,6 +600,7 @@ export component Board2dTab inherits Tab {
             }
 
             zoom-out-btn := SceneButton {
+                x: parent.width - self.width;
                 icon: @image-url("../../../../bootstrap-icons/icons/zoom-out.svg");
                 bg-color: tabs[index].background-color;
                 fg-color: tabs[index].foreground-color;
@@ -606,22 +610,28 @@ export component Board2dTab inherits Tab {
                 }
             }
 
-            toggle-background-image-btn := SceneButton {
+            background-image-btn := SliderSceneButton {
                 x: parent.width - self.width;
-                style: self.checked ? checkbox : button;
-                icon-scale: self.checked ? 0.8 : 0.9;
+                style: self.slider-enabled ? checkbox : button;
+                icon-scale: self.slider-enabled ? 0.8 : 0.9;
                 icon: Cmd.toggle-background-image.icon;
-                tooltip: Cmd.toggle-background-image.text;
+                tooltip: self.slider-enabled ? @tr("Background Image") : Cmd.toggle-background-image.text;
                 bg-color: tabs[index].background-color;
                 fg-color: tabs[index].foreground-color;
-                checked: tabs[index].background-image-set;
+                value: tabs[index].background-image-alpha;
+                slider-enabled: tabs[index].background-image-set;
 
-                clicked => {
+                button-clicked => {
                     Backend.trigger-tab(section-index, index, TabAction.toggle-background-image);
+                }
+
+                value-changed(value) => {
+                    tabs[index].background-image-alpha = value;
                 }
             }
 
             toggle-3d-btn := SceneButton {
+                x: parent.width - self.width;
                 text: "3D";
                 bg-color: tabs[index].background-color;
                 fg-color: tabs[index].foreground-color;

--- a/libs/librepcb/ui/widgets/sliderscenebutton.slint
+++ b/libs/librepcb/ui/widgets/sliderscenebutton.slint
@@ -1,60 +1,80 @@
-import { SceneButton } from "scenebutton.slint";
+import { SceneButton, SceneButtonStyle } from "scenebutton.slint";
 import { HorizontalSlider } from "slider.slint";
 
-export component SliderSceneButton inherits TouchArea {
+export component SliderSceneButton {
     in property <image> icon;
     in property <string> tooltip;
     in property <float> value;
     in property <brush> bg-color;
     in property <brush> fg-color;
+    in property <bool> enabled: true;
+    in property <bool> slider-enabled: true;
+    in property <SceneButtonStyle> style: uncheckbox;
+    in property <float> icon-scale: 0.9;
 
+    callback button-clicked();
     callback value-changed(value: float);
 
-    HorizontalLayout {
-        alignment: end;
+    button-clicked => {
+        value-changed(btn.checked ? 1 : 0);
+    }
 
-        if root.has-hover: VerticalLayout {
-            spacing: 5px;
+    ta := TouchArea {
+        enabled: enabled && slider-enabled;
 
-            Rectangle {
-                x: (parent.width - self.width) / 2;
-                width: self.preferred-width + 6px;
-                height: self.preferred-height + 2px;
-                background: bg-color;
-                border-radius: 5px;
+        HorizontalLayout {
+            alignment: end;
 
-                Text {
-                    color: fg-color;
-                    horizontal-alignment: center;
-                    font-size: 10px;
-                    text: tooltip;
-                    accessible-role: none;
+            if ta.enabled && ta.has-hover: VerticalLayout {
+                spacing: 5px;
+
+                Rectangle {
+                    x: (parent.width - self.width) / 2;
+                    width: self.preferred-width + 6px;
+                    height: self.preferred-height + 2px;
+                    background: bg-color;
+                    border-radius: 5px;
+
+                    Text {
+                        color: fg-color;
+                        horizontal-alignment: center;
+                        font-size: 10px;
+                        text: tooltip;
+                        accessible-role: none;
+                    }
+                }
+
+                slider := HorizontalSlider {
+                    min-width: 80px;
+                    value: value;
+                    focusable: false;
+                    accessible-label: tooltip;
+
+                    value-changed(value) => {
+                        value-changed(value);
+                    }
                 }
             }
 
-            slider := HorizontalSlider {
-                min-width: 80px;
-                value: value;
-                focusable: false;
+            btn := SceneButton {
+                icon: icon;
+                icon-scale: icon-scale;
+                bg-color: bg-color;
+                fg-color: fg-color;
+                style: style;
+                checked: {
+                    if style == SceneButtonStyle.uncheckbox {
+                        slider-enabled && (value < 0.2)
+                    } else {
+                        slider-enabled
+                    }
+                };
+                enabled: enabled;
                 accessible-label: tooltip;
 
-                value-changed(value) => {
-                    value-changed(value);
+                clicked => {
+                    root.button-clicked();
                 }
-            }
-        }
-
-        btn := SceneButton {
-            icon: icon;
-            icon-scale: 0.9;
-            bg-color: bg-color;
-            fg-color: fg-color;
-            style: uncheckbox;
-            checked: value < 0.2;
-            accessible-label: tooltip;
-
-            clicked => {
-                value-changed(self.checked ? 1 : 0);
             }
         }
     }


### PR DESCRIPTION
In the package- and board editor, support adjusting the opacity of the background image:

<img width="149" height="165" alt="image" src="https://github.com/user-attachments/assets/348aaddc-91df-4f37-8b59-4cef0a5cf816" />
