### PR TITLE
EagleLibraryImport: Auto-add "EAGLE Import" category

### DIFF
--- a/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryconverter.cpp
@@ -43,7 +43,7 @@ namespace eagleimport {
 using C = EagleTypeConverter;
 
 static QString generatedBy(QString libName, QStringList keys) {
-  if (libName.toLower().endsWith(".lbr")) {
+  if (libName.endsWith(".lbr", Qt::CaseInsensitive)) {
     libName.chop(4);
   }
   keys.prepend(libName);

--- a/libs/librepcb/eagleimport/eaglelibraryimport.cpp
+++ b/libs/librepcb/eagleimport/eaglelibraryimport.cpp
@@ -27,6 +27,8 @@
 
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/library/cat/componentcategory.h>
+#include <librepcb/core/library/cat/packagecategory.h>
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/library/dev/device.h>
 #include <librepcb/core/library/pkg/package.h>
@@ -316,6 +318,33 @@ bool EagleLibraryImport::setElementDependent(T& element,
   return false;
 }
 
+template <typename T>
+static void tryCreateCategoryIfRequired(const FilePath& libDir,
+                                        const Uuid& uuid,
+                                        const QSet<Uuid>& usedCategories,
+                                        MessageLogger& log) noexcept {
+  try {
+    if (!usedCategories.contains(uuid)) {
+      return;  // Category is not needed.
+    }
+    const FilePath fp =
+        libDir.getPathTo(T::getShortElementName()).getPathTo(uuid.toStr());
+    if (fp.getPathTo(".librepcb-" % T::getShortElementName())
+            .isExistingFile()) {
+      return;  // Category exists already.
+    }
+    TransactionalDirectory dir(TransactionalFileSystem::openRW(fp));
+    T cat(uuid, Version::fromString("0.1"), "EAGLE Import",
+          QDateTime::currentDateTime(),
+          ElementName(EagleLibraryImport::CATEGORY_NAME),
+          "Imported library elements.", "eagle");
+    cat.saveTo(dir);
+    dir.getFileSystem()->save();
+  } catch (const Exception& e) {
+    log.critical(QString("Failed to create category: %1").arg(e.getMsg()));
+  }
+}
+
 void EagleLibraryImport::run() noexcept {
   // Note: This method is called from a different thread, thus be careful with
   //       calling other methods to only call thread-safe methods!
@@ -325,6 +354,16 @@ void EagleLibraryImport::run() noexcept {
 
   int totalCount = getCheckedElementsCount();
   int count = 0;
+
+  // Create categories, if required.
+  tryCreateCategoryIfRequired<librepcb::ComponentCategory>(
+      mDestinationLibraryFp, getComponentCategory(),
+      mSettings->symbolCategories | mSettings->componentCategories |
+          mSettings->deviceCategories,
+      *globalLog);
+  tryCreateCategoryIfRequired<librepcb::PackageCategory>(
+      mDestinationLibraryFp, getPackageCategory(), mSettings->packageCategories,
+      *globalLog);
 
   foreach (const Symbol& sym, mSymbols) {
     if (mAbort) {
@@ -433,7 +472,19 @@ void EagleLibraryImport::run() noexcept {
                          "Placeholders are numbers", totalCount)
                           .arg(count)
                           .arg(totalCount));
-  emit finished();
+  emit importFinished();
+}
+
+/*******************************************************************************
+ *  Static Methods
+ ******************************************************************************/
+
+Uuid EagleLibraryImport::getComponentCategory() noexcept {
+  return Uuid::fromString("5d23e248-e18b-4d98-b9d7-541c54747b45");
+}
+
+Uuid EagleLibraryImport::getPackageCategory() noexcept {
+  return Uuid::fromString("f52fabb6-7cdf-4e61-b26a-9d8ec0b8bc49");
 }
 
 /*******************************************************************************

--- a/libs/librepcb/eagleimport/eaglelibraryimport.h
+++ b/libs/librepcb/eagleimport/eaglelibraryimport.h
@@ -60,6 +60,8 @@ class EagleLibraryImport final : public QThread {
   Q_OBJECT
 
 public:
+  static constexpr const char* CATEGORY_NAME = "EAGLE Import";
+
   struct Symbol {
     QString displayName;  // Same as symbol->getName()
     QString description;  // Same as symbol->getDescription()
@@ -133,13 +135,17 @@ public:
   // Operator Overloadings
   EagleLibraryImport& operator=(const EagleLibraryImport& rhs) = delete;
 
+  // Static Methods
+  static Uuid getComponentCategory() noexcept;
+  static Uuid getPackageCategory() noexcept;
+
 signals:
   void symbolCheckStateChanged(const QString& name, Qt::CheckState state);
   void packageCheckStateChanged(const QString& name, Qt::CheckState state);
   void componentCheckStateChanged(const QString& name, Qt::CheckState state);
   void progressStatus(const QString& status);
   void progressPercent(int percent);
-  void finished();
+  void importFinished();
 
 private:  // Methods
   template <typename T>

--- a/libs/librepcb/eagleimport/eagleprojectimport.cpp
+++ b/libs/librepcb/eagleimport/eagleprojectimport.cpp
@@ -1231,7 +1231,7 @@ void EagleProjectImport::importBoard(Project& project,
         std::optional<PositiveLength> size;
         if (sizeRaw >= *drillDiameter) {
           size = PositiveLength(sizeRaw);
-        } else if (size != 0) {
+        } else if (sizeRaw != 0) {
           log.warning(
               "Via size smaller than drill diameter, using automatic size "
               "instead.");

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardcontext.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardcontext.cpp
@@ -49,6 +49,7 @@ EagleLibraryImportWizardContext::EagleLibraryImportWizardContext(
     mImport(new EagleLibraryImport(dstLibFp, &Uuid::createRandom, parent)),
     mLbrFilePath(),
     mAddNamePrefix(false),
+    mAddToCategory(true),
     mComponentCategoryUuid(),
     mPackageCategoryUuid() {
   // Load settings.
@@ -59,6 +60,10 @@ EagleLibraryImportWizardContext::EagleLibraryImportWizardContext(
   setAddNamePrefix(
       clientSettings
           .value("library_editor/eagle_import_wizard/add_name_prefix", false)
+          .toBool());
+  setAddToCategory(
+      clientSettings
+          .value("library_editor/eagle_import_wizard/add_category", true)
           .toBool());
   setComponentCategory(Uuid::tryFromString(
       clientSettings
@@ -77,6 +82,8 @@ EagleLibraryImportWizardContext::~EagleLibraryImportWizardContext() noexcept {
                           mLbrFilePath.toStr());
   clientSettings.setValue("library_editor/eagle_import_wizard/add_name_prefix",
                           mAddNamePrefix);
+  clientSettings.setValue("library_editor/eagle_import_wizard/add_category",
+                          mAddToCategory);
   clientSettings.setValue(
       "library_editor/eagle_import_wizard/component_category",
       mComponentCategoryUuid ? mComponentCategoryUuid->toStr() : QString());
@@ -116,25 +123,40 @@ void EagleLibraryImportWizardContext::setAddNamePrefix(bool add) noexcept {
   mImport->setNamePrefix(add ? NAME_PREFIX : QString());
 }
 
+void EagleLibraryImportWizardContext::setAddToCategory(bool add) noexcept {
+  mAddToCategory = add;
+  setComponentCategory(mComponentCategoryUuid);
+  setPackageCategory(mPackageCategoryUuid);
+}
+
 void EagleLibraryImportWizardContext::setComponentCategory(
     const std::optional<Uuid>& uuid) noexcept {
   mComponentCategoryUuid = uuid;
-  mImport->setSymbolCategories(mComponentCategoryUuid
-                                   ? QSet<Uuid>{*mComponentCategoryUuid}
-                                   : QSet<Uuid>{});
-  mImport->setComponentCategories(mComponentCategoryUuid
-                                      ? QSet<Uuid>{*mComponentCategoryUuid}
-                                      : QSet<Uuid>{});
-  mImport->setDeviceCategories(mComponentCategoryUuid
-                                   ? QSet<Uuid>{*mComponentCategoryUuid}
-                                   : QSet<Uuid>{});
+
+  QSet<Uuid> categories;
+  if (mAddToCategory) {
+    categories.insert(EagleLibraryImport::getComponentCategory());
+  }
+  if (mComponentCategoryUuid) {
+    categories.insert(*mComponentCategoryUuid);
+  }
+  mImport->setSymbolCategories(categories);
+  mImport->setComponentCategories(categories);
+  mImport->setDeviceCategories(categories);
 }
 
 void EagleLibraryImportWizardContext::setPackageCategory(
     const std::optional<Uuid>& uuid) noexcept {
   mPackageCategoryUuid = uuid;
-  mImport->setPackageCategories(
-      mPackageCategoryUuid ? QSet<Uuid>{*mPackageCategoryUuid} : QSet<Uuid>{});
+
+  QSet<Uuid> categories;
+  if (mAddToCategory) {
+    categories.insert(EagleLibraryImport::getPackageCategory());
+  }
+  if (mPackageCategoryUuid) {
+    categories.insert(*mPackageCategoryUuid);
+  }
+  mImport->setPackageCategories(categories);
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardcontext.h
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardcontext.h
@@ -72,6 +72,7 @@ public:
   eagleimport::EagleLibraryImport& getImport() noexcept { return *mImport; }
   const FilePath& getLbrFilePath() const noexcept { return mLbrFilePath; }
   bool getAddNamePrefix() const noexcept { return mAddNamePrefix; }
+  bool getAddToCategory() const noexcept { return mAddToCategory; }
   const std::optional<Uuid>& getComponentCategory() const noexcept {
     return mComponentCategoryUuid;
   }
@@ -82,6 +83,7 @@ public:
   // Setters
   void setLbrFilePath(const QString& filePath) noexcept;
   void setAddNamePrefix(bool add) noexcept;
+  void setAddToCategory(bool add) noexcept;
   void setComponentCategory(const std::optional<Uuid>& uuid) noexcept;
   void setPackageCategory(const std::optional<Uuid>& uuid) noexcept;
 
@@ -98,6 +100,7 @@ private:  // Data
   QScopedPointer<eagleimport::EagleLibraryImport> mImport;
   FilePath mLbrFilePath;
   bool mAddNamePrefix;
+  bool mAddToCategory;
   std::optional<Uuid> mComponentCategoryUuid;
   std::optional<Uuid> mPackageCategoryUuid;
 };

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_result.cpp
@@ -54,12 +54,12 @@ EagleLibraryImportWizardPage_Result::EagleLibraryImportWizardPage_Result(
     mIsCompleted(false) {
   mUi->setupUi(this);
   mUi->gbxErrors->hide();
-  connect(&mContext->getImport(), &EagleLibraryImport::finished, this,
+  connect(&mContext->getImport(), &EagleLibraryImport::importFinished, this,
           &EagleLibraryImportWizardPage_Result::importFinished);
 
   // Connect finished signal directly with library scanner to get it emitted
   // even when closing this wizard while the import is still in progress.
-  connect(&mContext->getImport(), &EagleLibraryImport::finished,
+  connect(&mContext->getImport(), &EagleLibraryImport::importFinished,
           &mContext->getWorkspace().getLibraryDb(),
           &WorkspaceLibraryDb::startLibraryRescan);
 }
@@ -108,6 +108,11 @@ void EagleLibraryImportWizardPage_Result::importFinished() noexcept {
       connect(&mContext->getWorkspace().getLibraryDb(),
               &WorkspaceLibraryDb::scanProgressUpdate, mUi->prgImport,
               &QProgressBar::setValue, Qt::QueuedConnection));
+  mProgressBarConnections.append(connect(
+      &mContext->getWorkspace().getLibraryDb(),
+      &WorkspaceLibraryDb::scanFinished, this,
+      [this]() { mUi->prgImport->setFormat(tr("Finished!")); },
+      Qt::QueuedConnection));
 
   const auto log = mContext->getImport().getLogger();
   mUi->lblMessages->setText(log->getMessagesRichText(&mContext->getTheme()));

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_setoptions.cpp
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_setoptions.cpp
@@ -55,10 +55,14 @@ EagleLibraryImportWizardPage_SetOptions::
   mUi->setupUi(this);
   mUi->cbxAddNamePrefix->setText(mUi->cbxAddNamePrefix->text().arg(
       EagleLibraryImportWizardContext::NAME_PREFIX));
+  mUi->cbxAddToCategory->setText(mUi->cbxAddToCategory->text().arg(
+      eagleimport::EagleLibraryImport::CATEGORY_NAME));
   setButtonText(QWizard::CommitButton, tr("&Import!"));
   setCommitPage(true);
   connect(mUi->cbxAddNamePrefix, &QCheckBox::toggled, mContext.get(),
           &EagleLibraryImportWizardContext::setAddNamePrefix);
+  connect(mUi->cbxAddToCategory, &QCheckBox::toggled, mContext.get(),
+          &EagleLibraryImportWizardContext::setAddToCategory);
   connect(mUi->btnChooseComponentCategory, &QToolButton::clicked, this,
           [this]() {
             CategoryChooserDialog dialog(mContext->getWorkspace(),
@@ -98,6 +102,7 @@ EagleLibraryImportWizardPage_SetOptions::
 
 void EagleLibraryImportWizardPage_SetOptions::initializePage() {
   mUi->cbxAddNamePrefix->setChecked(mContext->getAddNamePrefix());
+  mUi->cbxAddToCategory->setChecked(mContext->getAddToCategory());
   mUi->gbxComponentCategory->setVisible(
       (mContext->getImport().getCheckedSymbolsCount() +
        mContext->getImport().getCheckedComponentsCount() +

--- a/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_setoptions.ui
+++ b/libs/librepcb/editor/library/eaglelibraryimportwizard/eaglelibraryimportwizardpage_setoptions.ui
@@ -19,45 +19,34 @@
   <property name="subTitle">
    <string>Choose the import options and click on the import button below to continue. If you are unsure about the options, just keep the default values.</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,1">
+   <property name="spacing">
+    <number>5</number>
+   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Prefix</string>
+    <widget class="QCheckBox" name="cbxAddNamePrefix">
+     <property name="toolTip">
+      <string>Helps to distinguish between manually created elements and imported elements.</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>3</number>
-      </property>
-      <property name="topMargin">
-       <number>3</number>
-      </property>
-      <property name="rightMargin">
-       <number>3</number>
-      </property>
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="cbxAddNamePrefix">
-        <property name="toolTip">
-         <string>Helps to distinguish between manually created elements and imported elements.</string>
-        </property>
-        <property name="text">
-         <string>Add prefix &quot;%1&quot; to all library element names</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="text">
+      <string>Add prefix &quot;%1&quot; to all library element names</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="cbxAddToCategory">
+     <property name="toolTip">
+      <string>Will list all imported elements under a dedicated category, to help finding them.</string>
+     </property>
+     <property name="text">
+      <string>Add all elements to &quot;%1&quot; category (recommended)</string>
+     </property>
     </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="gbxComponentCategory">
      <property name="title">
-      <string>Component Category</string>
+      <string>Additional Component Category</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="spacing">
@@ -67,13 +56,13 @@
        <number>3</number>
       </property>
       <property name="topMargin">
-       <number>3</number>
+       <number>1</number>
       </property>
       <property name="rightMargin">
        <number>3</number>
       </property>
       <property name="bottomMargin">
-       <number>3</number>
+       <number>1</number>
       </property>
       <item>
        <widget class="QLabel" name="lblComponentCategoryTree">
@@ -116,7 +105,7 @@
    <item>
     <widget class="QGroupBox" name="gbxPackageCategory">
      <property name="title">
-      <string>Package Category</string>
+      <string>Additional Package Category</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <property name="spacing">
@@ -126,13 +115,13 @@
        <number>3</number>
       </property>
       <property name="topMargin">
-       <number>3</number>
+       <number>1</number>
       </property>
       <property name="rightMargin">
        <number>3</number>
       </property>
       <property name="bottomMargin">
-       <number>3</number>
+       <number>1</number>
       </property>
       <item>
        <widget class="QLabel" name="lblPackageCategoryTree">
@@ -180,7 +169,7 @@
       </font>
      </property>
      <property name="text">
-      <string>&lt;b&gt;Attention:&lt;/b&gt; The import cannot be undone (except my manually removing the imported elements)!</string>
+      <string>&lt;b&gt;Attention:&lt;/b&gt; The import cannot be undone (except by manually removing the imported elements)!</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>

--- a/tests/unittests/eagleimport/eaglelibraryimporttest.cpp
+++ b/tests/unittests/eagleimport/eaglelibraryimporttest.cpp
@@ -51,7 +51,7 @@ TEST_F(EagleLibraryImportTest, testImport) {
 
   // Connect signals by hand because QSignalSpy is not threadsafe!
   int signalFinished = 0;
-  QObject::connect(&import, &EagleLibraryImport::finished,
+  QObject::connect(&import, &EagleLibraryImport::importFinished,
                    [&signalFinished]() { ++signalFinished; });
 
   QStringList parseErrors = import.open(src);

--- a/tests/unittests/eagleimport/eagletypeconvertertest.cpp
+++ b/tests/unittests/eagleimport/eagletypeconvertertest.cpp
@@ -49,8 +49,8 @@ namespace tests {
 
 class EagleTypeConverterTest : public ::testing::Test {
 protected:
-  static parseagle::DomElement dom(const QString& str) {
-    return parseagle::DomElement::parse(str);
+  static parseagle::DomElement dom(const QByteArray& data) {
+    return parseagle::DomElement::parse(data);
   }
 };
 
@@ -148,7 +148,7 @@ TEST_F(EagleTypeConverterTest, testConvertInversionSyntax) {
 TEST_F(EagleTypeConverterTest, testConvertAttributeValid) {
   EagleTypeConverter c;
   MessageLogger log;
-  const QString xml = "<attribute name=\"Foo Bar\" value=\"hello world!\"/>";
+  const char* xml = "<attribute name=\"Foo Bar\" value=\"hello world!\"/>";
   auto out = c.tryConvertAttribute(parseagle::Attribute(dom(xml)), log);
   ASSERT_TRUE(out != nullptr);
   EXPECT_EQ("FOO_BAR", out->getKey()->toStdString());
@@ -160,7 +160,7 @@ TEST_F(EagleTypeConverterTest, testConvertAttributeValid) {
 TEST_F(EagleTypeConverterTest, testConvertAttributeInvalid) {
   EagleTypeConverter c;
   MessageLogger log;
-  const QString xml = "<attribute name=\"!\" value=\"hello world!\"/>";
+  const char* xml = "<attribute name=\"!\" value=\"hello world!\"/>";
   auto out = c.tryConvertAttribute(parseagle::Attribute(dom(xml)), log);
   EXPECT_TRUE(out == nullptr);
   EXPECT_EQ(1, log.getMessages().count());
@@ -351,7 +351,8 @@ TEST_F(EagleTypeConverterTest, testConvertAndJoinWires) {
 
 TEST_F(EagleTypeConverterTest, testConvertRectangle) {
   EagleTypeConverter c;
-  QString xml = "<rectangle x1=\"1\" y1=\"2\" x2=\"4\" y2=\"3\" layer=\"1\"/>";
+  const char* xml =
+      "<rectangle x1=\"1\" y1=\"2\" x2=\"4\" y2=\"3\" layer=\"1\"/>";
   auto out = c.convertRectangle(parseagle::Rectangle(dom(xml)), true);
   EXPECT_EQ(1, out.layerId);
   EXPECT_EQ(UnsignedLength(0), out.lineWidth);
@@ -370,7 +371,7 @@ TEST_F(EagleTypeConverterTest, testConvertRectangle) {
 
 TEST_F(EagleTypeConverterTest, testConvertRectangleRotated) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<rectangle x1=\"1\" y1=\"2\" x2=\"4\" y2=\"3\" layer=\"1\" "
       "rot=\"R90\"/>";
   auto out = c.convertRectangle(parseagle::Rectangle(dom(xml)), false);
@@ -391,7 +392,7 @@ TEST_F(EagleTypeConverterTest, testConvertRectangleRotated) {
 
 TEST_F(EagleTypeConverterTest, testConvertPolygon) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<polygon width=\"2.54\" layer=\"1\">"
       "<vertex x=\"1\" y=\"2\" curve=\"45\"/>"
       "<vertex x=\"3\" y=\"4\"/>"
@@ -412,7 +413,7 @@ TEST_F(EagleTypeConverterTest, testConvertPolygon) {
 
 TEST_F(EagleTypeConverterTest, testConvertCircle) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<circle x=\"1\" y=\"2\" radius=\"3.5\" width=\"0.254\" layer=\"1\"/>";
   auto out = c.convertCircle(parseagle::Circle(dom(xml)), true);
   EXPECT_EQ(1, out.layerId);
@@ -432,7 +433,7 @@ TEST_F(EagleTypeConverterTest, testConvertCircle) {
 
 TEST_F(EagleTypeConverterTest, testConvertCircleFilled) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<circle x=\"1\" y=\"2\" radius=\"3.5\" width=\"0\" layer=\"1\"/>";
   auto out = c.convertCircle(parseagle::Circle(dom(xml)), false);
   EXPECT_EQ(1, out.layerId);
@@ -452,7 +453,7 @@ TEST_F(EagleTypeConverterTest, testConvertCircleFilled) {
 
 TEST_F(EagleTypeConverterTest, testConvertHole) {
   EagleTypeConverter c;
-  QString xml = "<hole x=\"1\" y=\"2\" drill=\"3.5\"/>";
+  const char* xml = "<hole x=\"1\" y=\"2\" drill=\"3.5\"/>";
   auto out = c.convertHole(parseagle::Hole(dom(xml)));
   EXPECT_EQ(PositiveLength(3500000), out->getDiameter());
   EXPECT_EQ(1, out->getPath()->getVertices().count());
@@ -462,7 +463,7 @@ TEST_F(EagleTypeConverterTest, testConvertHole) {
 
 TEST_F(EagleTypeConverterTest, testConvertFrame) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<frame x1=\"10\" y1=\"20\" x2=\"40\" y2=\"30\" columns=\"6\" rows=\"4\" "
       "layer=\"94\"/>";
   auto out = c.convertFrame(parseagle::Frame(dom(xml)));
@@ -500,7 +501,7 @@ TEST_F(EagleTypeConverterTest, testTryConvertSchematicTextSize) {
 
 TEST_F(EagleTypeConverterTest, testTryConvertSchematicText) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<text x=\"1\" y=\"2\" size=\"1.778\" layer=\"94\">foo\nbar</text>";
   auto out = c.tryConvertSchematicText(parseagle::Text(dom(xml)), true);
   ASSERT_TRUE(out);
@@ -532,7 +533,8 @@ TEST_F(EagleTypeConverterTest, testTryConvertBoardTextStrokeWidth) {
 
 TEST_F(EagleTypeConverterTest, testTryConvertBoardText) {
   EagleTypeConverter c;
-  QString xml = "<text x=\"1\" y=\"2\" size=\"3\" layer=\"1\">&gt;NAME</text>";
+  const char* xml =
+      "<text x=\"1\" y=\"2\" size=\"3\" layer=\"1\">&gt;NAME</text>";
   auto out = c.tryConvertBoardText(parseagle::Text(dom(xml)), true);
   ASSERT_TRUE(out);
   EXPECT_EQ(Layer::topCopper().getId().toStdString(),
@@ -552,7 +554,7 @@ TEST_F(EagleTypeConverterTest, testTryConvertBoardText) {
 
 TEST_F(EagleTypeConverterTest, testConvertSymbolPin) {
   EagleTypeConverter c;
-  QString xml = "<pin name=\"P$1\" x=\"1\" y=\"2\" length=\"point\"/>";
+  const char* xml = "<pin name=\"P$1\" x=\"1\" y=\"2\" length=\"point\"/>";
   auto out = c.convertSymbolPin(parseagle::Pin(dom(xml)));
   EXPECT_EQ("1", out.pin->getName()->toStdString());
   EXPECT_EQ(Point(1000000, 2000000), out.pin->getPosition());
@@ -564,7 +566,7 @@ TEST_F(EagleTypeConverterTest, testConvertSymbolPin) {
 
 TEST_F(EagleTypeConverterTest, testConvertSymbolPinRotated) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<pin name=\"P$1\" x=\"1\" y=\"2\" length=\"middle\" rot=\"R90\"/>";
   auto out = c.convertSymbolPin(parseagle::Pin(dom(xml)));
   EXPECT_EQ("1", out.pin->getName()->toStdString());
@@ -577,7 +579,7 @@ TEST_F(EagleTypeConverterTest, testConvertSymbolPinRotated) {
 
 TEST_F(EagleTypeConverterTest, testConvertThtPad) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<pad name=\"P$1\" x=\"1\" y=\"2\" drill=\"1.5\" shape=\"square\"/>";
   auto out =
       c.convertThtPad(parseagle::ThtPad(dom(xml)),
@@ -597,7 +599,7 @@ TEST_F(EagleTypeConverterTest, testConvertThtPad) {
 
 TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<pad name=\"P$1\" x=\"1\" y=\"2\" drill=\"1.5\" diameter=\"2.54\" "
       "shape=\"octagon\" rot=\"R90\"/>";
   auto out =
@@ -618,7 +620,7 @@ TEST_F(EagleTypeConverterTest, testConvertThtPadRotated) {
 
 TEST_F(EagleTypeConverterTest, testConvertSmtPad) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<smd name=\"P$1\" x=\"1\" y=\"2\" dx=\"3\" dy=\"4\" layer=\"1\"/>";
   auto out = c.convertSmtPad(parseagle::SmtPad(dom(xml)));
   EXPECT_EQ("1", out.first->getName()->toStdString());
@@ -634,7 +636,7 @@ TEST_F(EagleTypeConverterTest, testConvertSmtPad) {
 
 TEST_F(EagleTypeConverterTest, testConvertSmtPadRotated) {
   EagleTypeConverter c;
-  QString xml =
+  const char* xml =
       "<smd name=\"P$1\" x=\"1\" y=\"2\" dx=\"3\" dy=\"4\" layer=\"16\" "
       "rot=\"R90\"/>";
   auto out = c.convertSmtPad(parseagle::SmtPad(dom(xml)));


### PR DESCRIPTION
I think the best way of importing whole Eagle libraries is to add all imported library elements to a dedicated "EAGLE Import" component category, to make them discoverable easily in the "Add Component" dialog. This was already possible, but such a category had to be created manually (*before* starting the import wizard) and then choosing it manually in the import options, which was cumbersome. Thus now just doing it automatically (opt-out with checkbox). Both a component category and a package category will be created automatically in the opened library (if not existing yet).

In addition, some more Eagle import improvements:
- https://github.com/LibrePCB/parseagle/pull/21
- https://github.com/LibrePCB/parseagle/pull/20
- Fix false-positive warning claiming that vias had an invalid size
- Fix typo in import wizard