### PR TITLE
Device editor: Support opening dependent component & package

### DIFF
--- a/libs/librepcb/editor/library/dev/devicetab.cpp
+++ b/libs/librepcb/editor/library/dev/devicetab.cpp
@@ -24,6 +24,7 @@
 
 #include "../../graphics/slintgraphicsview.h"
 #include "../../guiapplication.h"
+#include "../../mainwindow.h"
 #include "../../modelview/attributelistmodel.h"
 #include "../../rulecheck/rulecheckmessagesmodel.h"
 #include "../../undocommandgroup.h"
@@ -501,6 +502,18 @@ void DeviceTab::trigger(ui::TabAction a) noexcept {
     }
     case ui::TabAction::DeviceSelectPackage: {
       selectPackage();
+      break;
+    }
+    case ui::TabAction::DeviceOpenComponent: {
+      if (mWindow && mComponent) {
+        mWindow->requestComponentTab(mComponent->getDirectory().getAbsPath());
+      }
+      break;
+    }
+    case ui::TabAction::DeviceOpenPackage: {
+      if (mWindow && mPackage) {
+        mWindow->requestPackageTab(mPackage->getDirectory().getAbsPath());
+      }
       break;
     }
     case ui::TabAction::DevicePinoutReset: {

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -1505,6 +1505,18 @@ void MainWindow::openBoard2dTab(int projectIndex, int index,
   }
 }
 
+void MainWindow::requestComponentTab(const FilePath& fp) noexcept {
+  if (auto editor = mApp.openLibrary(fp.getParentDir().getParentDir())) {
+    openComponentTab(*editor, fp, false);
+  }
+}
+
+void MainWindow::requestPackageTab(const FilePath& fp) noexcept {
+  if (auto editor = mApp.openLibrary(fp.getParentDir().getParentDir())) {
+    openPackageTab(*editor, fp, false);
+  }
+}
+
 void MainWindow::openBoard3dTab(int projectIndex, int index) noexcept {
   if (!switchToProjectTab<Board3dTab>(projectIndex, index)) {
     if (auto prjEditor = mApp.getProjects().value(projectIndex)) {

--- a/libs/librepcb/editor/mainwindow.h
+++ b/libs/librepcb/editor/mainwindow.h
@@ -98,6 +98,8 @@ public:
                                                  int index) noexcept;
   void openBoard2dTab(int projectIndex, int index,
                       bool switchToTab = true) noexcept;
+  void requestComponentTab(const FilePath& fp) noexcept;
+  void requestPackageTab(const FilePath& fp) noexcept;
 
   // Operator Overloadings
   MainWindow& operator=(const MainWindow& rhs) = delete;

--- a/libs/librepcb/ui/api/types.slint
+++ b/libs/librepcb/ui/api/types.slint
@@ -775,6 +775,8 @@ export enum TabAction {
     // Device tab
     device-select-component,
     device-select-package,
+    device-open-component,
+    device-open-package,
     device-pinout-reset,
     device-pinout-connect-auto,
     device-pinout-connect-interactively,

--- a/libs/librepcb/ui/library/dev/devicedependencycards.slint
+++ b/libs/librepcb/ui/library/dev/devicedependencycards.slint
@@ -1,7 +1,9 @@
 import {
     Button,
     IconButton,
+    LinkText,
     SceneButton,
+    ToolTip,
 } from "../../widgets.slint";
 import {
     Backend,
@@ -30,6 +32,7 @@ component DeviceDependencyCard inherits Rectangle {
 
     property <string> choose-text: @tr("Choose {}", type) + "...";
 
+    callback open-clicked;
     callback choose-clicked;
 
     background: error ? Data.theme.error : Data.theme.control-checked;
@@ -46,7 +49,8 @@ component DeviceDependencyCard inherits Rectangle {
             HorizontalLayout {
                 spacing: 8px;
 
-                title-txt := Text {
+                title-btn := LinkText {
+                    z: 20;
                     horizontal-stretch: 0;
                     font-size: 14px;
                     font-weight: 700;
@@ -54,7 +58,26 @@ component DeviceDependencyCard inherits Rectangle {
                     vertical-alignment: center;
                     color: error ? Data.theme.error-text : Data.theme.control-text;
                     text: error ? error-title : (name.is-empty ? uninitialized-title : name);
+                    enabled: !name.is-empty;
                     accessible-label: type;
+
+                    if self.enabled && self.has-hover: Rectangle {
+                        x: 0;
+                        y: parent.height - self.height;
+                        width: parent.preferred-width;
+                        height: 1px;
+                        background: parent.color;
+                    }
+
+                    if self.enabled && self.has-hover: ToolTip {
+                        x: parent.width + 5px;
+                        y: (parent.height - self.height) / 2;
+                        text: @tr("Open Editor");
+                    }
+
+                    clicked => {
+                        open-clicked();
+                    }
                 }
 
                 if (!read-only) && ((!name.is-empty) || error): choose-btn-1 := IconButton {
@@ -76,7 +99,7 @@ component DeviceDependencyCard inherits Rectangle {
                     horizontal-stretch: 1;
                     font-size: 10px;
                     font-weight: 300;
-                    color: title-txt.color;
+                    color: title-btn.color;
                     horizontal-alignment: right;
                     vertical-alignment: center;
                     text: type.to-uppercase();
@@ -89,7 +112,7 @@ component DeviceDependencyCard inherits Rectangle {
                 font-size: error ? 12px : 11px;
                 font-weight: error ? 600 : 400;
                 font-italic: true;
-                color: title-txt.color;
+                color: title-btn.color;
                 wrap: word-wrap;
                 overflow: elide;
                 text: description;
@@ -172,6 +195,10 @@ export component ComponentCard inherits DeviceDependencyCard {
     foreground-color: self.tabs[self.index].component-foreground-color;
     scene: 0;
 
+    open-clicked => {
+        Backend.trigger-tab(self.section-index, self.index, TabAction.device-open-component);
+    }
+
     choose-clicked => {
         Backend.trigger-tab(self.section-index, self.index, TabAction.device-select-component);
     }
@@ -187,6 +214,10 @@ export component PackageCard inherits DeviceDependencyCard {
     background-color: self.tabs[self.index].package-background-color;
     foreground-color: self.tabs[self.index].package-foreground-color;
     scene: 1;
+
+    open-clicked => {
+        Backend.trigger-tab(self.section-index, self.index, TabAction.device-open-package);
+    }
 
     choose-clicked => {
         Backend.trigger-tab(self.section-index, self.index, TabAction.device-select-package);

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -48,6 +48,13 @@ def _query_childs(element, query):
     if segment_name.startswith("#"):
         segment_name = segment_name[1:]
         childs = element.query_descendants().match_type_name(segment_name).find_all()
+    elif "{" in segment_name:
+        childs = []
+        start = segment_name.find("{")
+        end = segment_name.find("}")
+        for value in segment_name[start + 1 : end].split(","):
+            name = segment_name[:start] + value + segment_name[end + 1 :]
+            childs += element.query_descendants().match_id(name).find_all()
     else:
         childs = element.query_descendants().match_id(segment_name).find_all()
     if len(segment) > 1:
@@ -107,6 +114,9 @@ class Element:
     def click(self):
         self._element.single_click(slint_testing.PointerEventButton.Left)
 
+    def mclick(self):
+        self._element.double_click(slint_testing.PointerEventButton.Middle)
+
     def dclick(self):
         self._element.double_click(slint_testing.PointerEventButton.Left)
 
@@ -133,6 +143,8 @@ class ElementQuery:
     * Each string segment matches Slint elements by their ID.
     * Segments starting with "#" match Slint elements by type name rather than
       by ID.
+    * String segments to match the ID may contain placeholder like `foo-{a,b}`
+      to match *any* of those substrings (i.e. `foo-a` or `foo-b`).
     * Optionally, a last segment can be supplied to specify the expected number
       of Slint elements matching the query. A star "*" means any number of
       result is allowed (0..n). A question mark "?" means any number of result
@@ -324,6 +336,10 @@ class ElementQuery:
     def click(self):
         for x in self._results:
             x.click()
+
+    def mclick(self):
+        for x in self._results:
+            x.mclick()
 
     def dclick(self):
         for x in self._results:

--- a/tests/ui/mainwindow/test_device_editor.py
+++ b/tests/ui/mainwindow/test_device_editor.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test the device editor
+"""
+
+
+def test_open_package_and_component(librepcb):
+    librepcb.add_local_library_to_workspace("libraries/Populated Library.lplib")
+    with librepcb.open() as app:
+        app.get("SideBar::libraries-btn").click()
+        app.get("LibrariesPanel::local-libs #LibraryListViewItem").dclick()
+        tabs = app.get("#TabButton *")
+
+        # Open device
+        items = app.get("LibraryContentTab::elements-view LibraryTreeView::item-ta *")
+        items.wait(2, None)
+        items[1].dclick()  # C-0805 device
+        tabs.wait(3)
+        assert tabs[-1].label == "C-0805"
+
+        # Open package
+        app.get(
+            "DeviceContentTab::package-card DeviceDependencyCard::title-btn"
+        ).click()
+        tabs.wait(4)
+        assert tabs[-1].label == "C-0805"
+        tabs[-1].mclick()
+
+        # Open component
+        app.get(
+            "DeviceContentTab::component-card-{1,2} DeviceDependencyCard::title-btn"
+        ).click()
+        tabs.wait(4)
+        assert tabs[-1].label == "Capacitor Bipolar"
+        tabs[-1].mclick()


### PR DESCRIPTION
Add hyperlinks in the device editor to allow opening the dependent component or package in a new tab:

<img width="321" height="136" alt="image" src="https://github.com/user-attachments/assets/16c62233-6421-42b0-994d-3e91e610d401" />
