### PR TITLE
Board editor: Support drawing arcs in polygon/zone tools

### DIFF
--- a/libs/librepcb/core/geometry/path.cpp
+++ b/libs/librepcb/core/geometry/path.cpp
@@ -83,6 +83,18 @@ bool Path::isZeroLength() const noexcept {
   return true;
 }
 
+bool Path::isZeroArea() const noexcept {
+  if ((!isClosed()) || isZeroLength()) {
+    return true;
+  }
+
+  if (isCurved()) {
+    return mVertices.count() < 3;
+  } else {
+    return mVertices.count() < 4;
+  }
+}
+
 bool Path::isOnGrid(const PositiveLength& gridInterval) const noexcept {
   for (const auto& v : mVertices) {
     if (!v.getPos().isOnGrid(gridInterval)) {

--- a/libs/librepcb/core/geometry/path.h
+++ b/libs/librepcb/core/geometry/path.h
@@ -72,6 +72,7 @@ public:
   bool isClosed() const noexcept;
   bool isCurved() const noexcept;
   bool isZeroLength() const noexcept;
+  bool isZeroArea() const noexcept;
   bool isOnGrid(const PositiveLength& gridInterval) const noexcept;
   QVector<Vertex>& getVertices() noexcept {
     invalidatePainterPath();

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
@@ -249,35 +249,39 @@ bool PackageEditorState_DrawZone::abort(bool showErrMsgBox) noexcept {
 
 bool PackageEditorState_DrawZone::addNextSegment() noexcept {
   try {
-    // If no line was drawn, abort now.
-    QVector<Vertex> vertices = mCurrentZone->getOutline().getVertices();
-    const bool isEmpty = (vertices[vertices.count() - 1].getPos() ==
-                          vertices[vertices.count() - 2].getPos());
-    if (isEmpty) {
+    // If no valid zone has been drawn (area = 0), abort before committing
+    // anything.
+    Path path = mCurrentZone->getOutline();
+    QVector<Vertex> vertices = path.getVertices();
+    const bool hasArea = !path.cleaned().toClosedPath().isZeroArea();
+    const bool finish = path.isClosed() ||
+        (vertices[vertices.count() - 1].getPos() ==
+         vertices[vertices.count() - 2].getPos());
+    if (finish && (!hasArea)) {
       return abort();
     }
 
-    // If the outline is closed, remove the last vertex.
-    const bool closed = (vertices.first().getPos() == vertices.last().getPos());
-    if (closed) {
-      vertices.removeLast();
+    // If the zone represents a valid area, start a new undo command.
+    if (hasArea) {
+      path = path.cleaned().toOpenPath();
+      vertices = path.getVertices();
+      mCurrentEditCmd->setOutline(path, true);
+      mContext.undoStack.appendToCmdGroup(mCurrentEditCmd.release());
+      mContext.undoStack.commitCmdGroup();
+      mIsUndoCmdActive = false;
+
+      // Start a new undo command.
+      mContext.undoStack.beginCmdGroup(tr("Add Footprint Zone"));
+      mIsUndoCmdActive = true;
+      mCurrentEditCmd.reset(new CmdZoneEdit(*mCurrentZone));
     }
 
-    // Commit current segment.
-    mCurrentEditCmd->setOutline(Path(vertices), true);
-    mContext.undoStack.appendToCmdGroup(mCurrentEditCmd.release());
-    mContext.undoStack.commitCmdGroup();
-    mIsUndoCmdActive = false;
-
-    // If the outline is closed, abort now.
-    if (closed) {
+    // If this was the last vertex to be added, abort now.
+    if (finish) {
       return abort();
     }
 
-    // Add next segment.
-    mContext.undoStack.beginCmdGroup(tr("Add Footprint Zone"));
-    mIsUndoCmdActive = true;
-    mCurrentEditCmd.reset(new CmdZoneEdit(*mCurrentZone));
+    // Add new vertex.
     vertices.last().setAngle(mLastAngle);
     vertices.append(Vertex(mCursorPos, Angle::deg0()));
     mCurrentEditCmd->setOutline(Path(vertices), true);

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -403,6 +403,12 @@ ui::Board2dTabData Board2dTab::getDerivedUiData() const noexcept {
       mToolLineWidth.getUiData(),  // Tool line width
       mToolSize.getUiData(),  // Tool size
       mToolDrill.getUiData(),  // Tool drill
+      ui::AngleEditData{
+          // Tool angle
+          l2s(mToolAngle),  // Angle
+          false,  // Increase
+          false,  // Decrease
+      },
       mToolFilled,  // Tool filled
       mToolMirrored,  // Tool mirrored
       ui::LineEditData{
@@ -515,6 +521,15 @@ void Board2dTab::setDerivedUiData(const ui::Board2dTabData& data) noexcept {
       ((mToolDrill.getValue() > 0) && (!data.tool_pressfit))
           ? std::make_optional(PositiveLength(mToolDrill.getValue()))
           : std::nullopt);
+
+  // Tool angle
+  if (data.tool_angle.increase) {
+    emit angleRequested(mToolAngle + Angle::deg45());
+  } else if (data.tool_angle.decrease) {
+    emit angleRequested(mToolAngle - Angle::deg45());
+  } else {
+    emit angleRequested(s2angle(data.tool_angle.value));
+  }
 
   // Tool filled / auto-width
   emit filledRequested(data.tool_filled);
@@ -1642,6 +1657,17 @@ void Board2dTab::fsmToolEnter(BoardEditorState_DrawPolygon& state) noexcept {
       connect(&mToolLineWidth, &LengthEditContext::valueChangedUnsigned, &state,
               &BoardEditorState_DrawPolygon::setLineWidth));
 
+  // Angle
+  auto setAngle = [this](const Angle& angle) {
+    mToolAngle = angle;
+    onDerivedUiDataChanged.notify();
+  };
+  setAngle(state.getAngle());
+  mFsmStateConnections.append(connect(
+      &state, &BoardEditorState_DrawPolygon::angleChanged, this, setAngle));
+  mFsmStateConnections.append(connect(this, &Board2dTab::angleRequested, &state,
+                                      &BoardEditorState_DrawPolygon::setAngle));
+
   // Filled
   auto setFilled = [this](bool filled) {
     mToolFilled = filled;
@@ -1812,6 +1838,17 @@ void Board2dTab::fsmToolEnter(BoardEditorState_DrawZone& state) noexcept {
   mFsmStateConnections.append(connect(this, &Board2dTab::zoneRuleRequested,
                                       &state,
                                       &BoardEditorState_DrawZone::setRule));
+
+  // Angle
+  auto setAngle = [this](const Angle& angle) {
+    mToolAngle = angle;
+    onDerivedUiDataChanged.notify();
+  };
+  setAngle(state.getAngle());
+  mFsmStateConnections.append(connect(
+      &state, &BoardEditorState_DrawZone::angleChanged, this, setAngle));
+  mFsmStateConnections.append(connect(this, &Board2dTab::angleRequested, &state,
+                                      &BoardEditorState_DrawZone::setAngle));
 
   onDerivedUiDataChanged.notify();
 }

--- a/libs/librepcb/editor/project/board/board2dtab.h
+++ b/libs/librepcb/editor/project/board/board2dtab.h
@@ -192,6 +192,7 @@ signals:
   void viaDrillRequested(const std::optional<PositiveLength>& drill);
   void viaSizeRequested(const std::optional<PositiveLength>& size);
   void layerRequested(const Layer& layer);
+  void angleRequested(const Angle& angle);
   void filledRequested(bool filled);
   void mirroredRequested(bool mirrored);
   void valueRequested(const QString& value);
@@ -288,6 +289,7 @@ private:
   LengthEditContext mToolLineWidth;
   LengthEditContext mToolSize;
   LengthEditContext mToolDrill;
+  Angle mToolAngle;
   bool mToolFilled;  // Also used for auto width
   bool mToolMirrored;  // Also used for auto via size
   QString mToolValue;

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawpolygon.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawpolygon.cpp
@@ -48,6 +48,7 @@ BoardEditorState_DrawPolygon::BoardEditorState_DrawPolygon(
   : BoardEditorState(context),
     mIsUndoCmdActive(false),
     mLastSegmentPos(),
+    mLastAngle(0),
     mCurrentProperties(Uuid::createRandom(),  // UUID is not relevant here
                        Layer::boardOutlines(),  // Layer
                        UnsignedLength(0),  // Line width
@@ -57,7 +58,7 @@ BoardEditorState_DrawPolygon::BoardEditorState_DrawPolygon(
                        false  // Locked
                        ),
     mCurrentPolygon(nullptr),
-    mCurrentPolygonEditCmd(nullptr) {
+    mCurrentEditCmd(nullptr) {
 }
 
 BoardEditorState_DrawPolygon::~BoardEditorState_DrawPolygon() noexcept {
@@ -134,8 +135,8 @@ void BoardEditorState_DrawPolygon::setLayer(const Layer& layer) noexcept {
     emit layerChanged(mCurrentProperties.getLayer());
   }
 
-  if (mCurrentPolygonEditCmd) {
-    mCurrentPolygonEditCmd->setLayer(mCurrentProperties.getLayer(), true);
+  if (mCurrentEditCmd) {
+    mCurrentEditCmd->setLayer(mCurrentProperties.getLayer(), true);
     makeLayerVisible(mCurrentProperties.getLayer().getColorRole());
   }
 }
@@ -146,9 +147,23 @@ void BoardEditorState_DrawPolygon::setLineWidth(
     emit lineWidthChanged(mCurrentProperties.getLineWidth());
   }
 
-  if (mCurrentPolygonEditCmd) {
-    mCurrentPolygonEditCmd->setLineWidth(mCurrentProperties.getLineWidth(),
-                                         true);
+  if (mCurrentEditCmd) {
+    mCurrentEditCmd->setLineWidth(mCurrentProperties.getLineWidth(), true);
+  }
+}
+
+void BoardEditorState_DrawPolygon::setAngle(const Angle& angle) noexcept {
+  if (angle != mLastAngle) {
+    mLastAngle = angle;
+    emit angleChanged(mLastAngle);
+  }
+
+  if (mCurrentPolygon && mCurrentEditCmd) {
+    Path path = mCurrentPolygon->getData().getPath();
+    if (path.getVertices().count() > 1) {
+      path.getVertices()[path.getVertices().count() - 2].setAngle(mLastAngle);
+      mCurrentEditCmd->setPath(path, true);
+    }
   }
 }
 
@@ -157,9 +172,9 @@ void BoardEditorState_DrawPolygon::setFilled(bool filled) noexcept {
     emit filledChanged(mCurrentProperties.isFilled());
   }
 
-  if (mCurrentPolygonEditCmd) {
-    mCurrentPolygonEditCmd->setIsFilled(mCurrentProperties.isFilled(), true);
-    mCurrentPolygonEditCmd->setIsGrabArea(mCurrentProperties.isFilled(), true);
+  if (mCurrentEditCmd) {
+    mCurrentEditCmd->setIsFilled(mCurrentProperties.isFilled(), true);
+    mCurrentEditCmd->setIsGrabArea(mCurrentProperties.isFilled(), true);
   }
 }
 
@@ -179,7 +194,7 @@ bool BoardEditorState_DrawPolygon::startAddPolygon(const Point& pos) noexcept {
     mIsUndoCmdActive = true;
 
     // Add polygon with two vertices
-    mCurrentProperties.setPath(Path({Vertex(pos), Vertex(pos)}));
+    mCurrentProperties.setPath(Path({Vertex(pos, mLastAngle), Vertex(pos)}));
     mCurrentPolygon = new BI_Polygon(
         mContext.board,
         BoardPolygonData(Uuid::createRandom(), mCurrentProperties));
@@ -187,7 +202,7 @@ bool BoardEditorState_DrawPolygon::startAddPolygon(const Point& pos) noexcept {
         new CmdBoardPolygonAdd(*mCurrentPolygon));
 
     // Start undo command
-    mCurrentPolygonEditCmd.reset(new CmdBoardPolygonEdit(*mCurrentPolygon));
+    mCurrentEditCmd.reset(new CmdBoardPolygonEdit(*mCurrentPolygon));
     mLastSegmentPos = pos;
     makeLayerVisible(mCurrentProperties.getLayer().getColorRole());
     return true;
@@ -209,8 +224,8 @@ bool BoardEditorState_DrawPolygon::addSegment(const Point& pos) noexcept {
 
   try {
     // Finish undo command to allow reverting segment by segment
-    if (mCurrentPolygonEditCmd) {
-      mContext.undoStack.appendToCmdGroup(mCurrentPolygonEditCmd.release());
+    if (mCurrentEditCmd) {
+      mContext.undoStack.appendToCmdGroup(mCurrentEditCmd.release());
     }
     mContext.undoStack.commitCmdGroup();
     mIsUndoCmdActive = false;
@@ -224,12 +239,14 @@ bool BoardEditorState_DrawPolygon::addSegment(const Point& pos) noexcept {
     // Start a new undo command
     mContext.undoStack.beginCmdGroup(tr("Draw board polygon"));
     mIsUndoCmdActive = true;
-    mCurrentPolygonEditCmd.reset(new CmdBoardPolygonEdit(*mCurrentPolygon));
+    mCurrentEditCmd.reset(new CmdBoardPolygonEdit(*mCurrentPolygon));
 
     // Add new vertex
-    Path newPath = mCurrentPolygon->getData().getPath();
-    newPath.addVertex(pos, Angle::deg0());
-    mCurrentPolygonEditCmd->setPath(newPath, true);
+    QVector<Vertex> vertices =
+        mCurrentPolygon->getData().getPath().getVertices();
+    vertices.last().setAngle(mLastAngle);
+    vertices.append(Vertex(pos, Angle::deg0()));
+    mCurrentEditCmd->setPath(Path(vertices), true);
     mLastSegmentPos = pos;
     return true;
   } catch (const Exception& e) {
@@ -241,10 +258,10 @@ bool BoardEditorState_DrawPolygon::addSegment(const Point& pos) noexcept {
 
 bool BoardEditorState_DrawPolygon::updateLastVertexPosition(
     const Point& pos) noexcept {
-  if (mCurrentPolygonEditCmd) {
+  if (mCurrentEditCmd) {
     Path newPath = mCurrentPolygon->getData().getPath();
     newPath.getVertices().last().setPos(pos);
-    mCurrentPolygonEditCmd->setPath(newPath, true);
+    mCurrentEditCmd->setPath(newPath, true);
     return true;
   } else {
     return false;
@@ -254,7 +271,7 @@ bool BoardEditorState_DrawPolygon::updateLastVertexPosition(
 bool BoardEditorState_DrawPolygon::abortCommand(bool showErrMsgBox) noexcept {
   try {
     // Delete the current edit command
-    mCurrentPolygonEditCmd.reset();
+    mCurrentEditCmd.reset();
 
     // Abort the undo command
     if (mIsUndoCmdActive) {

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawpolygon.h
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawpolygon.h
@@ -83,6 +83,8 @@ public:
     return mCurrentProperties.getLineWidth();
   }
   void setLineWidth(const UnsignedLength& width) noexcept;
+  const Angle& getAngle() const noexcept { return mLastAngle; }
+  void setAngle(const Angle& angle) noexcept;
   bool getFilled() const noexcept { return mCurrentProperties.isFilled(); }
   void setFilled(bool filled) noexcept;
 
@@ -93,6 +95,7 @@ public:
 signals:
   void layerChanged(const Layer& layer);
   void lineWidthChanged(const UnsignedLength& width);
+  void angleChanged(const Angle& angle);
   void filledChanged(bool filled);
 
 private:  // Methods
@@ -105,6 +108,7 @@ private:
   // State
   bool mIsUndoCmdActive;
   Point mLastSegmentPos;
+  Angle mLastAngle;
 
   // Current tool settings
   BoardPolygonData mCurrentProperties;
@@ -112,7 +116,7 @@ private:
   // Information about the current polygon to place. Only valid if
   // mIsUndoCmdActive == true.
   BI_Polygon* mCurrentPolygon;
-  std::unique_ptr<CmdBoardPolygonEdit> mCurrentPolygonEditCmd;
+  std::unique_ptr<CmdBoardPolygonEdit> mCurrentEditCmd;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawzone.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawzone.cpp
@@ -50,6 +50,7 @@ BoardEditorState_DrawZone::BoardEditorState_DrawZone(
   : BoardEditorState(context),
     mIsUndoCmdActive(false),
     mLastVertexPos(),
+    mLastAngle(0),
     mCurrentProperties(Uuid::createRandom(),  // UUID is not relevant here
                        {&Layer::topCopper()},  // Layers
                        Zone::Rule::All,  // Rules
@@ -134,8 +135,8 @@ void BoardEditorState_DrawZone::setLayers(
     emit layersChanged(mCurrentProperties.getLayers());
   }
 
-  if (mCurrentZoneEditCmd) {
-    mCurrentZoneEditCmd->setLayers(mCurrentProperties.getLayers(), true);
+  if (mCurrentEditCmd) {
+    mCurrentEditCmd->setLayers(mCurrentProperties.getLayers(), true);
   }
 }
 
@@ -147,8 +148,22 @@ void BoardEditorState_DrawZone::setRule(Zone::Rule rule, bool enable) noexcept {
     emit rulesChanged(mCurrentProperties.getRules());
   }
 
-  if (mCurrentZoneEditCmd) {
-    mCurrentZoneEditCmd->setRules(mCurrentProperties.getRules(), true);
+  if (mCurrentEditCmd) {
+    mCurrentEditCmd->setRules(mCurrentProperties.getRules(), true);
+  }
+}
+
+void BoardEditorState_DrawZone::setAngle(const Angle& angle) noexcept {
+  if (angle != mLastAngle) {
+    mLastAngle = angle;
+    emit angleChanged(mLastAngle);
+  }
+
+  if (mCurrentZone && mCurrentEditCmd) {
+    Path path = mCurrentZone->getData().getOutline();
+    Q_ASSERT(path.getVertices().count() >= 2);
+    path.getVertices()[path.getVertices().count() - 2].setAngle(mLastAngle);
+    mCurrentEditCmd->setOutline(path, true);
   }
 }
 
@@ -168,14 +183,14 @@ bool BoardEditorState_DrawZone::startAddZone(const Point& pos) noexcept {
     mIsUndoCmdActive = true;
 
     // Add zone with two vertices
-    mCurrentProperties.setOutline(Path({Vertex(pos), Vertex(pos)}));
+    mCurrentProperties.setOutline(Path({Vertex(pos, mLastAngle), Vertex(pos)}));
     mCurrentZone =
         new BI_Zone(mContext.board,
                     BoardZoneData(Uuid::createRandom(), mCurrentProperties));
     mContext.undoStack.appendToCmdGroup(new CmdBoardZoneAdd(*mCurrentZone));
 
     // Start undo command
-    mCurrentZoneEditCmd.reset(new CmdBoardZoneEdit(*mCurrentZone));
+    mCurrentEditCmd.reset(new CmdBoardZoneEdit(*mCurrentZone));
     mLastVertexPos = pos;
     makeLayerVisible(ColorRole::boardZones());
     for (auto layer : mCurrentProperties.getLayers()) {
@@ -192,38 +207,45 @@ bool BoardEditorState_DrawZone::startAddZone(const Point& pos) noexcept {
 bool BoardEditorState_DrawZone::addSegment(const Point& pos) noexcept {
   Q_ASSERT(mIsUndoCmdActive == true);
 
-  // Abort if no segment drawn
-  if (pos == mLastVertexPos) {
-    abortCommand(true);
-    return false;
-  }
-
-  // Abort if the path has been closed.
-  Path path = mCurrentZone->getData().getOutline();
-  if (path.isClosed()) {
-    abortCommand(true);
-    return false;
-  }
-
   try {
-    // If the zone has more than 2 vertices, start a new undo command
-    if (path.getVertices().count() > 2) {
-      if (mCurrentZoneEditCmd) {
-        mContext.undoStack.appendToCmdGroup(mCurrentZoneEditCmd.release());
+    // If no valid zone has been drawn (area = 0), abort before committing
+    // anything.
+    Path path = mCurrentZone->getData().getOutline();
+    const bool hasArea = !path.cleaned().toClosedPath().isZeroArea();
+    const bool finish = path.isClosed() || (pos == mLastVertexPos);
+    if (finish && (!hasArea)) {
+      abortCommand(true);
+      return false;
+    }
+
+    // If the zone represents a valid area, start a new undo command.
+    if (hasArea) {
+      path = path.cleaned().toOpenPath();
+      if (mCurrentEditCmd) {
+        mCurrentEditCmd->setOutline(path, true);
+        mContext.undoStack.appendToCmdGroup(mCurrentEditCmd.release());
       }
       mContext.undoStack.commitCmdGroup();
       mIsUndoCmdActive = false;
 
-      // Start a new undo command
-      mContext.undoStack.beginCmdGroup(tr("Draw board zone"));
+      // Start a new undo command.
+      mContext.undoStack.beginCmdGroup(tr("Draw Board Zone"));
       mIsUndoCmdActive = true;
-      mCurrentZoneEditCmd.reset(new CmdBoardZoneEdit(*mCurrentZone));
+      mCurrentEditCmd.reset(new CmdBoardZoneEdit(*mCurrentZone));
     }
 
-    // Add new vertex
-    path.addVertex(pos, Angle::deg0());
-    if (mCurrentZoneEditCmd) {
-      mCurrentZoneEditCmd->setOutline(path, true);
+    // If this was the last vertex to be added, abort now.
+    if (finish) {
+      abortCommand(true);
+      return false;
+    }
+
+    // Add new vertex.
+    QVector<Vertex> vertices = path.getVertices();
+    vertices.last().setAngle(mLastAngle);
+    vertices.append(Vertex(pos, Angle::deg0()));
+    if (mCurrentEditCmd) {
+      mCurrentEditCmd->setOutline(Path(vertices), true);
     }
     mLastVertexPos = pos;
     return true;
@@ -236,10 +258,10 @@ bool BoardEditorState_DrawZone::addSegment(const Point& pos) noexcept {
 
 bool BoardEditorState_DrawZone::updateLastVertexPosition(
     const Point& pos) noexcept {
-  if (mCurrentZoneEditCmd) {
+  if (mCurrentEditCmd) {
     Path newPath = mCurrentZone->getData().getOutline();
     newPath.getVertices().last().setPos(pos);
-    mCurrentZoneEditCmd->setOutline(Path(newPath), true);
+    mCurrentEditCmd->setOutline(Path(newPath), true);
     return true;
   } else {
     return false;
@@ -249,7 +271,7 @@ bool BoardEditorState_DrawZone::updateLastVertexPosition(
 bool BoardEditorState_DrawZone::abortCommand(bool showErrMsgBox) noexcept {
   try {
     // Delete the current edit command
-    mCurrentZoneEditCmd.reset();
+    mCurrentEditCmd.reset();
 
     // Abort the undo command
     if (mIsUndoCmdActive) {

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawzone.h
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_drawzone.h
@@ -85,6 +85,8 @@ public:
     return mCurrentProperties.getRules();
   }
   void setRule(Zone::Rule rule, bool enable) noexcept;
+  const Angle& getAngle() const noexcept { return mLastAngle; }
+  void setAngle(const Angle& angle) noexcept;
 
   // Operator Overloadings
   BoardEditorState_DrawZone& operator=(const BoardEditorState_DrawZone& rhs) =
@@ -93,6 +95,7 @@ public:
 signals:
   void layersChanged(const QSet<const Layer*>& layers);
   void rulesChanged(Zone::Rules rules);
+  void angleChanged(const Angle& angle);
 
 private:  // Methods
   bool startAddZone(const Point& pos) noexcept;
@@ -104,6 +107,7 @@ private:  // Data
   // State
   bool mIsUndoCmdActive;
   Point mLastVertexPos;
+  Angle mLastAngle;
 
   // Current tool settings
   BoardZoneData mCurrentProperties;
@@ -111,7 +115,7 @@ private:  // Data
   // Information about the current zone to place. Only valid if
   // mIsUndoCmdActive == true.
   BI_Zone* mCurrentZone;
-  std::unique_ptr<CmdBoardZoneEdit> mCurrentZoneEditCmd;
+  std::unique_ptr<CmdBoardZoneEdit> mCurrentEditCmd;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/ui/api/types.slint
+++ b/libs/librepcb/ui/api/types.slint
@@ -1327,6 +1327,7 @@ export struct Board2dTabData {
     tool-line-width: LengthEditData,
     tool-size: LengthEditData,
     tool-drill: LengthEditData,
+    tool-angle: AngleEditData,
     tool-filled: bool,  // Also used for 'auto' trace width
     tool-mirrored: bool,  // Also used for 'auto' via size
     tool-value: LineEditData,

--- a/libs/librepcb/ui/project/board/drawpolygontoolbar.slint
+++ b/libs/librepcb/ui/project/board/drawpolygontoolbar.slint
@@ -1,4 +1,5 @@
 import {
+    AngleEdit,
     ComboBox,
     LengthEdit,
     ToolBarButton,
@@ -45,6 +46,24 @@ export component DrawPolygonToolBar inherits HorizontalLayout {
 
         decrease-triggered => {
             tabs[section.current-tab-index].tool-line-width.decrease = true;
+        }
+    }
+
+    angle-edt := AngleEdit {
+        data: tabs[section.current-tab-index].tool-angle;
+        tooltip: @tr("Arc Angle");
+        min-width-text: "123.4 °";
+
+        value-changed(v) => {
+            tabs[section.current-tab-index].tool-angle.value = v;
+        }
+
+        increase-triggered => {
+            tabs[section.current-tab-index].tool-angle.increase = true;
+        }
+
+        decrease-triggered => {
+            tabs[section.current-tab-index].tool-angle.decrease = true;
         }
     }
 

--- a/libs/librepcb/ui/project/board/drawzonetoolbar.slint
+++ b/libs/librepcb/ui/project/board/drawzonetoolbar.slint
@@ -1,4 +1,8 @@
-import { ComboBox, TextFlagsBox } from "../../widgets.slint";
+import {
+    AngleEdit,
+    ComboBox,
+    TextFlagsBox,
+} from "../../widgets.slint";
 import {
     Board2dTabData,
     WindowSectionData,
@@ -51,6 +55,24 @@ export component DrawZoneToolBar inherits HorizontalLayout {
             } else if idx == 3 {
                 tabs[section.current-tab-index].tool-no-devices = state;
             }
+        }
+    }
+
+    angle-edt := AngleEdit {
+        data: tabs[section.current-tab-index].tool-angle;
+        tooltip: @tr("Arc Angle");
+        min-width-text: "123.4 °";
+
+        value-changed(v) => {
+            tabs[section.current-tab-index].tool-angle.value = v;
+        }
+
+        increase-triggered => {
+            tabs[section.current-tab-index].tool-angle.increase = true;
+        }
+
+        decrease-triggered => {
+            tabs[section.current-tab-index].tool-angle.decrease = true;
         }
     }
 }


### PR DESCRIPTION
So far, it was not possible to draw arcs in the board editor at the moment when drawing a new polygon or zone. It was only possible to add arcs afterwards through the properties dialog.

Now the toolbar of the polygon and zone tools have a new input field to specify the angle of the current polygon- or zone segment, so arcs can be created out of the box.