### PR TITLE
Do not auto-correct invalid pad/via drill/size properties

### DIFF
--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.cpp
@@ -76,6 +76,13 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   mUi->customShapePathEditor->setLengthUnit(lengthUnit);
   mUi->holeEditorWidget->configureClientSettings(
       lengthUnit, settingsPrefix % "/hole_editor");
+  connect(mUi->edtHoleDiameter, &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (const std::shared_ptr<PadHole> holePtr = mHoles.value(0)) {
+              holePtr->setDiameter(value);
+              mUi->holeEditorWidget->setDiameter(value);
+            }
+          });
   connect(mUi->lblHoleDetails, &QLabel::linkActivated, this,
           [this]() { mUi->tabWidget->setCurrentWidget(mUi->tabHoles); });
   connect(mUi->btnConvertToSmt, &QToolButton::clicked, this,
@@ -107,7 +114,7 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
   connect(mUi->btnAddHole, &QToolButton::clicked, this,
           &FootprintPadPropertiesDialog::addHole);
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
-          &FootprintPadPropertiesDialog::on_buttonBox_clicked);
+          &FootprintPadPropertiesDialog::buttonBoxClicked);
 
   // Disable some widgets if not applicable for the selected shape.
   connect(mUi->btnShapeRound, &QRadioButton::toggled, this,
@@ -149,34 +156,6 @@ FootprintPadPropertiesDialog::FootprintPadPropertiesDialog(
           &FootprintPadPropertiesDialog::updateAbsoluteRadius);
   connect(mUi->edtHeight, &PositiveLengthEdit::valueChanged, this,
           &FootprintPadPropertiesDialog::updateAbsoluteRadius);
-
-  // Avoid creating pads with a drill diameter larger than its size!
-  // See https://github.com/LibrePCB/LibrePCB/issues/946.
-  connect(mUi->edtWidth, &PositiveLengthEdit::valueChanged, this,
-          [this](const PositiveLength& value) {
-            if (value < mUi->edtHoleDiameter->getValue()) {
-              mUi->edtHoleDiameter->setValue(value);
-            }
-          });
-  connect(mUi->edtHeight, &PositiveLengthEdit::valueChanged, this,
-          [this](const PositiveLength& value) {
-            if (value < mUi->edtHoleDiameter->getValue()) {
-              mUi->edtHoleDiameter->setValue(value);
-            }
-          });
-  connect(mUi->edtHoleDiameter, &PositiveLengthEdit::valueChanged, this,
-          [this](const PositiveLength& value) {
-            if (value > mUi->edtWidth->getValue()) {
-              mUi->edtWidth->setValue(value);
-            }
-            if (value > mUi->edtHeight->getValue()) {
-              mUi->edtHeight->setValue(value);
-            }
-            if (const std::shared_ptr<PadHole> holePtr = mHoles.value(0)) {
-              holePtr->setDiameter(value);
-              mUi->holeEditorWidget->setDiameter(value);
-            }
-          });
 
   // Enable custom mask offset only when allowed.
   connect(mUi->rbtnStopMaskManual, &QRadioButton::toggled,
@@ -442,8 +421,7 @@ void FootprintPadPropertiesDialog::applyTypicalSmtProperties() noexcept {
   mUi->rbtnSolderPasteAuto->setChecked(true);
 }
 
-void FootprintPadPropertiesDialog::on_buttonBox_clicked(
-    QAbstractButton* button) {
+void FootprintPadPropertiesDialog::buttonBoxClicked(QAbstractButton* button) {
   switch (mUi->buttonBox->buttonRole(button)) {
     case QDialogButtonBox::ApplyRole:
       applyChanges();
@@ -462,16 +440,39 @@ void FootprintPadPropertiesDialog::on_buttonBox_clicked(
   }
 }
 
+void FootprintPadPropertiesDialog::accept() noexcept {
+  if (applyChanges()) {
+    QDialog::accept();
+  }
+}
+
 bool FootprintPadPropertiesDialog::applyChanges() noexcept {
+  QStringList errors;
+
+  // Check if drill diameter <= pad size.
+  if ((!mHoles.isEmpty()) && (!mUi->btnShapeCustom->isChecked()) &&
+      (mUi->edtHoleDiameter->getValue() >
+       std::min(mUi->edtWidth->getValue(), mUi->edtHeight->getValue()))) {
+    errors.append(
+        tr("The drill diameter is exceeding the pad width or height. Reduce "
+           "the drill diameter or increase the pad width and/or height."));
+  }
+
   // Clean and validate custom outline path.
   const Path customOutlinePath =
       mUi->customShapePathEditor->getPath().cleaned().toOpenPath();
   mUi->customShapePathEditor->setPath(customOutlinePath);
   if (mUi->btnShapeCustom->isChecked() &&
       (!PadGeometry::isValidCustomOutline(customOutlinePath))) {
-    QMessageBox::critical(
-        this, tr("Invalid outline"),
+    errors.append(
         tr("The custom pad outline does not represent a valid area."));
+  }
+
+  // Deny creating invalid pads.
+  // See https://github.com/LibrePCB/LibrePCB/issues/946 and
+  // see https://github.com/LibrePCB/LibrePCB/issues/1715.
+  if (!errors.isEmpty()) {
+    QMessageBox::critical(this, tr("Invalid Properties"), errors.join("\n\n"));
     return false;
   }
 

--- a/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
+++ b/libs/librepcb/editor/library/pkg/footprintpadpropertiesdialog.h
@@ -87,7 +87,8 @@ private:  // Methods
   void setSelectedHole(int index) noexcept;
   void applyTypicalThtProperties() noexcept;
   void applyTypicalSmtProperties() noexcept;
-  void on_buttonBox_clicked(QAbstractButton* button);
+  void buttonBoxClicked(QAbstractButton* button);
+  void accept() noexcept override;
   bool applyChanges() noexcept;
 
 private:  // Data

--- a/libs/librepcb/editor/project/board/boardpadpropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/board/boardpadpropertiesdialog.cpp
@@ -75,6 +75,13 @@ BoardPadPropertiesDialog::BoardPadPropertiesDialog(
   mUi->customShapePathEditor->setLengthUnit(lengthUnit);
   mUi->holeEditorWidget->configureClientSettings(
       lengthUnit, settingsPrefix % "/hole_editor");
+  connect(mUi->edtHoleDiameter, &PositiveLengthEdit::valueChanged, this,
+          [this](const PositiveLength& value) {
+            if (const std::shared_ptr<PadHole> holePtr = mHoles.value(0)) {
+              holePtr->setDiameter(value);
+              mUi->holeEditorWidget->setDiameter(value);
+            }
+          });
   connect(mUi->lblHoleDetails, &QLabel::linkActivated, this,
           [this]() { mUi->tabWidget->setCurrentWidget(mUi->tabHoles); });
   connect(mUi->btnConvertToSmt, &QToolButton::clicked, this,
@@ -106,7 +113,7 @@ BoardPadPropertiesDialog::BoardPadPropertiesDialog(
   connect(mUi->btnAddHole, &QToolButton::clicked, this,
           &BoardPadPropertiesDialog::addHole);
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
-          &BoardPadPropertiesDialog::on_buttonBox_clicked);
+          &BoardPadPropertiesDialog::buttonBoxClicked);
 
   // Disable some widgets if not applicable for the selected shape.
   connect(mUi->btnShapeRound, &QRadioButton::toggled, this,
@@ -149,34 +156,6 @@ BoardPadPropertiesDialog::BoardPadPropertiesDialog(
           &BoardPadPropertiesDialog::updateAbsoluteRadius);
   connect(mUi->edtHeight, &PositiveLengthEdit::valueChanged, this,
           &BoardPadPropertiesDialog::updateAbsoluteRadius);
-
-  // Avoid creating pads with a drill diameter larger than its size!
-  // See https://github.com/LibrePCB/LibrePCB/issues/946.
-  connect(mUi->edtWidth, &PositiveLengthEdit::valueChanged, this,
-          [this](const PositiveLength& value) {
-            if (value < mUi->edtHoleDiameter->getValue()) {
-              mUi->edtHoleDiameter->setValue(value);
-            }
-          });
-  connect(mUi->edtHeight, &PositiveLengthEdit::valueChanged, this,
-          [this](const PositiveLength& value) {
-            if (value < mUi->edtHoleDiameter->getValue()) {
-              mUi->edtHoleDiameter->setValue(value);
-            }
-          });
-  connect(mUi->edtHoleDiameter, &PositiveLengthEdit::valueChanged, this,
-          [this](const PositiveLength& value) {
-            if (value > mUi->edtWidth->getValue()) {
-              mUi->edtWidth->setValue(value);
-            }
-            if (value > mUi->edtHeight->getValue()) {
-              mUi->edtHeight->setValue(value);
-            }
-            if (const std::shared_ptr<PadHole> holePtr = mHoles.value(0)) {
-              holePtr->setDiameter(value);
-              mUi->holeEditorWidget->setDiameter(value);
-            }
-          });
 
   // Enable custom mask offset only when allowed.
   connect(mUi->rbtnStopMaskManual, &QRadioButton::toggled,
@@ -391,7 +370,7 @@ void BoardPadPropertiesDialog::applyTypicalSmtProperties() noexcept {
   mUi->rbtnSolderPasteAuto->setChecked(true);
 }
 
-void BoardPadPropertiesDialog::on_buttonBox_clicked(QAbstractButton* button) {
+void BoardPadPropertiesDialog::buttonBoxClicked(QAbstractButton* button) {
   switch (mUi->buttonBox->buttonRole(button)) {
     case QDialogButtonBox::ApplyRole:
       applyChanges();
@@ -410,16 +389,39 @@ void BoardPadPropertiesDialog::on_buttonBox_clicked(QAbstractButton* button) {
   }
 }
 
+void BoardPadPropertiesDialog::accept() noexcept {
+  if (applyChanges()) {
+    QDialog::accept();
+  }
+}
+
 bool BoardPadPropertiesDialog::applyChanges() noexcept {
+  QStringList errors;
+
+  // Check if drill diameter <= pad size.
+  if ((!mHoles.isEmpty()) && (!mUi->btnShapeCustom->isChecked()) &&
+      (mUi->edtHoleDiameter->getValue() >
+       std::min(mUi->edtWidth->getValue(), mUi->edtHeight->getValue()))) {
+    errors.append(
+        tr("The drill diameter is exceeding the pad width or height. Reduce "
+           "the drill diameter or increase the pad width and/or height."));
+  }
+
   // Clean and validate custom outline path.
   const Path customOutlinePath =
       mUi->customShapePathEditor->getPath().cleaned().toOpenPath();
   mUi->customShapePathEditor->setPath(customOutlinePath);
   if (mUi->btnShapeCustom->isChecked() &&
       (!PadGeometry::isValidCustomOutline(customOutlinePath))) {
-    QMessageBox::critical(
-        this, tr("Invalid outline"),
+    errors.append(
         tr("The custom pad outline does not represent a valid area."));
+  }
+
+  // Deny creating invalid pads.
+  // See https://github.com/LibrePCB/LibrePCB/issues/946 and
+  // see https://github.com/LibrePCB/LibrePCB/issues/1715.
+  if (!errors.isEmpty()) {
+    QMessageBox::critical(this, tr("Invalid Properties"), errors.join("\n\n"));
     return false;
   }
 

--- a/libs/librepcb/editor/project/board/boardpadpropertiesdialog.h
+++ b/libs/librepcb/editor/project/board/boardpadpropertiesdialog.h
@@ -80,7 +80,8 @@ private:  // Methods
   void setSelectedHole(int index) noexcept;
   void applyTypicalThtProperties() noexcept;
   void applyTypicalSmtProperties() noexcept;
-  void on_buttonBox_clicked(QAbstractButton* button);
+  void buttonBoxClicked(QAbstractButton* button);
+  void accept() noexcept override;
   bool applyChanges() noexcept;
 
 private:  // Data

--- a/libs/librepcb/editor/project/board/boardviapropertiesdialog.cpp
+++ b/libs/librepcb/editor/project/board/boardviapropertiesdialog.cpp
@@ -87,7 +87,7 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(
         mVia.getBoard().getDesignRules().getViaAnnularRing()));
   };
 
-  // Set up automatic/manual drill/size toggle switch.
+  // Set up automatic/manual drill/size.
   connect(mUi->cbxDrillDiameterFromDesignRules, &QCheckBox::toggled, this,
           [this, applyDrillFromDesignRules](bool checked) {
             mUi->edtDrillDiameter->setEnabled(!checked);
@@ -105,22 +105,10 @@ BoardViaPropertiesDialog::BoardViaPropertiesDialog(
               mUi->cbxDrillDiameterFromDesignRules->setChecked(false);
             }
           });
-
-  // Avoid creating vias with a drill diameter larger than its size!
-  // See https://github.com/LibrePCB/LibrePCB/issues/946.
-  connect(mUi->edtSize, &PositiveLengthEdit::valueChanged, this,
-          [this](const PositiveLength& value) {
-            if ((!mUi->cbxDrillDiameterFromDesignRules->isChecked()) &&
-                (value < mUi->edtDrillDiameter->getValue())) {
-              mUi->edtDrillDiameter->setValue(value);
-            }
-          });
   connect(mUi->edtDrillDiameter, &PositiveLengthEdit::valueChanged, this,
-          [this, applySizeFromDesignRules](const PositiveLength& value) {
+          [this, applySizeFromDesignRules]() {
             if (mUi->cbxSizeFromDesignRules->isChecked()) {
               applySizeFromDesignRules();
-            } else if (value > mUi->edtSize->getValue()) {
-              mUi->edtSize->setValue(value);
             }
           });
 
@@ -191,13 +179,30 @@ void BoardViaPropertiesDialog::buttonBoxClicked(
   }
 }
 
-void BoardViaPropertiesDialog::accept() {
+void BoardViaPropertiesDialog::accept() noexcept {
   if (applyChanges()) {
     QDialog::accept();
   }
 }
 
 bool BoardViaPropertiesDialog::applyChanges() noexcept {
+  QStringList errors;
+
+  // Check if drill diameter <= via size.
+  if (mUi->edtDrillDiameter->getValue() > mUi->edtSize->getValue()) {
+    errors.append(
+        tr("The drill diameter is exceeding the outer via size. Reduce "
+           "the drill diameter or increase the via size."));
+  }
+
+  // Deny creating invalid pads.
+  // See https://github.com/LibrePCB/LibrePCB/issues/946 and
+  // see https://github.com/LibrePCB/LibrePCB/issues/1715.
+  if (!errors.isEmpty()) {
+    QMessageBox::critical(this, tr("Invalid Properties"), errors.join("\n\n"));
+    return false;
+  }
+
   try {
     std::unique_ptr<CmdBoardViaEdit> cmd(new CmdBoardViaEdit(mVia));
     cmd->setPosition(Point(mUi->edtPosX->getValue(), mUi->edtPosY->getValue()),

--- a/libs/librepcb/editor/project/board/boardviapropertiesdialog.h
+++ b/libs/librepcb/editor/project/board/boardviapropertiesdialog.h
@@ -68,7 +68,7 @@ public:
 private:
   // Private Methods
   void buttonBoxClicked(QAbstractButton* button) noexcept;
-  void accept();
+  void accept() noexcept override;
   bool applyChanges() noexcept;
 
   // General


### PR DESCRIPTION
If a drill diameter is set to a larger value than the outer via/pad size, do not automatically increase/decrease the other property anymore because this can accidentally lead to wrong results. Instead, show a warning and deny the invalid properties.

Fixes #1715