### PR TITLE
Refactor schematic text rendering without QStaticText

### DIFF
--- a/libs/librepcb/editor/graphics/origincrossgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/origincrossgraphicsitem.cpp
@@ -74,6 +74,9 @@ void OriginCrossGraphicsItem::setSize(const UnsignedLength& size) noexcept {
 
 void OriginCrossGraphicsItem::setLayer(
     const std::shared_ptr<const GraphicsLayer>& layer) noexcept {
+  if (layer == mLayer) {
+    return;
+  }
   if (mLayer) {
     mLayer->onEdited.detach(mOnLayerEditedSlot);
   }
@@ -87,8 +90,10 @@ void OriginCrossGraphicsItem::setLayer(
 }
 
 void OriginCrossGraphicsItem::setState(GraphicsLayer::State state) noexcept {
-  mState = state;
-  update();
+  if (state != mState) {
+    mState = state;
+    update();
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/graphics/primitivetextgraphicsitem.cpp
+++ b/libs/librepcb/editor/graphics/primitivetextgraphicsitem.cpp
@@ -56,6 +56,8 @@ PrimitiveTextGraphicsItem::PrimitiveTextGraphicsItem(
     mFont(Application::getDefaultSansSerifFont()),
     mTextFlags(0),
     mShapeEnabled(true),
+    mLevelOfDetailToPixelate(2.5),
+    mLevelOfDetailToHide(1),
     mOnLayerEditedSlot(*this, &PrimitiveTextGraphicsItem::layerEdited) {
   setFlag(QGraphicsItem::ItemIsSelectable, true);
 
@@ -141,8 +143,10 @@ void PrimitiveTextGraphicsItem::setLayer(
 }
 
 void PrimitiveTextGraphicsItem::setState(GraphicsLayer::State state) noexcept {
-  mState = state;
-  update();
+  if (state != mState) {
+    mState = state;
+    update();
+  }
 }
 
 /*******************************************************************************
@@ -167,12 +171,25 @@ void PrimitiveTextGraphicsItem::paint(QPainter* painter,
   if (option->state.testFlag(QStyle::State_Selected)) {
     state = GraphicsLayer::State::Highlighted;
   }
+  const qreal lod =
+      option->levelOfDetailFromTransform(painter->worldTransform()) *
+      mHeight->toPx();
 
-  painter->setFont(mFont);
-  painter->setPen(QPen(mLayer->getColor(state),
-                       OverlineMarkupParser::getLineWidth(mHeight->toPx())));
-  painter->drawText(QRectF(), mTextFlags, mDisplayText);
-  painter->drawLines(mOverlines);
+  if (lod < mLevelOfDetailToHide) {
+    // Extremely small, do not render at all.
+  } else if (lod < mLevelOfDetailToPixelate) {
+    // Still small, render only as a pattern.
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(QBrush(mLayer->getColor(state), Qt::Dense5Pattern));
+    painter->drawRect(mBoundingRect);
+  } else {
+    // Render text.
+    painter->setFont(mFont);
+    painter->setPen(QPen(mLayer->getColor(state),
+                         OverlineMarkupParser::getLineWidth(mHeight->toPx())));
+    painter->drawText(QRectF(), mTextFlags, mDisplayText);
+    painter->drawLines(mOverlines);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/graphics/primitivetextgraphicsitem.h
+++ b/libs/librepcb/editor/graphics/primitivetextgraphicsitem.h
@@ -70,6 +70,12 @@ public:
   void setLayer(const std::shared_ptr<const GraphicsLayer>& layer) noexcept;
   void setShapeEnabled(bool enabled) noexcept { mShapeEnabled = enabled; }
   void setState(GraphicsLayer::State state) noexcept;
+  void setLevelOfDetailToPixelate(qreal lod) noexcept {
+    mLevelOfDetailToPixelate = lod;
+  }
+  void setLevelOfDetailToHide(qreal lod) noexcept {
+    mLevelOfDetailToHide = lod;
+  }
 
   // Inherited from QGraphicsItem
   QRectF boundingRect() const noexcept override { return mBoundingRect; }
@@ -101,6 +107,8 @@ private:  // Data
   QRectF mBoundingRect;
   QPainterPath mShape;
   bool mShapeEnabled;
+  qreal mLevelOfDetailToPixelate;
+  qreal mLevelOfDetailToHide;
 
   // Slots
   GraphicsLayer::OnEditedSlot mOnLayerEditedSlot;

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_buslabel.cpp
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_buslabel.cpp
@@ -22,18 +22,17 @@
  ******************************************************************************/
 #include "sgi_buslabel.h"
 
-#include "../../../graphics/graphicslayer.h"
 #include "../../../graphics/graphicslayerlist.h"
 #include "../../../graphics/linegraphicsitem.h"
+#include "../../../graphics/origincrossgraphicsitem.h"
+#include "../../../graphics/primitivetextgraphicsitem.h"
 #include "../schematicgraphicsscene.h"
 
-#include <librepcb/core/application.h>
 #include <librepcb/core/project/circuit/bus.h>
 #include <librepcb/core/project/schematic/items/si_buslabel.h>
 #include <librepcb/core/project/schematic/items/si_bussegment.h>
 #include <librepcb/core/types/alignment.h>
-#include <librepcb/core/utils/overlinemarkupparser.h>
-#include <librepcb/core/utils/toolbox.h>
+#include <librepcb/core/types/length.h>
 #include <librepcb/core/workspace/colorrole.h>
 
 #include <QtCore>
@@ -45,8 +44,6 @@
 namespace librepcb {
 namespace editor {
 
-QVector<QLineF> SGI_BusLabel::sOriginCrossLines;
-
 /*******************************************************************************
  *  Constructors / Destructor
  ******************************************************************************/
@@ -54,102 +51,79 @@ QVector<QLineF> SGI_BusLabel::sOriginCrossLines;
 SGI_BusLabel::SGI_BusLabel(
     SI_BusLabel& label, const GraphicsLayerList& layers,
     std::shared_ptr<const SchematicGraphicsScene::Context> context) noexcept
-  : QGraphicsItem(),
-    mBusLabel(label),
+  : QGraphicsItemGroup(),
+    mLabel(label),
     mContext(context),
-    mOriginCrossLayer(layers.get(ColorRole::schematicReferences())),
-    mBusLabelLayer(layers.get(ColorRole::schematicBusLabels())),
-    mOnEditedSlot(*this, &SGI_BusLabel::busLabelEdited) {
+    mTextGraphicsItem(new PrimitiveTextGraphicsItem(this)),
+    mOriginCrossGraphicsItem(new OriginCrossGraphicsItem(this)),
+    mAnchorGraphicsItem(new LineGraphicsItem()),
+    mOnEditedSlot(*this, &SGI_BusLabel::labelEdited) {
+  setFlag(QGraphicsItem::ItemHasNoContents, true);
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   setZValue(SchematicGraphicsScene::ZValue_Buses);
 
-  mStaticText.setTextFormat(Qt::PlainText);
-  mStaticText.setPerformanceHint(QStaticText::AggressiveCaching);
+  mTextGraphicsItem->setLayer(layers.get(ColorRole::schematicBusLabels()));
+  mTextGraphicsItem->setFont(PrimitiveTextGraphicsItem::Font::Monospace);
+  mTextGraphicsItem->setHeight(PositiveLength(Length::fromPx(4)));
+  mTextGraphicsItem->setLevelOfDetailToPixelate(6);
+  mTextGraphicsItem->setLevelOfDetailToHide(2);
+  mTextGraphicsItem->setSelected(isSelected());
 
-  mFont = Application::getDefaultMonospaceFont();
-  mFont.setPixelSize(4);
+  mOriginCrossGraphicsItem->setLayer(
+      layers.get(ColorRole::schematicReferences()));
+  mOriginCrossGraphicsItem->setSize(UnsignedLength(800000));
+  mOriginCrossGraphicsItem->setSelected(isSelected());
 
-  if (sOriginCrossLines.isEmpty()) {
-    qreal crossSizePx = Length(400000).toPx();
-    sOriginCrossLines.append(QLineF(-crossSizePx, 0, crossSizePx, 0));
-    sOriginCrossLines.append(QLineF(0, -crossSizePx, 0, crossSizePx));
-  }
-
-  // create anchor graphics item
-  mAnchorGraphicsItem.reset(new LineGraphicsItem());
-  mAnchorGraphicsItem->setZValue(SchematicGraphicsScene::ZValue_Buses);
   mAnchorGraphicsItem->setLayer(layers.get(ColorRole::schematicReferences()));
+  mAnchorGraphicsItem->setZValue(SchematicGraphicsScene::ZValue_Buses);
   mAnchorGraphicsItem->setSelected(isSelected());
 
+  updateContext();
   updatePosition();
   updateRotation();
+  updateMirrored();
   updateText();
   updateAnchor();
 
-  mBusLabel.onEdited.attach(mOnEditedSlot);
+  mLabel.onEdited.attach(mOnEditedSlot);
 }
 
 SGI_BusLabel::~SGI_BusLabel() noexcept {
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void SGI_BusLabel::updateContext() noexcept {
+  const Bus* bus = &mLabel.getBusSegment().getBus();
+  const GraphicsLayer::State state = mContext->getLayerState(false, bus);
+  mTextGraphicsItem->setState(state);
+  mOriginCrossGraphicsItem->setState(state);
+  mAnchorGraphicsItem->setState(state);
+}
+
+/*******************************************************************************
  *  Inherited from QGraphicsItem
  ******************************************************************************/
 
-void SGI_BusLabel::paint(QPainter* painter,
-                         const QStyleOptionGraphicsItem* option,
-                         QWidget* widget) noexcept {
-  Q_UNUSED(widget);
-
-  // If the net label layer is disabled, do not draw anything.
-  if ((!mBusLabelLayer) || (!mBusLabelLayer->isVisible())) {
-    return;
-  }
-
-  const Bus* bus = &mBusLabel.getBusSegment().getBus();
-  const bool selected = option->state.testFlag(QStyle::State_Selected);
-  const GraphicsLayer::State state = mContext->getLayerState(selected, bus);
-
-  const qreal lod =
-      option->levelOfDetailFromTransform(painter->worldTransform());
-
-  if (mOriginCrossLayer && mOriginCrossLayer->isVisible() && (lod > 2)) {
-    // draw origin cross
-    painter->setPen(QPen(mOriginCrossLayer->getColor(state), 0));
-    painter->drawLines(sOriginCrossLines);
-  }
-
-  if (lod > 1) {
-    // draw text
-    painter->setPen(QPen(mBusLabelLayer->getColor(state), 0));
-    painter->setFont(mFont);
-    painter->save();
-    if (mRotate180) {
-      painter->rotate(180);
-    }
-    painter->drawStaticText(mTextOrigin, mStaticText);
-    painter->setPen(QPen(mBusLabelLayer->getColor(state), qreal(4) / 15));
-    painter->drawLines(mOverlines);
-    painter->restore();
-  } else {
-    // draw filled rect
-    painter->setPen(Qt::NoPen);
-    painter->setBrush(
-        QBrush(mBusLabelLayer->getColor(state), Qt::Dense5Pattern));
-    painter->drawRect(mBoundingRect);
-  }
+QPainterPath SGI_BusLabel::shape() const noexcept {
+  return mTextGraphicsItem->mapToParent(mTextGraphicsItem->shape()) |
+      mOriginCrossGraphicsItem->shape();
 }
 
 QVariant SGI_BusLabel::itemChange(GraphicsItemChange change,
                                   const QVariant& value) noexcept {
   if ((change == ItemSceneHasChanged) && mAnchorGraphicsItem) {
     if (QGraphicsScene* s = mAnchorGraphicsItem->scene()) {
-      s->removeItem(mAnchorGraphicsItem.data());
+      s->removeItem(mAnchorGraphicsItem.get());
     }
     if (QGraphicsScene* s = scene()) {
-      s->addItem(mAnchorGraphicsItem.data());
+      s->addItem(mAnchorGraphicsItem.get());
     }
   } else if ((change == ItemSelectedHasChanged) && mAnchorGraphicsItem) {
+    mTextGraphicsItem->setSelected(value.toBool());
+    mOriginCrossGraphicsItem->setSelected(value.toBool());
     mAnchorGraphicsItem->setSelected(value.toBool());
   }
   return QGraphicsItem::itemChange(change, value);
@@ -159,8 +133,8 @@ QVariant SGI_BusLabel::itemChange(GraphicsItemChange change,
  *  Private Methods
  ******************************************************************************/
 
-void SGI_BusLabel::busLabelEdited(const SI_BusLabel& obj,
-                                  SI_BusLabel::Event event) noexcept {
+void SGI_BusLabel::labelEdited(const SI_BusLabel& obj,
+                               SI_BusLabel::Event event) noexcept {
   Q_UNUSED(obj);
   switch (event) {
     case SI_BusLabel::Event::PositionChanged:
@@ -169,9 +143,10 @@ void SGI_BusLabel::busLabelEdited(const SI_BusLabel& obj,
       break;
     case SI_BusLabel::Event::RotationChanged:
       updateRotation();
-      updateText();
       break;
     case SI_BusLabel::Event::MirroredChanged:
+      updateMirrored();
+      break;
     case SI_BusLabel::Event::BusNameChanged:
       updateText();
       break;
@@ -179,66 +154,34 @@ void SGI_BusLabel::busLabelEdited(const SI_BusLabel& obj,
       updateAnchor();
       break;
     default:
-      qWarning() << "Unhandled switch-case in SGI_BusLabel::netLabelEdited():"
+      qWarning() << "Unhandled switch-case in SGI_BusLabel::labelEdited():"
                  << static_cast<int>(event);
       break;
   }
 }
 
 void SGI_BusLabel::updatePosition() noexcept {
-  setPos(mBusLabel.getPosition().toPxQPointF());
+  setPos(mLabel.getPosition().toPxQPointF());
 }
 
 void SGI_BusLabel::updateRotation() noexcept {
-  setRotation(-mBusLabel.getRotation().toDeg());
+  mTextGraphicsItem->setRotation(mLabel.getRotation());
+  mOriginCrossGraphicsItem->setRotation(mLabel.getRotation());
+}
+
+void SGI_BusLabel::updateMirrored() noexcept {
+  mTextGraphicsItem->setAlignment(
+      Alignment(mLabel.getMirrored() ? HAlign::right() : HAlign::left(),
+                VAlign::bottom()));
 }
 
 void SGI_BusLabel::updateText() noexcept {
-  prepareGeometryChange();
-
-  mRotate180 = Toolbox::isTextUpsideDown(mBusLabel.getRotation());
-
-  const Alignment align(
-      mBusLabel.getMirrored() ? HAlign::right() : HAlign::left(),
-      VAlign::bottom());
-  const int flags =
-      mRotate180 ? align.mirrored().toQtAlign() : align.toQtAlign();
-
-  QString displayText;
-  const QFontMetricsF fm(mFont);
-  OverlineMarkupParser::process(*mBusLabel.getBusSegment().getBus().getName(),
-                                fm, flags, displayText, mOverlines,
-                                mBoundingRect);
-
-  mStaticText.setText(displayText);
-  mStaticText.prepare(QTransform(), mFont);
-  if (mBusLabel.getMirrored() ^ mRotate180) {
-    mTextOrigin.setX(-mStaticText.size().width());
-  } else {
-    mTextOrigin.setX(0);
-  }
-  mTextOrigin.setY(mRotate180 ? 0 : -mStaticText.size().height());
-  mStaticText.prepare(QTransform()
-                          .rotate(mRotate180 ? 180 : 0)
-                          .translate(mTextOrigin.x(), mTextOrigin.y()),
-                      mFont);
-
-  QRectF rect =
-      QRectF(0, 0, mStaticText.size().width(), -mStaticText.size().height())
-          .normalized();
-
-  if (mBusLabel.getMirrored()) rect.moveLeft(-mStaticText.size().width());
-
-  qreal len = sOriginCrossLines[0].length();
-  mBoundingRect =
-      rect.united(QRectF(-len / 2, -len / 2, len, len)).normalized();
-
-  update();
+  mTextGraphicsItem->setText(*mLabel.getBusSegment().getBus().getName(), true);
 }
 
 void SGI_BusLabel::updateAnchor() noexcept {
-  mAnchorGraphicsItem->setLine(mBusLabel.getPosition(),
-                               mBusLabel.getAnchorPosition());
+  mAnchorGraphicsItem->setLine(mLabel.getPosition(),
+                               mLabel.getAnchorPosition());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_buslabel.h
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_buslabel.h
@@ -39,6 +39,8 @@ namespace librepcb {
 namespace editor {
 
 class LineGraphicsItem;
+class OriginCrossGraphicsItem;
+class PrimitiveTextGraphicsItem;
 
 /*******************************************************************************
  *  Class SGI_BusLabel
@@ -47,7 +49,7 @@ class LineGraphicsItem;
 /**
  * @brief The SGI_BusLabel class
  */
-class SGI_BusLabel final : public QGraphicsItem {
+class SGI_BusLabel final : public QGraphicsItemGroup {
 public:
   // Constructors / Destructor
   SGI_BusLabel() = delete;
@@ -58,46 +60,34 @@ public:
   virtual ~SGI_BusLabel() noexcept;
 
   // General Methods
-  SI_BusLabel& getBusLabel() noexcept { return mBusLabel; }
+  SI_BusLabel& getBusLabel() noexcept { return mLabel; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
-  QRectF boundingRect() const noexcept override { return mBoundingRect; }
-  void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-             QWidget* widget) noexcept override;
+  QPainterPath shape() const noexcept override;
 
   // Operator Overloadings
   SGI_BusLabel& operator=(const SGI_BusLabel& rhs) = delete;
 
 private:  // Methods
-  void busLabelEdited(const SI_BusLabel& obj,
-                      SI_BusLabel::Event event) noexcept;
+  void labelEdited(const SI_BusLabel& obj, SI_BusLabel::Event event) noexcept;
   virtual QVariant itemChange(GraphicsItemChange change,
                               const QVariant& value) noexcept override;
   void updatePosition() noexcept;
   void updateRotation() noexcept;
+  void updateMirrored() noexcept;
   void updateText() noexcept;
   void updateAnchor() noexcept;
 
 private:  // Data
-  SI_BusLabel& mBusLabel;
+  SI_BusLabel& mLabel;
   std::shared_ptr<const SchematicGraphicsScene::Context> mContext;
-  std::shared_ptr<const GraphicsLayer> mOriginCrossLayer;
-  std::shared_ptr<const GraphicsLayer> mBusLabelLayer;
-  QScopedPointer<LineGraphicsItem> mAnchorGraphicsItem;
-
-  // Cached Attributes
-  QStaticText mStaticText;
-  QVector<QLineF> mOverlines;
-  QFont mFont;
-  bool mRotate180;
-  QPointF mTextOrigin;
-  QRectF mBoundingRect;
+  std::unique_ptr<PrimitiveTextGraphicsItem> mTextGraphicsItem;
+  std::unique_ptr<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
+  std::unique_ptr<LineGraphicsItem> mAnchorGraphicsItem;
 
   // Slots
   SI_BusLabel::OnEditedSlot mOnEditedSlot;
-
-  // Static Stuff
-  static QVector<QLineF> sOriginCrossLines;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_netlabel.cpp
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_netlabel.cpp
@@ -22,18 +22,17 @@
  ******************************************************************************/
 #include "sgi_netlabel.h"
 
-#include "../../../graphics/graphicslayer.h"
 #include "../../../graphics/graphicslayerlist.h"
 #include "../../../graphics/linegraphicsitem.h"
+#include "../../../graphics/origincrossgraphicsitem.h"
+#include "../../../graphics/primitivetextgraphicsitem.h"
 #include "../schematicgraphicsscene.h"
 
-#include <librepcb/core/application.h>
 #include <librepcb/core/project/circuit/netsignal.h>
 #include <librepcb/core/project/schematic/items/si_netlabel.h>
 #include <librepcb/core/project/schematic/items/si_netsegment.h>
 #include <librepcb/core/types/alignment.h>
-#include <librepcb/core/utils/overlinemarkupparser.h>
-#include <librepcb/core/utils/toolbox.h>
+#include <librepcb/core/types/length.h>
 #include <librepcb/core/workspace/colorrole.h>
 
 #include <QtCore>
@@ -45,110 +44,86 @@
 namespace librepcb {
 namespace editor {
 
-QVector<QLineF> SGI_NetLabel::sOriginCrossLines;
-
 /*******************************************************************************
  *  Constructors / Destructor
  ******************************************************************************/
 
 SGI_NetLabel::SGI_NetLabel(
-    SI_NetLabel& netlabel, const GraphicsLayerList& layers,
+    SI_NetLabel& label, const GraphicsLayerList& layers,
     std::shared_ptr<const SchematicGraphicsScene::Context> context) noexcept
-  : QGraphicsItem(),
-    mNetLabel(netlabel),
+  : QGraphicsItemGroup(),
+    mLabel(label),
     mContext(context),
-    mOriginCrossLayer(layers.get(ColorRole::schematicReferences())),
-    mNetLabelLayer(layers.get(ColorRole::schematicNetLabels())),
-    mOnEditedSlot(*this, &SGI_NetLabel::netLabelEdited) {
+    mTextGraphicsItem(new PrimitiveTextGraphicsItem(this)),
+    mOriginCrossGraphicsItem(new OriginCrossGraphicsItem(this)),
+    mAnchorGraphicsItem(new LineGraphicsItem()),
+    mOnEditedSlot(*this, &SGI_NetLabel::labelEdited) {
+  setFlag(QGraphicsItem::ItemHasNoContents, true);
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   setZValue(SchematicGraphicsScene::ZValue_NetLabels);
 
-  mStaticText.setTextFormat(Qt::PlainText);
-  mStaticText.setPerformanceHint(QStaticText::AggressiveCaching);
+  mTextGraphicsItem->setLayer(layers.get(ColorRole::schematicNetLabels()));
+  mTextGraphicsItem->setFont(PrimitiveTextGraphicsItem::Font::Monospace);
+  mTextGraphicsItem->setHeight(PositiveLength(Length::fromPx(4)));
+  mTextGraphicsItem->setLevelOfDetailToPixelate(6);
+  mTextGraphicsItem->setLevelOfDetailToHide(2);
+  mTextGraphicsItem->setSelected(isSelected());
 
-  mFont = Application::getDefaultMonospaceFont();
-  mFont.setPixelSize(4);
+  mOriginCrossGraphicsItem->setLayer(
+      layers.get(ColorRole::schematicReferences()));
+  mOriginCrossGraphicsItem->setSize(UnsignedLength(800000));
+  mOriginCrossGraphicsItem->setSelected(isSelected());
 
-  if (sOriginCrossLines.isEmpty()) {
-    qreal crossSizePx = Length(400000).toPx();
-    sOriginCrossLines.append(QLineF(-crossSizePx, 0, crossSizePx, 0));
-    sOriginCrossLines.append(QLineF(0, -crossSizePx, 0, crossSizePx));
-  }
-
-  // create anchor graphics item
-  mAnchorGraphicsItem.reset(new LineGraphicsItem());
-  mAnchorGraphicsItem->setZValue(SchematicGraphicsScene::ZValue_NetLabels);
   mAnchorGraphicsItem->setLayer(layers.get(ColorRole::schematicReferences()));
+  mAnchorGraphicsItem->setZValue(SchematicGraphicsScene::ZValue_NetLabels);
   mAnchorGraphicsItem->setSelected(isSelected());
 
+  updateContext();
   updatePosition();
   updateRotation();
+  updateMirrored();
   updateText();
   updateAnchor();
 
-  mNetLabel.onEdited.attach(mOnEditedSlot);
+  mLabel.onEdited.attach(mOnEditedSlot);
 }
 
 SGI_NetLabel::~SGI_NetLabel() noexcept {
 }
 
 /*******************************************************************************
+ *  General Methods
+ ******************************************************************************/
+
+void SGI_NetLabel::updateContext() noexcept {
+  const NetSignal* net = &mLabel.getNetSegment().getNetSignal();
+  const GraphicsLayer::State state = mContext->getLayerState(false, net);
+  mTextGraphicsItem->setState(state);
+  mOriginCrossGraphicsItem->setState(state);
+  mAnchorGraphicsItem->setState(state);
+}
+
+/*******************************************************************************
  *  Inherited from QGraphicsItem
  ******************************************************************************/
 
-void SGI_NetLabel::paint(QPainter* painter,
-                         const QStyleOptionGraphicsItem* option,
-                         QWidget* widget) noexcept {
-  Q_UNUSED(widget);
-
-  // If the net label layer is disabled, do not draw anything.
-  if ((!mNetLabelLayer) || (!mNetLabelLayer->isVisible())) {
-    return;
-  }
-
-  const qreal lod =
-      option->levelOfDetailFromTransform(painter->worldTransform());
-  const NetSignal* net = &mNetLabel.getNetSegment().getNetSignal();
-  const bool selected = option->state.testFlag(QStyle::State_Selected);
-  const GraphicsLayer::State state = mContext->getLayerState(selected, net);
-
-  if (mOriginCrossLayer && mOriginCrossLayer->isVisible() && (lod > 2)) {
-    // draw origin cross
-    painter->setPen(QPen(mOriginCrossLayer->getColor(state), 0));
-    painter->drawLines(sOriginCrossLines);
-  }
-
-  if (lod > 1) {
-    // draw text
-    painter->setPen(QPen(mNetLabelLayer->getColor(state), 0));
-    painter->setFont(mFont);
-    painter->save();
-    if (mRotate180) {
-      painter->rotate(180);
-    }
-    painter->drawStaticText(mTextOrigin, mStaticText);
-    painter->setPen(QPen(mNetLabelLayer->getColor(state), qreal(4) / 15));
-    painter->drawLines(mOverlines);
-    painter->restore();
-  } else {
-    // draw filled rect
-    painter->setPen(Qt::NoPen);
-    painter->setBrush(
-        QBrush(mNetLabelLayer->getColor(state), Qt::Dense5Pattern));
-    painter->drawRect(mBoundingRect);
-  }
+QPainterPath SGI_NetLabel::shape() const noexcept {
+  return mTextGraphicsItem->mapToParent(mTextGraphicsItem->shape()) |
+      mOriginCrossGraphicsItem->shape();
 }
 
 QVariant SGI_NetLabel::itemChange(GraphicsItemChange change,
                                   const QVariant& value) noexcept {
   if ((change == ItemSceneHasChanged) && mAnchorGraphicsItem) {
     if (QGraphicsScene* s = mAnchorGraphicsItem->scene()) {
-      s->removeItem(mAnchorGraphicsItem.data());
+      s->removeItem(mAnchorGraphicsItem.get());
     }
     if (QGraphicsScene* s = scene()) {
-      s->addItem(mAnchorGraphicsItem.data());
+      s->addItem(mAnchorGraphicsItem.get());
     }
   } else if ((change == ItemSelectedHasChanged) && mAnchorGraphicsItem) {
+    mTextGraphicsItem->setSelected(value.toBool());
+    mOriginCrossGraphicsItem->setSelected(value.toBool());
     mAnchorGraphicsItem->setSelected(value.toBool());
   }
   return QGraphicsItem::itemChange(change, value);
@@ -158,8 +133,8 @@ QVariant SGI_NetLabel::itemChange(GraphicsItemChange change,
  *  Private Methods
  ******************************************************************************/
 
-void SGI_NetLabel::netLabelEdited(const SI_NetLabel& obj,
-                                  SI_NetLabel::Event event) noexcept {
+void SGI_NetLabel::labelEdited(const SI_NetLabel& obj,
+                               SI_NetLabel::Event event) noexcept {
   Q_UNUSED(obj);
   switch (event) {
     case SI_NetLabel::Event::PositionChanged:
@@ -168,9 +143,10 @@ void SGI_NetLabel::netLabelEdited(const SI_NetLabel& obj,
       break;
     case SI_NetLabel::Event::RotationChanged:
       updateRotation();
-      updateText();
       break;
     case SI_NetLabel::Event::MirroredChanged:
+      updateMirrored();
+      break;
     case SI_NetLabel::Event::NetNameChanged:
       updateText();
       break;
@@ -178,66 +154,35 @@ void SGI_NetLabel::netLabelEdited(const SI_NetLabel& obj,
       updateAnchor();
       break;
     default:
-      qWarning() << "Unhandled switch-case in SGI_NetLabel::netLabelEdited():"
+      qWarning() << "Unhandled switch-case in SGI_NetLabel::labelEdited():"
                  << static_cast<int>(event);
       break;
   }
 }
 
 void SGI_NetLabel::updatePosition() noexcept {
-  setPos(mNetLabel.getPosition().toPxQPointF());
+  setPos(mLabel.getPosition().toPxQPointF());
 }
 
 void SGI_NetLabel::updateRotation() noexcept {
-  setRotation(-mNetLabel.getRotation().toDeg());
+  mTextGraphicsItem->setRotation(mLabel.getRotation());
+  mOriginCrossGraphicsItem->setRotation(mLabel.getRotation());
+}
+
+void SGI_NetLabel::updateMirrored() noexcept {
+  mTextGraphicsItem->setAlignment(
+      Alignment(mLabel.getMirrored() ? HAlign::right() : HAlign::left(),
+                VAlign::bottom()));
 }
 
 void SGI_NetLabel::updateText() noexcept {
-  prepareGeometryChange();
-
-  mRotate180 = Toolbox::isTextUpsideDown(mNetLabel.getRotation());
-
-  const Alignment align(
-      mNetLabel.getMirrored() ? HAlign::right() : HAlign::left(),
-      VAlign::bottom());
-  const int flags =
-      mRotate180 ? align.mirrored().toQtAlign() : align.toQtAlign();
-
-  QString displayText;
-  const QFontMetricsF fm(mFont);
-  OverlineMarkupParser::process(
-      *mNetLabel.getNetSegment().getNetSignal().getName(), fm, flags,
-      displayText, mOverlines, mBoundingRect);
-
-  mStaticText.setText(displayText);
-  mStaticText.prepare(QTransform(), mFont);
-  if (mNetLabel.getMirrored() ^ mRotate180) {
-    mTextOrigin.setX(-mStaticText.size().width());
-  } else {
-    mTextOrigin.setX(0);
-  }
-  mTextOrigin.setY(mRotate180 ? 0 : -mStaticText.size().height());
-  mStaticText.prepare(QTransform()
-                          .rotate(mRotate180 ? 180 : 0)
-                          .translate(mTextOrigin.x(), mTextOrigin.y()),
-                      mFont);
-
-  QRectF rect =
-      QRectF(0, 0, mStaticText.size().width(), -mStaticText.size().height())
-          .normalized();
-
-  if (mNetLabel.getMirrored()) rect.moveLeft(-mStaticText.size().width());
-
-  qreal len = sOriginCrossLines[0].length();
-  mBoundingRect =
-      rect.united(QRectF(-len / 2, -len / 2, len, len)).normalized();
-
-  update();
+  mTextGraphicsItem->setText(*mLabel.getNetSegment().getNetSignal().getName(),
+                             true);
 }
 
 void SGI_NetLabel::updateAnchor() noexcept {
-  mAnchorGraphicsItem->setLine(mNetLabel.getPosition(),
-                               mNetLabel.getAnchorPosition());
+  mAnchorGraphicsItem->setLine(mLabel.getPosition(),
+                               mLabel.getAnchorPosition());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_netlabel.h
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_netlabel.h
@@ -39,6 +39,8 @@ namespace librepcb {
 namespace editor {
 
 class LineGraphicsItem;
+class OriginCrossGraphicsItem;
+class PrimitiveTextGraphicsItem;
 
 /*******************************************************************************
  *  Class SGI_NetLabel
@@ -47,57 +49,45 @@ class LineGraphicsItem;
 /**
  * @brief The SGI_NetLabel class
  */
-class SGI_NetLabel final : public QGraphicsItem {
+class SGI_NetLabel final : public QGraphicsItemGroup {
 public:
   // Constructors / Destructor
   SGI_NetLabel() = delete;
   SGI_NetLabel(const SGI_NetLabel& other) = delete;
   SGI_NetLabel(
-      SI_NetLabel& netlabel, const GraphicsLayerList& layers,
+      SI_NetLabel& label, const GraphicsLayerList& layers,
       std::shared_ptr<const SchematicGraphicsScene::Context> context) noexcept;
   virtual ~SGI_NetLabel() noexcept;
 
   // General Methods
-  SI_NetLabel& getNetLabel() noexcept { return mNetLabel; }
+  SI_NetLabel& getNetLabel() noexcept { return mLabel; }
+  void updateContext() noexcept;
 
   // Inherited from QGraphicsItem
-  QRectF boundingRect() const noexcept override { return mBoundingRect; }
-  void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-             QWidget* widget) noexcept override;
+  QPainterPath shape() const noexcept override;
 
   // Operator Overloadings
   SGI_NetLabel& operator=(const SGI_NetLabel& rhs) = delete;
 
 private:  // Methods
-  void netLabelEdited(const SI_NetLabel& obj,
-                      SI_NetLabel::Event event) noexcept;
+  void labelEdited(const SI_NetLabel& obj, SI_NetLabel::Event event) noexcept;
   virtual QVariant itemChange(GraphicsItemChange change,
                               const QVariant& value) noexcept override;
   void updatePosition() noexcept;
   void updateRotation() noexcept;
+  void updateMirrored() noexcept;
   void updateText() noexcept;
   void updateAnchor() noexcept;
 
 private:  // Data
-  SI_NetLabel& mNetLabel;
+  SI_NetLabel& mLabel;
   std::shared_ptr<const SchematicGraphicsScene::Context> mContext;
-  std::shared_ptr<const GraphicsLayer> mOriginCrossLayer;
-  std::shared_ptr<const GraphicsLayer> mNetLabelLayer;
-  QScopedPointer<LineGraphicsItem> mAnchorGraphicsItem;
-
-  // Cached Attributes
-  QStaticText mStaticText;
-  QVector<QLineF> mOverlines;
-  QFont mFont;
-  bool mRotate180;
-  QPointF mTextOrigin;
-  QRectF mBoundingRect;
+  std::unique_ptr<PrimitiveTextGraphicsItem> mTextGraphicsItem;
+  std::unique_ptr<OriginCrossGraphicsItem> mOriginCrossGraphicsItem;
+  std::unique_ptr<LineGraphicsItem> mAnchorGraphicsItem;
 
   // Slots
   SI_NetLabel::OnEditedSlot mOnEditedSlot;
-
-  // Static Stuff
-  static QVector<QLineF> sOriginCrossLines;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/schematic/graphicsitems/sgi_symbolpin.cpp
+++ b/libs/librepcb/editor/project/schematic/graphicsitems/sgi_symbolpin.cpp
@@ -96,6 +96,8 @@ SGI_SymbolPin::SGI_SymbolPin(
   mNumbersGraphicsItem->setFont(PrimitiveTextGraphicsItem::Font::SansSerif);
   mNumbersGraphicsItem->setHeight(PositiveLength(1500000));
   mNumbersGraphicsItem->setLayer(mLayers.get(ColorRole::schematicPinNumbers()));
+  mNumbersGraphicsItem->setLevelOfDetailToPixelate(0);
+  mNumbersGraphicsItem->setLevelOfDetailToHide(3.5);
   mNumbersGraphicsItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
   mNumbersGraphicsItem->setFlag(QGraphicsItem::ItemStacksBehindParent, true);
 

--- a/libs/librepcb/editor/project/schematic/schematicgraphicsscene.cpp
+++ b/libs/librepcb/editor/project/schematic/schematicgraphicsscene.cpp
@@ -356,7 +356,7 @@ void SchematicGraphicsScene::updateCrossProbe() noexcept {
     item->update();
   }
   foreach (auto item, mBusLabels) {
-    item->update();
+    item->updateContext();
   }
   foreach (auto item, mNetPoints) {
     item->update();
@@ -365,7 +365,7 @@ void SchematicGraphicsScene::updateCrossProbe() noexcept {
     item->update();
   }
   foreach (auto item, mNetLabels) {
-    item->update();
+    item->updateContext();
   }
   foreach (auto item, mTexts) {
     item->updateContext();


### PR DESCRIPTION
~~Fixes a crash due to a bug in Qt in combination with libfreetype 2.14, see https://librepcb.discourse.group/t/bug-librepcb-crashes-on-two-finger-vertical-scroll/1028~~

EDIT: Does not fix the crash :-/