### PR TITLE
UI: Support resizing side panel

### DIFF
--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -370,6 +370,10 @@ MainWindow::MainWindow(GuiApplication& app,
     // since the user wants to control window geometry then.
     qInfo() << "Failed to restore window geometry, e.g. due to window manager.";
   }
+  if (float f = cs.value(mSettingsPrefix % "/panel_width_factor").toFloat();
+      f > 0) {
+    d.set_panel_width_factor(f);
+  }
   d.set_erc_zoom_to_location(
       cs.value(mSettingsPrefix % "/erc_zoom_to_location", true).toBool());
   d.set_drc_zoom_to_location(
@@ -745,6 +749,8 @@ slint::CloseRequestResponse MainWindow::closeRequested() noexcept {
   QSettings cs;
   const ui::Data& d = mWindow->global<ui::Data>();
   cs.setValue(mSettingsPrefix % "/geometry", mWidget->saveGeometry());
+  cs.setValue(mSettingsPrefix % "/panel_width_factor",
+              d.get_panel_width_factor());
   cs.setValue(mSettingsPrefix % "/erc_zoom_to_location",
               d.get_erc_zoom_to_location());
   cs.setValue(mSettingsPrefix % "/drc_zoom_to_location",

--- a/libs/librepcb/ui/api/data.slint
+++ b/libs/librepcb/ui/api/data.slint
@@ -37,19 +37,21 @@ export global Data {
     // Preview mode: True for preview, set to false by the backend
     in property <bool> preview-mode: true;
 
-    // Theme (will be overridden by the backend at runtime)
+    // Settings & App Info (will be overridden by the backend at runtime)
     in property <Theme> theme: Themes.dark;
+    in property <string> about-librepcb-details: "LibrePCB Version: 1.2.0\nGit Revision:     f079fa97b\nBuild Date:       2024-12-02T19:12:08\nQt Version:       6.2.4 (built against 6.2.4)\nCPU Architecture: x86_64\nOperating System: Ubuntu Core 22\nPlatform Plugin:  xcb\nTLS Library:      OpenSSL 3.0.2 15 Mar 2022\nOCC Library:      OCCT 7.7.2\nRuntime:          Snap";
 
     // Window data
     in property <int> window-id: 1;
     in property <string> window-title: "LibrePCB 1.2.0-unstable";
     in property <[int]> window-ids: [0, 1, 2];
 
-    // Detailed app version information etc.
-    in property <string> about-librepcb-details: "LibrePCB Version: 1.2.0\nGit Revision:     f079fa97b\nBuild Date:       2024-12-02T19:12:08\nQt Version:       6.2.4 (built against 6.2.4)\nCPU Architecture: x86_64\nOperating System: Ubuntu Core 22\nPlatform Plugin:  xcb\nTLS Library:      OpenSSL 3.0.2 15 Mar 2022\nOCC Library:      OCCT 7.7.2\nRuntime:          Snap";
-
-    // Current side panel page
+    // State
+    in-out property <float> panel-width-factor: 1;
     in property <PanelPage> panel-page: PanelPage.home;
+    in property <bool> erc-zoom-to-location: true; // ERC panel: "zoom to location"
+    in property <bool> drc-zoom-to-location: true; // DRC panel: "zoom to location"
+    in property <bool> order-pcb-open-web-browser: true; // Order panel: "open web browser after upload"
 
     // Window sections
     in-out property <[WindowSectionData]> sections: [
@@ -1582,13 +1584,6 @@ export global Data {
     // and the units order to AttributeType::getAvailableUnits()!
     in property <[string]> attribute-types: ["String", "Capacitance", "Power"];
     in property <[[string]]> attribute-units: [[], ["nF", "F"], ["mW", "W", "kW"]];
-
-    // Rule check panel: Checked state of the "zoom to location" feature
-    in property <bool> erc-zoom-to-location: true;
-    in property <bool> drc-zoom-to-location: true;
-
-    // Order PCB panel: Checked state of the "open web browser after upload" feature
-    in property <bool> order-pcb-open-web-browser: true;
 
     // CALCULATED, DO NET SET IN BACKEND
     in-out property <WindowSectionData> current-section: sections[current-section-index];

--- a/libs/librepcb/ui/appwindow.slint
+++ b/libs/librepcb/ui/appwindow.slint
@@ -28,8 +28,8 @@ import {
 } from "api.slint";
 
 export component AppWindow inherits Window {
-    property <float> panel-width-factor: (Data.sections.length > 1) ? 0.25 : 0.3;
-    property <length> panel-width: min(self.width * panel-width-factor, 350px);
+    property <length> default-panel-width: min(self.width * ((Data.sections.length > 1) ? 0.25 : 0.3), 350px);
+    property <length> panel-width: clamp(default-panel-width * Data.panel-width-factor, 50px, root.width - 200px);
     property <length> actual-panel-width: (Data.panel-page != PanelPage.none) ? panel-width : 0;
 
     title: Data.window-title;
@@ -115,6 +115,41 @@ export component AppWindow inherits Window {
             height: sidebar.height;
             background: Data.theme.control;
             visible: Data.panel-page != PanelPage.none;
+
+            TouchArea {
+                // Note: This touch area goes only to the *right* of the panel,
+                // to avoid overlapping the panel content. And the width of 5px
+                // is just enough to allow grabbing the handle even if there's
+                // a scrollbar in the panel (which have a TouchArea that
+                // overflows the side panel by 4px).
+                x: panel.width;
+                width: self.has-hover ? 10px : 5px;
+                mouse-cursor: MouseCursor.col-resize;
+
+                if self.has-hover || self.pressed: Rectangle {
+                    x: 0;
+                    width: 1px;
+                    background: Data.theme.base-text-disabled;
+                    opacity: 0.7;
+                }
+
+                property <float> previous-panel-width-factor;
+                property <PanelPage> previous-panel-page;
+                pointer-event(event) => {
+                    if (event.button == PointerEventButton.left) && (event.kind == PointerEventKind.down) {
+                        previous-panel-page = Data.panel-page;
+                        previous-panel-width-factor = Data.panel-width-factor;
+                    } else if self.pressed && (event.kind == PointerEventKind.move) {
+                        if (self.x + self.mouse-x) > 50px {
+                            Data.panel-page = previous-panel-page;
+                            Data.panel-width-factor = max(self.x + self.mouse-x, 100px) / default-panel-width;
+                        } else if Data.panel-page != PanelPage.none {
+                            Data.panel-page = PanelPage.none;
+                            Data.panel-width-factor = previous-panel-width-factor;
+                        }
+                    }
+                }
+            }
 
             if Data.panel-page == PanelPage.home: home-panel := HomePanel { }
 

--- a/libs/librepcb/ui/documentspanel.slint
+++ b/libs/librepcb/ui/documentspanel.slint
@@ -162,7 +162,7 @@ component ProjectSection inherits Rectangle {
                 title: project.name.to-uppercase();
                 highlight: project-index == Data.current-project-index;
 
-                if project.unsaved-changes && project.writable: save-btn := IconButton {
+                if (self.max-buttons >= 5) && project.unsaved-changes && project.writable: save-btn := IconButton {
                     cmd: Cmd.save;
                     icon-scale: 60%;
                     color-enabled: Data.theme.base-text-warning;
@@ -172,7 +172,7 @@ component ProjectSection inherits Rectangle {
                     }
                 }
 
-                new-sheet-btn := IconButton {
+                if self.max-buttons >= 4: new-sheet-btn := IconButton {
                     cmd: Cmd.sheet-new;
                     icon-scale: 60%;
 
@@ -181,7 +181,7 @@ component ProjectSection inherits Rectangle {
                     }
                 }
 
-                new-board-btn := IconButton {
+                if self.max-buttons >= 3: new-board-btn := IconButton {
                     cmd: Cmd.board-new;
                     icon: @image-url("../../bootstrap-icons/icons/motherboard.svg");
                     icon-scale: 60%;
@@ -191,7 +191,7 @@ component ProjectSection inherits Rectangle {
                     }
                 }
 
-                setup-dialog-btn := IconButton {
+                if self.max-buttons >= 2: setup-dialog-btn := IconButton {
                     cmd: Cmd.project-setup;
                     icon-scale: 60%;
 
@@ -200,7 +200,7 @@ component ProjectSection inherits Rectangle {
                     }
                 }
 
-                close-btn := IconButton {
+                if self.max-buttons >= 1: close-btn := IconButton {
                     cmd: Cmd.project-close;
                     icon-scale: 60%;
 
@@ -402,6 +402,7 @@ export component DocumentsPanel inherits ScrollView {
     mouse-drag-pan-enabled: true;
 
     VerticalLayout {
+        width: 100%;
         alignment: start;
 
         for project[project-index] in Data.projects: project-item := ProjectSection {

--- a/libs/librepcb/ui/graphicslayerspanel.slint
+++ b/libs/librepcb/ui/graphicslayerspanel.slint
@@ -142,7 +142,7 @@ export component GraphicsLayersPanel inherits FocusScope {
             title: @tr("Layers").to-uppercase();
             highlight: root.has-focus;
 
-            top-btn := IconButton {
+            if self.max-buttons >= 6: top-btn := IconButton {
                 width: self.height;
                 icon: @image-url("../../bootstrap-icons/icons/front.svg");
                 icon-scale: 0.6;
@@ -153,7 +153,7 @@ export component GraphicsLayersPanel inherits FocusScope {
                 }
             }
 
-            bot-btn := IconButton {
+            if self.max-buttons >= 5: bot-btn := IconButton {
                 width: self.height;
                 icon: @image-url("../../bootstrap-icons/icons/back.svg");
                 icon-scale: 0.6;
@@ -164,7 +164,7 @@ export component GraphicsLayersPanel inherits FocusScope {
                 }
             }
 
-            top-bot-btn := IconButton {
+            if self.max-buttons >= 4: top-bot-btn := IconButton {
                 width: self.height;
                 icon: @image-url("../../bootstrap-icons/icons/union.svg");
                 icon-scale: 0.6;
@@ -175,7 +175,7 @@ export component GraphicsLayersPanel inherits FocusScope {
                 }
             }
 
-            show-all-btn := IconButton {
+            if self.max-buttons >= 3: show-all-btn := IconButton {
                 width: self.height;
                 icon: @image-url("../../bootstrap-icons/icons/eye-fill.svg");
                 icon-scale: 0.7;
@@ -186,7 +186,7 @@ export component GraphicsLayersPanel inherits FocusScope {
                 }
             }
 
-            hide-all-btn := IconButton {
+            if self.max-buttons >= 2: hide-all-btn := IconButton {
                 width: self.height;
                 icon: @image-url("../../bootstrap-icons/icons/eye-slash-fill.svg");
                 icon-scale: 0.7;
@@ -197,7 +197,7 @@ export component GraphicsLayersPanel inherits FocusScope {
                 }
             }
 
-            layer-setup-btn := IconButton {
+            if self.max-buttons >= 1: layer-setup-btn := IconButton {
                 width: self.height;
                 icon: @image-url("../../font-awesome/svgs/solid/sliders.svg");
                 icon-scale: 0.7;

--- a/libs/librepcb/ui/library/librariespanel.slint
+++ b/libs/librepcb/ui/library/librariespanel.slint
@@ -322,7 +322,7 @@ component LibrariesPanelSection inherits FocusScope {
             highlight: root.has-focus;
             show-spinner: data.refreshing;
 
-            if remote && (!data.refreshing): LinkText {
+            if remote && (!data.refreshing) && (self.max-buttons >= 5): LinkText {
                 width: self.preferred-width + 2px;
                 horizontal-alignment: left;
                 vertical-alignment: center;
@@ -600,6 +600,8 @@ export component LibrariesPanel inherits VerticalLayout {
                     Text {
                         x: 0;
                         y: (parent.height - self.height) / 2 + 1px;
+                        width: 100%;
+                        height: 100%;
                         font-weight: 700;
                         overflow: elide;
                         vertical-alignment: center;

--- a/libs/librepcb/ui/project/orderpanel.slint
+++ b/libs/librepcb/ui/project/orderpanel.slint
@@ -323,11 +323,12 @@ export component OrderPanel inherits FocusScope {
             }
         }
 
-        PanelHeader {
+        property <bool> show-details: root.width > 200px;
+        if show-details: PanelHeader {
             title: @tr("Details");
         }
 
-        VerticalLayout {
+        if show-details: VerticalLayout {
             padding: 8px;
             spacing: 8px;
 

--- a/libs/librepcb/ui/widgets/panelheader.slint
+++ b/libs/librepcb/ui/widgets/panelheader.slint
@@ -7,6 +7,7 @@ export component PanelHeader inherits Rectangle {
     in property <string> note;
     in property <bool> show-spinner: false;
     in property <bool> highlight: false;
+    out property <int> max-buttons: floor(self.width / self.height) - 1;
     property <length> content-height: 24px;
 
     height: spacing-top + content-height + 2px;


### PR DESCRIPTION
* Allow resizing side panel by dragging the vertical handle
* Some content in the side panel automatically disappear if there's not enough space for it
* Below a certain width, the panel automatically collapses completely
* Save width on application exit & restore on next start
* Width is stored as a factor, so the effective panel width still scales with the window width

[Peek 2026-04-30 18-26.webm](https://github.com/user-attachments/assets/2c3554f0-c9cc-4417-b61a-0449734743cd)

EDIT: Made the color on hover more subtle, not green.