### PR TITLE
Update parseagle to get rid of QtXML dependency

### DIFF
--- a/libs/librepcb/core/library/cat/componentcategory.cpp
+++ b/libs/librepcb/core/library/cat/componentcategory.cpp
@@ -37,11 +37,13 @@ namespace librepcb {
 
 ComponentCategory::ComponentCategory(const Uuid& uuid, const Version& version,
                                      const QString& author,
+                                     const QDateTime& created,
                                      const ElementName& name_en_US,
                                      const QString& description_en_US,
                                      const QString& keywords_en_US)
   : LibraryCategory(getShortElementName(), getLongElementName(), uuid, version,
-                    author, name_en_US, description_en_US, keywords_en_US) {
+                    author, created, name_en_US, description_en_US,
+                    keywords_en_US) {
 }
 
 ComponentCategory::ComponentCategory(

--- a/libs/librepcb/core/library/cat/componentcategory.h
+++ b/libs/librepcb/core/library/cat/componentcategory.h
@@ -49,7 +49,8 @@ public:
   ComponentCategory() = delete;
   ComponentCategory(const ComponentCategory& other) = delete;
   ComponentCategory(const Uuid& uuid, const Version& version,
-                    const QString& author, const ElementName& name_en_US,
+                    const QString& author, const QDateTime& created,
+                    const ElementName& name_en_US,
                     const QString& description_en_US,
                     const QString& keywords_en_US);
   ~ComponentCategory() noexcept;

--- a/libs/librepcb/core/library/cat/librarycategory.cpp
+++ b/libs/librepcb/core/library/cat/librarycategory.cpp
@@ -35,15 +35,13 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-LibraryCategory::LibraryCategory(const QString& shortElementName,
-                                 const QString& longElementName,
-                                 const Uuid& uuid, const Version& version,
-                                 const QString& author,
-                                 const ElementName& name_en_US,
-                                 const QString& description_en_US,
-                                 const QString& keywords_en_US)
+LibraryCategory::LibraryCategory(
+    const QString& shortElementName, const QString& longElementName,
+    const Uuid& uuid, const Version& version, const QString& author,
+    const QDateTime& created, const ElementName& name_en_US,
+    const QString& description_en_US, const QString& keywords_en_US)
   : LibraryBaseElement(shortElementName, longElementName, uuid, version, author,
-                       name_en_US, description_en_US, keywords_en_US) {
+                       created, name_en_US, description_en_US, keywords_en_US) {
 }
 
 LibraryCategory::LibraryCategory(

--- a/libs/librepcb/core/library/cat/librarycategory.h
+++ b/libs/librepcb/core/library/cat/librarycategory.h
@@ -50,7 +50,7 @@ public:
   LibraryCategory(const QString& shortElementName,
                   const QString& longElementName, const Uuid& uuid,
                   const Version& version, const QString& author,
-                  const ElementName& name_en_US,
+                  const QDateTime& created, const ElementName& name_en_US,
                   const QString& description_en_US,
                   const QString& keywords_en_US);
   LibraryCategory(const QString& shortElementName,

--- a/libs/librepcb/core/library/cat/packagecategory.cpp
+++ b/libs/librepcb/core/library/cat/packagecategory.cpp
@@ -37,11 +37,13 @@ namespace librepcb {
 
 PackageCategory::PackageCategory(const Uuid& uuid, const Version& version,
                                  const QString& author,
+                                 const QDateTime& created,
                                  const ElementName& name_en_US,
                                  const QString& description_en_US,
                                  const QString& keywords_en_US)
   : LibraryCategory(getShortElementName(), getLongElementName(), uuid, version,
-                    author, name_en_US, description_en_US, keywords_en_US) {
+                    author, created, name_en_US, description_en_US,
+                    keywords_en_US) {
 }
 
 PackageCategory::PackageCategory(

--- a/libs/librepcb/core/library/cat/packagecategory.h
+++ b/libs/librepcb/core/library/cat/packagecategory.h
@@ -49,7 +49,8 @@ public:
   PackageCategory() = delete;
   PackageCategory(const PackageCategory& other) = delete;
   PackageCategory(const Uuid& uuid, const Version& version,
-                  const QString& author, const ElementName& name_en_US,
+                  const QString& author, const QDateTime& created,
+                  const ElementName& name_en_US,
                   const QString& description_en_US,
                   const QString& keywords_en_US);
   ~PackageCategory() noexcept;

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -37,11 +37,13 @@ namespace librepcb {
  ******************************************************************************/
 
 Component::Component(const Uuid& uuid, const Version& version,
-                     const QString& author, const ElementName& name_en_US,
+                     const QString& author, const QDateTime& created,
+                     const ElementName& name_en_US,
                      const QString& description_en_US,
                      const QString& keywords_en_US)
   : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US),
+                   author, created, name_en_US, description_en_US,
+                   keywords_en_US),
     mSchematicOnly(false),
     mDefaultValue(),
     mPrefixes(ComponentPrefix("")) {

--- a/libs/librepcb/core/library/cmp/component.h
+++ b/libs/librepcb/core/library/cmp/component.h
@@ -78,8 +78,8 @@ public:
   Component() = delete;
   Component(const Component& other) = delete;
   Component(const Uuid& uuid, const Version& version, const QString& author,
-            const ElementName& name_en_US, const QString& description_en_US,
-            const QString& keywords_en_US);
+            const QDateTime& created, const ElementName& name_en_US,
+            const QString& description_en_US, const QString& keywords_en_US);
   ~Component() noexcept;
 
   // General

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -37,11 +37,12 @@ namespace librepcb {
  ******************************************************************************/
 
 Device::Device(const Uuid& uuid, const Version& version, const QString& author,
-               const ElementName& name_en_US, const QString& description_en_US,
-               const QString& keywords_en_US, const Uuid& component,
-               const Uuid& package)
+               const QDateTime& created, const ElementName& name_en_US,
+               const QString& description_en_US, const QString& keywords_en_US,
+               const Uuid& component, const Uuid& package)
   : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US),
+                   author, created, name_en_US, description_en_US,
+                   keywords_en_US),
     mComponentUuid(component),
     mPackageUuid(package),
     mPadSignalMap(),

--- a/libs/librepcb/core/library/dev/device.h
+++ b/libs/librepcb/core/library/dev/device.h
@@ -60,9 +60,9 @@ public:
   Device() = delete;
   Device(const Device& other) = delete;
   Device(const Uuid& uuid, const Version& version, const QString& author,
-         const ElementName& name_en_US, const QString& description_en_US,
-         const QString& keywords_en_US, const Uuid& component,
-         const Uuid& package);
+         const QDateTime& created, const ElementName& name_en_US,
+         const QString& description_en_US, const QString& keywords_en_US,
+         const Uuid& component, const Uuid& package);
   ~Device() noexcept;
 
   // Getters

--- a/libs/librepcb/core/library/library.cpp
+++ b/libs/librepcb/core/library/library.cpp
@@ -46,11 +46,12 @@ namespace librepcb {
  ******************************************************************************/
 
 Library::Library(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
+                 const QString& author, const QDateTime& created,
+                 const ElementName& name_en_US,
                  const QString& description_en_US,
                  const QString& keywords_en_US)
   : LibraryBaseElement(getShortElementName(), getLongElementName(), uuid,
-                       version, author, name_en_US, description_en_US,
+                       version, author, created, name_en_US, description_en_US,
                        keywords_en_US),
     mManufacturer("") {
 }

--- a/libs/librepcb/core/library/library.h
+++ b/libs/librepcb/core/library/library.h
@@ -51,8 +51,8 @@ public:
   Library() = delete;
   Library(const Library& other) = delete;
   Library(const Uuid& uuid, const Version& version, const QString& author,
-          const ElementName& name_en_US, const QString& description_en_US,
-          const QString& keywords_en_US);
+          const QDateTime& created, const ElementName& name_en_US,
+          const QString& description_en_US, const QString& keywords_en_US);
   ~Library() noexcept;
 
   // Getters

--- a/libs/librepcb/core/library/librarybaseelement.cpp
+++ b/libs/librepcb/core/library/librarybaseelement.cpp
@@ -39,13 +39,11 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-LibraryBaseElement::LibraryBaseElement(const QString& shortElementName,
-                                       const QString& longElementName,
-                                       const Uuid& uuid, const Version& version,
-                                       const QString& author,
-                                       const ElementName& name_en_US,
-                                       const QString& description_en_US,
-                                       const QString& keywords_en_US)
+LibraryBaseElement::LibraryBaseElement(
+    const QString& shortElementName, const QString& longElementName,
+    const Uuid& uuid, const Version& version, const QString& author,
+    const QDateTime& created, const ElementName& name_en_US,
+    const QString& description_en_US, const QString& keywords_en_US)
   : QObject(nullptr),
     mShortElementName(shortElementName),
     mLongElementName(longElementName),
@@ -53,7 +51,7 @@ LibraryBaseElement::LibraryBaseElement(const QString& shortElementName,
     mUuid(uuid),
     mVersion(version),
     mAuthor(author),
-    mCreated(QDateTime::currentDateTime()),
+    mCreated(created),
     mIsDeprecated(false),
     mNames(name_en_US),
     mDescriptions(description_en_US),

--- a/libs/librepcb/core/library/librarybaseelement.h
+++ b/libs/librepcb/core/library/librarybaseelement.h
@@ -55,7 +55,7 @@ public:
   LibraryBaseElement(const QString& shortElementName,
                      const QString& longElementName, const Uuid& uuid,
                      const Version& version, const QString& author,
-                     const ElementName& name_en_US,
+                     const QDateTime& created, const ElementName& name_en_US,
                      const QString& description_en_US,
                      const QString& keywords_en_US);
   LibraryBaseElement(const QString& shortElementName,

--- a/libs/librepcb/core/library/libraryelement.cpp
+++ b/libs/librepcb/core/library/libraryelement.cpp
@@ -39,11 +39,12 @@ namespace librepcb {
 LibraryElement::LibraryElement(const QString& shortElementName,
                                const QString& longElementName, const Uuid& uuid,
                                const Version& version, const QString& author,
+                               const QDateTime& created,
                                const ElementName& name_en_US,
                                const QString& description_en_US,
                                const QString& keywords_en_US)
   : LibraryBaseElement(shortElementName, longElementName, uuid, version, author,
-                       name_en_US, description_en_US, keywords_en_US),
+                       created, name_en_US, description_en_US, keywords_en_US),
     mGeneratedBy() {
 }
 

--- a/libs/librepcb/core/library/libraryelement.h
+++ b/libs/librepcb/core/library/libraryelement.h
@@ -52,7 +52,7 @@ public:
   LibraryElement(const QString& shortElementName,
                  const QString& longElementName, const Uuid& uuid,
                  const Version& version, const QString& author,
-                 const ElementName& name_en_US,
+                 const QDateTime& created, const ElementName& name_en_US,
                  const QString& description_en_US,
                  const QString& keywords_en_US);
   LibraryElement(const QString& shortElementName,

--- a/libs/librepcb/core/library/org/organization.cpp
+++ b/libs/librepcb/core/library/org/organization.cpp
@@ -37,11 +37,12 @@ namespace librepcb {
  ******************************************************************************/
 
 Organization::Organization(const Uuid& uuid, const Version& version,
-                           const QString& author, const ElementName& name_en_US,
+                           const QString& author, const QDateTime& created,
+                           const ElementName& name_en_US,
                            const QString& description_en_US,
                            const QString& keywords_en_US)
   : LibraryBaseElement(getShortElementName(), getLongElementName(), uuid,
-                       version, author, name_en_US, description_en_US,
+                       version, author, created, name_en_US, description_en_US,
                        keywords_en_US),
     mLogoPng(),
     mUrl(),

--- a/libs/librepcb/core/library/org/organization.h
+++ b/libs/librepcb/core/library/org/organization.h
@@ -52,8 +52,8 @@ public:
   Organization() = delete;
   Organization(const Organization& other) = delete;
   Organization(const Uuid& uuid, const Version& version, const QString& author,
-               const ElementName& name_en_US, const QString& description_en_US,
-               const QString& keywords_en_US);
+               const QDateTime& created, const ElementName& name_en_US,
+               const QString& description_en_US, const QString& keywords_en_US);
   ~Organization() noexcept;
 
   // Getters

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -82,11 +82,13 @@ inline Package::AssemblyType deserialize(const SExpression& node) {
  ******************************************************************************/
 
 Package::Package(const Uuid& uuid, const Version& version,
-                 const QString& author, const ElementName& name_en_US,
+                 const QString& author, const QDateTime& created,
+                 const ElementName& name_en_US,
                  const QString& description_en_US,
                  const QString& keywords_en_US, AssemblyType assemblyType)
   : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US),
+                   author, created, name_en_US, description_en_US,
+                   keywords_en_US),
     mAlternativeNames(),
     mAssemblyType(assemblyType),
     mGridInterval(2540000),

--- a/libs/librepcb/core/library/pkg/package.h
+++ b/libs/librepcb/core/library/pkg/package.h
@@ -90,8 +90,9 @@ public:
   Package() = delete;
   Package(const Package& other) = delete;
   Package(const Uuid& uuid, const Version& version, const QString& author,
-          const ElementName& name_en_US, const QString& description_en_US,
-          const QString& keywords_en_US, AssemblyType assemblyType);
+          const QDateTime& created, const ElementName& name_en_US,
+          const QString& description_en_US, const QString& keywords_en_US,
+          AssemblyType assemblyType);
   ~Package() noexcept;
 
   // Getters

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -37,10 +37,11 @@ namespace librepcb {
  ******************************************************************************/
 
 Symbol::Symbol(const Uuid& uuid, const Version& version, const QString& author,
-               const ElementName& name_en_US, const QString& description_en_US,
-               const QString& keywords_en_US)
+               const QDateTime& created, const ElementName& name_en_US,
+               const QString& description_en_US, const QString& keywords_en_US)
   : LibraryElement(getShortElementName(), getLongElementName(), uuid, version,
-                   author, name_en_US, description_en_US, keywords_en_US),
+                   author, created, name_en_US, description_en_US,
+                   keywords_en_US),
     onEdited(*this),
     mGridInterval(2540000),
     mPins(),

--- a/libs/librepcb/core/library/sym/symbol.h
+++ b/libs/librepcb/core/library/sym/symbol.h
@@ -72,8 +72,8 @@ public:
   Symbol() = delete;
   Symbol(const Symbol& other) = delete;
   Symbol(const Uuid& uuid, const Version& version, const QString& author,
-         const ElementName& name_en_US, const QString& description_en_US,
-         const QString& keywords_en_US);
+         const QDateTime& created, const ElementName& name_en_US,
+         const QString& description_en_US, const QString& keywords_en_US);
   ~Symbol() noexcept;
 
   // Getters: Attributes

--- a/libs/librepcb/core/project/project.cpp
+++ b/libs/librepcb/core/project/project.cpp
@@ -48,11 +48,11 @@ namespace librepcb {
  ******************************************************************************/
 
 Project::Project(std::unique_ptr<TransactionalDirectory> directory,
-                 const QString& filename)
+                 const QString& filename, const Uuid& uuid)
   : QObject(nullptr),
     mDirectory(std::move(directory)),
     mFilename(filename),
-    mUuid(Uuid::createRandom()),
+    mUuid(uuid),
     mName("Unnamed"),
     mAuthor(),
     mVersion("v1"),
@@ -526,8 +526,8 @@ void Project::save() {
  ******************************************************************************/
 
 std::unique_ptr<Project> Project::create(
-    std::unique_ptr<TransactionalDirectory> directory,
-    const QString& filename) {
+    std::unique_ptr<TransactionalDirectory> directory, const QString& filename,
+    std::function<Uuid()> createUuid) {
   Q_ASSERT(directory);
   qDebug().nospace() << "Create project "
                      << directory->getAbsPath(filename).toNative() << "...";
@@ -552,16 +552,17 @@ std::unique_ptr<Project> Project::create(
   }
 
   // Create empty project.
-  std::unique_ptr<Project> p(new Project(std::move(directory), filename));
+  std::unique_ptr<Project> p(
+      new Project(std::move(directory), filename, createUuid()));
 
   // Add default assembly variant with name "Std".
   p->getCircuit().addAssemblyVariant(std::make_shared<AssemblyVariant>(
-      Uuid::createRandom(), FileProofName("Std"), "Standard assembly"));
+      createUuid(), FileProofName("Std"), "Standard assembly"));
 
   // Add default netclass with name "default".
   {
-    NetClass* netclass = new NetClass(p->getCircuit(), Uuid::createRandom(),
-                                      ElementName("default"));
+    NetClass* netclass =
+        new NetClass(p->getCircuit(), createUuid(), ElementName("default"));
     p->getCircuit().addNetClass(*netclass);
   }
 

--- a/libs/librepcb/core/project/project.h
+++ b/libs/librepcb/core/project/project.h
@@ -34,6 +34,8 @@
 
 #include <QtCore>
 
+#include <functional>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -81,11 +83,12 @@ public:
    *
    * @param directory     The project directory to use.
    * @param filename      The filename of the *.lpp project file.
+   * @param uuid          The UUID of the new project.
    *
    * @throw Exception     If the project could not be opened successfully
    */
   Project(std::unique_ptr<TransactionalDirectory> directory,
-          const QString& filename);
+          const QString& filename, const Uuid& uuid = Uuid::createRandom());
 
   /**
    * @brief The destructor will close the whole project (without saving!)
@@ -518,7 +521,8 @@ public:
 
   static std::unique_ptr<Project> create(
       std::unique_ptr<TransactionalDirectory> directory,
-      const QString& filename);
+      const QString& filename,
+      std::function<Uuid()> createUuid = &Uuid::createRandom);
   static bool isFilePathInsideProjectDirectory(const FilePath& fp) noexcept;
   static bool isProjectFile(const FilePath& file) noexcept;
   static bool isProjectDirectory(const FilePath& dir) noexcept;

--- a/libs/librepcb/core/serialization/sexpression.cpp
+++ b/libs/librepcb/core/serialization/sexpression.cpp
@@ -624,6 +624,7 @@ std::unique_ptr<SExpression> serialize(const QUrl& obj) {
 
 template <>
 std::unique_ptr<SExpression> serialize(const QDateTime& obj) {
+  if (!obj.isValid()) throw LogicError(__FILE__, __LINE__);
   return SExpression::createToken(obj.toUTC().toString(Qt::ISODate));
 }
 

--- a/libs/librepcb/core/utils/tangentpathjoiner.cpp
+++ b/libs/librepcb/core/utils/tangentpathjoiner.cpp
@@ -122,37 +122,39 @@ QVector<Path> TangentPathJoiner::join(QVector<Path> paths, qint64 timeoutMs,
   QElapsedTimer timer;
   timer.start();
   findAllPaths(found, paths, timer, timeoutMs, Result(), timedOut);
-  std::sort(found.begin(), found.end(),
-            [&paths](const Result& r1, const Result& r2) {
-              // Prio 1: Closed paths
-              if (r1.isClosed() != r2.isClosed()) {
-                return r1.isClosed();
-              }
-              // Prio 2: Long open paths or closed paths with a large area,
-              // to get the outest most polygons instead of polygons inside
-              // e.g. a symbol body
-              const qreal l1 = r1.calcLengthOrArea(paths);
-              const qreal l2 = r2.calcLengthOrArea(paths);
-              if (l1 != l2) {
-                return l1 > l2;
-              }
-              // Prio 3: Paths consisting of many joints
-              int c1 = r1.segments.count();
-              int c2 = r2.segments.count();
-              if (c1 != c2) {
-                return c1 > c2;
-              }
-              // Prio 4: Lower, non-reversed indices
-              for (int i = 0; i < c1; ++i) {
-                if (r1.segments.at(i).reverse != r2.segments.at(i).reverse) {
-                  return r2.segments.at(i).reverse;
-                }
-                if (r1.segments.at(i).index != r2.segments.at(i).index) {
-                  return r1.segments.at(i).index < r2.segments.at(i).index;
-                }
-              }
-              return false;
-            });
+  std::stable_sort(
+      found.begin(), found.end(), [&paths](const Result& r1, const Result& r2) {
+        // Prio 1: Closed paths
+        if (r1.isClosed() != r2.isClosed()) {
+          return r1.isClosed();
+        }
+        // Prio 2: Long open paths or closed paths with a large area,
+        // to get the outest most polygons instead of polygons inside
+        // e.g. a symbol body. Use a tolerance to avoid sub-ULP floating-point
+        // differences (accumulation order, FMA) from producing
+        // platform-dependent orderings for geometrically equivalent candidates.
+        const double l1 = r1.calcLengthOrArea(paths);
+        const double l2 = r2.calcLengthOrArea(paths);
+        if (std::abs(l1 - l2) > 50e-9) {
+          return l1 > l2;
+        }
+        // Prio 3: Paths consisting of many joints
+        int c1 = r1.segments.count();
+        int c2 = r2.segments.count();
+        if (c1 != c2) {
+          return c1 > c2;
+        }
+        // Prio 4: Lower, non-reversed indices
+        for (int i = 0; i < c1; ++i) {
+          if (r1.segments.at(i).reverse != r2.segments.at(i).reverse) {
+            return r2.segments.at(i).reverse;
+          }
+          if (r1.segments.at(i).index != r2.segments.at(i).index) {
+            return r1.segments.at(i).index < r2.segments.at(i).index;
+          }
+        }
+        return false;
+      });
 
   // Add found paths to result.
   QSet<int> consumedIndices;

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -56,9 +56,11 @@ static QString generatedBy(QString libName, QStringList keys) {
  ******************************************************************************/
 
 EagleLibraryConverterSettings::EagleLibraryConverterSettings() noexcept
-  : namePrefix(),
+  : createUuid(&Uuid::createRandom),
+    namePrefix(),
     version(Version::fromString("0.1")),
     author("EAGLE Import"),
+    created(QDateTime::currentDateTime()),
     keywords("eagle,import"),
     autoThtAnnularWidth(EagleTypeConverter::getDefaultAutoThtAnnularWidth()) {
 }
@@ -69,7 +71,9 @@ EagleLibraryConverterSettings::EagleLibraryConverterSettings() noexcept
 
 EagleLibraryConverter::EagleLibraryConverter(
     const EagleLibraryConverterSettings& settings, QObject* parent) noexcept
-  : QObject(parent), mSettings(settings) {
+  : QObject(parent),
+    mSettings(settings),
+    mTc(new EagleTypeConverter(settings.createUuid)) {
 }
 
 EagleLibraryConverter::~EagleLibraryConverter() noexcept {
@@ -114,9 +118,10 @@ std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
     throw LogicError(__FILE__, __LINE__, "Duplicate import.");
   }
   std::unique_ptr<Symbol> symbol(new Symbol(
-      Uuid::createRandom(), mSettings.version, mSettings.author,
-      C::convertElementName(mSettings.namePrefix + eagleSymbol.getName()),
-      C::convertElementDescription(eagleSymbol.getDescription()),
+      mSettings.createUuid(), mSettings.version, mSettings.author,
+      mSettings.created,
+      mTc->convertElementName(mSettings.namePrefix + eagleSymbol.getName()),
+      mTc->convertElementDescription(eagleSymbol.getDescription()),
       mSettings.keywords));
   symbol->setGeneratedBy(generatedBy(libName, {eagleSymbol.getName()}));
   symbol->setCategories(mSettings.symbolCategories);
@@ -129,38 +134,48 @@ std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
         // pins.
         const bool grabArea = !eagleSymbol.getPins().isEmpty();
         geometries +=
-            C::convertAndJoinWires(eagleSymbol.getWires(), grabArea, log);
+            mTc->convertAndJoinWires(eagleSymbol.getWires(), grabArea, log);
       },
       log);
   foreach (const auto& obj, eagleSymbol.getRectangles()) {
-    geometries.append(C::convertRectangle(obj, true));
+    geometries.append(mTc->convertRectangle(obj, true));
   }
   foreach (const auto& obj, eagleSymbol.getPolygons()) {
-    geometries.append(C::convertPolygon(obj, true));
+    geometries.append(mTc->convertPolygon(obj, true));
   }
   foreach (const auto& obj, eagleSymbol.getCircles()) {
-    geometries.append(C::convertCircle(obj, true));
+    geometries.append(mTc->convertCircle(obj, true));
   }
   foreach (const auto& obj, eagleSymbol.getFrames()) {
-    geometries.append(C::convertFrame(obj));
+    geometries.append(mTc->convertFrame(obj));
   }
   // Disable grab area on geometries located *within* another grab area to
   // avoid overlapping grab areas, but also to avoid triggering issue
   // https://github.com/LibrePCB/LibrePCB/issues/1278.
-  std::sort(geometries.begin(), geometries.end(),
-            [](const EagleTypeConverter::Geometry& a,
-               const EagleTypeConverter::Geometry& b) {
-              if (a.path.isClosed() != b.path.isClosed()) {
-                return a.path.isClosed();
-              }
-              if (a.path.isClosed()) {
-                return a.path.calcAreaOfStraightSegments() >
-                    b.path.calcAreaOfStraightSegments();
-              } else {
-                return a.path.getTotalStraightLength() >
-                    b.path.getTotalStraightLength();
-              }
-            });
+  std::stable_sort(geometries.begin(), geometries.end(),
+                   [](const EagleTypeConverter::Geometry& a,
+                      const EagleTypeConverter::Geometry& b) {
+                     if (a.path.isClosed() != b.path.isClosed()) {
+                       return a.path.isClosed();
+                     }
+                     if (a.path.isClosed()) {
+                       // Use a tolerance to avoid sub-ULP floating-point
+                       // differences (accumulation order, FMA) from producing
+                       // platform-dependent orderings for geometrically
+                       // equivalent candidates.
+                       const double a1 = a.path.calcAreaOfStraightSegments();
+                       const double a2 = b.path.calcAreaOfStraightSegments();
+                       if (std::abs(a1 - a2) > 50e-9) {
+                         return a1 > a2;
+                       }
+                     }
+                     const UnsignedLength l1 = a.path.getTotalStraightLength();
+                     const UnsignedLength l2 = b.path.getTotalStraightLength();
+                     if ((*l1 - *l2).abs() < Length(50)) {
+                       return l1 > l2;
+                     }
+                     return false;
+                   });
   QPainterPath totalGrabArea;
   totalGrabArea.setFillRule(Qt::WindingFill);
   for (EagleTypeConverter::Geometry& g : geometries) {
@@ -176,9 +191,9 @@ std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
   foreach (const auto& g, geometries) {
     tryOrLogError(
         [&]() {
-          if (auto o = C::tryConvertToSchematicCircle(g)) {
+          if (auto o = mTc->tryConvertToSchematicCircle(g)) {
             symbol->getCircles().append(o);
-          } else if (auto o = C::tryConvertToSchematicPolygon(g)) {
+          } else if (auto o = mTc->tryConvertToSchematicPolygon(g)) {
             symbol->getPolygons().append(o);
           } else {
             log.warning(tr("Skipped graphics object on layer %1 (%2).")
@@ -189,7 +204,7 @@ std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
         log);
   }
   foreach (const auto& obj, eagleSymbol.getTexts()) {
-    if (auto lpObj = C::tryConvertSchematicText(obj, true)) {
+    if (auto lpObj = mTc->tryConvertSchematicText(obj, true)) {
       symbol->getTexts().append(lpObj);
     } else {
       log.warning(tr("Skipped text on layer %1 (%2).")
@@ -200,7 +215,7 @@ std::unique_ptr<Symbol> EagleLibraryConverter::createSymbol(
   foreach (const auto& obj, eagleSymbol.getPins()) {
     tryOrLogError(
         [&]() {
-          const auto pinObj = C::convertSymbolPin(obj);
+          const auto pinObj = mTc->convertSymbolPin(obj);
           symbol->getPins().append(pinObj.pin);
           mSymbolPinMap[key][obj.getName()] = std::make_pair(
               std::make_shared<parseagle::Pin>(obj), pinObj.pin->getUuid());
@@ -225,13 +240,14 @@ std::unique_ptr<Package> EagleLibraryConverter::createPackage(
     throw LogicError(__FILE__, __LINE__, "Duplicate import.");
   }
   std::unique_ptr<Package> package(new Package(
-      Uuid::createRandom(), mSettings.version, mSettings.author,
-      C::convertElementName(mSettings.namePrefix + eaglePackage.getName()),
-      C::convertElementDescription(eaglePackage.getDescription()),
+      mSettings.createUuid(), mSettings.version, mSettings.author,
+      mSettings.created,
+      mTc->convertElementName(mSettings.namePrefix + eaglePackage.getName()),
+      mTc->convertElementDescription(eaglePackage.getDescription()),
       mSettings.keywords, librepcb::Package::AssemblyType::Auto));
   package->setGeneratedBy(generatedBy(libName, {eaglePackage.getName()}));
   package->setCategories(mSettings.packageCategories);
-  auto footprint = std::make_shared<Footprint>(Uuid::createRandom(),
+  auto footprint = std::make_shared<Footprint>(mSettings.createUuid(),
                                                ElementName("default"), "");
   package->getFootprints().append(footprint);
 
@@ -239,29 +255,29 @@ std::unique_ptr<Package> EagleLibraryConverter::createPackage(
   tryOrLogError(
       [&]() {
         geometries +=
-            C::convertAndJoinWires(eaglePackage.getWires(), false, log);
+            mTc->convertAndJoinWires(eaglePackage.getWires(), false, log);
       },
       log);
   foreach (const auto& obj, eaglePackage.getRectangles()) {
-    geometries.append(C::convertRectangle(obj, false));
+    geometries.append(mTc->convertRectangle(obj, false));
   }
   foreach (const auto& obj, eaglePackage.getPolygons()) {
-    geometries.append(C::convertPolygon(obj, false));
+    geometries.append(mTc->convertPolygon(obj, false));
   }
   foreach (const auto& obj, eaglePackage.getCircles()) {
-    geometries.append(C::convertCircle(obj, false));
+    geometries.append(mTc->convertCircle(obj, false));
   }
   foreach (const auto& g, geometries) {
     tryOrLogError(
         [&]() {
-          const auto zones = C::tryConvertToBoardZones(g);
+          const auto zones = mTc->tryConvertToBoardZones(g);
           if (!zones.isEmpty()) {
             foreach (const auto& o, zones) {
               footprint->getZones().append(o);
             }
-          } else if (auto o = C::tryConvertToBoardCircle(g)) {
+          } else if (auto o = mTc->tryConvertToBoardCircle(g)) {
             footprint->getCircles().append(o);
-          } else if (auto o = C::tryConvertToBoardPolygon(g)) {
+          } else if (auto o = mTc->tryConvertToBoardPolygon(g)) {
             footprint->getPolygons().append(o);
           } else {
             log.warning(tr("Skipped graphics object on layer %1 (%2).")
@@ -272,7 +288,7 @@ std::unique_ptr<Package> EagleLibraryConverter::createPackage(
         log);
   }
   foreach (const auto& obj, eaglePackage.getTexts()) {
-    if (auto lpObj = C::tryConvertBoardText(obj, true)) {
+    if (auto lpObj = mTc->tryConvertBoardText(obj, true)) {
       footprint->getStrokeTexts().append(lpObj);
     } else {
       log.warning(tr("Skipped text on layer %1 (%2).")
@@ -281,13 +297,13 @@ std::unique_ptr<Package> EagleLibraryConverter::createPackage(
     }
   }
   foreach (const auto& obj, eaglePackage.getHoles()) {
-    tryOrLogError([&]() { footprint->getHoles().append(C::convertHole(obj)); },
-                  log);
+    tryOrLogError(
+        [&]() { footprint->getHoles().append(mTc->convertHole(obj)); }, log);
   }
   foreach (const auto& obj, eaglePackage.getThtPads()) {
     tryOrLogError(
         [&]() {
-          auto pair = C::convertThtPad(obj, mSettings.autoThtAnnularWidth);
+          auto pair = mTc->convertThtPad(obj, mSettings.autoThtAnnularWidth);
           package->getPads().append(pair.first);
           footprint->getPads().append(pair.second);
           mPackagePadMap[key][obj.getName()] = pair.first->getUuid();
@@ -297,7 +313,7 @@ std::unique_ptr<Package> EagleLibraryConverter::createPackage(
   foreach (const auto& obj, eaglePackage.getSmtPads()) {
     tryOrLogError(
         [&]() {
-          auto pair = C::convertSmtPad(obj);
+          auto pair = mTc->convertSmtPad(obj);
           package->getPads().append(pair.first);
           footprint->getPads().append(pair.second);
           mPackagePadMap[key][obj.getName()] = pair.first->getUuid();
@@ -311,7 +327,7 @@ std::unique_ptr<Package> EagleLibraryConverter::createPackage(
       (courtyardZone->getLayers() == Zone::Layers(Zone::Layer::Top)) &&
       (courtyardZone->getRules() == Zone::Rules(Zone::Rule::NoDevices))) {
     footprint->getPolygons().append(std::make_shared<Polygon>(
-        Uuid::createRandom(), Layer::topCourtyard(), UnsignedLength(0), false,
+        mSettings.createUuid(), Layer::topCourtyard(), UnsignedLength(0), false,
         false, courtyardZone->getOutline()));
     footprint->getZones().clear();
   }
@@ -349,19 +365,21 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
     throw LogicError(__FILE__, __LINE__, "Duplicate import.");
   }
   std::unique_ptr<Component> component(new Component(
-      Uuid::createRandom(), mSettings.version, mSettings.author,
-      C::convertComponentName(mSettings.namePrefix + eagleDeviceSet.getName()),
-      C::convertElementDescription(eagleDeviceSet.getDescription()),
+      mSettings.createUuid(), mSettings.version, mSettings.author,
+      mSettings.created,
+      mTc->convertComponentName(mSettings.namePrefix +
+                                eagleDeviceSet.getName()),
+      mTc->convertElementDescription(eagleDeviceSet.getDescription()),
       mSettings.keywords));
   component->setGeneratedBy(generatedBy(libName, {eagleDeviceSet.getName()}));
   component->setCategories(mSettings.componentCategories);
   component->setPrefixes(NormDependentPrefixMap(
-      C::convertComponentPrefix(eagleDeviceSet.getPrefix())));
+      mTc->convertComponentPrefix(eagleDeviceSet.getPrefix())));
   component->setDefaultValue(eagleDeviceSet.getUserValue()
                                  ? "{{ MPN }}"
                                  : "{{ MPN or DEVICE or COMPONENT }}");
   auto symbolVariant = std::make_shared<ComponentSymbolVariant>(
-      Uuid::createRandom(), "", ElementName("default"), "");
+      mSettings.createUuid(), "", ElementName("default"), "");
   component->getSymbolVariants().append(symbolVariant);
   QHash<QString, int> pinCount;
   foreach (const auto& gate, eagleDeviceSet.getGates()) {
@@ -381,13 +399,13 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
           tr("Dependent symbol \"%1\" not imported.").arg(gate.getSymbol()));
     }
     auto item = std::make_shared<ComponentSymbolVariantItem>(
-        Uuid::createRandom(), *symbolUuid, C::convertPoint(gate.getPosition()),
-        Angle(0), true,
-        C::convertGateName(addGateSuffixes ? gate.getName() : ""));
+        mSettings.createUuid(), *symbolUuid,
+        mTc->convertPoint(gate.getPosition()), Angle(0), true,
+        mTc->convertGateName(addGateSuffixes ? gate.getName() : ""));
     symbolVariant->getSymbolItems().append(item);
     for (auto pinIt = mSymbolPinMap[symbolKey].constBegin();
          pinIt != mSymbolPinMap[symbolKey].constEnd(); pinIt++) {
-      Uuid signalUuid = Uuid::createRandom();
+      Uuid signalUuid = mSettings.createUuid();
       QString signalName = pinIt.key();
       if ((pinCount[signalName] > 1) ||
           (component->getSignals().contains(signalName))) {
@@ -411,7 +429,7 @@ std::unique_ptr<Component> EagleLibraryConverter::createComponent(
           (pinIt->first->getFunction() == parseagle::PinFunction::Clock) ||
           (pinIt->first->getFunction() == parseagle::PinFunction::DotClock);
       component->getSignals().append(std::make_shared<ComponentSignal>(
-          signalUuid, C::convertPinOrPadName(signalName), signalRole,
+          signalUuid, mTc->convertPinOrPadName(signalName), signalRole,
           forcedNetName, isRequired, isNegated, isClock));
       item->getPinSignalMap().append(
           std::make_shared<ComponentPinSignalMapItem>(pinIt->second.value(),
@@ -456,10 +474,11 @@ std::unique_ptr<Device> EagleLibraryConverter::createDevice(
                            .arg(eagleDevice.getPackage()));
   }
   std::unique_ptr<Device> device(new Device(
-      Uuid::createRandom(), mSettings.version, mSettings.author,
-      C::convertDeviceName(mSettings.namePrefix + eagleDeviceSet.getName(),
-                           eagleDevice.getName()),
-      C::convertElementDescription(eagleDeviceSet.getDescription()),
+      mSettings.createUuid(), mSettings.version, mSettings.author,
+      mSettings.created,
+      mTc->convertDeviceName(mSettings.namePrefix + eagleDeviceSet.getName(),
+                             eagleDevice.getName()),
+      mTc->convertElementDescription(eagleDeviceSet.getDescription()),
       mSettings.keywords, *componentUuid, *packageUuid));
   device->setGeneratedBy(generatedBy(
       devLibName, {eagleDeviceSet.getName(), eagleDevice.getName()}));
@@ -479,9 +498,9 @@ std::unique_ptr<Device> EagleLibraryConverter::createDevice(
   }
   foreach (const auto& eagleTechnology, eagleDevice.getTechnologies()) {
     AttributeList attributes;
-    C::tryConvertAttributes(eagleTechnology.getAttributes(), attributes, log);
+    mTc->tryConvertAttributes(eagleTechnology.getAttributes(), attributes, log);
     SimpleString mpn(""), manufacturer("");
-    C::tryExtractMpnAndManufacturer(attributes, mpn, manufacturer);
+    mTc->tryExtractMpnAndManufacturer(attributes, mpn, manufacturer);
     if (mpn->isEmpty()) {
       mpn = cleanSimpleString(eagleTechnology.getName());  // Good idea or not?
     }

--- a/libs/librepcb/eagleimport/eaglelibraryconverter.h
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.h
@@ -29,6 +29,7 @@
 
 #include <QtCore>
 
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -54,6 +55,8 @@ class Symbol;
 
 namespace eagleimport {
 
+class EagleTypeConverter;
+
 /*******************************************************************************
  *  Struct EagleLibraryConverterSettings
  ******************************************************************************/
@@ -64,9 +67,11 @@ namespace eagleimport {
 struct EagleLibraryConverterSettings final {
   EagleLibraryConverterSettings() noexcept;
 
+  std::function<Uuid()> createUuid;
   QString namePrefix;
   Version version;
   QString author;
+  QDateTime created;
   QString keywords;
   QSet<Uuid> symbolCategories;
   QSet<Uuid> packageCategories;
@@ -124,8 +129,9 @@ public:
 private:  // Methods
   void tryOrLogError(std::function<void()> func, MessageLogger& log);
 
-private:  // Data
+private:
   EagleLibraryConverterSettings mSettings;
+  std::unique_ptr<EagleTypeConverter> mTc;
 
   // State
 

--- a/libs/librepcb/eagleimport/eaglelibraryimport.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryimport.cpp
@@ -47,9 +47,11 @@ namespace eagleimport {
  ******************************************************************************/
 
 EagleLibraryImport::EagleLibraryImport(const FilePath& dstLibFp,
+                                       std::function<Uuid()> createUuid,
                                        QObject* parent) noexcept
   : QThread(parent),
     mDestinationLibraryFp(dstLibFp),
+    mCreateUuid(createUuid),
     mSettings(new EagleLibraryConverterSettings()),
     mLogger(new MessageLogger(true)),
     mAbort(false) {
@@ -156,6 +158,7 @@ QStringList EagleLibraryImport::open(const FilePath& lbr) {
 
   try {
     parseagle::Library lib(lbr.toStr(), &errors);
+    EagleTypeConverter tc(mCreateUuid);
 
     foreach (const parseagle::Symbol& symbol, lib.getSymbols()) {
       mSymbols.append(Symbol{
@@ -180,8 +183,7 @@ QStringList EagleLibraryImport::open(const FilePath& lbr) {
       foreach (const parseagle::Gate& gate, deviceSet.getGates()) {
         symbolDisplayNames.insert(gate.getSymbol());
       }
-      const QString cmpName =
-          *EagleTypeConverter::convertComponentName(deviceSet.getName());
+      const QString cmpName = *tc.convertComponentName(deviceSet.getName());
       mComponents.append(Component{
           cmpName,
           deviceSet.getDescription(),
@@ -191,8 +193,7 @@ QStringList EagleLibraryImport::open(const FilePath& lbr) {
       });
       foreach (const parseagle::Device& device, deviceSet.getDevices()) {
         mDevices.append(Device{
-            *EagleTypeConverter::convertDeviceName(deviceSet.getName(),
-                                                   device.getName()),
+            *tc.convertDeviceName(deviceSet.getName(), device.getName()),
             deviceSet.getDescription(),
             Qt::Unchecked,
             cmpName,

--- a/libs/librepcb/eagleimport/eaglelibraryimport.h
+++ b/libs/librepcb/eagleimport/eaglelibraryimport.h
@@ -95,6 +95,7 @@ public:
   // Constructors / Destructor
   EagleLibraryImport(const EagleLibraryImport& other) = delete;
   EagleLibraryImport(const FilePath& dstLibFp,
+                     std::function<Uuid()> createUuid = &Uuid::createRandom,
                      QObject* parent = nullptr) noexcept;
   ~EagleLibraryImport() noexcept;
 
@@ -153,6 +154,7 @@ private:  // Methods
 
 private:  // Data
   const FilePath mDestinationLibraryFp;
+  std::function<Uuid()> mCreateUuid;
   QScopedPointer<EagleLibraryConverterSettings> mSettings;
   std::shared_ptr<MessageLogger> mLogger;
 

--- a/libs/librepcb/eagleimport/eagleprojectimport.cpp
+++ b/libs/librepcb/eagleimport/eagleprojectimport.cpp
@@ -87,8 +87,15 @@ using C = EagleTypeConverter;
  *  Constructors / Destructor
  ******************************************************************************/
 
-EagleProjectImport::EagleProjectImport(QObject* parent) noexcept
-  : QObject(parent), mLogger(new MessageLogger(true)) {
+EagleProjectImport::EagleProjectImport(std::function<Uuid()> createUuid,
+                                       const QDateTime& created,
+                                       QObject* parent) noexcept
+  : QObject(parent),
+    mCreateUuid(createUuid),
+    mCreatedDateTime(created),
+    mTc(new EagleTypeConverter(createUuid)),
+    mLogger(new MessageLogger(true)) {
+  Q_ASSERT(mCreateUuid);
 }
 
 EagleProjectImport::~EagleProjectImport() noexcept {
@@ -173,6 +180,8 @@ void EagleProjectImport::import(Project& project) {
     // Try to apply the automatic THT annular width to get correct pad sizes in
     // footprints.
     EagleLibraryConverterSettings settings;
+    settings.createUuid = mCreateUuid;
+    settings.created = mCreatedDateTime;
     try {
       if (auto r = tryGetDrcRatio("rvPadBottom", "rlMinPadBottom",
                                   "rlMaxPadBottom")) {
@@ -197,21 +206,21 @@ void EagleProjectImport::import(Project& project) {
       if (name.isEmpty()) {
         name = libCmp.getUuid().toStr().left(8);  // Not so nice...
       }
-      ComponentInstance* cmp = new ComponentInstance(
-          project.getCircuit(), Uuid::createRandom(), libCmp,
-          symbVar->getUuid(), CircuitIdentifier(name));
+      ComponentInstance* cmp =
+          new ComponentInstance(project.getCircuit(), mCreateUuid(), libCmp,
+                                symbVar->getUuid(), CircuitIdentifier(name));
       if (!part.getValue().isEmpty()) {
         cmp->setValue(part.getValue());
       }
       AttributeList attributes = cmp->getAttributes();
-      C::tryConvertAttributes(part.getAttributes(), attributes, log);
+      mTc->tryConvertAttributes(part.getAttributes(), attributes, log);
       auto eagleDevSet = getDeviceSet(part.getLibrary(), part.getLibraryUrn(),
                                       part.getDeviceSet());
       const parseagle::Device eagleDev =
           getDevice(*eagleDevSet, part.getDevice());
       if (const parseagle::Technology* eagleTech =
               tryGetTechnology(eagleDev, part.getTechnology())) {
-        C::tryConvertAttributes(eagleTech->getAttributes(), attributes, log);
+        mTc->tryConvertAttributes(eagleTech->getAttributes(), attributes, log);
         if ((!attributes.contains("MPN")) &&
             (!attributes.contains("MANUFACTURER_PART_NUMBER")) &&
             (!attributes.contains("PART_NUMBER")) &&
@@ -413,14 +422,14 @@ void EagleProjectImport::importSchematic(Project& project,
   Schematic* schematic = new librepcb::Schematic(
       project,
       std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory()),
-      dirName, Uuid::createRandom(),
+      dirName, mCreateUuid(),
       ElementName(name));  // can throw
   project.addSchematic(*schematic);
 
   // Grid settings
   PositiveLength gridInterval = schematic->getGridInterval();
   LengthUnit gridUnit = schematic->getGridUnit();
-  C::convertGrid(mSchematic->getGrid(), gridInterval, gridUnit);
+  mTc->convertGrid(mSchematic->getGrid(), gridInterval, gridUnit);
   schematic->setGridInterval(gridInterval);
   schematic->setGridUnit(gridUnit);
 
@@ -442,11 +451,11 @@ void EagleProjectImport::importSchematic(Project& project,
     }
     const bool mirror = eagleInst.getRotation().getMirror();
     const Angle rotation =
-        C::convertAngle(mirror ? -eagleInst.getRotation().getAngle()
-                               : eagleInst.getRotation().getAngle());
+        mTc->convertAngle(mirror ? -eagleInst.getRotation().getAngle()
+                                 : eagleInst.getRotation().getAngle());
     SI_Symbol* symInst =
-        new SI_Symbol(*schematic, Uuid::createRandom(), *cmpInst, *gateIt,
-                      C::convertPoint(eagleInst.getPosition()), rotation,
+        new SI_Symbol(*schematic, mCreateUuid(), *cmpInst, *gateIt,
+                      mTc->convertPoint(eagleInst.getPosition()), rotation,
                       mirror, !eagleInst.getSmashed());
     if (eagleInst.getSmashed()) {
       foreach (const parseagle::Attribute& eagleAttr,
@@ -455,7 +464,7 @@ void EagleProjectImport::importSchematic(Project& project,
           continue;
         }
         try {
-          if (auto lpObj = C::tryConvertSchematicAttribute(eagleAttr)) {
+          if (auto lpObj = mTc->tryConvertSchematicAttribute(eagleAttr)) {
             SI_Text* obj = new SI_Text(*schematic, *lpObj);
             symInst->addText(*obj);
           } else {
@@ -488,24 +497,24 @@ void EagleProjectImport::importSchematic(Project& project,
   // Geometry
   QList<C::Geometry> geometries;
   try {
-    geometries += C::convertAndJoinWires(sheet.getWires(), true, log);
+    geometries += mTc->convertAndJoinWires(sheet.getWires(), true, log);
   } catch (const Exception& e) {
     log.warning(QString("Failed to join wires: %1").arg(e.getMsg()));
   }
   foreach (const parseagle::Rectangle& eagleObj, sheet.getRectangles()) {
-    geometries.append(C::convertRectangle(eagleObj, true));
+    geometries.append(mTc->convertRectangle(eagleObj, true));
   }
   foreach (const parseagle::Polygon& eagleObj, sheet.getPolygons()) {
-    geometries.append(C::convertPolygon(eagleObj, true));
+    geometries.append(mTc->convertPolygon(eagleObj, true));
   }
   foreach (const parseagle::Circle& eagleObj, sheet.getCircles()) {
-    geometries.append(C::convertCircle(eagleObj, true));
+    geometries.append(mTc->convertCircle(eagleObj, true));
   }
   foreach (const parseagle::Frame& eagleObj, sheet.getFrames()) {
-    geometries.append(C::convertFrame(eagleObj));
+    geometries.append(mTc->convertFrame(eagleObj));
   }
   foreach (const auto& g, geometries) {
-    if (auto o = C::tryConvertToSchematicPolygon(g)) {
+    if (auto o = mTc->tryConvertToSchematicPolygon(g)) {
       o->setIsGrabArea(g.grabArea && o->isFilled());
       SI_Polygon* obj = new SI_Polygon(*schematic, *o);
       schematic->addPolygon(*obj);
@@ -519,7 +528,7 @@ void EagleProjectImport::importSchematic(Project& project,
   // Texts
   foreach (const parseagle::Text& eagleObj, sheet.getTexts()) {
     try {
-      if (auto lpObj = C::tryConvertSchematicText(eagleObj, false)) {
+      if (auto lpObj = mTc->tryConvertSchematicText(eagleObj, false)) {
         SI_Text* obj = new SI_Text(*schematic, *lpObj);
         schematic->addText(*obj);
       } else {
@@ -540,8 +549,8 @@ void EagleProjectImport::importSchematic(Project& project,
     for (const parseagle::Segment& eagleSegment : eagleNet.getSegments()) {
       for (const parseagle::Wire& eagleWire : eagleSegment.getWires()) {
         if (eagleWire.getP1() == eagleWire.getP2()) continue;
-        netWireEndpoints.insert(C::convertPoint(eagleWire.getP1()));
-        netWireEndpoints.insert(C::convertPoint(eagleWire.getP2()));
+        netWireEndpoints.insert(mTc->convertPoint(eagleWire.getP1()));
+        netWireEndpoints.insert(mTc->convertPoint(eagleWire.getP2()));
       }
     }
   }
@@ -552,14 +561,14 @@ void EagleProjectImport::importSchematic(Project& project,
       Bus& bus = importBus(project, eagleBus.getName());
       for (const parseagle::Segment& eagleSeg : eagleBus.getSegments()) {
         std::unique_ptr<SI_BusSegment> busSegment(
-            new SI_BusSegment(*schematic, Uuid::createRandom(), bus));
+            new SI_BusSegment(*schematic, mCreateUuid(), bus));
 
         QHash<Point, SI_BusJunction*> junctionMap;
         auto getOrCreateJunction = [&](const Point& pos) {
           auto it = junctionMap.find(pos);
           if (it == junctionMap.end()) {
             SI_BusJunction* j =
-                new SI_BusJunction(*busSegment, Uuid::createRandom(), pos);
+                new SI_BusJunction(*busSegment, mCreateUuid(), pos);
             it = junctionMap.insert(pos, j);
           }
           return *it;
@@ -567,8 +576,8 @@ void EagleProjectImport::importSchematic(Project& project,
 
         QList<SI_BusLine*> lines;
         for (const parseagle::Wire& wire : eagleSeg.getWires()) {
-          const Point p1 = C::convertPoint(wire.getP1());
-          const Point p2 = C::convertPoint(wire.getP2());
+          const Point p1 = mTc->convertPoint(wire.getP1());
+          const Point p2 = mTc->convertPoint(wire.getP2());
           if (p1 == p2) continue;
 
           if (wire.getWireStyle() != parseagle::WireStyle::Continuous) {
@@ -601,8 +610,8 @@ void EagleProjectImport::importSchematic(Project& project,
           for (int i = 0; i < pathPoints.count() - 1; ++i) {
             SI_BusJunction* a = getOrCreateJunction(pathPoints.at(i));
             SI_BusJunction* b = getOrCreateJunction(pathPoints.at(i + 1));
-            lines.append(new SI_BusLine(*busSegment, Uuid::createRandom(), *a,
-                                        *b, SI_BusLine::getDefaultWidth()));
+            lines.append(new SI_BusLine(*busSegment, mCreateUuid(), *a, *b,
+                                        SI_BusLine::getDefaultWidth()));
           }
         }
 
@@ -615,12 +624,12 @@ void EagleProjectImport::importSchematic(Project& project,
 
         for (const parseagle::Label& eagleLabel : eagleSeg.getLabels()) {
           const Angle rot =
-              C::convertAngle(eagleLabel.getRotation().getAngle());
+              mTc->convertAngle(eagleLabel.getRotation().getAngle());
           const bool mirror = eagleLabel.getRotation().getMirror();
-          const Point pos = C::convertPoint(eagleLabel.getPosition());
+          const Point pos = mTc->convertPoint(eagleLabel.getPosition());
           SI_BusLabel* busLabel = new SI_BusLabel(
               *busSegment,
-              NetLabel(Uuid::createRandom(), pos, mirror ? -rot : rot, mirror));
+              NetLabel(mCreateUuid(), pos, mirror ? -rot : rot, mirror));
           busSegment->addLabel(*busLabel);
         }
         busSegment->addJunctionsAndLines(junctionMap.values(), lines);
@@ -684,9 +693,8 @@ void EagleProjectImport::importSchematic(Project& project,
           if (it != anchorMap.end()) {
             // There's another pin on the same position -> add a netline to
             // connect them since EAGLE implicitly consider them as connected.
-            splitter.addNetLine(NetLine(Uuid::createRandom(),
-                                        SI_NetLine::getDefaultWidth(), *it,
-                                        pinAnchor));
+            splitter.addNetLine(NetLine(
+                mCreateUuid(), SI_NetLine::getDefaultWidth(), *it, pinAnchor));
           }
           anchorMap.insert(symbolPin->getPosition(), pinAnchor);
         }
@@ -706,10 +714,11 @@ void EagleProjectImport::importSchematic(Project& project,
         }
 
         // Convert wires.
-        auto getOrCreateAnchor = [&anchorMap, &splitter](const Point& pos) {
+        auto getOrCreateAnchor = [this, &anchorMap,
+                                  &splitter](const Point& pos) {
           auto it = anchorMap.find(pos);
           if (it == anchorMap.end()) {
-            const Junction junction(Uuid::createRandom(), pos);
+            const Junction junction(mCreateUuid(), pos);
             splitter.addJunction(junction);
             it = anchorMap.insert(pos,
                                   NetLineAnchor::junction(junction.getUuid()));
@@ -721,10 +730,14 @@ void EagleProjectImport::importSchematic(Project& project,
           if (eagleWire.getP1() == eagleWire.getP2()) {
             continue;
           }
+          // Evaluate anchors in separate statements to ensure a deterministic
+          // order of mCreateUuid() calls across compilers/platforms.
+          const NetLineAnchor p1 =
+              getOrCreateAnchor(mTc->convertPoint(eagleWire.getP1()));
+          const NetLineAnchor p2 =
+              getOrCreateAnchor(mTc->convertPoint(eagleWire.getP2()));
           splitter.addNetLine(
-              NetLine(Uuid::createRandom(), SI_NetLine::getDefaultWidth(),
-                      getOrCreateAnchor(C::convertPoint(eagleWire.getP1())),
-                      getOrCreateAnchor(C::convertPoint(eagleWire.getP2()))));
+              NetLine(mCreateUuid(), SI_NetLine::getDefaultWidth(), p1, p2));
           if (eagleWire.getWireStyle() != parseagle::WireStyle::Continuous) {
             log.warning(
                 tr("Dashed/dotted line is not supported, converting to "
@@ -737,9 +750,9 @@ void EagleProjectImport::importSchematic(Project& project,
         }
         foreach (const parseagle::Label& eagleLabel, eagleSegment.getLabels()) {
           const Angle rot =
-              C::convertAngle(eagleLabel.getRotation().getAngle());
+              mTc->convertAngle(eagleLabel.getRotation().getAngle());
           const bool mirror = eagleLabel.getRotation().getMirror();
-          Point pos = C::convertPoint(eagleLabel.getPosition());
+          Point pos = mTc->convertPoint(eagleLabel.getPosition());
           if (eagleLabel.getXref()) {
             pos += Point(mirror ? -254000 : 254000, -1270000)
                        .rotated(mirror ? -rot : rot);
@@ -748,7 +761,7 @@ void EagleProjectImport::importSchematic(Project& project,
                    "normal net label."));
           }
           splitter.addNetLabel(
-              NetLabel(Uuid::createRandom(), pos, mirror ? -rot : rot, mirror));
+              NetLabel(mCreateUuid(), pos, mirror ? -rot : rot, mirror));
         }
       }
 
@@ -773,7 +786,7 @@ void EagleProjectImport::importSchematic(Project& project,
       };
       foreach (const auto& segment, splitter.split()) {
         SI_NetSegment* netSegment =
-            new SI_NetSegment(*schematic, Uuid::createRandom(), netSignal);
+            new SI_NetSegment(*schematic, mCreateUuid(), netSignal);
         schematic->addNetSegment(*netSegment);
         QList<SI_NetPoint*> netPoints;
         QList<SI_NetLine*> netLines;
@@ -806,9 +819,9 @@ NetSignal& EagleProjectImport::importNet(Project& project,
                                          const parseagle::Net& net) {
   auto it = mNetSignalMap.find(net.getName());
   if (it == mNetSignalMap.end()) {
-    const Uuid uuid = Uuid::createRandom();
+    const Uuid uuid = mCreateUuid();
     QString name =
-        C::convertInversionSyntax(cleanCircuitIdentifier(net.getName()));
+        mTc->convertInversionSyntax(cleanCircuitIdentifier(net.getName()));
     if (name.isEmpty()) {
       name = uuid.toStr().left(8);
     } else if (project.getCircuit().getNetSignalByName(name)) {
@@ -833,7 +846,7 @@ Bus& EagleProjectImport::importBus(Project& project,
                                    const QString& eagleBusName) {
   auto it = mBusMap.find(eagleBusName);
   if (it == mBusMap.end()) {
-    const Uuid uuid = Uuid::createRandom();
+    const Uuid uuid = mCreateUuid();
     // Eagle bus names use format "ALIAS" or "ALIAS:net1,net2" or
     // "ALIAS:net[i..j]" where "ALIAS:" is optional. If present, use it as name.
     QString name = cleanBusName(eagleBusName.split(":").first());
@@ -859,21 +872,21 @@ void EagleProjectImport::importBoard(Project& project,
   Board* board = new librepcb::Board(
       project,
       std::unique_ptr<TransactionalDirectory>(new TransactionalDirectory()),
-      "default", Uuid::createRandom(),
+      "default", mCreateUuid(),
       ElementName("default"));  // can throw
   project.addBoard(*board);
 
   // Grid settings
   PositiveLength gridInterval = board->getGridInterval();
   LengthUnit gridUnit = board->getGridUnit();
-  C::convertGrid(mBoard->getGrid(), gridInterval, gridUnit);
+  mTc->convertGrid(mBoard->getGrid(), gridInterval, gridUnit);
   board->setGridInterval(gridInterval);
   board->setGridUnit(gridUnit);
 
   // Layer setup
   QHash<const Layer*, const Layer*> copperLayerMap;
   if (auto p = mBoard->getDesignRules().tryGetParam("layerSetup")) {
-    copperLayerMap = C::convertLayerSetup(p->getValue());
+    copperLayerMap = mTc->convertLayerSetup(p->getValue());
   }
   copperLayerMap.insert(&Layer::topCopper(), &Layer::topCopper());
   copperLayerMap.insert(&Layer::botCopper(), &Layer::botCopper());
@@ -890,10 +903,10 @@ void EagleProjectImport::importBoard(Project& project,
     r.setPadCmpSideAutoAnnularRing(false);  // Not sure if EAGLE supports this.
     r.setPadInnerAutoAnnularRing(true);  // Not sure if EAGLE supports this.
     if (auto p = mBoard->getDesignRules().tryGetParam("mdCopperDimension")) {
-      copperBoardDistance = C::convertParamTo<UnsignedLength>(*p);
+      copperBoardDistance = mTc->convertParamTo<UnsignedLength>(*p);
     }
     if (auto p = mBoard->getDesignRules().tryGetParam("mlViaStopLimit")) {
-      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      const auto value = mTc->convertParamTo<UnsignedLength>(*p);
       r.setStopMaskMaxViaDiameter(value);
     }
     if (board->getInnerLayerCount() > 0) {
@@ -937,29 +950,29 @@ void EagleProjectImport::importBoard(Project& project,
   try {
     BoardDesignRuleCheckSettings s = board->getDrcSettings();
     if (auto p = mBoard->getDesignRules().tryGetParam("mdWireWire")) {
-      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      const auto value = mTc->convertParamTo<UnsignedLength>(*p);
       s.setMinCopperCopperClearance(value);
     }
     if (auto p = mBoard->getDesignRules().tryGetParam("mdCopperDimension")) {
-      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      const auto value = mTc->convertParamTo<UnsignedLength>(*p);
       s.setMinCopperBoardClearance(value);
       s.setMinCopperNpthClearance(value);
     }
     if (auto p = mBoard->getDesignRules().tryGetParam("mdDrill")) {
-      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      const auto value = mTc->convertParamTo<UnsignedLength>(*p);
       s.setMinDrillDrillClearance(value);
       s.setMinDrillBoardClearance(value);
     }
     if (auto p = mBoard->getDesignRules().tryGetParam("msWidth")) {
-      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      const auto value = mTc->convertParamTo<UnsignedLength>(*p);
       s.setMinCopperWidth(value);
     }
     if (auto p = mBoard->getDesignRules().tryGetParam("rlMinViaInner")) {
-      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      const auto value = mTc->convertParamTo<UnsignedLength>(*p);
       s.setMinPthAnnularRing(value);
     }
     if (auto p = mBoard->getDesignRules().tryGetParam("msDrill")) {
-      const auto value = C::convertParamTo<UnsignedLength>(*p);
+      const auto value = mTc->convertParamTo<UnsignedLength>(*p);
       s.setMinNpthDrillDiameter(value);
       s.setMinPthDrillDiameter(value);
     }
@@ -993,12 +1006,14 @@ void EagleProjectImport::importBoard(Project& project,
                             cmpIt->libUrn, cmpIt->devSetName, cmpIt->devName,
                             eagleElem.getLibrary(), eagleElem.getLibraryUrn());
     const bool mirror = eagleElem.getRotation().getMirror();
-    const Angle rotation = C::convertAngle(eagleElem.getRotation().getAngle());
-    BI_Device* devInst = new BI_Device(
-        *board, *cmpInst, libDev.getUuid(),
-        libPkg.getFootprints().first()->getUuid(),
-        C::convertPoint(eagleElem.getPosition()), mirror ? -rotation : rotation,
-        mirror, eagleElem.getLocked(), true, !eagleElem.getSmashed());
+    const Angle rotation =
+        mTc->convertAngle(eagleElem.getRotation().getAngle());
+    BI_Device* devInst =
+        new BI_Device(*board, *cmpInst, libDev.getUuid(),
+                      libPkg.getFootprints().first()->getUuid(),
+                      mTc->convertPoint(eagleElem.getPosition()),
+                      mirror ? -rotation : rotation, mirror,
+                      eagleElem.getLocked(), true, !eagleElem.getSmashed());
     board->addDeviceInstance(*devInst);
 
     // Add stroke texts.
@@ -1009,7 +1024,7 @@ void EagleProjectImport::importBoard(Project& project,
           continue;
         }
         try {
-          if (auto lpObj = C::tryConvertBoardAttribute(eagleAttr)) {
+          if (auto lpObj = mTc->tryConvertBoardAttribute(eagleAttr)) {
             BI_StrokeText* obj = new BI_StrokeText(
                 *board,
                 BoardStrokeTextData(
@@ -1057,7 +1072,7 @@ void EagleProjectImport::importBoard(Project& project,
           project.getCircuit().getAssemblyVariants().getUuidSet());
     }
     SimpleString mpn(""), manufacturer("");
-    C::tryExtractMpnAndManufacturer(attributes, mpn, manufacturer);
+    mTc->tryExtractMpnAndManufacturer(attributes, mpn, manufacturer);
     if (!mpn->isEmpty()) {
       // Convert attributes to a Part.
       assemblyOption->getParts().append(
@@ -1070,21 +1085,21 @@ void EagleProjectImport::importBoard(Project& project,
   // Geometry
   QList<C::Geometry> geometries;
   try {
-    geometries += C::convertAndJoinWires(mBoard->getWires(), true, log);
+    geometries += mTc->convertAndJoinWires(mBoard->getWires(), true, log);
   } catch (const Exception& e) {
     log.warning(QString("Failed to join wires: %1").arg(e.getMsg()));
   }
   foreach (const parseagle::Rectangle& eagleObj, mBoard->getRectangles()) {
-    geometries.append(C::convertRectangle(eagleObj, true));
+    geometries.append(mTc->convertRectangle(eagleObj, true));
   }
   foreach (const parseagle::Polygon& eagleObj, mBoard->getPolygons()) {
-    geometries.append(C::convertPolygon(eagleObj, true));
+    geometries.append(mTc->convertPolygon(eagleObj, true));
   }
   foreach (const parseagle::Circle& eagleObj, mBoard->getCircles()) {
-    geometries.append(C::convertCircle(eagleObj, true));
+    geometries.append(mTc->convertCircle(eagleObj, true));
   }
   foreach (const auto& g, geometries) {
-    const auto zones = C::tryConvertToBoardZones(g);
+    const auto zones = mTc->tryConvertToBoardZones(g);
     if (!zones.isEmpty()) {
       foreach (const auto zone, zones) {
         QSet<const Layer*> layers;
@@ -1105,7 +1120,7 @@ void EagleProjectImport::importBoard(Project& project,
                                       zone->getOutline(), false));
         board->addZone(*obj);
       }
-    } else if (auto o = C::tryConvertToBoardPolygon(g)) {
+    } else if (auto o = mTc->tryConvertToBoardPolygon(g)) {
       o->setIsGrabArea(g.grabArea && o->isFilled());
       BI_Polygon* obj = new BI_Polygon(
           *board,
@@ -1123,7 +1138,7 @@ void EagleProjectImport::importBoard(Project& project,
   // Texts
   foreach (const parseagle::Text& eagleObj, mBoard->getTexts()) {
     try {
-      if (auto lpObj = C::tryConvertBoardText(eagleObj, false)) {
+      if (auto lpObj = mTc->tryConvertBoardText(eagleObj, false)) {
         BI_StrokeText* obj = new BI_StrokeText(
             *board,
             BoardStrokeTextData(
@@ -1147,7 +1162,7 @@ void EagleProjectImport::importBoard(Project& project,
   // Holes
   foreach (const parseagle::Hole& eagleObj, mBoard->getHoles()) {
     try {
-      std::shared_ptr<Hole> lpObj = C::convertHole(eagleObj);
+      std::shared_ptr<Hole> lpObj = mTc->convertHole(eagleObj);
       BI_Hole* obj = new BI_Hole(
           *board,
           BoardHoleData(lpObj->getUuid(), lpObj->getDiameter(),
@@ -1201,8 +1216,8 @@ void EagleProjectImport::importBoard(Project& project,
         const bool validLayers = eagleVia.tryGetStartLayer(startLayerId) &&
             eagleVia.tryGetEndLayer(endLayerId);
         const Layer* startLayer =
-            mapLayer(C::tryConvertBoardLayer(startLayerId));
-        const Layer* endLayer = mapLayer(C::tryConvertBoardLayer(endLayerId));
+            mapLayer(mTc->tryConvertBoardLayer(startLayerId));
+        const Layer* endLayer = mapLayer(mTc->tryConvertBoardLayer(endLayerId));
         if ((!validLayers) || (!startLayer) || (!endLayer) ||
             (!startLayer->isCopper()) || (!endLayer->isCopper()) ||
             (startLayer->getCopperNumber() > endLayer->getCopperNumber())) {
@@ -1211,8 +1226,8 @@ void EagleProjectImport::importBoard(Project& project,
                                  .arg(eagleVia.getExtent()));
         }
         const PositiveLength drillDiameter(
-            C::convertLength(eagleVia.getDrill()));
-        const Length sizeRaw = C::convertLength(eagleVia.getDiameter());
+            mTc->convertLength(eagleVia.getDrill()));
+        const Length sizeRaw = mTc->convertLength(eagleVia.getDiameter());
         std::optional<PositiveLength> size;
         if (sizeRaw >= *drillDiameter) {
           size = PositiveLength(sizeRaw);
@@ -1231,8 +1246,8 @@ void EagleProjectImport::importBoard(Project& project,
               tr("Square/octagon via shape not supported, converting to "
                  "circular."));
         }
-        const Via via(Uuid::createRandom(), *startLayer, *endLayer,
-                      C::convertPoint(eagleVia.getPosition()), drillDiameter,
+        const Via via(mCreateUuid(), *startLayer, *endLayer,
+                      mTc->convertPoint(eagleVia.getPosition()), drillDiameter,
                       size, stopMaskConfig);
         splitter.addVia(via, false);
         const TraceAnchor viaAnchor = TraceAnchor::via(via.getUuid());
@@ -1240,8 +1255,9 @@ void EagleProjectImport::importBoard(Project& project,
       }
 
       // Convert traces.
-      auto getOrCreateAnchor = [&padMap, &anchorMap, &splitter, netSignal](
-                                   const Layer& layer, const Point& pos) {
+      auto getOrCreateAnchor = [this, &padMap, &anchorMap, &splitter,
+                                netSignal](const Layer& layer,
+                                           const Point& pos) {
         // Find via.
         auto it = anchorMap.find(std::make_pair(nullptr, pos));
         // Find net point.
@@ -1269,7 +1285,7 @@ void EagleProjectImport::importBoard(Project& project,
         }
         // Find or add net point.
         if (it == anchorMap.end()) {
-          const Junction junction(Uuid::createRandom(), pos);
+          const Junction junction(mCreateUuid(), pos);
           splitter.addJunction(junction);
           it = anchorMap.insert(std::make_pair(&layer, pos),
                                 TraceAnchor::junction(junction.getUuid()));
@@ -1286,16 +1302,16 @@ void EagleProjectImport::importBoard(Project& project,
           continue;
         }
         const Layer* layer =
-            mapLayer(C::tryConvertBoardLayer(eagleWire.getLayer()));
+            mapLayer(mTc->tryConvertBoardLayer(eagleWire.getLayer()));
         if ((!layer) || (!layer->isCopper())) {
           log.critical(QString("Skipped trace on invalid layer: %1")
                            .arg(eagleWire.getLayer()));
           continue;
         }
         const TraceAnchor p1 =
-            getOrCreateAnchor(*layer, C::convertPoint(eagleWire.getP1()));
+            getOrCreateAnchor(*layer, mTc->convertPoint(eagleWire.getP1()));
         const TraceAnchor p2 =
-            getOrCreateAnchor(*layer, C::convertPoint(eagleWire.getP2()));
+            getOrCreateAnchor(*layer, mTc->convertPoint(eagleWire.getP2()));
         if (p1 == p2) {
           log.info("Attaching a trace to a pad removed a short trace segment.");
           continue;
@@ -1314,8 +1330,8 @@ void EagleProjectImport::importBoard(Project& project,
               tr("Curved trace is not supported, converting to straight."));
         }
         splitter.addTrace(Trace(
-            Uuid::createRandom(), *layer,
-            PositiveLength(C::convertLength(eagleWire.getWidth())), p1, p2));
+            mCreateUuid(), *layer,
+            PositiveLength(mTc->convertLength(eagleWire.getWidth())), p1, p2));
       }
 
       // Determine segments and add them to the board.
@@ -1339,7 +1355,7 @@ void EagleProjectImport::importBoard(Project& project,
       };
       foreach (const auto& segment, splitter.split()) {
         BI_NetSegment* netSegment =
-            new BI_NetSegment(*board, Uuid::createRandom(), netSignal);
+            new BI_NetSegment(*board, mCreateUuid(), netSignal);
         board->addNetSegment(*netSegment);
         QList<BI_Pad*> pads;
         QList<BI_Via*> vias;
@@ -1372,28 +1388,28 @@ void EagleProjectImport::importBoard(Project& project,
     foreach (const parseagle::Polygon& eagleObj, eagleSignal.getPolygons()) {
       try {
         const Layer* layer =
-            mapLayer(C::tryConvertBoardLayer(eagleObj.getLayer()));
+            mapLayer(mTc->tryConvertBoardLayer(eagleObj.getLayer()));
         if ((!layer) || (!layer->isCopper())) {
           throw RuntimeError(__FILE__, __LINE__, "Plane not on copper layer.");
         }
         if (eagleObj.getPour() == parseagle::PolygonPour::Cutout) {
-          const Path path = C::convertVertices(eagleObj.getVertices(), false);
-          const Length lineWidth = C::convertLength(eagleObj.getWidth());
+          const Path path = mTc->convertVertices(eagleObj.getVertices(), false);
+          const Length lineWidth = mTc->convertLength(eagleObj.getWidth());
           foreach (const Path& outline,
-                   C::convertBoardZoneOutline(path, lineWidth)) {
+                   mTc->convertBoardZoneOutline(path, lineWidth)) {
             BI_Zone* zone = new BI_Zone(
                 *board,
-                BoardZoneData(Uuid::createRandom(), {layer},
-                              Zone::Rule::NoPlanes, outline, false));
+                BoardZoneData(mCreateUuid(), {layer}, Zone::Rule::NoPlanes,
+                              outline, false));
             board->addZone(*zone);
           }
         } else {
-          const Length isolate = C::convertLength(eagleObj.getIsolate());
+          const Length isolate = mTc->convertLength(eagleObj.getIsolate());
           BI_Plane* obj =
-              new BI_Plane(*board, Uuid::createRandom(), *layer, netSignal,
-                           C::convertVertices(eagleObj.getVertices(), false));
+              new BI_Plane(*board, mCreateUuid(), *layer, netSignal,
+                           mTc->convertVertices(eagleObj.getVertices(), false));
           obj->setMinWidth(
-              UnsignedLength(C::convertLength(eagleObj.getWidth())));
+              UnsignedLength(mTc->convertLength(eagleObj.getWidth())));
           obj->setMinClearanceToCopper(
               (isolate > 0)
                   ? UnsignedLength(isolate)
@@ -1428,9 +1444,9 @@ std::optional<BoundedUnsignedRatio> EagleProjectImport::tryGetDrcRatio(
     const auto pmin = mBoard->getDesignRules().tryGetParam(nmin);
     const auto pmax = mBoard->getDesignRules().tryGetParam(nmax);
     if (pr && pmin && pmax) {
-      const auto vr = C::convertParamTo<UnsignedRatio>(*pr);
-      const auto vmin = C::convertParamTo<UnsignedLength>(*pmin);
-      const auto vmax = C::convertParamTo<UnsignedLength>(*pmax);
+      const auto vr = mTc->convertParamTo<UnsignedRatio>(*pr);
+      const auto vmin = mTc->convertParamTo<UnsignedLength>(*pmin);
+      const auto vmax = mTc->convertParamTo<UnsignedLength>(*pmax);
       // Note: Eagle allows to specify min>max so we have to correct this
       // case. It seems the min value is ignored then.
       return std::make_optional(

--- a/libs/librepcb/eagleimport/eagleprojectimport.h
+++ b/libs/librepcb/eagleimport/eagleprojectimport.h
@@ -28,6 +28,7 @@
 
 #include <QtCore>
 
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -66,6 +67,7 @@ class Symbol;
 namespace eagleimport {
 
 class EagleLibraryConverter;
+class EagleTypeConverter;
 
 /*******************************************************************************
  *  Class EagleProjectImport
@@ -80,7 +82,10 @@ class EagleProjectImport final : public QObject {
 public:
   // Constructors / Destructor
   EagleProjectImport(const EagleProjectImport& other) = delete;
-  explicit EagleProjectImport(QObject* parent = nullptr) noexcept;
+  explicit EagleProjectImport(
+      std::function<Uuid()> createUuid = &Uuid::createRandom,
+      const QDateTime& created = QDateTime::currentDateTime(),
+      QObject* parent = nullptr) noexcept;
   ~EagleProjectImport() noexcept;
 
   // Getters
@@ -142,6 +147,9 @@ private:  // Methods
   const parseagle::Part& getPart(const QString& name) const;
 
 private:  // Data
+  std::function<Uuid()> mCreateUuid;
+  const QDateTime mCreatedDateTime;
+  std::unique_ptr<EagleTypeConverter> mTc;
   std::shared_ptr<MessageLogger> mLogger;
   QString mProjectName;
   QScopedPointer<parseagle::Schematic> mSchematic;

--- a/libs/librepcb/eagleimport/eagletypeconverter.cpp
+++ b/libs/librepcb/eagleimport/eagletypeconverter.cpp
@@ -55,10 +55,23 @@ namespace librepcb {
 namespace eagleimport {
 
 /*******************************************************************************
+ *  Constructors / Destructor
+ ******************************************************************************/
+
+EagleTypeConverter::EagleTypeConverter(
+    std::function<Uuid()> createUuid) noexcept
+  : mCreateUuid(createUuid) {
+  Q_ASSERT(mCreateUuid);
+}
+
+EagleTypeConverter::~EagleTypeConverter() noexcept {
+}
+
+/*******************************************************************************
  *  General Methods
  ******************************************************************************/
 
-ElementName EagleTypeConverter::convertElementName(const QString& n) {
+ElementName EagleTypeConverter::convertElementName(const QString& n) const {
   QString name = cleanElementName(n);
   if (name.isEmpty()) {
     name = "Unnamed";  // No tr() to ensure valid ElementName.
@@ -66,21 +79,21 @@ ElementName EagleTypeConverter::convertElementName(const QString& n) {
   return ElementName(name);  // Can theoretically throw, but should not.
 }
 
-QString EagleTypeConverter::convertElementDescription(const QString& d) {
+QString EagleTypeConverter::convertElementDescription(const QString& d) const {
   QTextDocument doc;
   doc.setHtml(QString(d).replace("\n", "<br/>"));
   return doc.toPlainText().trimmed().split("\n", Qt::SkipEmptyParts).join("\n");
 }
 
-ElementName EagleTypeConverter::convertComponentName(QString n) {
+ElementName EagleTypeConverter::convertComponentName(QString n) const {
   if ((n.length() > 1) && (n.endsWith("-") || n.endsWith("_"))) {
     n.chop(1);
   }
   return convertElementName(n);  // Can theoretically throw, but should not.
 }
 
-ElementName EagleTypeConverter::convertDeviceName(const QString& deviceSetName,
-                                                  const QString& deviceName) {
+ElementName EagleTypeConverter::convertDeviceName(
+    const QString& deviceSetName, const QString& deviceName) const {
   const bool addSeparator = (!deviceSetName.endsWith("-")) &&
       (!deviceSetName.endsWith("_")) && (!deviceName.startsWith("-")) &&
       (!deviceName.startsWith("_"));
@@ -93,18 +106,20 @@ ElementName EagleTypeConverter::convertDeviceName(const QString& deviceSetName,
   return convertElementName(name);  // Can theoretically throw, but should not.
 }
 
-ComponentPrefix EagleTypeConverter::convertComponentPrefix(const QString& p) {
+ComponentPrefix EagleTypeConverter::convertComponentPrefix(
+    const QString& p) const {
   return ComponentPrefix(
       cleanComponentPrefix(p));  // Can theoretically throw, but should not.
 }
 
 ComponentSymbolVariantItemSuffix EagleTypeConverter::convertGateName(
-    const QString& n) {
+    const QString& n) const {
   return ComponentSymbolVariantItemSuffix(
       cleanComponentSymbolVariantItemSuffix(n));
 }
 
-CircuitIdentifier EagleTypeConverter::convertPinOrPadName(const QString& n) {
+CircuitIdentifier EagleTypeConverter::convertPinOrPadName(
+    const QString& n) const {
   QString name = convertInversionSyntax(cleanCircuitIdentifier(n));
   if ((name.length() > 2) && (name.startsWith("P$"))) {
     name.remove(0, 2);
@@ -115,7 +130,8 @@ CircuitIdentifier EagleTypeConverter::convertPinOrPadName(const QString& n) {
   return CircuitIdentifier(name);
 }
 
-QString EagleTypeConverter::convertInversionSyntax(const QString& s) noexcept {
+QString EagleTypeConverter::convertInversionSyntax(
+    const QString& s) const noexcept {
   QString out;
   bool inputOverlined = false;
   bool outputOverlined = false;
@@ -137,7 +153,7 @@ QString EagleTypeConverter::convertInversionSyntax(const QString& s) noexcept {
 }
 
 std::shared_ptr<Attribute> EagleTypeConverter::tryConvertAttribute(
-    const parseagle::Attribute& a, MessageLogger& log) {
+    const parseagle::Attribute& a, MessageLogger& log) const {
   const QString key = cleanAttributeKey(a.getName());
   if (key.isEmpty()) {
     log.warning(QString("Skipped attribute '%1' due to invalid name.")
@@ -150,7 +166,7 @@ std::shared_ptr<Attribute> EagleTypeConverter::tryConvertAttribute(
 
 void EagleTypeConverter::tryConvertAttributes(
     const QList<parseagle::Attribute>& in, AttributeList& out,
-    MessageLogger& log) {
+    MessageLogger& log) const {
   foreach (const auto& eagleAttr, in) {
     if (auto lpObj = tryConvertAttribute(eagleAttr, log)) {
       if (!out.contains(*lpObj->getKey())) {
@@ -162,7 +178,7 @@ void EagleTypeConverter::tryConvertAttributes(
 
 void EagleTypeConverter::tryExtractMpnAndManufacturer(
     AttributeList& attributes, SimpleString& mpn,
-    SimpleString& manufacturer) noexcept {
+    SimpleString& manufacturer) const noexcept {
   for (auto name : {"MPN", "MANUFACTURER_PART_NUMBER", "PART_NUMBER"}) {
     if (auto a = attributes.find(name)) {
       if (mpn->isEmpty()) {
@@ -181,7 +197,8 @@ void EagleTypeConverter::tryExtractMpnAndManufacturer(
   }
 }
 
-const Layer* EagleTypeConverter::tryConvertSchematicLayer(int id) noexcept {
+const Layer* EagleTypeConverter::tryConvertSchematicLayer(
+    int id) const noexcept {
   switch (id) {
     case 90:  // modules
       // Not sure what this layer is used for, discard or not?!
@@ -212,7 +229,7 @@ const Layer* EagleTypeConverter::tryConvertSchematicLayer(int id) noexcept {
   }
 }
 
-const Layer* EagleTypeConverter::tryConvertBoardLayer(int id) noexcept {
+const Layer* EagleTypeConverter::tryConvertBoardLayer(int id) const noexcept {
   switch (id) {
     case 1:  // tCu
       return &Layer::topCopper();
@@ -315,7 +332,7 @@ const Layer* EagleTypeConverter::tryConvertBoardLayer(int id) noexcept {
 }
 
 QHash<const Layer*, const Layer*> EagleTypeConverter::convertLayerSetup(
-    const QString& s) {
+    const QString& s) const {
   QString tmp = s;
   tmp.replace(QRegularExpression("[:\\*+\\(\\)\\[\\]]"), " ");
   QSet<int> numbers;
@@ -343,7 +360,7 @@ QHash<const Layer*, const Layer*> EagleTypeConverter::convertLayerSetup(
   return result;
 }
 
-Alignment EagleTypeConverter::convertAlignment(parseagle::Alignment a) {
+Alignment EagleTypeConverter::convertAlignment(parseagle::Alignment a) const {
   switch (a) {
     case parseagle::Alignment::BottomLeft:
       return Alignment(HAlign::left(), VAlign::bottom());
@@ -368,11 +385,12 @@ Alignment EagleTypeConverter::convertAlignment(parseagle::Alignment a) {
   }
 }
 
-Length EagleTypeConverter::convertLength(double l) {
+Length EagleTypeConverter::convertLength(double l) const {
   return Length::fromMm(l);
 }
 
-UnsignedLength EagleTypeConverter::convertLineWidth(double w, int layerId) {
+UnsignedLength EagleTypeConverter::convertLineWidth(double w,
+                                                    int layerId) const {
   Length l;
   switch (layerId) {
     case 20:  // dimension
@@ -387,7 +405,7 @@ UnsignedLength EagleTypeConverter::convertLineWidth(double w, int layerId) {
 }
 
 template <>
-Length EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+Length EagleTypeConverter::convertParamTo(const parseagle::Param& p) const {
   const QMap<QString, LengthUnit> unitMap = {
       {"mic", LengthUnit::micrometers()},
       {"mm", LengthUnit::millimeters()},
@@ -407,17 +425,19 @@ Length EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
 }
 
 template <>
-UnsignedLength EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+UnsignedLength EagleTypeConverter::convertParamTo(
+    const parseagle::Param& p) const {
   return UnsignedLength(convertParamTo<Length>(p));
 }
 
 template <>
-PositiveLength EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+PositiveLength EagleTypeConverter::convertParamTo(
+    const parseagle::Param& p) const {
   return PositiveLength(convertParamTo<Length>(p));
 }
 
 template <>
-Ratio EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+Ratio EagleTypeConverter::convertParamTo(const parseagle::Param& p) const {
   double value;
   if (p.tryGetValueAsDouble(value)) {
     return Ratio::fromNormalized(value);
@@ -429,21 +449,22 @@ Ratio EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
 }
 
 template <>
-UnsignedRatio EagleTypeConverter::convertParamTo(const parseagle::Param& p) {
+UnsignedRatio EagleTypeConverter::convertParamTo(
+    const parseagle::Param& p) const {
   return UnsignedRatio(convertParamTo<Ratio>(p));
 }
 
-Point EagleTypeConverter::convertPoint(const parseagle::Point& p) {
+Point EagleTypeConverter::convertPoint(const parseagle::Point& p) const {
   return Point::fromMm(p.x, p.y);
 }
 
-Angle EagleTypeConverter::convertAngle(double a) {
+Angle EagleTypeConverter::convertAngle(double a) const {
   return Angle::fromDeg(a);
 }
 
 void EagleTypeConverter::convertGrid(const parseagle::Grid& g,
                                      PositiveLength& interval,
-                                     LengthUnit& unit) {
+                                     LengthUnit& unit) const {
   const QMap<parseagle::GridUnit, LengthUnit> unitMap = {
       {parseagle::GridUnit::Micrometers, LengthUnit::micrometers()},
       {parseagle::GridUnit::Millimeters, LengthUnit::millimeters()},
@@ -461,12 +482,12 @@ void EagleTypeConverter::convertGrid(const parseagle::Grid& g,
   }
 }
 
-Vertex EagleTypeConverter::convertVertex(const parseagle::Vertex& v) {
+Vertex EagleTypeConverter::convertVertex(const parseagle::Vertex& v) const {
   return Vertex(convertPoint(v.getPosition()), convertAngle(v.getCurve()));
 }
 
 Path EagleTypeConverter::convertVertices(const QList<parseagle::Vertex>& v,
-                                         bool close) {
+                                         bool close) const {
   Path path;
   foreach (const parseagle::Vertex& vertex, v) {
     path.addVertex(convertVertex(vertex));
@@ -479,7 +500,7 @@ Path EagleTypeConverter::convertVertices(const QList<parseagle::Vertex>& v,
 
 QList<EagleTypeConverter::Geometry> EagleTypeConverter::convertAndJoinWires(
     const QList<parseagle::Wire>& wires, bool isGrabAreaIfClosed,
-    MessageLogger& log) {
+    MessageLogger& log) const {
   QList<Geometry> polygons;
 
   QMap<std::pair<int, UnsignedLength>, QList<parseagle::Wire>> joinableWires;
@@ -553,7 +574,7 @@ QList<EagleTypeConverter::Geometry> EagleTypeConverter::convertAndJoinWires(
 }
 
 EagleTypeConverter::Geometry EagleTypeConverter::convertRectangle(
-    const parseagle::Rectangle& r, bool isGrabArea) {
+    const parseagle::Rectangle& r, bool isGrabArea) const {
   const Point p1 = convertPoint(r.getP1());
   const Point p2 = convertPoint(r.getP2());
   const Point center = (p1 + p2) / 2;
@@ -570,7 +591,7 @@ EagleTypeConverter::Geometry EagleTypeConverter::convertRectangle(
 }
 
 EagleTypeConverter::Geometry EagleTypeConverter::convertPolygon(
-    const parseagle::Polygon& p, bool isGrabArea) {
+    const parseagle::Polygon& p, bool isGrabArea) const {
   return Geometry{
       p.getLayer(),  // Layer
       convertLineWidth(p.getWidth(), p.getLayer()),  // Line width
@@ -582,7 +603,7 @@ EagleTypeConverter::Geometry EagleTypeConverter::convertPolygon(
 }
 
 EagleTypeConverter::Geometry EagleTypeConverter::convertCircle(
-    const parseagle::Circle& c, bool isGrabArea) {
+    const parseagle::Circle& c, bool isGrabArea) const {
   const bool filled = (c.getWidth() == 0);  // EAGLE fills zero-width circles!
   const UnsignedLength lineWidth = convertLineWidth(c.getWidth(), c.getLayer());
   const Point pos = convertPoint(c.getPosition());
@@ -598,9 +619,9 @@ EagleTypeConverter::Geometry EagleTypeConverter::convertCircle(
 }
 
 std::shared_ptr<Hole> EagleTypeConverter::convertHole(
-    const parseagle::Hole& h) {
+    const parseagle::Hole& h) const {
   return std::make_shared<Hole>(
-      Uuid::createRandom(),  // UUID
+      mCreateUuid(),  // UUID
       PositiveLength(convertLength(h.getDiameter())),  // Diameter
       makeNonEmptyPath(convertPoint(h.getPosition())),  // Path
       MaskConfig::automatic()  // Stop mask
@@ -608,7 +629,7 @@ std::shared_ptr<Hole> EagleTypeConverter::convertHole(
 }
 
 EagleTypeConverter::Geometry EagleTypeConverter::convertFrame(
-    const parseagle::Frame& f) {
+    const parseagle::Frame& f) const {
   const Length width(3810000);
   const Point p1 = convertPoint(f.getP1());
   const Point p2 = convertPoint(f.getP2());
@@ -626,7 +647,7 @@ EagleTypeConverter::Geometry EagleTypeConverter::convertFrame(
   };
 }
 
-QString EagleTypeConverter::convertTextValue(const QString& v) {
+QString EagleTypeConverter::convertTextValue(const QString& v) const {
   QString value = v;
   if (value == ">DRAWING_NAME") {
     value = "{{PROJECT}}";
@@ -640,12 +661,12 @@ QString EagleTypeConverter::convertTextValue(const QString& v) {
   return value;
 }
 
-PositiveLength EagleTypeConverter::convertSchematicTextSize(double s) {
+PositiveLength EagleTypeConverter::convertSchematicTextSize(double s) const {
   return PositiveLength(Length::fromMm(s * 2.5 / 1.778));
 }
 
 std::shared_ptr<Text> EagleTypeConverter::tryConvertSchematicText(
-    const parseagle::Text& t, bool allowLocked) {
+    const parseagle::Text& t, bool allowLocked) const {
   if (auto layer = tryConvertSchematicLayer(t.getLayer())) {
     const bool mirror = t.getRotation().getMirror();
     const Angle rotation = convertAngle(t.getRotation().getAngle());
@@ -653,7 +674,7 @@ std::shared_ptr<Text> EagleTypeConverter::tryConvertSchematicText(
     const bool locked = allowLocked && (*layer != Layer::symbolNames()) &&
         (*layer != Layer::symbolValues());
     return std::make_shared<Text>(
-        Uuid::createRandom(),  // UUID
+        mCreateUuid(),  // UUID
         *layer,  // Layer
         convertTextValue(t.getValue()),  // Text
         convertPoint(t.getPosition()),  // Position
@@ -668,13 +689,13 @@ std::shared_ptr<Text> EagleTypeConverter::tryConvertSchematicText(
 }
 
 std::shared_ptr<Text> EagleTypeConverter::tryConvertSchematicAttribute(
-    const parseagle::Attribute& t) {
+    const parseagle::Attribute& t) const {
   if (auto layer = tryConvertSchematicLayer(t.getLayer())) {
     const bool mirror = t.getRotation().getMirror();
     const Angle rotation = convertAngle(t.getRotation().getAngle());
     const Alignment alignment = convertAlignment(t.getAlignment());
     return std::make_shared<Text>(
-        Uuid::createRandom(),  // UUID
+        mCreateUuid(),  // UUID
         *layer,  // Layer
         convertTextValue(">" % t.getName()),  // Text
         convertPoint(t.getPosition()),  // Position
@@ -689,7 +710,7 @@ std::shared_ptr<Text> EagleTypeConverter::tryConvertSchematicAttribute(
 }
 
 PositiveLength EagleTypeConverter::convertBoardTextSize(int layerId,
-                                                        double size) {
+                                                        double size) const {
   Length newSize = Length::fromMm(size * 0.85);
   // Avoid too small texts on silkscreen layers. Do not touch texts on
   // functional layers like copper to avoid possible unintended effects.
@@ -708,9 +729,8 @@ PositiveLength EagleTypeConverter::convertBoardTextSize(int layerId,
   return PositiveLength(newSize);
 }
 
-UnsignedLength EagleTypeConverter::convertBoardTextStrokeWidth(int layerId,
-                                                               double size,
-                                                               int ratio) {
+UnsignedLength EagleTypeConverter::convertBoardTextStrokeWidth(
+    int layerId, double size, int ratio) const {
   if (ratio == 0) {
     ratio = 15;
   }
@@ -733,7 +753,7 @@ UnsignedLength EagleTypeConverter::convertBoardTextStrokeWidth(int layerId,
 }
 
 std::shared_ptr<StrokeText> EagleTypeConverter::tryConvertBoardText(
-    const parseagle::Text& t, bool allowLocked) {
+    const parseagle::Text& t, bool allowLocked) const {
   if (auto layer = tryConvertBoardLayer(t.getLayer())) {
     const bool mirror = t.getRotation().getMirror();
     const Angle rotation = convertAngle(t.getRotation().getAngle());
@@ -741,7 +761,7 @@ std::shared_ptr<StrokeText> EagleTypeConverter::tryConvertBoardText(
         (*layer != Layer::topValues()) && (*layer != Layer::botNames()) &&
         (*layer != Layer::botValues());
     return std::make_shared<StrokeText>(
-        Uuid::createRandom(),  // UUID
+        mCreateUuid(),  // UUID
         *layer,  // Layer
         convertTextValue(t.getValue()),  // Text
         convertPoint(t.getPosition()),  // Position
@@ -762,12 +782,12 @@ std::shared_ptr<StrokeText> EagleTypeConverter::tryConvertBoardText(
 }
 
 std::shared_ptr<StrokeText> EagleTypeConverter::tryConvertBoardAttribute(
-    const parseagle::Attribute& t) {
+    const parseagle::Attribute& t) const {
   if (auto layer = tryConvertBoardLayer(t.getLayer())) {
     const bool mirror = t.getRotation().getMirror();
     const Angle rotation = convertAngle(t.getRotation().getAngle());
     return std::make_shared<StrokeText>(
-        Uuid::createRandom(),  // UUID
+        mCreateUuid(),  // UUID
         *layer,  // Layer
         convertTextValue(">" % t.getName()),  // Text
         convertPoint(t.getPosition()),  // Position
@@ -788,7 +808,7 @@ std::shared_ptr<StrokeText> EagleTypeConverter::tryConvertBoardAttribute(
 }
 
 EagleTypeConverter::Pin EagleTypeConverter::convertSymbolPin(
-    const parseagle::Pin& p) {
+    const parseagle::Pin& p) const {
   Pin result;
   const bool isDot = (p.getFunction() == parseagle::PinFunction::Dot) ||
       (p.getFunction() == parseagle::PinFunction::DotClock);
@@ -797,7 +817,7 @@ EagleTypeConverter::Pin EagleTypeConverter::convertSymbolPin(
   const UnsignedLength dotDiameter(isDot ? 1700000 : 0);
   const UnsignedLength totalLength(convertLength(p.getLengthInMillimeters()));
   result.pin = std::make_shared<SymbolPin>(
-      Uuid::createRandom(),  // UUID
+      mCreateUuid(),  // UUID
       convertPinOrPadName(p.getName()),  // Name
       convertPoint(p.getPosition()),  // Position
       UnsignedLength(
@@ -810,7 +830,7 @@ EagleTypeConverter::Pin EagleTypeConverter::convertSymbolPin(
   );
   if (isDot) {
     result.circle =
-        std::make_shared<Circle>(Uuid::createRandom(), Layer::symbolOutlines(),
+        std::make_shared<Circle>(mCreateUuid(), Layer::symbolOutlines(),
                                  UnsignedLength(158750), false, false,
                                  Point((*totalLength) - (*dotDiameter) / 2, 0)
                                          .rotated(result.pin->getRotation()) +
@@ -828,7 +848,7 @@ EagleTypeConverter::Pin EagleTypeConverter::convertSymbolPin(
                           .rotated(result.pin->getRotation())
                           .translated(result.pin->getPosition());
     result.polygon =
-        std::make_shared<Polygon>(Uuid::createRandom(), Layer::symbolOutlines(),
+        std::make_shared<Polygon>(mCreateUuid(), Layer::symbolOutlines(),
                                   UnsignedLength(158750), false, false, path);
   }
   return result;
@@ -837,8 +857,8 @@ EagleTypeConverter::Pin EagleTypeConverter::convertSymbolPin(
 std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
     EagleTypeConverter::convertThtPad(
         const parseagle::ThtPad& p,
-        const BoundedUnsignedRatio& autoAnnularWidth) {
-  Uuid uuid = Uuid::createRandom();
+        const BoundedUnsignedRatio& autoAnnularWidth) const {
+  Uuid uuid = mCreateUuid();
   const PositiveLength drillDiameter(convertLength(p.getDrillDiameter()));
   Length size = convertLength(p.getOuterDiameter());
   if (size <= 0) {
@@ -899,15 +919,15 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
           UnsignedLength(0),  // Copper clearance
           Pad::ComponentSide::Top,  // Side
           Pad::Function::Unspecified,  // Function
-          PadHoleList{std::make_shared<PadHole>(
-              Uuid::createRandom(), drillDiameter,
-              makeNonEmptyPath(Point(0, 0)))}  // Holes
+          PadHoleList{std::make_shared<PadHole>(mCreateUuid(), drillDiameter,
+                                                makeNonEmptyPath(Point(0, 0)))}
+          // Holes
           ));
 }
 
 std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
-    EagleTypeConverter::convertSmtPad(const parseagle::SmtPad& p) {
-  Uuid uuid = Uuid::createRandom();
+    EagleTypeConverter::convertSmtPad(const parseagle::SmtPad& p) const {
+  Uuid uuid = mCreateUuid();
   const Layer* layer = tryConvertBoardLayer(p.getLayer());
   Pad::ComponentSide side;
   if (layer == &Layer::topCopper()) {
@@ -944,10 +964,10 @@ std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
 }
 
 std::shared_ptr<Circle> EagleTypeConverter::tryConvertToSchematicCircle(
-    const Geometry& g) {
+    const Geometry& g) const {
   if (g.circle) {
     if (auto layer = tryConvertSchematicLayer(g.layerId)) {
-      return std::make_shared<Circle>(Uuid::createRandom(), *layer, g.lineWidth,
+      return std::make_shared<Circle>(mCreateUuid(), *layer, g.lineWidth,
                                       g.filled, g.grabArea, g.circle->first,
                                       g.circle->second);
     }
@@ -956,16 +976,16 @@ std::shared_ptr<Circle> EagleTypeConverter::tryConvertToSchematicCircle(
 }
 
 std::shared_ptr<Polygon> EagleTypeConverter::tryConvertToSchematicPolygon(
-    const Geometry& g) {
+    const Geometry& g) const {
   if (auto layer = tryConvertSchematicLayer(g.layerId)) {
-    return std::make_shared<Polygon>(Uuid::createRandom(), *layer, g.lineWidth,
+    return std::make_shared<Polygon>(mCreateUuid(), *layer, g.lineWidth,
                                      g.filled, g.grabArea, g.path);
   }
   return nullptr;
 }
 
 QVector<Path> EagleTypeConverter::convertBoardZoneOutline(
-    const Path& outline, const Length& lineWidth) {
+    const Path& outline, const Length& lineWidth) const {
   const PositiveLength maxArcTolerance(10000);
   if ((lineWidth / 2) > (*maxArcTolerance)) {
     ClipperLib::Paths paths{ClipperHelpers::convert(outline, maxArcTolerance)};
@@ -978,7 +998,7 @@ QVector<Path> EagleTypeConverter::convertBoardZoneOutline(
 }
 
 QVector<std::shared_ptr<Zone>> EagleTypeConverter::tryConvertToBoardZones(
-    const Geometry& g) {
+    const Geometry& g) const {
   Zone::Layers layers = Zone::Layers();
   Zone::Rules rules = Zone::Rules();
   switch (g.layerId) {
@@ -1008,16 +1028,16 @@ QVector<std::shared_ptr<Zone>> EagleTypeConverter::tryConvertToBoardZones(
   QVector<std::shared_ptr<Zone>> result;
   foreach (const Path& outline, convertBoardZoneOutline(g.path, *g.lineWidth)) {
     result.append(
-        std::make_shared<Zone>(Uuid::createRandom(), layers, rules, outline));
+        std::make_shared<Zone>(mCreateUuid(), layers, rules, outline));
   }
   return result;
 }
 
 std::shared_ptr<Circle> EagleTypeConverter::tryConvertToBoardCircle(
-    const Geometry& g) {
+    const Geometry& g) const {
   if (g.circle) {
     if (auto layer = tryConvertBoardLayer(g.layerId)) {
-      return std::make_shared<Circle>(Uuid::createRandom(), *layer, g.lineWidth,
+      return std::make_shared<Circle>(mCreateUuid(), *layer, g.lineWidth,
                                       g.filled, g.grabArea, g.circle->first,
                                       g.circle->second);
     }
@@ -1026,9 +1046,9 @@ std::shared_ptr<Circle> EagleTypeConverter::tryConvertToBoardCircle(
 }
 
 std::shared_ptr<Polygon> EagleTypeConverter::tryConvertToBoardPolygon(
-    const Geometry& g) {
+    const Geometry& g) const {
   if (auto layer = tryConvertBoardLayer(g.layerId)) {
-    return std::make_shared<Polygon>(Uuid::createRandom(), *layer, g.lineWidth,
+    return std::make_shared<Polygon>(mCreateUuid(), *layer, g.lineWidth,
                                      g.filled, g.grabArea, g.path);
   }
   return nullptr;

--- a/libs/librepcb/eagleimport/eagletypeconverter.h
+++ b/libs/librepcb/eagleimport/eagletypeconverter.h
@@ -41,10 +41,12 @@
 #include <librepcb/core/types/elementname.h>
 #include <librepcb/core/types/point.h>
 #include <librepcb/core/types/simplestring.h>
+#include <librepcb/core/types/uuid.h>
 #include <parseagle/common/enums.h>
 
 #include <QtCore>
 
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -118,9 +120,10 @@ public:
   };
 
   // Constructors / Destructor
-  EagleTypeConverter() = delete;
+  EagleTypeConverter(
+      std::function<Uuid()> createUuid = &Uuid::createRandom) noexcept;
   EagleTypeConverter(const EagleTypeConverter& other) = delete;
-  ~EagleTypeConverter() = delete;
+  ~EagleTypeConverter() noexcept;
 
   /**
    * @brief Convert an element (e.g. symbol) name
@@ -133,7 +136,7 @@ public:
    *
    * @return LibrePCB element name
    */
-  static ElementName convertElementName(const QString& n);
+  ElementName convertElementName(const QString& n) const;
 
   /**
    * @brief Convert an element (e.g. symbol) description
@@ -144,7 +147,7 @@ public:
    *
    * @return LibrePCB element description (no HTML)
    */
-  static QString convertElementDescription(const QString& d);
+  QString convertElementDescription(const QString& d) const;
 
   /**
    * @brief Convert a component name
@@ -156,7 +159,7 @@ public:
    *
    * @return LibrePCB component name (e.g. "R-0805")
    */
-  static ElementName convertComponentName(QString n);
+  ElementName convertComponentName(QString n) const;
 
   /**
    * @brief Convert a device name
@@ -169,8 +172,8 @@ public:
    *
    * @return LibrePCB device name
    */
-  static ElementName convertDeviceName(const QString& deviceSetName,
-                                       const QString& deviceName);
+  ElementName convertDeviceName(const QString& deviceSetName,
+                                const QString& deviceName) const;
 
   /**
    * @brief Convert a component prefix
@@ -182,7 +185,7 @@ public:
    *
    * @return LibrePCB component prefix
    */
-  static ComponentPrefix convertComponentPrefix(const QString& p);
+  ComponentPrefix convertComponentPrefix(const QString& p) const;
 
   /**
    * @brief Convert a component gate name
@@ -194,7 +197,7 @@ public:
    *
    * @return LibrePCB component symbol variant item suffix
    */
-  static ComponentSymbolVariantItemSuffix convertGateName(const QString& n);
+  ComponentSymbolVariantItemSuffix convertGateName(const QString& n) const;
 
   /**
    * @brief Convert a pin or pad name
@@ -206,7 +209,7 @@ public:
    *
    * @return LibrePCB circuit identifier
    */
-  static CircuitIdentifier convertPinOrPadName(const QString& n);
+  CircuitIdentifier convertPinOrPadName(const QString& n) const;
 
   /**
    * @brief Convert the inversion syntax of a text
@@ -215,7 +218,7 @@ public:
    *
    * @return Same text but with LibrePCB inversion syntax (e.g. "!RST/EN")
    */
-  static QString convertInversionSyntax(const QString& s) noexcept;
+  QString convertInversionSyntax(const QString& s) const noexcept;
 
   /**
    * @brief Try converting an attribute
@@ -225,8 +228,8 @@ public:
    *
    * @return LibrePCB attribute (nullptr on failure)
    */
-  static std::shared_ptr<Attribute> tryConvertAttribute(
-      const parseagle::Attribute& a, MessageLogger& log);
+  std::shared_ptr<Attribute> tryConvertAttribute(const parseagle::Attribute& a,
+                                                 MessageLogger& log) const;
 
   /**
    * @brief Try converting a list of attributes
@@ -241,8 +244,8 @@ public:
    *
    * @see #tryConvertAttribute()
    */
-  static void tryConvertAttributes(const QList<parseagle::Attribute>& in,
-                                   AttributeList& out, MessageLogger& log);
+  void tryConvertAttributes(const QList<parseagle::Attribute>& in,
+                            AttributeList& out, MessageLogger& log) const;
 
   /**
    * @brief Try extracting MPN and manufacturer from a list of attributes
@@ -252,9 +255,9 @@ public:
    * @param mpn           The found MPN (unmodified if not found)
    * @param manufacturer  The found manufacturer name (unmodified if not found)
    */
-  static void tryExtractMpnAndManufacturer(AttributeList& attributes,
-                                           SimpleString& mpn,
-                                           SimpleString& manufacturer) noexcept;
+  void tryExtractMpnAndManufacturer(AttributeList& attributes,
+                                    SimpleString& mpn,
+                                    SimpleString& manufacturer) const noexcept;
 
   /**
    * @brief Try to convert a layer ID to a schematic layer
@@ -263,7 +266,7 @@ public:
    *
    * @return LibrePCB schematic/symbol layer (`nullptr` to discard object)
    */
-  static const Layer* tryConvertSchematicLayer(int id) noexcept;
+  const Layer* tryConvertSchematicLayer(int id) const noexcept;
 
   /**
    * @brief Try to convert a layer ID to a board layer
@@ -272,7 +275,7 @@ public:
    *
    * @return LibrePCB board/footprint layer (`nullptr` to discard object)
    */
-  static const Layer* tryConvertBoardLayer(int id) noexcept;
+  const Layer* tryConvertBoardLayer(int id) const noexcept;
 
   /**
    * @brief Convert a layer setup string
@@ -281,7 +284,7 @@ public:
    *
    * @return Map to move all inner copper layers to the top (remove gaps)
    */
-  static QHash<const Layer*, const Layer*> convertLayerSetup(const QString& s);
+  QHash<const Layer*, const Layer*> convertLayerSetup(const QString& s) const;
 
   /**
    * @brief Convert an alignment
@@ -290,7 +293,7 @@ public:
    *
    * @return LibrePCB alignment
    */
-  static Alignment convertAlignment(parseagle::Alignment a);
+  Alignment convertAlignment(parseagle::Alignment a) const;
 
   /**
    * @brief Convert a length
@@ -299,7 +302,7 @@ public:
    *
    * @return LibrePCB length
    */
-  static Length convertLength(double l);
+  Length convertLength(double l) const;
 
   /**
    * @brief Convert a line width for a given layer
@@ -312,7 +315,7 @@ public:
    *
    * @return LibrePCB line width length
    */
-  static UnsignedLength convertLineWidth(double w, int layerId);
+  UnsignedLength convertLineWidth(double w, int layerId) const;
 
   /**
    * @brief Convert a parameter value to a LibrePCB type
@@ -326,7 +329,7 @@ public:
    * @throws If the value could not be converted
    */
   template <typename T>
-  static T convertParamTo(const parseagle::Param& p);
+  T convertParamTo(const parseagle::Param& p) const;
 
   /**
    * @brief Convert a point
@@ -335,7 +338,7 @@ public:
    *
    * @return LibrePCB point
    */
-  static Point convertPoint(const parseagle::Point& p);
+  Point convertPoint(const parseagle::Point& p) const;
 
   /**
    * @brief Convert an angle
@@ -344,7 +347,7 @@ public:
    *
    * @return LibrePCB angle
    */
-  static Angle convertAngle(double a);
+  Angle convertAngle(double a) const;
 
   /**
    * @brief Convert grid settings
@@ -356,8 +359,8 @@ public:
    * @param interval  LibrePCB grid interval (output)
    * @param unit      LibrePCB grid unit (output)
    */
-  static void convertGrid(const parseagle::Grid& g, PositiveLength& interval,
-                          LengthUnit& unit);
+  void convertGrid(const parseagle::Grid& g, PositiveLength& interval,
+                   LengthUnit& unit) const;
 
   /**
    * @brief Convert a vertex
@@ -366,7 +369,7 @@ public:
    *
    * @return LibrePCB vertex
    */
-  static Vertex convertVertex(const parseagle::Vertex& v);
+  Vertex convertVertex(const parseagle::Vertex& v) const;
 
   /**
    * @brief Convert vertices
@@ -376,7 +379,7 @@ public:
    *
    * @return LibrePCB path
    */
-  static Path convertVertices(const QList<parseagle::Vertex>& v, bool close);
+  Path convertVertices(const QList<parseagle::Vertex>& v, bool close) const;
 
   /**
    * @brief Try to join and convert multiple wires to polygons
@@ -388,9 +391,9 @@ public:
    *
    * @return Joined polygons as intermediate geometries
    */
-  static QList<Geometry> convertAndJoinWires(
-      const QList<parseagle::Wire>& wires, bool isGrabAreaIfClosed,
-      MessageLogger& log);
+  QList<Geometry> convertAndJoinWires(const QList<parseagle::Wire>& wires,
+                                      bool isGrabAreaIfClosed,
+                                      MessageLogger& log) const;
 
   /**
    * @brief Convert a rectangle
@@ -400,8 +403,8 @@ public:
    *
    * @return Intermediate geometry containing 4 line segments
    */
-  static Geometry convertRectangle(const parseagle::Rectangle& r,
-                                   bool isGrabArea);
+  Geometry convertRectangle(const parseagle::Rectangle& r,
+                            bool isGrabArea) const;
 
   /**
    * @brief Convert a polygon
@@ -411,7 +414,7 @@ public:
    *
    * @return Intermediate geometry (always closed)
    */
-  static Geometry convertPolygon(const parseagle::Polygon& p, bool isGrabArea);
+  Geometry convertPolygon(const parseagle::Polygon& p, bool isGrabArea) const;
 
   /**
    * @brief Convert a circle
@@ -421,7 +424,7 @@ public:
    *
    * @return Intermediate geometry
    */
-  static Geometry convertCircle(const parseagle::Circle& c, bool isGrabArea);
+  Geometry convertCircle(const parseagle::Circle& c, bool isGrabArea) const;
 
   /**
    * @brief Convert a hole
@@ -430,7 +433,7 @@ public:
    *
    * @return LibrePCB hole
    */
-  static std::shared_ptr<Hole> convertHole(const parseagle::Hole& h);
+  std::shared_ptr<Hole> convertHole(const parseagle::Hole& h) const;
 
   /**
    * @brief Convert a frame
@@ -439,7 +442,7 @@ public:
    *
    * @return Intermediate geometry containing 4 line segments
    */
-  static Geometry convertFrame(const parseagle::Frame& f);
+  Geometry convertFrame(const parseagle::Frame& f) const;
 
   /**
    * @brief Convert a text value
@@ -448,7 +451,7 @@ public:
    *
    * @return LibrePCB text value (e.g. "{{NAME}}")
    */
-  static QString convertTextValue(const QString& v);
+  QString convertTextValue(const QString& v) const;
 
   /**
    * @brief Convert the size (height) of a schematic text
@@ -457,7 +460,7 @@ public:
    *
    * @return LibrePCB text size
    */
-  static PositiveLength convertSchematicTextSize(double s);
+  PositiveLength convertSchematicTextSize(double s) const;
 
   /**
    * @brief Try to convert a schematic/symbol text
@@ -470,8 +473,8 @@ public:
    *
    * @return LibrePCB text if the layer is supported, otherwise `nullptr`
    */
-  static std::shared_ptr<Text> tryConvertSchematicText(const parseagle::Text& t,
-                                                       bool allowLocked);
+  std::shared_ptr<Text> tryConvertSchematicText(const parseagle::Text& t,
+                                                bool allowLocked) const;
 
   /**
    * @brief Try to convert a schematic/symbol attribute text
@@ -480,8 +483,8 @@ public:
    *
    * @return LibrePCB text if the layer is supported, otherwise `nullptr`
    */
-  static std::shared_ptr<Text> tryConvertSchematicAttribute(
-      const parseagle::Attribute& t);
+  std::shared_ptr<Text> tryConvertSchematicAttribute(
+      const parseagle::Attribute& t) const;
 
   /**
    * @brief Convert the size (height) of a board text
@@ -491,7 +494,7 @@ public:
    *
    * @return LibrePCB text size
    */
-  static PositiveLength convertBoardTextSize(int layerId, double size);
+  PositiveLength convertBoardTextSize(int layerId, double size) const;
 
   /**
    * @brief Convert the stroke width of a board text
@@ -502,8 +505,8 @@ public:
    *
    * @return LibrePCB stroke text width
    */
-  static UnsignedLength convertBoardTextStrokeWidth(int layerId, double size,
-                                                    int ratio);
+  UnsignedLength convertBoardTextStrokeWidth(int layerId, double size,
+                                             int ratio) const;
 
   /**
    * @brief Try to cnvert a board/footprint text
@@ -516,8 +519,8 @@ public:
    *
    * @return LibrePCB text if the layer is supported, otherwise `nullptr`
    */
-  static std::shared_ptr<StrokeText> tryConvertBoardText(
-      const parseagle::Text& t, bool allowLocked);
+  std::shared_ptr<StrokeText> tryConvertBoardText(const parseagle::Text& t,
+                                                  bool allowLocked) const;
 
   /**
    * @brief Try to convert a board/footprint attribute text
@@ -526,8 +529,8 @@ public:
    *
    * @return LibrePCB text if the layer is supported, otherwise `nullptr`
    */
-  static std::shared_ptr<StrokeText> tryConvertBoardAttribute(
-      const parseagle::Attribute& t);
+  std::shared_ptr<StrokeText> tryConvertBoardAttribute(
+      const parseagle::Attribute& t) const;
 
   /**
    * @brief Convert a symbol pin
@@ -536,7 +539,7 @@ public:
    *
    * @return LibrePCB objects to represent the pin
    */
-  static Pin convertSymbolPin(const parseagle::Pin& p);
+  Pin convertSymbolPin(const parseagle::Pin& p) const;
 
   /**
    * @brief Convert a THT pad
@@ -548,9 +551,9 @@ public:
    *
    * @return LibrePCB package pad + footprint pad
    */
-  static std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
+  std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
       convertThtPad(const parseagle::ThtPad& p,
-                    const BoundedUnsignedRatio& autoAnnularWidth);
+                    const BoundedUnsignedRatio& autoAnnularWidth) const;
 
   /**
    * @brief Convert an SMT pad
@@ -559,8 +562,8 @@ public:
    *
    * @return LibrePCB package pad + footprint pad
    */
-  static std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
-      convertSmtPad(const parseagle::SmtPad& p);
+  std::pair<std::shared_ptr<PackagePad>, std::shared_ptr<FootprintPad>>
+      convertSmtPad(const parseagle::SmtPad& p) const;
 
   /**
    * @brief Try to convert an intermediate geometry to a schematic circle
@@ -570,7 +573,7 @@ public:
    * @return    A circle if the geometry represents a circle on a valid
    *            schematic layer, otherwise `nullptr`
    */
-  static std::shared_ptr<Circle> tryConvertToSchematicCircle(const Geometry& g);
+  std::shared_ptr<Circle> tryConvertToSchematicCircle(const Geometry& g) const;
 
   /**
    * @brief Try to convert an intermediate geometry to a schematic polygon
@@ -579,8 +582,8 @@ public:
    *
    * @return A polygon if the layer is valid for schematics, otherwise `nullptr`
    */
-  static std::shared_ptr<Polygon> tryConvertToSchematicPolygon(
-      const Geometry& g);
+  std::shared_ptr<Polygon> tryConvertToSchematicPolygon(
+      const Geometry& g) const;
 
   /**
    * @brief Convert the outline of a board zone
@@ -593,8 +596,8 @@ public:
    *
    * @return Possibly multiple paths with the LibrePCB zone outline(s)
    */
-  static QVector<Path> convertBoardZoneOutline(const Path& outline,
-                                               const Length& lineWidth);
+  QVector<Path> convertBoardZoneOutline(const Path& outline,
+                                        const Length& lineWidth) const;
 
   /**
    * @brief Try to convert an intermediate geometry to board keepout zones
@@ -604,8 +607,8 @@ public:
    * @return    A keepout zone(s) if the geometry represents a zone,
    *            otherwise an empty vector
    */
-  static QVector<std::shared_ptr<Zone>> tryConvertToBoardZones(
-      const Geometry& g);
+  QVector<std::shared_ptr<Zone>> tryConvertToBoardZones(
+      const Geometry& g) const;
 
   /**
    * @brief Try to convert an intermediate geometry to a board circle
@@ -615,7 +618,7 @@ public:
    * @return    A circle if the geometry represents a circle on a valid
    *            board layer, otherwise `nullptr`
    */
-  static std::shared_ptr<Circle> tryConvertToBoardCircle(const Geometry& g);
+  std::shared_ptr<Circle> tryConvertToBoardCircle(const Geometry& g) const;
 
   /**
    * @brief Try to convert an intermediate geometry to a board polygon
@@ -624,7 +627,7 @@ public:
    *
    * @return A polygon if the layer is valid for boards, otherwise `nullptr`
    */
-  static std::shared_ptr<Polygon> tryConvertToBoardPolygon(const Geometry& g);
+  std::shared_ptr<Polygon> tryConvertToBoardPolygon(const Geometry& g) const;
 
   /**
    * @brief Get the EAGLE layer name for a given layer ID
@@ -648,6 +651,9 @@ public:
 
   // Operator Overloadings
   EagleTypeConverter& operator=(const EagleTypeConverter& rhs) = delete;
+
+private:
+  std::function<Uuid()> mCreateUuid;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/createlibrarytab.cpp
+++ b/libs/librepcb/editor/library/createlibrarytab.cpp
@@ -120,7 +120,8 @@ void CreateLibraryTab::trigger(ui::TabAction a) noexcept {
         // Create the new library.
         QScopedPointer<Library> lib(new Library(
             Uuid::createRandom(), *mVersion, s2q(mUiData.author).trimmed(),
-            *mName, s2q(mUiData.description).trimmed(),
+            QDateTime::currentDateTime(), *mName,
+            s2q(mUiData.description).trimmed(),
             QString("")));  // can throw
         if (mUrl) {
           lib->setUrl(*mUrl);

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardcontext.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardcontext.cpp
@@ -46,7 +46,7 @@ EagleLibraryImportWizardContext::EagleLibraryImportWizardContext(
   : QObject(parent),
     mTheme(theme),
     mWorkspace(workspace),
-    mImport(new EagleLibraryImport(dstLibFp, parent)),
+    mImport(new EagleLibraryImport(dstLibFp, &Uuid::createRandom, parent)),
     mLbrFilePath(),
     mAddNamePrefix(false),
     mComponentCategoryUuid(),

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -1011,7 +1011,8 @@ void MainWindow::openComponentCategoryTab(LibraryEditor& editor,
         cat.reset(new ComponentCategory(
             Uuid::createRandom(), Version::fromString("0.1"),
             mApp.getWorkspace().getSettings().userName.get(),
-            ElementName("New Component Category"), QString(), QString()));
+            QDateTime::currentDateTime(), ElementName("New Component Category"),
+            QString(), QString()));
         if (copyFrom) {
           mode = ComponentCategoryTab::Mode::Duplicate;
           auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
@@ -1051,7 +1052,8 @@ void MainWindow::openPackageCategoryTab(LibraryEditor& editor,
         cat.reset(new PackageCategory(
             Uuid::createRandom(), Version::fromString("0.1"),
             mApp.getWorkspace().getSettings().userName.get(),
-            ElementName("New Package Category"), QString(), QString()));
+            QDateTime::currentDateTime(), ElementName("New Package Category"),
+            QString(), QString()));
         if (copyFrom) {
           mode = PackageCategoryTab::Mode::Duplicate;
           auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
@@ -1089,6 +1091,7 @@ void MainWindow::openSymbolTab(LibraryEditor& editor, const FilePath& fp,
         mode = SymbolTab::Mode::New;
         sym.reset(new Symbol(Uuid::createRandom(), Version::fromString("0.1"),
                              mApp.getWorkspace().getSettings().userName.get(),
+                             QDateTime::currentDateTime(),
                              ElementName("New Symbol"), QString(), QString()));
         if (copyFrom) {
           mode = SymbolTab::Mode::Duplicate;
@@ -1171,6 +1174,7 @@ void MainWindow::openPackageTab(LibraryEditor& editor, const FilePath& fp,
         mode = PackageTab::Mode::New;
         pkg.reset(new Package(Uuid::createRandom(), Version::fromString("0.1"),
                               mApp.getWorkspace().getSettings().userName.get(),
+                              QDateTime::currentDateTime(),
                               ElementName("New Package"), QString(), QString(),
                               Package::AssemblyType::Auto));
         if (copyFrom) {
@@ -1306,6 +1310,7 @@ void MainWindow::openComponentTab(LibraryEditor& editor, const FilePath& fp,
         cmp.reset(
             new Component(Uuid::createRandom(), Version::fromString("0.1"),
                           mApp.getWorkspace().getSettings().userName.get(),
+                          QDateTime::currentDateTime(),
                           ElementName("New Component"), QString(), QString()));
         if (copyFrom) {
           mode = ComponentTab::Mode::Duplicate;
@@ -1393,6 +1398,7 @@ void MainWindow::openDeviceTab(LibraryEditor& editor, const FilePath& fp,
         mode = DeviceTab::Mode::New;
         dev.reset(new Device(Uuid::createRandom(), Version::fromString("0.1"),
                              mApp.getWorkspace().getSettings().userName.get(),
+                             QDateTime::currentDateTime(),
                              ElementName("New Device"), QString(), QString(),
                              Uuid::createRandom(), Uuid::createRandom()));
         if (copyFrom) {
@@ -1438,7 +1444,8 @@ void MainWindow::openOrganizationTab(LibraryEditor& editor, const FilePath& fp,
         org.reset(new Organization(
             Uuid::createRandom(), Version::fromString("0.1"),
             mApp.getWorkspace().getSettings().userName.get(),
-            ElementName("New Organization"), QString(), QString()));
+            QDateTime::currentDateTime(), ElementName("New Organization"),
+            QString(), QString()));
         if (copyFrom) {
           mode = OrganizationTab::Mode::Duplicate;
           auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);

--- a/libs/librepcb/kicadimport/kicadlibraryconverter.cpp
+++ b/libs/librepcb/kicadimport/kicadlibraryconverter.cpp
@@ -55,6 +55,7 @@ KiCadLibraryConverterSettings::KiCadLibraryConverterSettings() noexcept
   : namePrefix(),
     version(Version::fromString("0.1")),
     author("KiCad Import"),
+    created(QDateTime::currentDateTime()),
     keywords("kicad,import") {
 }
 
@@ -90,6 +91,7 @@ std::unique_ptr<Package> KiCadLibraryConverter::createPackage(
   }
   std::unique_ptr<Package> package(new Package(
       Uuid::createRandom(), mSettings.version, mSettings.author,
+      mSettings.created,
       C::convertElementName(mSettings.namePrefix + kiFpt.name),
       C::convertElementDescription(libFp, kiFpt.name, kiFpt.properties),
       C::convertElementKeywords(mSettings.keywords, kiFpt.properties),
@@ -272,6 +274,7 @@ std::unique_ptr<Symbol> KiCadLibraryConverter::createSymbol(
   }
   std::unique_ptr<Symbol> symbol(new Symbol(
       Uuid::createRandom(), mSettings.version, mSettings.author,
+      mSettings.created,
       C::convertElementName(mSettings.namePrefix + kiGate.name),
       C::convertElementDescription(libFp, kiGate.name, kiSym.properties),
       C::convertElementKeywords(mSettings.keywords, kiSym.properties)));
@@ -360,6 +363,7 @@ std::unique_ptr<Component> KiCadLibraryConverter::createComponent(
   }
   std::unique_ptr<Component> component(new Component(
       Uuid::createRandom(), mSettings.version, mSettings.author,
+      mSettings.created,
       C::convertElementName(mSettings.namePrefix + kiSym.name),
       C::convertElementDescription(libFp, kiSym.name, kiSym.properties),
       C::convertElementKeywords(mSettings.keywords, kiSym.properties)));
@@ -471,6 +475,7 @@ std::unique_ptr<Device> KiCadLibraryConverter::createDevice(
   }
   std::unique_ptr<Device> device(new Device(
       Uuid::createRandom(), mSettings.version, mSettings.author,
+      mSettings.created,
       C::convertElementName(mSettings.namePrefix + kiSym.name),
       C::convertElementDescription(libFp, kiSym.name, kiSym.properties),
       C::convertElementKeywords(mSettings.keywords, kiSym.properties),

--- a/libs/librepcb/kicadimport/kicadlibraryconverter.h
+++ b/libs/librepcb/kicadimport/kicadlibraryconverter.h
@@ -60,6 +60,7 @@ struct KiCadLibraryConverterSettings final {
   QString namePrefix;
   Version version;
   QString author;
+  QDateTime created;
   QString keywords;
   QSet<Uuid> symbolCategories;
   QSet<Uuid> packageCategories;

--- a/tests/unittests/core/library/librarybaseelementtest.cpp
+++ b/tests/unittests/core/library/librarybaseelementtest.cpp
@@ -47,7 +47,7 @@ protected:
 
     mNewElement.reset(new LibraryBaseElement(
         "sym", "symbol", Uuid::createRandom(), Version::fromString("1.0"),
-        "test", ElementName("Test"), "", ""));
+        "test", QDateTime::currentDateTime(), ElementName("Test"), "", ""));
   }
 
   virtual ~LibraryBaseElementTest() {

--- a/tests/unittests/core/project/projectlibrarytest.cpp
+++ b/tests/unittests/core/project/projectlibrarytest.cpp
@@ -57,9 +57,9 @@ protected:
     mLibFs = TransactionalFileSystem::openRW(mLibDir);
 
     // create symbol inside project library
-    mExistingSymbol.reset(new Symbol(Uuid::createRandom(),
-                                     Version::fromString("1"), "",
-                                     ElementName("Existing Symbol"), "", ""));
+    mExistingSymbol.reset(new Symbol(
+        Uuid::createRandom(), Version::fromString("1"), "",
+        QDateTime::currentDateTime(), ElementName("Existing Symbol"), "", ""));
     TransactionalDirectory libSymDir(mLibFs, "sym");
     mExistingSymbol->saveIntoParentDirectory(libSymDir);
     mLibFs->save();
@@ -71,7 +71,8 @@ protected:
 
     // create symbol outside the project library (emulating workspace library)
     mNewSymbol.reset(new Symbol(Uuid::createRandom(), Version::fromString("1"),
-                                "", ElementName("New Symbol"), "", ""));
+                                "", QDateTime::currentDateTime(),
+                                ElementName("New Symbol"), "", ""));
     TransactionalDirectory tempSymDir(mTempFs);
     mNewSymbol->saveIntoParentDirectory(tempSymDir);
     mTempFs->save();

--- a/tests/unittests/core/utils/tangentpathjoinertest.cpp
+++ b/tests/unittests/core/utils/tangentpathjoinertest.cpp
@@ -82,14 +82,14 @@ TEST_F(TangentPathJoinerTest, testOnlyOneVertex) {
 TEST_F(TangentPathJoinerTest, testOneClosedPath) {
   QVector<Path> input = {Path(QVector<Vertex>{
       Vertex(Point(0, 0)),
-      Vertex(Point(1, 0)),
-      Vertex(Point(1, 1)),
+      Vertex(Point(1000, 0)),
+      Vertex(Point(1000, 1000)),
       Vertex(Point(0, 0)),
   })};
   QVector<Path> expected = {Path(QVector<Vertex>{
       Vertex(Point(0, 0)),
-      Vertex(Point(1, 0)),
-      Vertex(Point(1, 1)),
+      Vertex(Point(1000, 0)),
+      Vertex(Point(1000, 1000)),
       Vertex(Point(0, 0)),
   })};
   QVector<Path> output = TangentPathJoiner::join(input);
@@ -99,13 +99,13 @@ TEST_F(TangentPathJoinerTest, testOneClosedPath) {
 TEST_F(TangentPathJoinerTest, testOneOpenPath) {
   QVector<Path> input = {Path(QVector<Vertex>{
       Vertex(Point(0, 0)),
-      Vertex(Point(1, 0)),
-      Vertex(Point(1, 1)),
+      Vertex(Point(1000, 0)),
+      Vertex(Point(1000, 1000)),
   })};
   QVector<Path> expected = {Path(QVector<Vertex>{
       Vertex(Point(0, 0)),
-      Vertex(Point(1, 0)),
-      Vertex(Point(1, 1)),
+      Vertex(Point(1000, 0)),
+      Vertex(Point(1000, 1000)),
   })};
   QVector<Path> output = TangentPathJoiner::join(input);
   EXPECT_EQ(str(expected), str(output)) << debug(expected, output);
@@ -115,17 +115,17 @@ TEST_F(TangentPathJoinerTest, testTwoTangentPaths) {
   QVector<Path> input = {
       Path(QVector<Vertex>{
           Vertex(Point(0, 0), Angle::deg90()),
-          Vertex(Point(1, 0)),
+          Vertex(Point(1000, 0)),
       }),
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0), Angle::deg180()),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0), Angle::deg180()),
+          Vertex(Point(1000, 1000)),
       }),
   };
   QVector<Path> expected = {Path(QVector<Vertex>{
       Vertex(Point(0, 0), Angle::deg90()),
-      Vertex(Point(1, 0), Angle::deg180()),
-      Vertex(Point(1, 1)),
+      Vertex(Point(1000, 0), Angle::deg180()),
+      Vertex(Point(1000, 1000)),
   })};
   QVector<Path> output = TangentPathJoiner::join(input);
   EXPECT_EQ(str(expected), str(output)) << debug(expected, output);
@@ -134,18 +134,18 @@ TEST_F(TangentPathJoinerTest, testTwoTangentPaths) {
 TEST_F(TangentPathJoinerTest, testTwoTangentPathsFirstReversed) {
   QVector<Path> input = {
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0), Angle::deg90()),
+          Vertex(Point(1000, 0), Angle::deg90()),
           Vertex(Point(0, 0)),
       }),
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0), Angle::deg180()),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0), Angle::deg180()),
+          Vertex(Point(1000, 1000)),
       }),
   };
   QVector<Path> expected = {Path(QVector<Vertex>{
       Vertex(Point(0, 0), -Angle::deg90()),
-      Vertex(Point(1, 0), Angle::deg180()),
-      Vertex(Point(1, 1)),
+      Vertex(Point(1000, 0), Angle::deg180()),
+      Vertex(Point(1000, 1000)),
   })};
   QVector<Path> output = TangentPathJoiner::join(input);
   EXPECT_EQ(str(expected), str(output)) << debug(expected, output);
@@ -155,17 +155,17 @@ TEST_F(TangentPathJoinerTest, testTwoTangentPathsSecondReversed) {
   QVector<Path> input = {
       Path(QVector<Vertex>{
           Vertex(Point(0, 0), Angle::deg90()),
-          Vertex(Point(1, 0)),
+          Vertex(Point(1000, 0)),
       }),
       Path(QVector<Vertex>{
-          Vertex(Point(1, 1), Angle::deg180()),
-          Vertex(Point(1, 0)),
+          Vertex(Point(1000, 1000), Angle::deg180()),
+          Vertex(Point(1000, 0)),
       }),
   };
   QVector<Path> expected = {Path(QVector<Vertex>{
       Vertex(Point(0, 0), Angle::deg90()),
-      Vertex(Point(1, 0), -Angle::deg180()),
-      Vertex(Point(1, 1)),
+      Vertex(Point(1000, 0), -Angle::deg180()),
+      Vertex(Point(1000, 1000)),
   })};
   QVector<Path> output = TangentPathJoiner::join(input);
   EXPECT_EQ(str(expected), str(output)) << debug(expected, output);
@@ -174,17 +174,17 @@ TEST_F(TangentPathJoinerTest, testTwoTangentPathsSecondReversed) {
 TEST_F(TangentPathJoinerTest, testTwoTangentPathsBothReversed) {
   QVector<Path> input = {
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0), Angle::deg90()),
+          Vertex(Point(1000, 0), Angle::deg90()),
           Vertex(Point(0, 0)),
       }),
       Path(QVector<Vertex>{
-          Vertex(Point(1, 1), Angle::deg180()),
-          Vertex(Point(1, 0)),
+          Vertex(Point(1000, 1000), Angle::deg180()),
+          Vertex(Point(1000, 0)),
       }),
   };
   QVector<Path> expected = {Path(QVector<Vertex>{
-      Vertex(Point(1, 1), Angle::deg180()),
-      Vertex(Point(1, 0), Angle::deg90()),
+      Vertex(Point(1000, 1000), Angle::deg180()),
+      Vertex(Point(1000, 0), Angle::deg90()),
       Vertex(Point(0, 0)),
   })};
   QVector<Path> output = TangentPathJoiner::join(input);
@@ -195,37 +195,37 @@ TEST_F(TangentPathJoinerTest, testTwoNestedRects) {
   QVector<Path> input = {
       Path(QVector<Vertex>{
           Vertex(Point(0, 0)),
-          Vertex(Point(0, 1)),
-          Vertex(Point(1, 1)),
+          Vertex(Point(0, 1000)),
+          Vertex(Point(1000, 1000)),
       }),
       Path(QVector<Vertex>{
           Vertex(Point(0, 0)),
-          Vertex(Point(1, 0)),
+          Vertex(Point(1000, 0)),
       }),
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0)),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(1000, 1000)),
       }),
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0)),
-          Vertex(Point(2, 0)),
-          Vertex(Point(2, 1)),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(2000, 0)),
+          Vertex(Point(2000, 1000)),
+          Vertex(Point(1000, 1000)),
       }),
   };
   QVector<Path> expected = {
       Path(QVector<Vertex>{
-          Vertex(Point(1, 1)),
-          Vertex(Point(0, 1)),
+          Vertex(Point(1000, 1000)),
+          Vertex(Point(0, 1000)),
           Vertex(Point(0, 0)),
-          Vertex(Point(1, 0)),
-          Vertex(Point(2, 0)),
-          Vertex(Point(2, 1)),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(2000, 0)),
+          Vertex(Point(2000, 1000)),
+          Vertex(Point(1000, 1000)),
       }),
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0)),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(1000, 1000)),
       }),
   };
   QVector<Path> output = TangentPathJoiner::join(input);
@@ -236,65 +236,65 @@ TEST_F(TangentPathJoinerTest, testSeveralTangentAndNonTangentPaths) {
   QVector<Path> input = {
       // Path 2, Segment 2
       Path(QVector<Vertex>{
-          Vertex(Point(1, 0)),
-          Vertex(Point(1, 1), Angle::deg90()),
-          Vertex(Point(2, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(1000, 1000), Angle::deg90()),
+          Vertex(Point(2000, 1000)),
       }),
       // Path 1 (closed)
       Path(QVector<Vertex>{
           Vertex(Point(0, 0), Angle::deg90()),
-          Vertex(Point(1, 0)),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(1000, 1000)),
           Vertex(Point(0, 0)),
       }),
       // Path 3 (open)
       Path(QVector<Vertex>{
-          Vertex(Point(5, 5), Angle::deg90()),
-          Vertex(Point(6, 6)),
-          Vertex(Point(7, 7)),
+          Vertex(Point(5000, 5000), Angle::deg90()),
+          Vertex(Point(6000, 6000)),
+          Vertex(Point(7000, 7000)),
       }),
       // Path 2, Segment 1
       Path(QVector<Vertex>{
           Vertex(Point(0, 0)),
-          Vertex(Point(1, 0)),
+          Vertex(Point(1000, 0)),
       }),
       // Path 2, Segment 4 (reversed)
       Path(QVector<Vertex>{
-          Vertex(Point(4, 1)),
-          Vertex(Point(3, 1), Angle::deg90()),
-          Vertex(Point(3, 0)),
-          Vertex(Point(2, 0)),
+          Vertex(Point(4000, 1000)),
+          Vertex(Point(3000, 1000), Angle::deg90()),
+          Vertex(Point(3000, 0)),
+          Vertex(Point(2000, 0)),
       }),
       // Path 2, Segment 3
       Path(QVector<Vertex>{
-          Vertex(Point(2, 1), Angle::deg90()),
-          Vertex(Point(2, 0)),
+          Vertex(Point(2000, 1000), Angle::deg90()),
+          Vertex(Point(2000, 0)),
       }),
   };
   QVector<Path> expected = {
       // Path 1 (closed)
       Path(QVector<Vertex>{
           Vertex(Point(0, 0), Angle::deg90()),
-          Vertex(Point(1, 0)),
-          Vertex(Point(1, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(1000, 1000)),
           Vertex(Point(0, 0)),
       }),
       // Path 2 (joined)
       Path(QVector<Vertex>{
           Vertex(Point(0, 0)),
-          Vertex(Point(1, 0)),
-          Vertex(Point(1, 1), Angle::deg90()),
-          Vertex(Point(2, 1), Angle::deg90()),
-          Vertex(Point(2, 0)),
-          Vertex(Point(3, 0), -Angle::deg90()),
-          Vertex(Point(3, 1)),
-          Vertex(Point(4, 1)),
+          Vertex(Point(1000, 0)),
+          Vertex(Point(1000, 1000), Angle::deg90()),
+          Vertex(Point(2000, 1000), Angle::deg90()),
+          Vertex(Point(2000, 0)),
+          Vertex(Point(3000, 0), -Angle::deg90()),
+          Vertex(Point(3000, 1000)),
+          Vertex(Point(4000, 1000)),
       }),
       // Path 3 (open)
       Path(QVector<Vertex>{
-          Vertex(Point(5, 5), Angle::deg90()),
-          Vertex(Point(6, 6)),
-          Vertex(Point(7, 7)),
+          Vertex(Point(5000, 5000), Angle::deg90()),
+          Vertex(Point(6000, 6000)),
+          Vertex(Point(7000, 7000)),
       }),
   };
   QVector<Path> output = TangentPathJoiner::join(input);
@@ -306,15 +306,15 @@ TEST_F(TangentPathJoinerTest, testManyIndependentPaths) {
   QVector<Path> input;
   for (int i = 0; i < 1000; ++i) {
     QVector<Vertex> vertices{
-        Vertex(Point(i, 0)),  Vertex(Point(i, 1), Angle::deg90()),
-        Vertex(Point(i, 2)),  Vertex(Point(i, 3)),
-        Vertex(Point(i, 4)),  Vertex(Point(i, 5)),
-        Vertex(Point(i, 6)),  Vertex(Point(i, 7)),
-        Vertex(Point(i, 8)),  Vertex(Point(i, 9)),
-        Vertex(Point(i, 10)), Vertex(Point(i, 11)),
-        Vertex(Point(i, 12)), Vertex(Point(i, 13)),
-        Vertex(Point(i, 14)), Vertex(Point(i, 15)),
-        Vertex(Point(i, 16)), Vertex(Point(i, 17)),
+        Vertex(Point(i, 0)),     Vertex(Point(i, 1), Angle::deg90()),
+        Vertex(Point(i, 2000)),  Vertex(Point(i, 3000)),
+        Vertex(Point(i, 4000)),  Vertex(Point(i, 5000)),
+        Vertex(Point(i, 6000)),  Vertex(Point(i, 7000)),
+        Vertex(Point(i, 8000)),  Vertex(Point(i, 9000)),
+        Vertex(Point(i, 10000)), Vertex(Point(i, 11000)),
+        Vertex(Point(i, 12000)), Vertex(Point(i, 13000)),
+        Vertex(Point(i, 14000)), Vertex(Point(i, 15000)),
+        Vertex(Point(i, 16000)), Vertex(Point(i, 17000)),
     };
     input.append(Path(vertices));
   }
@@ -330,14 +330,14 @@ TEST_F(TangentPathJoinerTest, testManyTangentPaths) {
   for (int i = 0; i < 1000; ++i) {
     QVector<Vertex> vertices{
         Vertex(Point(i, 0)),     Vertex(Point(i, 1), Angle::deg90()),
-        Vertex(Point(i, 2)),     Vertex(Point(i, 3)),
-        Vertex(Point(i, 4)),     Vertex(Point(i, 5)),
-        Vertex(Point(i, 6)),     Vertex(Point(i, 7)),
-        Vertex(Point(i, 8)),     Vertex(Point(i, 9)),
-        Vertex(Point(i, 10)),    Vertex(Point(i, 11)),
-        Vertex(Point(i, 12)),    Vertex(Point(i, 13)),
-        Vertex(Point(i, 14)),    Vertex(Point(i, 15)),
-        Vertex(Point(i, 16)),    Vertex(Point(i, 17)),
+        Vertex(Point(i, 2000)),  Vertex(Point(i, 3000)),
+        Vertex(Point(i, 4000)),  Vertex(Point(i, 5000)),
+        Vertex(Point(i, 6000)),  Vertex(Point(i, 7000)),
+        Vertex(Point(i, 8000)),  Vertex(Point(i, 9000)),
+        Vertex(Point(i, 10000)), Vertex(Point(i, 11000)),
+        Vertex(Point(i, 12000)), Vertex(Point(i, 13000)),
+        Vertex(Point(i, 14000)), Vertex(Point(i, 15000)),
+        Vertex(Point(i, 16000)), Vertex(Point(i, 17000)),
         Vertex(Point(i + 1, 0)),
     };
     input.append(Path(vertices));

--- a/tests/unittests/eagleimport/eagleprojectimporttest.cpp
+++ b/tests/unittests/eagleimport/eagleprojectimporttest.cpp
@@ -20,13 +20,17 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "../testhelpers.h"
+
 #include <gtest/gtest.h>
 #include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/project/circuit/circuit.h>
 #include <librepcb/core/project/project.h>
 #include <librepcb/core/project/projectloader.h>
+#include <librepcb/core/types/uuid.h>
 #include <librepcb/eagleimport/eagleprojectimport.h>
 
 #include <QtCore>
@@ -40,6 +44,8 @@ namespace librepcb {
 namespace eagleimport {
 namespace tests {
 
+using namespace librepcb::tests;
+
 /*******************************************************************************
  *  Test Class
  ******************************************************************************/
@@ -52,11 +58,7 @@ protected:
 
   ~EagleProjectImportTest() { QDir(mTmpDir.toStr()).removeRecursively(); }
 
-  FilePath getSch(const QString& fp) const noexcept {
-    return FilePath(TEST_DATA_DIR "/unittests/eagleimport/" % fp);
-  }
-
-  FilePath getBrd(const QString& fp) const noexcept {
+  FilePath getPathTo(const QString& fp) const noexcept {
     return FilePath(TEST_DATA_DIR "/unittests/eagleimport/" % fp);
   }
 
@@ -74,7 +76,8 @@ TEST_F(EagleProjectImportTest, testImportOnlySchematic) {
   EagleProjectImport import;
   EXPECT_FALSE(import.isReady());
 
-  const QStringList msgs = import.open(getSch("testproject.sch"), FilePath());
+  const QStringList msgs =
+      import.open(getPathTo("testproject/testproject.sch"), FilePath());
   EXPECT_TRUE(import.isReady());
   EXPECT_EQ("testproject", import.getProjectName().toStdString());
   EXPECT_EQ("", msgs.join(";").toStdString());
@@ -99,19 +102,28 @@ TEST_F(EagleProjectImportTest, testImportOnlySchematic) {
 }
 
 TEST_F(EagleProjectImportTest, testImportWithBoard) {
-  EagleProjectImport import;
+  auto uuidFactory = TestHelpers::createDeterministicUuidFactory();
+  EagleProjectImport import(uuidFactory,
+                            TestHelpers::createDeterministicDateTime());
   EXPECT_FALSE(import.isReady());
 
   const QStringList msgs =
-      import.open(getSch("testproject.sch"), getBrd("testproject.brd"));
+      import.open(getPathTo("testproject/testproject.sch"),
+                  getPathTo("testproject/testproject.brd"));
   EXPECT_TRUE(import.isReady());
   EXPECT_EQ("testproject", import.getProjectName().toStdString());
   EXPECT_EQ("", msgs.join(";").toStdString());
 
+  const FilePath outFp = getPathTo("testproject/actual");
+  FileUtils::removeDirRecursively(outFp);
+
   {
     // Populate and save project.
+    std::unique_ptr<TransactionalDirectory> dir(
+        new TransactionalDirectory(TransactionalFileSystem::openRW(outFp)));
     std::unique_ptr<Project> project =
-        Project::create(getProjectDir(), "test.lpp");
+        Project::create(std::move(dir), "test.lpp", uuidFactory);
+    project->setCreated(TestHelpers::createDeterministicDateTime());
     import.import(*project);
     project->save();
     project->getDirectory().getFileSystem()->save();
@@ -119,12 +131,17 @@ TEST_F(EagleProjectImportTest, testImportWithBoard) {
 
   {
     // Open project again to see if there's no problem with it.
+    std::unique_ptr<TransactionalDirectory> dir(
+        new TransactionalDirectory(TransactionalFileSystem::openRO(outFp)));
     ProjectLoader loader;
-    std::unique_ptr<Project> project = loader.open(getProjectDir(), "test.lpp");
+    std::unique_ptr<Project> project = loader.open(std::move(dir), "test.lpp");
     EXPECT_EQ(1, project->getSchematics().count());
     EXPECT_EQ(1, project->getBoards().count());
     EXPECT_EQ(4, project->getCircuit().getBuses().count());
   }
+
+  // Compare exported project with golden sample.
+  TestHelpers::compareDirectories(outFp, getPathTo("testproject/expected"));
 }
 
 // This project has strange embedded libraries which shall be tested.
@@ -132,8 +149,9 @@ TEST_F(EagleProjectImportTest, testArduinoMicro) {
   EagleProjectImport import;
   EXPECT_FALSE(import.isReady());
 
-  const QStringList msgs = import.open(getSch("arduino-micro/Micro_Rev1j.sch"),
-                                       getBrd("arduino-micro/Micro_Rev1j.brd"));
+  const QStringList msgs =
+      import.open(getPathTo("arduino-micro/Micro_Rev1j.sch"),
+                  getPathTo("arduino-micro/Micro_Rev1j.brd"));
   EXPECT_TRUE(import.isReady());
   EXPECT_EQ("Micro_Rev1j", import.getProjectName().toStdString());
   EXPECT_EQ("", msgs.join(";").toStdString());
@@ -160,8 +178,8 @@ TEST_F(EagleProjectImportTest, testNodino) {
   EagleProjectImport import;
   EXPECT_FALSE(import.isReady());
 
-  const QStringList msgs = import.open(getSch("nodino-rc7/Nodino-RC7.sch"),
-                                       getBrd("nodino-rc7/Nodino-RC7.brd"));
+  const QStringList msgs = import.open(getPathTo("nodino-rc7/Nodino-RC7.sch"),
+                                       getPathTo("nodino-rc7/Nodino-RC7.brd"));
   EXPECT_TRUE(import.isReady());
   EXPECT_EQ("Nodino-RC7", import.getProjectName().toStdString());
   EXPECT_EQ("", msgs.join(";").toStdString());

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -50,9 +50,7 @@ namespace tests {
 class EagleTypeConverterTest : public ::testing::Test {
 protected:
   static parseagle::DomElement dom(const QString& str) {
-    QDomDocument doc;
-    doc.setContent(str);
-    return parseagle::DomElement(doc.documentElement());
+    return parseagle::DomElement::parse(str);
   }
 };
 

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -43,8 +43,6 @@ namespace librepcb {
 namespace eagleimport {
 namespace tests {
 
-using C = EagleTypeConverter;
-
 /*******************************************************************************
  *  Test Class
  ******************************************************************************/
@@ -63,89 +61,97 @@ protected:
  ******************************************************************************/
 
 TEST_F(EagleTypeConverterTest, testConvertElementName) {
-  EXPECT_EQ("Valid Name", C::convertElementName("Valid Name")->toStdString());
-  EXPECT_EQ("X", C::convertElementName(" \nX ")->toStdString());
-  EXPECT_EQ("Unnamed", C::convertElementName("\n")->toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("Valid Name", c.convertElementName("Valid Name")->toStdString());
+  EXPECT_EQ("X", c.convertElementName(" \nX ")->toStdString());
+  EXPECT_EQ("Unnamed", c.convertElementName("\n")->toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertElementDescription) {
-  EXPECT_EQ("", C::convertElementDescription("").toStdString());
-  EXPECT_EQ("Text", C::convertElementDescription(" Text ").toStdString());
-  EXPECT_EQ("X\nY", C::convertElementDescription("X\nY").toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("", c.convertElementDescription("").toStdString());
+  EXPECT_EQ("Text", c.convertElementDescription(" Text ").toStdString());
+  EXPECT_EQ("X\nY", c.convertElementDescription("X\nY").toStdString());
   EXPECT_EQ("X\nY",
-            C::convertElementDescription("<b>X</b><br/>Y").toStdString());
+            c.convertElementDescription("<b>X</b><br/>Y").toStdString());
   EXPECT_EQ("X\nY",
-            C::convertElementDescription("<b>X</b>\n<br/>Y").toStdString());
+            c.convertElementDescription("<b>X</b>\n<br/>Y").toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertComponentName) {
-  EXPECT_EQ("Valid Name", C::convertComponentName("Valid Name")->toStdString());
-  EXPECT_EQ("X", C::convertComponentName(" \nX ")->toStdString());
-  EXPECT_EQ("Foo - Bar", C::convertComponentName("Foo - Bar-")->toStdString());
-  EXPECT_EQ("Foo _ Bar", C::convertComponentName("Foo _ Bar_")->toStdString());
-  EXPECT_EQ("-", C::convertComponentName("-")->toStdString());
-  EXPECT_EQ("Unnamed", C::convertComponentName("\n")->toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("Valid Name", c.convertComponentName("Valid Name")->toStdString());
+  EXPECT_EQ("X", c.convertComponentName(" \nX ")->toStdString());
+  EXPECT_EQ("Foo - Bar", c.convertComponentName("Foo - Bar-")->toStdString());
+  EXPECT_EQ("Foo _ Bar", c.convertComponentName("Foo _ Bar_")->toStdString());
+  EXPECT_EQ("-", c.convertComponentName("-")->toStdString());
+  EXPECT_EQ("Unnamed", c.convertComponentName("\n")->toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertDeviceName) {
-  EXPECT_EQ("Valid Name",
-            C::convertDeviceName("Valid Name", "")->toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("Valid Name", c.convertDeviceName("Valid Name", "")->toStdString());
   EXPECT_EQ("Valid Name-Foo",
-            C::convertDeviceName("Valid Name", "Foo")->toStdString());
+            c.convertDeviceName("Valid Name", "Foo")->toStdString());
   EXPECT_EQ("Valid Name-Foo",
-            C::convertDeviceName("Valid Name-", "Foo")->toStdString());
+            c.convertDeviceName("Valid Name-", "Foo")->toStdString());
   EXPECT_EQ("Valid Name_Foo",
-            C::convertDeviceName("Valid Name_", "Foo")->toStdString());
+            c.convertDeviceName("Valid Name_", "Foo")->toStdString());
   EXPECT_EQ("Valid Name-Foo",
-            C::convertDeviceName("Valid Name-", "Foo")->toStdString());
+            c.convertDeviceName("Valid Name-", "Foo")->toStdString());
   EXPECT_EQ("Valid Name_Foo",
-            C::convertDeviceName("Valid Name_", "Foo")->toStdString());
+            c.convertDeviceName("Valid Name_", "Foo")->toStdString());
   EXPECT_EQ("Valid Name-Foo",
-            C::convertDeviceName("Valid Name", "-Foo")->toStdString());
+            c.convertDeviceName("Valid Name", "-Foo")->toStdString());
   EXPECT_EQ("Valid Name_Foo",
-            C::convertDeviceName("Valid Name", "_Foo")->toStdString());
-  EXPECT_EQ("X", C::convertDeviceName(" \nX ", "")->toStdString());
-  EXPECT_EQ("Unnamed", C::convertDeviceName("\n", "")->toStdString());
-  EXPECT_EQ("Unnamed", C::convertDeviceName("", "")->toStdString());
+            c.convertDeviceName("Valid Name", "_Foo")->toStdString());
+  EXPECT_EQ("X", c.convertDeviceName(" \nX ", "")->toStdString());
+  EXPECT_EQ("Unnamed", c.convertDeviceName("\n", "")->toStdString());
+  EXPECT_EQ("Unnamed", c.convertDeviceName("", "")->toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertComponentPrefix) {
-  EXPECT_EQ("", C::convertComponentPrefix("")->toStdString());
-  EXPECT_EQ("", C::convertComponentPrefix("$42+")->toStdString());
-  EXPECT_EQ("C", C::convertComponentPrefix("C")->toStdString());
-  EXPECT_EQ("Foo_Bar", C::convertComponentPrefix(" Foo Bar ")->toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("", c.convertComponentPrefix("")->toStdString());
+  EXPECT_EQ("", c.convertComponentPrefix("$42+")->toStdString());
+  EXPECT_EQ("C", c.convertComponentPrefix("C")->toStdString());
+  EXPECT_EQ("Foo_Bar", c.convertComponentPrefix(" Foo Bar ")->toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertGateName) {
-  EXPECT_EQ("", C::convertGateName("")->toStdString());
-  EXPECT_EQ("G42", C::convertGateName("G$42")->toStdString());
-  EXPECT_EQ("1", C::convertGateName("-1")->toStdString());
-  EXPECT_EQ("Foo_Bar", C::convertGateName(" Foo Bar ")->toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("", c.convertGateName("")->toStdString());
+  EXPECT_EQ("G42", c.convertGateName("G$42")->toStdString());
+  EXPECT_EQ("1", c.convertGateName("-1")->toStdString());
+  EXPECT_EQ("Foo_Bar", c.convertGateName(" Foo Bar ")->toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertPinOrPadName) {
-  EXPECT_EQ("Unnamed", C::convertPinOrPadName(" ")->toStdString());
-  EXPECT_EQ("42", C::convertPinOrPadName("P$42")->toStdString());
-  EXPECT_EQ("3", C::convertPinOrPadName("3")->toStdString());
-  EXPECT_EQ("Foo_Bar", C::convertPinOrPadName(" Foo Bar ")->toStdString());
-  EXPECT_EQ("!FOO!/BAR", C::convertPinOrPadName("!FOO/BAR")->toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("Unnamed", c.convertPinOrPadName(" ")->toStdString());
+  EXPECT_EQ("42", c.convertPinOrPadName("P$42")->toStdString());
+  EXPECT_EQ("3", c.convertPinOrPadName("3")->toStdString());
+  EXPECT_EQ("Foo_Bar", c.convertPinOrPadName(" Foo Bar ")->toStdString());
+  EXPECT_EQ("!FOO!/BAR", c.convertPinOrPadName("!FOO/BAR")->toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertInversionSyntax) {
-  EXPECT_EQ("FOO", C::convertInversionSyntax("FOO").toStdString());
-  EXPECT_EQ("!FOO", C::convertInversionSyntax("!FOO").toStdString());
-  EXPECT_EQ("!FOO", C::convertInversionSyntax("!FOO!").toStdString());
-  EXPECT_EQ("!FOO/BAR", C::convertInversionSyntax("!FOO!/BAR").toStdString());
-  EXPECT_EQ("!FOO!/BAR", C::convertInversionSyntax("!FOO/BAR").toStdString());
-  EXPECT_EQ("FOO/!BAR", C::convertInversionSyntax("FOO/!BAR").toStdString());
-  EXPECT_EQ("FOO/!BAR", C::convertInversionSyntax("FOO/!BAR!").toStdString());
-  EXPECT_EQ("A/!B/C", C::convertInversionSyntax("A/!B!/C").toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("FOO", c.convertInversionSyntax("FOO").toStdString());
+  EXPECT_EQ("!FOO", c.convertInversionSyntax("!FOO").toStdString());
+  EXPECT_EQ("!FOO", c.convertInversionSyntax("!FOO!").toStdString());
+  EXPECT_EQ("!FOO/BAR", c.convertInversionSyntax("!FOO!/BAR").toStdString());
+  EXPECT_EQ("!FOO!/BAR", c.convertInversionSyntax("!FOO/BAR").toStdString());
+  EXPECT_EQ("FOO/!BAR", c.convertInversionSyntax("FOO/!BAR").toStdString());
+  EXPECT_EQ("FOO/!BAR", c.convertInversionSyntax("FOO/!BAR!").toStdString());
+  EXPECT_EQ("A/!B/C", c.convertInversionSyntax("A/!B!/C").toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertAttributeValid) {
+  EagleTypeConverter c;
   MessageLogger log;
   const QString xml = "<attribute name=\"Foo Bar\" value=\"hello world!\"/>";
-  auto out = C::tryConvertAttribute(parseagle::Attribute(dom(xml)), log);
+  auto out = c.tryConvertAttribute(parseagle::Attribute(dom(xml)), log);
   ASSERT_TRUE(out != nullptr);
   EXPECT_EQ("FOO_BAR", out->getKey()->toStdString());
   EXPECT_EQ("hello world!", out->getValue().toStdString());
@@ -154,40 +160,44 @@ TEST_F(EagleTypeConverterTest, testConvertAttributeValid) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertAttributeInvalid) {
+  EagleTypeConverter c;
   MessageLogger log;
   const QString xml = "<attribute name=\"!\" value=\"hello world!\"/>";
-  auto out = C::tryConvertAttribute(parseagle::Attribute(dom(xml)), log);
+  auto out = c.tryConvertAttribute(parseagle::Attribute(dom(xml)), log);
   EXPECT_TRUE(out == nullptr);
   EXPECT_EQ(1, log.getMessages().count());
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertSchematicLayer) {
-  EXPECT_EQ(nullptr, C::tryConvertSchematicLayer(1));  // tCu
-  EXPECT_EQ(&Layer::symbolOutlines(), C::tryConvertSchematicLayer(94));  // sym
-  EXPECT_EQ(nullptr, C::tryConvertSchematicLayer(999));  // non existent
+  EagleTypeConverter c;
+  EXPECT_EQ(nullptr, c.tryConvertSchematicLayer(1));  // tCu
+  EXPECT_EQ(&Layer::symbolOutlines(), c.tryConvertSchematicLayer(94));  // sym
+  EXPECT_EQ(nullptr, c.tryConvertSchematicLayer(999));  // non existent
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertBoardLayer) {
-  EXPECT_EQ(&Layer::topCopper(), C::tryConvertBoardLayer(1));  // tCu
-  EXPECT_EQ(Layer::innerCopper(2), C::tryConvertBoardLayer(3));  // inner 2
-  EXPECT_EQ(&Layer::botCopper(), C::tryConvertBoardLayer(16));  // bCu
-  EXPECT_EQ(nullptr, C::tryConvertBoardLayer(94));  // symbols
-  EXPECT_EQ(nullptr, C::tryConvertBoardLayer(999));  // non existent
+  EagleTypeConverter c;
+  EXPECT_EQ(&Layer::topCopper(), c.tryConvertBoardLayer(1));  // tCu
+  EXPECT_EQ(Layer::innerCopper(2), c.tryConvertBoardLayer(3));  // inner 2
+  EXPECT_EQ(&Layer::botCopper(), c.tryConvertBoardLayer(16));  // bCu
+  EXPECT_EQ(nullptr, c.tryConvertBoardLayer(94));  // symbols
+  EXPECT_EQ(nullptr, c.tryConvertBoardLayer(999));  // non existent
 }
 
 TEST_F(EagleTypeConverterTest, testConvertLayerSetup) {
+  EagleTypeConverter c;
   typedef QHash<const Layer*, const Layer*> T;
-  EXPECT_EQ((T{}), C::convertLayerSetup(""));
+  EXPECT_EQ((T{}), c.convertLayerSetup(""));
   EXPECT_EQ((T{
                 {&Layer::topCopper(), &Layer::topCopper()},
                 {&Layer::botCopper(), &Layer::botCopper()},
             }),
-            C::convertLayerSetup("1*16"));
+            c.convertLayerSetup("1*16"));
   EXPECT_EQ((T{
                 {&Layer::topCopper(), &Layer::topCopper()},
                 {&Layer::botCopper(), &Layer::botCopper()},
             }),
-            C::convertLayerSetup("(1*16)"));
+            c.convertLayerSetup("(1*16)"));
   EXPECT_EQ((T{
                 {&Layer::topCopper(), &Layer::topCopper()},
                 {Layer::innerCopper(1), Layer::innerCopper(1)},
@@ -196,7 +206,7 @@ TEST_F(EagleTypeConverterTest, testConvertLayerSetup) {
                 {Layer::innerCopper(14), Layer::innerCopper(4)},
                 {&Layer::botCopper(), &Layer::botCopper()},
             }),
-            C::convertLayerSetup("[2:1+((2*3)+(14*15))+16:15]"));
+            c.convertLayerSetup("[2:1+((2*3)+(14*15))+16:15]"));
   EXPECT_EQ((T{
                 {&Layer::topCopper(), &Layer::topCopper()},
                 {Layer::innerCopper(1), Layer::innerCopper(1)},
@@ -205,55 +215,62 @@ TEST_F(EagleTypeConverterTest, testConvertLayerSetup) {
                 {Layer::innerCopper(4), Layer::innerCopper(4)},
                 {&Layer::botCopper(), &Layer::botCopper()},
             }),
-            C::convertLayerSetup("[2:1+[3:2+(3*4)+5:4]+16:5]"));
-  EXPECT_THROW(C::convertLayerSetup("1*Foo*16"), Exception);
+            c.convertLayerSetup("[2:1+[3:2+(3*4)+5:4]+16:5]"));
+  EXPECT_THROW(c.convertLayerSetup("1*Foo*16"), Exception);
 }
 
 TEST_F(EagleTypeConverterTest, testConvertAlignment) {
+  EagleTypeConverter c;
   EXPECT_EQ(Qt::AlignBottom | Qt::AlignRight,
-            C::convertAlignment(parseagle::Alignment::BottomRight).toQtAlign());
+            c.convertAlignment(parseagle::Alignment::BottomRight).toQtAlign());
   EXPECT_EQ(Qt::AlignTop | Qt::AlignHCenter,
-            C::convertAlignment(parseagle::Alignment::TopCenter).toQtAlign());
+            c.convertAlignment(parseagle::Alignment::TopCenter).toQtAlign());
 }
 
 TEST_F(EagleTypeConverterTest, testConvertLength) {
-  EXPECT_EQ(Length(0), C::convertLength(0));
-  EXPECT_EQ(Length(-1234567), C::convertLength(-1.234567));
-  EXPECT_EQ(Length(1234567), C::convertLength(1.234567));
+  EagleTypeConverter c;
+  EXPECT_EQ(Length(0), c.convertLength(0));
+  EXPECT_EQ(Length(-1234567), c.convertLength(-1.234567));
+  EXPECT_EQ(Length(1234567), c.convertLength(1.234567));
 }
 
 TEST_F(EagleTypeConverterTest, testConvertLineWidth) {
-  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(0, 20));  // dimension
-  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(0, 46));  // milling
-  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(1.23, 20));  // dimension
-  EXPECT_EQ(UnsignedLength(0), C::convertLineWidth(1.23, 46));  // milling
-  EXPECT_EQ(UnsignedLength(1230000), C::convertLineWidth(1.23, 1));  // tCu
-  EXPECT_EQ(UnsignedLength(1230000), C::convertLineWidth(1.23, 94));  // symbols
-  EXPECT_THROW(C::convertLineWidth(-1.23, 94), Exception);
+  EagleTypeConverter c;
+  EXPECT_EQ(UnsignedLength(0), c.convertLineWidth(0, 20));  // dimension
+  EXPECT_EQ(UnsignedLength(0), c.convertLineWidth(0, 46));  // milling
+  EXPECT_EQ(UnsignedLength(0), c.convertLineWidth(1.23, 20));  // dimension
+  EXPECT_EQ(UnsignedLength(0), c.convertLineWidth(1.23, 46));  // milling
+  EXPECT_EQ(UnsignedLength(1230000), c.convertLineWidth(1.23, 1));  // tCu
+  EXPECT_EQ(UnsignedLength(1230000), c.convertLineWidth(1.23, 94));  // symbols
+  EXPECT_THROW(c.convertLineWidth(-1.23, 94), Exception);
 }
 
 TEST_F(EagleTypeConverterTest, testConvertPoint) {
-  EXPECT_EQ(Point(0, 0), C::convertPoint(parseagle::Point{0, 0}));
+  EagleTypeConverter c;
+  EXPECT_EQ(Point(0, 0), c.convertPoint(parseagle::Point{0, 0}));
   EXPECT_EQ(Point(-1234567, 1234567),
-            C::convertPoint(parseagle::Point{-1.234567, 1.234567}));
+            c.convertPoint(parseagle::Point{-1.234567, 1.234567}));
 }
 
 TEST_F(EagleTypeConverterTest, testConvertAngle) {
-  EXPECT_EQ(Angle(0), C::convertAngle(0));
-  EXPECT_EQ(Angle(-1234567), C::convertAngle(-1.234567));
-  EXPECT_EQ(Angle(1234567), C::convertAngle(1.234567));
+  EagleTypeConverter c;
+  EXPECT_EQ(Angle(0), c.convertAngle(0));
+  EXPECT_EQ(Angle(-1234567), c.convertAngle(-1.234567));
+  EXPECT_EQ(Angle(1234567), c.convertAngle(1.234567));
 }
 
 TEST_F(EagleTypeConverterTest, testConvertVertex) {
+  EagleTypeConverter c;
   EXPECT_EQ(
       Vertex(Point(0, 0), Angle(0)),
-      C::convertVertex(parseagle::Vertex(dom("<vertex x=\"0\" y=\"0\"/>"))));
+      c.convertVertex(parseagle::Vertex(dom("<vertex x=\"0\" y=\"0\"/>"))));
   EXPECT_EQ(Vertex(Point(-6350000, 2540000), Angle(90000000)),
-            C::convertVertex(parseagle::Vertex(
+            c.convertVertex(parseagle::Vertex(
                 dom("<vertex x=\"-6.35\" y=\"2.54\" curve=\"90\"/>"))));
 }
 
 TEST_F(EagleTypeConverterTest, testConvertVertices) {
+  EagleTypeConverter c;
   QList<parseagle::Vertex> vertices{
       parseagle::Vertex(dom("<vertex x=\"-45.72\" y=\"-5.08\" curve=\"45\"/>")),
       parseagle::Vertex(dom("<vertex x=\"-35.56\" y=\"-5.08\"/>")),
@@ -265,10 +282,11 @@ TEST_F(EagleTypeConverterTest, testConvertVertices) {
       Vertex(Point(-38100000, -12700000), Angle(0)),
       Vertex(Point(-45720000, -5080000), Angle(0)),
   });
-  EXPECT_EQ(expected, C::convertVertices(vertices, true));
+  EXPECT_EQ(expected, c.convertVertices(vertices, true));
 }
 
 TEST_F(EagleTypeConverterTest, testConvertAndJoinWires) {
+  EagleTypeConverter c;
   MessageLogger log;
   QList<parseagle::Wire> wires{
       // clang-format off
@@ -280,7 +298,7 @@ TEST_F(EagleTypeConverterTest, testConvertAndJoinWires) {
       parseagle::Wire(dom("<wire x1=\"7\" y1=\"8\" x2=\"9\" y2=\"9\" width=\"-1\" layer=\"2\"/>")),
       // clang-format on
   };
-  auto out = C::convertAndJoinWires(wires, true, log);
+  auto out = c.convertAndJoinWires(wires, true, log);
   ASSERT_EQ(4, out.count());
   EXPECT_EQ(1, log.getMessages().count());
 
@@ -334,8 +352,9 @@ TEST_F(EagleTypeConverterTest, testConvertAndJoinWires) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertRectangle) {
+  EagleTypeConverter c;
   QString xml = "<rectangle x1=\"1\" y1=\"2\" x2=\"4\" y2=\"3\" layer=\"1\"/>";
-  auto out = C::convertRectangle(parseagle::Rectangle(dom(xml)), true);
+  auto out = c.convertRectangle(parseagle::Rectangle(dom(xml)), true);
   EXPECT_EQ(1, out.layerId);
   EXPECT_EQ(UnsignedLength(0), out.lineWidth);
   EXPECT_EQ(true, out.filled);  // EAGLE rectangles are always filled.
@@ -352,10 +371,11 @@ TEST_F(EagleTypeConverterTest, testConvertRectangle) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertRectangleRotated) {
+  EagleTypeConverter c;
   QString xml =
       "<rectangle x1=\"1\" y1=\"2\" x2=\"4\" y2=\"3\" layer=\"1\" "
       "rot=\"R90\"/>";
-  auto out = C::convertRectangle(parseagle::Rectangle(dom(xml)), false);
+  auto out = c.convertRectangle(parseagle::Rectangle(dom(xml)), false);
   EXPECT_EQ(1, out.layerId);
   EXPECT_EQ(UnsignedLength(0), out.lineWidth);
   EXPECT_EQ(true, out.filled);  // EAGLE rectangles are always filled.
@@ -372,12 +392,13 @@ TEST_F(EagleTypeConverterTest, testConvertRectangleRotated) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertPolygon) {
+  EagleTypeConverter c;
   QString xml =
       "<polygon width=\"2.54\" layer=\"1\">"
       "<vertex x=\"1\" y=\"2\" curve=\"45\"/>"
       "<vertex x=\"3\" y=\"4\"/>"
       "</polygon>";
-  auto out = C::convertPolygon(parseagle::Polygon(dom(xml)), false);
+  auto out = c.convertPolygon(parseagle::Polygon(dom(xml)), false);
   EXPECT_EQ(1, out.layerId);
   EXPECT_EQ(UnsignedLength(2540000), out.lineWidth);
   EXPECT_EQ(true, out.filled);  // EAGLE polygons are always filled.
@@ -392,9 +413,10 @@ TEST_F(EagleTypeConverterTest, testConvertPolygon) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertCircle) {
+  EagleTypeConverter c;
   QString xml =
       "<circle x=\"1\" y=\"2\" radius=\"3.5\" width=\"0.254\" layer=\"1\"/>";
-  auto out = C::convertCircle(parseagle::Circle(dom(xml)), true);
+  auto out = c.convertCircle(parseagle::Circle(dom(xml)), true);
   EXPECT_EQ(1, out.layerId);
   EXPECT_EQ(UnsignedLength(254000), out.lineWidth);
   EXPECT_EQ(false, out.filled);  // Not filled if line width != 0.
@@ -411,9 +433,10 @@ TEST_F(EagleTypeConverterTest, testConvertCircle) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertCircleFilled) {
+  EagleTypeConverter c;
   QString xml =
       "<circle x=\"1\" y=\"2\" radius=\"3.5\" width=\"0\" layer=\"1\"/>";
-  auto out = C::convertCircle(parseagle::Circle(dom(xml)), false);
+  auto out = c.convertCircle(parseagle::Circle(dom(xml)), false);
   EXPECT_EQ(1, out.layerId);
   EXPECT_EQ(UnsignedLength(0), out.lineWidth);
   EXPECT_EQ(true, out.filled);  // Filled if line width == 0.
@@ -430,8 +453,9 @@ TEST_F(EagleTypeConverterTest, testConvertCircleFilled) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertHole) {
+  EagleTypeConverter c;
   QString xml = "<hole x=\"1\" y=\"2\" drill=\"3.5\"/>";
-  auto out = C::convertHole(parseagle::Hole(dom(xml)));
+  auto out = c.convertHole(parseagle::Hole(dom(xml)));
   EXPECT_EQ(PositiveLength(3500000), out->getDiameter());
   EXPECT_EQ(1, out->getPath()->getVertices().count());
   EXPECT_EQ(Point(1000000, 2000000),
@@ -439,10 +463,11 @@ TEST_F(EagleTypeConverterTest, testConvertHole) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertFrame) {
+  EagleTypeConverter c;
   QString xml =
       "<frame x1=\"10\" y1=\"20\" x2=\"40\" y2=\"30\" columns=\"6\" rows=\"4\" "
       "layer=\"94\"/>";
-  auto out = C::convertFrame(parseagle::Frame(dom(xml)));
+  auto out = c.convertFrame(parseagle::Frame(dom(xml)));
   EXPECT_EQ(94, out.layerId);
   EXPECT_EQ(UnsignedLength(200000), out.lineWidth);
   EXPECT_EQ(false, out.filled);  // Filled frames make no sense.
@@ -459,24 +484,27 @@ TEST_F(EagleTypeConverterTest, testConvertFrame) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertTextValue) {
-  EXPECT_EQ("", C::convertTextValue("").toStdString());
-  EXPECT_EQ("{{NAME}}", C::convertTextValue(">NAME").toStdString());
-  EXPECT_EQ("{{VALUE}}", C::convertTextValue(">VALUE").toStdString());
-  EXPECT_EQ("Some Text", C::convertTextValue("Some Text").toStdString());
+  EagleTypeConverter c;
+  EXPECT_EQ("", c.convertTextValue("").toStdString());
+  EXPECT_EQ("{{NAME}}", c.convertTextValue(">NAME").toStdString());
+  EXPECT_EQ("{{VALUE}}", c.convertTextValue(">VALUE").toStdString());
+  EXPECT_EQ("Some Text", c.convertTextValue("Some Text").toStdString());
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertSchematicTextSize) {
+  EagleTypeConverter c;
   // Attention: The conversion factor is never exactly correct due to different
   // font layouting, but it seems to be a good value in most cases. Also it
   // makes sense to convert EAGLEs default name/value size of 1.778mm (is this
   // true?) to the LibrePCB's default name/value size of 2.5mm.
-  EXPECT_EQ(PositiveLength(2500000), C::convertSchematicTextSize(1.778));
+  EXPECT_EQ(PositiveLength(2500000), c.convertSchematicTextSize(1.778));
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertSchematicText) {
+  EagleTypeConverter c;
   QString xml =
       "<text x=\"1\" y=\"2\" size=\"1.778\" layer=\"94\">foo\nbar</text>";
-  auto out = C::tryConvertSchematicText(parseagle::Text(dom(xml)), true);
+  auto out = c.tryConvertSchematicText(parseagle::Text(dom(xml)), true);
   ASSERT_TRUE(out);
   EXPECT_EQ(Layer::symbolOutlines().getId().toStdString(),
             out->getLayer().getId().toStdString());
@@ -489,23 +517,25 @@ TEST_F(EagleTypeConverterTest, testTryConvertSchematicText) {
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertBoardTextSize) {
+  EagleTypeConverter c;
   // Attention: The conversion factor is never exactly correct due to different
   // font layouting, but it seems to be a good value for the vector font
   // (LibrePCB doesn't support other fonts anyway, so we don't care about them).
-  EXPECT_EQ(PositiveLength(1700000), C::convertBoardTextSize(1, 2));
+  EXPECT_EQ(PositiveLength(1700000), c.convertBoardTextSize(1, 2));
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertBoardTextStrokeWidth) {
-  EXPECT_EQ(UnsignedLength(1050000),
-            C::convertBoardTextStrokeWidth(1, 2.5, 42));
+  EagleTypeConverter c;
+  EXPECT_EQ(UnsignedLength(1050000), c.convertBoardTextStrokeWidth(1, 2.5, 42));
   // It seems the ratio is sometimes not defined and is thus set to 0%. In this
   // case, we fall back to a default ratio of 15%.
-  EXPECT_EQ(UnsignedLength(375000), C::convertBoardTextStrokeWidth(1, 2.5, 0));
+  EXPECT_EQ(UnsignedLength(375000), c.convertBoardTextStrokeWidth(1, 2.5, 0));
 }
 
 TEST_F(EagleTypeConverterTest, testTryConvertBoardText) {
+  EagleTypeConverter c;
   QString xml = "<text x=\"1\" y=\"2\" size=\"3\" layer=\"1\">&gt;NAME</text>";
-  auto out = C::tryConvertBoardText(parseagle::Text(dom(xml)), true);
+  auto out = c.tryConvertBoardText(parseagle::Text(dom(xml)), true);
   ASSERT_TRUE(out);
   EXPECT_EQ(Layer::topCopper().getId().toStdString(),
             out->getLayer().getId().toStdString());
@@ -523,8 +553,9 @@ TEST_F(EagleTypeConverterTest, testTryConvertBoardText) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertSymbolPin) {
+  EagleTypeConverter c;
   QString xml = "<pin name=\"P$1\" x=\"1\" y=\"2\" length=\"point\"/>";
-  auto out = C::convertSymbolPin(parseagle::Pin(dom(xml)));
+  auto out = c.convertSymbolPin(parseagle::Pin(dom(xml)));
   EXPECT_EQ("1", out.pin->getName()->toStdString());
   EXPECT_EQ(Point(1000000, 2000000), out.pin->getPosition());
   EXPECT_EQ(UnsignedLength(0), out.pin->getLength());
@@ -534,9 +565,10 @@ TEST_F(EagleTypeConverterTest, testConvertSymbolPin) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertSymbolPinRotated) {
+  EagleTypeConverter c;
   QString xml =
       "<pin name=\"P$1\" x=\"1\" y=\"2\" length=\"middle\" rot=\"R90\"/>";
-  auto out = C::convertSymbolPin(parseagle::Pin(dom(xml)));
+  auto out = c.convertSymbolPin(parseagle::Pin(dom(xml)));
   EXPECT_EQ("1", out.pin->getName()->toStdString());
   EXPECT_EQ(Point(1000000, 2000000), out.pin->getPosition());
   EXPECT_EQ(UnsignedLength(5080000), out.pin->getLength());
@@ -546,10 +578,12 @@ TEST_F(EagleTypeConverterTest, testConvertSymbolPinRotated) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertThtPad) {
+  EagleTypeConverter c;
   QString xml =
       "<pad name=\"P$1\" x=\"1\" y=\"2\" drill=\"1.5\" shape=\"square\"/>";
-  auto out = C::convertThtPad(parseagle::ThtPad(dom(xml)),
-                              C::getDefaultAutoThtAnnularWidth());
+  auto out =
+      c.convertThtPad(parseagle::ThtPad(dom(xml)),
+                      EagleTypeConverter::getDefaultAutoThtAnnularWidth());
   EXPECT_EQ("1", out.first->getName()->toStdString());
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
@@ -564,11 +598,13 @@ TEST_F(EagleTypeConverterTest, testConvertThtPad) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
+  EagleTypeConverter c;
   QString xml =
       "<pad name=\"P$1\" x=\"1\" y=\"2\" drill=\"1.5\" diameter=\"2.54\" "
       "shape=\"octagon\" rot=\"R90\"/>";
-  auto out = C::convertThtPad(parseagle::ThtPad(dom(xml)),
-                              C::getDefaultAutoThtAnnularWidth());
+  auto out =
+      c.convertThtPad(parseagle::ThtPad(dom(xml)),
+                      EagleTypeConverter::getDefaultAutoThtAnnularWidth());
   EXPECT_EQ("1", out.first->getName()->toStdString());
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
@@ -583,9 +619,10 @@ TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertSmtPad) {
+  EagleTypeConverter c;
   QString xml =
       "<smd name=\"P$1\" x=\"1\" y=\"2\" dx=\"3\" dy=\"4\" layer=\"1\"/>";
-  auto out = C::convertSmtPad(parseagle::SmtPad(dom(xml)));
+  auto out = c.convertSmtPad(parseagle::SmtPad(dom(xml)));
   EXPECT_EQ("1", out.first->getName()->toStdString());
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());
@@ -598,10 +635,11 @@ TEST_F(EagleTypeConverterTest, testConvertSmtPad) {
 }
 
 TEST_F(EagleTypeConverterTest, testConvertSmtPadRotated) {
+  EagleTypeConverter c;
   QString xml =
       "<smd name=\"P$1\" x=\"1\" y=\"2\" dx=\"3\" dy=\"4\" layer=\"16\" "
       "rot=\"R90\"/>";
-  auto out = C::convertSmtPad(parseagle::SmtPad(dom(xml)));
+  auto out = c.convertSmtPad(parseagle::SmtPad(dom(xml)));
   EXPECT_EQ("1", out.first->getName()->toStdString());
   EXPECT_EQ(out.first->getUuid(), out.second->getPackagePadUuid());
   EXPECT_EQ(Point(1000000, 2000000), out.second->getPosition());

--- a/tests/unittests/editor/library/cmd/cmdpackagereloadtest.cpp
+++ b/tests/unittests/editor/library/cmd/cmdpackagereloadtest.cpp
@@ -103,8 +103,8 @@ TEST_F(CmdPackageReloadTest, test) {
   // Create a "empty" library element and save it to the file system.
   std::unique_ptr<Package> element(
       new Package(Uuid::fromString("acd99b30-59a5-419f-b067-ae704e4364bb"),
-                  Version::fromString("0.1"), "", ElementName("name"), "", "",
-                  Package::AssemblyType::Auto));
+                  Version::fromString("0.1"), "", QDateTime::currentDateTime(),
+                  ElementName("name"), "", "", Package::AssemblyType::Auto));
   element->saveTo(*dir);
   fs->save();
 

--- a/tests/unittests/editor/library/cmd/cmdsymbolreloadtest.cpp
+++ b/tests/unittests/editor/library/cmd/cmdsymbolreloadtest.cpp
@@ -97,7 +97,8 @@ TEST_F(CmdSymbolReloadTest, test) {
   // Create a "empty" library element and save it to the file system.
   std::unique_ptr<Symbol> element(
       new Symbol(Uuid::fromString("acd99b30-59a5-419f-b067-ae704e4364bb"),
-                 Version::fromString("0.1"), "", ElementName("name"), "", ""));
+                 Version::fromString("0.1"), "", QDateTime::currentDateTime(),
+                 ElementName("name"), "", ""));
   element->saveTo(*dir);
   fs->save();
 

--- a/tests/unittests/editor/project/addcomponentdialogtest.cpp
+++ b/tests/unittests/editor/project/addcomponentdialogtest.cpp
@@ -167,7 +167,8 @@ TEST_F(AddComponentDialogTest, testChooseComponentDevice) {
 
   // Create component
   TransactionalDirectory cmp2Dir(mFs, uuid(4).toStr());
-  Component cmp2(uuid(4), version("0.1"), "", ElementName("cmp 2"), "", "");
+  Component cmp2(uuid(4), version("0.1"), "", QDateTime::currentDateTime(),
+                 ElementName("cmp 2"), "", "");
   auto cmp2SymbVar1 = std::make_shared<ComponentSymbolVariant>(
       uuid(7), "", ElementName("var 1"), "");
   cmp2.getSymbolVariants().append(cmp2SymbVar1);
@@ -178,14 +179,14 @@ TEST_F(AddComponentDialogTest, testChooseComponentDevice) {
 
   // Create package
   TransactionalDirectory pkg1Dir(mFs, uuid(5).toStr());
-  Package pkg1(uuid(5), version("0.1"), "", ElementName("pkg 1"), "", "",
-               Package::AssemblyType::Tht);
+  Package pkg1(uuid(5), version("0.1"), "", QDateTime::currentDateTime(),
+               ElementName("pkg 1"), "", "", Package::AssemblyType::Tht);
   pkg1.saveTo(pkg1Dir);
 
   // Create device
   TransactionalDirectory dev1Dir(mFs, uuid(6).toStr());
-  Device dev1(uuid(6), version("0.1"), "", ElementName("dev 1"), "", "",
-              uuid(4), uuid(5));
+  Device dev1(uuid(6), version("0.1"), "", QDateTime::currentDateTime(),
+              ElementName("dev 1"), "", "", uuid(4), uuid(5));
   dev1.saveTo(dev1Dir);
 
   // Save everything to disk
@@ -260,7 +261,8 @@ TEST_F(AddComponentDialogTest, testSetNormOrder) {
 
   // Create component
   TransactionalDirectory cmp2Dir(mFs, uuid(3).toStr());
-  Component cmp2(uuid(3), version("0.1"), "", ElementName("cmp 2"), "", "");
+  Component cmp2(uuid(3), version("0.1"), "", QDateTime::currentDateTime(),
+                 ElementName("cmp 2"), "", "");
   auto cmp2SymbVar1 = std::make_shared<ComponentSymbolVariant>(
       uuid(4), "", ElementName("var 1"), "");
   cmp2.getSymbolVariants().append(cmp2SymbVar1);

--- a/tests/unittests/testhelpers.cpp
+++ b/tests/unittests/testhelpers.cpp
@@ -23,6 +23,7 @@
 #include "testhelpers.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/utils/toolbox.h>
 
 #include <QtCore>
@@ -38,6 +39,53 @@ namespace tests {
 /*******************************************************************************
  *  Static Methods
  ******************************************************************************/
+
+std::function<Uuid()> TestHelpers::createDeterministicUuidFactory() noexcept {
+  auto counter = std::make_shared<quint64>(0);
+  return [counter]() -> Uuid {
+    ++(*counter);
+    return Uuid::fromString(QString("00000000-0000-4000-8000-%1")
+                                .arg(*counter, 12, 16, QLatin1Char('0')));
+  };
+}
+
+QDateTime TestHelpers::createDeterministicDateTime() noexcept {
+  return QDateTime::fromString("2000-01-02T03:04:05Z", Qt::ISODate);
+}
+
+void TestHelpers::compareDirectories(const FilePath& actual,
+                                     const FilePath& expected) {
+  const QList<FilePath> actualFiles =
+      FileUtils::getFilesInDirectory(actual, {}, true, false);
+  const QList<FilePath> expectedFiles =
+      FileUtils::getFilesInDirectory(expected, {}, true, false);
+
+  // Build relative-path sets for structural comparison.
+  QSet<QString> actualRels, expectedRels;
+  for (const FilePath& fp : actualFiles) {
+    actualRels.insert(fp.toRelative(actual));
+  }
+  for (const FilePath& fp : expectedFiles) {
+    expectedRels.insert(fp.toRelative(expected));
+  }
+
+  // Check for files missing in actual output.
+  for (const QString& rel : (expectedRels - actualRels)) {
+    ADD_FAILURE() << "Missing file in output: " << rel.toStdString();
+  }
+
+  // Check for unexpected files in actual output.
+  for (const QString& rel : (actualRels - expectedRels)) {
+    ADD_FAILURE() << "Unexpected file in output: " << rel.toStdString();
+  }
+
+  // Compare contents of files present in both, one at a time.
+  for (const QString& rel : (actualRels & expectedRels)) {
+    EXPECT_EQ(FileUtils::readFile(expected.getPathTo(rel)).toStdString(),
+              FileUtils::readFile(actual.getPathTo(rel)).toStdString())
+        << "File content differs: " << rel.toStdString();
+  }
+}
 
 void TestHelpers::testTabOrder(QWidget& widget) {
   // Skip test on systems other than Linux and Windows (details in function

--- a/tests/unittests/testhelpers.h
+++ b/tests/unittests/testhelpers.h
@@ -24,8 +24,12 @@
  *  Includes
  ******************************************************************************/
 #include <librepcb/core/exceptions.h>
+#include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/types/uuid.h>
 
 #include <QtCore>
+
+#include <functional>
 
 /*******************************************************************************
  *  Namespace
@@ -51,6 +55,37 @@ public:
   TestHelpers& operator=(const TestHelpers& rhs) = delete;
 
   // Static Methods
+
+  /**
+   * @brief Create an UUID factory that returns deterministic UUIDs
+   *
+   * This factory returns UUIDs of the form
+   * "00000000-0000-4000-8000-xxxxxxxxxxxx" with a monotonic counter.
+   *
+   * @return Factory function.
+   */
+  static std::function<Uuid()> createDeterministicUuidFactory() noexcept;
+
+  /**
+   * @brief Create a deterministic date time
+   *
+   * @return A hardcoded datetime.
+   */
+  static QDateTime createDeterministicDateTime() noexcept;
+
+  /**
+   * @brief Compare the contents of two directories recursively
+   *
+   * Recursively lists all files in both directories and checks that the sets
+   * of relative file paths are identical and that each file's content matches.
+   * Failures are reported via GTest macros, so this must only be called from
+   * within unit tests.
+   *
+   * @param actual    Directory produced by the code under test.
+   * @param expected  Golden sample directory to compare against.
+   */
+  static void compareDirectories(const FilePath& actual,
+                                 const FilePath& expected);
 
   /**
    * @brief Get a child object of a given parent object by path specification


### PR DESCRIPTION
Incorporating https://github.com/LibrePCB/parseagle/pull/18, to get rid of the deprecated QtXML dependency.

Added a golden sample unit test for `EagleProjectImport` to verify that the output after this patch remains the same as before.