### PR TITLE
Support using rust-core without FFI in external projects

### DIFF
--- a/ci/build_doxygen.sh
+++ b/ci/build_doxygen.sh
@@ -11,7 +11,7 @@ popd
 # Build Rust documentation
 for f in $(git ls-files -- '**Cargo.toml'); do
   cargo doc --manifest-path="$f" --target-dir="./dev/doxygen/output/rust/" \
-    --no-deps --document-private-items --features="fail-on-warnings"
+    --no-deps --document-private-items --features="fail-on-warnings,ffi"
   cp -rf ./dev/doxygen/output/rust/doc/* ./dev/doxygen/output/html/
   rm -rf ./dev/doxygen/output/rust
 done

--- a/libs/librepcb/rust-core/CMakeLists.txt
+++ b/libs/librepcb/rust-core/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_AUTORCC OFF)
 
 # Determine Cargo features
 set(CARGO_FEATURES)
+list(APPEND CARGO_FEATURES ffi)
 if(BUILD_DISALLOW_WARNINGS)
   list(APPEND CARGO_FEATURES fail-on-warnings)
 endif()

--- a/libs/librepcb/rust-core/Cargo.toml
+++ b/libs/librepcb/rust-core/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["lib", "staticlib"]
 
 [features]
 fail-on-warnings = []
+ffi = ["dep:cbindgen"]
 
 [build-dependencies]
-cbindgen = "0.27"
+cbindgen = { version = "0.27", optional = true }
 
 [dependencies]
 interactive-html-bom = "0.2.0"

--- a/libs/librepcb/rust-core/build.rs
+++ b/libs/librepcb/rust-core/build.rs
@@ -1,15 +1,20 @@
+#[cfg(feature = "ffi")]
 extern crate cbindgen;
 
+#[cfg(feature = "ffi")]
 use std::env;
 
 fn main() {
-  let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+  #[cfg(feature = "ffi")]
+  {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-  if let Ok(r) = cbindgen::generate(crate_dir) {
-    r.write_to_file("ffi.h");
-  } else {
-    // Do not fail the build on invalid source files as this is annoying
-    // during development beause it would suppress the compiler errors.
-    println!("cargo::warning=Failed to generate ffi.h with cbindgen.");
+    if let Ok(r) = cbindgen::generate(crate_dir) {
+      r.write_to_file("ffi.h");
+    } else {
+      // Do not fail the build on invalid source files as this is annoying
+      // during development beause it would suppress the compiler errors.
+      println!("cargo::warning=Failed to generate ffi.h with cbindgen.");
+    }
   }
 }

--- a/libs/librepcb/rust-core/src/lib.rs
+++ b/libs/librepcb/rust-core/src/lib.rs
@@ -5,13 +5,14 @@
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
 
-// Disable FFI functions for tests since it would lead to unresolved symbol
-// linker errors.
-#[cfg(not(test))]
+// Build FFI only if explicitly enabled. This allows to use the crate also
+// outside of LibrePCB (i.e. without C++ integration), and fixes unresolved
+// symbol linker errors when building the tests.
+#[cfg(feature = "ffi")]
 mod ffi;
 
 // Modules
-mod toolbox;
+pub mod toolbox;
 
 // Allow using the create! macro to create parametrized tests in test modules
 // without explicitly importing the parameterized_test crate every time.


### PR DESCRIPTION
I was experimenting with creating a Python wrapper for the rust-core crate, and figured out that currently that crate cannot be used from external Rust projects due to several issues, which have been fixed:

1. The crate-type included only "staticlib", which made it useless for other Rust projects. Fixed by adding "lib" to the crate-type list.
2. Because the FFI had a dependency to the C++ libraries, linker errors occurred when used outside of LibrePCB. Fixed by making the FFI opt-in with the feature flag "ffi".
3. The crate did not export any public types or functions. Fixed by making the `toolbox` module public.