### PR TITLE
Workspace settings: Make grid style a top-level setting

### DIFF
--- a/libs/librepcb/core/CMakeLists.txt
+++ b/libs/librepcb/core/CMakeLists.txt
@@ -495,6 +495,8 @@ add_library(
   types/busname.h
   types/circuitidentifier.h
   types/elementname.h
+  types/enums.cpp
+  types/enums.h
   types/fileproofname.h
   types/layer.cpp
   types/layer.h

--- a/libs/librepcb/core/types/enums.cpp
+++ b/libs/librepcb/core/types/enums.cpp
@@ -1,0 +1,72 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include "enums.h"
+
+#include "../exceptions.h"
+#include "../serialization/sexpression.h"
+
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Serialization
+ ******************************************************************************/
+
+template <>
+std::unique_ptr<SExpression> serialize(const GridStyle& obj) {
+  switch (obj) {
+    case GridStyle::None:
+      return SExpression::createToken("none");
+    case GridStyle::Dots:
+      return SExpression::createToken("dots");
+    case GridStyle::Lines:
+      return SExpression::createToken("lines");
+    default:
+      throw LogicError(__FILE__, __LINE__);
+  }
+}
+
+template <>
+GridStyle deserialize(const SExpression& sexpr) {
+  const QString str = sexpr.getValue();
+  if (str == "none") {
+    return GridStyle::None;
+  } else if (str == "dots") {
+    return GridStyle::Dots;
+  } else if (str == "lines") {
+    return GridStyle::Lines;
+  } else {
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("Unknown grid style: '%1'").arg(str));
+  }
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb

--- a/libs/librepcb/core/types/enums.h
+++ b/libs/librepcb/core/types/enums.h
@@ -1,0 +1,54 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBREPCB_CORE_ENUMS_H
+#define LIBREPCB_CORE_ENUMS_H
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <QtCore>
+
+/*******************************************************************************
+ *  Namespace / Forward Declarations
+ ******************************************************************************/
+namespace librepcb {
+
+/*******************************************************************************
+ *  Various Basic Enums
+ ******************************************************************************/
+
+/**
+ * @brief Grid style for the 2D graphics views
+ */
+enum class GridStyle : int {
+  None,
+  Dots,
+  Lines,
+};
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace librepcb
+
+Q_DECLARE_METATYPE(librepcb::GridStyle)
+
+#endif

--- a/libs/librepcb/core/workspace/theme.cpp
+++ b/libs/librepcb/core/workspace/theme.cpp
@@ -33,49 +33,11 @@
 namespace librepcb {
 
 /*******************************************************************************
- *  Non-Member Functions
- ******************************************************************************/
-
-template <>
-std::unique_ptr<SExpression> serialize(const Theme::GridStyle& obj) {
-  switch (obj) {
-    case Theme::GridStyle::None:
-      return SExpression::createToken("none");
-    case Theme::GridStyle::Dots:
-      return SExpression::createToken("dots");
-    case Theme::GridStyle::Lines:
-      return SExpression::createToken("lines");
-    default:
-      throw LogicError(__FILE__, __LINE__);
-  }
-}
-
-template <>
-inline Theme::GridStyle deserialize(const SExpression& sexpr) {
-  const QString str = sexpr.getValue();
-  if (str == "none") {
-    return Theme::GridStyle::None;
-  } else if (str == "dots") {
-    return Theme::GridStyle::Dots;
-  } else if (str == "lines") {
-    return Theme::GridStyle::Lines;
-  } else {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString("Unknown grid style: '%1'").arg(str));
-  }
-}
-
-/*******************************************************************************
  *  Constructors / Destructor
  ******************************************************************************/
 
 Theme::Theme(const Uuid& uuid, const QString& name) noexcept
-  : mNodes(),
-    mUuid(uuid),
-    mName(name),
-    mColors(),
-    mSchematicGridStyle(GridStyle::Lines),
-    mBoardGridStyle(GridStyle::Lines) {
+  : mNodes(), mUuid(uuid), mName(name), mColors() {
   // clang-format off
   const char* sch = QT_TR_NOOP("Schematic");
   const char* brd = QT_TR_NOOP("Board");
@@ -206,9 +168,7 @@ Theme::Theme(const Theme& other) noexcept
   : mNodes(other.mNodes),
     mUuid(other.mUuid),
     mName(other.mName),
-    mColors(other.mColors),
-    mSchematicGridStyle(other.mSchematicGridStyle),
-    mBoardGridStyle(other.mBoardGridStyle) {
+    mColors(other.mColors) {
 }
 
 Theme::~Theme() noexcept {
@@ -267,20 +227,6 @@ void Theme::setColors(const QList<ThemeColor>& colors) noexcept {
   }
 }
 
-void Theme::setSchematicGridStyle(GridStyle style) noexcept {
-  if (style != mSchematicGridStyle) {
-    mSchematicGridStyle = style;
-    addNode("schematic_grid_style").appendChild(style);
-  }
-}
-
-void Theme::setBoardGridStyle(GridStyle style) noexcept {
-  if (style != mBoardGridStyle) {
-    mBoardGridStyle = style;
-    addNode("board_grid_style").appendChild(style);
-  }
-}
-
 /*******************************************************************************
  *  General Methods
  ******************************************************************************/
@@ -303,12 +249,6 @@ void Theme::load(const SExpression& root) {
       }
     }
   }
-  if (const SExpression* value = root.tryGetChild("schematic_grid_style/@0")) {
-    mSchematicGridStyle = deserialize<GridStyle>(*value);
-  }
-  if (const SExpression* value = root.tryGetChild("board_grid_style/@0")) {
-    mBoardGridStyle = deserialize<GridStyle>(*value);
-  }
 }
 
 void Theme::serialize(SExpression& root) const {
@@ -330,8 +270,6 @@ bool Theme::operator==(const Theme& rhs) const noexcept {
       && (mUuid == rhs.mUuid)  //
       && (mName == rhs.mName)  //
       && (mColors == rhs.mColors)  //
-      && (mSchematicGridStyle == rhs.mSchematicGridStyle)  //
-      && (mBoardGridStyle == rhs.mBoardGridStyle)  //
       ;
 }
 
@@ -340,8 +278,6 @@ Theme& Theme::operator=(const Theme& rhs) noexcept {
   mUuid = rhs.mUuid;
   mName = rhs.mName;
   mColors = rhs.mColors;
-  mSchematicGridStyle = rhs.mSchematicGridStyle;
-  mBoardGridStyle = rhs.mBoardGridStyle;
   return *this;
 }
 

--- a/libs/librepcb/core/workspace/theme.h
+++ b/libs/librepcb/core/workspace/theme.h
@@ -45,13 +45,6 @@ class Theme final {
   Q_DECLARE_TR_FUNCTIONS(Theme)
 
 public:
-  // Types
-  enum class GridStyle : int {
-    None,
-    Dots,
-    Lines,
-  };
-
   struct Color {
     // clang-format off
     static constexpr const char* sSchematicBackground      = "schematic_background";
@@ -141,16 +134,10 @@ public:
   const QString& getName() const noexcept { return mName; }
   const QList<ThemeColor>& getColors() const noexcept { return mColors; }
   const ThemeColor& getColor(const QString& identifier) const noexcept;
-  GridStyle getSchematicGridStyle() const noexcept {
-    return mSchematicGridStyle;
-  }
-  GridStyle getBoardGridStyle() const noexcept { return mBoardGridStyle; }
 
   // Setters
   void setName(const QString& name) noexcept;
   void setColors(const QList<ThemeColor>& colors) noexcept;
-  void setSchematicGridStyle(GridStyle style) noexcept;
-  void setBoardGridStyle(GridStyle style) noexcept;
 
   // General Methods
   void restoreDefaults() noexcept;
@@ -178,8 +165,6 @@ private:  // Data
   Uuid mUuid;
   QString mName;
   QList<ThemeColor> mColors;
-  GridStyle mSchematicGridStyle;
-  GridStyle mBoardGridStyle;
 };
 
 /*******************************************************************************
@@ -187,7 +172,5 @@ private:  // Data
  ******************************************************************************/
 
 }  // namespace librepcb
-
-Q_DECLARE_METATYPE(librepcb::Theme::GridStyle)
 
 #endif

--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -108,6 +108,8 @@ WorkspaceSettings::WorkspaceSettings(QObject* parent)
                               this),
     keyboardShortcuts(this),
     themes(this),
+    schematicGridStyle("schematic_grid_style", GridStyle::Lines, this),
+    boardGridStyle("board_grid_style", GridStyle::Lines, this),
     dismissedMessages("dismissed_messages", "message", QSet<QString>(), this) {
 }
 
@@ -124,6 +126,30 @@ void WorkspaceSettings::load(const SExpression& node,
            node.getChildren(SExpression::Type::List)) {
     mFileContent.insert(child->getName(), *child);
   }
+
+  // Migrating grid style from themes to the new global settings. This should
+  // be moved to the official file format migration for file format v3.
+  try {
+    auto it = mFileContent.find("themes");
+    if (it != mFileContent.end()) {
+      const Uuid active = deserialize<Uuid>(it->getChild("active/@0"));
+      for (const SExpression* themeNode : it->getChildren("theme")) {
+        if (themeNode->getChild("@0").getValue() == active.toStr()) {
+          if (const SExpression* node =
+                  themeNode->tryGetChild("schematic_grid_style/@0")) {
+            schematicGridStyle.setInitial(deserialize<GridStyle>(*node));
+          }
+          if (const SExpression* node =
+                  themeNode->tryGetChild("board_grid_style/@0")) {
+            boardGridStyle.setInitial(deserialize<GridStyle>(*node));
+          }
+        }
+      }
+    }
+  } catch (const Exception& e) {
+    qCritical() << "Could not migrate old workspace settings:" << e.getMsg();
+  }
+
   foreach (WorkspaceSettingsItem* item, getAllItems()) {
     try {
       if (mFileContent.contains(item->getKey())) {

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -24,6 +24,7 @@
  *  Includes
  ******************************************************************************/
 #include "../exceptions.h"
+#include "../types/enums.h"
 #include "../types/lengthunit.h"
 #include "workspacesettingsitem_genericvalue.h"
 #include "workspacesettingsitem_genericvaluelist.h"
@@ -309,6 +310,20 @@ public:
    * @see ::librepcb::WorkspaceSettingsItem_KeyboardShortcuts
    */
   WorkspaceSettingsItem_Themes themes;
+
+  /**
+   * @brief Schematic grid style
+   *
+   * Default: ::librepcb::GridStyle::Lines
+   */
+  WorkspaceSettingsItem_GenericValue<GridStyle> schematicGridStyle;
+
+  /**
+   * @brief Schematic grid style
+   *
+   * Default: ::librepcb::GridStyle::Lines
+   */
+  WorkspaceSettingsItem_GenericValue<GridStyle> boardGridStyle;
 
   /**
    * @brief Dismissed messages

--- a/libs/librepcb/core/workspace/workspacesettingsitem_genericvalue.h
+++ b/libs/librepcb/core/workspace/workspacesettingsitem_genericvalue.h
@@ -75,6 +75,23 @@ public:
   }
 
   /**
+   * @brief Set the initial value
+   *
+   * @warning This is a hacky, temporary way to initialize specific workspace
+   *          settings with the value of another workspace setting, as required
+   *          for file format migrations! Do not call this method unless you
+   *          know exactly what you are doing.
+   *
+   * @param value   The initial value
+   */
+  void setInitial(const T& value) noexcept {
+    if (value != mCurrentValue) {
+      mCurrentValue = value;
+      emit edited();
+    }
+  }
+
+  /**
    * @brief Get the default value
    *
    * @return Default value

--- a/libs/librepcb/editor/graphics/graphicsscene.cpp
+++ b/libs/librepcb/editor/graphics/graphicsscene.cpp
@@ -43,7 +43,7 @@ namespace editor {
 
 GraphicsScene::GraphicsScene(QObject* parent) noexcept
   : QGraphicsScene(parent),
-    mGridStyle(Theme::GridStyle::None),
+    mGridStyle(GridStyle::None),
     mGridInterval(2540000),
     mBackgroundColor(Qt::white),
     mGridColor(Qt::gray),
@@ -89,7 +89,7 @@ void GraphicsScene::setOverlayColors(const QColor& fill,
   setForegroundBrush(foregroundBrush());  // this will repaint the foreground
 }
 
-void GraphicsScene::setGridStyle(Theme::GridStyle style) noexcept {
+void GraphicsScene::setGridStyle(GridStyle style) noexcept {
   if (style != mGridStyle) {
     mGridStyle = style;
     setBackgroundBrush(backgroundBrush());  // this will repaint the background
@@ -200,7 +200,7 @@ void GraphicsScene::drawBackground(QPainter* painter,
   painter->fillRect(rect, mBackgroundColor);
 
   // draw background grid lines
-  gridPen.setWidth((mGridStyle == Theme::GridStyle::Dots) ? 2 : 1);
+  gridPen.setWidth((mGridStyle == GridStyle::Dots) ? 2 : 1);
   painter->setPen(gridPen);
   painter->setBrush(Qt::NoBrush);
   const qreal lod = QStyleOptionGraphicsItem::levelOfDetailFromTransform(
@@ -217,7 +217,7 @@ void GraphicsScene::drawBackground(QPainter* painter,
   int xIndex = qFloor(rect.left() / gridIntervalPixels);
   int yIndex = -qFloor(rect.bottom() / gridIntervalPixels);
   switch (mGridStyle) {
-    case Theme::GridStyle::Lines: {
+    case GridStyle::Lines: {
       QVarLengthArray<QLineF, 450> minorLines;
       QVarLengthArray<QLineF, 50> majorLines;
       for (qreal x = left; x < right; x += gridIntervalPixels) {
@@ -244,7 +244,7 @@ void GraphicsScene::drawBackground(QPainter* painter,
       break;
     }
 
-    case Theme::GridStyle::Dots: {
+    case GridStyle::Dots: {
       QVarLengthArray<QPointF, 1800> minorDots;
       QVarLengthArray<QPointF, 200> majorDots;
       for (qreal x = left; x < right; x += gridIntervalPixels) {

--- a/libs/librepcb/editor/graphics/graphicsscene.h
+++ b/libs/librepcb/editor/graphics/graphicsscene.h
@@ -23,9 +23,9 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include <librepcb/core/types/enums.h>
 #include <librepcb/core/types/lengthunit.h>
 #include <librepcb/core/types/point.h>
-#include <librepcb/core/workspace/theme.h>
 
 #include <QtCore>
 #include <QtWidgets>
@@ -73,13 +73,13 @@ public:
   const PositiveLength& getGridInterval() const noexcept {
     return mGridInterval;
   }
-  Theme::GridStyle getGridStyle() const noexcept { return mGridStyle; }
+  GridStyle getGridStyle() const noexcept { return mGridStyle; }
 
   // Setters
   void setBackgroundColors(const QColor& fill, const QColor& grid) noexcept;
   void setOverlayColors(const QColor& fill, const QColor& content) noexcept;
   void setSelectionRectColors(const QColor& line, const QColor& fill) noexcept;
-  void setGridStyle(Theme::GridStyle style) noexcept;
+  void setGridStyle(GridStyle style) noexcept;
   void setGridInterval(const PositiveLength& interval) noexcept;
   void setOriginCrossVisible(bool visible) noexcept;
   void setGrayOut(bool grayOut) noexcept;
@@ -114,7 +114,7 @@ protected:
   void drawForeground(QPainter* painter, const QRectF& rect) noexcept override;
 
 private:
-  Theme::GridStyle mGridStyle;
+  GridStyle mGridStyle;
   PositiveLength mGridInterval;
   QColor mBackgroundColor;
   QColor mGridColor;

--- a/libs/librepcb/editor/library/cmp/componentgateeditor.cpp
+++ b/libs/librepcb/editor/library/cmp/componentgateeditor.cpp
@@ -222,7 +222,7 @@ void ComponentGateEditor::reloadSymbol() noexcept {
     mScene->setSelectionRectColors(
         theme.getColor(Theme::Color::sSchematicSelection).getPrimaryColor(),
         theme.getColor(Theme::Color::sSchematicSelection).getSecondaryColor());
-    mScene->setGridStyle(Theme::GridStyle::None);
+    mScene->setGridStyle(GridStyle::None);
     mGraphicsItem.reset(new SymbolGraphicsItem(
         const_cast<Symbol&>(*mSymbol), mLayers, mComponent, mGate,
         mWorkspace.getSettings().libraryLocaleOrder.get(), false));

--- a/libs/librepcb/editor/library/cmp/componentvarianteditor.cpp
+++ b/libs/librepcb/editor/library/cmp/componentvarianteditor.cpp
@@ -84,7 +84,7 @@ ComponentVariantEditor::ComponentVariantEditor(
   mScene->setSelectionRectColors(
       theme.getColor(Theme::Color::sSchematicSelection).getPrimaryColor(),
       theme.getColor(Theme::Color::sSchematicSelection).getSecondaryColor());
-  mScene->setGridStyle(Theme::GridStyle::Lines);  // Required for positioning.
+  mScene->setGridStyle(GridStyle::Lines);  // Required for positioning.
   connect(mScene.get(), &GraphicsScene::changed, this, [this]() {
     ++mFrameIndex;
     emit uiDataChanged();

--- a/libs/librepcb/editor/library/dev/devicetab.cpp
+++ b/libs/librepcb/editor/library/dev/devicetab.cpp
@@ -133,7 +133,7 @@ DeviceTab::DeviceTab(LibraryEditor& editor, std::unique_ptr<Device> dev,
   mComponentScene->setSelectionRectColors(
       theme.getColor(Theme::Color::sSchematicSelection).getPrimaryColor(),
       theme.getColor(Theme::Color::sSchematicSelection).getSecondaryColor());
-  mComponentScene->setGridStyle(Theme::GridStyle::Lines);
+  mComponentScene->setGridStyle(GridStyle::Lines);
 
   // Setup package scene.
   mPackageScene->setOriginCrossVisible(false);  // It's rather disruptive.
@@ -146,7 +146,7 @@ DeviceTab::DeviceTab(LibraryEditor& editor, std::unique_ptr<Device> dev,
   mPackageScene->setSelectionRectColors(
       theme.getColor(Theme::Color::sBoardSelection).getPrimaryColor(),
       theme.getColor(Theme::Color::sBoardSelection).getSecondaryColor());
-  mPackageScene->setGridStyle(Theme::GridStyle::Lines);
+  mPackageScene->setGridStyle(GridStyle::Lines);
 
   // Setup default manufacturer.
   mParts->setDefaultManufacturer(mEditor.getLibrary().getManufacturer());

--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -109,10 +109,7 @@ PackageTab::PackageTab(LibraryEditor& editor, std::unique_ptr<Package> pkg,
     mWizardMode(mode != Mode::Open),
     mCurrentPageIndex(mWizardMode ? 0 : 2),
     mView3d(false),
-    mGridStyle(mApp.getWorkspace()
-                   .getSettings()
-                   .themes.getActive()
-                   .getBoardGridStyle()),
+    mGridStyle(mApp.getWorkspace().getSettings().boardGridStyle.get()),
     mUnit(LengthUnit::millimeters()),
     mChooseCategory(false),
     mOpenGlProjection(new OpenGlProjection()),
@@ -208,6 +205,13 @@ PackageTab::PackageTab(LibraryEditor& editor, std::unique_ptr<Package> pkg,
                                        mUnit,     *mLayers,    *this,
                                        nullptr,   nullptr};
   mFsm.reset(new PackageEditorFsm(fsmContext));
+
+  // Apply workspace settings whenever they have been modified.
+  connect(&mApp.getWorkspace().getSettings().boardGridStyle,
+          &WorkspaceSettingsItem::edited, this, [this]() {
+            mGridStyle = mApp.getWorkspace().getSettings().boardGridStyle.get();
+            applyTheme();
+          });
 
   // Load the first footprint & 3D model.
   setCurrentFootprintIndex(0);

--- a/libs/librepcb/editor/library/pkg/packagetab.h
+++ b/libs/librepcb/editor/library/pkg/packagetab.h
@@ -36,10 +36,10 @@
 #include <librepcb/core/library/pkg/package.h>
 #include <librepcb/core/types/alignment.h>
 #include <librepcb/core/types/elementname.h>
+#include <librepcb/core/types/enums.h>
 #include <librepcb/core/types/length.h>
 #include <librepcb/core/types/lengthunit.h>
 #include <librepcb/core/types/version.h>
-#include <librepcb/core/workspace/theme.h>
 
 #include <QtCore>
 
@@ -234,7 +234,7 @@ private:
   bool mWizardMode;
   int mCurrentPageIndex;
   bool mView3d;
-  Theme::GridStyle mGridStyle;
+  GridStyle mGridStyle;
   LengthUnit mUnit;
   bool mChooseCategory;
   std::shared_ptr<PackageModel> mCurrentModel;

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -91,10 +91,7 @@ SymbolTab::SymbolTab(LibraryEditor& editor, std::unique_ptr<Symbol> sym,
     mMsgImportPins(mApp.getWorkspace(), "EMPTY_SYMBOL_IMPORT_PINS"),
     mWizardMode(mode != Mode::Open),
     mCurrentPageIndex(mWizardMode ? 0 : 1),
-    mGridStyle(mApp.getWorkspace()
-                   .getSettings()
-                   .themes.getActive()
-                   .getSchematicGridStyle()),
+    mGridStyle(mApp.getWorkspace().getSettings().schematicGridStyle.get()),
     mUnit(LengthUnit::millimeters()),
     mChooseCategory(false),
     mCompactLayout(false),
@@ -152,6 +149,14 @@ SymbolTab::SymbolTab(LibraryEditor& editor, std::unique_ptr<Symbol> sym,
   SymbolEditorFsm::Context fsmContext{*mSymbol, *mUndoStack, !isWritable(),
                                       mUnit, *this};
   mFsm.reset(new SymbolEditorFsm(fsmContext));
+
+  // Apply workspace settings whenever they have been modified.
+  connect(&mApp.getWorkspace().getSettings().schematicGridStyle,
+          &WorkspaceSettingsItem::edited, this, [this]() {
+            mGridStyle =
+                mApp.getWorkspace().getSettings().schematicGridStyle.get();
+            applyTheme();
+          });
 
   // Refresh content.
   refreshUiData();

--- a/libs/librepcb/editor/library/sym/symboltab.h
+++ b/libs/librepcb/editor/library/sym/symboltab.h
@@ -32,10 +32,11 @@
 
 #include <librepcb/core/types/alignment.h>
 #include <librepcb/core/types/elementname.h>
+#include <librepcb/core/types/enums.h>
 #include <librepcb/core/types/length.h>
 #include <librepcb/core/types/lengthunit.h>
+#include <librepcb/core/types/uuid.h>
 #include <librepcb/core/types/version.h>
-#include <librepcb/core/workspace/theme.h>
 
 #include <QtCore>
 
@@ -207,7 +208,7 @@ private:
   // State
   bool mWizardMode;
   int mCurrentPageIndex;
-  Theme::GridStyle mGridStyle;
+  GridStyle mGridStyle;
   LengthUnit mUnit;
   bool mChooseCategory;
   bool mCompactLayout;

--- a/libs/librepcb/editor/project/addcomponentdialog.cpp
+++ b/libs/librepcb/editor/project/addcomponentdialog.cpp
@@ -184,7 +184,7 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
   mComponentPreviewScene->setBackgroundColors(
       theme.getColor(Theme::Color::sSchematicBackground).getPrimaryColor(),
       theme.getColor(Theme::Color::sSchematicBackground).getSecondaryColor());
-  mComponentPreviewScene->setGridStyle(theme.getBoardGridStyle());
+  mComponentPreviewScene->setGridStyle(mSettings.schematicGridStyle.get());
   mComponentPreviewScene->setOriginCrossVisible(false);
   mUi->viewComponent->setSpinnerColor(
       theme.getColor(Theme::Color::sSchematicBackground).getSecondaryColor());
@@ -194,7 +194,7 @@ AddComponentDialog::AddComponentDialog(const WorkspaceLibraryDb& db,
   mDevicePreviewScene->setBackgroundColors(
       theme.getColor(Theme::Color::sBoardBackground).getPrimaryColor(),
       theme.getColor(Theme::Color::sBoardBackground).getSecondaryColor());
-  mDevicePreviewScene->setGridStyle(theme.getBoardGridStyle());
+  mDevicePreviewScene->setGridStyle(mSettings.boardGridStyle.get());
   mDevicePreviewScene->setOriginCrossVisible(false);
   mUi->viewDevice->setSpinnerColor(
       theme.getColor(Theme::Color::sBoardBackground).getSecondaryColor());

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -149,10 +149,7 @@ Board2dTab::Board2dTab(GuiApplication& app, BoardEditor& editor,
     mMsgEmptySchematics(app.getWorkspace(), "EMPTY_BOARD_NO_COMPONENTS"),
     mMsgSetupDesignRules(app.getWorkspace(), "EMPTY_BOARD_SETUP_DESIGN_RULES"),
     mMsgPlaceDevices(app.getWorkspace(), "EMPTY_BOARD_PLACE_DEVICES"),
-    mGridStyle(mApp.getWorkspace()
-                   .getSettings()
-                   .themes.getActive()
-                   .getBoardGridStyle()),
+    mGridStyle(mApp.getWorkspace().getSettings().boardGridStyle.get()),
     mIgnorePlacementLocks(false),
     mFrameIndex(0),
     mToolFeatures(),
@@ -276,7 +273,12 @@ Board2dTab::Board2dTab(GuiApplication& app, BoardEditor& editor,
   };
   mFsm.reset(new BoardEditorFsm(fsmContext));
 
-  // Apply theme whenever it has been modified.
+  // Apply workspace settings whenever they have been modified.
+  connect(&mApp.getWorkspace().getSettings().boardGridStyle,
+          &WorkspaceSettingsItem::edited, this, [this]() {
+            mGridStyle = mApp.getWorkspace().getSettings().boardGridStyle.get();
+            applyTheme();
+          });
   connect(&mApp.getWorkspace().getSettings().themes,
           &WorkspaceSettingsItem_Themes::edited, this, &Board2dTab::applyTheme);
   applyTheme();

--- a/libs/librepcb/editor/project/board/board2dtab.h
+++ b/libs/librepcb/editor/project/board/board2dtab.h
@@ -266,7 +266,7 @@ private:
 
   // State
   SearchContext mSearchContext;
-  Theme::GridStyle mGridStyle;
+  GridStyle mGridStyle;
   QPointF mSceneImagePos;
   bool mIgnorePlacementLocks;
   int mFrameIndex;

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_addhole.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_addhole.cpp
@@ -28,6 +28,7 @@
 
 #include <librepcb/core/geometry/hole.h>
 #include <librepcb/core/project/board/board.h>
+#include <librepcb/core/workspace/theme.h>
 
 #include <QtCore>
 

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_addpad.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_addpad.cpp
@@ -37,6 +37,7 @@
 #include <librepcb/core/project/circuit/netsignal.h>
 #include <librepcb/core/project/project.h>
 #include <librepcb/core/utils/toolbox.h>
+#include <librepcb/core/workspace/theme.h>
 
 #include <QtCore>
 

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_text.cpp
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_text.cpp
@@ -27,6 +27,8 @@
 #include "../../../graphics/textgraphicsitem.h"
 #include "../schematicgraphicsscene.h"
 
+#include <librepcb/core/workspace/theme.h>
+
 #include <QtCore>
 #include <QtWidgets>
 

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -118,10 +118,7 @@ SchematicTab::SchematicTab(GuiApplication& app, SchematicEditor& editor,
                                 this)),
     mMsgInstallLibraries(app.getWorkspace(), "EMPTY_SCHEMATIC_NO_LIBRARIES"),
     mMsgAddDrawingFrame(app.getWorkspace(), "EMPTY_SCHEMATIC_ADD_FRAME"),
-    mGridStyle(mApp.getWorkspace()
-                   .getSettings()
-                   .themes.getActive()
-                   .getSchematicGridStyle()),
+    mGridStyle(mApp.getWorkspace().getSettings().schematicGridStyle.get()),
     mIgnorePlacementLocks(false),
     mFrameIndex(0),
     mToolFeatures(),
@@ -209,7 +206,13 @@ SchematicTab::SchematicTab(GuiApplication& app, SchematicEditor& editor,
   };
   mFsm.reset(new SchematicEditorFsm(fsmContext));
 
-  // Apply theme whenever it has been modified.
+  // Apply workspace settings whenever they have been modified.
+  connect(&mApp.getWorkspace().getSettings().schematicGridStyle,
+          &WorkspaceSettingsItem::edited, this, [this]() {
+            mGridStyle =
+                mApp.getWorkspace().getSettings().schematicGridStyle.get();
+            applyTheme();
+          });
   connect(&mApp.getWorkspace().getSettings().themes,
           &WorkspaceSettingsItem_Themes::edited, this,
           &SchematicTab::applyTheme);

--- a/libs/librepcb/editor/project/schematic/schematictab.h
+++ b/libs/librepcb/editor/project/schematic/schematictab.h
@@ -188,7 +188,7 @@ private:
 
   // State
   SearchContext mSearchContext;
-  Theme::GridStyle mGridStyle;
+  GridStyle mGridStyle;
   QPointF mSceneImagePos;
   bool mIgnorePlacementLocks;
   int mFrameIndex;

--- a/libs/librepcb/editor/utils/uihelpers.cpp
+++ b/libs/librepcb/editor/utils/uihelpers.cpp
@@ -117,13 +117,13 @@ ui::Theme l2s(const UiTheme& v) noexcept {
   };
 }
 
-ui::GridStyle l2s(Theme::GridStyle v) noexcept {
+ui::GridStyle l2s(GridStyle v) noexcept {
   switch (v) {
-    case Theme::GridStyle::Lines:
+    case GridStyle::Lines:
       return ui::GridStyle::Lines;
-    case Theme::GridStyle::Dots:
+    case GridStyle::Dots:
       return ui::GridStyle::Dots;
-    case Theme::GridStyle::None:
+    case GridStyle::None:
       return ui::GridStyle::None;
     default:
       qCritical() << "Unhandled value in GridStyle conversion.";
@@ -131,17 +131,17 @@ ui::GridStyle l2s(Theme::GridStyle v) noexcept {
   }
 }
 
-Theme::GridStyle s2l(ui::GridStyle v) noexcept {
+GridStyle s2l(ui::GridStyle v) noexcept {
   switch (v) {
     case ui::GridStyle::Lines:
-      return Theme::GridStyle::Lines;
+      return GridStyle::Lines;
     case ui::GridStyle::Dots:
-      return Theme::GridStyle::Dots;
+      return GridStyle::Dots;
     case ui::GridStyle::None:
-      return Theme::GridStyle::None;
+      return GridStyle::None;
     default:
       qCritical() << "Unhandled value in GridStyle conversion.";
-      return Theme::GridStyle::None;
+      return GridStyle::None;
   }
 }
 

--- a/libs/librepcb/editor/utils/uihelpers.h
+++ b/libs/librepcb/editor/utils/uihelpers.h
@@ -29,10 +29,10 @@
 #include <librepcb/core/library/pkg/package.h>
 #include <librepcb/core/rulecheck/rulecheckmessage.h>
 #include <librepcb/core/types/alignment.h>
+#include <librepcb/core/types/enums.h>
 #include <librepcb/core/types/length.h>
 #include <librepcb/core/types/lengthunit.h>
 #include <librepcb/core/types/ratio.h>
-#include <librepcb/core/workspace/theme.h>
 #include <librepcb/core/workspace/uitheme.h>
 
 #include <optional>
@@ -71,8 +71,8 @@ Ratio s2ratio(int v) noexcept;
 
 ui::Theme l2s(const UiTheme& v) noexcept;
 
-ui::GridStyle l2s(Theme::GridStyle v) noexcept;
-Theme::GridStyle s2l(ui::GridStyle v) noexcept;
+ui::GridStyle l2s(GridStyle v) noexcept;
+GridStyle s2l(ui::GridStyle v) noexcept;
 
 ui::LengthUnit l2s(const LengthUnit& v) noexcept;
 LengthUnit s2l(ui::LengthUnit v) noexcept;

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -65,6 +65,8 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
     mKeyboardShortcutsModel(new KeyboardShortcutsModel(this)),
     mKeyboardShortcutsFilterModel(new QSortFilterProxyModel(this)),
     mUi(new Ui::WorkspaceSettingsDialog),
+    mOldSchematicGridStyle(mSettings.schematicGridStyle.get()),
+    mOldBoardGridStyle(mSettings.boardGridStyle.get()),
     mOldActiveTheme(Uuid::createRandom()) {
   mUi->setupUi(this);
 
@@ -302,15 +304,6 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
 
   // Initialize themes widgets.
   {
-    for (QComboBox* cbx :
-         {mUi->cbxSchematicGridStyle, mUi->cbxBoardGridStyle}) {
-      cbx->addItem(tr("None", "Grid style"),
-                   QVariant::fromValue(Theme::GridStyle::None));
-      cbx->addItem(tr("Dots", "Grid style"),
-                   QVariant::fromValue(Theme::GridStyle::Dots));
-      cbx->addItem(tr("Lines", "Grid style"),
-                   QVariant::fromValue(Theme::GridStyle::Lines));
-    }
     auto askName = [this](const QString& title, const QString& defaultName) {
       return QInputDialog::getText(this, title, tr("Name:"), QLineEdit::Normal,
                                    defaultName);
@@ -407,24 +400,31 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
               initColorTreeWidgetItem(*item, colors[index]);
               mSettings.themes.setAll(themes);
             });
-    for (auto cfg : {
-             std::make_pair(mUi->cbxSchematicGridStyle,
-                            &Theme::setSchematicGridStyle),
-             std::make_pair(mUi->cbxBoardGridStyle, &Theme::setBoardGridStyle),
-         }) {
-      connect(cfg.first,
+  }
+
+  // Initialize grid style widgets.
+  {
+    auto setup = [this](
+                     QComboBox* cbx,
+                     WorkspaceSettingsItem_GenericValue<GridStyle>& setting) {
+      cbx->addItem(tr("None", "Grid style"),
+                   QVariant::fromValue(GridStyle::None));
+      cbx->addItem(tr("Dots", "Grid style"),
+                   QVariant::fromValue(GridStyle::Dots));
+      cbx->addItem(tr("Lines", "Grid style"),
+                   QVariant::fromValue(GridStyle::Lines));
+      connect(cbx,
               static_cast<void (QComboBox::*)(int)>(
                   &QComboBox::currentIndexChanged),
-              this, [this, cfg](int index) {
-                auto themes = mSettings.themes.getAll();
-                auto theme = themes.find(mSettings.themes.getActiveUuid());
-                if (theme == themes.end()) return;
-                const Theme::GridStyle style =
-                    cfg.first->itemData(index).value<Theme::GridStyle>();
-                ((*theme).*cfg.second)(style);
-                mSettings.themes.setAll(themes);
+              this, [cbx, &setting](int index) {
+                const QVariant data = cbx->itemData(index);
+                if (data.isValid()) {
+                  setting.set(data.value<GridStyle>());
+                }
               });
-    }
+    };
+    setup(mUi->cbxSchematicGridStyle, mSettings.schematicGridStyle);
+    setup(mUi->cbxBoardGridStyle, mSettings.boardGridStyle);
   }
 
   // Now load all current settings
@@ -643,17 +643,6 @@ void WorkspaceSettingsDialog::themeIndexChanged(int index) noexcept {
     initColorTreeWidgetItem(*item, theme.getColors().at(i));
   }
   mUi->treeThemeColors->setEnabled(valid);
-
-  // Grid style.
-  for (const auto& cfg : {
-           std::make_pair(mUi->cbxSchematicGridStyle,
-                          theme.getSchematicGridStyle()),
-           std::make_pair(mUi->cbxBoardGridStyle, theme.getBoardGridStyle()),
-       }) {
-    const int index = cfg.first->findData(QVariant::fromValue(cfg.second));
-    cfg.first->setCurrentIndex(index);
-    cfg.first->setEnabled(valid);
-  }
 }
 
 void WorkspaceSettingsDialog::initColorTreeWidgetItem(
@@ -772,6 +761,13 @@ void WorkspaceSettingsDialog::loadSettings() noexcept {
 
   // Themes
   updateThemesList();
+
+  // Grid style
+  auto loadGridStyle = [](QComboBox* cbx, GridStyle gridStyle) {
+    cbx->setCurrentIndex(cbx->findData(QVariant::fromValue(gridStyle)));
+  };
+  loadGridStyle(mUi->cbxSchematicGridStyle, mSettings.schematicGridStyle.get());
+  loadGridStyle(mUi->cbxBoardGridStyle, mSettings.boardGridStyle.get());
 }
 
 void WorkspaceSettingsDialog::saveSettings() noexcept {
@@ -827,6 +823,8 @@ void WorkspaceSettingsDialog::saveSettings() noexcept {
 
     // Themes were applied immediately.
 
+    // Grid style was applied immediately.
+
     // Save settings to disk.
     mWorkspace.saveSettings();  // can throw
   } catch (const Exception& e) {
@@ -837,6 +835,8 @@ void WorkspaceSettingsDialog::saveSettings() noexcept {
 void WorkspaceSettingsDialog::discardTemporaryModifications() noexcept {
   mOldUiTheme = mSettings.uiTheme.get();
   mOldApplicationLocale = mSettings.applicationLocale.get();
+  mOldSchematicGridStyle = mSettings.schematicGridStyle.get();
+  mOldBoardGridStyle = mSettings.boardGridStyle.get();
   mOldThemes = mSettings.themes.getAll();
   mOldActiveTheme = mSettings.themes.getActiveUuid();
 }
@@ -844,15 +844,20 @@ void WorkspaceSettingsDialog::discardTemporaryModifications() noexcept {
 void WorkspaceSettingsDialog::revertTemporaryModifications() noexcept {
   mSettings.uiTheme.set(mOldUiTheme);
   mSettings.applicationLocale.set(mOldApplicationLocale);
+  mSettings.schematicGridStyle.set(mOldSchematicGridStyle);
+  mSettings.boardGridStyle.set(mOldBoardGridStyle);
   mSettings.themes.setAll(mOldThemes);
   mSettings.themes.setActiveUuid(mOldActiveTheme);
 }
 
 bool WorkspaceSettingsDialog::hasTemporaryModifications() const noexcept {
-  return (mSettings.uiTheme.get() != mOldUiTheme) ||
-      (mSettings.applicationLocale.get() != mOldApplicationLocale) ||
-      (mSettings.themes.getAll() != mOldThemes) ||
-      (mSettings.themes.getActiveUuid() != mOldActiveTheme);
+  return (mSettings.uiTheme.get() != mOldUiTheme)  //
+      || (mSettings.applicationLocale.get() != mOldApplicationLocale)  //
+      || (mSettings.schematicGridStyle.get() != mOldSchematicGridStyle)  //
+      || (mSettings.boardGridStyle.get() != mOldBoardGridStyle)  //
+      || (mSettings.themes.getAll() != mOldThemes)  //
+      || (mSettings.themes.getActiveUuid() != mOldActiveTheme)  //
+      ;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.h
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.h
@@ -121,6 +121,8 @@ private:
   // Original values of temporarily changed settings
   QString mOldUiTheme;
   QString mOldApplicationLocale;
+  GridStyle mOldSchematicGridStyle;
+  GridStyle mOldBoardGridStyle;
   QMap<Uuid, Theme> mOldThemes;
   Uuid mOldActiveTheme;
 };

--- a/tests/unittests/core/workspace/workspacesettingstest.cpp
+++ b/tests/unittests/core/workspace/workspacesettingstest.cpp
@@ -48,6 +48,7 @@ class WorkspaceSettingsTest : public ::testing::Test {};
 TEST_F(WorkspaceSettingsTest, testLoadFromSExpression) {
   std::unique_ptr<SExpression> root = SExpression::parse(
       "(librepcb_workspace_settings\n"
+      " (ui_theme \"dark\")\n"
       " (user \"Foo Bar\")\n"
       " (application_locale \"de_CH\")\n"
       " (default_length_unit micrometers)\n"
@@ -72,6 +73,8 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpression) {
       " (external_pdf_reader\n"
       "  (command \"evince \\\"{{FILEPATH}}\\\"\")\n"
       " )\n"
+      " (schematic_grid_style dots)\n"
+      " (board_grid_style none)\n"
       " (dismissed_messages\n"
       "  (message \"SOME_MESSAGE: foo\")\n"
       "  (message \"SOME_MESSAGE: bar\")\n"
@@ -81,6 +84,7 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpression) {
 
   WorkspaceSettings obj;
   obj.load(*root, Application::getFileFormatVersion());
+  EXPECT_EQ("dark", obj.uiTheme.get());
   EXPECT_EQ("Foo Bar", obj.userName.get());
   EXPECT_EQ("de_CH", obj.applicationLocale.get());
   EXPECT_EQ(LengthUnit::micrometers(), obj.defaultLengthUnit.get());
@@ -99,6 +103,8 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpression) {
             obj.externalFileManagerCommands.get());
   EXPECT_EQ(QStringList{"evince \"{{FILEPATH}}\""},
             obj.externalPdfReaderCommands.get());
+  EXPECT_EQ(GridStyle::Dots, obj.schematicGridStyle.get());
+  EXPECT_EQ(GridStyle::None, obj.boardGridStyle.get());
   EXPECT_EQ((QSet<QString>{"SOME_MESSAGE: foo", "SOME_MESSAGE: bar"}),
             obj.dismissedMessages.get());
 }
@@ -106,6 +112,7 @@ TEST_F(WorkspaceSettingsTest, testLoadFromSExpression) {
 TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   // Store
   WorkspaceSettings obj1;
+  obj1.uiTheme.set("light");
   obj1.userName.set("foo bar");
   obj1.applicationLocale.set("de_CH");
   obj1.defaultLengthUnit.set(LengthUnit::nanometers());
@@ -120,12 +127,15 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
   obj1.externalWebBrowserCommands.set({"foo", "bar"});
   obj1.externalFileManagerCommands.set({"file", "manager"});
   obj1.externalPdfReaderCommands.set({"pdf", "reader"});
+  obj1.schematicGridStyle.set(GridStyle::None);
+  obj1.boardGridStyle.set(GridStyle::Lines);
   obj1.dismissedMessages.set({"foo", "bar"});
   const std::unique_ptr<const SExpression> root1 = obj1.serialize();
 
   // Load
   WorkspaceSettings obj2;
   obj2.load(*root1, Application::getFileFormatVersion());
+  EXPECT_EQ(obj1.uiTheme.get(), obj2.uiTheme.get());
   EXPECT_EQ(obj1.userName.get().toStdString(),
             obj2.userName.get().toStdString());
   EXPECT_EQ(obj1.applicationLocale.get().toStdString(),
@@ -143,6 +153,8 @@ TEST_F(WorkspaceSettingsTest, testStoreAndLoad) {
             obj2.externalFileManagerCommands.get());
   EXPECT_EQ(obj1.externalPdfReaderCommands.get(),
             obj2.externalPdfReaderCommands.get());
+  EXPECT_EQ(obj1.schematicGridStyle.get(), obj2.schematicGridStyle.get());
+  EXPECT_EQ(obj1.boardGridStyle.get(), obj2.boardGridStyle.get());
   EXPECT_EQ(obj1.dismissedMessages.get(), obj2.dismissedMessages.get());
   const std::unique_ptr<const SExpression> root2 = obj2.serialize();
 


### PR DESCRIPTION
I think it was a wrong design decision to make the grid style part of the themes, thus now factoring out of themes and make them top-level workspace settings instead. So the grid style is now independent of themes.

In addition, changing the grid style in the settings is now applied immediately.

Performs an intermediate file format upgrade of workspace settings, see also #1732.