### PR TITLE
Board editor: Support flipping view to bottom side

### DIFF
--- a/img/images.qrc
+++ b/img/images.qrc
@@ -4,6 +4,7 @@
         <file alias="/bi/align-bottom.svg">../libs/bootstrap-icons/icons/align-bottom.svg</file>
         <file alias="/bi/align-center.svg">../libs/bootstrap-icons/icons/align-center.svg</file>
         <file alias="/bi/align-top.svg">../libs/bootstrap-icons/icons/align-top.svg</file>
+        <file alias="/bi/arrow-repeat.svg">../libs/bootstrap-icons/icons/arrow-repeat.svg</file>
         <file alias="/bi/badge-3d.svg">../libs/bootstrap-icons/icons/badge-3d.svg</file>
         <file alias="/bi/bootstrap-reboot.svg">../libs/bootstrap-icons/icons/bootstrap-reboot.svg</file>
         <file alias="/bi/box-arrow-left.svg">../libs/bootstrap-icons/icons/box-arrow-left.svg</file>

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -868,6 +868,15 @@ public:
       {QKeySequence(Qt::CTRL | Qt::Key_Minus)},
       &categoryView,
   };
+  EditorCommand flipView{
+      "flip_view",  // clang-format break
+      QT_TR_NOOP("Flip View"),
+      QT_TR_NOOP("Switch between top view and bottom view"),
+      ":/bi/arrow-repeat.svg",
+      EditorCommand::Flags(),
+      {QKeySequence(Qt::CTRL | Qt::Key_2)},
+      &categoryView,
+  };
   EditorCommand gridIncrease{
       "grid_increase",  // clang-format break
       QT_TR_NOOP("Increase Grid Interval"),

--- a/libs/librepcb/editor/editorcommandsetupdater.h
+++ b/libs/librepcb/editor/editorcommandsetupdater.h
@@ -95,6 +95,7 @@ public:
     out.set_zoom_fit_content(l2s(cmd.zoomFitContent, out.get_zoom_fit_content()));
     out.set_zoom_in(l2s(cmd.zoomIn, out.get_zoom_in()));
     out.set_zoom_out(l2s(cmd.zoomOut, out.get_zoom_out()));
+    out.set_flip_view(l2s(cmd.flipView, out.get_flip_view()));
     out.set_grid_increase(l2s(cmd.gridIncrease, out.get_grid_increase()));
     out.set_grid_decrease(l2s(cmd.gridDecrease, out.get_grid_decrease()));
     out.set_show_pin_numbers(l2s(cmd.showPinNumbers, out.get_show_pin_numbers()));

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.cpp
@@ -119,6 +119,11 @@ void PrimitiveFootprintPadGraphicsItem::setText(const QString& text) noexcept {
   updateTextHeight();
 }
 
+void PrimitiveFootprintPadGraphicsItem::setTextMirrored(
+    bool mirrored) noexcept {
+  mTextGraphicsItem->setMirrored(mirrored);
+}
+
 void PrimitiveFootprintPadGraphicsItem::setToolTipText(
     const QString& text) noexcept {
   setToolTip(text);

--- a/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivefootprintpadgraphicsitem.h
@@ -70,6 +70,7 @@ public:
   void setRotation(const Angle& rotation) noexcept;
   void setMirrored(bool mirrored) noexcept;
   void setText(const QString& text) noexcept;
+  void setTextMirrored(bool mirrored) noexcept;
   void setToolTipText(const QString& text) noexcept;
   void setLayer(const QString& layerName) noexcept;
   void setGeometries(const QHash<const Layer*, QList<PadGeometry>>& geometries,

--- a/libs/librepcb/editor/graphics/slintgraphicsview.cpp
+++ b/libs/librepcb/editor/graphics/slintgraphicsview.cpp
@@ -52,6 +52,7 @@ SlintGraphicsView::SlintGraphicsView(const QRectF& defaultSceneRect,
     mDefaultSceneRect(defaultSceneRect),
     mDefaultMargins(defaultMargins),
     mEventHandler(nullptr),
+    mMirror(false),
     mAnimation(new QVariantAnimation(this)) {
   mAnimation->setDuration(500);
   mAnimation->setEasingCurve(QEasingCurve::InOutCubic);
@@ -81,10 +82,18 @@ QPainterPath SlintGraphicsView::calcPosWithTolerance(
 
 Point SlintGraphicsView::mapToScenePos(const QPointF& pos,
                                        qreal devicePixelRatio) const noexcept {
+  return Point::fromPx(mapToScenePosPx(pos, devicePixelRatio));
+}
+
+QPointF SlintGraphicsView::mapToScenePosPx(
+    QPointF pos, qreal devicePixelRatio) const noexcept {
+  if (mMirror && (mViewSize.width() > 0)) {
+    pos.setX(mViewSize.width() - pos.x());
+  }
   QTransform tf;
   tf.translate(mProjection.offset.x(), mProjection.offset.y());
   tf.scale(1 / mProjection.scale, 1 / mProjection.scale);
-  return Point::fromPx(tf.map(pos * devicePixelRatio));
+  return tf.map(pos * devicePixelRatio);
 }
 
 /*******************************************************************************
@@ -120,6 +129,13 @@ void SlintGraphicsView::setUseOpenGl(bool use) noexcept {
 void SlintGraphicsView::setEventHandler(
     IF_GraphicsViewEventHandler* obj) noexcept {
   mEventHandler = obj;
+}
+
+void SlintGraphicsView::setMirror(bool mirror) noexcept {
+  if (mirror != mMirror) {
+    mMirror = mirror;
+    emit transformChanged();
+  }
 }
 
 slint::Image SlintGraphicsView::render(GraphicsScene& scene, float width,
@@ -170,7 +186,17 @@ slint::Image SlintGraphicsView::render(GraphicsScene& scene, float width,
     QRectF sceneRect(0, 0, size.width() / mProjection.scale,
                      size.height() / mProjection.scale);
     sceneRect.translate(mProjection.offset);
+
+    // Render the scene, either mirrored or not.
+    if (mMirror) {
+      painter.save();
+      painter.translate(size.width(), 0);
+      painter.scale(-1, 1);
+    }
     scene.render(&painter, targetRect, sceneRect);
+    if (mMirror) {
+      painter.restore();
+    }
 
     // If there was an OpenGL error, print it at the bottom right.
     if (!openGlError.isEmpty()) {
@@ -197,10 +223,7 @@ bool SlintGraphicsView::pointerEvent(
   using slint::private_api::PointerEventButton;
   using slint::private_api::PointerEventKind;
 
-  QTransform tf;
-  tf.translate(mProjection.offset.x(), mProjection.offset.y());
-  tf.scale(1 / mProjection.scale, 1 / mProjection.scale);
-  const QPointF scenePosPx = tf.map(pos);
+  const QPointF scenePosPx = mapToScenePosPx(pos, 1);
   mMouseEvent.scenePos = Point::fromPx(scenePosPx);
   mMouseEvent.modifiers = s2q(e.modifiers);
 
@@ -408,7 +431,11 @@ void SlintGraphicsView::scroll(const QPointF& delta) noexcept {
   applyProjection(projection);
 }
 
-void SlintGraphicsView::zoom(const QPointF& center, qreal factor) noexcept {
+void SlintGraphicsView::zoom(QPointF center, qreal factor) noexcept {
+  if (mMirror && (mViewSize.width() > 0)) {
+    center.setX(mViewSize.width() - center.x());
+  }
+
   Projection projection = mProjection;
 
   QTransform tf;

--- a/libs/librepcb/editor/graphics/slintgraphicsview.h
+++ b/libs/librepcb/editor/graphics/slintgraphicsview.h
@@ -91,10 +91,12 @@ public:
                                     qreal multiplier) const noexcept;
   Point mapToScenePos(const QPointF& pos,
                       qreal devicePixelRatio) const noexcept;
+  QPointF mapToScenePosPx(QPointF pos, qreal devicePixelRatio) const noexcept;
 
   // General Methods
   void setUseOpenGl(bool use) noexcept;
   void setEventHandler(IF_GraphicsViewEventHandler* obj) noexcept;
+  void setMirror(bool mirror) noexcept;
   slint::Image render(GraphicsScene& scene, float width, float height) noexcept;
   bool pointerEvent(const QPointF& pos,
                     slint::private_api::PointerEvent e) noexcept;
@@ -126,7 +128,7 @@ signals:
 
 private:  // Methods
   void scroll(const QPointF& delta) noexcept;
-  void zoom(const QPointF& center, qreal factor) noexcept;
+  void zoom(QPointF center, qreal factor) noexcept;
   void smoothTo(const Projection& projection) noexcept;
   bool applyProjection(const Projection& projection) noexcept;
   QRectF validateSceneRect(const QRectF& r) const noexcept;
@@ -141,6 +143,7 @@ private:  // Data
   QString mGlError;
   Projection mProjection;
   QSizeF mViewSize;
+  bool mMirror;
 
   GraphicsSceneMouseEvent mMouseEvent;
   QDeadlineTimer mLeftMouseButtonDoubleClickTimer;

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -563,10 +563,15 @@ void Board2dTab::activate() noexcept {
           &mBoardEditor, &BoardEditor::schedulePlanesRebuild);
 
   mScene.reset(new BoardGraphicsScene(
-      mBoard, *mLayers, mProjectEditor.getHighlightedNetSignals(), this));
+      mBoard, *mLayers,
+      std::shared_ptr<BoardGraphicsScene::Context>(
+          new BoardGraphicsScene::Context{
+              mProjectEditor.getHighlightedNetSignals(),  // highlighted nets
+          }),
+      this));
   mScene->setGridInterval(mBoard.getGridInterval());
   connect(&mProjectEditor, &ProjectEditor::highlightedNetSignalsChanged,
-          mScene.get(), &BoardGraphicsScene::updateHighlightedNetSignals);
+          mScene.get(), &BoardGraphicsScene::updateContext);
   connect(mScene.get(), &GraphicsScene::changed, this,
           &Board2dTab::requestRepaint);
 

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -367,6 +367,7 @@ ui::Board2dTabData Board2dTab::getDerivedUiData() const noexcept {
       l2s(mGridStyle),  // Grid style
       l2s(*mBoard.getGridInterval()),  // Grid interval
       l2s(mBoard.getGridUnit()),  // Length unit
+      mScene->isFlipped(),  // Flip view (view from bottom)
       mBackgroundImageGraphicsItem->isVisible(),  // Background image set
       static_cast<float>(mBackgroundImageGraphicsItem->opacity()),  // BG alpha
       mIgnorePlacementLocks,  // Ignore placement locks
@@ -451,6 +452,10 @@ void Board2dTab::setDerivedUiData(const ui::Board2dTabData& data) noexcept {
     mBoard.setGridUnit(unit);
     mProjectEditor.setManualModificationsMade();
   }
+
+  // Flip view (view from bottom)
+  mScene->setFlipped(data.flip_view);
+  mView->setMirror(data.flip_view);
 
   // Background image
   mBackgroundImageGraphicsItem->setOpacity(data.background_image_alpha);
@@ -567,6 +572,7 @@ void Board2dTab::activate() noexcept {
       std::shared_ptr<BoardGraphicsScene::Context>(
           new BoardGraphicsScene::Context{
               mProjectEditor.getHighlightedNetSignals(),  // highlighted nets
+              false,  // flip view
           }),
       this));
   mScene->setGridInterval(mBoard.getGridInterval());

--- a/libs/librepcb/editor/project/board/boardgraphicsscene.cpp
+++ b/libs/librepcb/editor/project/board/boardgraphicsscene.cpp
@@ -161,6 +161,13 @@ BoardGraphicsScene::~BoardGraphicsScene() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void BoardGraphicsScene::setFlipped(bool flip) noexcept {
+  if (flip != mContext->flipView) {
+    mContext->flipView = flip;
+    updateContext();
+  }
+}
+
 void BoardGraphicsScene::selectAll() noexcept {
   foreach (auto item, mDevices) {
     item->setSelected(true);
@@ -307,6 +314,9 @@ void BoardGraphicsScene::clearSelection() noexcept {
 }
 
 void BoardGraphicsScene::updateContext() noexcept {
+  foreach (auto item, mDevices) {
+    item->updateContext();
+  }
   foreach (auto item, mPads) {
     item->updateContext();
   }
@@ -316,29 +326,52 @@ void BoardGraphicsScene::updateContext() noexcept {
   foreach (auto item, mPads) {
     item->updateContext();
   }
+  foreach (auto item, mNetPoints) {
+    item->updateContext();
+  }
   foreach (auto item, mNetLines) {
     item->updateContext();
   }
   foreach (auto item, mPlanes) {
     item->updateContext();
   }
+  foreach (auto item, mZones) {
+    item->updateContext();
+  }
   foreach (auto item, mAirWires) {
+    item->updateContext();
+  }
+  foreach (auto item, mPolygons) {
+    item->updateContext();
+  }
+  foreach (auto item, mStrokeTexts) {
     item->updateContext();
   }
 }
 
-qreal BoardGraphicsScene::getZValueOfCopperLayer(const Layer& layer) noexcept {
+qreal BoardGraphicsScene::getZValueOfCopperLayer(const Layer& layer,
+                                                 bool flip) noexcept {
   if (layer.isTop()) {
-    return ZValue_CopperTop;
+    return getFlippedZValue(ZValue_CopperTop, flip);
   } else if (layer.isBottom()) {
-    return ZValue_CopperBottom;
+    return getFlippedZValue(ZValue_CopperBottom, flip);
   } else if (layer.isInner()) {
     // 0.0 => TOP
     // 1.0 => BOTTOM
     const qreal delta = static_cast<qreal>(layer.getCopperNumber()) / 100.0;
-    return (static_cast<int>(ZValue_InnerTop) - delta);
+    return flip ? (static_cast<int>(ZValue_InnerBottom) + delta)
+                : (static_cast<int>(ZValue_InnerTop) - delta);
   } else {
     return ZValue_Default;
+  }
+}
+
+qreal BoardGraphicsScene::getFlippedZValue(ItemZValue value,
+                                           bool flip) noexcept {
+  if (flip && (value >= ZValue_Bottom) && (value <= ZValue_Top)) {
+    return static_cast<qreal>(ZValue_Top + ZValue_Bottom - value);
+  } else {
+    return static_cast<qreal>(value);
   }
 }
 
@@ -349,7 +382,7 @@ qreal BoardGraphicsScene::getZValueOfCopperLayer(const Layer& layer) noexcept {
 void BoardGraphicsScene::addDevice(BI_Device& device) noexcept {
   Q_ASSERT(!mDevices.contains(&device));
   std::shared_ptr<BGI_Device> item =
-      std::make_shared<BGI_Device>(device, mLayers);
+      std::make_shared<BGI_Device>(device, mLayers, mContext);
   addItem(*item);
   mDevices.insert(&device, item);
 
@@ -496,7 +529,7 @@ void BoardGraphicsScene::removeVia(BI_Via& via) noexcept {
 void BoardGraphicsScene::addNetPoint(BI_NetPoint& netPoint) noexcept {
   Q_ASSERT(!mNetPoints.contains(&netPoint));
   std::shared_ptr<BGI_NetPoint> item =
-      std::make_shared<BGI_NetPoint>(netPoint, mLayers);
+      std::make_shared<BGI_NetPoint>(netPoint, mLayers, mContext);
   addItem(*item);
   mNetPoints.insert(&netPoint, item);
 }
@@ -543,7 +576,8 @@ void BoardGraphicsScene::removePlane(BI_Plane& plane) noexcept {
 
 void BoardGraphicsScene::addZone(BI_Zone& zone) noexcept {
   Q_ASSERT(!mZones.contains(&zone));
-  std::shared_ptr<BGI_Zone> item = std::make_shared<BGI_Zone>(zone, mLayers);
+  std::shared_ptr<BGI_Zone> item =
+      std::make_shared<BGI_Zone>(zone, mLayers, mContext);
   addItem(*item);
   mZones.insert(&zone, item);
 }
@@ -559,7 +593,7 @@ void BoardGraphicsScene::removeZone(BI_Zone& zone) noexcept {
 void BoardGraphicsScene::addPolygon(BI_Polygon& polygon) noexcept {
   Q_ASSERT(!mPolygons.contains(&polygon));
   std::shared_ptr<BGI_Polygon> item =
-      std::make_shared<BGI_Polygon>(polygon, mLayers);
+      std::make_shared<BGI_Polygon>(polygon, mLayers, mContext);
   addItem(*item);
   mPolygons.insert(&polygon, item);
 }
@@ -575,7 +609,7 @@ void BoardGraphicsScene::removePolygon(BI_Polygon& polygon) noexcept {
 void BoardGraphicsScene::addStrokeText(BI_StrokeText& text) noexcept {
   Q_ASSERT(!mStrokeTexts.contains(&text));
   std::shared_ptr<BGI_StrokeText> item = std::make_shared<BGI_StrokeText>(
-      text, mDevices.value(text.getDevice()), mLayers);
+      text, mDevices.value(text.getDevice()), mLayers, mContext);
   addItem(*item);
   mStrokeTexts.insert(&text, item);
 }

--- a/libs/librepcb/editor/project/board/boardgraphicsscene.cpp
+++ b/libs/librepcb/editor/project/board/boardgraphicsscene.cpp
@@ -63,14 +63,11 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BoardGraphicsScene::BoardGraphicsScene(
-    Board& board, const GraphicsLayerList& layers,
-    std::shared_ptr<const QSet<const NetSignal*>> highlightedNetSignals,
-    QObject* parent) noexcept
-  : GraphicsScene(parent),
-    mBoard(board),
-    mLayers(layers),
-    mHighlightedNetSignals(highlightedNetSignals) {
+BoardGraphicsScene::BoardGraphicsScene(Board& board,
+                                       const GraphicsLayerList& layers,
+                                       std::shared_ptr<Context> context,
+                                       QObject* parent) noexcept
+  : GraphicsScene(parent), mBoard(board), mLayers(layers), mContext(context) {
   foreach (BI_Device* obj, mBoard.getDeviceInstances()) {
     addDevice(*obj);
   }
@@ -309,24 +306,24 @@ void BoardGraphicsScene::clearSelection() noexcept {
   }
 }
 
-void BoardGraphicsScene::updateHighlightedNetSignals() noexcept {
+void BoardGraphicsScene::updateContext() noexcept {
   foreach (auto item, mPads) {
-    item->updateHighlightedNetSignals();
+    item->updateContext();
   }
   foreach (auto item, mVias) {
-    item->update();
+    item->updateContext();
   }
   foreach (auto item, mPads) {
-    item->update();
+    item->updateContext();
   }
   foreach (auto item, mNetLines) {
-    item->update();
+    item->updateContext();
   }
   foreach (auto item, mPlanes) {
-    item->update();
+    item->updateContext();
   }
   foreach (auto item, mAirWires) {
-    item->update();
+    item->updateContext();
   }
 }
 
@@ -393,7 +390,7 @@ void BoardGraphicsScene::addPad(BI_Pad& pad,
                                 std::weak_ptr<BGI_Device> device) noexcept {
   Q_ASSERT(!mPads.contains(&pad));
   std::shared_ptr<BGI_Pad> item =
-      std::make_shared<BGI_Pad>(pad, device, mLayers, mHighlightedNetSignals);
+      std::make_shared<BGI_Pad>(pad, device, mLayers, mContext);
   addItem(*item);
   mPads.insert(&pad, item);
 }
@@ -483,7 +480,7 @@ void BoardGraphicsScene::removeNetSegmentElements(
 void BoardGraphicsScene::addVia(BI_Via& via) noexcept {
   Q_ASSERT(!mVias.contains(&via));
   std::shared_ptr<BGI_Via> item =
-      std::make_shared<BGI_Via>(via, mLayers, mHighlightedNetSignals);
+      std::make_shared<BGI_Via>(via, mLayers, mContext);
   addItem(*item);
   mVias.insert(&via, item);
 }
@@ -515,7 +512,7 @@ void BoardGraphicsScene::removeNetPoint(BI_NetPoint& netPoint) noexcept {
 void BoardGraphicsScene::addNetLine(BI_NetLine& netLine) noexcept {
   Q_ASSERT(!mNetLines.contains(&netLine));
   std::shared_ptr<BGI_NetLine> item =
-      std::make_shared<BGI_NetLine>(netLine, mLayers, mHighlightedNetSignals);
+      std::make_shared<BGI_NetLine>(netLine, mLayers, mContext);
   addItem(*item);
   mNetLines.insert(&netLine, item);
 }
@@ -531,7 +528,7 @@ void BoardGraphicsScene::removeNetLine(BI_NetLine& netLine) noexcept {
 void BoardGraphicsScene::addPlane(BI_Plane& plane) noexcept {
   Q_ASSERT(!mPlanes.contains(&plane));
   std::shared_ptr<BGI_Plane> item =
-      std::make_shared<BGI_Plane>(plane, mLayers, mHighlightedNetSignals);
+      std::make_shared<BGI_Plane>(plane, mLayers, mContext);
   addItem(*item);
   mPlanes.insert(&plane, item);
 }
@@ -609,7 +606,7 @@ void BoardGraphicsScene::removeHole(BI_Hole& hole) noexcept {
 void BoardGraphicsScene::addAirWire(BI_AirWire& airWire) noexcept {
   Q_ASSERT(!mAirWires.contains(&airWire));
   std::shared_ptr<BGI_AirWire> item =
-      std::make_shared<BGI_AirWire>(airWire, mLayers, mHighlightedNetSignals);
+      std::make_shared<BGI_AirWire>(airWire, mLayers, mContext);
   addItem(*item);
   mAirWires.insert(&airWire, item);
 }

--- a/libs/librepcb/editor/project/board/boardgraphicsscene.h
+++ b/libs/librepcb/editor/project/board/boardgraphicsscene.h
@@ -112,13 +112,16 @@ public:
     ZValue_AirWires,  ///< For ::librepcb::BI_AirWire items
   };
 
+  struct Context {
+    std::shared_ptr<const QSet<const NetSignal*>> highlightedNets;
+  };
+
   // Constructors / Destructor
   BoardGraphicsScene() = delete;
   BoardGraphicsScene(const BoardGraphicsScene& other) = delete;
-  explicit BoardGraphicsScene(
-      Board& board, const GraphicsLayerList& layers,
-      std::shared_ptr<const QSet<const NetSignal*>> highlightedNetSignals,
-      QObject* parent = nullptr) noexcept;
+  explicit BoardGraphicsScene(Board& board, const GraphicsLayerList& layers,
+                              std::shared_ptr<Context> context,
+                              QObject* parent = nullptr) noexcept;
   virtual ~BoardGraphicsScene() noexcept;
 
   // Getters
@@ -167,7 +170,7 @@ public:
   void selectItemsInRect(const Point& p1, const Point& p2) noexcept;
   void selectNetSegment(BI_NetSegment& netSegment) noexcept;
   void clearSelection() noexcept;
-  void updateHighlightedNetSignals() noexcept;
+  void updateContext() noexcept;
   static qreal getZValueOfCopperLayer(const Layer& layer) noexcept;
 
   // Operator Overloadings
@@ -210,7 +213,7 @@ private:  // Methods
 private:  // Data
   Board& mBoard;
   const GraphicsLayerList& mLayers;
-  std::shared_ptr<const QSet<const NetSignal*>> mHighlightedNetSignals;
+  std::shared_ptr<Context> mContext;
   QHash<BI_Device*, std::shared_ptr<BGI_Device>> mDevices;
   QHash<BI_Pad*, std::shared_ptr<BGI_Pad>> mPads;
   QHash<BI_Via*, std::shared_ptr<BGI_Via>> mVias;

--- a/libs/librepcb/editor/project/board/boardgraphicsscene.h
+++ b/libs/librepcb/editor/project/board/boardgraphicsscene.h
@@ -90,6 +90,7 @@ public:
    */
   enum ItemZValue {
     ZValue_Default = 0,  ///< this is the default value (behind all other items)
+    ZValue_Bottom,  ///< For automatic flipping, see #getFlippedZValue()
     ZValue_TextsBottom,  ///< For ::librepcb::BI_StrokeText items
     ZValue_PolygonsBottom,  ///< For ::librepcb::BI_Polygon items
     ZValue_DevicesBottom,  ///< For ::librepcb::BI_Device items
@@ -106,6 +107,7 @@ public:
     ZValue_DevicesTop,  ///< For ::librepcb::BI_Device items
     ZValue_PolygonsTop,  ///< For ::librepcb::BI_Polygon items
     ZValue_TextsTop,  ///< For ::librepcb::BI_StrokeText items
+    ZValue_Top,  ///< For automatic flipping, see #getFlippedZValue()
     ZValue_Holes,  ///< For ::librepcb::BI_Hole items
     ZValue_Vias,  ///< For ::librepcb::BI_Via items
     ZValue_Texts,  ///< For ::librepcb::BI_StrokeText items
@@ -114,6 +116,7 @@ public:
 
   struct Context {
     std::shared_ptr<const QSet<const NetSignal*>> highlightedNets;
+    bool flipView = false;
   };
 
   // Constructors / Destructor
@@ -166,12 +169,15 @@ public:
   }
 
   // General Methods
+  void setFlipped(bool flip) noexcept;
+  bool isFlipped() const noexcept { return mContext->flipView; }
   void selectAll() noexcept;
   void selectItemsInRect(const Point& p1, const Point& p2) noexcept;
   void selectNetSegment(BI_NetSegment& netSegment) noexcept;
   void clearSelection() noexcept;
   void updateContext() noexcept;
-  static qreal getZValueOfCopperLayer(const Layer& layer) noexcept;
+  static qreal getZValueOfCopperLayer(const Layer& layer, bool flip) noexcept;
+  static qreal getFlippedZValue(ItemZValue value, bool flip) noexcept;
 
   // Operator Overloadings
   BoardGraphicsScene& operator=(const BoardGraphicsScene& rhs) = delete;

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate.cpp
@@ -221,13 +221,13 @@ QList<std::shared_ptr<QGraphicsItem>> BoardEditorState::findItemsAtPos(
     return flags.testFlag(FindFlag::SkipLowerPriorityMatches) &&
         lowestPriority && (prio > (*lowestPriority));
   };
-  auto priorityFromLayer = [](const Layer& layer) {
+  auto priorityFromLayer = [scene](const Layer& layer) {
     if (layer.isTop()) {
-      return 100;
+      return scene->isFlipped() ? 300 : 100;
     } else if (layer.isInner()) {
       return 200;
     } else if (layer.isBottom()) {
-      return 300;
+      return scene->isFlipped() ? 100 : 300;
     } else {
       return 0;
     }

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_airwire.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_airwire.cpp
@@ -43,12 +43,12 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_AirWire::BGI_AirWire(BI_AirWire& airwire, const GraphicsLayerList& layers,
-                         std::shared_ptr<const QSet<const NetSignal*>>
-                             highlightedNetSignals) noexcept
+BGI_AirWire::BGI_AirWire(
+    BI_AirWire& airwire, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItem(),
     mAirWire(airwire),
-    mHighlightedNetSignals(highlightedNetSignals),
+    mContext(context),
     mLayer(layers.get(Theme::Color::sBoardAirWires)),
     mOnLayerEditedSlot(*this, &BGI_AirWire::layerEdited) {
   setZValue(BoardGraphicsScene::ZValue_AirWires);
@@ -81,6 +81,14 @@ BGI_AirWire::~BGI_AirWire() noexcept {
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_AirWire::updateContext() noexcept {
+  update();
+}
+
+/*******************************************************************************
  *  Inherited from QGraphicsItem
  ******************************************************************************/
 
@@ -90,7 +98,7 @@ void BGI_AirWire::paint(QPainter* painter,
   Q_UNUSED(widget);
 
   const bool highlight = option->state.testFlag(QStyle::State_Selected) ||
-      mHighlightedNetSignals->contains(&mAirWire.getNetSignal());
+      mContext->highlightedNets->contains(&mAirWire.getNetSignal());
   const qreal lod =
       option->levelOfDetailFromTransform(painter->worldTransform());
 

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_airwire.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_airwire.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../../graphics/graphicslayer.h"
+#include "../boardgraphicsscene.h"
 
 #include <QtCore>
 #include <QtWidgets>
@@ -55,13 +56,14 @@ public:
   // Constructors / Destructor
   BGI_AirWire() = delete;
   BGI_AirWire(const BGI_AirWire& other) = delete;
-  BGI_AirWire(BI_AirWire& airwire, const GraphicsLayerList& layers,
-              std::shared_ptr<const QSet<const NetSignal*>>
-                  highlightedNetSignals) noexcept;
+  BGI_AirWire(
+      BI_AirWire& airwire, const GraphicsLayerList& layers,
+      std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_AirWire() noexcept;
 
   // General Methods
   BI_AirWire& getAirWire() noexcept { return mAirWire; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QRectF boundingRect() const { return mBoundingRect; }
@@ -77,7 +79,7 @@ private:  // Methods
 
 private:  // Data
   BI_AirWire& mAirWire;
-  std::shared_ptr<const QSet<const NetSignal*>> mHighlightedNetSignals;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   std::shared_ptr<const GraphicsLayer> mLayer;
 
   // Cached Attributes

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_device.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_device.cpp
@@ -51,12 +51,14 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_Device::BGI_Device(BI_Device& device,
-                       const GraphicsLayerList& layers) noexcept
+BGI_Device::BGI_Device(
+    BI_Device& device, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItemGroup(),
     onEdited(*this),
     mDevice(device),
     mLayers(layers),
+    mContext(context),
     mGrabAreaLayer(nullptr),
     mOnEditedSlot(*this, &BGI_Device::deviceEdited),
     mOnLayerEditedSlot(*this, &BGI_Device::layerEdited) {
@@ -117,6 +119,14 @@ BGI_Device::BGI_Device(BI_Device& device,
 }
 
 BGI_Device::~BGI_Device() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_Device::updateContext() noexcept {
+  updateBoardSide();
 }
 
 /*******************************************************************************
@@ -217,9 +227,11 @@ void BGI_Device::updateBoardSide() noexcept {
   // Update Z value.
   const bool top = !mDevice.getMirrored();
   if (top) {
-    setZValue(BoardGraphicsScene::ZValue_DevicesTop);
+    setZValue(BoardGraphicsScene::getFlippedZValue(
+        BoardGraphicsScene::ZValue_DevicesTop, mContext->flipView));
   } else {
-    setZValue(BoardGraphicsScene::ZValue_DevicesBottom);
+    setZValue(BoardGraphicsScene::getFlippedZValue(
+        BoardGraphicsScene::ZValue_DevicesBottom, mContext->flipView));
   }
 
   // Update grab area layer.

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_device.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_device.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../../graphics/graphicslayer.h"
+#include "../boardgraphicsscene.h"
 
 #include <librepcb/core/project/board/items/bi_device.h>
 
@@ -68,11 +69,14 @@ public:
   // Constructors / Destructor
   BGI_Device() = delete;
   BGI_Device(const BGI_Device& other) = delete;
-  BGI_Device(BI_Device& device, const GraphicsLayerList& layers) noexcept;
+  BGI_Device(
+      BI_Device& device, const GraphicsLayerList& layers,
+      std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_Device() noexcept;
 
   // General Methods
   BI_Device& getDevice() noexcept { return mDevice; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;
@@ -97,6 +101,7 @@ private:  // Methods
 private:  // Data
   BI_Device& mDevice;
   const GraphicsLayerList& mLayers;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   std::shared_ptr<const GraphicsLayer> mGrabAreaLayer;
   std::shared_ptr<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
   QVector<std::shared_ptr<PrimitiveCircleGraphicsItem>> mCircleGraphicsItems;

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.cpp
@@ -43,13 +43,13 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_NetLine::BGI_NetLine(BI_NetLine& netline, const GraphicsLayerList& layers,
-                         std::shared_ptr<const QSet<const NetSignal*>>
-                             highlightedNetSignals) noexcept
+BGI_NetLine::BGI_NetLine(
+    BI_NetLine& netline, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItem(),
     mNetLine(netline),
     mLayers(layers),
-    mHighlightedNetSignals(highlightedNetSignals),
+    mContext(context),
     mLayer(nullptr),
     mOnNetLineEditedSlot(*this, &BGI_NetLine::netLineEdited),
     mOnLayerEditedSlot(*this, &BGI_NetLine::layerEdited) {
@@ -67,6 +67,14 @@ BGI_NetLine::~BGI_NetLine() noexcept {
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_NetLine::updateContext() noexcept {
+  update();
+}
+
+/*******************************************************************************
  *  Inherited from QGraphicsItem
  ******************************************************************************/
 
@@ -81,7 +89,7 @@ void BGI_NetLine::paint(QPainter* painter,
 
   const NetSignal* netsignal = mNetLine.getNetSegment().getNetSignal();
   const bool highlight = option->state.testFlag(QStyle::State_Selected) ||
-      mHighlightedNetSignals->contains(netsignal);
+      mContext->highlightedNets->contains(netsignal);
 
   // draw line
   if (mLayer->isVisible()) {

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.cpp
@@ -71,6 +71,7 @@ BGI_NetLine::~BGI_NetLine() noexcept {
  ******************************************************************************/
 
 void BGI_NetLine::updateContext() noexcept {
+  updateLayer();
   update();
 }
 
@@ -168,7 +169,8 @@ void BGI_NetLine::updateLine() noexcept {
 
 void BGI_NetLine::updateLayer() noexcept {
   // set Z value
-  setZValue(BoardGraphicsScene::getZValueOfCopperLayer(mNetLine.getLayer()));
+  setZValue(BoardGraphicsScene::getZValueOfCopperLayer(mNetLine.getLayer(),
+                                                       mContext->flipView));
 
   // set layer
   if (mLayer) {

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_netline.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../../graphics/graphicslayer.h"
+#include "../boardgraphicsscene.h"
 
 #include <librepcb/core/project/board/items/bi_netline.h>
 
@@ -55,13 +56,14 @@ public:
   // Constructors / Destructor
   BGI_NetLine() = delete;
   BGI_NetLine(const BGI_NetLine& other) = delete;
-  BGI_NetLine(BI_NetLine& netline, const GraphicsLayerList& layers,
-              std::shared_ptr<const QSet<const NetSignal*>>
-                  highlightedNetSignals) noexcept;
+  BGI_NetLine(
+      BI_NetLine& netline, const GraphicsLayerList& layers,
+      std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_NetLine() noexcept;
 
   // General Methods
   BI_NetLine& getNetLine() noexcept { return mNetLine; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QRectF boundingRect() const noexcept override { return mBoundingRect; }
@@ -85,7 +87,7 @@ private:  // Data
   // Attributes
   BI_NetLine& mNetLine;
   const GraphicsLayerList& mLayers;
-  std::shared_ptr<const QSet<const NetSignal*>> mHighlightedNetSignals;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   std::shared_ptr<const GraphicsLayer> mLayer;
 
   // Cached Attributes

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_netpoint.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_netpoint.cpp
@@ -42,11 +42,13 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_NetPoint::BGI_NetPoint(BI_NetPoint& netpoint,
-                           const GraphicsLayerList& layers) noexcept
+BGI_NetPoint::BGI_NetPoint(
+    BI_NetPoint& netpoint, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItem(),
     mNetPoint(netpoint),
     mLayers(layers),
+    mContext(context),
     mLayer(nullptr),
     mOnEditedSlot(*this, &BGI_NetPoint::netPointEdited),
     mOnLayerEditedSlot(*this, &BGI_NetPoint::layerEdited) {
@@ -62,6 +64,14 @@ BGI_NetPoint::BGI_NetPoint(BI_NetPoint& netpoint,
 }
 
 BGI_NetPoint::~BGI_NetPoint() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_NetPoint::updateContext() noexcept {
+  updateLayer();
 }
 
 /*******************************************************************************
@@ -130,7 +140,8 @@ void BGI_NetPoint::layerEdited(const GraphicsLayer& layer,
 void BGI_NetPoint::updateLayer() noexcept {
   // Set Z value.
   const Layer* layer = mNetPoint.getLayerOfTraces();
-  setZValue(layer ? BoardGraphicsScene::getZValueOfCopperLayer(*layer)
+  setZValue(layer ? BoardGraphicsScene::getZValueOfCopperLayer(
+                        *layer, mContext->flipView)
                   : static_cast<qreal>(BoardGraphicsScene::ZValue_Default));
 
   // Set layer.

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_netpoint.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_netpoint.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../../graphics/graphicslayer.h"
+#include "../boardgraphicsscene.h"
 
 #include <librepcb/core/project/board/items/bi_netpoint.h>
 
@@ -50,11 +51,14 @@ public:
   // Constructors / Destructor
   BGI_NetPoint() = delete;
   BGI_NetPoint(const BGI_NetPoint& other) = delete;
-  BGI_NetPoint(BI_NetPoint& netpoint, const GraphicsLayerList& layers) noexcept;
+  BGI_NetPoint(
+      BI_NetPoint& netpoint, const GraphicsLayerList& layers,
+      std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_NetPoint() noexcept;
 
   // General Methods
   BI_NetPoint& getNetPoint() noexcept { return mNetPoint; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QRectF boundingRect() const noexcept override { return mBoundingRect; }
@@ -80,6 +84,7 @@ private:  // Data
   // General Attributes
   BI_NetPoint& mNetPoint;
   const GraphicsLayerList& mLayers;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   std::shared_ptr<const GraphicsLayer> mLayer;
 
   // Cached Attributes

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_pad.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_pad.cpp
@@ -48,14 +48,14 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_Pad::BGI_Pad(BI_Pad& pad, std::weak_ptr<BGI_Device> deviceItem,
-                 const GraphicsLayerList& layers,
-                 std::shared_ptr<const QSet<const NetSignal*>>
-                     highlightedNetSignals) noexcept
+BGI_Pad::BGI_Pad(
+    BI_Pad& pad, std::weak_ptr<BGI_Device> deviceItem,
+    const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItemGroup(),
     mPad(pad),
     mDeviceGraphicsItem(deviceItem),
-    mHighlightedNetSignals(highlightedNetSignals),
+    mContext(context),
     mGraphicsItem(new PrimitiveFootprintPadGraphicsItem(layers, false, this)),
     mOnPadEditedSlot(*this, &BGI_Pad::padEdited),
     mOnDeviceEditedSlot(*this, &BGI_Pad::deviceGraphicsItemEdited) {
@@ -84,7 +84,7 @@ BGI_Pad::~BGI_Pad() noexcept {
  *  General Methods
  ******************************************************************************/
 
-void BGI_Pad::updateHighlightedNetSignals() noexcept {
+void BGI_Pad::updateContext() noexcept {
   updateHightlighted(isSelected());
 }
 
@@ -199,7 +199,7 @@ void BGI_Pad::updateToolTip() noexcept {
 
 void BGI_Pad::updateHightlighted(bool selected) noexcept {
   mGraphicsItem->setSelected(
-      selected || mHighlightedNetSignals->contains(mPad.getNetSignal()));
+      selected || mContext->highlightedNets->contains(mPad.getNetSignal()));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_pad.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_pad.cpp
@@ -66,6 +66,7 @@ BGI_Pad::BGI_Pad(
   mGraphicsItem->setRotation(mPad.getRotation());
   mGraphicsItem->setMirrored(mPad.getMirrored());
   mGraphicsItem->setText(mPad.getText());
+  mGraphicsItem->setTextMirrored(mContext->flipView);
   mGraphicsItem->setGeometries(mPad.getGeometries(),
                                *mPad.getProperties().getCopperClearance());
   updateLayer();
@@ -86,6 +87,7 @@ BGI_Pad::~BGI_Pad() noexcept {
 
 void BGI_Pad::updateContext() noexcept {
   updateHightlighted(isSelected());
+  mGraphicsItem->setTextMirrored(mContext->flipView);
 }
 
 /*******************************************************************************
@@ -165,10 +167,12 @@ void BGI_Pad::updateLayer() noexcept {
     setZValue(BoardGraphicsScene::ZValue_PadsTop);
     mGraphicsItem->setLayer(Theme::Color::sBoardPads);
   } else if (mPad.getSolderLayer() == Layer::topCopper()) {
-    setZValue(BoardGraphicsScene::ZValue_PadsTop);
+    setZValue(BoardGraphicsScene::getFlippedZValue(
+        BoardGraphicsScene::ZValue_PadsTop, mContext->flipView));
     mGraphicsItem->setLayer(Theme::Color::sBoardCopperTop);
   } else {
-    setZValue(BoardGraphicsScene::ZValue_PadsBottom);
+    setZValue(BoardGraphicsScene::getFlippedZValue(
+        BoardGraphicsScene::ZValue_PadsBottom, mContext->flipView));
     mGraphicsItem->setLayer(Theme::Color::sBoardCopperBot);
   }
 }

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_pad.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_pad.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../boardgraphicsscene.h"
 #include "bgi_device.h"
 
 #include <librepcb/core/project/board/items/bi_pad.h>
@@ -60,8 +61,7 @@ public:
   BGI_Pad(const BGI_Pad& other) = delete;
   BGI_Pad(BI_Pad& pad, std::weak_ptr<BGI_Device> deviceItem,
           const GraphicsLayerList& layers,
-          std::shared_ptr<const QSet<const NetSignal*>>
-              highlightedNetSignals) noexcept;
+          std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_Pad() noexcept;
 
   // General Methods
@@ -69,7 +69,7 @@ public:
   const std::weak_ptr<BGI_Device>& getDeviceGraphicsItem() noexcept {
     return mDeviceGraphicsItem;
   }
-  void updateHighlightedNetSignals() noexcept;
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;
@@ -90,7 +90,7 @@ private:  // Methods
 private:  // Data
   BI_Pad& mPad;
   std::weak_ptr<BGI_Device> mDeviceGraphicsItem;
-  std::shared_ptr<const QSet<const NetSignal*>> mHighlightedNetSignals;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   QScopedPointer<PrimitiveFootprintPadGraphicsItem> mGraphicsItem;
 
   // Slots

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_plane.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_plane.cpp
@@ -44,13 +44,13 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_Plane::BGI_Plane(BI_Plane& plane, const GraphicsLayerList& layers,
-                     std::shared_ptr<const QSet<const NetSignal*>>
-                         highlightedNetSignals) noexcept
+BGI_Plane::BGI_Plane(
+    BI_Plane& plane, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItem(),
     mPlane(plane),
     mLayers(layers),
-    mHighlightedNetSignals(highlightedNetSignals),
+    mContext(context),
     mLayer(nullptr),
     mBoundingRectMarginPx(0),
     mLineWidthPx(0),
@@ -114,6 +114,14 @@ QVector<int> BGI_Plane::getVertexIndicesAtPosition(
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_Plane::updateContext() noexcept {
+  update();
+}
+
+/*******************************************************************************
  *  Inherited from QGraphicsItem
  ******************************************************************************/
 
@@ -146,7 +154,7 @@ void BGI_Plane::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
 
   const bool selected = option->state.testFlag(QStyle::State_Selected);
   const bool highlight =
-      selected || mHighlightedNetSignals->contains(mPlane.getNetSignal());
+      selected || mContext->highlightedNets->contains(mPlane.getNetSignal());
   const qreal lod =
       option->levelOfDetailFromTransform(painter->worldTransform());
 

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_plane.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_plane.cpp
@@ -118,6 +118,7 @@ QVector<int> BGI_Plane::getVertexIndicesAtPosition(
  ******************************************************************************/
 
 void BGI_Plane::updateContext() noexcept {
+  updateLayer();
   update();
 }
 
@@ -282,13 +283,8 @@ void BGI_Plane::updateOutlineAndFragments() noexcept {
 }
 
 void BGI_Plane::updateLayer() noexcept {
-  if (mPlane.getLayer() == Layer::topCopper()) {
-    setZValue(BoardGraphicsScene::ZValue_PlanesTop);
-  } else if (mPlane.getLayer() == Layer::botCopper()) {
-    setZValue(BoardGraphicsScene::ZValue_PlanesBottom);
-  } else {
-    setZValue(BoardGraphicsScene::getZValueOfCopperLayer(mPlane.getLayer()));
-  }
+  setZValue(BoardGraphicsScene::getZValueOfCopperLayer(mPlane.getLayer(),
+                                                       mContext->flipView));
 
   if (mLayer) {
     mLayer->onEdited.detach(mOnLayerEditedSlot);

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_plane.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_plane.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../../graphics/graphicslayer.h"
+#include "../boardgraphicsscene.h"
 
 #include <librepcb/core/project/board/items/bi_plane.h>
 #include <librepcb/core/types/point.h>
@@ -58,9 +59,9 @@ public:
   // Constructors / Destructor
   BGI_Plane() = delete;
   BGI_Plane(const BGI_Plane& other) = delete;
-  BGI_Plane(BI_Plane& plane, const GraphicsLayerList& layers,
-            std::shared_ptr<const QSet<const NetSignal*>>
-                highlightedNetSignals) noexcept;
+  BGI_Plane(
+      BI_Plane& plane, const GraphicsLayerList& layers,
+      std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_Plane() noexcept;
 
   // Getters
@@ -82,6 +83,7 @@ public:
 
   // General Methods
   BI_Plane& getPlane() noexcept { return mPlane; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QVariant itemChange(GraphicsItemChange change,
@@ -111,7 +113,7 @@ private:  // Data
   // General Attributes
   BI_Plane& mPlane;
   const GraphicsLayerList& mLayers;
-  std::shared_ptr<const QSet<const NetSignal*>> mHighlightedNetSignals;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
 
   // Cached Attributes
   std::shared_ptr<const GraphicsLayer> mLayer;

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_polygon.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_polygon.cpp
@@ -38,13 +38,15 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_Polygon::BGI_Polygon(BI_Polygon& polygon,
-                         const GraphicsLayerList& layers) noexcept
+BGI_Polygon::BGI_Polygon(
+    BI_Polygon& polygon, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItemGroup(),
     mPolygon(polygon),
     mPolygonObj(polygon.getData().getUuid(), polygon.getData().getLayer(),
                 polygon.getData().getLineWidth(), polygon.getData().isFilled(),
                 polygon.getData().isGrabArea(), polygon.getData().getPath()),
+    mContext(context),
     mGraphicsItem(new PolygonGraphicsItem(mPolygonObj, layers, this)),
     mOnEditedSlot(*this, &BGI_Polygon::polygonEdited) {
   setFlag(QGraphicsItem::ItemHasNoContents, true);
@@ -57,6 +59,14 @@ BGI_Polygon::BGI_Polygon(BI_Polygon& polygon,
 }
 
 BGI_Polygon::~BGI_Polygon() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_Polygon::updateContext() noexcept {
+  updateZValue();
 }
 
 /*******************************************************************************
@@ -109,9 +119,11 @@ void BGI_Polygon::polygonEdited(const BI_Polygon& obj,
 }
 
 void BGI_Polygon::updateZValue() noexcept {
-  setZValue(mPolygon.getData().getLayer().isBottom()
-                ? BoardGraphicsScene::ZValue_PolygonsBottom
-                : BoardGraphicsScene::ZValue_PolygonsTop);
+  setZValue(BoardGraphicsScene::getFlippedZValue(
+      mPolygon.getData().getLayer().isBottom()
+          ? BoardGraphicsScene::ZValue_PolygonsBottom
+          : BoardGraphicsScene::ZValue_PolygonsTop,
+      mContext->flipView));
 }
 
 void BGI_Polygon::updateEditable() noexcept {

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_polygon.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_polygon.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../boardgraphicsscene.h"
+
 #include <librepcb/core/geometry/polygon.h>
 #include <librepcb/core/project/board/items/bi_polygon.h>
 
@@ -50,7 +52,9 @@ public:
   // Constructors / Destructor
   BGI_Polygon() = delete;
   BGI_Polygon(const BGI_Polygon& other) = delete;
-  BGI_Polygon(BI_Polygon& polygon, const GraphicsLayerList& layers) noexcept;
+  BGI_Polygon(
+      BI_Polygon& polygon, const GraphicsLayerList& layers,
+      std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_Polygon() noexcept;
 
   // General Methods
@@ -58,6 +62,7 @@ public:
   const PolygonGraphicsItem& getGraphicsItem() const noexcept {
     return *mGraphicsItem;
   }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;
@@ -75,6 +80,7 @@ private:  // Methods
 private:  // Data
   BI_Polygon& mPolygon;
   Polygon mPolygonObj;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   QScopedPointer<PolygonGraphicsItem> mGraphicsItem;
 
   // Slots

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_stroketext.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_stroketext.cpp
@@ -44,13 +44,15 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_StrokeText::BGI_StrokeText(BI_StrokeText& text,
-                               std::weak_ptr<BGI_Device> deviceItem,
-                               const GraphicsLayerList& layers) noexcept
+BGI_StrokeText::BGI_StrokeText(
+    BI_StrokeText& text, std::weak_ptr<BGI_Device> deviceItem,
+    const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItemGroup(),
     mText(text),
     mDeviceGraphicsItem(deviceItem),
     mLayers(layers),
+    mContext(context),
     mPathGraphicsItem(new PrimitivePathGraphicsItem(this)),
     mOriginCrossGraphicsItem(new OriginCrossGraphicsItem(this)),
     mAnchorGraphicsItem(new LineGraphicsItem()),
@@ -76,6 +78,14 @@ BGI_StrokeText::BGI_StrokeText(BI_StrokeText& text,
 }
 
 BGI_StrokeText::~BGI_StrokeText() noexcept {
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_StrokeText::updateContext() noexcept {
+  updateLayer();
 }
 
 /*******************************************************************************
@@ -180,7 +190,7 @@ void BGI_StrokeText::updateLayer() noexcept {
   } else if (mText.getData().getLayer().isBottom()) {
     zValue = BoardGraphicsScene::ZValue_TextsBottom;
   }
-  setZValue(static_cast<qreal>(zValue));
+  setZValue(BoardGraphicsScene::getFlippedZValue(zValue, mContext->flipView));
   mAnchorGraphicsItem->setZValue(static_cast<qreal>(zValue));
 
   std::shared_ptr<const GraphicsLayer> layer =

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_stroketext.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_stroketext.h
@@ -23,6 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../boardgraphicsscene.h"
 #include "bgi_device.h"
 
 #include <librepcb/core/project/board/items/bi_stroketext.h>
@@ -53,8 +54,10 @@ public:
   // Constructors / Destructor
   BGI_StrokeText() = delete;
   BGI_StrokeText(const BGI_StrokeText& other) = delete;
-  BGI_StrokeText(BI_StrokeText& text, std::weak_ptr<BGI_Device> deviceItem,
-                 const GraphicsLayerList& layers) noexcept;
+  BGI_StrokeText(
+      BI_StrokeText& text, std::weak_ptr<BGI_Device> deviceItem,
+      const GraphicsLayerList& layers,
+      std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_StrokeText() noexcept;
 
   // General Methods
@@ -62,6 +65,7 @@ public:
   const std::weak_ptr<BGI_Device>& getDeviceGraphicsItem() noexcept {
     return mDeviceGraphicsItem;
   }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   virtual QPainterPath shape() const noexcept override;
@@ -88,6 +92,7 @@ private:  // Data
   BI_StrokeText& mText;
   std::weak_ptr<BGI_Device> mDeviceGraphicsItem;
   const GraphicsLayerList& mLayers;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   QScopedPointer<PrimitivePathGraphicsItem> mPathGraphicsItem;
   QScopedPointer<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
   QScopedPointer<LineGraphicsItem> mAnchorGraphicsItem;

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_via.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_via.cpp
@@ -72,6 +72,7 @@ BGI_Via::BGI_Via(
   mTextGraphicsItem->setLineWidth(UnsignedLength(100000));
   mTextGraphicsItem->setLighterColors(true);  // More contrast for readability.
   mTextGraphicsItem->setShapeMode(PrimitivePathGraphicsItem::ShapeMode::None);
+  mTextGraphicsItem->setMirrored(mContext->flipView);
   mTextGraphicsItem->setZValue(500);
 
   updatePosition();
@@ -98,6 +99,7 @@ BGI_Via::~BGI_Via() noexcept {
  ******************************************************************************/
 
 void BGI_Via::updateContext() noexcept {
+  mTextGraphicsItem->setMirrored(mContext->flipView);
   update();
 }
 

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_via.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_via.cpp
@@ -51,13 +51,13 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_Via::BGI_Via(BI_Via& via, const GraphicsLayerList& layers,
-                 std::shared_ptr<const QSet<const NetSignal*>>
-                     highlightedNetSignals) noexcept
+BGI_Via::BGI_Via(
+    BI_Via& via, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItem(),
     mVia(via),
     mLayers(layers),
-    mHighlightedNetSignals(highlightedNetSignals),
+    mContext(context),
     mViaLayer(layers.get(Theme::Color::sBoardVias)),
     mTopStopMaskLayer(layers.get(Theme::Color::sBoardStopMaskTop)),
     mBottomStopMaskLayer(layers.get(Theme::Color::sBoardStopMaskBot)),
@@ -94,6 +94,14 @@ BGI_Via::~BGI_Via() noexcept {
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_Via::updateContext() noexcept {
+  update();
+}
+
+/*******************************************************************************
  *  Inherited from QGraphicsItem
  ******************************************************************************/
 
@@ -107,7 +115,7 @@ void BGI_Via::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
 
   const NetSignal* netsignal = mVia.getNetSegment().getNetSignal();
   const bool highlight = option->state.testFlag(QStyle::State_Selected) ||
-      mHighlightedNetSignals->contains(netsignal);
+      mContext->highlightedNets->contains(netsignal);
 
   if (mBottomStopMaskLayer && mBottomStopMaskLayer->isVisible() &&
       (!mStopMaskBottom.isEmpty())) {

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_via.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_via.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../../../graphics/graphicslayer.h"
+#include "../boardgraphicsscene.h"
 
 #include <librepcb/core/project/board/items/bi_via.h>
 
@@ -59,12 +60,12 @@ public:
   BGI_Via() = delete;
   BGI_Via(const BGI_Via& other) = delete;
   BGI_Via(BI_Via& via, const GraphicsLayerList& layers,
-          std::shared_ptr<const QSet<const NetSignal*>>
-              highlightedNetSignals) noexcept;
+          std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_Via() noexcept;
 
   // General Methods
   BI_Via& getVia() noexcept { return mVia; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
   QRectF boundingRect() const noexcept override { return mBoundingRect; }
@@ -93,7 +94,7 @@ private:  // Data
   // General Attributes
   BI_Via& mVia;
   const GraphicsLayerList& mLayers;
-  std::shared_ptr<const QSet<const NetSignal*>> mHighlightedNetSignals;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   std::shared_ptr<const GraphicsLayer> mViaLayer;
   std::shared_ptr<const GraphicsLayer> mTopStopMaskLayer;
   std::shared_ptr<const GraphicsLayer> mBottomStopMaskLayer;

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_zone.cpp
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_zone.cpp
@@ -41,9 +41,12 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-BGI_Zone::BGI_Zone(BI_Zone& zone, const GraphicsLayerList& layers) noexcept
+BGI_Zone::BGI_Zone(
+    BI_Zone& zone, const GraphicsLayerList& layers,
+    std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept
   : QGraphicsItemGroup(),
     mZone(zone),
+    mContext(context),
     mGraphicsItem(new PrimitiveZoneGraphicsItem(layers, this)),
     mOnEditedSlot(*this, &BGI_Zone::zoneEdited) {
   setFlag(QGraphicsItem::ItemHasNoContents, true);
@@ -72,6 +75,14 @@ int BGI_Zone::getLineIndexAtPosition(const Point& pos) const noexcept {
 QVector<int> BGI_Zone::getVertexIndicesAtPosition(
     const Point& pos) const noexcept {
   return mGraphicsItem->getVertexIndicesAtPosition(pos);
+}
+
+/*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void BGI_Zone::updateContext() noexcept {
+  updateZValue();
 }
 
 /*******************************************************************************
@@ -121,7 +132,8 @@ void BGI_Zone::zoneEdited(const BI_Zone& obj, BI_Zone::Event event) noexcept {
 void BGI_Zone::updateZValue() noexcept {
   auto layers = Layer::sorted(mZone.getData().getLayers());
   if (!layers.isEmpty()) {
-    setZValue(BoardGraphicsScene::getZValueOfCopperLayer(*layers.first()));
+    setZValue(BoardGraphicsScene::getZValueOfCopperLayer(*layers.first(),
+                                                         mContext->flipView));
   }
 }
 

--- a/libs/librepcb/editor/project/board/graphicsitems/bgi_zone.h
+++ b/libs/librepcb/editor/project/board/graphicsitems/bgi_zone.h
@@ -23,6 +23,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../boardgraphicsscene.h"
+
 #include <librepcb/core/geometry/zone.h>
 #include <librepcb/core/project/board/items/bi_zone.h>
 
@@ -50,7 +52,8 @@ public:
   // Constructors / Destructor
   BGI_Zone() = delete;
   BGI_Zone(const BGI_Zone& other) = delete;
-  BGI_Zone(BI_Zone& zone, const GraphicsLayerList& layers) noexcept;
+  BGI_Zone(BI_Zone& zone, const GraphicsLayerList& layers,
+           std::shared_ptr<const BoardGraphicsScene::Context> context) noexcept;
   virtual ~BGI_Zone() noexcept;
 
   // General Methods
@@ -74,6 +77,8 @@ public:
   /// @return       All indices of the vertices at the specified position.
   QVector<int> getVertexIndicesAtPosition(const Point& pos) const noexcept;
 
+  void updateContext() noexcept;
+
   // Inherited from QGraphicsItem
   QPainterPath shape() const noexcept override;
 
@@ -89,6 +94,7 @@ private:  // Methods
 
 private:  // Data
   BI_Zone& mZone;
+  std::shared_ptr<const BoardGraphicsScene::Context> mContext;
   QScopedPointer<PrimitiveZoneGraphicsItem> mGraphicsItem;
 
   // Slots

--- a/libs/librepcb/ui/api/editorcommandset.slint
+++ b/libs/librepcb/ui/api/editorcommandset.slint
@@ -794,6 +794,16 @@ export global EditorCommandSet {
         key: "-",
     };
 
+    in property <EditorCommand> flip-view: {
+        id: "flip_view",
+        icon: @image-url("../../../bootstrap-icons/icons/arrow-repeat.svg"),
+        text: "Flip View",
+        status-tip: "Switch between top view and bottom view",
+        shortcut: "Ctrl+2",
+        modifiers: { alt: false, control: true, shift: false, meta: false },
+        key: "2",
+    };
+
     in property <EditorCommand> grid-increase: {
         id: "grid_increase",
         icon: @image-url("../../../font-awesome/svgs/solid/caret-up.svg"),

--- a/libs/librepcb/ui/api/shortcuts.slint
+++ b/libs/librepcb/ui/api/shortcuts.slint
@@ -1132,6 +1132,9 @@ export global Shortcuts {
         } else if Backend.is-shortcut(event, Cmd.ignore-locks) {
             Data.current-section.board-2d-tabs[tab].ignore-placement-locks = !Data.current-section.board-2d-tabs[tab].ignore-placement-locks;
             return true;
+        } else if Backend.is-shortcut(event, Cmd.flip-view) {
+            Data.current-section.board-2d-tabs[tab].flip-view = !Data.current-section.board-2d-tabs[tab].flip-view;
+            return true;
         } else if Backend.is-shortcut(event, Cmd.toggle-3d) {
             Backend.trigger-board(Data.current-section.board-2d-tabs[tab].project-index, Data.current-section.board-2d-tabs[tab].board-index, BoardAction.open-3d);
             return true;

--- a/libs/librepcb/ui/api/types.slint
+++ b/libs/librepcb/ui/api/types.slint
@@ -1281,6 +1281,7 @@ export struct Board2dTabData {
     grid-style: GridStyle,
     grid-interval: Int64,
     unit: LengthUnit,
+    flip-view: bool,
     background-image-set: bool,
     background-image-alpha: float,
     ignore-placement-locks: bool,

--- a/libs/librepcb/ui/mainmenubar.slint
+++ b/libs/librepcb/ui/mainmenubar.slint
@@ -855,6 +855,18 @@ export component MainMenuBar inherits Rectangle {
                         close-menu();
                     }
                 }
+
+                flip-view-item := MenuItem {
+                    property <bool> flip: Data.current-section.board-2d-tabs[Data.current-section.current-tab-index].flip-view;
+
+                    cmd: Cmd.flip-view;
+                    enabled: Data.current-tab.type == TabType.board-2d;
+
+                    clicked => {
+                        Data.current-section.board-2d-tabs[Data.current-section.current-tab-index].flip-view = !flip;
+                        close-menu();
+                    }
+                }
             }
         }
 

--- a/libs/librepcb/ui/project/board/board2dtab.slint
+++ b/libs/librepcb/ui/project/board/board2dtab.slint
@@ -610,6 +610,21 @@ export component Board2dTab inherits Tab {
                 }
             }
 
+            flip-btn := SceneButton {
+                x: parent.width - self.width;
+                style: self.checked ? checkbox : button;
+                icon-scale: self.checked ? 1.0 : 1.1;
+                icon: Cmd.flip-view.icon;
+                tooltip: Cmd.flip-view.text;
+                bg-color: tabs[index].background-color;
+                fg-color: tabs[index].foreground-color;
+                checked: tabs[index].flip-view;
+
+                clicked => {
+                    tabs[index].flip-view = !tabs[index].flip-view;
+                }
+            }
+
             background-image-btn := SliderSceneButton {
                 x: parent.width - self.width;
                 style: self.slider-enabled ? checkbox : button;


### PR DESCRIPTION
Support flipping the board view, so the board can be viewed and edited from its bottom side. For now, only horizontal flipping is supported.

<img width="128" height="191" alt="image" src="https://github.com/user-attachments/assets/e189e239-7e6d-47af-866a-34c1ae9503ac" />

Closes #1398