### PR TITLE
Keep auto-fit in 2D views until manual zoom/pan

### DIFF
--- a/libs/librepcb/editor/graphics/slintgraphicsview.cpp
+++ b/libs/librepcb/editor/graphics/slintgraphicsview.cpp
@@ -174,7 +174,8 @@ slint::Image SlintGraphicsView::render(GraphicsScene& scene, float width,
     painter.setRenderHints(QPainter::Antialiasing |
                            QPainter::SmoothPixmapTransform);
     const QRectF targetRect(QPoint(0, 0), size);
-    if (mViewSize.isEmpty()) {
+    if ((mViewSize != targetRect.size()) &&
+        (mProjection.autoFitInView || mViewSize.isEmpty())) {
       const QRectF target = targetRect.marginsRemoved(mDefaultMargins);
       const QRectF initialRect = validateSceneRect(scene.itemsBoundingRect());
       mProjection.scale =
@@ -298,6 +299,7 @@ bool SlintGraphicsView::pointerEvent(
     }
     if (mPanning) {
       Projection projection = mProjection;
+      projection.autoFitInView = false;
       projection.offset -= scenePosPx - mPanningStartScenePos;
       applyProjection(projection);
       return true;
@@ -376,7 +378,8 @@ void SlintGraphicsView::zoomOut() noexcept {
   zoom(QPointF(mViewSize.width() / 2, mViewSize.height() / 2), 1 / 1.3);
 }
 
-void SlintGraphicsView::zoomToSceneRect(const QRectF& r) noexcept {
+void SlintGraphicsView::zoomToSceneRect(const QRectF& r,
+                                        bool autoFitInView) noexcept {
   const QRectF sourceRect = validateSceneRect(r);
   const QRectF targetRect =
       QRectF(QPointF(0, 0), mViewSize).marginsRemoved(mDefaultMargins);
@@ -386,6 +389,7 @@ void SlintGraphicsView::zoomToSceneRect(const QRectF& r) noexcept {
   }
 
   Projection projection;
+  projection.autoFitInView = autoFitInView;
   projection.scale =
       boundedScaleFactor(std::min(targetRect.width() / sourceRect.width(),
                                   targetRect.height() / sourceRect.height()));
@@ -433,6 +437,7 @@ QMarginsF SlintGraphicsView::defaultEditorMargins() noexcept {
 
 void SlintGraphicsView::scroll(const QPointF& delta) noexcept {
   Projection projection = mProjection;
+  projection.autoFitInView = false;
   projection.offset += delta;
   applyProjection(projection);
 }
@@ -443,6 +448,7 @@ void SlintGraphicsView::zoom(QPointF center, qreal factor) noexcept {
   }
 
   Projection projection = mProjection;
+  projection.autoFitInView = false;
 
   QTransform tf;
   tf.translate(projection.offset.x(), projection.offset.y());

--- a/libs/librepcb/editor/graphics/slintgraphicsview.h
+++ b/libs/librepcb/editor/graphics/slintgraphicsview.h
@@ -53,24 +53,28 @@ class SlintGraphicsView final : public QObject {
   Q_OBJECT
 
   struct Projection {
+    bool autoFitInView = true;  ///< Default `true`, cleared on zoom/pan events
     QPointF offset;
     qreal scale = 1;
 
     Projection interpolated(const Projection& delta,
                             qreal factor) const noexcept {
       return Projection{
+          factor == qreal(1) ? delta.autoFitInView : false,
           offset + delta.offset * factor,
           scale + delta.scale * factor,
       };
     }
     bool operator==(const Projection& rhs) const noexcept {
-      return (offset == rhs.offset) && (scale == rhs.scale);
+      return (autoFitInView == rhs.autoFitInView) && (offset == rhs.offset) &&
+          (scale == rhs.scale);
     }
     bool operator!=(const Projection& rhs) const noexcept {
       return !(*this == rhs);
     }
     Projection operator-(const Projection& rhs) const noexcept {
       return Projection{
+          autoFitInView,
           offset - rhs.offset,
           scale - rhs.scale,
       };
@@ -110,7 +114,7 @@ public:
   void scrollDown() noexcept;
   void zoomIn() noexcept;
   void zoomOut() noexcept;
-  void zoomToSceneRect(const QRectF& r) noexcept;
+  void zoomToSceneRect(const QRectF& r, bool autoFitInView) noexcept;
 
   // Static Methods
   static QRectF defaultSymbolSceneRect() noexcept;

--- a/libs/librepcb/editor/library/dev/devicetab.cpp
+++ b/libs/librepcb/editor/library/dev/devicetab.cpp
@@ -482,8 +482,9 @@ void DeviceTab::trigger(ui::TabAction a) noexcept {
     case ui::TabAction::ZoomFit: {
       // Currently we can't distinguish in which view the action was
       // triggered, thus applying to both views.
-      mComponentView->zoomToSceneRect(mComponentScene->itemsBoundingRect());
-      mPackageView->zoomToSceneRect(mPackageScene->itemsBoundingRect());
+      mComponentView->zoomToSceneRect(mComponentScene->itemsBoundingRect(),
+                                      true);
+      mPackageView->zoomToSceneRect(mPackageScene->itemsBoundingRect(), true);
       break;
     }
     case ui::TabAction::OpenDatasheet: {

--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -850,7 +850,7 @@ void PackageTab::trigger(ui::TabAction a) noexcept {
       if (mView3d && mOpenGlView) {
         mOpenGlView->zoomAll();
       } else if ((!mView3d) && mView && mScene) {
-        mView->zoomToSceneRect(mScene->itemsBoundingRect());
+        mView->zoomToSceneRect(mScene->itemsBoundingRect(), true);
       }
       break;
     }

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -583,7 +583,7 @@ void SymbolTab::trigger(ui::TabAction a) noexcept {
       break;
     }
     case ui::TabAction::ZoomFit: {
-      if (mScene) mView->zoomToSceneRect(mScene->itemsBoundingRect());
+      if (mScene) mView->zoomToSceneRect(mScene->itemsBoundingRect(), true);
       break;
     }
     case ui::TabAction::SymbolImportPins: {

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -890,7 +890,7 @@ void Board2dTab::trigger(ui::TabAction a) noexcept {
       break;
     }
     case ui::TabAction::ZoomFit: {
-      if (mScene) mView->zoomToSceneRect(mScene->itemsBoundingRect());
+      if (mScene) mView->zoomToSceneRect(mScene->itemsBoundingRect(), true);
       break;
     }
     case ui::TabAction::ToggleBackgroundImage: {
@@ -1998,7 +1998,7 @@ void Board2dTab::highlightDrcMessage(
     rect.adjust(-margin, -margin, margin, margin);
     mScene->setSceneRectMarker(rect);
     if (zoomTo) {
-      mView->zoomToSceneRect(rect);
+      mView->zoomToSceneRect(rect, false);
     }
   }
 }
@@ -2696,7 +2696,7 @@ void Board2dTab::goToDevice(const QString& name, int index) noexcept {
             std::min(1.5f * std::max(rect.size().width(), rect.size().height()),
                      Length::fromMm(10).toPx());
         rect.adjust(-margin, -margin, margin, margin);
-        mView->zoomToSceneRect(rect);
+        mView->zoomToSceneRect(rect, false);
       } else {
         mProjectEditor.getCrossProbe()->set(nullptr, {}, {}, {}, {});
       }

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsmadapter.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsmadapter.h
@@ -94,7 +94,8 @@ public:
   virtual QPainterPath fsmCalcPosWithTolerance(
       const Point& pos, qreal multiplier) const noexcept = 0;
   virtual Point fsmMapGlobalPosToScenePos(const QPoint& pos) const noexcept = 0;
-  virtual void fsmZoomToSceneRect(const QRectF& r) noexcept = 0;
+  virtual void fsmZoomToSceneRect(const QRectF& r,
+                                  bool autoFitInView) noexcept = 0;
   virtual void fsmCrossProbe(
       const QSet<const NetSignal*>& nets = {},
       const QSet<const ComponentInstance*>& components = {},

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addcomponent.cpp
@@ -511,7 +511,7 @@ void SchematicEditorState_AddComponent::startAddingComponent(
       mIsUndoCmdActive = false;
       abortCommand(false);  // reset attributes
       if (auto scene = getActiveSchematicScene()) {
-        mAdapter.fsmZoomToSceneRect(scene->itemsBoundingRect());
+        mAdapter.fsmZoomToSceneRect(scene->itemsBoundingRect(), true);
       }
       emit requestLeavingState();
     }

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -431,7 +431,8 @@ void SchematicTab::highlightErcMessage(
     if (zoomTo) {
       const qreal zoomMargin = Length(20000000).toPx();
       mView->zoomToSceneRect(
-          rect.adjusted(-zoomMargin, -zoomMargin, zoomMargin, zoomMargin));
+          rect.adjusted(-zoomMargin, -zoomMargin, zoomMargin, zoomMargin),
+          false);
     }
   }
 }
@@ -611,7 +612,7 @@ void SchematicTab::trigger(ui::TabAction a) noexcept {
       break;
     }
     case ui::TabAction::ZoomFit: {
-      if (mScene) mView->zoomToSceneRect(mScene->itemsBoundingRect());
+      if (mScene) mView->zoomToSceneRect(mScene->itemsBoundingRect(), true);
       break;
     }
     case ui::TabAction::FindRefreshSuggestions: {
@@ -874,8 +875,9 @@ Point SchematicTab::fsmMapGlobalPosToScenePos(
   }
 }
 
-void SchematicTab::fsmZoomToSceneRect(const QRectF& r) noexcept {
-  mView->zoomToSceneRect(r);
+void SchematicTab::fsmZoomToSceneRect(const QRectF& r,
+                                      bool autoFitInView) noexcept {
+  mView->zoomToSceneRect(r, autoFitInView);
 }
 
 void SchematicTab::fsmCrossProbe(
@@ -1281,7 +1283,7 @@ void SchematicTab::goToSymbol(const QString& name, int index) noexcept {
             std::min(1.5f * std::max(rect.size().width(), rect.size().height()),
                      Length::fromMm(10).toPx());
         rect.adjust(-margin, -margin, margin, margin);
-        mView->zoomToSceneRect(rect);
+        mView->zoomToSceneRect(rect, false);
       }
     }
   }

--- a/libs/librepcb/editor/project/schematic/schematictab.h
+++ b/libs/librepcb/editor/project/schematic/schematictab.h
@@ -130,7 +130,8 @@ public:
   QPainterPath fsmCalcPosWithTolerance(
       const Point& pos, qreal multiplier) const noexcept override;
   Point fsmMapGlobalPosToScenePos(const QPoint& pos) const noexcept override;
-  void fsmZoomToSceneRect(const QRectF& r) noexcept override;
+  void fsmZoomToSceneRect(const QRectF& r,
+                          bool autoFitInView) noexcept override;
   void fsmCrossProbe(
       const QSet<const NetSignal*>& nets = {},
       const QSet<const ComponentInstance*>& components = {},


### PR DESCRIPTION
Automatically fit 2D content like schematics or boards into the view even during window resizing, window splitting etc. The auto-fit gets disabled only when the user invokes any manual zoom/pan operation.