### PR TITLE
When closing a library tab, ask for saving modifications

### DIFF
--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -456,7 +456,7 @@ void GuiApplication::closeLibrary(const FilePath& libDir) noexcept {
 bool GuiApplication::requestClosingAllLibraries() noexcept {
   for (std::size_t i = 0; i < mLibraries->row_count(); ++i) {
     if (auto lib = mLibraries->value(i)) {
-      if (!lib->requestClose()) {
+      if (!lib->requestCloseAllTabs()) {
         return false;
       }
     }

--- a/libs/librepcb/editor/library/lib/librarytab.cpp
+++ b/libs/librepcb/editor/library/lib/librarytab.cpp
@@ -117,6 +117,14 @@ LibraryTab::LibraryTab(LibraryEditor& editor, bool wizardMode,
 }
 
 LibraryTab::~LibraryTab() noexcept {
+  // If this was the last library tab, discard any unsaved changes in the
+  // library since the library editor might still be kept open, and a new
+  // library tab may be opened in future. That new tab shall then start with
+  // an empty undo stack.
+  if (mEditor.getNumberOfLibraryTabs() <= 1) {
+    mEditor.discardUnsavedChanges();
+  }
+
   deactivate();
 
   mUndoStack.release();  // We have "borrowed" it from the library editor...
@@ -395,14 +403,28 @@ void LibraryTab::trigger(ui::TabAction a) noexcept {
       break;
     }
     case ui::TabAction::Close: {
-      commitUiData();
-      WindowTab::trigger(a);
+      // Note: The LibraryEditor might still be kept open even when closing
+      // the library overview tab. However, it would be a bit counter-intuitive
+      // if this tab can be closed without saving the modifications. Let's make
+      // it behave identical to all the other library editor tabs.
+      if (requestClose()) {
+        WindowTab::trigger(a);
+      }
       break;
     }
     default: {
       WindowTab::trigger(a);
       break;
     }
+  }
+}
+
+bool LibraryTab::requestClose() noexcept {
+  commitUiData();
+  if (mEditor.getNumberOfLibraryTabs() > 1) {
+    return true;  // Still other library tabs open.
+  } else {
+    return mEditor.requestCloseLibrary();  // This was the last library tab.
   }
 }
 

--- a/libs/librepcb/editor/library/lib/librarytab.h
+++ b/libs/librepcb/editor/library/lib/librarytab.h
@@ -85,6 +85,7 @@ public:
   ui::LibraryTabData getDerivedUiData() const noexcept;
   void setDerivedUiData(const ui::LibraryTabData& data) noexcept;
   void trigger(ui::TabAction a) noexcept override;
+  bool requestClose() noexcept override;
 
   // Operator Overloadings
   LibraryTab& operator=(const LibraryTab& rhs) = delete;

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -25,6 +25,7 @@
 #include "../guiapplication.h"
 #include "../undostack.h"
 #include "../utils/slinthelpers.h"
+#include "lib/librarytab.h"
 #include "libraryeditortab.h"
 
 #include <librepcb/core/fileio/transactionalfilesystem.h>
@@ -104,18 +105,24 @@ void LibraryEditor::setUiData(const ui::LibraryData& data) noexcept {
   Q_UNUSED(data);
 }
 
-bool LibraryEditor::requestClose() noexcept {
-  // Check all opened tabs first.
+bool LibraryEditor::requestCloseAllTabs() noexcept {
   for (auto tab : mRegisteredTabs) {
     Q_ASSERT(tab);
     if (tab && (!tab->requestClose())) {
       return false;
     }
   }
+  // If multiple library tabs are open, requestCloseLibrary() was not called
+  // by LibraryTab::requestClose(), so we have to do it now.
+  if ((getNumberOfLibraryTabs() != 1) && (!requestCloseLibrary())) {
+    return false;
+  }
+  return true;
+}
 
-  // Then check this library.
+bool LibraryEditor::requestCloseLibrary() noexcept {
   if ((!hasUnsavedChanges()) || (!mLibrary->getDirectory().isWritable())) {
-    return true;  // Nothing to save.
+    return true;  // No unsaved changes.
   }
 
   const QMessageBox::StandardButton choice = QMessageBox::question(
@@ -132,12 +139,28 @@ bool LibraryEditor::requestClose() noexcept {
   } else {
     return false;
   }
-
-  return true;
 }
 
 bool LibraryEditor::hasUnsavedChanges() const noexcept {
   return mManualModificationsMade || (!mUndoStack->isClean());
+}
+
+bool LibraryEditor::discardUnsavedChanges() noexcept {
+  try {
+    while ((!mUndoStack->isClean()) && mUndoStack->canUndo()) {
+      mUndoStack->undo();  // can throw
+    }
+    Q_ASSERT(mUndoStack->isClean());
+    mUndoStack->clear();
+    if (mManualModificationsMade) {
+      mManualModificationsMade = false;
+      emit manualModificationsMade();
+    }
+    return true;
+  } catch (const Exception& e) {
+    QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    return false;
+  }
 }
 
 void LibraryEditor::setManualModificationsMade() noexcept {
@@ -181,6 +204,16 @@ void LibraryEditor::forceClosingTabs(const QSet<FilePath>& fp) noexcept {
       tab->closeEnforced();
     }
   }
+}
+
+int LibraryEditor::getNumberOfLibraryTabs() const noexcept {
+  int count = 0;
+  for (auto tab : mRegisteredTabs) {
+    if (dynamic_cast<LibraryTab*>(tab.get())) {
+      ++count;
+    }
+  }
+  return count;
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -80,6 +80,20 @@ public:
   void setUiData(const ui::LibraryData& data) noexcept;
 
   /**
+   * @brief Request to close all opened tabs
+   *
+   * If there are unsaved changes in any of the opened tabs, this method will
+   * ask the user whether the changes should be saved or not. If the user clicks
+   * on "cancel" or the library elements could not be saved successfully, this
+   * method will return false. If there were no unsaved changes or they were
+   * all successfully saved, the method returns true.
+   *
+   * @retval true     All tabs closed, library editor is safe to be closed.
+   * @retval false    Library still has unsaved changes.
+   */
+  bool requestCloseAllTabs() noexcept;
+
+  /**
    * @brief Request to close the library
    *
    * If there are unsaved changes to the library, this method will ask the user
@@ -88,12 +102,14 @@ public:
    * false. If there were no unsaved changes or they were successfully saved,
    * the method returns true.
    *
-   * @retval true   Library is safe to be closed.
-   * @retval false  Library still has unsaved changes.
+   * @retval true     Library is safe to be closed.
+   * @retval false    Library still has unsaved changes.
    */
-  bool requestClose() noexcept;
+  bool requestCloseLibrary() noexcept;
 
   bool hasUnsavedChanges() const noexcept;
+
+  bool discardUnsavedChanges() noexcept;
 
   /**
    * @brief Set the flag that manual modifications (no undo stack) are made
@@ -109,8 +125,8 @@ public:
 
   void registerTab(LibraryEditorTab& tab) noexcept;
   void unregisterTab(LibraryEditorTab& tab) noexcept;
-
   void forceClosingTabs(const QSet<FilePath>& fp) noexcept;
+  int getNumberOfLibraryTabs() const noexcept;
 
   // Operator Overloadings
   LibraryEditor& operator=(const LibraryEditor& rhs) = delete;

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -807,7 +807,7 @@ void MainWindow::triggerLibraryElement(slint::SharedString path,
     }
     case ui::LibraryElementAction::Close: {
       if (auto lib = mApp.getLibrary(fp)) {
-        if (lib->requestClose()) {
+        if (lib->requestCloseAllTabs()) {
           mApp.closeLibrary(fp);
         }
       }
@@ -1031,6 +1031,7 @@ void MainWindow::openComponentCategoryTab(LibraryEditor& editor,
       }
       addTab(
           std::make_shared<ComponentCategoryTab>(editor, std::move(cat), mode));
+    } catch (const UserCanceled& e) {
     } catch (const Exception& e) {
       QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
     }
@@ -1072,6 +1073,7 @@ void MainWindow::openPackageCategoryTab(LibraryEditor& editor,
       }
       addTab(
           std::make_shared<PackageCategoryTab>(editor, std::move(cat), mode));
+    } catch (const UserCanceled& e) {
     } catch (const Exception& e) {
       QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
     }
@@ -1155,6 +1157,7 @@ void MainWindow::openSymbolTab(LibraryEditor& editor, const FilePath& fp,
         }
       }
       addTab(std::make_shared<SymbolTab>(editor, std::move(sym), mode));
+    } catch (const UserCanceled& e) {
     } catch (const Exception& e) {
       QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
     }
@@ -1290,6 +1293,7 @@ void MainWindow::openPackageTab(LibraryEditor& editor, const FilePath& fp,
         }
       }
       addTab(std::make_shared<PackageTab>(editor, std::move(pkg), mode));
+    } catch (const UserCanceled& e) {
     } catch (const Exception& e) {
       QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
     }
@@ -1379,6 +1383,7 @@ void MainWindow::openComponentTab(LibraryEditor& editor, const FilePath& fp,
         }
       }
       addTab(std::make_shared<ComponentTab>(editor, std::move(cmp), mode));
+    } catch (const UserCanceled& e) {
     } catch (const Exception& e) {
       QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
     }
@@ -1424,6 +1429,7 @@ void MainWindow::openDeviceTab(LibraryEditor& editor, const FilePath& fp,
         }
       }
       addTab(std::make_shared<DeviceTab>(editor, std::move(dev), mode));
+    } catch (const UserCanceled& e) {
     } catch (const Exception& e) {
       QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
     }
@@ -1473,6 +1479,7 @@ void MainWindow::openOrganizationTab(LibraryEditor& editor, const FilePath& fp,
         }
       }
       addTab(std::make_shared<OrganizationTab>(editor, std::move(org), mode));
+    } catch (const UserCanceled& e) {
     } catch (const Exception& e) {
       QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
     }

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -175,6 +175,12 @@ class ElementQuery:
         else:
             self.wait(1)
 
+    def __len__(self):
+        """
+        Get the number of results
+        """
+        return len(self._results)
+
     def __getitem__(self, index):
         """
         Get a particular result by index (an `Element` object)

--- a/tests/ui/mainwindow/test_library_editor.py
+++ b/tests/ui/mainwindow/test_library_editor.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test the library editor
+"""
+
+
+def test_close_tab_with_reverted_changes(librepcb):
+    librepcb.add_local_library_to_workspace("libraries/Populated Library.lplib")
+    with librepcb.open() as app:
+        app.get("SideBar::libraries-btn").click()
+        app.get("LibrariesPanel::local-libs #LibraryListViewItem").dclick()
+        tabs = app.get("#TabButton *")
+        tabs.wait(2)
+
+        # Open a device to keep the library open.
+        items = app.get("LibraryContentTab::elements-view LibraryTreeView::item-ta *")
+        items.wait(2, None)
+        items[1].dclick()
+        tabs.wait(3)
+        tabs[1].click()
+
+        # If compact mode is used, switch to the metadata tab.
+        app.get("#LibraryTab")  # Wait for the tab before accessing NavBar.
+        nav_items = app.get("LibraryTab::navbar NavBar::item-btn *")
+        if len(nav_items) > 0:
+            nav_items[0].click()
+
+        # Edit description and move focus to apply it.
+        app.get("LibraryMetadataTab::name-edt").click()
+        app.get("LibraryMetadataTab::name-edt").set_value("test")
+        app.get("LibraryMetadataTab::description-edt").click()
+        app.get("MainMenuBar::undo-btn").wait_for(enabled=True)
+        app.get("MainMenuBar::redo-btn").wait_for(enabled=False)
+
+        # Trigger undo and verify the change.
+        app.get("MainMenuBar::undo-btn").click()
+        app.get("LibraryMetadataTab::name-edt").wait_for(value="Populated Library")
+        app.get("MainMenuBar::undo-btn").wait_for(enabled=False)
+        app.get("MainMenuBar::redo-btn").wait_for(enabled=True)
+
+        # Close the tab shall now be possible without asking for saving.
+        tabs[1].mclick()
+        tabs.wait(2)
+
+        # When opening the library tab again, the undo stack must be cleared.
+        app.get("#DocumentsPanel LibrarySection::overview-item").click()
+        app.get("#LibraryTab")  # Wait for the tab before accessing NavBar.
+        nav_items.wait(0, None)
+        if len(nav_items) > 0:
+            nav_items[0].click()
+        app.get("LibraryMetadataTab::name-edt").wait_for(value="Populated Library")
+        app.get("MainMenuBar::undo-btn").wait_for(enabled=False)
+        app.get("MainMenuBar::redo-btn").wait_for(enabled=False)


### PR DESCRIPTION
Ask for saving library modifications already when closing the last library tab, not later when closing the whole library in the documents panel. I think it's more intuitive this way.