### PR TITLE
UI: Fix unreliable keyboard shortcuts in library editor tabs

### DIFF
--- a/libs/librepcb/ui/library/cat/categorytab.slint
+++ b/libs/librepcb/ui/library/cat/categorytab.slint
@@ -195,10 +195,12 @@ component CategoryTab inherits Tab {
         item-picked(idx, item) => {
             tabs[index].new-parent = item.user-data;
             tabs[index].choose-parent = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             tabs[index].choose-parent = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
     }
 }

--- a/libs/librepcb/ui/library/cmp/componenttab.slint
+++ b/libs/librepcb/ui/library/cmp/componenttab.slint
@@ -578,6 +578,7 @@ export component ComponentTab inherits Tab {
             page-clicked(id) => {
                 Data.set-current-tab(section-index, index);
                 tabs[index].page-index = id;
+                root.focus();  // The focused component may have been deleted.
             }
         }
 
@@ -633,10 +634,12 @@ export component ComponentTab inherits Tab {
         item-picked(idx, item) => {
             tabs[index].new-category = item.user-data;
             tabs[index].choose-category = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             tabs[index].choose-category = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
     }
 

--- a/libs/librepcb/ui/library/dev/devicetab.slint
+++ b/libs/librepcb/ui/library/dev/devicetab.slint
@@ -319,6 +319,8 @@ component DeviceContentTab {
     property <bool> interactive: tabs[index].interactive-pinout-number > 0;
     property <int> attributes-editor-part-index: -1;  // -1 = hide popup
 
+    callback move-focus-to-tab;
+
     VerticalLayout {
         alignment: ((!tabs[index].wizard-mode) || (tabs[index].page-index == 2)) ? stretch : start;
         padding: 8px;
@@ -456,12 +458,6 @@ component DeviceContentTab {
         // only controlling its visibility.
         visible: attributes-editor-part-index >= 0;
 
-        changed visible => {
-            if self.visible {
-                self.focus();
-            }
-        }
-
         attributes-overlay-view := AttributeListView {
             model: tabs[index].parts[attributes-editor-part-index].attributes;
             read-only: read-only;
@@ -475,10 +471,12 @@ component DeviceContentTab {
         accepted => {
             Backend.trigger-tab(section-index, index, TabAction.apply);
             attributes-editor-part-index = -1;
+            move-focus-to-tab();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             attributes-editor-part-index = -1;
+            move-focus-to-tab();  // Keep keyboard shortcuts working.
         }
     }
 }
@@ -522,6 +520,7 @@ export component DeviceTab inherits Tab {
             page-clicked(id) => {
                 Data.set-current-tab(section-index, index);
                 tabs[index].page-index = id;
+                root.focus();  // The focused component may have been deleted.
             }
         }
 
@@ -547,6 +546,10 @@ export component DeviceTab inherits Tab {
             read-only: read-only;
             page-height: root.height;
             window-height: window-height;
+
+            move-focus-to-tab => {
+                root.focus();
+            }
         }
     }
 
@@ -558,10 +561,12 @@ export component DeviceTab inherits Tab {
         item-picked(idx, item) => {
             tabs[index].new-category = item.user-data;
             tabs[index].choose-category = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             tabs[index].choose-category = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
     }
 

--- a/libs/librepcb/ui/library/lib/librarytab.slint
+++ b/libs/librepcb/ui/library/lib/librarytab.slint
@@ -824,6 +824,7 @@ export component LibraryTab inherits Tab {
             page-clicked(id) => {
                 Data.set-current-tab(section-index, index);
                 tabs[index].page-index = id;
+                root.focus();  // The focused component may have been deleted.
             }
         }
 
@@ -869,10 +870,12 @@ export component LibraryTab inherits Tab {
         item-clicked(idx) => {
             self.model[idx].checked = true;
             show-add-dependency-dialog = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             show-add-dependency-dialog = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
     }
 
@@ -886,10 +889,12 @@ export component LibraryTab inherits Tab {
             tabs[index].move-or-copy-to-lib = path;
             tabs[index].move-or-copy-action = move-or-copy-action;
             move-or-copy-action = LibraryElementsMoveAction.none;
+            root.focus();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             move-or-copy-action = LibraryElementsMoveAction.none;
+            root.focus();  // Keep keyboard shortcuts working.
         }
     }
 }

--- a/libs/librepcb/ui/library/pkg/packagetab.slint
+++ b/libs/librepcb/ui/library/pkg/packagetab.slint
@@ -1118,6 +1118,8 @@ export component PackageTab inherits Tab {
                 } else {
                     tabs[index].page-index = id;
                 }
+
+                root.focus();  // The focused component may have been deleted.
             }
         }
 
@@ -1159,10 +1161,12 @@ export component PackageTab inherits Tab {
         item-picked(idx, item) => {
             tabs[index].new-category = item.user-data;
             tabs[index].choose-category = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             tabs[index].choose-category = false;
+            root.focus();  // Keep keyboard shortcuts working.
         }
     }
 

--- a/libs/librepcb/ui/library/sym/symboltab.slint
+++ b/libs/librepcb/ui/library/sym/symboltab.slint
@@ -53,6 +53,8 @@ component SymbolMetadataTab {
     in property <int> index;
     in property <bool> read-only;
 
+    callback move-focus-to-tab;
+
     GridLayout {
         padding: 8px;
         spacing: 8px;
@@ -216,10 +218,12 @@ component SymbolMetadataTab {
         item-picked(idx, item) => {
             tabs[index].new-category = item.user-data;
             tabs[index].choose-category = false;
+            move-focus-to-tab();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
             tabs[index].choose-category = false;
+            move-focus-to-tab();  // Keep keyboard shortcuts working.
         }
     }
 }
@@ -681,6 +685,7 @@ export component SymbolTab inherits Tab {
             page-clicked(id) => {
                 Data.set-current-tab(section-index, index);
                 tabs[index].page-index = id;
+                root.focus();  // The focused component may have been deleted.
             }
         }
 
@@ -714,6 +719,10 @@ export component SymbolTab inherits Tab {
                 tabs: tabs;
                 index: index;
                 read-only: read-only;
+
+                move-focus-to-tab => {
+                    root.focus();
+                }
             }
         }
     }

--- a/libs/librepcb/ui/widgets/overlaydialog.slint
+++ b/libs/librepcb/ui/widgets/overlaydialog.slint
@@ -7,6 +7,9 @@ export component OverlayDialog inherits Rectangle {
     background: black.with-alpha(0.3 - Data.theme.base.to-hsv().value * 0.2);
     forward-focus: fs;
 
+    // IMPORTANT: In both of those handlers, you have to explicitly set the
+    // focus on one of your components, since the OverlayDialog looses focus
+    // on close, which will break keyboard shortcuts!
     callback accepted;
     callback rejected;
 
@@ -18,7 +21,14 @@ export component OverlayDialog inherits Rectangle {
 
     // Set focus on show, to make keyboard shortcuts working.
     init => {
-        self.focus();
+        if self.visible {
+            self.focus();
+        }
+    }
+    changed visible => {
+        if self.visible {
+            self.focus();
+        }
     }
 
     ta := TouchArea {


### PR DESCRIPTION
Sometimes after switching sub-tabs or closing a popup in the library editor tabs, keyboard shortcuts were not working anymore until manually focusing some UI element again. Fixed by preventing from loosing focus.