### PR TITLE
Package editor: Explicitly make newly added 3D models visible

### DIFF
--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -859,6 +859,15 @@ void PackageTab::trigger(ui::TabAction a) noexcept {
     case ui::TabAction::PackageAddModel: {
       if (auto index = mModels->add()) {
         setCurrentModelIndex(*index);
+
+        // Make sure the new model is visible, especially if the user opened
+        // the 3D view through the "3D" scene button which hides 3D models.
+        if (mAlpha.value(OpenGlObject::Type::Device, 1.0f) < 0.1f) {
+          mAlpha[OpenGlObject::Type::Device] = 1.0f;
+          if (mOpenGlView) {
+            mOpenGlView->setAlpha(mAlpha);
+          }
+        }
       }
       break;
     }


### PR DESCRIPTION
If the opacity of 3D models is set to 0%, newly added 3D models were not visible, which is counterintuitive.