### PR TITLE
Automatically close library when closing its last tab

### DIFF
--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -433,6 +433,9 @@ std::shared_ptr<LibraryEditor> GuiApplication::openLibrary(
     // Keep handle.
     const int index = mLibraries->count();
     auto editor = std::make_shared<LibraryEditor>(*this, std::move(lib), index);
+    connect(
+        editor.get(), &LibraryEditor::closeRequested, this,
+        [this, libDir]() { closeLibrary(libDir); }, Qt::QueuedConnection);
     mLibraries->insert(index, editor);
     switchToLibrary(index);
     return editor;

--- a/libs/librepcb/editor/library/libraryeditor.cpp
+++ b/libs/librepcb/editor/library/libraryeditor.cpp
@@ -195,6 +195,13 @@ void LibraryEditor::registerTab(LibraryEditorTab& tab) noexcept {
 void LibraryEditor::unregisterTab(LibraryEditorTab& tab) noexcept {
   Q_ASSERT(mRegisteredTabs.contains(&tab));
   mRegisteredTabs.removeAll(&tab);
+
+  // When closing the last tab of this library, automatically close the library
+  // editor too, to avoid spamming the documents panel with lots of opened
+  // libraries, required to be manually closed by the used.
+  if (mRegisteredTabs.isEmpty() && (!hasUnsavedChanges())) {
+    emit closeRequested();
+  }
 }
 
 void LibraryEditor::forceClosingTabs(const QSet<FilePath>& fp) noexcept {

--- a/libs/librepcb/editor/library/libraryeditor.h
+++ b/libs/librepcb/editor/library/libraryeditor.h
@@ -134,6 +134,7 @@ public:
 signals:
   void uiIndexChanged();
   void manualModificationsMade();
+  void closeRequested();
   void aboutToBeDestroyed();
 
 private:


### PR DESCRIPTION
Avoid spamming the documents panel with libraries which have actually no tabs open anymore. Now the user doesn't need to close libraries manually with the "X" button anymore, as they will be closed automatically when closing the last tab.