### PR TITLE
Library editor: Require explicit unlock to make breaking changes

### DIFF
--- a/libs/librepcb/core/library/cat/librarycategory.cpp
+++ b/libs/librepcb/core/library/cat/librarycategory.cpp
@@ -59,6 +59,11 @@ LibraryCategory::~LibraryCategory() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void LibraryCategory::duplicateFrom(const LibraryCategory& other) {
+  LibraryBaseElement::duplicateFrom(other);
+  setParentUuid(other.getParentUuid());
+}
+
 RuleCheckMessageList LibraryCategory::runChecks() const {
   LibraryCategoryCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/cat/librarycategory.h
+++ b/libs/librepcb/core/library/cat/librarycategory.h
@@ -70,6 +70,7 @@ public:
   }
 
   // General Methods
+  void duplicateFrom(const LibraryCategory& other);
   virtual RuleCheckMessageList runChecks() const override;
 
   // Operator Overloadings

--- a/libs/librepcb/core/library/cmp/component.cpp
+++ b/libs/librepcb/core/library/cmp/component.cpp
@@ -122,6 +122,54 @@ std::shared_ptr<const ComponentSymbolVariantItem> Component::getSymbVarItem(
  *  General Methods
  ******************************************************************************/
 
+void Component::duplicateFrom(const Component& other) {
+  LibraryElement::duplicateFrom(other);
+  setIsSchematicOnly(other.isSchematicOnly());
+  setDefaultValue(other.getDefaultValue());
+  setPrefixes(other.getPrefixes());
+  mAttributes = other.getAttributes();
+
+  // Copy signals but generate new UUIDs.
+  mSignals.clear();
+  QHash<Uuid, Uuid> signalUuidMap;
+  for (const ComponentSignal& signal : other.getSignals()) {
+    const Uuid newUuid = Uuid::createRandom();
+    signalUuidMap.insert(signal.getUuid(), newUuid);
+    mSignals.append(std::make_shared<ComponentSignal>(
+        newUuid, signal.getName(), signal.getRole(), signal.getForcedNetName(),
+        signal.isRequired(), signal.isNegated(), signal.isClock()));
+  }
+
+  // Copy symbol variants but generate new UUIDs.
+  mSymbolVariants.clear();
+  for (const ComponentSymbolVariant& var : other.getSymbolVariants()) {
+    // don't copy translations as they would need to be adjusted anyway
+    std::shared_ptr<ComponentSymbolVariant> copy(new ComponentSymbolVariant(
+        Uuid::createRandom(), var.getNorm(), var.getNames().getDefaultValue(),
+        var.getDescriptions().getDefaultValue()));
+    // Copy gates.
+    for (const ComponentSymbolVariantItem& item : var.getSymbolItems()) {
+      std::shared_ptr<ComponentSymbolVariantItem> gateCopy(
+          new ComponentSymbolVariantItem(
+              Uuid::createRandom(), item.getSymbolUuid(),
+              item.getSymbolPosition(), item.getSymbolRotation(),
+              item.isRequired(), item.getSuffix()));
+      // Copy pin-signal-map.
+      for (const ComponentPinSignalMapItem& map : item.getPinSignalMap()) {
+        std::optional<Uuid> signal = map.getSignalUuid();
+        if (signal) {
+          signal = *signalUuidMap.find(*map.getSignalUuid());
+        }
+        gateCopy->getPinSignalMap().append(
+            std::make_shared<ComponentPinSignalMapItem>(
+                map.getPinUuid(), signal, map.getDisplayType()));
+      }
+      copy->getSymbolItems().append(gateCopy);
+    }
+    mSymbolVariants.append(copy);
+  }
+}
+
 RuleCheckMessageList Component::runChecks() const {
   ComponentCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/cmp/component.h
+++ b/libs/librepcb/core/library/cmp/component.h
@@ -130,6 +130,7 @@ public:
       const Uuid& symbVar, const Uuid& item) const;
 
   // General Methods
+  void duplicateFrom(const Component& other);
   virtual RuleCheckMessageList runChecks() const override;
 
   // Operator Overloadings

--- a/libs/librepcb/core/library/dev/device.cpp
+++ b/libs/librepcb/core/library/dev/device.cpp
@@ -84,6 +84,15 @@ void Device::setPackageUuid(const Uuid& uuid) noexcept {
  *  General Methods
  ******************************************************************************/
 
+void Device::duplicateFrom(const Device& other) {
+  LibraryElement::duplicateFrom(other);
+  setComponentUuid(other.getComponentUuid());
+  setPackageUuid(other.getPackageUuid());
+  mPadSignalMap = other.getPadSignalMap();
+  mAttributes = other.getAttributes();
+  mParts = other.getParts();
+}
+
 RuleCheckMessageList Device::runChecks() const {
   DeviceCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/dev/device.h
+++ b/libs/librepcb/core/library/dev/device.h
@@ -82,6 +82,7 @@ public:
   void setPackageUuid(const Uuid& uuid) noexcept;
 
   // General Methods
+  void duplicateFrom(const Device& other);
   virtual RuleCheckMessageList runChecks() const override;
 
   // Operator Overloadings

--- a/libs/librepcb/core/library/librarybaseelement.cpp
+++ b/libs/librepcb/core/library/librarybaseelement.cpp
@@ -128,6 +128,18 @@ bool LibraryBaseElement::setMessageApproved(const SExpression& approval,
  *  General Methods
  ******************************************************************************/
 
+void LibraryBaseElement::duplicateFrom(const LibraryBaseElement& other) {
+  mDirectory->removeDirRecursively();  // Delete all files (will be re-added).
+  setVersion(other.getVersion());
+  setAuthor(other.getAuthor());
+  setCreated(other.getCreated());  // Note: should be overwritten afterwards.
+  setDeprecated(other.isDeprecated());
+  setNames(other.getNames());
+  setDescriptions(other.getDescriptions());
+  setKeywords(other.getKeywords());
+  setMessageApprovals(other.getMessageApprovals());
+}
+
 RuleCheckMessageList LibraryBaseElement::runChecks() const {
   LibraryBaseElementCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/librarybaseelement.h
+++ b/libs/librepcb/core/library/librarybaseelement.h
@@ -104,6 +104,7 @@ public:
   bool setMessageApproved(const SExpression& approval, bool approved) noexcept;
 
   // General Methods
+  void duplicateFrom(const LibraryBaseElement& other);
   virtual RuleCheckMessageList runChecks() const;
   virtual void save();
   virtual void saveTo(TransactionalDirectory& dest);

--- a/libs/librepcb/core/library/libraryelement.cpp
+++ b/libs/librepcb/core/library/libraryelement.cpp
@@ -70,6 +70,13 @@ LibraryElement::~LibraryElement() noexcept {
  *  General Methods
  ******************************************************************************/
 
+void LibraryElement::duplicateFrom(const LibraryElement& other) {
+  LibraryBaseElement::duplicateFrom(other);
+  setGeneratedBy(other.getGeneratedBy());
+  setCategories(other.getCategories());
+  setResources(other.getResources());
+}
+
 RuleCheckMessageList LibraryElement::runChecks() const {
   LibraryElementCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/libraryelement.h
+++ b/libs/librepcb/core/library/libraryelement.h
@@ -74,6 +74,7 @@ public:
   }
 
   // General Methods
+  void duplicateFrom(const LibraryElement& other);
   virtual RuleCheckMessageList runChecks() const override;
 
   // Operator Overloadings

--- a/libs/librepcb/core/library/org/organization.cpp
+++ b/libs/librepcb/core/library/org/organization.cpp
@@ -150,6 +150,37 @@ void Organization::setPcbDesignRules(
  *  General Methods
  ******************************************************************************/
 
+void Organization::duplicateFrom(const Organization& other) {
+  LibraryBaseElement::duplicateFrom(other);
+  setLogoPng(other.getLogoPng());
+  setUrl(other.getUrl());
+  setCountry(other.getCountry());
+  setFabs(other.getFabs());
+  setShipping(other.getShipping());
+  setIsSponsor(other.isSponsor());
+  setPriority(other.getPriority());
+  mOptions = other.mOptions;
+
+  // Copy PCB design rules but generate new UUIDs.
+  mPcbDesignRules.clear();
+  for (const OrganizationPcbDesignRules& rules : other.getPcbDesignRules()) {
+    OrganizationPcbDesignRules copy = rules;
+    copy.setUuid(Uuid::createRandom());
+    mPcbDesignRules.append(copy);
+  }
+
+  // Copy output jobs but generate new UUIDs.
+  for (OutputJobList* jobs :
+       {&mPcbOutputJobs, &mAssemblyOutputJobs, &mUserOutputJobs}) {
+    jobs->clear();
+    for (const auto& job : *jobs) {
+      auto copy = job.cloneShared();
+      copy->setUuid(Uuid::createRandom());
+      jobs->append(copy);
+    }
+  }
+}
+
 RuleCheckMessageList Organization::runChecks() const {
   OrganizationCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/org/organization.h
+++ b/libs/librepcb/core/library/org/organization.h
@@ -104,6 +104,7 @@ public:
   }
 
   // General Methods
+  void duplicateFrom(const Organization& other);
   virtual RuleCheckMessageList runChecks() const override;
   virtual void save() override;
 

--- a/libs/librepcb/core/library/pkg/package.cpp
+++ b/libs/librepcb/core/library/pkg/package.cpp
@@ -180,6 +180,104 @@ QVector<std::shared_ptr<const PackageModel>> Package::getModelsForFootprint(
  *  General Methods
  ******************************************************************************/
 
+void Package::duplicateFrom(const Package& other) {
+  LibraryElement::duplicateFrom(other);
+  setAlternativeNames(other.getAlternativeNames());
+  setAssemblyType(other.getAssemblyType(false));
+  setGridInterval(other.getGridInterval());
+  setMinCopperClearance(other.getMinCopperClearance());
+
+  // Copy pads but generate new UUIDs.
+  mPads.clear();
+  QHash<Uuid, std::optional<Uuid>> padUuidMap;
+  for (const PackagePad& pad : other.getPads()) {
+    const Uuid newUuid = Uuid::createRandom();
+    padUuidMap.insert(pad.getUuid(), newUuid);
+    mPads.append(std::make_shared<PackagePad>(newUuid, pad.getName()));
+  }
+
+  // Copy 3D models but generate new UUIDs.
+  mModels.clear();
+  QHash<Uuid, std::optional<Uuid>> modelsUuidMap;
+  for (const PackageModel& model : other.getModels()) {
+    auto newModel =
+        std::make_shared<PackageModel>(Uuid::createRandom(), model.getName());
+    modelsUuidMap.insert(model.getUuid(), newModel->getUuid());
+    mModels.append(newModel);
+    const QByteArray fileContent =
+        other.getDirectory().readIfExists(model.getFileName());
+    if (!fileContent.isNull()) {
+      mDirectory->write(newModel->getFileName(), fileContent);
+    }
+  }
+
+  // Copy footprints but generate new UUIDs.
+  mFootprints.clear();
+  for (const Footprint& footprint : other.getFootprints()) {
+    // Don't copy translations as they would need to be adjusted anyway.
+    std::shared_ptr<Footprint> newFootprint(new Footprint(
+        Uuid::createRandom(), footprint.getNames().getDefaultValue(),
+        footprint.getDescriptions().getDefaultValue()));
+    newFootprint->setModelPosition(footprint.getModelPosition());
+    newFootprint->setModelRotation(footprint.getModelRotation());
+    // Copy models but with the new UUIDs.
+    QSet<Uuid> models;
+    foreach (const Uuid& uuid, footprint.getModels()) {
+      if (auto newUuid = modelsUuidMap.value(uuid)) {
+        models.insert(*newUuid);
+      }
+    }
+    newFootprint->setModels(models);
+    // Copy pads but generate new UUIDs.
+    for (const FootprintPad& pad : footprint.getPads()) {
+      std::optional<Uuid> pkgPad = pad.getPackagePadUuid();
+      if (pkgPad) {
+        pkgPad = padUuidMap.value(*pkgPad);  // Translate to new UUID
+      }
+      newFootprint->getPads().append(std::make_shared<FootprintPad>(
+          Uuid::createRandom(), pkgPad, pad.getPosition(), pad.getRotation(),
+          pad.getShape(), pad.getWidth(), pad.getHeight(), pad.getRadius(),
+          pad.getCustomShapeOutline(), pad.getStopMaskConfig(),
+          pad.getSolderPasteConfig(), pad.getCopperClearance(),
+          pad.getComponentSide(), pad.getFunction(), pad.getHoles()));
+    }
+    // Copy polygons but generate new UUIDs.
+    for (const Polygon& polygon : footprint.getPolygons()) {
+      newFootprint->getPolygons().append(std::make_shared<Polygon>(
+          Uuid::createRandom(), polygon.getLayer(), polygon.getLineWidth(),
+          polygon.isFilled(), polygon.isGrabArea(), polygon.getPath()));
+    }
+    // Copy circles but generate new UUIDs.
+    for (const Circle& circle : footprint.getCircles()) {
+      newFootprint->getCircles().append(std::make_shared<Circle>(
+          Uuid::createRandom(), circle.getLayer(), circle.getLineWidth(),
+          circle.isFilled(), circle.isGrabArea(), circle.getCenter(),
+          circle.getDiameter()));
+    }
+    // Copy stroke texts but generate new UUIDs.
+    for (const StrokeText& text : footprint.getStrokeTexts()) {
+      newFootprint->getStrokeTexts().append(std::make_shared<StrokeText>(
+          Uuid::createRandom(), text.getLayer(), text.getText(),
+          text.getPosition(), text.getRotation(), text.getHeight(),
+          text.getStrokeWidth(), text.getLetterSpacing(), text.getLineSpacing(),
+          text.getAlign(), text.getMirrored(), text.getAutoRotate(),
+          text.isLocked()));
+    }
+    // Copy zones but generate new UUIDs.
+    for (const Zone& zone : footprint.getZones()) {
+      newFootprint->getZones().append(
+          std::make_shared<Zone>(Uuid::createRandom(), zone));
+    }
+    // Copy holes but generate new UUIDs.
+    for (const Hole& hole : footprint.getHoles()) {
+      newFootprint->getHoles().append(
+          std::make_shared<Hole>(Uuid::createRandom(), hole.getDiameter(),
+                                 hole.getPath(), hole.getStopMaskConfig()));
+    }
+    mFootprints.append(newFootprint);
+  }
+}
+
 RuleCheckMessageList Package::runChecks() const {
   PackageCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/pkg/package.h
+++ b/libs/librepcb/core/library/pkg/package.h
@@ -129,6 +129,7 @@ public:
   }
 
   // General Methods
+  void duplicateFrom(const Package& other);
   virtual RuleCheckMessageList runChecks() const override;
 
   // Operator Overloadings

--- a/libs/librepcb/core/library/sym/symbol.cpp
+++ b/libs/librepcb/core/library/sym/symbol.cpp
@@ -97,6 +97,61 @@ bool Symbol::isEmpty() const noexcept {
       mTexts.isEmpty() && mImages.isEmpty();
 }
 
+void Symbol::duplicateFrom(const Symbol& other) {
+  LibraryElement::duplicateFrom(other);
+  setGridInterval(other.getGridInterval());
+
+  // Copy pins but generate new UUIDs.
+  mPins.clear();
+  for (const SymbolPin& pin : other.getPins()) {
+    mPins.append(std::make_shared<SymbolPin>(
+        Uuid::createRandom(), pin.getName(), pin.getPosition(), pin.getLength(),
+        pin.getRotation(), pin.getNamePosition(), pin.getNameRotation(),
+        pin.getNameHeight(), pin.getNameAlignment()));
+  }
+
+  // Copy polygons but generate new UUIDs.
+  mPolygons.clear();
+  for (const Polygon& polygon : other.getPolygons()) {
+    mPolygons.append(std::make_shared<Polygon>(
+        Uuid::createRandom(), polygon.getLayer(), polygon.getLineWidth(),
+        polygon.isFilled(), polygon.isGrabArea(), polygon.getPath()));
+  }
+
+  // Copy circles but generate new UUIDs.
+  mCircles.clear();
+  for (const Circle& circle : other.getCircles()) {
+    mCircles.append(std::make_shared<Circle>(
+        Uuid::createRandom(), circle.getLayer(), circle.getLineWidth(),
+        circle.isFilled(), circle.isGrabArea(), circle.getCenter(),
+        circle.getDiameter()));
+  }
+
+  // Copy texts but generate new UUIDs.
+  mTexts.clear();
+  for (const Text& text : other.getTexts()) {
+    mTexts.append(std::make_shared<Text>(Uuid::createRandom(), text.getLayer(),
+                                         text.getText(), text.getPosition(),
+                                         text.getRotation(), text.getHeight(),
+                                         text.getAlign(), text.isLocked()));
+  }
+
+  // Copy images but generate new UUIDs.
+  mImages.clear();
+  QSet<QString> filesToCopy;
+  for (const Image& image : other.getImages()) {
+    mImages.append(std::make_shared<Image>(Uuid::createRandom(), image));
+    filesToCopy.insert(*image.getFileName());
+  }
+
+  // Copy all referenced files.
+  for (const QString& fileName : filesToCopy) {
+    if (other.getDirectory().fileExists(fileName)) {
+      mDirectory->write(fileName, other.getDirectory().read(fileName));
+    }
+  }
+}
+
 RuleCheckMessageList Symbol::runChecks() const {
   SymbolCheck check(*this);
   return check.runChecks();  // can throw

--- a/libs/librepcb/core/library/sym/symbol.h
+++ b/libs/librepcb/core/library/sym/symbol.h
@@ -100,6 +100,7 @@ public:
   const ImageList& getImages() const noexcept { return mImages; }
 
   // General Methods
+  void duplicateFrom(const Symbol& other);
   virtual RuleCheckMessageList runChecks() const override;
 
   // Operator Overloadings

--- a/libs/librepcb/editor/library/cmp/componenttab.cpp
+++ b/libs/librepcb/editor/library/cmp/componenttab.cpp
@@ -23,6 +23,7 @@
 #include "componenttab.h"
 
 #include "../../guiapplication.h"
+#include "../../mainwindow.h"
 #include "../../modelview/attributelistmodel.h"
 #include "../../rulecheck/rulecheckmessagesmodel.h"
 #include "../../undostack.h"
@@ -73,6 +74,7 @@ ComponentTab::ComponentTab(LibraryEditor& editor,
     mWizardMode(mode != Mode::Open),
     mCurrentPageIndex(mWizardMode ? 0 : 2),
     mChooseCategory(false),
+    mElementDuplicated(false),
     mNameParsed(mComponent->getNames().getDefaultValue()),
     mVersionParsed(mComponent->getVersion()),
     mDeprecated(false),
@@ -188,6 +190,7 @@ ui::ComponentTabData ComponentTab::getDerivedUiData() const noexcept {
       mDescription,  // Description
       mKeywords,  // Keywords
       mAuthor,  // Author
+      mAgeDays,  // Age in days
       mVersion,  // Version
       mVersionError,  // Version error
       mDeprecated,  // Deprecated
@@ -218,6 +221,7 @@ ui::ComponentTabData ComponentTab::getDerivedUiData() const noexcept {
       },
       l2s(mApp.getWorkspace().getSettings().defaultLengthUnit.get()),  // Unit
       mIsInterfaceBroken,  // Interface broken
+      mElementDuplicated && (!mDeprecated),  // Element duplicated
       slint::SharedString(),  // New category
   };
 }
@@ -272,6 +276,11 @@ void ComponentTab::setDerivedUiData(const ui::ComponentTabData& data) noexcept {
     }
   }
 
+  // Messages
+  if (data.deprecated || (!data.element_duplicated_msg)) {
+    mElementDuplicated = false;
+  }
+
   onDerivedUiDataChanged.notify();
 }
 
@@ -310,6 +319,16 @@ void ComponentTab::trigger(ui::TabAction a) noexcept {
       save();
       break;
     }
+    case ui::TabAction::SaveAs: {  // Duplicate the library element.
+      commitUiData();  // Exits the current tool and releases the undo stack.
+      if (mWindow &&
+          mWindow->openNewComponentTab(mEditor, {}, mComponent.get())) {
+        undoBreakingChanges(mIsInterfaceBroken);
+        mElementDuplicated = true;
+        onDerivedUiDataChanged.notify();
+      }
+      break;
+    }
     case ui::TabAction::Undo: {
       try {
         commitUiData();
@@ -326,6 +345,12 @@ void ComponentTab::trigger(ui::TabAction a) noexcept {
       } catch (const Exception& e) {
         QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
+      break;
+    }
+    case ui::TabAction::Unlock: {
+      mAllowBreakingChanges = true;
+      onUiDataChanged.notify();
+      onDerivedUiDataChanged.notify();
       break;
     }
     case ui::TabAction::Close: {
@@ -372,17 +397,22 @@ slint::Image ComponentTab::renderScene(float width, float height,
 bool ComponentTab::requestClose() noexcept {
   commitUiData();
 
-  if ((!hasUnsavedChanges()) || (!isWritable())) {
+  if (!hasUnsavedChanges()) {
     return true;  // Nothing to save.
   }
 
-  const QMessageBox::StandardButton choice = QMessageBox::question(
-      getWindow(), tr("Save Changes?"),
-      tr("The component '%1' contains unsaved changes.\n"
-         "Do you want to save them before closing it?")
-          .arg(*mComponent->getNames().getDefaultValue()),
-      QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
-      QMessageBox::Yes);
+  QMessageBox::StandardButtons buttons = QMessageBox::No | QMessageBox::Cancel;
+  QMessageBox::StandardButton defaultButton = QMessageBox::Cancel;
+  if ((!mIsInterfaceBroken) || mAllowBreakingChanges) {
+    buttons |= QMessageBox::Yes;
+    defaultButton = QMessageBox::Yes;
+  }
+  const QMessageBox::StandardButton choice =
+      QMessageBox::question(getWindow(), tr("Save Changes?"),
+                            tr("The component '%1' contains unsaved changes.\n"
+                               "Do you want to save them before closing it?")
+                                .arg(*mComponent->getNames().getDefaultValue()),
+                            buttons, defaultButton);
   if (choice == QMessageBox::Yes) {
     return save();
   } else if (choice == QMessageBox::No) {
@@ -545,7 +575,9 @@ bool ComponentTab::autoFix(
  ******************************************************************************/
 
 bool ComponentTab::isWritable() const noexcept {
-  return mIsNewElement || mComponent->getDirectory().isWritable();
+  return mIsNewElement ||
+      (mComponent->getDirectory().isWritable() &&
+       ((!mIsInterfaceBroken) || mAllowBreakingChanges));
 }
 
 bool ComponentTab::isInterfaceBroken() const noexcept {
@@ -609,6 +641,7 @@ void ComponentTab::refreshUiData() noexcept {
   mPrefixParsed = mComponent->getPrefixes().getDefaultValue();
   mDefaultValue = q2s(mComponent->getDefaultValue());
   validateComponentDefaultValue(s2q(mDefaultValue), mDefaultValueError);
+  updateAgeDays(mComponent->getCreated());
 
   if (auto dbRes = mComponent->getResources().value(0)) {
     mDatasheetUrl = q2s(dbRes->getUrl().toString());

--- a/libs/librepcb/editor/library/cmp/componenttab.h
+++ b/libs/librepcb/editor/library/cmp/componenttab.h
@@ -116,6 +116,7 @@ private:
   bool mWizardMode;
   int mCurrentPageIndex;
   bool mChooseCategory;
+  bool mElementDuplicated;
 
   // Library metadata to be applied
   slint::SharedString mName;

--- a/libs/librepcb/editor/library/dev/devicetab.cpp
+++ b/libs/librepcb/editor/library/dev/devicetab.cpp
@@ -101,6 +101,7 @@ DeviceTab::DeviceTab(LibraryEditor& editor, std::unique_ptr<Device> dev,
     mComponentSelected(true),
     mPackageSelected(true),
     mChooseCategory(false),
+    mElementDuplicated(false),
     mFrameIndex(0),
     mNameParsed(mDevice->getNames().getDefaultValue()),
     mVersionParsed(mDevice->getVersion()),
@@ -297,6 +298,7 @@ ui::DeviceTabData DeviceTab::getDerivedUiData() const noexcept {
       mDescription,  // Description
       mKeywords,  // Keywords
       mAuthor,  // Author
+      mAgeDays,  // Age in days
       mVersion,  // Version
       mVersionError,  // Version error
       mDeprecated,  // Deprecated
@@ -329,6 +331,7 @@ ui::DeviceTabData DeviceTab::getDerivedUiData() const noexcept {
       q2s(brdBgColors.primary),  // Package background color
       q2s(brdBgColors.secondary),  // Package foreground color
       mIsInterfaceBroken,  // Interface broken
+      mElementDuplicated && (!mDeprecated),  // Element duplicated
       hasUnconnectedPads,  // Has unconnected pads
       hasAutoConnectablePads,  // Has auto-connectable pads
       areAllPadsUnconnected,  // All pads unconnected
@@ -368,6 +371,11 @@ void DeviceTab::setDerivedUiData(const ui::DeviceTabData& data) noexcept {
   mChooseCategory = data.choose_category;
   mDatasheetUrl = data.datasheet_url;
   validateUrl(s2q(mDatasheetUrl), mDatasheetUrlError, true);
+
+  // Messages
+  if (data.deprecated || (!data.element_duplicated_msg)) {
+    mElementDuplicated = false;
+  }
 
   // Interactive pinout
   mPinoutBuilder->setCurrentSignalIndex(data.interactive_pinout_signal_index);
@@ -456,6 +464,15 @@ void DeviceTab::trigger(ui::TabAction a) noexcept {
       save();
       break;
     }
+    case ui::TabAction::SaveAs: {  // Duplicate the library element.
+      commitUiData();  // Exits the current tool and releases the undo stack.
+      if (mWindow && mWindow->openNewDeviceTab(mEditor, {}, mDevice.get())) {
+        undoBreakingChanges(mIsInterfaceBroken);
+        mElementDuplicated = true;
+        onDerivedUiDataChanged.notify();
+      }
+      break;
+    }
     case ui::TabAction::Undo: {
       try {
         commitUiData();
@@ -472,6 +489,12 @@ void DeviceTab::trigger(ui::TabAction a) noexcept {
       } catch (const Exception& e) {
         QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
+      break;
+    }
+    case ui::TabAction::Unlock: {
+      mAllowBreakingChanges = true;
+      onUiDataChanged.notify();
+      onDerivedUiDataChanged.notify();
       break;
     }
     case ui::TabAction::Close: {
@@ -586,17 +609,22 @@ bool DeviceTab::processSceneScrolled(const QPointF& pos,
 bool DeviceTab::requestClose() noexcept {
   commitUiData();
 
-  if ((!hasUnsavedChanges()) || (!isWritable())) {
+  if (!hasUnsavedChanges()) {
     return true;  // Nothing to save.
   }
 
-  const QMessageBox::StandardButton choice = QMessageBox::question(
-      getWindow(), tr("Save Changes?"),
-      tr("The device '%1' contains unsaved changes.\n"
-         "Do you want to save them before closing it?")
-          .arg(*mDevice->getNames().getDefaultValue()),
-      QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
-      QMessageBox::Yes);
+  QMessageBox::StandardButtons buttons = QMessageBox::No | QMessageBox::Cancel;
+  QMessageBox::StandardButton defaultButton = QMessageBox::Cancel;
+  if ((!mIsInterfaceBroken) || mAllowBreakingChanges) {
+    buttons |= QMessageBox::Yes;
+    defaultButton = QMessageBox::Yes;
+  }
+  const QMessageBox::StandardButton choice =
+      QMessageBox::question(getWindow(), tr("Save Changes?"),
+                            tr("The device '%1' contains unsaved changes.\n"
+                               "Do you want to save them before closing it?")
+                                .arg(*mDevice->getNames().getDefaultValue()),
+                            buttons, defaultButton);
   if (choice == QMessageBox::Yes) {
     return save();
   } else if (choice == QMessageBox::No) {
@@ -692,7 +720,9 @@ bool DeviceTab::autoFix(const MsgMissingCategories& msg) {
  ******************************************************************************/
 
 bool DeviceTab::isWritable() const noexcept {
-  return mIsNewElement || mDevice->getDirectory().isWritable();
+  return mIsNewElement ||
+      (mDevice->getDirectory().isWritable() &&
+       ((!mIsInterfaceBroken) || mAllowBreakingChanges));
 }
 
 static QString cleanDescription(const LocalizedDescriptionMap& descs) noexcept {
@@ -711,6 +741,7 @@ void DeviceTab::refreshUiData() noexcept {
   mVersionParsed = mDevice->getVersion();
   mDeprecated = mDevice->isDeprecated();
   mCategories->setCategories(mDevice->getCategories());
+  updateAgeDays(mDevice->getCreated());
 
   if (auto dbRes = mDevice->getResources().value(0)) {
     mDatasheetUrl = q2s(dbRes->getUrl().toString());

--- a/libs/librepcb/editor/library/dev/devicetab.h
+++ b/libs/librepcb/editor/library/dev/devicetab.h
@@ -149,6 +149,7 @@ private:
   bool mComponentSelected;
   bool mPackageSelected;
   bool mChooseCategory;
+  bool mElementDuplicated;
   int mFrameIndex;
 
   // Library metadata to be applied

--- a/libs/librepcb/editor/library/downloadlibrarytab.cpp
+++ b/libs/librepcb/editor/library/downloadlibrarytab.cpp
@@ -22,7 +22,8 @@
  ******************************************************************************/
 #include "downloadlibrarytab.h"
 
-#include "guiapplication.h"
+#include "../guiapplication.h"
+#include "../mainwindow.h"
 #include "librariesmodel.h"
 #include "librarydownload.h"
 #include "utils/slinthelpers.h"
@@ -220,8 +221,10 @@ void DownloadLibraryTab::downloadFinished(bool success,
 
   if (success) {
     // Highlight the new library in the libraries tab.
-    emit panelPageRequested(ui::PanelPage::Libraries);
-    mApp.getLocalLibraries().highlightLibraryOnNextRescan(mDirectory);
+    if (mWindow) {
+      mWindow->showPanelPage(ui::PanelPage::Libraries);
+      mApp.getLocalLibraries().highlightLibraryOnNextRescan(mDirectory);
+    }
 
     // Force rescan to index the new library.
     mApp.getWorkspace().getLibraryDb().startLibraryRescan();

--- a/libs/librepcb/editor/library/lib/librarytab.cpp
+++ b/libs/librepcb/editor/library/lib/librarytab.cpp
@@ -23,6 +23,7 @@
 #include "librarytab.h"
 
 #include "../../dialogs/filedialog.h"
+#include "../../mainwindow.h"
 #include "../../rulecheck/rulecheckmessagesmodel.h"
 #include "../../undostack.h"
 #include "../../utils/editortoolbox.h"
@@ -314,34 +315,34 @@ void LibraryTab::trigger(ui::TabAction a) noexcept {
       break;
     }
     case ui::TabAction::EditProperties: {
-      if (item && item->path.isValid()) {
+      if (item && item->path.isValid() && mWindow) {
         switch (item->type) {
           case ui::LibraryTreeViewItemType::ComponentCategory: {
-            emit componentCategoryEditorRequested(mEditor, item->path, false);
+            mWindow->openComponentCategoryTab(mEditor, item->path);
             break;
           }
           case ui::LibraryTreeViewItemType::PackageCategory: {
-            emit packageCategoryEditorRequested(mEditor, item->path, false);
+            mWindow->openPackageCategoryTab(mEditor, item->path);
             break;
           }
           case ui::LibraryTreeViewItemType::Symbol: {
-            emit symbolEditorRequested(mEditor, item->path, false);
+            mWindow->openSymbolTab(mEditor, item->path);
             break;
           }
           case ui::LibraryTreeViewItemType::Package: {
-            emit packageEditorRequested(mEditor, item->path, false);
+            mWindow->openPackageTab(mEditor, item->path);
             break;
           }
           case ui::LibraryTreeViewItemType::Component: {
-            emit componentEditorRequested(mEditor, item->path, false);
+            mWindow->openComponentTab(mEditor, item->path);
             break;
           }
           case ui::LibraryTreeViewItemType::Device: {
-            emit deviceEditorRequested(mEditor, item->path, false);
+            mWindow->openDeviceTab(mEditor, item->path);
             break;
           }
           case ui::LibraryTreeViewItemType::Organization: {
-            emit organizationEditorRequested(mEditor, item->path, false);
+            mWindow->openOrganizationTab(mEditor, item->path);
             break;
           }
           default: {
@@ -947,38 +948,38 @@ QList<std::shared_ptr<LibraryTab::TreeItem>> LibraryTab::getSelectedElements()
 
 void LibraryTab::duplicateElements(
     const QList<std::shared_ptr<TreeItem>>& items) noexcept {
-  if (items.count() != 1) {
+  if ((items.count() != 1) || (!mWindow)) {
     return;
   }
 
   auto item = items.first();
   switch (item->type) {
     case ui::LibraryTreeViewItemType::ComponentCategory: {
-      emit componentCategoryEditorRequested(mEditor, item->path, true);
+      mWindow->openNewComponentCategoryTab(mEditor, item->path);
       break;
     }
     case ui::LibraryTreeViewItemType::PackageCategory: {
-      emit packageCategoryEditorRequested(mEditor, item->path, true);
+      mWindow->openNewPackageCategoryTab(mEditor, item->path);
       break;
     }
     case ui::LibraryTreeViewItemType::Symbol: {
-      emit symbolEditorRequested(mEditor, item->path, true);
+      mWindow->openNewSymbolTab(mEditor, item->path);
       break;
     }
     case ui::LibraryTreeViewItemType::Package: {
-      emit packageEditorRequested(mEditor, item->path, true);
+      mWindow->openNewPackageTab(mEditor, item->path);
       break;
     }
     case ui::LibraryTreeViewItemType::Component: {
-      emit componentEditorRequested(mEditor, item->path, true);
+      mWindow->openNewComponentTab(mEditor, item->path);
       break;
     }
     case ui::LibraryTreeViewItemType::Device: {
-      emit deviceEditorRequested(mEditor, item->path, true);
+      mWindow->openNewDeviceTab(mEditor, item->path);
       break;
     }
     case ui::LibraryTreeViewItemType::Organization: {
-      emit organizationEditorRequested(mEditor, item->path, true);
+      mWindow->openNewOrganizationTab(mEditor, item->path);
       break;
     }
     default: {

--- a/libs/librepcb/editor/library/lib/librarytab.h
+++ b/libs/librepcb/editor/library/lib/librarytab.h
@@ -90,22 +90,6 @@ public:
   // Operator Overloadings
   LibraryTab& operator=(const LibraryTab& rhs) = delete;
 
-signals:
-  void componentCategoryEditorRequested(LibraryEditor& editor,
-                                        const FilePath& fp, bool copyFrom);
-  void packageCategoryEditorRequested(LibraryEditor& editor, const FilePath& fp,
-                                      bool copyFrom);
-  void symbolEditorRequested(LibraryEditor& editor, const FilePath& fp,
-                             bool copyFrom);
-  void packageEditorRequested(LibraryEditor& editor, const FilePath& fp,
-                              bool copyFrom);
-  void componentEditorRequested(LibraryEditor& editor, const FilePath& fp,
-                                bool copyFrom);
-  void deviceEditorRequested(LibraryEditor& editor, const FilePath& fp,
-                             bool copyFrom);
-  void organizationEditorRequested(LibraryEditor& editor, const FilePath& fp,
-                                   bool copyFrom);
-
 protected:
   std::optional<std::pair<RuleCheckMessageList, QSet<SExpression>>>
       runChecksImpl() override;

--- a/libs/librepcb/editor/library/libraryeditortab.cpp
+++ b/libs/librepcb/editor/library/libraryeditortab.cpp
@@ -51,6 +51,8 @@ LibraryEditorTab::LibraryEditorTab(LibraryEditor& editor,
     mEditor(editor),
     mUndoStack(new UndoStack()),
     mManualModificationsMade(false),
+    mAllowBreakingChanges(false),
+    mAgeDays(0),
     mCheckMessages(new RuleCheckMessagesModel()),
     mAutoReloadOnFileModifications(false) {
   // Connect library editor.
@@ -102,8 +104,23 @@ bool LibraryEditorTab::isPathOutsideLibDir() const noexcept {
       (!fp.isLocatedInDir(mEditor.getFilePath()));
 }
 
+void LibraryEditorTab::updateAgeDays(const QDateTime& created) noexcept {
+  mAgeDays = created.secsTo(QDateTime::currentDateTime()) / float(24 * 3600);
+}
+
 bool LibraryEditorTab::hasUnsavedChanges() const noexcept {
   return mManualModificationsMade || (!mUndoStack->isClean());
+}
+
+void LibraryEditorTab::undoBreakingChanges(
+    const bool& interfaceBroken) noexcept {
+  try {
+    while (interfaceBroken && mUndoStack->canUndo()) {
+      mUndoStack->undo();
+    }
+  } catch (const Exception& e) {
+    qCritical() << "Failed to undo breaking changes:" << e.getMsg();
+  }
 }
 
 void LibraryEditorTab::setWatchedFiles(
@@ -118,10 +135,14 @@ void LibraryEditorTab::setWatchedFiles(
   for (const QString& name : filenames) {
     const FilePath fp = dir.getAbsPath(name);
     try {
-      const QByteArray content = dir.read(name);
-      const QByteArray sha256 = QCryptographicHash::hash(
-          content, QCryptographicHash::Algorithm::Sha256);
-      mWatchedFileHashes.insert(fp, sha256);
+      // Note: For newly created library elements, no files may have been
+      // written to the file system yet, so we skip those to avoid errors.
+      const QByteArray content = dir.readIfExists(name);
+      if (!content.isNull()) {
+        const QByteArray sha256 = QCryptographicHash::hash(
+            content, QCryptographicHash::Algorithm::Sha256);
+        mWatchedFileHashes.insert(fp, sha256);
+      }
     } catch (const Exception& e) {
       qCritical().nospace().noquote()
           << "Failed to hash file '" << fp.toNative() << "': " << e.getMsg();

--- a/libs/librepcb/editor/library/libraryeditortab.h
+++ b/libs/librepcb/editor/library/libraryeditortab.h
@@ -71,7 +71,9 @@ public:
 
 protected:
   bool isPathOutsideLibDir() const noexcept;
+  void updateAgeDays(const QDateTime& created) noexcept;
   bool hasUnsavedChanges() const noexcept;
+  void undoBreakingChanges(const bool& interfaceBroken) noexcept;
   void setWatchedFiles(const TransactionalDirectory& dir,
                        const QSet<QString>& filenames) noexcept;
   virtual void watchedFilesModifiedChanged() noexcept {}
@@ -97,6 +99,8 @@ protected:
   LibraryEditor& mEditor;
   std::unique_ptr<UndoStack> mUndoStack;
   bool mManualModificationsMade;
+  bool mAllowBreakingChanges;  ///< Default false, sticks at true after enabling
+  float mAgeDays;  ///< Age of library element in days (from "created" datetime)
 
   // Rule check
   QSet<SExpression> mSupportedApprovals;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsm.h
@@ -89,7 +89,6 @@ public:  // Types
   struct Context {
     Package& package;
     UndoStack& undoStack;
-    const bool readOnly;
     LengthUnit& lengthUnit;
     const GraphicsLayerList& layers;
     PackageEditorFsmAdapter& adapter;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorfsmadapter.h
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorfsmadapter.h
@@ -79,6 +79,7 @@ public:
   };
   Q_DECLARE_FLAGS(Features, Feature)
 
+  virtual bool fsmIsWritable() const noexcept = 0;
   virtual QWidget* fsmGetParentWidget() noexcept = 0;
   virtual GraphicsScene* fsmGetGraphicsScene() noexcept = 0;
   virtual PositiveLength fsmGetGridInterval() const noexcept = 0;

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_select.cpp
@@ -201,10 +201,11 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       // get items under cursor
       QList<std::shared_ptr<QGraphicsItem>> items =
           findItemsAtPosition(mStartPos);
-      if (findPolygonVerticesAtPosition(mStartPos) && (!mContext.readOnly)) {
+      if (findPolygonVerticesAtPosition(mStartPos) &&
+          mAdapter.fsmIsWritable()) {
         setState(SubState::MOVING_POLYGON_VERTEX);
       } else if (findZoneVerticesAtPosition(mStartPos) &&
-                 (!mContext.readOnly)) {
+                 mAdapter.fsmIsWritable()) {
         setState(SubState::MOVING_ZONE_VERTEX);
       } else if (items.isEmpty()) {
         // start selecting
@@ -264,7 +265,7 @@ bool PackageEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
         scheduleUpdateAvailableFeatures();  // Selection might have changed.
 
         // Start moving, if not read only.
-        if (!mContext.readOnly) {
+        if (mAdapter.fsmIsWritable()) {
           Q_ASSERT(!mCmdDragSelectedItems);
           setState(SubState::MOVING);
         }
@@ -769,7 +770,8 @@ bool PackageEditorState_Select::openContextMenuAtPos(
               });
           int remainingVertices =
               polygon->getPath().getVertices().count() - vertices.count();
-          aRemove->setEnabled((remainingVertices >= 2) && (!mContext.readOnly));
+          aRemove->setEnabled((remainingVertices >= 2) &&
+                              mAdapter.fsmIsWritable());
           mb.addAction(aRemove);
         }
 
@@ -779,7 +781,7 @@ bool PackageEditorState_Select::openContextMenuAtPos(
               cmd.vertexAdd.createAction(&menu, this, [=, this]() {
                 startAddingPolygonVertex(polygon, lineIndex, pos);
               });
-          aAddVertex->setEnabled(!mContext.readOnly);
+          aAddVertex->setEnabled(mAdapter.fsmIsWritable());
           mb.addAction(aAddVertex);
         }
 
@@ -802,7 +804,8 @@ bool PackageEditorState_Select::openContextMenuAtPos(
               [this, zone, vertices]() { removeZoneVertices(zone, vertices); });
           int remainingVertices =
               zone->getOutline().getVertices().count() - vertices.count();
-          aRemove->setEnabled((remainingVertices >= 2) && (!mContext.readOnly));
+          aRemove->setEnabled((remainingVertices >= 2) &&
+                              mAdapter.fsmIsWritable());
           mb.addAction(aRemove);
         }
 
@@ -811,7 +814,7 @@ bool PackageEditorState_Select::openContextMenuAtPos(
           QAction* aAddVertex = cmd.vertexAdd.createAction(
               &menu, this,
               [=, this]() { startAddingZoneVertex(zone, lineIndex, pos); });
-          aAddVertex->setEnabled(!mContext.readOnly);
+          aAddVertex->setEnabled(mAdapter.fsmIsWritable());
           mb.addAction(aAddVertex);
         }
 
@@ -916,7 +919,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     FootprintPadPropertiesDialog dialog(
         mContext.package, i->getObj(), mContext.undoStack, getLengthUnit(),
         "package_editor/footprint_pad_properties_dialog", parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<StrokeTextGraphicsItem>(item)) {
@@ -924,7 +927,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
         i->getObj(), mContext.undoStack, getAllowedTextLayers(),
         getLengthUnit(), "package_editor/stroke_text_properties_dialog",
         parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<PolygonGraphicsItem>(item)) {
@@ -932,7 +935,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
         i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "package_editor/polygon_properties_dialog",
         parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<CircleGraphicsItem>(item)) {
@@ -940,14 +943,14 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
         i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "package_editor/circle_properties_dialog",
         parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<ZoneGraphicsItem>(item)) {
     ZonePropertiesDialog dialog(
         i->getObj(), mContext.undoStack, getLengthUnit(), mContext.layers,
         "package_editor/zone_properties_dialog", parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<HoleGraphicsItem>(item)) {
@@ -956,7 +959,7 @@ bool PackageEditorState_Select::openPropertiesDialogOfItem(
     HolePropertiesDialog dialog(
         const_cast<Hole&>(i->getObj()), mContext.undoStack, getLengthUnit(),
         "package_editor/hole_properties_dialog", parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   }
@@ -1704,7 +1707,7 @@ PackageEditorFsmAdapter::Features
   if (mContext.currentFootprint) {
     if (mState != SubState::PASTING) {
       features |= PackageEditorFsmAdapter::Feature::Select;
-      if (!mContext.readOnly) {
+      if (mAdapter.fsmIsWritable()) {
         features |= PackageEditorFsmAdapter::Feature::ImportGraphics;
         if (FootprintClipboardData::isValid(qApp->clipboard()->mimeData())) {
           features |= PackageEditorFsmAdapter::Feature::Paste;
@@ -1717,7 +1720,7 @@ PackageEditorFsmAdapter::Features
       if (cmd.getSelectedItemsCount() > 0) {
         features |= PackageEditorFsmAdapter::Feature::Copy;
         features |= PackageEditorFsmAdapter::Feature::Properties;
-        if (!mContext.readOnly) {
+        if (mAdapter.fsmIsWritable()) {
           features |= PackageEditorFsmAdapter::Feature::Cut;
           features |= PackageEditorFsmAdapter::Feature::Remove;
           features |= PackageEditorFsmAdapter::Feature::Rotate;

--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -32,6 +32,7 @@
 #include "../../graphics/graphicsscene.h"
 #include "../../graphics/slintgraphicsview.h"
 #include "../../guiapplication.h"
+#include "../../mainwindow.h"
 #include "../../rulecheck/rulecheckmessagesmodel.h"
 #include "../../undostack.h"
 #include "../../utils/editortoolbox.h"
@@ -113,6 +114,7 @@ PackageTab::PackageTab(LibraryEditor& editor, std::unique_ptr<Package> pkg,
     mGridStyle(mApp.getWorkspace().getSettings().boardGridStyle.get()),
     mUnit(LengthUnit::millimeters()),
     mChooseCategory(false),
+    mElementDuplicated(false),
     mOpenGlProjection(new OpenGlProjection()),
     mFrameIndex(0),
     mNameParsed(mPackage->getNames().getDefaultValue()),
@@ -202,9 +204,9 @@ PackageTab::PackageTab(LibraryEditor& editor, std::unique_ptr<Package> pkg,
   applyBackgroundImageSettings();
 
   // Load finite state machine (FSM).
-  PackageEditorFsm::Context fsmContext{*mPackage, *mUndoStack, !isWritable(),
-                                       mUnit,     *mLayers,    *this,
-                                       nullptr,   nullptr};
+  PackageEditorFsm::Context fsmContext{
+      *mPackage, *mUndoStack, mUnit, *mLayers, *this, nullptr, nullptr,
+  };
   mFsm.reset(new PackageEditorFsm(fsmContext));
 
   // Apply workspace settings whenever they have been modified.
@@ -274,7 +276,7 @@ FilePath PackageTab::getDirectoryPath() const noexcept {
 }
 
 ui::TabData PackageTab::getUiData() const noexcept {
-  const bool writable = isWritable();
+  const bool writable = fsmIsWritable();
 
   ui::TabFeatures features = {};
   features.save = toFs(writable);
@@ -282,7 +284,7 @@ ui::TabData PackageTab::getUiData() const noexcept {
   features.redo = toFs(mUndoStack->canRedo());
   if ((!mWizardMode) && (mCurrentPageIndex == 2) && (!mView3d) &&
       mFsm->getCurrentFootprint()) {
-    features.grid = toFs(isWritable());
+    features.grid = toFs(writable);
     features.zoom = toFs(true);
     features.background_image = toFs(true);
     features.import_graphics =
@@ -344,6 +346,7 @@ ui::PackageTabData PackageTab::getDerivedUiData() const noexcept {
       mDescription,  // Description
       mKeywords,  // Keywords
       mAuthor,  // Author
+      mAgeDays,  // Age in days
       mVersion,  // Version
       mVersionError,  // Version error
       mDeprecated,  // Deprecated
@@ -367,7 +370,7 @@ ui::PackageTabData PackageTab::getDerivedUiData() const noexcept {
           mCheckMessages->getUnapprovedCount(),  // Check unapproved count
           mCheckMessages->getErrorCount(),  // Check errors count
           mCheckError,  // Check execution error
-          !isWritable(),  // Check read-only
+          !fsmIsWritable(),  // Check read-only
       },
       q2s(bgColor),  // Background color
       q2s(fgColor),  // Foreground color
@@ -386,6 +389,7 @@ ui::PackageTabData PackageTab::getDerivedUiData() const noexcept {
       q2s(errors.join("\n\n")),  // Error
       !mModifiedWatchedFiles.isEmpty(),  // Watched files modified
       mIsInterfaceBroken,  // Interface broken
+      mElementDuplicated && (!mDeprecated),  // Element duplicated
       mTool,  // Tool
       q2s(((mView3d && mOpenGlView) ? mOpenGlView->isPanning()
                                     : mView->isPanning())
@@ -535,6 +539,11 @@ void PackageTab::setDerivedUiData(const ui::PackageTabData& data) noexcept {
   mAlpha[OpenGlObject::Type::Device] = qBound(0.0f, data.devices_alpha, 1.0f);
   if (mOpenGlView) {
     mOpenGlView->setAlpha(mAlpha);
+  }
+
+  // Messages
+  if (data.deprecated || (!data.element_duplicated_msg)) {
+    mElementDuplicated = false;
   }
 
   // Tool
@@ -687,6 +696,15 @@ void PackageTab::trigger(ui::TabAction a) noexcept {
       save();
       break;
     }
+    case ui::TabAction::SaveAs: {  // Duplicate the library element.
+      commitUiData();  // Exits the current tool and releases the undo stack.
+      if (mWindow && mWindow->openNewPackageTab(mEditor, {}, mPackage.get())) {
+        undoBreakingChanges(mIsInterfaceBroken);
+        mElementDuplicated = true;
+        onDerivedUiDataChanged.notify();
+      }
+      break;
+    }
     case ui::TabAction::ReloadFromDisk: {
       try {
         reloadFromDisk();
@@ -711,6 +729,12 @@ void PackageTab::trigger(ui::TabAction a) noexcept {
       } catch (const Exception& e) {
         QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
+      break;
+    }
+    case ui::TabAction::Unlock: {
+      mAllowBreakingChanges = true;
+      onUiDataChanged.notify();
+      onDerivedUiDataChanged.notify();
       break;
     }
     case ui::TabAction::Close: {
@@ -1026,17 +1050,22 @@ bool PackageTab::processSceneKeyReleased(
 bool PackageTab::requestClose() noexcept {
   commitUiData();
 
-  if ((!hasUnsavedChanges()) || (!isWritable())) {
+  if (!hasUnsavedChanges()) {
     return true;  // Nothing to save.
   }
 
-  const QMessageBox::StandardButton choice = QMessageBox::question(
-      getWindow(), tr("Save Changes?"),
-      tr("The package '%1' contains unsaved changes.\n"
-         "Do you want to save them before closing it?")
-          .arg(*mPackage->getNames().getDefaultValue()),
-      QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
-      QMessageBox::Yes);
+  QMessageBox::StandardButtons buttons = QMessageBox::No | QMessageBox::Cancel;
+  QMessageBox::StandardButton defaultButton = QMessageBox::Cancel;
+  if ((!mIsInterfaceBroken) || mAllowBreakingChanges) {
+    buttons |= QMessageBox::Yes;
+    defaultButton = QMessageBox::Yes;
+  }
+  const QMessageBox::StandardButton choice =
+      QMessageBox::question(getWindow(), tr("Save Changes?"),
+                            tr("The package '%1' contains unsaved changes.\n"
+                               "Do you want to save them before closing it?")
+                                .arg(*mPackage->getNames().getDefaultValue()),
+                            buttons, defaultButton);
   if (choice == QMessageBox::Yes) {
     return save();
   } else if (choice == QMessageBox::No) {
@@ -1089,6 +1118,12 @@ bool PackageTab::graphicsSceneRightMouseButtonReleased(
 /*******************************************************************************
  *  PackageEditorFsmAdapter
  ******************************************************************************/
+
+bool PackageTab::fsmIsWritable() const noexcept {
+  return mIsNewElement ||
+      (mPackage->getDirectory().isWritable() &&
+       ((!mIsInterfaceBroken) || mAllowBreakingChanges));
+}
 
 QWidget* PackageTab::fsmGetParentWidget() noexcept {
   return getWindow();
@@ -2423,10 +2458,6 @@ void PackageTab::autoSelectCurrentModelIndex() noexcept {
   }
 }
 
-bool PackageTab::isWritable() const noexcept {
-  return mIsNewElement || mPackage->getDirectory().isWritable();
-}
-
 void PackageTab::refreshUiData() noexcept {
   mName = q2s(*mPackage->getNames().getDefaultValue());
   mNameError = slint::SharedString();
@@ -2441,6 +2472,7 @@ void PackageTab::refreshUiData() noexcept {
   mCategories->setCategories(mPackage->getCategories());
   mAssemblyType = mPackage->getAssemblyType(false);
   mMinCopperClearance.setValueUnsigned(mPackage->getMinCopperClearance());
+  updateAgeDays(mPackage->getCreated());
 
   // Update "interface broken" only when no command is active since it would
   // be annoying to get it during intermediate states.

--- a/libs/librepcb/editor/library/pkg/packagetab.h
+++ b/libs/librepcb/editor/library/pkg/packagetab.h
@@ -132,6 +132,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
 
   // PackageEditorFsmAdapter
+  bool fsmIsWritable() const noexcept override;
   QWidget* fsmGetParentWidget() noexcept override;
   GraphicsScene* fsmGetGraphicsScene() noexcept override;
   PositiveLength fsmGetGridInterval() const noexcept override;
@@ -206,7 +207,6 @@ private:
   void setCurrentFootprintIndex(int index) noexcept;
   void setCurrentModelIndex(int index) noexcept;
   void autoSelectCurrentModelIndex() noexcept;
-  bool isWritable() const noexcept;
   void refreshUiData() noexcept;
   void commitUiData() noexcept;
   bool save() noexcept;
@@ -238,6 +238,7 @@ private:
   GridStyle mGridStyle;
   LengthUnit mUnit;
   bool mChooseCategory;
+  bool mElementDuplicated;
   std::shared_ptr<PackageModel> mCurrentModel;
   std::unique_ptr<OpenGlProjection> mOpenGlProjection;
   QHash<OpenGlObject::Type, float> mAlpha;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsm.h
@@ -79,7 +79,6 @@ public:  // Types
   struct Context {
     Symbol& symbol;
     UndoStack& undoStack;
-    const bool readOnly;
     const LengthUnit& lengthUnit;
     SymbolEditorFsmAdapter& adapter;
   };

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorfsmadapter.h
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorfsmadapter.h
@@ -75,6 +75,7 @@ public:
   };
   Q_DECLARE_FLAGS(Features, Feature)
 
+  virtual bool fsmIsWritable() const noexcept = 0;
   virtual QWidget* fsmGetParentWidget() noexcept = 0;
   virtual GraphicsScene* fsmGetGraphicsScene() noexcept = 0;
   virtual SymbolGraphicsItem* fsmGetGraphicsItem() noexcept = 0;

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_select.cpp
@@ -200,9 +200,11 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
       // get items under cursor
       QList<std::shared_ptr<QGraphicsItem>> items =
           findItemsAtPosition(mStartPos);
-      if (findPolygonVerticesAtPosition(mStartPos) && (!mContext.readOnly)) {
+      if (findPolygonVerticesAtPosition(mStartPos) &&
+          mAdapter.fsmIsWritable()) {
         setState(SubState::MOVING_POLYGON_VERTEX);
-      } else if (findImageHandleAtPosition(mStartPos) && (!mContext.readOnly)) {
+      } else if (findImageHandleAtPosition(mStartPos) &&
+                 mAdapter.fsmIsWritable()) {
         setState(SubState::RESIZING_IMAGE);
       } else if (items.isEmpty()) {
         // start selecting
@@ -260,7 +262,7 @@ bool SymbolEditorState_Select::processGraphicsSceneLeftMouseButtonPressed(
         scheduleUpdateAvailableFeatures();  // Selection might have changed.
 
         // Start moving, if not read only.
-        if (!mContext.readOnly) {
+        if (mAdapter.fsmIsWritable()) {
           Q_ASSERT(!mCmdDragSelectedItems);
           setState(SubState::MOVING);
         }
@@ -694,7 +696,7 @@ bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
         int remainingVertices =
             polygon->getPath().getVertices().count() - vertices.count();
         aRemoveVertex->setEnabled((remainingVertices >= 2) &&
-                                  (!mContext.readOnly));
+                                  mAdapter.fsmIsWritable());
         mb.addAction(aRemoveVertex);
       }
 
@@ -703,7 +705,7 @@ bool SymbolEditorState_Select::openContextMenuAtPos(const Point& pos) noexcept {
         QAction* aAddVertex = cmd.vertexAdd.createAction(
             &menu, this,
             [=, this]() { startAddingPolygonVertex(polygon, lineIndex, pos); });
-        aAddVertex->setEnabled(!mContext.readOnly);
+        aAddVertex->setEnabled(mAdapter.fsmIsWritable());
         mb.addAction(aAddVertex);
       }
 
@@ -769,7 +771,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
     SymbolPinPropertiesDialog dialog(
         i->getPtr(), mContext.undoStack, getLengthUnit(),
         "symbol_editor/pin_properties_dialog", parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<TextGraphicsItem>(item)) {
@@ -777,7 +779,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
                                 getAllowedTextLayers(), getLengthUnit(),
                                 "symbol_editor/text_properties_dialog",
                                 parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<PolygonGraphicsItem>(item)) {
@@ -785,7 +787,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
         i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "symbol_editor/polygon_properties_dialog",
         parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   } else if (auto i = std::dynamic_pointer_cast<CircleGraphicsItem>(item)) {
@@ -793,7 +795,7 @@ bool SymbolEditorState_Select::openPropertiesDialogOfItem(
         i->getObj(), mContext.undoStack, getAllowedCircleAndPolygonLayers(),
         getLengthUnit(), "symbol_editor/circle_properties_dialog",
         parentWidget());
-    dialog.setReadOnly(mContext.readOnly);
+    dialog.setReadOnly(!mAdapter.fsmIsWritable());
     dialog.exec();
     return true;
   }
@@ -1105,7 +1107,7 @@ SymbolEditorFsmAdapter::Features
 
   if (mState != SubState::PASTING) {
     features |= SymbolEditorFsmAdapter::Feature::Select;
-    if (!mContext.readOnly) {
+    if (mAdapter.fsmIsWritable()) {
       features |= SymbolEditorFsmAdapter::Feature::ImportGraphics;
       if (SymbolClipboardData::isValid(qApp->clipboard()->mimeData()) ||
           ImageHelpers::isImageInClipboard()) {
@@ -1119,7 +1121,7 @@ SymbolEditorFsmAdapter::Features
     if (cmd.getSelectedItemsCount() > 0) {
       features |= SymbolEditorFsmAdapter::Feature::Copy;
       features |= SymbolEditorFsmAdapter::Feature::Properties;
-      if (!mContext.readOnly) {
+      if (mAdapter.fsmIsWritable()) {
         features |= SymbolEditorFsmAdapter::Feature::Cut;
         features |= SymbolEditorFsmAdapter::Feature::Remove;
         features |= SymbolEditorFsmAdapter::Feature::Rotate;

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -26,6 +26,7 @@
 #include "../../graphics/graphicsscene.h"
 #include "../../graphics/slintgraphicsview.h"
 #include "../../guiapplication.h"
+#include "../../mainwindow.h"
 #include "../../rulecheck/rulecheckmessagesmodel.h"
 #include "../../undostack.h"
 #include "../../utils/editortoolbox.h"
@@ -95,6 +96,7 @@ SymbolTab::SymbolTab(LibraryEditor& editor, std::unique_ptr<Symbol> sym,
     mGridStyle(mApp.getWorkspace().getSettings().schematicGridStyle.get()),
     mUnit(LengthUnit::millimeters()),
     mChooseCategory(false),
+    mElementDuplicated(false),
     mCompactLayout(false),
     mFrameIndex(0),
     mNameParsed(mSymbol->getNames().getDefaultValue()),
@@ -147,8 +149,7 @@ SymbolTab::SymbolTab(LibraryEditor& editor, std::unique_ptr<Symbol> sym,
           [this]() { onDerivedUiDataChanged.notify(); });
 
   // Load finite state machine (FSM).
-  SymbolEditorFsm::Context fsmContext{*mSymbol, *mUndoStack, !isWritable(),
-                                      mUnit, *this};
+  SymbolEditorFsm::Context fsmContext{*mSymbol, *mUndoStack, mUnit, *this};
   mFsm.reset(new SymbolEditorFsm(fsmContext));
 
   // Apply workspace settings whenever they have been modified.
@@ -211,14 +212,14 @@ FilePath SymbolTab::getDirectoryPath() const noexcept {
 }
 
 ui::TabData SymbolTab::getUiData() const noexcept {
-  const bool writable = isWritable();
+  const bool writable = fsmIsWritable();
 
   ui::TabFeatures features = {};
   features.save = toFs(writable);
   features.undo = toFs(mUndoStack->canUndo());
   features.redo = toFs(mUndoStack->canRedo());
   if ((!mWizardMode) && ((!mCompactLayout) || (mCurrentPageIndex == 1))) {
-    features.grid = toFs(isWritable());
+    features.grid = toFs(writable);
     features.zoom = toFs(true);
     features.import_graphics =
         toFs(mToolFeatures.testFlag(Feature::ImportGraphics));
@@ -267,6 +268,7 @@ ui::SymbolTabData SymbolTab::getDerivedUiData() const noexcept {
       mDescription,  // Description
       mKeywords,  // Keywords
       mAuthor,  // Author
+      mAgeDays,  // Age in days
       mVersion,  // Version
       mVersionError,  // Version error
       mDeprecated,  // Deprecated
@@ -280,7 +282,7 @@ ui::SymbolTabData SymbolTab::getDerivedUiData() const noexcept {
           mCheckMessages->getUnapprovedCount(),  // Check unapproved count
           mCheckMessages->getErrorCount(),  // Check errors count
           mCheckError,  // Check execution error
-          !isWritable(),  // Check read-only
+          !fsmIsWritable(),  // Check read-only
       },
       q2s(bgColor),  // Background color
       q2s(fgColor),  // Foreground color
@@ -291,6 +293,7 @@ ui::SymbolTabData SymbolTab::getDerivedUiData() const noexcept {
       l2s(mUnit),  // Unit
       !mModifiedWatchedFiles.isEmpty(),  // Watched files modified
       mIsInterfaceBroken,  // Interface broken
+      mElementDuplicated && (!mDeprecated),  // Element duplicated
       mMsgImportPins.getUiData(),  // Message "import pins"
       mTool,  // Tool
       q2s(mView->isPanning() ? Qt::ClosedHandCursor
@@ -373,6 +376,9 @@ void SymbolTab::setDerivedUiData(const ui::SymbolTabData& data) noexcept {
 
   // Messages
   mMsgImportPins.setUiData(data.import_pins_msg);
+  if (data.deprecated || (!data.element_duplicated_msg)) {
+    mElementDuplicated = false;
+  }
 
   // Tool
   if (const Layer* layer = mToolLayersQt.value(data.tool_layer.current_index)) {
@@ -436,6 +442,15 @@ void SymbolTab::trigger(ui::TabAction a) noexcept {
       save();
       break;
     }
+    case ui::TabAction::SaveAs: {  // Duplicate the library element.
+      commitUiData();  // Exits the current tool and releases the undo stack.
+      if (mWindow && mWindow->openNewSymbolTab(mEditor, {}, mSymbol.get())) {
+        undoBreakingChanges(mIsInterfaceBroken);
+        mElementDuplicated = true;
+        onDerivedUiDataChanged.notify();
+      }
+      break;
+    }
     case ui::TabAction::ReloadFromDisk: {
       try {
         reloadFromDisk();
@@ -460,6 +475,12 @@ void SymbolTab::trigger(ui::TabAction a) noexcept {
       } catch (const Exception& e) {
         QMessageBox::critical(getWindow(), tr("Error"), e.getMsg());
       }
+      break;
+    }
+    case ui::TabAction::Unlock: {
+      mAllowBreakingChanges = true;
+      onUiDataChanged.notify();
+      onDerivedUiDataChanged.notify();
       break;
     }
     case ui::TabAction::Close: {
@@ -681,17 +702,22 @@ bool SymbolTab::processSceneKeyReleased(
 bool SymbolTab::requestClose() noexcept {
   commitUiData();
 
-  if ((!hasUnsavedChanges()) || (!isWritable())) {
+  if (!hasUnsavedChanges()) {
     return true;  // Nothing to save.
   }
 
-  const QMessageBox::StandardButton choice = QMessageBox::question(
-      getWindow(), tr("Save Changes?"),
-      tr("The symbol '%1' contains unsaved changes.\n"
-         "Do you want to save them before closing it?")
-          .arg(*mSymbol->getNames().getDefaultValue()),
-      QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
-      QMessageBox::Yes);
+  QMessageBox::StandardButtons buttons = QMessageBox::No | QMessageBox::Cancel;
+  QMessageBox::StandardButton defaultButton = QMessageBox::Cancel;
+  if ((!mIsInterfaceBroken) || mAllowBreakingChanges) {
+    buttons |= QMessageBox::Yes;
+    defaultButton = QMessageBox::Yes;
+  }
+  const QMessageBox::StandardButton choice =
+      QMessageBox::question(getWindow(), tr("Save Changes?"),
+                            tr("The symbol '%1' contains unsaved changes.\n"
+                               "Do you want to save them before closing it?")
+                                .arg(*mSymbol->getNames().getDefaultValue()),
+                            buttons, defaultButton);
   if (choice == QMessageBox::Yes) {
     return save();
   } else if (choice == QMessageBox::No) {
@@ -744,6 +770,12 @@ bool SymbolTab::graphicsSceneRightMouseButtonReleased(
 /*******************************************************************************
  *  SymbolEditorFsmAdapter
  ******************************************************************************/
+
+bool SymbolTab::fsmIsWritable() const noexcept {
+  return mIsNewElement ||
+      (mSymbol->getDirectory().isWritable() &&
+       ((!mIsInterfaceBroken) || mAllowBreakingChanges));
+}
 
 QWidget* SymbolTab::fsmGetParentWidget() noexcept {
   return getWindow();
@@ -853,7 +885,7 @@ void SymbolTab::fsmToolEnter(SymbolEditorState_DrawLine& state) noexcept {
   // Layers
   mToolLayersQt = Layer::sorted(state.getAvailableLayers());
   mToolLayers->clear();
-  for (const Layer* layer : mToolLayersQt) {
+  for (const Layer* layer : std::as_const(mToolLayersQt)) {
     mToolLayers->push_back(q2s(layer->getNameTr()));
   }
 
@@ -899,7 +931,7 @@ void SymbolTab::fsmToolEnter(SymbolEditorState_DrawRect& state) noexcept {
   // Layers
   mToolLayersQt = Layer::sorted(state.getAvailableLayers());
   mToolLayers->clear();
-  for (const Layer* layer : mToolLayersQt) {
+  for (const Layer* layer : std::as_const(mToolLayersQt)) {
     mToolLayers->push_back(q2s(layer->getNameTr()));
   }
 
@@ -957,7 +989,7 @@ void SymbolTab::fsmToolEnter(SymbolEditorState_DrawPolygon& state) noexcept {
   // Layers
   mToolLayersQt = Layer::sorted(state.getAvailableLayers());
   mToolLayers->clear();
-  for (const Layer* layer : mToolLayersQt) {
+  for (const Layer* layer : std::as_const(mToolLayersQt)) {
     mToolLayers->push_back(q2s(layer->getNameTr()));
   }
 
@@ -1030,7 +1062,7 @@ void SymbolTab::fsmToolEnter(SymbolEditorState_DrawCircle& state) noexcept {
   // Layers
   mToolLayersQt = Layer::sorted(state.getAvailableLayers());
   mToolLayers->clear();
-  for (const Layer* layer : mToolLayersQt) {
+  for (const Layer* layer : std::as_const(mToolLayersQt)) {
     mToolLayers->push_back(q2s(layer->getNameTr()));
   }
 
@@ -1090,7 +1122,7 @@ void SymbolTab::fsmToolEnter(SymbolEditorState_DrawArc& state) noexcept {
   // Layers
   mToolLayersQt = Layer::sorted(state.getAvailableLayers());
   mToolLayers->clear();
-  for (const Layer* layer : mToolLayersQt) {
+  for (const Layer* layer : std::as_const(mToolLayersQt)) {
     mToolLayers->push_back(q2s(layer->getNameTr()));
   }
 
@@ -1201,7 +1233,7 @@ void SymbolTab::fsmToolEnter(SymbolEditorState_DrawText& state) noexcept {
   // Layers
   mToolLayersQt = Layer::sorted(state.getAvailableLayers());
   mToolLayers->clear();
-  for (const Layer* layer : mToolLayersQt) {
+  for (const Layer* layer : std::as_const(mToolLayersQt)) {
     mToolLayers->push_back(q2s(layer->getNameTr()));
   }
 
@@ -1483,10 +1515,6 @@ bool SymbolTab::autoFix(const MsgSymbolOriginNotInCenter& msg) {
  *  Private Methods
  ******************************************************************************/
 
-bool SymbolTab::isWritable() const noexcept {
-  return mIsNewElement || mSymbol->getDirectory().isWritable();
-}
-
 void SymbolTab::refreshUiData() noexcept {
   mName = q2s(*mSymbol->getNames().getDefaultValue());
   mNameError = slint::SharedString();
@@ -1499,6 +1527,7 @@ void SymbolTab::refreshUiData() noexcept {
   mVersionParsed = mSymbol->getVersion();
   mDeprecated = mSymbol->isDeprecated();
   mCategories->setCategories(mSymbol->getCategories());
+  updateAgeDays(mSymbol->getCreated());
 
   mMsgImportPins.setActive(mSymbol->isEmpty());
 

--- a/libs/librepcb/editor/library/sym/symboltab.h
+++ b/libs/librepcb/editor/library/sym/symboltab.h
@@ -123,6 +123,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
 
   // SymbolEditorFsmAdapter
+  bool fsmIsWritable() const noexcept override;
   QWidget* fsmGetParentWidget() noexcept override;
   GraphicsScene* fsmGetGraphicsScene() noexcept override;
   SymbolGraphicsItem* fsmGetGraphicsItem() noexcept override;
@@ -184,7 +185,6 @@ protected:
   void notifyDerivedUiDataChanged() noexcept override;
 
 private:
-  bool isWritable() const noexcept;
   void refreshUiData() noexcept;
   void commitUiData() noexcept;
   bool save() noexcept;
@@ -212,6 +212,7 @@ private:
   GridStyle mGridStyle;
   LengthUnit mUnit;
   bool mChooseCategory;
+  bool mElementDuplicated;
   bool mCompactLayout;
   QPointF mSceneImagePos;
   int mFrameIndex;

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -415,8 +415,6 @@ void MainWindow::addSection(int newIndex, bool makeCurrent) noexcept {
     const ui::Data& d = mWindow->global<ui::Data>();
     d.fn_current_tab_changed();
   });
-  connect(s.get(), &WindowSection::panelPageRequested, this,
-          &MainWindow::showPanelPage);
   connect(s.get(), &WindowSection::cursorCoordinatesChanged, this,
           [this](const Point& pos, const LengthUnit& unit) {
             const ui::Data& d = mWindow->global<ui::Data>();
@@ -530,6 +528,195 @@ void MainWindow::setCurrentLibrary(int index) noexcept {
 void MainWindow::setCurrentProject(int index) noexcept {
   const ui::Data& d = mWindow->global<ui::Data>();
   d.fn_set_current_project(index);
+}
+
+void MainWindow::openLibraryTab(const FilePath& fp, bool wizardMode) noexcept {
+  if (auto editor = mApp.openLibrary(fp)) {
+    if (!switchToLibraryElementTab<LibraryTab>(fp)) {
+      addTab(std::make_shared<LibraryTab>(*editor, wizardMode));
+    }
+  }
+}
+
+void MainWindow::openComponentCategoryTab(LibraryEditor& editor,
+                                          const FilePath& fp) noexcept {
+  openLibraryElementTab<ComponentCategory, ComponentCategoryTab>(editor, fp);
+}
+
+bool MainWindow::openNewComponentCategoryTab(
+    LibraryEditor& editor, const FilePath& duplicateFromFp,
+    const ComponentCategory* duplicateFromObj) noexcept {
+  return openNewLibraryElementTab<ComponentCategory, ComponentCategoryTab>(
+      editor, duplicateFromFp, duplicateFromObj, [this]() {
+        return std::unique_ptr<ComponentCategory>(new ComponentCategory(
+            Uuid::createRandom(), Version::fromString("0.1"),
+            mApp.getWorkspace().getSettings().userName.get(),
+            QDateTime::currentDateTime(), ElementName("New Component Category"),
+            QString(), QString()));
+      });
+}
+
+void MainWindow::openPackageCategoryTab(LibraryEditor& editor,
+                                        const FilePath& fp) noexcept {
+  openLibraryElementTab<PackageCategory, PackageCategoryTab>(editor, fp);
+}
+
+bool MainWindow::openNewPackageCategoryTab(
+    LibraryEditor& editor, const FilePath& duplicateFromFp,
+    const PackageCategory* duplicateFromObj) noexcept {
+  return openNewLibraryElementTab<PackageCategory, PackageCategoryTab>(
+      editor, duplicateFromFp, duplicateFromObj, [this]() {
+        return std::unique_ptr<PackageCategory>(new PackageCategory(
+            Uuid::createRandom(), Version::fromString("0.1"),
+            mApp.getWorkspace().getSettings().userName.get(),
+            QDateTime::currentDateTime(), ElementName("New Package Category"),
+            QString(), QString()));
+      });
+}
+
+void MainWindow::openSymbolTab(LibraryEditor& editor,
+                               const FilePath& fp) noexcept {
+  openLibraryElementTab<Symbol, SymbolTab>(editor, fp);
+}
+
+bool MainWindow::openNewSymbolTab(LibraryEditor& editor,
+                                  const FilePath& duplicateFromFp,
+                                  const Symbol* duplicateFromObj) noexcept {
+  return openNewLibraryElementTab<Symbol, SymbolTab>(
+      editor, duplicateFromFp, duplicateFromObj, [this]() {
+        return std::unique_ptr<Symbol>(
+            new Symbol(Uuid::createRandom(), Version::fromString("0.1"),
+                       mApp.getWorkspace().getSettings().userName.get(),
+                       QDateTime::currentDateTime(), ElementName("New Symbol"),
+                       QString(), QString()));
+      });
+}
+
+void MainWindow::openPackageTab(LibraryEditor& editor,
+                                const FilePath& fp) noexcept {
+  openLibraryElementTab<Package, PackageTab>(editor, fp);
+}
+
+bool MainWindow::openNewPackageTab(LibraryEditor& editor,
+                                   const FilePath& duplicateFromFp,
+                                   const Package* duplicateFromObj) noexcept {
+  return openNewLibraryElementTab<Package, PackageTab>(
+      editor, duplicateFromFp, duplicateFromObj, [this]() {
+        std::unique_ptr<Package> obj(new Package(
+            Uuid::createRandom(), Version::fromString("0.1"),
+            mApp.getWorkspace().getSettings().userName.get(),
+            QDateTime::currentDateTime(), ElementName("New Package"), QString(),
+            QString(), Package::AssemblyType::Auto));
+        obj->getFootprints().append(std::make_shared<Footprint>(
+            Uuid::createRandom(), ElementName("default"), ""));
+        return obj;
+      });
+}
+
+void MainWindow::openComponentTab(LibraryEditor& editor,
+                                  const FilePath& fp) noexcept {
+  openLibraryElementTab<Component, ComponentTab>(editor, fp);
+}
+
+bool MainWindow::openNewComponentTab(
+    LibraryEditor& editor, const FilePath& duplicateFromFp,
+    const Component* duplicateFromObj) noexcept {
+  return openNewLibraryElementTab<Component, ComponentTab>(
+      editor, duplicateFromFp, duplicateFromObj, [this]() {
+        std::unique_ptr<Component> obj(
+            new Component(Uuid::createRandom(), Version::fromString("0.1"),
+                          mApp.getWorkspace().getSettings().userName.get(),
+                          QDateTime::currentDateTime(),
+                          ElementName("New Component"), QString(), QString()));
+        obj->getSymbolVariants().append(
+            std::make_shared<ComponentSymbolVariant>(
+                Uuid::createRandom(), "", ElementName("default"), ""));
+        return obj;
+      });
+}
+
+void MainWindow::openDeviceTab(LibraryEditor& editor,
+                               const FilePath& fp) noexcept {
+  openLibraryElementTab<Device, DeviceTab>(editor, fp);
+}
+
+bool MainWindow::openNewDeviceTab(LibraryEditor& editor,
+                                  const FilePath& duplicateFromFp,
+                                  const Device* duplicateFromObj) noexcept {
+  return openNewLibraryElementTab<Device, DeviceTab>(
+      editor, duplicateFromFp, duplicateFromObj, [this]() {
+        return std::unique_ptr<Device>(new Device(
+            Uuid::createRandom(), Version::fromString("0.1"),
+            mApp.getWorkspace().getSettings().userName.get(),
+            QDateTime::currentDateTime(), ElementName("New Device"), QString(),
+            QString(), Uuid::createRandom(), Uuid::createRandom()));
+      });
+}
+
+void MainWindow::openOrganizationTab(LibraryEditor& editor,
+                                     const FilePath& fp) noexcept {
+  openLibraryElementTab<Organization, OrganizationTab>(editor, fp);
+}
+
+bool MainWindow::openNewOrganizationTab(
+    LibraryEditor& editor, const FilePath& duplicateFromFp,
+    const Organization* duplicateFromObj) noexcept {
+  return openNewLibraryElementTab<Organization, OrganizationTab>(
+      editor, duplicateFromFp, duplicateFromObj, [this]() {
+        return std::unique_ptr<Organization>(new Organization(
+            Uuid::createRandom(), Version::fromString("0.1"),
+            mApp.getWorkspace().getSettings().userName.get(),
+            QDateTime::currentDateTime(), ElementName("New Organization"),
+            QString(), QString()));
+      });
+}
+
+std::shared_ptr<SchematicTab> MainWindow::openSchematicTab(int projectIndex,
+                                                           int index) noexcept {
+  if (auto tab = switchToProjectTab<SchematicTab>(projectIndex, index)) {
+    return tab;
+  } else if (auto prjEditor = mApp.getProjects().value(projectIndex)) {
+    if (auto schEditor = prjEditor->getSchematics().value(index)) {
+      auto tab = std::make_shared<SchematicTab>(mApp, *schEditor);
+      addTab(tab);
+      return tab;
+    }
+  }
+  return nullptr;
+}
+
+void MainWindow::openBoard2dTab(int projectIndex, int index,
+                                bool switchToTab) noexcept {
+  if (!switchToProjectTab<Board2dTab>(projectIndex, index)) {
+    if (auto prjEditor = mApp.getProjects().value(projectIndex)) {
+      if (auto brdEditor = prjEditor->getBoards().value(index)) {
+        addTab(std::make_shared<Board2dTab>(mApp, *brdEditor), -1, -1,
+               switchToTab, switchToTab);
+      }
+    }
+  }
+}
+
+void MainWindow::openBoard3dTab(int projectIndex, int index) noexcept {
+  if (!switchToProjectTab<Board3dTab>(projectIndex, index)) {
+    if (auto prjEditor = mApp.getProjects().value(projectIndex)) {
+      if (auto brdEditor = prjEditor->getBoards().value(index)) {
+        addTab(std::make_shared<Board3dTab>(mApp, *brdEditor));
+      }
+    }
+  }
+}
+
+void MainWindow::requestComponentTab(const FilePath& fp) noexcept {
+  if (auto editor = mApp.openLibrary(fp.getParentDir().getParentDir())) {
+    openComponentTab(*editor, fp);
+  }
+}
+
+void MainWindow::requestPackageTab(const FilePath& fp) noexcept {
+  if (auto editor = mApp.openLibrary(fp.getParentDir().getParentDir())) {
+    openPackageTab(*editor, fp);
+  }
 }
 
 /*******************************************************************************
@@ -746,43 +933,43 @@ void MainWindow::triggerLibrary(slint::SharedString path,
     }
     case ui::LibraryAction::NewComponentCategory: {
       if (auto editor = mApp.getLibrary(fp)) {
-        openComponentCategoryTab(*editor, FilePath(), false);
+        openNewComponentCategoryTab(*editor);
       }
       break;
     }
     case ui::LibraryAction::NewPackageCategory: {
       if (auto editor = mApp.getLibrary(fp)) {
-        openPackageCategoryTab(*editor, FilePath(), false);
+        openNewPackageCategoryTab(*editor);
       }
       break;
     }
     case ui::LibraryAction::NewSymbol: {
       if (auto editor = mApp.getLibrary(fp)) {
-        openSymbolTab(*editor, FilePath(), false);
+        openNewSymbolTab(*editor);
       }
       break;
     }
     case ui::LibraryAction::NewPackage: {
       if (auto editor = mApp.getLibrary(fp)) {
-        openPackageTab(*editor, FilePath(), false);
+        openNewPackageTab(*editor);
       }
       break;
     }
     case ui::LibraryAction::NewComponent: {
       if (auto editor = mApp.getLibrary(fp)) {
-        openComponentTab(*editor, FilePath(), false);
+        openNewComponentTab(*editor);
       }
       break;
     }
     case ui::LibraryAction::NewDevice: {
       if (auto editor = mApp.getLibrary(fp)) {
-        openDeviceTab(*editor, FilePath(), false);
+        openNewDeviceTab(*editor);
       }
       break;
     }
     case ui::LibraryAction::NewOrganization: {
       if (auto editor = mApp.getLibrary(fp)) {
-        openOrganizationTab(*editor, FilePath(), false);
+        openNewOrganizationTab(*editor);
       }
       break;
     }
@@ -981,343 +1168,58 @@ void MainWindow::triggerBoard(int project, int board,
   }
 }
 
-void MainWindow::openLibraryTab(const FilePath& fp, bool wizardMode) noexcept {
-  if (auto editor = mApp.openLibrary(fp)) {
-    if (!switchToLibraryElementTab<LibraryTab>(fp)) {
-      auto tab = std::make_shared<LibraryTab>(*editor, wizardMode);
-      connect(tab.get(), &LibraryTab::componentCategoryEditorRequested, this,
-              &MainWindow::openComponentCategoryTab);
-      connect(tab.get(), &LibraryTab::packageCategoryEditorRequested, this,
-              &MainWindow::openPackageCategoryTab);
-      connect(tab.get(), &LibraryTab::symbolEditorRequested, this,
-              &MainWindow::openSymbolTab);
-      connect(tab.get(), &LibraryTab::packageEditorRequested, this,
-              &MainWindow::openPackageTab);
-      connect(tab.get(), &LibraryTab::componentEditorRequested, this,
-              &MainWindow::openComponentTab);
-      connect(tab.get(), &LibraryTab::deviceEditorRequested, this,
-              &MainWindow::openDeviceTab);
-      connect(tab.get(), &LibraryTab::organizationEditorRequested, this,
-              &MainWindow::openOrganizationTab);
-      addTab(tab);
-    }
-  }
-}
-
-void MainWindow::openComponentCategoryTab(LibraryEditor& editor,
-                                          const FilePath& fp,
-                                          bool copyFrom) noexcept {
-  if (copyFrom || (!switchToLibraryElementTab<ComponentCategoryTab>(fp))) {
-    try {
-      std::unique_ptr<ComponentCategory> cat;
-      ComponentCategoryTab::Mode mode = ComponentCategoryTab::Mode::Open;
-      if (fp.isValid() && (!copyFrom)) {
-        auto fs = TransactionalFileSystem::open(
-            fp, editor.isWritable(), &askForRestoringBackup,
-            DirectoryLockHandlerDialog::createDirectoryLockCallback());
-        cat = ComponentCategory::open(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));
-      } else {
-        mode = ComponentCategoryTab::Mode::New;
-        cat.reset(new ComponentCategory(
-            Uuid::createRandom(), Version::fromString("0.1"),
-            mApp.getWorkspace().getSettings().userName.get(),
-            QDateTime::currentDateTime(), ElementName("New Component Category"),
-            QString(), QString()));
-        if (copyFrom) {
-          mode = ComponentCategoryTab::Mode::Duplicate;
-          auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
-          std::unique_ptr<ComponentCategory> src =
-              ComponentCategory::open(std::unique_ptr<TransactionalDirectory>(
-                  new TransactionalDirectory(fs)));
-          duplicateLibraryElement(*cat, *src);
-        }
-      }
-      addTab(
-          std::make_shared<ComponentCategoryTab>(editor, std::move(cat), mode));
-    } catch (const UserCanceled& e) {
-    } catch (const Exception& e) {
-      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
-    }
-  }
-}
-
-void MainWindow::openPackageCategoryTab(LibraryEditor& editor,
-                                        const FilePath& fp,
-                                        bool copyFrom) noexcept {
-  if (copyFrom || (!switchToLibraryElementTab<PackageCategoryTab>(fp))) {
-    try {
-      std::unique_ptr<PackageCategory> cat;
-      PackageCategoryTab::Mode mode = PackageCategoryTab::Mode::Open;
-      if (fp.isValid() && (!copyFrom)) {
-        auto fs = TransactionalFileSystem::open(
-            fp, editor.isWritable(), &askForRestoringBackup,
-            DirectoryLockHandlerDialog::createDirectoryLockCallback());
-        cat = PackageCategory::open(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));
-      } else {
-        mode = PackageCategoryTab::Mode::New;
-        cat.reset(new PackageCategory(
-            Uuid::createRandom(), Version::fromString("0.1"),
-            mApp.getWorkspace().getSettings().userName.get(),
-            QDateTime::currentDateTime(), ElementName("New Package Category"),
-            QString(), QString()));
-        if (copyFrom) {
-          mode = PackageCategoryTab::Mode::Duplicate;
-          auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
-          std::unique_ptr<PackageCategory> src =
-              PackageCategory::open(std::unique_ptr<TransactionalDirectory>(
-                  new TransactionalDirectory(fs)));
-          duplicateLibraryElement(*cat, *src);
-        }
-      }
-      addTab(
-          std::make_shared<PackageCategoryTab>(editor, std::move(cat), mode));
-    } catch (const UserCanceled& e) {
-    } catch (const Exception& e) {
-      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
-    }
-  }
-}
-
-void MainWindow::openSymbolTab(LibraryEditor& editor, const FilePath& fp,
-                               bool copyFrom) noexcept {
-  if (copyFrom || (!switchToLibraryElementTab<SymbolTab>(fp))) {
-    try {
-      std::unique_ptr<Symbol> sym;
-      SymbolTab::Mode mode = SymbolTab::Mode::Open;
-      if (fp.isValid() && (!copyFrom)) {
-        auto fs = TransactionalFileSystem::open(
-            fp, editor.isWritable(), &askForRestoringBackup,
-            DirectoryLockHandlerDialog::createDirectoryLockCallback());
-        sym = Symbol::open(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));
-      } else {
-        mode = SymbolTab::Mode::New;
-        sym.reset(new Symbol(Uuid::createRandom(), Version::fromString("0.1"),
-                             mApp.getWorkspace().getSettings().userName.get(),
-                             QDateTime::currentDateTime(),
-                             ElementName("New Symbol"), QString(), QString()));
-        if (copyFrom) {
-          mode = SymbolTab::Mode::Duplicate;
-          auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
-          std::unique_ptr<Symbol> src =
-              Symbol::open(std::unique_ptr<TransactionalDirectory>(
-                  new TransactionalDirectory(fs)));
-          duplicateLibraryElement(*sym, *src);
-        }
-      }
-      addTab(std::make_shared<SymbolTab>(editor, std::move(sym), mode));
-    } catch (const UserCanceled& e) {
-    } catch (const Exception& e) {
-      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
-    }
-  }
-}
-
-void MainWindow::openPackageTab(LibraryEditor& editor, const FilePath& fp,
-                                bool copyFrom) noexcept {
-  if (copyFrom || (!switchToLibraryElementTab<PackageTab>(fp))) {
-    try {
-      std::unique_ptr<Package> pkg;
-      PackageTab::Mode mode = PackageTab::Mode::Open;
-      if (fp.isValid() && (!copyFrom)) {
-        auto fs = TransactionalFileSystem::open(
-            fp, editor.isWritable(), &askForRestoringBackup,
-            DirectoryLockHandlerDialog::createDirectoryLockCallback());
-        pkg = Package::open(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));
-      } else {
-        mode = PackageTab::Mode::New;
-        pkg.reset(new Package(Uuid::createRandom(), Version::fromString("0.1"),
-                              mApp.getWorkspace().getSettings().userName.get(),
-                              QDateTime::currentDateTime(),
-                              ElementName("New Package"), QString(), QString(),
-                              Package::AssemblyType::Auto));
-        if (copyFrom) {
-          mode = PackageTab::Mode::Duplicate;
-          auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
-          std::unique_ptr<Package> src =
-              Package::open(std::unique_ptr<TransactionalDirectory>(
-                  new TransactionalDirectory(fs)));
-          duplicateLibraryElement(*pkg, *src);
-        } else {
-          pkg->getFootprints().append(std::make_shared<Footprint>(
-              Uuid::createRandom(), ElementName("default"), ""));
-        }
-      }
-      addTab(std::make_shared<PackageTab>(editor, std::move(pkg), mode));
-    } catch (const UserCanceled& e) {
-    } catch (const Exception& e) {
-      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
-    }
-  }
-}
-
-void MainWindow::openComponentTab(LibraryEditor& editor, const FilePath& fp,
-                                  bool copyFrom) noexcept {
-  if (copyFrom || (!switchToLibraryElementTab<ComponentTab>(fp))) {
-    try {
-      std::unique_ptr<Component> cmp;
-      ComponentTab::Mode mode = ComponentTab::Mode::Open;
-      if (fp.isValid() && (!copyFrom)) {
-        auto fs = TransactionalFileSystem::open(
-            fp, editor.isWritable(), &askForRestoringBackup,
-            DirectoryLockHandlerDialog::createDirectoryLockCallback());
-        cmp = Component::open(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));
-      } else {
-        mode = ComponentTab::Mode::New;
-        cmp.reset(
-            new Component(Uuid::createRandom(), Version::fromString("0.1"),
-                          mApp.getWorkspace().getSettings().userName.get(),
-                          QDateTime::currentDateTime(),
-                          ElementName("New Component"), QString(), QString()));
-        if (copyFrom) {
-          mode = ComponentTab::Mode::Duplicate;
-          auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
-          std::unique_ptr<Component> src =
-              Component::open(std::unique_ptr<TransactionalDirectory>(
-                  new TransactionalDirectory(fs)));
-          duplicateLibraryElement(*cmp, *src);
-        } else {
-          cmp->getSymbolVariants().append(
-              std::make_shared<ComponentSymbolVariant>(
-                  Uuid::createRandom(), "", ElementName("default"), ""));
-        }
-      }
-      addTab(std::make_shared<ComponentTab>(editor, std::move(cmp), mode));
-    } catch (const UserCanceled& e) {
-    } catch (const Exception& e) {
-      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
-    }
-  }
-}
-
-void MainWindow::openDeviceTab(LibraryEditor& editor, const FilePath& fp,
-                               bool copyFrom) noexcept {
-  if (copyFrom || (!switchToLibraryElementTab<DeviceTab>(fp))) {
-    try {
-      std::unique_ptr<Device> dev;
-      DeviceTab::Mode mode = DeviceTab::Mode::Open;
-      if (fp.isValid() && (!copyFrom)) {
-        auto fs = TransactionalFileSystem::open(
-            fp, editor.isWritable(), &askForRestoringBackup,
-            DirectoryLockHandlerDialog::createDirectoryLockCallback());
-        dev = Device::open(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));
-      } else {
-        mode = DeviceTab::Mode::New;
-        dev.reset(new Device(Uuid::createRandom(), Version::fromString("0.1"),
-                             mApp.getWorkspace().getSettings().userName.get(),
-                             QDateTime::currentDateTime(),
-                             ElementName("New Device"), QString(), QString(),
-                             Uuid::createRandom(), Uuid::createRandom()));
-        if (copyFrom) {
-          mode = DeviceTab::Mode::Duplicate;
-          auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
-          std::unique_ptr<Device> src =
-              Device::open(std::unique_ptr<TransactionalDirectory>(
-                  new TransactionalDirectory(fs)));
-          duplicateLibraryElement(*dev, *src);
-        }
-      }
-      addTab(std::make_shared<DeviceTab>(editor, std::move(dev), mode));
-    } catch (const UserCanceled& e) {
-    } catch (const Exception& e) {
-      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
-    }
-  }
-}
-
-void MainWindow::openOrganizationTab(LibraryEditor& editor, const FilePath& fp,
-                                     bool copyFrom) noexcept {
-  if (copyFrom || (!switchToLibraryElementTab<OrganizationTab>(fp))) {
-    try {
-      std::unique_ptr<Organization> org;
-      OrganizationTab::Mode mode = OrganizationTab::Mode::Open;
-      if (fp.isValid() && (!copyFrom)) {
-        auto fs = TransactionalFileSystem::open(
-            fp, editor.isWritable(), &askForRestoringBackup,
-            DirectoryLockHandlerDialog::createDirectoryLockCallback());
-        org = Organization::open(std::unique_ptr<TransactionalDirectory>(
-            new TransactionalDirectory(fs)));
-      } else {
-        mode = OrganizationTab::Mode::New;
-        org.reset(new Organization(
-            Uuid::createRandom(), Version::fromString("0.1"),
-            mApp.getWorkspace().getSettings().userName.get(),
-            QDateTime::currentDateTime(), ElementName("New Organization"),
-            QString(), QString()));
-        if (copyFrom) {
-          mode = OrganizationTab::Mode::Duplicate;
-          auto fs = TransactionalFileSystem::openRO(fp, &askForRestoringBackup);
-          std::unique_ptr<Organization> src =
-              Organization::open(std::unique_ptr<TransactionalDirectory>(
-                  new TransactionalDirectory(fs)));
-          duplicateLibraryElement(*org, *src);
-        }
-      }
-      addTab(std::make_shared<OrganizationTab>(editor, std::move(org), mode));
-    } catch (const UserCanceled& e) {
-    } catch (const Exception& e) {
-      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
-    }
-  }
-}
-
-std::shared_ptr<SchematicTab> MainWindow::openSchematicTab(int projectIndex,
-                                                           int index) noexcept {
-  if (auto tab = switchToProjectTab<SchematicTab>(projectIndex, index)) {
-    return tab;
-  } else if (auto prjEditor = mApp.getProjects().value(projectIndex)) {
-    if (auto schEditor = prjEditor->getSchematics().value(index)) {
-      auto tab = std::make_shared<SchematicTab>(mApp, *schEditor);
-      addTab(tab);
-      return tab;
-    }
-  }
-  return nullptr;
-}
-
-void MainWindow::openBoard2dTab(int projectIndex, int index,
-                                bool switchToTab) noexcept {
-  if (!switchToProjectTab<Board2dTab>(projectIndex, index)) {
-    if (auto prjEditor = mApp.getProjects().value(projectIndex)) {
-      if (auto brdEditor = prjEditor->getBoards().value(index)) {
-        addTab(std::make_shared<Board2dTab>(mApp, *brdEditor), -1, -1,
-               switchToTab, switchToTab);
-      }
-    }
-  }
-}
-
-void MainWindow::requestComponentTab(const FilePath& fp) noexcept {
-  if (auto editor = mApp.openLibrary(fp.getParentDir().getParentDir())) {
-    openComponentTab(*editor, fp, false);
-  }
-}
-
-void MainWindow::requestPackageTab(const FilePath& fp) noexcept {
-  if (auto editor = mApp.openLibrary(fp.getParentDir().getParentDir())) {
-    openPackageTab(*editor, fp, false);
-  }
-}
-
-void MainWindow::openBoard3dTab(int projectIndex, int index) noexcept {
-  if (!switchToProjectTab<Board3dTab>(projectIndex, index)) {
-    if (auto prjEditor = mApp.getProjects().value(projectIndex)) {
-      if (auto brdEditor = prjEditor->getBoards().value(index)) {
-        addTab(std::make_shared<Board3dTab>(mApp, *brdEditor));
-      }
-    }
-  }
-}
-
 void MainWindow::updateHomeTabSection() noexcept {
   for (int i = 0; i < mSections->count(); ++i) {
     mSections->at(i)->setHomeTabVisible(i == 0);
   }
+}
+
+template <typename Element, typename Tab>
+void MainWindow::openLibraryElementTab(LibraryEditor& editor,
+                                       const FilePath& fp) noexcept {
+  if (!switchToLibraryElementTab<Tab>(fp)) {
+    try {
+      auto fs = TransactionalFileSystem::open(
+          fp, editor.isWritable(), &askForRestoringBackup,
+          DirectoryLockHandlerDialog::createDirectoryLockCallback());
+      std::unique_ptr<Element> obj =
+          Element::open(std::unique_ptr<TransactionalDirectory>(
+              new TransactionalDirectory(fs)));
+      addTab(std::make_shared<Tab>(editor, std::move(obj), Tab::Mode::Open));
+    } catch (const UserCanceled& e) {
+    } catch (const Exception& e) {
+      QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
+    }
+  }
+}
+
+template <typename Element, typename Tab>
+bool MainWindow::openNewLibraryElementTab(
+    LibraryEditor& editor, const FilePath& duplicateFromFp,
+    const Element* duplicateFromObj,
+    std::function<std::unique_ptr<Element>()> factory) noexcept {
+  try {
+    auto obj = factory();
+    std::unique_ptr<Element> src;
+    if ((!duplicateFromObj) && duplicateFromFp.isValid()) {
+      auto fs = TransactionalFileSystem::openRO(duplicateFromFp,
+                                                &askForRestoringBackup);
+      src = Element::open(std::unique_ptr<TransactionalDirectory>(
+          new TransactionalDirectory(fs)));
+      duplicateFromObj = src.get();
+    }
+    if (duplicateFromObj) {
+      duplicateLibraryElement(*obj, *duplicateFromObj);
+    }
+    addTab(std::make_shared<Tab>(
+        editor, std::move(obj),
+        duplicateFromObj ? Tab::Mode::Duplicate : Tab::Mode::New));
+    return true;
+  } catch (const UserCanceled& e) {
+  } catch (const Exception& e) {
+    QMessageBox::critical(mWidget, tr("Error"), e.getMsg());
+  }
+  return false;
 }
 
 template <typename T>

--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -129,6 +129,14 @@ static LocalizedNameMap copyLibraryElementNames(const LocalizedNameMap& names) {
   return LocalizedNameMap(names.getDefaultValue());
 }
 
+template <typename T>
+static void duplicateLibraryElement(T& element, const T& other) {
+  element.duplicateFrom(other);
+  element.setCreated(QDateTime::currentDateTime());
+  element.setVersion(Version::fromString("0.1"));
+  element.setNames(copyLibraryElementNames(other.getNames()));
+}
+
 /*******************************************************************************
  *  Constructors / Destructor
  ******************************************************************************/
@@ -1022,11 +1030,7 @@ void MainWindow::openComponentCategoryTab(LibraryEditor& editor,
           std::unique_ptr<ComponentCategory> src =
               ComponentCategory::open(std::unique_ptr<TransactionalDirectory>(
                   new TransactionalDirectory(fs)));
-          cat->setNames(copyLibraryElementNames(src->getNames()));
-          cat->setDescriptions(src->getDescriptions());
-          cat->setKeywords(src->getKeywords());
-          cat->setMessageApprovals(src->getMessageApprovals());
-          cat->setParentUuid(src->getParentUuid());
+          duplicateLibraryElement(*cat, *src);
         }
       }
       addTab(
@@ -1064,11 +1068,7 @@ void MainWindow::openPackageCategoryTab(LibraryEditor& editor,
           std::unique_ptr<PackageCategory> src =
               PackageCategory::open(std::unique_ptr<TransactionalDirectory>(
                   new TransactionalDirectory(fs)));
-          cat->setNames(copyLibraryElementNames(src->getNames()));
-          cat->setDescriptions(src->getDescriptions());
-          cat->setKeywords(src->getKeywords());
-          cat->setMessageApprovals(src->getMessageApprovals());
-          cat->setParentUuid(src->getParentUuid());
+          duplicateLibraryElement(*cat, *src);
         }
       }
       addTab(
@@ -1104,56 +1104,7 @@ void MainWindow::openSymbolTab(LibraryEditor& editor, const FilePath& fp,
           std::unique_ptr<Symbol> src =
               Symbol::open(std::unique_ptr<TransactionalDirectory>(
                   new TransactionalDirectory(fs)));
-          sym->setNames(copyLibraryElementNames(src->getNames()));
-          sym->setDescriptions(src->getDescriptions());
-          sym->setKeywords(src->getKeywords());
-          sym->setMessageApprovals(src->getMessageApprovals());
-          sym->setCategories(src->getCategories());
-          sym->setResources(src->getResources());
-          sym->setGridInterval(src->getGridInterval());
-          QSet<QString> filesToCopy;
-          // Copy pins but generate new UUIDs.
-          for (const SymbolPin& pin : src->getPins()) {
-            sym->getPins().append(std::make_shared<SymbolPin>(
-                Uuid::createRandom(), pin.getName(), pin.getPosition(),
-                pin.getLength(), pin.getRotation(), pin.getNamePosition(),
-                pin.getNameRotation(), pin.getNameHeight(),
-                pin.getNameAlignment()));
-          }
-          // Copy polygons but generate new UUIDs.
-          for (const Polygon& polygon : src->getPolygons()) {
-            sym->getPolygons().append(std::make_shared<Polygon>(
-                Uuid::createRandom(), polygon.getLayer(),
-                polygon.getLineWidth(), polygon.isFilled(),
-                polygon.isGrabArea(), polygon.getPath()));
-          }
-          // Copy circles but generate new UUIDs.
-          for (const Circle& circle : src->getCircles()) {
-            sym->getCircles().append(std::make_shared<Circle>(
-                Uuid::createRandom(), circle.getLayer(), circle.getLineWidth(),
-                circle.isFilled(), circle.isGrabArea(), circle.getCenter(),
-                circle.getDiameter()));
-          }
-          // Copy texts but generate new UUIDs.
-          for (const Text& text : src->getTexts()) {
-            sym->getTexts().append(std::make_shared<Text>(
-                Uuid::createRandom(), text.getLayer(), text.getText(),
-                text.getPosition(), text.getRotation(), text.getHeight(),
-                text.getAlign(), text.isLocked()));
-          }
-          // Copy images but generate new UUIDs.
-          for (const Image& image : src->getImages()) {
-            sym->getImages().append(
-                std::make_shared<Image>(Uuid::createRandom(), image));
-            filesToCopy.insert(*image.getFileName());
-          }
-          // Copy all referenced files.
-          for (const QString& fileName : filesToCopy) {
-            if (src->getDirectory().fileExists(fileName)) {
-              sym->getDirectory().write(fileName,
-                                        src->getDirectory().read(fileName));
-            }
-          }
+          duplicateLibraryElement(*sym, *src);
         }
       }
       addTab(std::make_shared<SymbolTab>(editor, std::move(sym), mode));
@@ -1189,104 +1140,7 @@ void MainWindow::openPackageTab(LibraryEditor& editor, const FilePath& fp,
           std::unique_ptr<Package> src =
               Package::open(std::unique_ptr<TransactionalDirectory>(
                   new TransactionalDirectory(fs)));
-          pkg->setNames(copyLibraryElementNames(src->getNames()));
-          pkg->setDescriptions(src->getDescriptions());
-          pkg->setKeywords(src->getKeywords());
-          pkg->setMessageApprovals(src->getMessageApprovals());
-          pkg->setCategories(src->getCategories());
-          pkg->setResources(src->getResources());
-          pkg->setAssemblyType(src->getAssemblyType(false));
-          pkg->setGridInterval(src->getGridInterval());
-          pkg->setMinCopperClearance(src->getMinCopperClearance());
-          // Copy pads but generate new UUIDs.
-          QHash<Uuid, std::optional<Uuid>> padUuidMap;
-          for (const PackagePad& pad : src->getPads()) {
-            const Uuid newUuid = Uuid::createRandom();
-            padUuidMap.insert(pad.getUuid(), newUuid);
-            pkg->getPads().append(
-                std::make_shared<PackagePad>(newUuid, pad.getName()));
-          }
-          // Copy 3D models but generate new UUIDs.
-          QHash<Uuid, std::optional<Uuid>> modelsUuidMap;
-          for (const PackageModel& model : src->getModels()) {
-            auto newModel = std::make_shared<PackageModel>(Uuid::createRandom(),
-                                                           model.getName());
-            modelsUuidMap.insert(model.getUuid(), newModel->getUuid());
-            pkg->getModels().append(newModel);
-            const QByteArray fileContent =
-                src->getDirectory().readIfExists(model.getFileName());
-            if (!fileContent.isNull()) {
-              pkg->getDirectory().write(newModel->getFileName(), fileContent);
-            }
-          }
-          // Copy footprints but generate new UUIDs.
-          for (const Footprint& footprint : src->getFootprints()) {
-            // Don't copy translations as they would need to be adjusted anyway.
-            std::shared_ptr<Footprint> newFootprint(new Footprint(
-                Uuid::createRandom(), footprint.getNames().getDefaultValue(),
-                footprint.getDescriptions().getDefaultValue()));
-            newFootprint->setModelPosition(footprint.getModelPosition());
-            newFootprint->setModelRotation(footprint.getModelRotation());
-            // Copy models but with the new UUIDs.
-            QSet<Uuid> models;
-            foreach (const Uuid& uuid, footprint.getModels()) {
-              if (auto newUuid = modelsUuidMap.value(uuid)) {
-                models.insert(*newUuid);
-              }
-            }
-            newFootprint->setModels(models);
-            // Copy pads but generate new UUIDs.
-            for (const FootprintPad& pad : footprint.getPads()) {
-              std::optional<Uuid> pkgPad = pad.getPackagePadUuid();
-              if (pkgPad) {
-                pkgPad = padUuidMap.value(*pkgPad);  // Translate to new UUID
-              }
-              newFootprint->getPads().append(std::make_shared<FootprintPad>(
-                  Uuid::createRandom(), pkgPad, pad.getPosition(),
-                  pad.getRotation(), pad.getShape(), pad.getWidth(),
-                  pad.getHeight(), pad.getRadius(), pad.getCustomShapeOutline(),
-                  pad.getStopMaskConfig(), pad.getSolderPasteConfig(),
-                  pad.getCopperClearance(), pad.getComponentSide(),
-                  pad.getFunction(), pad.getHoles()));
-            }
-            // Copy polygons but generate new UUIDs.
-            for (const Polygon& polygon : footprint.getPolygons()) {
-              newFootprint->getPolygons().append(std::make_shared<Polygon>(
-                  Uuid::createRandom(), polygon.getLayer(),
-                  polygon.getLineWidth(), polygon.isFilled(),
-                  polygon.isGrabArea(), polygon.getPath()));
-            }
-            // Copy circles but generate new UUIDs.
-            for (const Circle& circle : footprint.getCircles()) {
-              newFootprint->getCircles().append(std::make_shared<Circle>(
-                  Uuid::createRandom(), circle.getLayer(),
-                  circle.getLineWidth(), circle.isFilled(), circle.isGrabArea(),
-                  circle.getCenter(), circle.getDiameter()));
-            }
-            // Copy stroke texts but generate new UUIDs.
-            for (const StrokeText& text : footprint.getStrokeTexts()) {
-              newFootprint->getStrokeTexts().append(
-                  std::make_shared<StrokeText>(
-                      Uuid::createRandom(), text.getLayer(), text.getText(),
-                      text.getPosition(), text.getRotation(), text.getHeight(),
-                      text.getStrokeWidth(), text.getLetterSpacing(),
-                      text.getLineSpacing(), text.getAlign(),
-                      text.getMirrored(), text.getAutoRotate(),
-                      text.isLocked()));
-            }
-            // Copy zones but generate new UUIDs.
-            for (const Zone& zone : footprint.getZones()) {
-              newFootprint->getZones().append(
-                  std::make_shared<Zone>(Uuid::createRandom(), zone));
-            }
-            // Copy holes but generate new UUIDs.
-            for (const Hole& hole : footprint.getHoles()) {
-              newFootprint->getHoles().append(std::make_shared<Hole>(
-                  Uuid::createRandom(), hole.getDiameter(), hole.getPath(),
-                  hole.getStopMaskConfig()));
-            }
-            pkg->getFootprints().append(newFootprint);
-          }
+          duplicateLibraryElement(*pkg, *src);
         } else {
           pkg->getFootprints().append(std::make_shared<Footprint>(
               Uuid::createRandom(), ElementName("default"), ""));
@@ -1325,57 +1179,7 @@ void MainWindow::openComponentTab(LibraryEditor& editor, const FilePath& fp,
           std::unique_ptr<Component> src =
               Component::open(std::unique_ptr<TransactionalDirectory>(
                   new TransactionalDirectory(fs)));
-          cmp->setNames(copyLibraryElementNames(src->getNames()));
-          cmp->setDescriptions(src->getDescriptions());
-          cmp->setKeywords(src->getKeywords());
-          cmp->setMessageApprovals(src->getMessageApprovals());
-          cmp->setCategories(src->getCategories());
-          cmp->setResources(src->getResources());
-          cmp->setIsSchematicOnly(src->isSchematicOnly());
-          cmp->getAttributes() = src->getAttributes();
-          cmp->setDefaultValue(src->getDefaultValue());
-          cmp->setPrefixes(src->getPrefixes());
-          // Copy signals but generate new UUIDs.
-          QHash<Uuid, Uuid> signalUuidMap;
-          for (const ComponentSignal& signal : src->getSignals()) {
-            const Uuid newUuid = Uuid::createRandom();
-            signalUuidMap.insert(signal.getUuid(), newUuid);
-            cmp->getSignals().append(std::make_shared<ComponentSignal>(
-                newUuid, signal.getName(), signal.getRole(),
-                signal.getForcedNetName(), signal.isRequired(),
-                signal.isNegated(), signal.isClock()));
-          }
-          // Copy symbol variants but generate new UUIDs.
-          for (const ComponentSymbolVariant& var : src->getSymbolVariants()) {
-            // don't copy translations as they would need to be adjusted anyway
-            std::shared_ptr<ComponentSymbolVariant> copy(
-                new ComponentSymbolVariant(
-                    Uuid::createRandom(), var.getNorm(),
-                    var.getNames().getDefaultValue(),
-                    var.getDescriptions().getDefaultValue()));
-            // Copy gates.
-            for (const ComponentSymbolVariantItem& item :
-                 var.getSymbolItems()) {
-              std::shared_ptr<ComponentSymbolVariantItem> gateCopy(
-                  new ComponentSymbolVariantItem(
-                      Uuid::createRandom(), item.getSymbolUuid(),
-                      item.getSymbolPosition(), item.getSymbolRotation(),
-                      item.isRequired(), item.getSuffix()));
-              // Copy pin-signal-map.
-              for (const ComponentPinSignalMapItem& map :
-                   item.getPinSignalMap()) {
-                std::optional<Uuid> signal = map.getSignalUuid();
-                if (signal) {
-                  signal = *signalUuidMap.find(*map.getSignalUuid());
-                }
-                gateCopy->getPinSignalMap().append(
-                    std::make_shared<ComponentPinSignalMapItem>(
-                        map.getPinUuid(), signal, map.getDisplayType()));
-              }
-              copy->getSymbolItems().append(gateCopy);
-            }
-            cmp->getSymbolVariants().append(copy);
-          }
+          duplicateLibraryElement(*cmp, *src);
         } else {
           cmp->getSymbolVariants().append(
               std::make_shared<ComponentSymbolVariant>(
@@ -1415,17 +1219,7 @@ void MainWindow::openDeviceTab(LibraryEditor& editor, const FilePath& fp,
           std::unique_ptr<Device> src =
               Device::open(std::unique_ptr<TransactionalDirectory>(
                   new TransactionalDirectory(fs)));
-          dev->setNames(copyLibraryElementNames(src->getNames()));
-          dev->setDescriptions(src->getDescriptions());
-          dev->setKeywords(src->getKeywords());
-          dev->setMessageApprovals(src->getMessageApprovals());
-          dev->setCategories(src->getCategories());
-          dev->setResources(src->getResources());
-          dev->setComponentUuid(src->getComponentUuid());
-          dev->setPackageUuid(src->getPackageUuid());
-          dev->getPadSignalMap() = src->getPadSignalMap();
-          dev->getAttributes() = src->getAttributes();
-          dev->getParts() = src->getParts();
+          duplicateLibraryElement(*dev, *src);
         }
       }
       addTab(std::make_shared<DeviceTab>(editor, std::move(dev), mode));
@@ -1461,21 +1255,7 @@ void MainWindow::openOrganizationTab(LibraryEditor& editor, const FilePath& fp,
           std::unique_ptr<Organization> src =
               Organization::open(std::unique_ptr<TransactionalDirectory>(
                   new TransactionalDirectory(fs)));
-          org->setNames(copyLibraryElementNames(src->getNames()));
-          org->setDescriptions(src->getDescriptions());
-          org->setKeywords(src->getKeywords());
-          org->setMessageApprovals(src->getMessageApprovals());
-          org->setLogoPng(src->getLogoPng());
-          org->setUrl(src->getUrl());
-          org->setCountry(src->getCountry());
-          org->setFabs(src->getFabs());
-          org->setShipping(src->getShipping());
-          org->setIsSponsor(src->isSponsor());
-          org->setPriority(src->getPriority());
-          org->setPcbDesignRules(src->getPcbDesignRules());
-          org->setPcbOutputJobs(src->getPcbOutputJobs());
-          org->setAssemblyOutputJobs(src->getAssemblyOutputJobs());
-          org->setUserOutputJobs(src->getUserOutputJobs());
+          duplicateLibraryElement(*org, *src);
         }
       }
       addTab(std::make_shared<OrganizationTab>(editor, std::move(org), mode));

--- a/libs/librepcb/editor/mainwindow.h
+++ b/libs/librepcb/editor/mainwindow.h
@@ -26,6 +26,7 @@
 #include "ui.h"
 #include "utils/uiobjectlist.h"
 
+#include <librepcb/core/fileio/filepath.h>
 #include <librepcb/core/utils/signalslot.h>
 
 #include <QtCore>
@@ -37,8 +38,14 @@
  ******************************************************************************/
 namespace librepcb {
 
-class FilePath;
+class Component;
+class ComponentCategory;
+class Device;
+class Organization;
+class Package;
+class PackageCategory;
 class RuleCheckMessage;
+class Symbol;
 
 namespace editor {
 
@@ -94,10 +101,42 @@ public:
                            bool zoomTo) noexcept;
   void setCurrentLibrary(int index) noexcept;
   void setCurrentProject(int index) noexcept;
+  void openLibraryTab(const FilePath& fp, bool wizardMode) noexcept;
+  void openComponentCategoryTab(LibraryEditor& editor,
+                                const FilePath& fp) noexcept;
+  bool openNewComponentCategoryTab(
+      LibraryEditor& editor, const FilePath& duplicateFromFp = {},
+      const ComponentCategory* duplicateFromObj = nullptr) noexcept;
+  void openPackageCategoryTab(LibraryEditor& editor,
+                              const FilePath& fp) noexcept;
+  bool openNewPackageCategoryTab(
+      LibraryEditor& editor, const FilePath& duplicateFromFp = {},
+      const PackageCategory* duplicateFromObj = nullptr) noexcept;
+  void openSymbolTab(LibraryEditor& editor, const FilePath& fp) noexcept;
+  bool openNewSymbolTab(LibraryEditor& editor,
+                        const FilePath& duplicateFromFp = {},
+                        const Symbol* duplicateFromObj = nullptr) noexcept;
+  void openPackageTab(LibraryEditor& editor, const FilePath& fp) noexcept;
+  bool openNewPackageTab(LibraryEditor& editor,
+                         const FilePath& duplicateFromFp = {},
+                         const Package* duplicateFromObj = nullptr) noexcept;
+  void openComponentTab(LibraryEditor& editor, const FilePath& fp) noexcept;
+  bool openNewComponentTab(
+      LibraryEditor& editor, const FilePath& duplicateFromFp = {},
+      const Component* duplicateFromObj = nullptr) noexcept;
+  void openDeviceTab(LibraryEditor& editor, const FilePath& fp) noexcept;
+  bool openNewDeviceTab(LibraryEditor& editor,
+                        const FilePath& duplicateFromFp = {},
+                        const Device* duplicateFromObj = nullptr) noexcept;
+  void openOrganizationTab(LibraryEditor& editor, const FilePath& fp) noexcept;
+  bool openNewOrganizationTab(
+      LibraryEditor& editor, const FilePath& duplicateFromFp = {},
+      const Organization* duplicateFromObj = nullptr) noexcept;
   std::shared_ptr<SchematicTab> openSchematicTab(int projectIndex,
                                                  int index) noexcept;
   void openBoard2dTab(int projectIndex, int index,
                       bool switchToTab = true) noexcept;
+  void openBoard3dTab(int projectIndex, int index) noexcept;
   void requestComponentTab(const FilePath& fp) noexcept;
   void requestPackageTab(const FilePath& fp) noexcept;
 
@@ -119,23 +158,15 @@ private:
   void triggerSchematic(int project, int schematic,
                         ui::SchematicAction a) noexcept;
   void triggerBoard(int project, int board, ui::BoardAction a) noexcept;
-  void openLibraryTab(const FilePath& fp, bool wizardMode) noexcept;
-  void openComponentCategoryTab(LibraryEditor& editor, const FilePath& fp,
-                                bool copyFrom) noexcept;
-  void openPackageCategoryTab(LibraryEditor& editor, const FilePath& fp,
-                              bool copyFrom) noexcept;
-  void openSymbolTab(LibraryEditor& editor, const FilePath& fp,
-                     bool copyFrom) noexcept;
-  void openPackageTab(LibraryEditor& editor, const FilePath& fp,
-                      bool copyFrom) noexcept;
-  void openComponentTab(LibraryEditor& editor, const FilePath& fp,
-                        bool copyFrom) noexcept;
-  void openDeviceTab(LibraryEditor& editor, const FilePath& fp,
-                     bool copyFrom) noexcept;
-  void openOrganizationTab(LibraryEditor& editor, const FilePath& fp,
-                           bool copyFrom) noexcept;
-  void openBoard3dTab(int projectIndex, int index) noexcept;
   void updateHomeTabSection() noexcept;
+  template <typename Element, typename Tab>
+  void openLibraryElementTab(LibraryEditor& editor,
+                             const FilePath& fp) noexcept;
+  template <typename Element, typename Tab>
+  bool openNewLibraryElementTab(
+      LibraryEditor& editor, const FilePath& duplicateFromFp,
+      const Element* duplicateFromObj,
+      std::function<std::unique_ptr<Element>()> factory) noexcept;
   template <typename T>
   bool switchToTab() noexcept;
   template <typename T>

--- a/libs/librepcb/editor/windowsection.cpp
+++ b/libs/librepcb/editor/windowsection.cpp
@@ -129,8 +129,6 @@ void WindowSection::addTab(std::shared_ptr<WindowTab> tab, int index,
   // from the UI, we have to close it immediately to avoid dangling references.
   connect(tab.get(), &WindowTab::closeEnforced, this,
           &WindowSection::tabCloseRequested);
-  connect(tab.get(), &WindowTab::panelPageRequested, this,
-          &WindowSection::panelPageRequested);
   connect(tab.get(), &WindowTab::statusBarMessageChanged, this,
           &WindowSection::statusBarMessageChanged);
   connect(tab.get(), &WindowTab::cursorCoordinatesChanged, this,
@@ -165,8 +163,6 @@ std::shared_ptr<WindowTab> WindowSection::removeTab(int index,
                &WindowSection::tabCloseRequested);
     disconnect(tab.get(), &WindowTab::closeEnforced, this,
                &WindowSection::tabCloseRequested);
-    disconnect(tab.get(), &WindowTab::panelPageRequested, this,
-               &WindowSection::panelPageRequested);
     disconnect(tab.get(), &WindowTab::statusBarMessageChanged, this,
                &WindowSection::statusBarMessageChanged);
     disconnect(tab.get(), &WindowTab::cursorCoordinatesChanged, this,

--- a/libs/librepcb/editor/windowsection.h
+++ b/libs/librepcb/editor/windowsection.h
@@ -147,7 +147,6 @@ public:
 
 signals:
   void currentTabChanged();
-  void panelPageRequested(ui::PanelPage p);
   void derivedUiDataChanged(std::size_t index);
   void statusBarMessageChanged(const QString& message, int timeoutMs);
   void cursorCoordinatesChanged(const Point& pos, const LengthUnit& unit);

--- a/libs/librepcb/editor/windowtab.h
+++ b/libs/librepcb/editor/windowtab.h
@@ -100,7 +100,6 @@ public:
   WindowTab& operator=(const WindowTab& rhs) = delete;
 
 signals:
-  void panelPageRequested(ui::PanelPage p);
   void closeRequested();
   void closeEnforced();
   void statusBarMessageChanged(const QString& message, int timeoutMs);

--- a/libs/librepcb/ui/api/data.slint
+++ b/libs/librepcb/ui/api/data.slint
@@ -646,6 +646,7 @@ export global Data {
                     description: "Foo Bar\nMultiline\nBlabla",
                     keywords: "Foo,Bar,Hello World",
                     author: "Somebody",
+                    age-days: 100,
                     version: "0.1",
                     deprecated: false,
                     categories: [
@@ -696,6 +697,7 @@ export global Data {
                     overlay-text-color: Colors.black,
                     files-modified: true,
                     interface-broken-msg: true,
+                    element-duplicated-msg: true,
                     import-pins-msg: {
                         visible: true,
                         supports-dont-show-again: false,

--- a/libs/librepcb/ui/api/types.slint
+++ b/libs/librepcb/ui/api/types.slint
@@ -687,6 +687,7 @@ export enum TabAction {
 
     // General
     save,
+    save-as,
     reload-from-disk,
     print,
     export-image,
@@ -973,6 +974,7 @@ export struct SymbolTabData {
     description: string,
     keywords: string,
     author: string,
+    age-days: float,
     version: string,
     version-error: string,
     deprecated: bool,
@@ -995,6 +997,7 @@ export struct SymbolTabData {
     // Messages
     files-modified: bool,  // From the file system watcher
     interface-broken-msg: bool,
+    element-duplicated-msg: bool,
     import-pins-msg: DismissableMessageData,
 
     // Data about the currently active tool
@@ -1035,6 +1038,7 @@ export struct PackageTabData {
     description: string,
     keywords: string,
     author: string,
+    age-days: float,
     version: string,
     version-error: string,
     deprecated: bool,
@@ -1074,6 +1078,7 @@ export struct PackageTabData {
     // Messages
     files-modified: bool,  // From the file system watcher
     interface-broken-msg: bool,
+    element-duplicated-msg: bool,
 
     // Data about the currently active tool
     tool: EditorTool,
@@ -1126,6 +1131,7 @@ export struct ComponentTabData {
     description: string,
     keywords: string,
     author: string,
+    age-days: float,
     version: string,
     version-error: string,
     deprecated: bool,
@@ -1154,6 +1160,7 @@ export struct ComponentTabData {
 
     // Messages
     interface-broken-msg: bool,
+    element-duplicated-msg: bool,
 
     // Actions
     new-category: string,  // Set to UUID by UI, reset by backend
@@ -1173,6 +1180,7 @@ export struct DeviceTabData {
     description: string,
     keywords: string,
     author: string,
+    age-days: float,
     version: string,
     version-error: string,
     deprecated: bool,
@@ -1203,6 +1211,7 @@ export struct DeviceTabData {
 
     // Messages
     interface-broken-msg: bool,
+    element-duplicated-msg: bool,
 
     // Pinout assignment
     has-unconnected-pads: bool,

--- a/libs/librepcb/ui/library/cmp/componenttab.slint
+++ b/libs/librepcb/ui/library/cmp/componenttab.slint
@@ -23,6 +23,7 @@ import {
 import {
     BreakingChangesMessageBanner,
     CheckErrorsMessageBanner,
+    ElementDuplicatedMessageBanner,
 } from "../messagebanners.slint";
 import {
     WizardHeaderPanel,
@@ -551,6 +552,25 @@ export component ComponentTab inherits Tab {
     VerticalLayout {
         BreakingChangesMessageBanner {
             shown: tabs[index].interface-broken-msg;
+            is-unlocked: !read-only;
+            age-days: tabs[index].age-days;
+
+            action-invoked(action) => {
+                Backend.trigger-tab(section-index, index, action);
+            }
+        }
+
+        ElementDuplicatedMessageBanner {
+            shown: tabs[index].element-duplicated-msg;
+
+            deprecate-clicked => {
+                tabs[index].deprecated = true;
+                Backend.trigger-tab(section-index, index, TabAction.apply);
+            }
+
+            cancel-clicked => {
+                tabs[index].element-duplicated-msg = false;
+            }
         }
 
         CheckErrorsMessageBanner {

--- a/libs/librepcb/ui/library/dev/devicepinoutlistview.slint
+++ b/libs/librepcb/ui/library/dev/devicepinoutlistview.slint
@@ -4,6 +4,7 @@ import { Data, DevicePinoutData } from "../../api.slint";
 export component DevicePinoutListView inherits ScrollView {
     in-out property <[DevicePinoutData]> model;
     in-out property <[string]> signal-names;
+    in property <bool> read-only;
     in property <length> window-height;
     property <length> row-height: 25px;
 
@@ -45,6 +46,7 @@ export component DevicePinoutListView inherits ScrollView {
                     current-index: item.signal-index;
                     editable-only-when-focused: true;
                     enabled: self.model.length > 1;  // If component signals available
+                    read-only: read-only;
                     accessible-label: "signal of pad " + item.pad-name;
 
                     current-index-changed(idx) => {

--- a/libs/librepcb/ui/library/dev/devicepinoutpanel.slint
+++ b/libs/librepcb/ui/library/dev/devicepinoutpanel.slint
@@ -93,6 +93,7 @@ component DevicePinoutShortcutsOverlay inherits GridLayout {
 component DeviceInteractiveSignalListView inherits ScrollView {
     in-out property <[DeviceInteractivePinoutSignalData]> model;
     in property <int> current-index;
+    in property <bool> read-only;
 
     min-height: min(l.preferred-height, 50px);
     min-width: l.min-width;
@@ -105,6 +106,7 @@ component DeviceInteractiveSignalListView inherits ScrollView {
     l := VerticalLayout {
         for item[index] in model: item-ta := TouchArea {
             mouse-cursor: pointer;
+            enabled: !read-only;
 
             Rectangle {
                 property <bool> is-current: index == current-index;
@@ -215,7 +217,7 @@ export component DevicePinoutPanel inherits Rectangle {
                 }
             }
 
-            if (!interactive) && (tabs[index].pinout.length > 0): reset-btn := IconButton {
+            if (!read-only) && (!interactive) && (tabs[index].pinout.length > 0): reset-btn := IconButton {
                 height: 18px;
                 style: hyperlink;
                 icon: @image-url("../../../../bootstrap-icons/icons/bootstrap-reboot.svg");
@@ -279,6 +281,7 @@ export component DevicePinoutPanel inherits Rectangle {
                         placeholder-text: @tr("Type to filter signals...");
                         border-color: transparent;
                         frameless: true;
+                        read-only: read-only;
                         accessible-label: "signal filter";
 
                         // Actually we want to gain the focus in the init()
@@ -335,6 +338,7 @@ export component DevicePinoutPanel inherits Rectangle {
                     vertical-stretch: 1;
                     model: tabs[index].interactive-pinout-signals;
                     current-index: tabs[index].interactive-pinout-signal-index;
+                    read-only: read-only;
 
                     signal-clicked(idx) => {
                         tabs[index].interactive-pinout-signal-index = idx;
@@ -347,6 +351,7 @@ export component DevicePinoutPanel inherits Rectangle {
                     window-height: window-height;
                     model: tabs[index].pinout;
                     signal-names: tabs[index].signal-names;
+                    read-only: read-only;
                     visible: !interactive;
                 }
 
@@ -370,7 +375,7 @@ export component DevicePinoutPanel inherits Rectangle {
                         text: @tr("The package contains no pads, thus the pinout is empty.");
                     }
 
-                    if tabs[index].has-auto-connectable-pads: auto-connect-btn := Button {
+                    if (!read-only) && tabs[index].has-auto-connectable-pads: auto-connect-btn := Button {
                         text: @tr("Auto-Connect By Names");
                         icon: @image-url("../../../../font-awesome/svgs/solid/wand-magic-sparkles.svg");
                         status-tip: @tr("Try to automatically connect pads to signals by their name");
@@ -381,7 +386,7 @@ export component DevicePinoutPanel inherits Rectangle {
                         }
                     }
 
-                    if tabs[index].has-unconnected-pads: interactive-connect-btn := Button {
+                    if (!read-only) && tabs[index].has-unconnected-pads: interactive-connect-btn := Button {
                         text: @tr("Connect Interactively");
                         icon: @image-url("../../../../font-awesome/svgs/solid/hand-sparkles.svg");
                         status-tip: @tr("Connect the remaining pads one by one in an interactive mode");
@@ -392,7 +397,7 @@ export component DevicePinoutPanel inherits Rectangle {
                         }
                     }
 
-                    if tabs[index].all-pads-unconnected: import-btn := Button {
+                    if (!read-only) && tabs[index].all-pads-unconnected: import-btn := Button {
                         text: @tr("Load From File");
                         icon: @image-url("../../../../font-awesome/svgs/solid/arrow-up-from-bracket.svg");
                         status-tip: @tr("Import the pinout from a CSV file with these columns:") + " Pad,Signal";

--- a/libs/librepcb/ui/library/dev/devicetab.slint
+++ b/libs/librepcb/ui/library/dev/devicetab.slint
@@ -21,6 +21,7 @@ import {
 import {
     BreakingChangesMessageBanner,
     CheckErrorsMessageBanner,
+    ElementDuplicatedMessageBanner,
 } from "../messagebanners.slint";
 import { WizardHeader } from "../wizardheader.slint";
 import {
@@ -494,6 +495,25 @@ export component DeviceTab inherits Tab {
     VerticalLayout {
         BreakingChangesMessageBanner {
             shown: tabs[index].interface-broken-msg;
+            is-unlocked: !read-only;
+            age-days: tabs[index].age-days;
+
+            action-invoked(action) => {
+                Backend.trigger-tab(section-index, index, action);
+            }
+        }
+
+        ElementDuplicatedMessageBanner {
+            shown: tabs[index].element-duplicated-msg;
+
+            deprecate-clicked => {
+                tabs[index].deprecated = true;
+                Backend.trigger-tab(section-index, index, TabAction.apply);
+            }
+
+            cancel-clicked => {
+                tabs[index].element-duplicated-msg = false;
+            }
         }
 
         CheckErrorsMessageBanner {

--- a/libs/librepcb/ui/library/messagebanners.slint
+++ b/libs/librepcb/ui/library/messagebanners.slint
@@ -1,11 +1,163 @@
 import {
     Button,
+    LinkText,
     MessageBanner,
 } from "../widgets.slint";
-import { Data } from "../api.slint";
+import {
+    Data,
+    EditorCommandSet as Cmd,
+    TabAction,
+} from "../api.slint";
 
 export component BreakingChangesMessageBanner inherits MessageBanner {
-    text: @tr("Attention").to-uppercase() + ": " + @tr("You have changed some important properties of this library element. This is a serious issue as it breaks all dependent library elements! If this library element is already used somewhere, it is highly recommended to create a new one instead of modifying this one.");
+    in property <bool> is-unlocked;
+    in property <float> age-days;
+    property <bool> unlock-btn-hovered: false;
+    property <string> unlock-hover-text: @tr("If you are 100% sure that this library element is not referenced from any other library elements or projects yet, you may click & hold this button to remove the write protection. In case it is already used, this can end up in a fiasco! If in doubt, create a duplicate.");
+
+    background: Data.theme.error;
+    text-color: Data.theme.error-text;
+
+    callback action-invoked(action: TabAction);
+
+    HorizontalLayout {
+        spacing: 5px;
+
+        VerticalLayout {
+            alignment: center;
+
+            Text {
+                color: root.text-color;
+                font-weight: 700;
+                horizontal-alignment: left;
+                wrap: word-wrap;
+                text: @tr("Attention").to-uppercase() + ": " + @tr("Some of the applied modifications are not backward-compatible!");
+            }
+
+            if !is-unlocked: Rectangle {
+                Text {
+                    width: 100%;
+                    height: 100%;
+                    color: root.text-color;
+                    horizontal-alignment: left;
+                    wrap: word-wrap;
+                    text: @tr("To avoid breaking other library elements or projects which reference this element, the editor has been put into read-only mode and saving is not possible anymore. Either undo the breaking changes, or duplicate this library element and make the modifications in the new library element.");
+                    visible: !unlock-btn-hovered;
+                }
+
+                Text {
+                    width: 100%;
+                    height: 100%;
+                    color: root.text-color;
+                    horizontal-alignment: left;
+                    wrap: word-wrap;
+                    font-italic: true;
+                    text: unlock-hover-text;
+                    visible: unlock-btn-hovered;
+                    accessible-role: none;
+                }
+            }
+
+            if is-unlocked: Text {
+                color: root.text-color;
+                horizontal-alignment: left;
+                wrap: word-wrap;
+                font-italic: true;
+                text: @tr("You have removed the write protection. Keep in mind: With great power comes great responsibility!");
+            }
+        }
+
+        VerticalLayout {
+            width: self.preferred-width;
+            alignment: center;
+            spacing: 5px;
+
+            duplicate-btn := Button {
+                icon: @image-url("../../../font-awesome/svgs/solid/arrow-up-right-from-square.svg");
+                text: @tr("Duplicate");
+                status-tip: @tr("Create a new library element by duplicating this one");
+                primary: true;
+
+                clicked => {
+                    action-invoked(TabAction.save-as);
+                }
+            }
+
+            if !is-unlocked: unlock-btn := Button {
+                icon: @image-url("../../../font-awesome/svgs/solid/lock-open.svg");
+                text: @tr("Unlock").to-uppercase();
+                accessible-description: unlock-hover-text;
+
+                changed has-hover => {
+                    unlock-btn-hovered = self.has-hover;
+                }
+
+                if self.pressed: Rectangle {
+                    width: parent.width - 4px;
+                    height: parent.height - 4px;
+                    background: Data.theme.control;
+
+                    Rectangle {
+                        property <float> progress: 0.1;
+
+                        x: 0;
+                        width: parent.width * min(progress, 1);
+                        background: Data.theme.error;
+
+                        Timer {
+                            running: true;
+                            interval: 15ms;
+
+                            triggered => {
+                                progress = progress + 0.02 * (1 - clamp(age-days / 30, 0, 0.7));
+                                if progress > 1 {
+                                    self.running = false;
+                                    action-invoked(TabAction.unlock);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+export component ElementDuplicatedMessageBanner inherits MessageBanner {
+    background: Data.theme.info;
+
+    callback deprecate-clicked <=> deprecate-btn.clicked;
+    callback cancel-clicked <=> cancel-btn.clicked;
+
+    HorizontalLayout {
+        spacing: 5px;
+
+        VerticalLayout {
+            alignment: center;
+
+            Text {
+                color: Data.theme.info-text;
+                horizontal-alignment: left;
+                wrap: word-wrap;
+                text: @tr("This library element has been duplicated. Mark it as deprecated?");
+            }
+        }
+
+        deprecate-btn := Button {
+            y: (parent.height - self.height) / 2;
+            width: self.preferred-width;
+            text: @tr("Deprecate");
+            status-tip: @tr("Mark this library element as deprecated");
+            border-width: 1px;
+            primary: true;
+        }
+
+        cancel-btn := Button {
+            y: (parent.height - self.height) / 2;
+            width: self.preferred-width;
+            text: @tr("Cancel");
+        }
+    }
 }
 
 export component CheckErrorsMessageBanner inherits MessageBanner {
@@ -21,7 +173,6 @@ export component FilesModifiedMessageBanner inherits MessageBanner {
         spacing: 5px;
 
         VerticalLayout {
-            horizontal-stretch: 1;
             alignment: center;
 
             Text {
@@ -42,7 +193,7 @@ export component FilesModifiedMessageBanner inherits MessageBanner {
 
         reload-btn := Button {
             y: (parent.height - self.height) / 2;
-            horizontal-stretch: 0;
+            width: self.preferred-width;
             text: @tr("Reload");
             status-tip: @tr("Discard modifications (if any) and reload the modified files from disk");
         }

--- a/libs/librepcb/ui/library/pkg/packagetab.slint
+++ b/libs/librepcb/ui/library/pkg/packagetab.slint
@@ -31,6 +31,7 @@ import {
 import {
     BreakingChangesMessageBanner,
     CheckErrorsMessageBanner,
+    ElementDuplicatedMessageBanner,
     FilesModifiedMessageBanner,
 } from "../messagebanners.slint";
 import {
@@ -1070,6 +1071,25 @@ export component PackageTab inherits Tab {
 
         BreakingChangesMessageBanner {
             shown: tabs[index].interface-broken-msg;
+            is-unlocked: !read-only;
+            age-days: tabs[index].age-days;
+
+            action-invoked(action) => {
+                Backend.trigger-tab(section-index, index, action);
+            }
+        }
+
+        ElementDuplicatedMessageBanner {
+            shown: tabs[index].element-duplicated-msg;
+
+            deprecate-clicked => {
+                tabs[index].deprecated = true;
+                Backend.trigger-tab(section-index, index, TabAction.apply);
+            }
+
+            cancel-clicked => {
+                tabs[index].element-duplicated-msg = false;
+            }
         }
 
         CheckErrorsMessageBanner {

--- a/libs/librepcb/ui/library/sym/symboltab.slint
+++ b/libs/librepcb/ui/library/sym/symboltab.slint
@@ -18,6 +18,7 @@ import {
 import {
     BreakingChangesMessageBanner,
     CheckErrorsMessageBanner,
+    ElementDuplicatedMessageBanner,
     FilesModifiedMessageBanner,
 } from "../messagebanners.slint";
 import {
@@ -662,6 +663,25 @@ export component SymbolTab inherits Tab {
 
         BreakingChangesMessageBanner {
             shown: tabs[index].interface-broken-msg;
+            is-unlocked: !read-only;
+            age-days: tabs[index].age-days;
+
+            action-invoked(action) => {
+                Backend.trigger-tab(section-index, index, action);
+            }
+        }
+
+        ElementDuplicatedMessageBanner {
+            shown: tabs[index].element-duplicated-msg;
+
+            deprecate-clicked => {
+                tabs[index].deprecated = true;
+                Backend.trigger-tab(section-index, index, TabAction.apply);
+            }
+
+            cancel-clicked => {
+                tabs[index].element-duplicated-msg = false;
+            }
         }
 
         CheckErrorsMessageBanner {

--- a/libs/librepcb/ui/widgets/button.slint
+++ b/libs/librepcb/ui/widgets/button.slint
@@ -51,7 +51,9 @@ export component Button inherits Rectangle {
             Data.theme.control-border
         }
     };
-    border-width: (primary && enabled) ? 0 : 1px;
+    // We used 0px for enabled, primary buttons before, but it doesn't look
+    // good on special backgrounds (e.g. error or warning messages).
+    border-width: 1px;
     forward-focus: fs;
 
     // Accessibility

--- a/libs/librepcb/ui/widgets/messagebanner.slint
+++ b/libs/librepcb/ui/widgets/messagebanner.slint
@@ -5,13 +5,16 @@ export component MessageBanner inherits Rectangle {
     in property <string> text;
     in property <color> text-color: Data.theme.warning-text;
 
+    // Do not directly animate the height, as it would also animate when the
+    // window is resized, which is annoying.
+    property <float> height-factor: shown ? 1 : 0;
+    animate height-factor { duration: 150ms; }
+
     width: 100%;
-    height: shown ? self.preferred-height : 0;
+    height: self.preferred-height * height-factor;
     background: Data.theme.warning;
     visible: self.height > 0;
     clip: true;
-
-    animate height { duration: 150ms; }
 
     VerticalLayout {
         padding: 5px;


### PR DESCRIPTION
Implementing various changes in the library editor to avoid people from (accidentally) making breaking changes and then ending up in troubles, which is regularly leading to "bug reports" from users. So the act of making breaking changes has to be harder than it is currently.

* When making a breaking change to an existing library element, the editor is immediately put into a read-only mode to disallow making any further changes or to save the library element. So it is not possible anymore to make breaking changes without an explicit user action to remove the write protection.
* A red banner warns about the breaking change and recommends to create a new, duplicate library element instead (similar to the behavior before, but the banner is now red instead of yellow, and the text is more clear).
* A new "Duplicate" button is provided to easily create a duplicate, which will then be opened in a new tab.
* When making a duplicate, the original element displays a banner asking to mark the library element as deprecated.
* Alternatively, an unlock button allows to remove the write protection and the library element can be edited and saved again. The button needs to be hold down for a moment, to indicate this is a dangerous action. The required hold time even depends on the age of the library element (the older, the longer to hold) :nerd_face: 

https://github.com/user-attachments/assets/80f60faa-9c1a-42c2-9028-ab47ecf09488

Closes #1681 