### PR TITLE
Implement shading in 3D views

### DIFF
--- a/libs/librepcb/editor/3d/opengltriangleobject.cpp
+++ b/libs/librepcb/editor/3d/opengltriangleobject.cpp
@@ -31,6 +31,24 @@
 namespace librepcb {
 namespace editor {
 
+// Helper to avoid too dark colors, since colors close to black make the
+// 3D shading almost invisible. Edges and faces are much better visible on
+// dark gray than on black objects.
+static QColor lighterDarkColor(QColor color, qreal minValue) {
+  float h, s, v, a;
+  color.getHsvF(&h, &s, &v, &a);
+  if (v >= minValue) return color;  // Not dark enough to touch
+
+  // How far into the "dark zone" are we? 0.0 = at minValue, 1.0 = pure black
+  float t = 1.0 - (v / minValue);
+  t = t * t * (3.0 - 2.0 * t);  // Smoothstep for natural, non-linear transition
+
+  return QColor::fromHsvF(h,
+                          s * (1.0 - t),  // Desaturate proportionally
+                          v + t * (minValue - v),  // Lift value toward minValue
+                          a);
+}
+
 /*******************************************************************************
  *  Constructors / Destructor
  ******************************************************************************/
@@ -55,7 +73,7 @@ OpenGlTriangleObject::~OpenGlTriangleObject() noexcept {
 void OpenGlTriangleObject::setData(const QColor& color,
                                    const QVector<QVector3D>& data) noexcept {
   QMutexLocker lock(&mMutex);
-  mColor = color;
+  mColor = lighterDarkColor(color, 0.2);
   mNewTriangles = data;
 }
 

--- a/libs/librepcb/editor/3d/slintopenglview.cpp
+++ b/libs/librepcb/editor/3d/slintopenglview.cpp
@@ -46,6 +46,10 @@
 namespace librepcb {
 namespace editor {
 
+// Not sure what is a good light direction...
+const QVector3D SlintOpenGlView::sLightDir =
+    QVector3D(0.0f, 0.2f, 0.75f).normalized();
+
 static qreal calcAspectRatio(qreal width, qreal height) noexcept {
   return (height > 1) ? (width / height) : 1;
 }
@@ -177,15 +181,18 @@ slint::Image SlintOpenGlView::render(float width, float height) noexcept {
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   // Set modelview-projection matrix.
-  const qreal zNear = 0.1;
-  const qreal zFar = 100.0;
+  QMatrix4x4 modelView;
+  modelView.setToIdentity();
+  modelView.translate(mProjection.center.x(), mProjection.center.y(),
+                      -sCameraPosZ);
+  modelView = modelView * mProjection.transform;
   QMatrix4x4 projection;
   projection.setToIdentity();
-  projection.perspective(mProjection.fov, calcAspectRatio(width, height), zNear,
-                         zFar);
-  projection.translate(mProjection.center.x(), mProjection.center.y(),
-                       -sCameraPosZ);
-  mProgram->setUniformValue("mvp_matrix", projection * mProjection.transform);
+  projection.perspective(mProjection.fov, calcAspectRatio(width, height),
+                         sNearZ, sFarZ);
+  mProgram->setUniformValue("mv_matrix", modelView);
+  mProgram->setUniformValue("mvp_matrix", projection * modelView);
+  mProgram->setUniformValue("light_dir", sLightDir);
 
   // Limit alpha of silkscreen.
   auto alpha = mAlpha;
@@ -330,7 +337,7 @@ void SlintOpenGlView::initializeGl() noexcept {
   glEnable(GL_DEPTH_TEST);
   glEnable(GL_MULTISAMPLE);
   glEnable(GL_BLEND);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
   glEnable(GL_LINE_SMOOTH);
   glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
 

--- a/libs/librepcb/editor/3d/slintopenglview.h
+++ b/libs/librepcb/editor/3d/slintopenglview.h
@@ -160,7 +160,10 @@ private:  // Data
   QVector<std::shared_ptr<OpenGlObject>> mObjects;
 
   // Static Variables
+  static constexpr qreal sNearZ = 0.1;
+  static constexpr qreal sFarZ = 100.0;
   static constexpr qreal sCameraPosZ = 5.0;
+  static const QVector3D sLightDir;
 };
 
 /*******************************************************************************

--- a/share/librepcb/opengl/3d-fragment-shader.glsl
+++ b/share/librepcb/opengl/3d-fragment-shader.glsl
@@ -1,10 +1,26 @@
 #ifdef GL_ES
+#extension GL_OES_standard_derivatives : enable
 precision mediump int;
 precision mediump float;
 #endif
 
+uniform vec3 light_dir;  // Direction toward light, in view space.
+
 varying vec4 v_color;
+varying vec3 v_view_pos;
 
 void main() {
-    gl_FragColor = v_color;
+    // Flat shading: derive face normal from screen-space position derivatives.
+    vec3 dx = dFdx(v_view_pos);
+    vec3 dy = dFdy(v_view_pos);
+    vec3 normal = normalize(cross(dx, dy));
+    // Ensure the normal faces the camera (camera looks along -Z in view space).
+    if (normal.z < 0.0) normal = -normal;
+
+    float ndotl = max(0.0, dot(normal, normalize(light_dir)));
+    float ambient = 0.35;
+    float diffuse = (1.0 - ambient) * ndotl;
+    float intensity = ambient + diffuse;
+
+    gl_FragColor = vec4(v_color.rgb * intensity, v_color.a);
 }

--- a/share/librepcb/opengl/3d-vertex-shader.glsl
+++ b/share/librepcb/opengl/3d-vertex-shader.glsl
@@ -3,14 +3,17 @@ precision mediump int;
 precision mediump float;
 #endif
 
+uniform mat4 mv_matrix;
 uniform mat4 mvp_matrix;
 
 attribute vec4 a_position;
 attribute vec4 a_color;
 
 varying vec4 v_color;
+varying vec3 v_view_pos;
 
 void main() {
     v_color = a_color;
+    v_view_pos = (mv_matrix * a_position).xyz;
     gl_Position = mvp_matrix * a_position;
 }


### PR DESCRIPTION
Implements simple shading in the 3D viewer, to make device models looking much more natural.

## Before:

<img width="623" height="547" alt="image" src="https://github.com/user-attachments/assets/b1f52c97-b888-4faf-8d92-a5800951e71c" />

## After:

<img width="616" height="564" alt="image" src="https://github.com/user-attachments/assets/deb7c33e-6ce5-4327-a150-75a7cf11448b" />

No real shadow, but I guess this is fine.

Closes #1245 