### PR TITLE
Automatically update remote libraries (4 configurable modes)

### DIFF
--- a/libs/librepcb/core/network/filedownload.cpp
+++ b/libs/librepcb/core/network/filedownload.cpp
@@ -71,6 +71,12 @@ void FileDownload::setZipExtractionDirectory(
   mZipDiscoveryCallback = discoveryCallback;
 }
 
+void FileDownload::setZipCleanupCallback(
+    std::function<void(const FilePath&)> cb) noexcept {
+  Q_ASSERT(!mStarted);
+  mZipCleanupCallback = cb;
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
@@ -160,6 +166,12 @@ void FileDownload::finalizeRequest() {
     FileUtils::move(srcDirFp, mExtractZipToDir);  // can throw
   } catch (const Exception& e) {
     QDir().rename(backupDirFp.toStr(), mExtractZipToDir.toStr());
+    return;  // Do not call cleanup callback!
+  }
+
+  // Call cleanup callback.
+  if (mZipCleanupCallback) {
+    mZipCleanupCallback(mExtractZipToDir);
   }
 }
 

--- a/libs/librepcb/core/network/filedownload.cpp
+++ b/libs/librepcb/core/network/filedownload.cpp
@@ -23,8 +23,9 @@
 #include "filedownload.h"
 
 #include "../exceptions.h"
+#include "../fileio/fileutils.h"
 #include "../fileio/ziparchive.h"
-#include "../utils/scopeguard.h"
+#include "../utils/scopeguardlist.h"
 
 #include <QtCore>
 
@@ -37,12 +38,15 @@ namespace librepcb {
  *  Constructors / Destructor
  ******************************************************************************/
 
-FileDownload::FileDownload(const QUrl& url, const FilePath& dest) noexcept
+FileDownload::FileDownload(const QUrl& url, const FilePath& dest,
+                           std::shared_ptr<QSemaphore> semaphore) noexcept
   : NetworkRequestBase(url),
+    mSemaphore(semaphore),
     mDestination(dest),
-    mHashAlgorithm(QCryptographicHash::Md5),
+    mHash(),
     mExpectedChecksum(),
     mExtractZipToDir() {
+  Q_ASSERT(mSemaphore);
 }
 
 FileDownload::~FileDownload() noexcept {
@@ -55,13 +59,16 @@ FileDownload::~FileDownload() noexcept {
 void FileDownload::setExpectedChecksum(QCryptographicHash::Algorithm algorithm,
                                        const QByteArray& checksum) noexcept {
   Q_ASSERT(!mStarted);
-  mHashAlgorithm = algorithm;
+  mHash.reset(new QCryptographicHash(algorithm));
   mExpectedChecksum = checksum;
 }
 
-void FileDownload::setZipExtractionDirectory(const FilePath& dir) noexcept {
+void FileDownload::setZipExtractionDirectory(
+    const FilePath& dir,
+    std::function<FilePath(const FilePath&)> discoveryCallback) noexcept {
   Q_ASSERT(!mStarted);
   mExtractZipToDir = dir;
+  mZipDiscoveryCallback = discoveryCallback;
 }
 
 /*******************************************************************************
@@ -69,23 +76,14 @@ void FileDownload::setZipExtractionDirectory(const FilePath& dir) noexcept {
  ******************************************************************************/
 
 void FileDownload::prepareRequest() {
-  // check destination filepath
-  if (mDestination.isExistingFile() || mDestination.isExistingDir()) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString("The destination file exists already: %1")
-                           .arg(mDestination.toNative()));
-  }
+  // Limit number of parallel file access threads.
+  mSemaphore->acquire();
+  QSemaphoreReleaser releaser(*mSemaphore);
 
-  // create destination directory
-  if (!mDestination.getParentDir().isEmptyDir()) {
-    if (!QDir().mkpath(mDestination.getParentDir().toStr())) {
-      throw RuntimeError(__FILE__, __LINE__,
-                         QString("Could not create directory \"%1\".")
-                             .arg(mDestination.getParentDir().toNative()));
-    }
-  }
+  // Create destination directory.
+  FileUtils::makePath(mDestination.getParentDir());  // can throw
 
-  // open temporary destination file
+  // Open temporary destination file.
   mFile.reset(new QSaveFile(mDestination.toStr(), this));
   if (!mFile->open(QIODevice::WriteOnly)) {
     throw RuntimeError(__FILE__, __LINE__,
@@ -95,36 +93,11 @@ void FileDownload::prepareRequest() {
 }
 
 void FileDownload::finalizeRequest() {
-  // check destination filepath again
-  if (mDestination.isExistingFile() || mDestination.isExistingDir()) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       QString("The destination file exists already: %1")
-                           .arg(mDestination.toNative()));
-  }
-
-  // save to destination file
-  if (!mFile->commit()) {
-    throw RuntimeError(__FILE__, __LINE__,
-                       tr("Error while writing file \"%1\": %2")
-                           .arg(mDestination.toNative(), mFile->errorString()));
-  }
-
-  // if an error occurs below this line, remove the downloaded file
-  auto sg = scopeGuard([this]() { QFile::remove(mDestination.toStr()); });
-
-  // verify checksum of downloaded file
-  if (!mExpectedChecksum.isEmpty()) {
+  // Verify checksum of downloaded file.
+  if (mHash) {
     emit progressState(tr("Verify checksum..."));
-    QFile file(mDestination.toStr());
-    if (!file.open(QFile::ReadOnly)) {
-      throw RuntimeError(__FILE__, __LINE__,
-                         tr("Error while readback file \"%1\": %2")
-                             .arg(mDestination.toNative(), file.errorString()));
-    }
-    QCryptographicHash hash(mHashAlgorithm);
-    hash.addData(&file);
-    QString result = hash.result().toHex();
-    QString expected = mExpectedChecksum.toHex();
+    const QString result = mHash->result().toHex();
+    const QString expected = mExpectedChecksum.toHex();
     if (result != expected) {
       qDebug().nospace() << "Expected checksum " << expected << " but got "
                          << result << ".";
@@ -136,14 +109,57 @@ void FileDownload::finalizeRequest() {
     }
   }
 
-  // extract zip file if necessary
-  if (mExtractZipToDir.isValid()) {
-    emit progressState(tr("Extract files..."));
-    ZipArchive zip(mDestination);  // can throw
-    zip.extractTo(mExtractZipToDir);  // can throw
-  } else {
-    // do NOT remove the downloaded file
-    sg.dismiss();
+  // Limit number of parallel file access / unzip threads.
+  mSemaphore->acquire();
+  QSemaphoreReleaser releaser(*mSemaphore);
+
+  // Save to destination file.
+  emit progressState(tr("Write file..."));
+  if (!mFile->commit()) {
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("Error while writing file \"%1\": %2")
+                           .arg(mDestination.toNative(), mFile->errorString()));
+  }
+
+  // If the downloaded file is not a ZIP, we are done now.
+  if (!mExtractZipToDir.isValid()) {
+    return;
+  }
+
+  // Clean up temporary files and folders.
+  emit progressState(tr("Remove temporary files..."));
+  ScopeGuardList sgl;
+  sgl.add([fp = mDestination.toStr()]() { QFile::remove(fp); });
+  const FilePath tmpDirFp(mExtractZipToDir.toStr() % ".tmp");
+  FileUtils::removeDirRecursively(tmpDirFp);  // can throw
+  sgl.add([fp = tmpDirFp.toStr()]() { QDir(fp).removeRecursively(); });
+  const FilePath backupDirFp(mExtractZipToDir.toStr() % ".backup");
+  FileUtils::removeDirRecursively(backupDirFp);  // can throw
+  sgl.add([fp = backupDirFp.toStr()]() { QDir(fp).removeRecursively(); });
+
+  // Extract ZIP to temporary directory.
+  emit progressState(tr("Extract ZIP..."));
+  ZipArchive zip(mDestination);  // can throw
+  zip.extractTo(tmpDirFp);  // can throw
+
+  // Find the directory of interest in the temporary directory.
+  const FilePath srcDirFp = mZipDiscoveryCallback
+      ? mZipDiscoveryCallback(tmpDirFp)  // can throw
+      : tmpDirFp;
+  Q_ASSERT((srcDirFp == tmpDirFp) || srcDirFp.isLocatedInDir(tmpDirFp));
+
+  // Create backup of destination directory. This is better than removing
+  // the destination directory recursively, as this would not be atomic.
+  if (mExtractZipToDir.isExistingDir()) {
+    FileUtils::move(mExtractZipToDir, backupDirFp);  // can throw
+  }
+
+  // Move downloaded directory to destination.
+  // If this fails, try to restore the backup.
+  try {
+    FileUtils::move(srcDirFp, mExtractZipToDir);  // can throw
+  } catch (const Exception& e) {
+    QDir().rename(backupDirFp.toStr(), mExtractZipToDir.toStr());
   }
 }
 
@@ -157,7 +173,11 @@ void FileDownload::emitSuccessfullyFinishedSignals(
 }
 
 void FileDownload::fetchNewData(QIODevice& device) noexcept {
-  mFile->write(device.readAll());
+  const QByteArray data = device.readAll();
+  mFile->write(data);
+  if (mHash) {
+    mHash->addData(data);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/network/filedownload.h
+++ b/libs/librepcb/core/network/filedownload.h
@@ -111,6 +111,16 @@ public:
                                  std::function<FilePath(const FilePath&)>
                                      discoveryCallback = nullptr) noexcept;
 
+  /**
+   * @brief Set a cleanup callback for ZIP downloads
+   *
+   * The callback will be called from the download thread after the download
+   * succeeded, with the downloaded directory passed as argument.
+   *
+   * @param cb       The callback to call. Shall never throw exceptions!
+   */
+  void setZipCleanupCallback(std::function<void(const FilePath&)> cb) noexcept;
+
   // Operator Overloadings
   FileDownload& operator=(const FileDownload& rhs) = delete;
 
@@ -150,6 +160,7 @@ private:
   QByteArray mExpectedChecksum;
   FilePath mExtractZipToDir;
   std::function<FilePath(const FilePath&)> mZipDiscoveryCallback;
+  std::function<void(const FilePath&)> mZipCleanupCallback;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/network/filedownload.h
+++ b/libs/librepcb/core/network/filedownload.h
@@ -28,6 +28,8 @@
 
 #include <QtCore>
 
+#include <functional>
+
 /*******************************************************************************
  *  Namespace / Forward Declarations
  ******************************************************************************/
@@ -54,10 +56,17 @@ public:
   /**
    * @brief Constructor
    *
-   * @param url           The URL to the file to download
-   * @param dest          The path to the destination file (must not exist!)
+   * @param url         The URL to the file to download
+   * @param dest        The path to the destination file. If it exists already,
+   *                    it will be overwritten.
+   * @param semaphore   Semaphore to limit the number of threads which perform
+   *                    file opterations or unzip at the same time. For this
+   *                    to work, the same semaphore needs to be passed to all
+   *                    parallel file downloads. If this is not needed, pass
+   *                    `std::make_shared<QSemaphore>(1)`.
    */
-  FileDownload(const QUrl& url, const FilePath& dest) noexcept;
+  FileDownload(const QUrl& url, const FilePath& dest,
+               std::shared_ptr<QSemaphore> semaphore) noexcept;
 
   ~FileDownload() noexcept;
 
@@ -84,9 +93,23 @@ public:
    *
    * @note The downloaded ZIP file will be removed after extracting it.
    *
-   * @param dir           Destination directory (may or may not exist)
+   * @note  Writing/overwriting the destination directory will be done
+   *        atomically. The extraction goes into a temporary directory, which
+   *        then gets renamed afterwards. A previously already existing
+   *        destination directory will be backed up and restored after a
+   *        failure, and removed after success.
+   *
+   * @param dir               Destination directory (may or may not exist).
+   * @param discoveryCallback Optional function to find the subfolder of the
+   *                          downloaded ZIP which shall be moved to the
+   *                          destination path (to strip root folders from ZIP).
+   *                          IMPORTANT: The callback must either return the
+   *                          passed path as-is, a valid path to a subdirectory
+   *                          of it, or it must throw an exception!
    */
-  void setZipExtractionDirectory(const FilePath& dir) noexcept;
+  void setZipExtractionDirectory(const FilePath& dir,
+                                 std::function<FilePath(const FilePath&)>
+                                     discoveryCallback = nullptr) noexcept;
 
   // Operator Overloadings
   FileDownload& operator=(const FileDownload& rhs) = delete;
@@ -119,12 +142,14 @@ private:  // Methods
   void emitSuccessfullyFinishedSignals(QString contentType) noexcept override;
   void fetchNewData(QIODevice& device) noexcept override;
 
-private:  // Data
+private:
+  std::shared_ptr<QSemaphore> mSemaphore;
   FilePath mDestination;
-  QScopedPointer<QSaveFile> mFile;
-  QCryptographicHash::Algorithm mHashAlgorithm;
+  std::unique_ptr<QSaveFile> mFile;
+  std::unique_ptr<QCryptographicHash> mHash;
   QByteArray mExpectedChecksum;
   FilePath mExtractZipToDir;
+  std::function<FilePath(const FilePath&)> mZipDiscoveryCallback;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/core/types/enums.cpp
+++ b/libs/librepcb/core/types/enums.cpp
@@ -25,7 +25,7 @@
 #include "../exceptions.h"
 #include "../serialization/sexpression.h"
 
-#include <QtCore>
+#include <QString>
 
 /*******************************************************************************
  *  Namespace
@@ -35,6 +35,39 @@ namespace librepcb {
 /*******************************************************************************
  *  Serialization
  ******************************************************************************/
+
+template <>
+std::unique_ptr<SExpression> serialize(const AutoUpdateMode& obj) {
+  switch (obj) {
+    case AutoUpdateMode::Disabled:
+      return SExpression::createToken("disabled");
+    case AutoUpdateMode::Check:
+      return SExpression::createToken("check");
+    case AutoUpdateMode::Notify:
+      return SExpression::createToken("notify");
+    case AutoUpdateMode::Install:
+      return SExpression::createToken("install");
+    default:
+      throw LogicError(__FILE__, __LINE__);
+  }
+}
+
+template <>
+AutoUpdateMode deserialize(const SExpression& sexpr) {
+  const QString str = sexpr.getValue();
+  if (str == "disabled") {
+    return AutoUpdateMode::Disabled;
+  } else if (str == "check") {
+    return AutoUpdateMode::Check;
+  } else if (str == "notify") {
+    return AutoUpdateMode::Notify;
+  } else if (str == "install") {
+    return AutoUpdateMode::Install;
+  } else {
+    throw RuntimeError(__FILE__, __LINE__,
+                       QString("Unknown auto update mode: '%1'").arg(str));
+  }
+}
 
 template <>
 std::unique_ptr<SExpression> serialize(const GridStyle& obj) {

--- a/libs/librepcb/core/types/enums.h
+++ b/libs/librepcb/core/types/enums.h
@@ -23,7 +23,7 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <QtCore>
+#include <QMetaType>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -33,6 +33,17 @@ namespace librepcb {
 /*******************************************************************************
  *  Various Basic Enums
  ******************************************************************************/
+
+/**
+ * @brief Mode for automatic online updates
+ */
+enum class AutoUpdateMode : int {
+  // Note: Sorted to make comparison operators working in a meaningful way.
+  Disabled,  ///< Automatic update check disabled
+  Check,  ///< Automatically check for updates, but no notification
+  Notify,  ///< Automatically check for updates, then notify the user
+  Install,  ///< Automatically check for, download, and install updates
+};
 
 /**
  * @brief Grid style for the 2D graphics views
@@ -49,6 +60,7 @@ enum class GridStyle : int {
 
 }  // namespace librepcb
 
+Q_DECLARE_METATYPE(librepcb::AutoUpdateMode)
 Q_DECLARE_METATYPE(librepcb::GridStyle)
 
 #endif

--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -99,6 +99,7 @@ WorkspaceSettings::WorkspaceSettings(QObject* parent)
                      },
                  },
                  this),
+    librariesAutoUpdateMode("library_updates", AutoUpdateMode::Install, this),
     autofetchLivePartInformation("autofetch_live_part_information", true, this),
     externalWebBrowserCommands("external_web_browser", "command", QStringList(),
                                this),

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -245,6 +245,13 @@ public:
   WorkspaceSettingsItem_GenericValueList<QList<ApiEndpoint>, true> apiEndpoints;
 
   /**
+   * @brief Automatic update mode for libraries
+   *
+   * Default: ::librepcb::AutoUpdateMode::Install
+   */
+  WorkspaceSettingsItem_GenericValue<AutoUpdateMode> librariesAutoUpdateMode;
+
+  /**
    * @brief Enable auto-fetch of live parts information (through #apiEndpoints)
    *
    * Default: True

--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -277,6 +277,8 @@ GuiApplication::GuiApplication(Workspace& ws, bool fileFormatIsOutdated,
   // Setup library models & filter.
   connect(mRemoteLibraries.get(), &LibrariesModel::onlineVersionsAvailable,
           mLocalLibraries.get(), &LibrariesModel::setOnlineVersions);
+  connect(mRemoteLibraries.get(), &LibrariesModel::notificationEmitted,
+          mNotifications.get(), &NotificationsModel::push);
   connect(mRemoteLibraries.get(), &LibrariesModel::aboutToUninstallLibrary,
           this, &GuiApplication::closeLibrary);
 
@@ -675,6 +677,8 @@ std::shared_ptr<MainWindow> GuiApplication::createNewWindow(
             [](const ui::LibraryInfoData& a, const ui::LibraryInfoData& b) {
               if ((a.progress > 0) != (b.progress > 0)) {
                 return a.progress > 0;
+              } else if (a.duplicate != b.duplicate) {
+                return a.duplicate;
               } else if (a.outdated != b.outdated) {
                 return a.outdated;
               } else if (a.installed_version.empty() !=

--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -277,8 +277,20 @@ GuiApplication::GuiApplication(Workspace& ws, bool fileFormatIsOutdated,
   // Setup library models & filter.
   connect(mRemoteLibraries.get(), &LibrariesModel::onlineVersionsAvailable,
           mLocalLibraries.get(), &LibrariesModel::setOnlineVersions);
+  connect(mRemoteLibraries.get(), &LibrariesModel::panelPageRequested, this,
+          [this]() {
+            if (auto win = getCurrentWindow()) {
+              win->showPanelPage(ui::PanelPage::Libraries);
+            }
+          });
   connect(mRemoteLibraries.get(), &LibrariesModel::notificationEmitted,
           mNotifications.get(), &NotificationsModel::push);
+  connect(mRemoteLibraries.get(), &LibrariesModel::statusBarMessageChanged,
+          this, [this](const QString& message, int timeoutMs) {
+            for (auto window : *mWindows) {
+              window->showStatusBarMessage(message, timeoutMs);
+            }
+          });
   connect(mRemoteLibraries.get(), &LibrariesModel::aboutToUninstallLibrary,
           this, &GuiApplication::closeLibrary);
 

--- a/libs/librepcb/editor/library/downloadlibrarytab.cpp
+++ b/libs/librepcb/editor/library/downloadlibrarytab.cpp
@@ -117,19 +117,22 @@ void DownloadLibraryTab::trigger(ui::TabAction a) noexcept {
         mUiData.download_progress = 0;
         onDerivedUiDataChanged.notify();
 
-        mDownload.reset(new LibraryDownload(*mUrl, mDirectory));
-        connect(mDownload.get(), &LibraryDownload::progressState,
+        mDownload.reset(new LibraryDownload(*mUrl, mDirectory,
+                                            std::make_shared<QSemaphore>(1)));
+        connect(mDownload.get(), &LibraryDownload::progressState, this,
                 [this](const QString& state) {
                   mUiData.download_status = q2s(state);
                   onDerivedUiDataChanged.notify();
                 });
-        connect(mDownload.get(), &LibraryDownload::progressPercent,
+        connect(mDownload.get(), &LibraryDownload::progressPercent, this,
                 [this](int percent) {
                   mUiData.download_progress = percent;
                   onDerivedUiDataChanged.notify();
                 });
+        // IMPORTANT: Must be QueuedConnection to avoid use-after-free since
+        // the LibraryDownload object gets deleted within downloadFinished()!
         connect(mDownload.get(), &LibraryDownload::finished, this,
-                &DownloadLibraryTab::downloadFinished);
+                &DownloadLibraryTab::downloadFinished, Qt::QueuedConnection);
         mDownload->start();
       } catch (const Exception& e) {
         mUiData.download_status = q2s(e.getMsg());

--- a/libs/librepcb/editor/library/librariesmodel.cpp
+++ b/libs/librepcb/editor/library/librariesmodel.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "librariesmodel.h"
 
+#include "../notification.h"
 #include "../utils/slinthelpers.h"
 #include "librarydownload.h"
 
@@ -89,6 +90,10 @@ ui::LibraryListData LibrariesModel::getUiData() const noexcept {
   data.count = mMergedLibs.size();
   data.installed = mInstalledLibs.size();
   for (auto& lib : mMergedLibs) {
+    if (lib.duplicate) {
+      ++data.pending_uninstalls;
+      continue;
+    }
     if (lib.outdated) {
       ++data.outdated;
     }
@@ -215,66 +220,77 @@ void LibrariesModel::applyChanges() noexcept {
   // extracting more than a few ZIP files at the same time...
   auto semaphore = std::make_shared<QSemaphore>(4);
 
-  int installed = 0;
+  // Remove libraries first.
   int uninstalled = 0;
   for (auto& lib : mMergedLibs) {
     const auto uuid = Uuid::tryFromString(s2q(lib.uuid));
-    if (!uuid) continue;
+    if ((!uuid) || (!isMarkedForUninstall(lib))) continue;
 
-    if (isMarkedForInstall(lib) || isMarkedForUpdate(lib)) {
-      // Install/update library.
-      const auto onlineLib = mOnlineLibs.find(*uuid);
-      if (onlineLib == mOnlineLibs.end()) continue;
-
-      // Determine destination directory.
-      const FilePath destDir = mWorkspace.getLibrariesPath().getPathTo(
-          "remote/" % onlineLib->uuid.toStr() % ".lplib");
-
-      // Start download.
-      auto dl = std::make_shared<LibraryDownload>(onlineLib->downloadUrl,
-                                                  destDir, semaphore);
-      if (onlineLib->downloadSize > 0) {
-        dl->setExpectedZipFileSize(onlineLib->downloadSize);
-      }
-      if (!onlineLib->downloadSha256.isEmpty()) {
-        dl->setExpectedChecksum(QCryptographicHash::Sha256,
-                                QByteArray::fromHex(onlineLib->downloadSha256));
-      }
-      connect(
-          dl.get(), &LibraryDownload::progressPercent, this,
-          [this, uuid](int percent) {
-            if (auto i = indexOf(*uuid)) {
-              mMergedLibs.at(*i).progress = percent;
-              notify_row_changed(*i);
-            }
-          },
-          Qt::QueuedConnection);
-      connect(
-          dl.get(), &LibraryDownload::finished, this,
-          [this, uuid, dl](bool success, const QString& errMsg) {
-            Q_UNUSED(success);
-            Q_UNUSED(errMsg);
-            mDownloadsInProgress.removeOne(dl);
-            if (mDownloadsInProgress.isEmpty()) {
-              mWorkspace.getLibraryDb().startLibraryRescan();
-            }
-          },
-          Qt::QueuedConnection);
-      mDownloadsInProgress.append(dl);
-      dl->start();
-      ++installed;
-    } else if (isMarkedForUninstall(lib)) {
-      // Uninstall library.
-      try {
-        const FilePath fp(s2q(lib.path));
-        emit aboutToUninstallLibrary(fp);  // Let the app close it if needed
-        FileUtils::removeDirRecursively(fp);  // can throw
-      } catch (const Exception& e) {
-        // TODO: This should be implemented without message box some day...
-        QMessageBox::critical(nullptr, tr("Error"), e.getMsg());
-      }
-      ++uninstalled;
+    try {
+      const FilePath fp(s2q(lib.path));
+      emit aboutToUninstallLibrary(fp);  // Let the app close it if needed
+      FileUtils::removeDirRecursively(fp);  // can throw
+      mInstalledLibDirs[*uuid].remove(fp);  // Important for duplicates!
+    } catch (const Exception& e) {
+      emit notificationEmitted(std::make_shared<Notification>(
+          ui::NotificationType::Critical, tr("Failed to Uninstall Library"),
+          tr("The directory '%1' could not be removed: %2")
+              .arg(s2q(lib.path), e.getMsg()),
+          QString(), QString(), true));
     }
+    ++uninstalled;
+  }
+
+  // Then start installations/updates.
+  int installed = 0;
+  for (auto& lib : mMergedLibs) {
+    const auto uuid = Uuid::tryFromString(s2q(lib.uuid));
+    if ((!uuid) || ((!isMarkedForInstall(lib)) && (!isMarkedForUpdate(lib)))) {
+      continue;
+    }
+
+    // Install/update library.
+    const auto onlineLib = mOnlineLibs.find(*uuid);
+    if (onlineLib == mOnlineLibs.end()) continue;
+
+    // Determine destination directory.
+    const FilePath destDir = mWorkspace.getLibrariesPath().getPathTo(
+        "remote/" % onlineLib->uuid.toStr() % ".lplib");
+
+    // Start download.
+    auto dl = std::make_shared<LibraryDownload>(onlineLib->downloadUrl, destDir,
+                                                semaphore);
+    if (onlineLib->downloadSize > 0) {
+      dl->setExpectedZipFileSize(onlineLib->downloadSize);
+    }
+    if (!onlineLib->downloadSha256.isEmpty()) {
+      dl->setExpectedChecksum(QCryptographicHash::Sha256,
+                              QByteArray::fromHex(onlineLib->downloadSha256));
+    }
+    dl->setExistingDirsToReplace(mInstalledLibDirs[onlineLib->uuid]);
+    connect(
+        dl.get(), &LibraryDownload::progressPercent, this,
+        [this, uuid](int percent) {
+          if (auto i = indexOf(*uuid)) {
+            mMergedLibs.at(*i).progress = percent;
+            notify_row_changed(*i);
+          }
+        },
+        Qt::QueuedConnection);
+    connect(
+        dl.get(), &LibraryDownload::finished, this,
+        [this, uuid, dl](bool success, const QString& errMsg) {
+          Q_UNUSED(success);
+          Q_UNUSED(errMsg);
+          mDownloadsInProgress.removeOne(dl);
+          if (mDownloadsInProgress.isEmpty()) {
+            mWorkspace.getLibraryDb().startLibraryRescan();
+          }
+        },
+        Qt::QueuedConnection);
+    mDownloadsInProgress.append(dl);
+    dl->start();
+    ++installed;
   }
 
   if ((installed == 0) && ((uninstalled > 0) || scanCanceled)) {
@@ -339,13 +355,21 @@ void LibrariesModel::set_row_data(std::size_t i,
 void LibrariesModel::updateLibraries(bool resetHighlight) noexcept {
   mInstalledLibs.clear();
   mInstalledLibsErrors.clear();
+  mInstalledLibDirs.clear();
 
   try {
+    QSet<Uuid> uuids;
     QMultiMap<Version, FilePath> libraries =
         mWorkspace.getLibraryDb().getAll<Library>();  // can throw
 
-    QSet<Uuid> uuids;
-    foreach (const FilePath& libDir, libraries) {
+    // Note: Iterate from high versions to low versions, to make sure the
+    // old versions are marked as duplicate, not the new versions. This avoids
+    // updating duplicate libraries even though another duplicate is already
+    // up-to-date.
+    auto rbegin = std::make_reverse_iterator(libraries.constEnd());
+    auto rend = std::make_reverse_iterator(libraries.constBegin());
+    for (auto it = rbegin; it != rend; ++it) {
+      const FilePath libDir = *it;
       Uuid uuid = Uuid::createRandom();
       Version version = Version::fromString("1");
       mWorkspace.getLibraryDb().getMetadata<Library>(libDir, &uuid,
@@ -370,9 +394,7 @@ void LibrariesModel::updateLibraries(bool resetHighlight) noexcept {
 
       const auto sName = q2s(name);
       mInstalledLibs.push_back(ui::LibraryInfoData{
-          uuids.contains(uuid)
-              ? slint::SharedString()
-              : q2s(uuid.toStr()),  // UUID (empty for duplicates)
+          q2s(uuid.toStr()),  // UUID
           q2s(libDir.toNative()),  // Path
           q2s(icon),  // Icon
           sName,  // Name
@@ -380,11 +402,13 @@ void LibrariesModel::updateLibraries(bool resetHighlight) noexcept {
           q2s(version.toStr()),  // Installed version
           slint::SharedString(),  // Online version
           false,  // Outdated
+          uuids.contains(uuid),  // Duplicate
           false,  // Recommended
           0,  // Progress [%]
-          true,  // Checked
+          !uuids.contains(uuid),  // Checked
           mHighlightedLib == libDir,  // Highlight
       });
+      mInstalledLibDirs[uuid].insert(libDir);
       uuids.insert(uuid);
     }
   } catch (const Exception& e) {
@@ -524,6 +548,7 @@ void LibrariesModel::updateMergedLibraries() noexcept {
           slint::SharedString(),  // Installed version
           q2s(lib.version.toStr()),  // Online version
           false,  // Outdated
+          false,  // Duplicate
           lib.recommended,  // Recommended
           0,  // Progress
           false,  // Checked
@@ -556,6 +581,7 @@ void LibrariesModel::updateCheckStates(bool notify) noexcept {
 void LibrariesModel::checkMissingDependenciesOfLibs() noexcept {
   QSet<Uuid> toBeInstalled;
   for (const auto& lib : mMergedLibs) {
+    if (lib.duplicate) continue;
     const auto uuid = Uuid::tryFromString(s2q(lib.uuid));
     if (uuid && isLibraryChecked(lib)) {
       toBeInstalled.insert(*uuid);
@@ -582,6 +608,7 @@ void LibrariesModel::checkMissingDependenciesOfLibs() noexcept {
 void LibrariesModel::uncheckLibsWithUnmetDependencies() noexcept {
   QSet<Uuid> toBeUninstalled;
   for (const auto& lib : mMergedLibs) {
+    if (lib.duplicate) continue;
     const auto uuid = Uuid::tryFromString(s2q(lib.uuid));
     if (uuid && (!isLibraryChecked(lib))) {
       toBeUninstalled.insert(*uuid);
@@ -608,22 +635,24 @@ void LibrariesModel::uncheckLibsWithUnmetDependencies() noexcept {
 bool LibrariesModel::isLibraryChecked(
     const ui::LibraryInfoData& lib) const noexcept {
   const auto uuid = Uuid::tryFromString(s2q(lib.uuid));
-  return uuid && mCheckStates.value(*uuid, !lib.installed_version.empty());
+  return uuid && (!lib.duplicate) &&
+      mCheckStates.value(*uuid, !lib.installed_version.empty());
 }
 
 bool LibrariesModel::isMarkedForInstall(
     const ui::LibraryInfoData& lib) noexcept {
-  return lib.installed_version.empty() && lib.checked;
+  return lib.installed_version.empty() && lib.checked && (!lib.duplicate);
 }
 
 bool LibrariesModel::isMarkedForUpdate(
     const ui::LibraryInfoData& lib) noexcept {
-  return (!lib.installed_version.empty()) && lib.outdated && lib.checked;
+  return (!lib.installed_version.empty()) && lib.outdated && lib.checked &&
+      (!lib.duplicate);
 }
 
 bool LibrariesModel::isMarkedForUninstall(
     const ui::LibraryInfoData& lib) noexcept {
-  return (!lib.installed_version.empty()) && (!lib.checked);
+  return ((!lib.installed_version.empty()) && (!lib.checked)) || lib.duplicate;
 }
 
 std::optional<std::size_t> LibrariesModel::indexOf(const Uuid& uuid) noexcept {

--- a/libs/librepcb/editor/library/librariesmodel.cpp
+++ b/libs/librepcb/editor/library/librariesmodel.cpp
@@ -210,6 +210,11 @@ void LibrariesModel::applyChanges() noexcept {
   qApp->setOverrideCursor(Qt::WaitCursor);
   auto cursorSg = scopeGuard([]() { qApp->restoreOverrideCursor(); });
 
+  // Limit number of parallel file access threads, mainly for unreliable
+  // operating systems like MS Windows. It seems to be overwhelmed when
+  // extracting more than a few ZIP files at the same time...
+  auto semaphore = std::make_shared<QSemaphore>(4);
+
   int installed = 0;
   int uninstalled = 0;
   for (auto& lib : mMergedLibs) {
@@ -226,8 +231,8 @@ void LibrariesModel::applyChanges() noexcept {
           "remote/" % onlineLib->uuid.toStr() % ".lplib");
 
       // Start download.
-      auto dl =
-          std::make_shared<LibraryDownload>(onlineLib->downloadUrl, destDir);
+      auto dl = std::make_shared<LibraryDownload>(onlineLib->downloadUrl,
+                                                  destDir, semaphore);
       if (onlineLib->downloadSize > 0) {
         dl->setExpectedZipFileSize(onlineLib->downloadSize);
       }

--- a/libs/librepcb/editor/library/librariesmodel.cpp
+++ b/libs/librepcb/editor/library/librariesmodel.cpp
@@ -45,6 +45,10 @@
 namespace librepcb {
 namespace editor {
 
+static AutoUpdateMode getUpdateMode(const Workspace& ws) noexcept {
+  return ws.getSettings().librariesAutoUpdateMode.get();
+}
+
 /*******************************************************************************
  *  Constructors / Destructor
  ******************************************************************************/
@@ -55,12 +59,21 @@ LibrariesModel::LibrariesModel(Workspace& ws, Mode mode,
     mWorkspace(ws),
     mMode(mode),
     mInitialized(false),
+    mIsAutoCheck(false),
+    mAutoUpdatesInstalled(false),
+    mAutoUpdateErrorCount(0),
     mRequestIcons(false) {
   connect(&mWorkspace.getLibraryDb(),
           &WorkspaceLibraryDb::scanLibraryListUpdated, this,
           &LibrariesModel::updateLibraries, Qt::QueuedConnection);
 
-  QTimer::singleShot(1000, this, [this]() { ensurePopulated(false); });
+  // Setup auto-update.
+  connect(&mAutoUpdateTimer, &QTimer::timeout, this, [this]() {
+    mAutoUpdateTimer.setInterval(25 * 3600 * 1000);  // 25h
+    emit statusBarMessageChanged(tr("Looking for library updates..."), 2500);
+    ensurePopulated(false, true);
+  });
+  mAutoUpdateTimer.start(1000);
 
   // When the list of API endpoints is modified, re-fetch all remote libraries.
   if (mMode == Mode::RemoteLibs) {
@@ -70,8 +83,15 @@ LibrariesModel::LibrariesModel(Workspace& ws, Mode mode,
               mOnlineLibsErrors.clear();
               mOnlineLibs.clear();
               updateMergedLibraries();
-              ensurePopulated(false);
+              ensurePopulated(false, false);
             });
+  }
+
+  // Load auto-update error count.
+  if (mMode == Mode::RemoteLibs) {
+    QSettings cs;
+    mAutoUpdateErrorCount =
+        cs.value("library_manager/auto_update_errors", 0).toInt();
   }
 }
 
@@ -141,14 +161,17 @@ void LibrariesModel::setOnlineVersions(
   }
 }
 
-void LibrariesModel::ensurePopulated(bool withIcons) noexcept {
+void LibrariesModel::ensurePopulated(bool withIcons,
+                                     bool isAutoCheck) noexcept {
   if (withIcons) {
     mRequestIcons = true;
   }
+  mIsAutoCheck = isAutoCheck;
   if (mInstalledLibs.empty() || (!mInstalledLibsErrors.isEmpty())) {
     updateLibraries(false);
   }
   if ((mMode == Mode::RemoteLibs) &&
+      (getUpdateMode(mWorkspace) != AutoUpdateMode::Disabled) &&
       (mApiEndpointsInProgress.isEmpty() &&
        (mOnlineLibs.isEmpty() || (!mOnlineLibsErrors.isEmpty())))) {
     requestOnlineLibraries(false);
@@ -165,6 +188,7 @@ void LibrariesModel::highlightLibraryOnNextRescan(const FilePath& fp) noexcept {
 void LibrariesModel::checkForUpdates() noexcept {
   if (mMode != Mode::RemoteLibs) return;
 
+  mIsAutoCheck = false;
   requestOnlineLibraries(true);
 }
 
@@ -284,6 +308,7 @@ void LibrariesModel::applyChanges() noexcept {
           Q_UNUSED(errMsg);
           mDownloadsInProgress.removeOne(dl);
           if (mDownloadsInProgress.isEmpty()) {
+            mAutoUpdatesInstalled = mIsAutoCheck;
             mWorkspace.getLibraryDb().startLibraryRescan();
           }
         },
@@ -422,7 +447,16 @@ void LibrariesModel::updateLibraries(bool resetHighlight) noexcept {
             });
 
   mInitialized = true;
-  updateMergedLibraries();
+  const ui::LibraryListData uiData = updateMergedLibraries();
+
+  if (mAutoUpdatesInstalled) {
+    if (uiData.all_up_to_date) {
+      emit statusBarMessageChanged(tr("Successfully updated libraries"), 2500);
+    } else if (uiData.pending_updates) {
+      emit statusBarMessageChanged(tr("Failed to update libraries"), 2500);
+    }
+    mAutoUpdatesInstalled = false;
+  }
 
   if (resetHighlight) {
     mHighlightedLib = std::nullopt;
@@ -458,9 +492,11 @@ void LibrariesModel::onlineLibraryListReceived(
     mOnlineLibs.insert(uuid, lib);
     versions.insert(uuid, lib.version);
   }
-  apiEndpointOperationFinished();
   updateMergedLibraries();
   emit onlineVersionsAvailable(versions);
+
+  // Must come after updateMergedLibraries(), for the auto-update.
+  apiEndpointOperationFinished();
 
   if (mRequestIcons) {
     requestMissingOnlineIcons();
@@ -468,7 +504,7 @@ void LibrariesModel::onlineLibraryListReceived(
 }
 
 void LibrariesModel::requestMissingOnlineIcons() noexcept {
-  for (const ApiEndpoint::Library& lib : mOnlineLibs) {
+  for (const ApiEndpoint::Library& lib : std::as_const(mOnlineLibs)) {
     if (!mIcons.contains(lib.uuid)) {
       const Uuid uuid = lib.uuid;
       mIcons[uuid] = QPixmap();  // Mark as "requested".
@@ -501,8 +537,7 @@ void LibrariesModel::errorWhileFetchingLibraryList(QString errorMsg) noexcept {
   const ApiEndpoint* endpoint = qobject_cast<ApiEndpoint*>(sender());
   mOnlineLibsErrors.append(
       tr("Failed to fetch libraries from '%1': %2")
-          .arg(endpoint ? endpoint->getUrl().toString() : QString())
-          .arg(errorMsg));
+          .arg(endpoint ? endpoint->getUrl().toString() : QString(), errorMsg));
   apiEndpointOperationFinished();
   emit uiDataChanged(getUiData());
 }
@@ -513,18 +548,102 @@ void LibrariesModel::apiEndpointOperationFinished() noexcept {
     return ep.get() == endpoint;
   });
   endpoint = nullptr;  // Not valid anymore!
+
   if (mApiEndpointsInProgress.isEmpty()) {
-    emit uiDataChanged(getUiData());
+    const auto uiData = getUiData();
+    emit uiDataChanged(uiData);
+
+    // Show status bar message.
+    qInfo() << "Remote libraries with update available:"
+            << uiData.pending_updates;
+    if (uiData.all_up_to_date) {
+      emit statusBarMessageChanged(tr("All libraries are up-to-date"), 2500);
+    } else if (uiData.pending_updates > 0) {
+      emit statusBarMessageChanged(tr("Update available for %n libraries",
+                                      nullptr, uiData.pending_updates),
+                                   2500);
+    }
+
+    // IMPORTANT: Depend auto-update on "pending_updates", not on "outdated"!
+    // If a library is installed multiple times, "outdated" stays > 0 even
+    // after the auto-update, so every app restart would re-trigger the update.
+    if (mIsAutoCheck && (uiData.pending_updates > 0) &&
+        mDownloadsInProgress.isEmpty()) {
+      AutoUpdateMode mode = getUpdateMode(mWorkspace);
+      bool allowAutoUpdate =
+          (uiData.pending_uninstalls == 0) && (uiData.pending_installs == 0);
+      if (mode == AutoUpdateMode::Install) {
+        if (!allowAutoUpdate) {
+          mode = AutoUpdateMode::Notify;
+        } else if (mAutoUpdateErrorCount < 3) {
+          setAutoUpdateErrorCount(mAutoUpdateErrorCount + 1);
+          startAutoUpdate();
+        } else {
+          mode = AutoUpdateMode::Notify;
+          allowAutoUpdate = false;
+          qCritical() << "Automatic library update not executed due to too "
+                         "many previous errors.";
+        }
+      }
+      if (mode == AutoUpdateMode::Notify) {
+        QString msg =
+            tr("There are %n library update(s) available for installation.",
+               nullptr, uiData.pending_updates) %
+            " ";
+        QString btnName;
+        if (allowAutoUpdate) {
+          msg +=
+              tr("See details in the libraries side panel, or click the button "
+                 "below to download & install all updates.");
+          btnName = tr("Update Libraries");
+        } else {
+          msg +=
+              tr("Automatic update is not available this time due to "
+                 "additional required installations or removals. Please check "
+                 "the libraries side panel to review and apply the changes.");
+          btnName = tr("Open Libraries Panel");
+        }
+        auto notification = std::make_shared<Notification>(
+            ui::NotificationType::Info, tr("Library Updates Available"), msg,
+            btnName, QString(), true);
+        if (allowAutoUpdate) {
+          connect(notification.get(), &Notification::buttonClicked, this,
+                  &LibrariesModel::startAutoUpdate, Qt::QueuedConnection);
+        } else {
+          connect(
+              notification.get(), &Notification::buttonClicked, this,
+              [this]() { emit panelPageRequested(ui::PanelPage::Libraries); },
+              Qt::QueuedConnection);
+        }
+        connect(notification.get(), &Notification::buttonClicked,
+                notification.get(), &Notification::dismiss,
+                Qt::QueuedConnection);
+        connect(this, &LibrariesModel::uiDataChanged, notification.get(),
+                &Notification::dismiss, Qt::QueuedConnection);
+        emit notificationEmitted(notification);
+      }
+    }
   }
 }
 
-void LibrariesModel::updateMergedLibraries() noexcept {
+void LibrariesModel::startAutoUpdate() noexcept {
+  const auto uiData = getUiData();
+  qInfo() << "Starting update of" << uiData.pending_updates
+          << "remote libraries...";
+  emit statusBarMessageChanged(
+      tr("Updating %n libraries...", nullptr, uiData.pending_updates), 5000);
+  mCheckStates.clear();
+  updateMergedLibraries();
+  applyChanges();
+}
+
+ui::LibraryListData LibrariesModel::updateMergedLibraries() noexcept {
   mMergedLibs = mInstalledLibs;
   for (auto& lib : mMergedLibs) {
     lib.online_version = mOnlineVersions.value(lib.uuid);
   }
 
-  for (const auto& lib : mOnlineLibs) {
+  for (const auto& lib : std::as_const(mOnlineLibs)) {
     bool isInstalled = false;
     for (std::size_t i = 0; i < mInstalledLibs.size(); ++i) {
       auto& installedLib = mMergedLibs.at(i);
@@ -562,7 +681,12 @@ void LibrariesModel::updateMergedLibraries() noexcept {
 
   notify_reset();
 
-  emit uiDataChanged(getUiData());
+  const ui::LibraryListData uiData = getUiData();
+  if ((mMode == Mode::RemoteLibs) && uiData.all_up_to_date) {
+    setAutoUpdateErrorCount(0);
+  }
+  emit uiDataChanged(uiData);
+  return uiData;
 }
 
 void LibrariesModel::updateCheckStates(bool notify) noexcept {
@@ -580,8 +704,7 @@ void LibrariesModel::updateCheckStates(bool notify) noexcept {
 
 void LibrariesModel::checkMissingDependenciesOfLibs() noexcept {
   QSet<Uuid> toBeInstalled;
-  for (const auto& lib : mMergedLibs) {
-    if (lib.duplicate) continue;
+  for (const auto& lib : std::as_const(mMergedLibs)) {
     const auto uuid = Uuid::tryFromString(s2q(lib.uuid));
     if (uuid && isLibraryChecked(lib)) {
       toBeInstalled.insert(*uuid);
@@ -590,7 +713,7 @@ void LibrariesModel::checkMissingDependenciesOfLibs() noexcept {
 
   while (true) {
     const int oldCount = toBeInstalled.count();
-    for (const auto& lib : mOnlineLibs) {
+    for (const auto& lib : std::as_const(mOnlineLibs)) {
       if (toBeInstalled.contains(lib.uuid)) {
         toBeInstalled |= lib.dependencies;
       }
@@ -600,15 +723,14 @@ void LibrariesModel::checkMissingDependenciesOfLibs() noexcept {
     }
   }
 
-  for (const Uuid& uuid : toBeInstalled) {
+  for (const Uuid& uuid : std::as_const(toBeInstalled)) {
     mCheckStates[uuid] = true;
   }
 }
 
 void LibrariesModel::uncheckLibsWithUnmetDependencies() noexcept {
   QSet<Uuid> toBeUninstalled;
-  for (const auto& lib : mMergedLibs) {
-    if (lib.duplicate) continue;
+  for (const auto& lib : std::as_const(mMergedLibs)) {
     const auto uuid = Uuid::tryFromString(s2q(lib.uuid));
     if (uuid && (!isLibraryChecked(lib))) {
       toBeUninstalled.insert(*uuid);
@@ -617,7 +739,7 @@ void LibrariesModel::uncheckLibsWithUnmetDependencies() noexcept {
 
   while (true) {
     const int oldCount = toBeUninstalled.count();
-    for (const auto& lib : mOnlineLibs) {
+    for (const auto& lib : std::as_const(mOnlineLibs)) {
       if (!(lib.dependencies & toBeUninstalled).isEmpty()) {
         toBeUninstalled.insert(lib.uuid);
       }
@@ -627,7 +749,7 @@ void LibrariesModel::uncheckLibsWithUnmetDependencies() noexcept {
     }
   }
 
-  for (const Uuid& uuid : toBeUninstalled) {
+  for (const Uuid& uuid : std::as_const(toBeUninstalled)) {
     mCheckStates[uuid] = false;
   }
 }
@@ -662,6 +784,14 @@ std::optional<std::size_t> LibrariesModel::indexOf(const Uuid& uuid) noexcept {
     }
   }
   return std::nullopt;
+}
+
+void LibrariesModel::setAutoUpdateErrorCount(int count) noexcept {
+  if (count != mAutoUpdateErrorCount) {
+    QSettings cs;
+    cs.setValue("library_manager/auto_update_errors", count);
+    mAutoUpdateErrorCount = count;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/librariesmodel.h
+++ b/libs/librepcb/editor/library/librariesmodel.h
@@ -30,6 +30,7 @@
 
 #include <QtCore>
 
+#include <memory>
 #include <vector>
 
 /*******************************************************************************
@@ -43,6 +44,7 @@ class Workspace;
 namespace editor {
 
 class LibraryDownload;
+class Notification;
 
 /*******************************************************************************
  *  Class LibrariesModel
@@ -90,6 +92,7 @@ signals:
   void uiDataChanged(ui::LibraryListData data);
   void onlineVersionsAvailable(const QHash<Uuid, Version>& versions);
   void aboutToUninstallLibrary(const FilePath& fp);
+  void notificationEmitted(std::shared_ptr<Notification> notification);
 
 private:
   void updateLibraries(bool resetHighlight = true) noexcept;
@@ -114,6 +117,7 @@ private:
   bool mInitialized;
   std::vector<ui::LibraryInfoData> mInstalledLibs;  /// Either local or remote
   QStringList mInstalledLibsErrors;
+  QHash<Uuid, QSet<FilePath>> mInstalledLibDirs;
   QHash<Uuid, ApiEndpoint::Library> mOnlineLibs;
   QStringList mOnlineLibsErrors;
   std::vector<ui::LibraryInfoData> mMergedLibs;

--- a/libs/librepcb/editor/library/librariesmodel.h
+++ b/libs/librepcb/editor/library/librariesmodel.h
@@ -71,7 +71,7 @@ public:
   // General Methods
   ui::LibraryListData getUiData() const noexcept;
   void setOnlineVersions(const QHash<Uuid, Version>& versions) noexcept;
-  void ensurePopulated(bool withIcons) noexcept;
+  void ensurePopulated(bool withIcons, bool isAutoCheck = false) noexcept;
   void highlightLibraryOnNextRescan(const FilePath& fp) noexcept;
   void checkForUpdates() noexcept;
   void cancelUpdateCheck() noexcept;
@@ -92,7 +92,9 @@ signals:
   void uiDataChanged(ui::LibraryListData data);
   void onlineVersionsAvailable(const QHash<Uuid, Version>& versions);
   void aboutToUninstallLibrary(const FilePath& fp);
+  void panelPageRequested(ui::PanelPage page);
   void notificationEmitted(std::shared_ptr<Notification> notification);
+  void statusBarMessageChanged(const QString& message, int timeoutMs);
 
 private:
   void updateLibraries(bool resetHighlight = true) noexcept;
@@ -102,7 +104,8 @@ private:
   void onlineIconReceived(const Uuid& uuid, const QByteArray& data) noexcept;
   void errorWhileFetchingLibraryList(QString errorMsg) noexcept;
   void apiEndpointOperationFinished() noexcept;
-  void updateMergedLibraries() noexcept;
+  void startAutoUpdate() noexcept;
+  ui::LibraryListData updateMergedLibraries() noexcept;
   void updateCheckStates(bool notify) noexcept;
   void checkMissingDependenciesOfLibs() noexcept;
   void uncheckLibsWithUnmetDependencies() noexcept;
@@ -111,10 +114,14 @@ private:
   static bool isMarkedForUpdate(const ui::LibraryInfoData& lib) noexcept;
   static bool isMarkedForUninstall(const ui::LibraryInfoData& lib) noexcept;
   std::optional<std::size_t> indexOf(const Uuid& uuid) noexcept;
+  void setAutoUpdateErrorCount(int count) noexcept;
 
   Workspace& mWorkspace;
   const Mode mMode;
   bool mInitialized;
+  bool mIsAutoCheck;
+  bool mAutoUpdatesInstalled;
+  int mAutoUpdateErrorCount;
   std::vector<ui::LibraryInfoData> mInstalledLibs;  /// Either local or remote
   QStringList mInstalledLibsErrors;
   QHash<Uuid, QSet<FilePath>> mInstalledLibDirs;
@@ -130,6 +137,8 @@ private:
 
   QList<std::shared_ptr<ApiEndpoint>> mApiEndpointsInProgress;
   QList<std::shared_ptr<LibraryDownload>> mDownloadsInProgress;
+
+  QTimer mAutoUpdateTimer;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/librarydownload.cpp
+++ b/libs/librepcb/editor/library/librarydownload.cpp
@@ -87,6 +87,22 @@ void LibraryDownload::setExpectedChecksum(
   }
 }
 
+void LibraryDownload::setExistingDirsToReplace(QSet<FilePath> dirs) noexcept {
+  if (mFileDownload) {
+    mFileDownload->setZipCleanupCallback([dirs](const FilePath& dst) {
+      for (const FilePath& fp : std::as_const(dirs)) {
+        if (fp != dst) {
+          qDebug() << "Removing existing library directory:" << fp.toNative();
+          QDir(fp.toStr()).removeRecursively();
+        }
+      }
+    });
+  } else {
+    qCritical() << "Calling LibraryDownload::setExistingDirsToReplace() after "
+                   "start() is not allowed!";
+  }
+}
+
 /*******************************************************************************
  *  Public Slots
  ******************************************************************************/

--- a/libs/librepcb/editor/library/librarydownload.cpp
+++ b/libs/librepcb/editor/library/librarydownload.cpp
@@ -38,14 +38,13 @@ namespace editor {
  *  Constructors / Destructor
  ******************************************************************************/
 
-LibraryDownload::LibraryDownload(const QUrl& urlToZip,
-                                 const FilePath& destDir) noexcept
-  : QObject(nullptr),
-    mDestDir(destDir),
-    mTempDestDir(destDir.toStr() % ".tmp"),
-    mTempZipFile(mDestDir.toStr() % ".zip") {
-  mFileDownload.reset(new FileDownload(urlToZip, mTempZipFile));
-  mFileDownload->setZipExtractionDirectory(mTempDestDir);
+LibraryDownload::LibraryDownload(const QUrl& urlToZip, const FilePath& destDir,
+                                 std::shared_ptr<QSemaphore> semaphore) noexcept
+  : QObject(nullptr) {
+  mFileDownload.reset(new FileDownload(
+      urlToZip, FilePath(destDir.toStr() % ".zip"), semaphore));
+  mFileDownload->setZipExtractionDirectory(destDir,
+                                           &LibraryDownload::findLibraryInZip);
   connect(mFileDownload.get(), &FileDownload::progressState, this,
           &LibraryDownload::progressState, Qt::QueuedConnection);
   connect(mFileDownload.get(), &FileDownload::progressPercent, this,
@@ -99,28 +98,6 @@ void LibraryDownload::start() noexcept {
     return;
   }
 
-  // Delete the temporary destination directory if it already exists. It might
-  // be left there after a failed or aborted download attempt.
-  if (mTempDestDir.isExistingDir()) {
-    try {
-      FileUtils::removeDirRecursively(mTempDestDir);
-    } catch (const Exception& e) {
-      emit finished(false, e.getMsg());
-      return;
-    }
-  }
-
-  // Delete the temporary ZIP file if it already exists. It might
-  // be left there after a failed or aborted download attempt.
-  if (mTempZipFile.isExistingFile()) {
-    try {
-      FileUtils::removeFile(mTempZipFile);
-    } catch (const Exception& e) {
-      emit finished(false, e.getMsg());
-      return;
-    }
-  }
-
   // Release ownership of the FileDownload object because it will be deleted by
   // itself after the download finished!
   mFileDownload.release()->start();
@@ -135,83 +112,34 @@ void LibraryDownload::abort() noexcept {
  ******************************************************************************/
 
 void LibraryDownload::downloadErrored(const QString& errMsg) noexcept {
-  emit LibraryDownload::finished(false, errMsg);
+  emit finished(false, errMsg);
 }
 
 void LibraryDownload::downloadAborted() noexcept {
-  emit LibraryDownload::finished(false, QString());
+  emit finished(false, QString());
 }
 
 void LibraryDownload::downloadSucceeded() noexcept {
-  // check if directory contains a library
-  FilePath libDir = getPathToLibDir();
-  if (!libDir.isValid()) {
-    try {
-      FileUtils::removeDirRecursively(mDestDir);
-    } catch (...) {
-    }  // clean up
-    emit finished(
-        false,
-        tr("The downloaded ZIP file does not contain a LibrePCB library."));
-    return;
-  }
-
-  // back-up existing library (if any)
-  FilePath backupDir = FilePath(mDestDir.toStr() % ".backup");
-  try {
-    FileUtils::removeDirRecursively(backupDir);  // can throw
-    if (mDestDir.isExistingDir())
-      FileUtils::move(mDestDir, backupDir);  // can throw
-  } catch (const Exception& e) {
-    try {
-      FileUtils::removeDirRecursively(backupDir);
-    } catch (...) {
-    }
-    emit finished(false, e.getMsg());
-    return;
-  }
-
-  // move downloaded directory to destination
-  try {
-    FileUtils::move(libDir, mDestDir);  // can throw
-  } catch (const Exception& e) {
-    try {
-      FileUtils::removeDirRecursively(mDestDir);
-      FileUtils::move(backupDir, mDestDir);
-      FileUtils::removeDirRecursively(mTempDestDir);
-    } catch (...) {
-    }
-    emit finished(false, e.getMsg());
-    return;
-  }
-
-  // clean up
-  try {
-    FileUtils::removeDirRecursively(mTempDestDir);  // can throw
-    FileUtils::removeDirRecursively(backupDir);  // can throw
-  } catch (...) {
-  }
-
   emit finished(true, QString());
 }
 
-FilePath LibraryDownload::getPathToLibDir() noexcept {
-  if (Library::isValidElementDirectory<Library>(mTempDestDir)) {
-    return mTempDestDir;
+FilePath LibraryDownload::findLibraryInZip(const FilePath& root) {
+  if (Library::isValidElementDirectory<Library>(root)) {
+    return root;
   }
 
-  QStringList subdirs =
-      QDir(mTempDestDir.toStr()).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
-  if (subdirs.count() != 1) {
-    return FilePath();
+  const QStringList subdirs =
+      QDir(root.toStr()).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+  if (subdirs.count() == 1) {
+    const FilePath subdir = root.getPathTo(subdirs.first());
+    if (Library::isValidElementDirectory<Library>(subdir)) {
+      return subdir;
+    }
   }
 
-  FilePath subdir = mTempDestDir.getPathTo(subdirs.first());
-  if (Library::isValidElementDirectory<Library>(subdir)) {
-    return subdir;
-  } else {
-    return FilePath();
-  }
+  throw RuntimeError(
+      __FILE__, __LINE__,
+      tr("The downloaded ZIP file does not contain a LibrePCB library."));
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/librarydownload.h
+++ b/libs/librepcb/editor/library/librarydownload.h
@@ -67,6 +67,13 @@ public:
   void setExpectedChecksum(QCryptographicHash::Algorithm algorithm,
                            const QByteArray& checksum) noexcept;
 
+  /**
+   * @brief Set existing directories of the library to download
+   *
+   * @param dirs  Directories which shall be removed after the download.
+   */
+  void setExistingDirsToReplace(QSet<FilePath> dirs) noexcept;
+
   // Operator Overloadings
   LibraryDownload& operator=(const LibraryDownload& rhs) = delete;
 

--- a/libs/librepcb/editor/library/librarydownload.h
+++ b/libs/librepcb/editor/library/librarydownload.h
@@ -52,13 +52,9 @@ public:
   // Constructors / Destructor
   LibraryDownload() = delete;
   LibraryDownload(const LibraryDownload& other) = delete;
-  LibraryDownload(const QUrl& urlToZip, const FilePath& destDir) noexcept;
+  LibraryDownload(const QUrl& urlToZip, const FilePath& destDir,
+                  std::shared_ptr<QSemaphore> semaphore) noexcept;
   ~LibraryDownload() noexcept;
-
-  // Getters
-  const FilePath& getDestinationDir() const noexcept { return mDestDir; }
-
-  // Setters
 
   /**
    * @copydoc ::librepcb::NetworkRequestBase::setExpectedReplyContentSize()
@@ -97,13 +93,10 @@ private:  // Methods
   void downloadErrored(const QString& errMsg) noexcept;
   void downloadAborted() noexcept;
   void downloadSucceeded() noexcept;
-  FilePath getPathToLibDir() noexcept;
+  static FilePath findLibraryInZip(const FilePath& root);
 
 private:  // Data
   std::unique_ptr<FileDownload> mFileDownload;
-  FilePath mDestDir;
-  FilePath mTempDestDir;
-  FilePath mTempZipFile;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizardcontext.cpp
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizardcontext.cpp
@@ -127,7 +127,8 @@ void InitializeWorkspaceWizardContext::installExampleProjects() const noexcept {
     const FilePath dst = dir.getPathTo(project.first);
     if (!dst.isExistingDir()) {
       FileDownload* dl =
-          new FileDownload(QUrl(project.second), FilePath::getRandomTempPath());
+          new FileDownload(QUrl(project.second), FilePath::getRandomTempPath(),
+                           std::make_shared<QSemaphore>(1));
       dl->setZipExtractionDirectory(dst);
       QGuiApplication::setOverrideCursor(Qt::WaitCursor);
       connect(dl, &FileDownload::finished, qApp,

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.cpp
@@ -400,6 +400,22 @@ WorkspaceSettingsDialog::WorkspaceSettingsDialog(Workspace& workspace,
     setup(mUi->cbxBoardGridStyle, mSettings.boardGridStyle);
   }
 
+  // Initialize automatic library update mode.
+  {
+    mUi->cbxLibrariesAutoUpdateMode->addItem(
+        tr("Disabled", "Update mode"),
+        QVariant::fromValue(AutoUpdateMode::Disabled));
+    mUi->cbxLibrariesAutoUpdateMode->addItem(
+        tr("Check (Silent)", "Update mode"),
+        QVariant::fromValue(AutoUpdateMode::Check));
+    mUi->cbxLibrariesAutoUpdateMode->addItem(
+        tr("Check & Notify", "Update mode"),
+        QVariant::fromValue(AutoUpdateMode::Notify));
+    mUi->cbxLibrariesAutoUpdateMode->addItem(
+        tr("Check & Install", "Update mode"),
+        QVariant::fromValue(AutoUpdateMode::Install));
+  }
+
   // Now load all current settings
   loadSettings();
 
@@ -762,6 +778,11 @@ void WorkspaceSettingsDialog::loadSettings() noexcept {
   };
   loadGridStyle(mUi->cbxSchematicGridStyle, mSettings.schematicGridStyle.get());
   loadGridStyle(mUi->cbxBoardGridStyle, mSettings.boardGridStyle.get());
+
+  // Automatic library update mode.
+  mUi->cbxLibrariesAutoUpdateMode->setCurrentIndex(
+      mUi->cbxLibrariesAutoUpdateMode->findData(
+          QVariant::fromValue(mSettings.librariesAutoUpdateMode.get())));
 }
 
 void WorkspaceSettingsDialog::saveSettings() noexcept {
@@ -818,6 +839,13 @@ void WorkspaceSettingsDialog::saveSettings() noexcept {
     // Themes were applied immediately.
 
     // Grid style was applied immediately.
+
+    // Automatic library update mode.
+    if (mUi->cbxLibrariesAutoUpdateMode->currentIndex() >= 0) {
+      mSettings.librariesAutoUpdateMode.set(
+          mUi->cbxLibrariesAutoUpdateMode->currentData()
+              .value<AutoUpdateMode>());
+    }
 
     // Save settings to disk.
     mWorkspace.saveSettings();  // can throw

--- a/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
+++ b/libs/librepcb/editor/workspace/workspacesettingsdialog.ui
@@ -824,14 +824,41 @@ To completely disable Internet access, just remove all entries.&lt;/p&gt;
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="cbxAutofetchLivePartInformation">
-         <property name="toolTip">
-          <string>&lt;p&gt;Allow the editors to automatically display live information about parts (lifecycle status, stock availability, price, ...) by requesting it from the configured API endpoints.&lt;/p&gt;&lt;p&gt;This may generate many API requests, especially while adding components to schematics.&lt;/p&gt;&lt;p&gt;If this feature is disabled, no such API requests are made (and no live information is displayed) without explicit user interaction.&lt;/p&gt;</string>
-         </property>
-         <property name="text">
-          <string>Auto-Fetch Live Part Information</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Automatic Library Updates:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cbxLibrariesAutoUpdateMode"/>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="cbxAutofetchLivePartInformation">
+           <property name="toolTip">
+            <string>&lt;p&gt;Allow the editors to automatically display live information about parts (lifecycle status, stock availability, price, ...) by requesting it from the configured API endpoints.&lt;/p&gt;&lt;p&gt;This may generate many API requests, especially while adding components to schematics.&lt;/p&gt;&lt;p&gt;If this feature is disabled, no such API requests are made (and no live information is displayed) without explicit user interaction.&lt;/p&gt;</string>
+           </property>
+           <property name="text">
+            <string>Auto-Fetch Live Part Information</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/libs/librepcb/ui/api/data.slint
+++ b/libs/librepcb/ui/api/data.slint
@@ -1372,11 +1372,20 @@ export global Data {
             checked: true,
         },
         {
+            uuid: "x",
             icon: @image-url("../../../../img/app/librepcb.svg"),
             name: "LibrePCB Connectors",
             description: "Official LibrePCB Connectors Library.",
             installed-version: "1.2.3",
             online-version: "1.2.3",
+            duplicate: true,
+        },
+        {
+            icon: @image-url("../../../../img/app/librepcb.svg"),
+            name: "LibrePCB Integrated Circuits",
+            description: "Official LibrePCB Integrated Circuits Library",
+            online-version: "0.7",
+            checked: true,
         },
         {
             uuid: "x",

--- a/libs/librepcb/ui/api/types.slint
+++ b/libs/librepcb/ui/api/types.slint
@@ -1436,7 +1436,8 @@ export struct LibraryInfoData {
     installed-version: string,  // Empty if not installed
     online-version: string,  // Empty if not a remote library
     outdated: bool,  // Only for outdated remote libraries
-    recommended: bool,
+    duplicate: bool,  // Only for remote libraries --> make read-only
+    recommended: bool,  // Only for remote libraries
     progress: int,  // [%], 0 if not installing
     checked: bool,
     highlight: bool,

--- a/libs/librepcb/ui/library/librariespanel.slint
+++ b/libs/librepcb/ui/library/librariespanel.slint
@@ -67,6 +67,11 @@ component LibraryListViewItem inherits Rectangle {
     property <color> status-color;
     property <image> status-icon;
     states [
+        duplicate when lib.duplicate: {
+            status-text: @tr("Duplicate, will be removed");
+            status-color: Data.theme.base-text-warning;
+            status-icon: @image-url("../../../font-awesome/svgs/solid/triangle-exclamation.svg");
+        }
         outdated when lib.outdated: {
             status-text: @tr("Outdated:") + " v" + lib.installed-version + " < v" + lib.online-version;
             status-color: Data.theme.base-text-error;
@@ -250,6 +255,7 @@ component LibraryListViewItem inherits Rectangle {
                 horizontal-stretch: 0;
                 checked: lib-checked;
                 enabled: enabled;
+                read-only: lib.duplicate;
                 focusable: false;
                 accessible-label: "use library";
 

--- a/libs/librepcb/ui/sidebar.slint
+++ b/libs/librepcb/ui/sidebar.slint
@@ -51,6 +51,7 @@ component SideBarButton inherits Rectangle {
     accessible-role: button;
     accessible-enabled: enabled;
     accessible-label: tooltip;
+    accessible-value: status;
     accessible-action-default => {
         ta.clicked();
     }

--- a/libs/librepcb/ui/widgets/switch.slint
+++ b/libs/librepcb/ui/widgets/switch.slint
@@ -8,6 +8,7 @@ export enum TextSide {
 export component Switch inherits Rectangle {
     in-out property <bool> checked: false;
     in property <bool> enabled: true;
+    in property <bool> read-only: false;
     in property <string> text;
     in property <TextSide> text-side: right;
     in property <length> size: 25px;
@@ -40,6 +41,7 @@ export component Switch inherits Rectangle {
     accessible-checkable: true;
     accessible-checked: checked;
     accessible-enabled: enabled;
+    accessible-read-only: read-only;
     accessible-label: text;
     accessible-action-default => {
         ta.clicked();
@@ -56,7 +58,7 @@ export component Switch inherits Rectangle {
         key-pressed(event) => {
             // Only consume Space, but not Return as the Return key is often
             // used to confirm a dialog or something like that.
-            if event.text == Key.Space {
+            if (event.text == Key.Space) && (!read-only) {
                 toggled(!checked);
                 return accept;
             }
@@ -127,6 +129,8 @@ export component Switch inherits Rectangle {
     }
 
     ta := TouchArea {
+        // If read-only, still have the TouchArea enabled to avoid clicks
+        // propagating to any control (e.g. list view) behind the switch.
         enabled: enabled;
 
         changed has-hover => {
@@ -146,7 +150,9 @@ export component Switch inherits Rectangle {
             if !root.status-tip.is-empty {
                 Data.status-tip = "";
             }
-            toggled(!checked);
+            if !read-only {
+                toggled(!checked);
+            }
         }
     }
 }

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -4,6 +4,7 @@
 import os
 import platform
 import pytest
+import re
 import shutil
 import slint_testing
 import time
@@ -435,6 +436,17 @@ class LibrePcbFixture(object):
             path = self.abspath(path)
         self.workspace_path = path
 
+    def set_library_update_mode(self, mode):
+        assert mode in ["disabled", "check", "notify", "install"]
+        old_value = "(library_updates check)"
+        fp = self.get_workspace_path("data/settings.lp")
+        with open(fp, "r") as f:
+            content = f.read()
+        assert old_value in content
+        content = content.replace(old_value, f"(library_updates {mode})")
+        with open(fp, "w") as f:
+            f.write(content)
+
     def add_project(self, project, as_lppz=False):
         src = os.path.join(DATA_DIR, "projects", project)
         dst = os.path.join(self.tmpdir, project)
@@ -461,6 +473,26 @@ class LibrePcbFixture(object):
         dest = self.get_workspace_libraries_path("local")
         dest = os.path.join(dest, os.path.basename(path))
         shutil.copytree(_long_path(path), _long_path(dest))
+
+    def add_remote_library_to_workspace(self, zip_path, mark_outdated=False):
+        if not os.path.isabs(zip_path):
+            zip_path = os.path.join(DATA_DIR, zip_path)
+        outdir = self.get_workspace_libraries_path("remote")
+        shutil.unpack_archive(_long_path(zip_path), _long_path(outdir))
+        dest = os.path.join(outdir, os.path.basename(zip_path).replace("zip", "lplib"))
+        with os.scandir(outdir) as it:
+            for entry in it:
+                if entry.is_dir() and not entry.name.endswith(".lplib"):
+                    os.rename(entry.path, dest)
+        if mark_outdated:
+            lp_file = os.path.join(dest, "library.lp")
+            with open(lp_file, "r") as f:
+                content = f.read()
+            content = re.sub(
+                r" \(version \"(\d+\.?)+\"\)", ' (version "0.0.0.1")', content
+            )
+            with open(lp_file, "w") as f:
+                f.write(content)
 
     def add_project_to_workspace(self, project):
         src = os.path.join(DATA_DIR, "projects", project)
@@ -521,6 +553,20 @@ class Helpers(object):
                 raise TimeoutError(
                     f"Expected directories {directories}, but found {dirs}."
                 )
+            time.sleep(0.02)
+
+    @staticmethod
+    def wait_for_notification(app, title, visible=True, timeout=10.0):
+        start = time.time()
+        while True:
+            items = app.get("#NotificationsPopup #NotificationItem *")
+            for item in items:
+                if visible and (item.label == title):
+                    return item
+            if not visible:
+                return None
+            if time.time() > (start + timeout):
+                raise TimeoutError(f"Notification not emitted: {title}")
             time.sleep(0.02)
 
 

--- a/tests/ui/library/test_library_update_modes.py
+++ b/tests/ui/library/test_library_update_modes.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import time
+
+
+"""
+Test the various library update modes
+"""
+
+REMOTE_LIBRARY_COUNT = 3  # The dummy API provides 3 libraries
+
+
+def test_disabled(librepcb, helpers):
+    librepcb.set_library_update_mode("disabled")
+    librepcb.add_remote_library_to_workspace("server/blobs/LibrePCB_Connectors.zip")
+    with librepcb.open() as app:
+        # Open libraries panel.
+        app.get("SideBar::libraries-btn").click()
+
+        # Library update would happen within 1 second, so we wait a bit longer.
+        time.sleep(2)
+
+        # Ensure that no sidebar emblem or notification is shown.
+        app.get("SideBar::libraries-btn").wait_for(value="")
+        helpers.wait_for_notification(app, "Library Updates Available", visible=False)
+
+        # Ensure that only the installed library is listed.
+        libs = app.get("LibrariesPanel::remote-libs #LibraryListViewItem *")
+        libs.wait(1)
+
+
+def test_check(librepcb, helpers):
+    librepcb.set_library_update_mode("check")
+    librepcb.add_remote_library_to_workspace(
+        "server/blobs/LibrePCB_Base.zip", mark_outdated=True
+    )
+    with librepcb.open() as app:
+        # Wait for the sidebar emblem to appear.
+        app.get("SideBar::libraries-btn").wait_for(value="1")
+
+        # Open libraries panel and check if remote libraries are listed.
+        app.get("SideBar::libraries-btn").click()
+        libs = app.get("LibrariesPanel::remote-libs #LibraryListViewItem *")
+        libs.wait(REMOTE_LIBRARY_COUNT)
+
+        # Check that no notification is shown.
+        helpers.wait_for_notification(app, "Library Updates Available", visible=False)
+
+        # Check emblem again, just to be sure no update was started.
+        app.get("SideBar::libraries-btn").wait_for(value="1")
+
+
+def test_notify(librepcb, helpers):
+    librepcb.set_library_update_mode("notify")
+    librepcb.add_remote_library_to_workspace(
+        "server/blobs/LibrePCB_Base.zip", mark_outdated=True
+    )
+    helpers.wait_for_directories(
+        librepcb.get_workspace_libraries_path("remote"),
+        ["LibrePCB_Base.lplib"],
+    )
+    with librepcb.open() as app:
+        # Wait for the sidebar emblem and notification to appear.
+        app.get("SideBar::libraries-btn").wait_for(value="1")
+        notification = helpers.wait_for_notification(app, "Library Updates Available")
+        app.get("SideBar::libraries-btn").wait_for(value="1")
+
+        # Click button to start the update and check that it disappears.
+        notification.trigger()
+        helpers.wait_for_notification(app, "Library Updates Available", visible=False)
+
+        # Wait until the update has been installed. Since the original library
+        # directory is not named by UUID, the directory will get renamed.
+        helpers.wait_for_directories(
+            librepcb.get_workspace_libraries_path("remote"),
+            ["a9ddf0c6-9b1c-4730-b300-01b4f192ad40.lplib"],
+        )
+
+
+def test_install(librepcb, helpers):
+    librepcb.set_library_update_mode("install")
+    librepcb.add_remote_library_to_workspace(
+        "server/blobs/LibrePCB_Base.zip", mark_outdated=True
+    )
+    helpers.wait_for_directories(
+        librepcb.get_workspace_libraries_path("remote"),
+        ["LibrePCB_Base.lplib"],
+    )
+    with librepcb.open() as app:
+        # Wait until the update has been installed. Since the original library
+        # directory is not named by UUID, the directory will get renamed.
+        helpers.wait_for_directories(
+            librepcb.get_workspace_libraries_path("remote"),
+            ["a9ddf0c6-9b1c-4730-b300-01b4f192ad40.lplib"],
+        )
+
+        # Check that no notification is shown.
+        helpers.wait_for_notification(app, "Library Updates Available", visible=False)
+        app.get("SideBar::libraries-btn").wait_for(value="")
+
+
+def test_install_with_errors(librepcb, helpers):
+    librepcb.set_library_update_mode("install")
+    librepcb.add_remote_library_to_workspace(
+        "server/blobs/LibrePCB_Base.zip", mark_outdated=True
+    )
+    # Create a file with the name of the library to be installed. This will
+    # cause the update to fail.
+    libpath = librepcb.get_workspace_libraries_path(
+        "remote/a9ddf0c6-9b1c-4730-b300-01b4f192ad40.lplib"
+    )
+    with open(libpath, "w") as f:
+        f.write("")
+    for i in range(5):
+        with librepcb.open() as app:
+            # Wait for the status emblem.
+            app.get("SideBar::libraries-btn").wait_for(value="1")
+
+            # Check that a notification is shown after 3 failures.
+            helpers.wait_for_notification(
+                app, "Library Updates Available", visible=(i >= 3)
+            )

--- a/tests/unittests/core/network/filedownloadtest.cpp
+++ b/tests/unittests/core/network/filedownloadtest.cpp
@@ -40,11 +40,12 @@ namespace tests {
  ******************************************************************************/
 
 typedef struct {
-  QUrl url;
-  QString destFilename;
-  QString extractDirname;
-  QByteArray sha256;
-  bool success;
+  const char* url;
+  const char* destFilename;
+  const char* extractDirname;
+  const char* sha256;
+  const char* errorMsg;
+  bool testExistingDestination;
 } FileDownloadTestData;
 
 /*******************************************************************************
@@ -66,7 +67,7 @@ protected:
   }
 
   FilePath getExtractToDir(const FileDownloadTestData& data) {
-    if (!data.extractDirname.isEmpty()) {
+    if (data.extractDirname) {
       return mTmpDir.getPathTo(data.extractDirname);
     } else {
       return FilePath();
@@ -87,7 +88,8 @@ NetworkAccessManager* FileDownloadTest::sDownloadManager = nullptr;
 TEST_P(FileDownloadTest, testConstructorAndSettersAndDestructor) {
   const FileDownloadTestData& data = GetParam();
 
-  FileDownload dl(data.url, getDestination(data));
+  FileDownload dl(QUrl::fromLocalFile(data.url), getDestination(data),
+                  std::make_shared<QSemaphore>(1));
   dl.setExpectedReplyContentSize(100);
   dl.setExpectedChecksum(QCryptographicHash::Sha1, QByteArray("42"));
   dl.setZipExtractionDirectory(getExtractToDir(data));
@@ -96,18 +98,21 @@ TEST_P(FileDownloadTest, testConstructorAndSettersAndDestructor) {
 TEST_P(FileDownloadTest, testDownload) {
   const FileDownloadTestData& data = GetParam();
 
-  // remove target file/directory
-  if (getDestination(data).isExistingFile()) {
-    FileUtils::removeFile(getDestination(data));
-  }
-  if (getExtractToDir(data).isExistingDir()) {
-    FileUtils::removeDirRecursively(getExtractToDir(data));
+  // create destination files
+  if (data.testExistingDestination) {
+    FileUtils::writeFile(getDestination(data), "Foo");
+    FileUtils::writeFile(getExtractToDir(data).getPathTo("foo"), "Foo");
   }
 
   // start the file download
-  FileDownload* dl = new FileDownload(data.url, getDestination(data));
+  FileDownload* dl =
+      new FileDownload(QUrl::fromLocalFile(data.url), getDestination(data),
+                       std::make_shared<QSemaphore>(1));
   dl->setZipExtractionDirectory(getExtractToDir(data));
-  dl->setExpectedChecksum(QCryptographicHash::Sha256, data.sha256);
+  if (data.sha256) {
+    dl->setExpectedChecksum(QCryptographicHash::Sha256,
+                            QByteArray::fromHex(data.sha256));
+  }
   QObject::connect(dl, &FileDownload::progressState, &mSignalReceiver,
                    &NetworkRequestBaseSignalReceiver::progressState);
   QObject::connect(dl, &FileDownload::progressPercent, &mSignalReceiver,
@@ -131,10 +136,8 @@ TEST_P(FileDownloadTest, testDownload) {
   dl->start();
 
   // wait until download finished (with timeout)
-  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
-  auto currentTime = []() {
-    return QDateTime::currentDateTime().toMSecsSinceEpoch();
-  };
+  qint64 start = QDateTime::currentMSecsSinceEpoch();
+  auto currentTime = []() { return QDateTime::currentMSecsSinceEpoch(); };
   while ((!mSignalReceiver.mDestroyed) && (currentTime() - start < 30000)) {
     QThread::msleep(100);
     qApp->processEvents();
@@ -151,29 +154,29 @@ TEST_P(FileDownloadTest, testDownload) {
   EXPECT_TRUE(mSignalReceiver.mReceivedData.isNull())
       << qPrintable(mSignalReceiver.mReceivedData);
   EXPECT_TRUE(mSignalReceiver.mReceivedContentType.isEmpty());
-  if (data.success) {
+  if (!data.errorMsg) {
     EXPECT_GE(mSignalReceiver.mSimpleProgressCallCount, 1);
     EXPECT_EQ(1, mSignalReceiver.mSucceededCallCount);
     EXPECT_EQ(0, mSignalReceiver.mErroredCallCount);
     EXPECT_EQ(1, mSignalReceiver.mFileDownloadedCallCount);
-    EXPECT_TRUE(mSignalReceiver.mErrorMessage.isNull())
-        << qPrintable(mSignalReceiver.mErrorMessage);
+    EXPECT_EQ("", mSignalReceiver.mErrorMessage.toStdString());
     EXPECT_TRUE(mSignalReceiver.mFinishedSuccess);
     EXPECT_EQ(getDestination(data), mSignalReceiver.mDownloadedToFilePath);
     EXPECT_EQ(getExtractToDir(data), mSignalReceiver.mExtractedToFilePath);
-    EXPECT_EQ(data.extractDirname.isNull(),
+    EXPECT_EQ(data.extractDirname == nullptr,
               getDestination(data).isExistingFile());
   } else {
     EXPECT_GE(mSignalReceiver.mSimpleProgressCallCount, 0);
     EXPECT_EQ(0, mSignalReceiver.mSucceededCallCount);
     EXPECT_EQ(1, mSignalReceiver.mErroredCallCount);
     EXPECT_EQ(0, mSignalReceiver.mFileDownloadedCallCount);
-    EXPECT_FALSE(mSignalReceiver.mErrorMessage.isEmpty())
-        << qPrintable(mSignalReceiver.mErrorMessage);
+    EXPECT_TRUE(
+        mSignalReceiver.mErrorMessage.toStdString().starts_with(data.errorMsg))
+        << mSignalReceiver.mErrorMessage.toStdString();
     EXPECT_FALSE(mSignalReceiver.mFinishedSuccess);
     EXPECT_FALSE(getDestination(data).isExistingFile());
   }
-  if (data.success && (!data.extractDirname.isNull())) {
+  if ((!data.errorMsg) && data.extractDirname) {
     EXPECT_EQ(1, mSignalReceiver.mZipFileExtractedCallCount);
     EXPECT_TRUE(getExtractToDir(data).isExistingDir());
     EXPECT_FALSE(getExtractToDir(data).isEmptyDir());
@@ -189,25 +192,35 @@ TEST_P(FileDownloadTest, testDownload) {
 
 // clang-format off
 INSTANTIATE_TEST_SUITE_P(FileDownloadTest, FileDownloadTest, ::testing::Values(
-    FileDownloadTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/unittests/librepcbcommon/FileDownloadTest/first_pcb.zip"),
-                          QString("first_pcb_downloaded.zip"),
-                          QString("first_pcb_extracted"),
-                          QByteArray::fromHex("f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f89"),
-                          true}),
-    FileDownloadTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/unittests/librepcbcommon/FileDownloadTest/first_pcb.zip"),
-                          QString("first_pcb_downloaded.zip"),
-                          QString(),
-                          QByteArray::fromHex("f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f88"), // wrong
+    FileDownloadTestData({TEST_DATA_DIR "/unittests/librepcbcommon/FileDownloadTest/first_pcb.zip",
+                          "first_pcb_downloaded.zip",
+                          "first_pcb_extracted",
+                          "f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f89",
+                          nullptr, // no error
                           false}),
-    FileDownloadTestData({QUrl::fromLocalFile(TEST_DATA_DIR "/unittests/librepcbcommon/FileDownloadTest/libraries"),
-                          QString("libraries.json"),
-                          QString(),
-                          QByteArray(),
+    FileDownloadTestData({TEST_DATA_DIR "/unittests/librepcbcommon/FileDownloadTest/first_pcb.zip",
+                          "first_pcb_downloaded.zip",
+                          "first_pcb_extracted",
+                          "f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f89",
+                          nullptr, // no error
                           true}),
-    FileDownloadTestData({QUrl::fromLocalFile("/some-invalid-url"),
-                          QString("some-invalid-url"),
-                          QString("some-invalid-url_extracted"),
-                          QByteArray(),
+    FileDownloadTestData({TEST_DATA_DIR "/unittests/librepcbcommon/FileDownloadTest/first_pcb.zip",
+                          "first_pcb_downloaded.zip",
+                          nullptr, // no extract dir
+                          "f6f18782790d2a185698f7028a83397d56ef6145679f646c8de5ddfc298d8f88", // wrong
+                          "Checksum verification of downloaded file failed!",
+                          false}),
+    FileDownloadTestData({TEST_DATA_DIR "/unittests/librepcbcommon/FileDownloadTest/libraries",
+                          "libraries.json",
+                          nullptr, // no extract dir
+                          nullptr, // no sha256
+                          nullptr, // no error
+                          false}),
+    FileDownloadTestData({"/some-invalid-url",
+                          "some-invalid-url",
+                          "some-invalid-url_extracted",
+                          nullptr, // no sha256
+                          "Error opening /some-invalid-url: ", // the rest is platform dependent
                           false})
 ));
 // clang-format on

--- a/tests/unittests/editor/library/librarydownloadtest.cpp
+++ b/tests/unittests/editor/library/librarydownloadtest.cpp
@@ -74,15 +74,14 @@ TEST_F(LibraryDownloadTest, testDownloadInvalidLibrary) {
 
   // start the file download
   LibraryDownload* dl =
-      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir,
+                          std::make_shared<QSemaphore>(1));
   QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
   dl->start();
 
   // wait until download finished (with timeout)
-  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
-  auto currentTime = []() {
-    return QDateTime::currentDateTime().toMSecsSinceEpoch();
-  };
+  qint64 start = QDateTime::currentMSecsSinceEpoch();
+  auto currentTime = []() { return QDateTime::currentMSecsSinceEpoch(); };
   while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
     QThread::msleep(100);
     qApp->processEvents();
@@ -109,15 +108,14 @@ TEST_F(LibraryDownloadTest, testDownloadValidLibrary) {
 
   // start the file download
   LibraryDownload* dl =
-      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir,
+                          std::make_shared<QSemaphore>(1));
   QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
   dl->start();
 
   // wait until download finished (with timeout)
-  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
-  auto currentTime = []() {
-    return QDateTime::currentDateTime().toMSecsSinceEpoch();
-  };
+  qint64 start = QDateTime::currentMSecsSinceEpoch();
+  auto currentTime = []() { return QDateTime::currentMSecsSinceEpoch(); };
   while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
     QThread::msleep(100);
     qApp->processEvents();
@@ -147,15 +145,14 @@ TEST_F(LibraryDownloadTest, testDownloadValidNestedLibrary) {
 
   // start the file download
   LibraryDownload* dl =
-      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir,
+                          std::make_shared<QSemaphore>(1));
   QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
   dl->start();
 
   // wait until download finished (with timeout)
-  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
-  auto currentTime = []() {
-    return QDateTime::currentDateTime().toMSecsSinceEpoch();
-  };
+  qint64 start = QDateTime::currentMSecsSinceEpoch();
+  auto currentTime = []() { return QDateTime::currentMSecsSinceEpoch(); };
   while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
     QThread::msleep(100);
     qApp->processEvents();
@@ -191,15 +188,14 @@ TEST_F(LibraryDownloadTest, testDownloadValidLibraryDestinationAlreadyExists) {
 
   // start the file download
   LibraryDownload* dl =
-      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir);
+      new LibraryDownload(QUrl::fromLocalFile(srcLibZip.toNative()), dstLibDir,
+                          std::make_shared<QSemaphore>(1));
   QSignalSpy spyFinished(dl, SIGNAL(finished(bool, QString)));
   dl->start();
 
   // wait until download finished (with timeout)
-  qint64 start = QDateTime::currentDateTime().toMSecsSinceEpoch();
-  auto currentTime = []() {
-    return QDateTime::currentDateTime().toMSecsSinceEpoch();
-  };
+  qint64 start = QDateTime::currentMSecsSinceEpoch();
+  auto currentTime = []() { return QDateTime::currentMSecsSinceEpoch(); };
   while ((spyFinished.isEmpty()) && (currentTime() - start < 30000)) {
     QThread::msleep(100);
     qApp->processEvents();


### PR DESCRIPTION
## Description

So far, the application automatically checked for updates of remote libraries, and then silently displayed the state in the libraries panel & sidebar. However, I think in most cases it is desired that libraries are automatically kept up-to-date at any time, i.e. updates should be downloaded & installed without any user interaction. Though not everyone might like this behavior, so I implemented a configuration option to choose between different update modes:

<img width="338" height="168" alt="image" src="https://github.com/user-attachments/assets/3910d0e5-aaa6-4a5e-ab4c-c54da550396d" />

So far, "Check (Silent)" was the implemented (hardcoded) mode. Now the default mode is "Check & Install". And for those who don't like automatic internet requests at all, a new "Disabled" mode is available . In this case, a manual click on "Check for Updates" in the libraries panel is required.

## Opt-In vs. Opt-Out

I am not sure about the default value of the new setting. Generally I like opt-in features. But in this case, I think it would be a bad default behavior if libraries are not kept up-to-date. The "Check & Notify" might be a compromise, but I don't like it because it would spam users with notifications. Imagine that several other notifications may occur at the same time (e.g. "application not installed" notification, "new version available" notification etc.) which I really dislike as such notifications are usually annoying. So we should try to keep the number of notifications as low as possible.

## Note

The auto-update is only executed if the update is considered "safe" - in case the update would require to install additional libraries (due to new dependencies of updated libraries) or to uninstall libraries (due to duplicates which need to be cleaned up), the update is not performed automatically but a notification is shown.

## Other Changes

Also slightly improved the installation/update/removal of libraries by moving some blocking operations from the GUI thread to a worker thread, limiting number of parallel file I/O threads, and fixing some small issues. Also improved the behavior of the library manager in case of duplicate libraries - those will now be cleaned up when clicking "Apply".