### PR TITLE
Support searching for nets in schematics & boards

### DIFF
--- a/img/images.qrc
+++ b/img/images.qrc
@@ -41,6 +41,7 @@
         <file alias="/fa/solid/caret-down.svg">../libs/font-awesome/svgs/solid/caret-down.svg</file>
         <file alias="/fa/solid/caret-up.svg">../libs/font-awesome/svgs/solid/caret-up.svg</file>
         <file alias="/fa/solid/cart-shopping.svg">../libs/font-awesome/svgs/solid/cart-shopping.svg</file>
+        <file alias="/fa/solid/circle-nodes.svg">../libs/font-awesome/svgs/solid/circle-nodes.svg</file>
         <file alias="/fa/solid/circle-notch.svg">../libs/font-awesome/svgs/solid/circle-notch.svg</file>
         <file alias="/fa/solid/circle.svg">../libs/font-awesome/svgs/solid/circle.svg</file>
         <file alias="/fa/solid/clone.svg">../libs/font-awesome/svgs/solid/clone.svg</file>

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -54,6 +54,10 @@
 #include "fsm/boardeditorstate_drawtrace.h"
 #include "fsm/boardeditorstate_drawzone.h"
 #include "graphicsitems/bgi_device.h"
+#include "graphicsitems/bgi_netline.h"
+#include "graphicsitems/bgi_pad.h"
+#include "graphicsitems/bgi_plane.h"
+#include "graphicsitems/bgi_via.h"
 
 #include <librepcb/core/application.h>
 #include <librepcb/core/attribute/attributesubstitutor.h>
@@ -72,7 +76,11 @@
 #include <librepcb/core/project/board/boardplanefragmentsbuilder.h>
 #include <librepcb/core/project/board/boardspecctraexport.h>
 #include <librepcb/core/project/board/items/bi_device.h>
+#include <librepcb/core/project/board/items/bi_netline.h>
+#include <librepcb/core/project/board/items/bi_netsegment.h>
+#include <librepcb/core/project/board/items/bi_pad.h>
 #include <librepcb/core/project/board/items/bi_plane.h>
+#include <librepcb/core/project/board/items/bi_via.h>
 #include <librepcb/core/project/circuit/circuit.h>
 #include <librepcb/core/project/circuit/componentinstance.h>
 #include <librepcb/core/project/circuit/netclass.h>
@@ -242,7 +250,7 @@ Board2dTab::Board2dTab(GuiApplication& app, BoardEditor& editor,
 
   // Connect search context.
   connect(&mSearchContext, &SearchContext::goToTriggered, this,
-          &Board2dTab::goToDevice);
+          &Board2dTab::goToObjects);
 
   // Setup messages.
   connect(&mProject.getCircuit(), &Circuit::componentAdded, this,
@@ -343,7 +351,7 @@ ui::TabData Board2dTab::getUiData() const noexcept {
       q2s(mProjectEditor.getUndoStack().getUndoCmdText()),  // Undo text
       q2s(mProjectEditor.getUndoStack().getRedoCmdText()),  // Redo text
       q2s(mSearchContext.getTerm()),  // Find term
-      mSearchContext.getSuggestions(),  // Find suggestions
+      mSearchContext.getModel(),  // Find suggestions
       mLayersModel,  // Layers
   };
 }
@@ -900,12 +908,17 @@ void Board2dTab::trigger(ui::TabAction a) noexcept {
       break;
     }
     case ui::TabAction::FindRefreshSuggestions: {
-      QStringList names;
+      QVector<SearchContext::Candidate> objects;
       for (const BI_Device* dev : mBoard.getDeviceInstances()) {
-        names.append(*dev->getComponentInstance().getName());
+        objects.append({SearchContext::ObjectType::Component,
+                        *dev->getComponentInstance().getName()});
       }
-      Toolbox::sortNumeric(names);
-      mSearchContext.setSuggestions(names);
+      for (const NetSignal* net : mProject.getCircuit().getNetSignals()) {
+        if (!net->isAnonymous()) {
+          objects.append({SearchContext::ObjectType::Net, *net->getName()});
+        }
+      }
+      mSearchContext.setCandidates(objects);
       break;
     }
     case ui::TabAction::FindNext: {
@@ -1964,7 +1977,7 @@ void Board2dTab::loadDesignRules(const QString& uiKey) noexcept {
     designRules.adjustToDrcSettings(drcSettings);
 
     // Apply changes to board.
-    std::unique_ptr<CmdBoardEdit> cmd(new CmdBoardEdit(mBoard));
+    std::unique_ptr<CmdBoardEdit> cmd = std::make_unique<CmdBoardEdit>(mBoard);
     cmd->setDesignRules(designRules);
     cmd->setDrcSettings(drcSettings);
     mProjectEditor.getUndoStack().execCmd(cmd.release());
@@ -2659,49 +2672,80 @@ void Board2dTab::execSpecctraImportDialog() noexcept {
   dlg.exec();
 }
 
-void Board2dTab::goToDevice(const QString& name, int index) noexcept {
-  QList<BI_Device*> deviceCandidates;
-  foreach (BI_Device* device, mBoard.getDeviceInstances().values()) {
-    if (device->getComponentInstance().getName()->startsWith(
-            name, Qt::CaseInsensitive)) {
-      deviceCandidates.append(device);
-    }
-  }
+void Board2dTab::goToObjects(
+    const QVector<SearchContext::Candidate>& objects) noexcept {
+  if (!mScene) return;
 
-  // Sort by name for a natural order of results.
-  Toolbox::sortNumeric(
-      deviceCandidates,
-      [](const QCollator& cmp, const BI_Device* a, const BI_Device* b) {
-        return cmp(*a->getComponentInstance().getName(),
-                   *b->getComponentInstance().getName());
-      },
-      Qt::CaseInsensitive, false);
-
-  if (!deviceCandidates.isEmpty()) {
-    while (index < 0) {
-      index += deviceCandidates.count();
-    }
-    index %= deviceCandidates.count();
-    BI_Device* device = deviceCandidates[index];
-    if (mScene) {
-      mScene->clearSelection();
-      if (auto item = mScene->getDevices().value(device)) {
-        item->setSelected(true);
-        mProjectEditor.getCrossProbe()->set(
-            nullptr, {}, {&device->getComponentInstance()}, {}, {});
-        QRectF rect = item->mapRectToScene(item->childrenBoundingRect());
-        // Zoom to a rectangle relative to the maximum graphics item dimension,
-        // occupying 1/4th of the screen, but limiting the margin to 10mm.
-        const qreal margin =
-            std::min(1.5f * std::max(rect.size().width(), rect.size().height()),
-                     Length::fromMm(10).toPx());
-        rect.adjust(-margin, -margin, margin, margin);
-        mView->zoomToSceneRect(rect, false);
-      } else {
-        mProjectEditor.getCrossProbe()->set(nullptr, {}, {}, {}, {});
+  // Cross-probe found objects.
+  QSet<const NetSignal*> nets;
+  QSet<const ComponentInstance*> components;
+  for (const auto& obj : objects) {
+    if (obj.type == SearchContext::ObjectType::Net) {
+      if (auto net = mProject.getCircuit().getNetSignalByName(obj.name)) {
+        nets.insert(net);
+      }
+    } else if (obj.type == SearchContext::ObjectType::Component) {
+      if (auto cmp =
+              mProject.getCircuit().getComponentInstanceByName(obj.name)) {
+        components.insert(cmp);
       }
     }
   }
+  mProjectEditor.getCrossProbe()->set(nullptr, nets, components, {}, {});
+
+  // Select objects & zoom to them.
+  mScene->clearSelection();
+  QRectF bbox;
+  auto setSelected = [&bbox](QGraphicsItem* item) {
+    item->setSelected(true);
+    bbox |= item->mapRectToScene(item->boundingRect() |
+                                 item->childrenBoundingRect());
+  };
+  if (!components.isEmpty()) {
+    for (const auto& item : mScene->getDevices()) {
+      if (components.contains(&item->getDevice().getComponentInstance())) {
+        setSelected(item.get());
+      }
+    }
+  }
+  if (!nets.isEmpty()) {
+    for (const auto& item : mScene->getPads()) {
+      const NetSignal* net = item->getPad().getNetSignal();
+      if (net && nets.contains(net)) {
+        setSelected(item.get());
+      }
+    }
+    for (const auto& item : mScene->getVias()) {
+      const NetSignal* net = item->getVia().getNetSegment().getNetSignal();
+      if (net && nets.contains(net)) {
+        setSelected(item.get());
+      }
+    }
+    for (const auto& item : mScene->getNetLines()) {
+      const NetSignal* net = item->getNetLine().getNetSegment().getNetSignal();
+      if (net && nets.contains(net)) {
+        setSelected(item.get());
+      }
+    }
+    for (const auto& item : mScene->getPlanes()) {
+      const NetSignal* net = item->getPlane().getNetSignal();
+      if (net && nets.contains(net)) {
+        setSelected(item.get());
+      }
+    }
+  }
+  if (!bbox.isEmpty()) {
+    // Zoom to a rectangle relative to the maximum graphics item dimension,
+    // occupying 1/4th of the screen, but limiting the margin to 10mm.
+    const qreal margin =
+        std::min(1.5f * std::max(bbox.size().width(), bbox.size().height()),
+                 Length::fromMm(10).toPx());
+    bbox.adjust(-margin, -margin, margin, margin);
+    mView->zoomToSceneRect(bbox, false);
+  }
+
+  // Enforce updating the info box for the selected objects.
+  mFsm->processChangedSelection();
 }
 
 bool Board2dTab::toggleBackgroundImage() noexcept {

--- a/libs/librepcb/editor/project/board/board2dtab.h
+++ b/libs/librepcb/editor/project/board/board2dtab.h
@@ -244,7 +244,7 @@ private:
   void execD356NetlistExportDialog() noexcept;
   void execSpecctraExportDialog() noexcept;
   void execSpecctraImportDialog() noexcept;
-  void goToDevice(const QString& name, int index) noexcept;
+  void goToObjects(const QVector<SearchContext::Candidate>& objects) noexcept;
   bool toggleBackgroundImage() noexcept;
   void applyBackgroundImageSettings() noexcept;
   FilePath getBackgroundImageCacheDir() const noexcept;

--- a/libs/librepcb/editor/project/board/fsm/boardeditorfsm.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorfsm.cpp
@@ -406,6 +406,15 @@ bool BoardEditorFsm::processGraphicsSceneRightMouseButtonReleased(
   return false;
 }
 
+bool BoardEditorFsm::processChangedSelection() noexcept {
+  if (BoardEditorState* state = getCurrentStateObj()) {
+    if (state->processChangedSelection()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/

--- a/libs/librepcb/editor/project/board/fsm/boardeditorfsm.h
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorfsm.h
@@ -156,6 +156,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept;
   bool processGraphicsSceneRightMouseButtonReleased(
       const GraphicsSceneMouseEvent& e) noexcept;
+  bool processChangedSelection() noexcept;
 
   // Operator Overloadings
   BoardEditorFsm& operator=(const BoardEditorFsm& rhs) = delete;

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate.h
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate.h
@@ -175,6 +175,7 @@ public:
     Q_UNUSED(e);
     return false;
   }
+  virtual bool processChangedSelection() noexcept { return false; }
 
   // Operator Overloadings
   BoardEditorState& operator=(const BoardEditorState& rhs) = delete;

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
@@ -149,7 +149,7 @@ bool BoardEditorState_Select::entry() noexcept {
   mUpdateAvailableFeaturesTimer->setSingleShot(true);
   mUpdateAvailableFeaturesTimer->setInterval(50);
   connect(mUpdateAvailableFeaturesTimer.get(), &QTimer::timeout, this,
-          &BoardEditorState_Select::updateAvailableFeatures);
+          [this]() { updateAvailableFeatures(true); });
   scheduleUpdateAvailableFeatures();
 
   mConnections.append(
@@ -1262,6 +1262,16 @@ bool BoardEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
   return true;
 }
 
+bool BoardEditorState_Select::processChangedSelection() noexcept {
+  // Actually it would be better to call scheduleUpdateAvailableFeatures(),
+  // but this doesn't work nicely with the "find" feature in the board editor,
+  // as it will reset the cross-probed objects, effectively clearing the
+  // highlighted objects. Thus we do a synchronous call where we can pass
+  // doCrossProbe=false.
+  updateAvailableFeatures(false);
+  return true;
+}
+
 /*******************************************************************************
  *  Private Methods
  ******************************************************************************/
@@ -1992,9 +2002,12 @@ void BoardEditorState_Select::scheduleUpdateAvailableFeatures() noexcept {
   if (mUpdateAvailableFeaturesTimer) mUpdateAvailableFeaturesTimer->start();
 }
 
-void BoardEditorState_Select::updateAvailableFeatures() noexcept {
+void BoardEditorState_Select::updateAvailableFeatures(
+    bool doCrossProbe) noexcept {
   BoardGraphicsScene* scene = getActiveBoardScene();
   if (!scene) return;
+
+  if (mUpdateAvailableFeaturesTimer) mUpdateAvailableFeaturesTimer->stop();
 
   std::optional<BoardEditorFsmAdapter::Features> features;
   QString infoText;
@@ -2158,7 +2171,7 @@ void BoardEditorState_Select::updateAvailableFeatures() noexcept {
         (!query.getStrokeTexts().isEmpty()) || (!query.getHoles().isEmpty())) {
       *features |= BoardEditorFsmAdapter::Feature::Properties;
     }
-    infoText = processSelection(query);
+    infoText = processSelection(query, doCrossProbe);
   } else {
     // Do not update features in other states.
   }
@@ -2190,10 +2203,12 @@ private:
 };
 
 QString BoardEditorState_Select::processSelection(
-    const BoardSelectionQuery& query) const noexcept {
+    const BoardSelectionQuery& query, bool doCrossProbe) const noexcept {
   const int totalCount = query.getResultCount();
   if (totalCount == 0) {
-    mAdapter.fsmCrossProbe();
+    if (doCrossProbe) {
+      mAdapter.fsmCrossProbe();
+    }
     return QString();
   }
 
@@ -2324,9 +2339,11 @@ QString BoardEditorState_Select::processSelection(
   }
 
   // Cross-probe selected objects to other editors.
-  mAdapter.fsmCrossProbe(crossProbeNets, crossProbeComponents,
-                         crossProbeComponentSignals,
-                         GraphicsLayer::State::Enabled);
+  if (doCrossProbe) {
+    mAdapter.fsmCrossProbe(crossProbeNets, crossProbeComponents,
+                           crossProbeComponentSignals,
+                           GraphicsLayer::State::Enabled);
+  }
 
   // Build key/value pairs for selected objects.
   QVector<std::pair<QString, QString>> keyValues;

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.h
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.h
@@ -113,6 +113,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
   bool processGraphicsSceneRightMouseButtonReleased(
       const GraphicsSceneMouseEvent& e) noexcept override;
+  bool processChangedSelection() noexcept override;
 
   // Operator Overloadings
   BoardEditorState_Select& operator=(const BoardEditorState_Select& rhs) =
@@ -191,8 +192,9 @@ private:  // Methods
   QList<DeviceMenuItem> getDeviceMenuItems(
       const ComponentInstance& cmpInst) const noexcept;
   void scheduleUpdateAvailableFeatures() noexcept;
-  void updateAvailableFeatures() noexcept;
-  QString processSelection(const BoardSelectionQuery& query) const noexcept;
+  void updateAvailableFeatures(bool doCrossProbe = true) noexcept;
+  QString processSelection(const BoardSelectionQuery& query,
+                           bool doCrossProbe) const noexcept;
 
 private:  // Data
   /// An undo command will be active while dragging pasted items

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.cpp
@@ -359,10 +359,9 @@ bool SchematicEditorFsm::processGraphicsSceneRightMouseButtonReleased(
   return false;
 }
 
-bool SchematicEditorFsm::processGridIntervalChanged(
-    const PositiveLength& interval) noexcept {
+bool SchematicEditorFsm::processChangedSelection() noexcept {
   if (SchematicEditorState* state = getCurrentStateObj()) {
-    if (state->processGridIntervalChanged(interval)) {
+    if (state->processChangedSelection()) {
       return true;
     }
   }

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.h
@@ -138,7 +138,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept;
   bool processGraphicsSceneRightMouseButtonReleased(
       const GraphicsSceneMouseEvent& e) noexcept;
-  bool processGridIntervalChanged(const PositiveLength& interval) noexcept;
+  bool processChangedSelection() noexcept;
 
   // Operator Overloadings
   SchematicEditorFsm& operator=(const SchematicEditorFsm& rhs) = delete;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
@@ -170,11 +170,7 @@ public:
     Q_UNUSED(e);
     return false;
   }
-  virtual bool processGridIntervalChanged(
-      const PositiveLength& interval) noexcept {
-    Q_UNUSED(interval);
-    return false;
-  }
+  virtual bool processChangedSelection() noexcept { return false; }
 
   // Operator Overloadings
   SchematicEditorState& operator=(const SchematicEditorState& rhs) = delete;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
@@ -117,7 +117,7 @@ bool SchematicEditorState_Select::entry() noexcept {
   mUpdateAvailableFeaturesTimer->setSingleShot(true);
   mUpdateAvailableFeaturesTimer->setInterval(50);
   connect(mUpdateAvailableFeaturesTimer.get(), &QTimer::timeout, this,
-          &SchematicEditorState_Select::updateAvailableFeatures);
+          [this]() { updateAvailableFeatures(true); });
   scheduleUpdateAvailableFeatures();
 
   mConnections.append(
@@ -767,10 +767,13 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
   return true;
 }
 
-bool SchematicEditorState_Select::processGridIntervalChanged(
-    const PositiveLength& interval) noexcept {
-  Q_UNUSED(interval);
-  scheduleUpdateAvailableFeatures();
+bool SchematicEditorState_Select::processChangedSelection() noexcept {
+  // Actually it would be better to call scheduleUpdateAvailableFeatures(),
+  // but this doesn't work nicely with the "find" feature in the schematic
+  // editor, as it will reset the cross-probed objects, effectively clearing
+  // the highlighted objects. Thus we do a synchronous call where we can pass
+  // doCrossProbe=false.
+  updateAvailableFeatures(false);
   return true;
 }
 
@@ -1178,7 +1181,8 @@ static bool isAnyOffGrid(const T& container,
   return false;
 }
 
-void SchematicEditorState_Select::updateAvailableFeatures() noexcept {
+void SchematicEditorState_Select::updateAvailableFeatures(
+    bool doCrossProbe) noexcept {
   std::optional<SchematicEditorFsmAdapter::Features> features;
   QString infoText;
   if (mSubState == SubState::PASTING) {
@@ -1245,7 +1249,7 @@ void SchematicEditorState_Select::updateAvailableFeatures() noexcept {
           (!query.getTexts().isEmpty())) {
         *features |= SchematicEditorFsmAdapter::Feature::Properties;
       }
-      infoText = processSelection(query);
+      infoText = processSelection(query, doCrossProbe);
     }
   } else {
     // Do not update features in other states.
@@ -1257,9 +1261,11 @@ void SchematicEditorState_Select::updateAvailableFeatures() noexcept {
 }
 
 QString SchematicEditorState_Select::processSelection(
-    const SchematicSelectionQuery& query) const noexcept {
+    const SchematicSelectionQuery& query, bool doCrossProbe) const noexcept {
   if (query.getResultCount() == 0) {
-    mAdapter.fsmCrossProbe();
+    if (doCrossProbe) {
+      mAdapter.fsmCrossProbe();
+    }
     return QString();
   }
 
@@ -1320,9 +1326,11 @@ QString SchematicEditorState_Select::processSelection(
   }
 
   // Cross-probe selected objects to other editors.
-  mAdapter.fsmCrossProbe(crossProbeNets, crossProbeComponents,
-                         crossProbeComponentSignals, crossProbeBuses,
-                         GraphicsLayer::State::Enabled);
+  if (doCrossProbe) {
+    mAdapter.fsmCrossProbe(crossProbeNets, crossProbeComponents,
+                           crossProbeComponentSignals, crossProbeBuses,
+                           GraphicsLayer::State::Enabled);
+  }
 
   // Build key/value pairs for selected objects.
   QVector<std::pair<QString, QString>> keyValues;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.h
@@ -99,8 +99,7 @@ public:
       const GraphicsSceneMouseEvent& e) noexcept override;
   bool processGraphicsSceneRightMouseButtonReleased(
       const GraphicsSceneMouseEvent& e) noexcept override;
-  bool processGridIntervalChanged(
-      const PositiveLength& interval) noexcept override;
+  bool processChangedSelection() noexcept override;
 
   // Operator Overloadings
   SchematicEditorState_Select& operator=(
@@ -130,8 +129,9 @@ private:  // Methods
   void openPolygonPropertiesDialog(Polygon& polygon) noexcept;
   void openTextPropertiesDialog(Text& text) noexcept;
   void scheduleUpdateAvailableFeatures() noexcept;
-  void updateAvailableFeatures() noexcept;
-  QString processSelection(const SchematicSelectionQuery& query) const noexcept;
+  void updateAvailableFeatures(bool doCrossProbe = true) noexcept;
+  QString processSelection(const SchematicSelectionQuery& query,
+                           bool doCrossProbe) const noexcept;
 
 private:  // Data
   /// enum for all possible substates

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -40,15 +40,25 @@
 #include "fsm/schematiceditorstate_addtext.h"
 #include "fsm/schematiceditorstate_drawbus.h"
 #include "fsm/schematiceditorstate_drawpolygon.h"
+#include "graphicsitems/sgi_netlabel.h"
+#include "graphicsitems/sgi_netline.h"
 #include "graphicsitems/sgi_symbol.h"
+#include "graphicsitems/sgi_symbolpin.h"
 #include "schematiceditor.h"
 #include "schematicgraphicsscene.h"
 
 #include <librepcb/core/attribute/attributetype.h>
 #include <librepcb/core/attribute/attributeunit.h>
+#include <librepcb/core/project/circuit/circuit.h>
+#include <librepcb/core/project/circuit/componentinstance.h>
+#include <librepcb/core/project/circuit/netsignal.h>
 #include <librepcb/core/project/erc/electricalrulecheckmessages.h>
 #include <librepcb/core/project/project.h>
+#include <librepcb/core/project/schematic/items/si_netlabel.h>
+#include <librepcb/core/project/schematic/items/si_netline.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
 #include <librepcb/core/project/schematic/items/si_symbol.h>
+#include <librepcb/core/project/schematic/items/si_symbolpin.h>
 #include <librepcb/core/project/schematic/schematic.h>
 #include <librepcb/core/project/schematic/schematicpainter.h>
 #include <librepcb/core/utils/toolbox.h>
@@ -188,7 +198,7 @@ SchematicTab::SchematicTab(GuiApplication& app, SchematicEditor& editor,
 
   // Connect search context.
   connect(&mSearchContext, &SearchContext::goToTriggered, this,
-          &SchematicTab::goToSymbol);
+          &SchematicTab::goToObjects);
 
   // Setup messages.
   connect(&mApp.getWorkspace().getLibraryDb(),
@@ -280,7 +290,7 @@ ui::TabData SchematicTab::getUiData() const noexcept {
       q2s(mProjectEditor.getUndoStack().getUndoCmdText()),  // Undo text
       q2s(mProjectEditor.getUndoStack().getRedoCmdText()),  // Redo text
       q2s(mSearchContext.getTerm()),  // Find term
-      mSearchContext.getSuggestions(),  // Find suggestions
+      mSearchContext.getModel(),  // Find suggestions
       nullptr,  // Layers
   };
 }
@@ -621,12 +631,19 @@ void SchematicTab::trigger(ui::TabAction a) noexcept {
       break;
     }
     case ui::TabAction::FindRefreshSuggestions: {
-      QStringList names;
+      QVector<SearchContext::Candidate> objects;
       for (const SI_Symbol* sym : mSchematic.getSymbols()) {
-        names.append(sym->getName());
+        if (!sym->getComponentInstance().isPureSchematicOnly()) {
+          objects.append(
+              {SearchContext::ObjectType::Component, sym->getName()});
+        }
       }
-      Toolbox::sortNumeric(names);
-      mSearchContext.setSuggestions(names);
+      for (const NetSignal* net : mProject.getCircuit().getNetSignals()) {
+        if (!net->isAnonymous()) {
+          objects.append({SearchContext::ObjectType::Net, *net->getName()});
+        }
+      }
+      mSearchContext.setCandidates(objects);
       break;
     }
     case ui::TabAction::FindNext: {
@@ -1255,43 +1272,74 @@ void SchematicTab::execGraphicsExportDialog(
   }
 }
 
-void SchematicTab::goToSymbol(const QString& name, int index) noexcept {
-  QList<SI_Symbol*> symbolCandidates;
-  foreach (SI_Symbol* symbol, mSchematic.getSymbols().values()) {
-    if (symbol->getName().startsWith(name, Qt::CaseInsensitive)) {
-      symbolCandidates.append(symbol);
-    }
-  }
+void SchematicTab::goToObjects(
+    const QVector<SearchContext::Candidate>& objects) noexcept {
+  if (!mScene) return;
 
-  // Sort by name for a natural order of results.
-  Toolbox::sortNumeric(
-      symbolCandidates,
-      [](const QCollator& cmp, const SI_Symbol* lhs, const SI_Symbol* rhs) {
-        return cmp(lhs->getName(), rhs->getName());
-      },
-      Qt::CaseInsensitive, false);
-
-  if (symbolCandidates.count()) {
-    while (index < 0) {
-      index += symbolCandidates.count();
-    }
-    index %= symbolCandidates.count();
-    SI_Symbol* symbol = symbolCandidates[index];
-    if (mScene) {
-      mScene->clearSelection();
-      if (auto item = mScene->getSymbols().value(symbol)) {
-        item->setSelected(true);
-        QRectF rect = item->mapRectToScene(item->childrenBoundingRect());
-        // Zoom to a rectangle relative to the maximum graphics item dimension,
-        // occupying 1/4th of the screen, but limiting the margin to 10mm.
-        const qreal margin =
-            std::min(1.5f * std::max(rect.size().width(), rect.size().height()),
-                     Length::fromMm(10).toPx());
-        rect.adjust(-margin, -margin, margin, margin);
-        mView->zoomToSceneRect(rect, false);
+  // Cross-probe found objects.
+  QSet<const NetSignal*> nets;
+  QSet<const ComponentInstance*> components;
+  for (const auto& obj : objects) {
+    if (obj.type == SearchContext::ObjectType::Net) {
+      if (auto net = mProject.getCircuit().getNetSignalByName(obj.name)) {
+        nets.insert(net);
+      }
+    } else if (obj.type == SearchContext::ObjectType::Component) {
+      if (auto cmp =
+              mProject.getCircuit().getComponentInstanceByName(obj.name)) {
+        components.insert(cmp);
       }
     }
   }
+  mProjectEditor.getCrossProbe()->set(nullptr, nets, components, {}, {});
+
+  // Select objects & zoom to them.
+  mScene->clearSelection();
+  QRectF bbox;
+  auto setSelected = [&bbox](QGraphicsItem* item) {
+    item->setSelected(true);
+    bbox |= item->mapRectToScene(item->boundingRect() |
+                                 item->childrenBoundingRect());
+  };
+  if (!components.isEmpty()) {
+    for (const auto& item : mScene->getSymbols()) {
+      if (components.contains(&item->getSymbol().getComponentInstance())) {
+        setSelected(item.get());
+      }
+    }
+  }
+  if (!nets.isEmpty()) {
+    for (const auto& item : mScene->getSymbolPins()) {
+      const NetSignal* net = item->getPin().getCompSigInstNetSignal();
+      if (net && nets.contains(net)) {
+        setSelected(item.get());
+      }
+    }
+    for (const auto& item : mScene->getNetLines()) {
+      const NetSignal& net = item->getNetLine().getNetSegment().getNetSignal();
+      if (nets.contains(&net)) {
+        setSelected(item.get());
+      }
+    }
+    for (const auto& item : mScene->getNetLabels()) {
+      const NetSignal& net = item->getNetLabel().getNetSegment().getNetSignal();
+      if (nets.contains(&net)) {
+        setSelected(item.get());
+      }
+    }
+  }
+  if (!bbox.isEmpty()) {
+    // Zoom to a rectangle relative to the maximum graphics item dimension,
+    // occupying 1/4th of the screen, but limiting the margin to 10mm.
+    const qreal margin =
+        std::min(1.5f * std::max(bbox.size().width(), bbox.size().height()),
+                 Length::fromMm(10).toPx());
+    bbox.adjust(-margin, -margin, margin, margin);
+    mView->zoomToSceneRect(bbox, false);
+  }
+
+  // Enforce updating the info box for the selected objects.
+  mFsm->processChangedSelection();
 }
 
 void SchematicTab::applyWorkspaceSettings() noexcept {

--- a/libs/librepcb/editor/project/schematic/schematictab.h
+++ b/libs/librepcb/editor/project/schematic/schematictab.h
@@ -170,7 +170,7 @@ private:
   void clearErcMarker() noexcept;
   void execGraphicsExportDialog(GraphicsExportDialog::Output output,
                                 const QString& settingsKey) noexcept;
-  void goToSymbol(const QString& name, int index) noexcept;
+  void goToObjects(const QVector<SearchContext::Candidate>& objects) noexcept;
   void applyWorkspaceSettings() noexcept;
   void requestRepaint() noexcept;
 

--- a/libs/librepcb/editor/utils/searchcontext.cpp
+++ b/libs/librepcb/editor/utils/searchcontext.cpp
@@ -22,11 +22,10 @@
  ******************************************************************************/
 #include "searchcontext.h"
 
+#include "editortoolbox.h"
 #include "slinthelpers.h"
 
 #include <QtCore>
-
-#include <memory>
 
 /*******************************************************************************
  *  Namespace
@@ -51,42 +50,46 @@ SearchContext::~SearchContext() noexcept {
 
 void SearchContext::init() noexcept {
   mTerm.clear();
+  mTermRe = std::nullopt;
   mForward = true;
   mIndex = 0;
-  mSuggestions = std::make_shared<slint::VectorModel<slint::SharedString>>();
-  QPointer<SearchContext> ctx = this;
-  mSuggestionsFiltered =
-      std::make_shared<slint::FilterModel<slint::SharedString>>(
-          mSuggestions, [ctx](const slint::SharedString& data) {
-            return ctx && s2q(data).toLower().startsWith(ctx->mTerm.toLower());
-          });
+  mCandidates.clear();
+  mCandidatesFiltered.clear();
+  mModel = std::make_shared<slint::VectorModel<ui::SimpleListItemData>>();
 }
 
 void SearchContext::deinit() noexcept {
-  mSuggestionsFiltered.reset();
-  mSuggestions.reset();
+  mModel.reset();
+  mCandidatesFiltered.clear();
+  mCandidates.clear();
 }
 
 void SearchContext::setTerm(const QString& term) noexcept {
   if (term != mTerm) {
     mTerm = term.trimmed();
+    if (mTerm.contains("*")) {
+      mTermRe = QRegularExpression::fromWildcard(mTerm, Qt::CaseInsensitive);
+    } else {
+      mTermRe = std::nullopt;
+    }
     mIndex = 0;
     mForward = true;
-    if (mSuggestionsFiltered) {
-      mSuggestionsFiltered->reset();
-    }
+    applyFilter();
   }
 }
 
-void SearchContext::setSuggestions(const QStringList& list) noexcept {
-  if (mSuggestions) {
-    std::vector<slint::SharedString> vector;
-    vector.reserve(list.size());
-    for (const auto& s : list) {
-      vector.push_back(q2s(s));
-    }
-    mSuggestions->set_vector(vector);
-  }
+void SearchContext::setCandidates(const QVector<Candidate>& list) noexcept {
+  mCandidates = list;
+  Toolbox::sortNumeric(
+      mCandidates,
+      [](const QCollator& cmp, const Candidate& a, const Candidate& b) {
+        if (a.type != b.type) {
+          return a.type < b.type;
+        } else {
+          return cmp(a.name, b.name);
+        }
+      });
+  applyFilter();
 }
 
 void SearchContext::findNext() noexcept {
@@ -94,8 +97,15 @@ void SearchContext::findNext() noexcept {
     mForward = true;
     mIndex += 2;
   }
-  emit goToTriggered(mTerm, mIndex);
-  ++mIndex;
+  if (mCandidatesFiltered.isEmpty() || mTermRe) {
+    emit goToTriggered(mCandidatesFiltered);
+  } else if (!mTerm.isEmpty()) {
+    mIndex %= mCandidatesFiltered.count();
+    emit goToTriggered(mCandidatesFiltered.mid(mIndex, 1));
+    ++mIndex;
+  } else {
+    emit goToTriggered({});
+  }
 }
 
 void SearchContext::findPrevious() noexcept {
@@ -103,8 +113,75 @@ void SearchContext::findPrevious() noexcept {
     mForward = false;
     mIndex -= 2;
   }
-  emit goToTriggered(mTerm, mIndex);
-  --mIndex;
+  if (mCandidatesFiltered.isEmpty() || mTermRe) {
+    emit goToTriggered(mCandidatesFiltered);
+  } else if (!mTerm.isEmpty()) {
+    mIndex %= mCandidatesFiltered.count();
+    emit goToTriggered(mCandidatesFiltered.mid(mIndex, 1));
+    --mIndex;
+  } else {
+    emit goToTriggered({});
+  }
+}
+
+/*******************************************************************************
+ *  Private Methods
+ ******************************************************************************/
+
+void SearchContext::applyFilter() noexcept {
+  if (!mModel) return;
+
+  const QHash<ObjectType, slint::Image> images = {
+      {ObjectType::Component,
+       q2s(EditorToolbox::svgIcon(":/bi/cpu.svg").pixmap(48, 48))},
+      {ObjectType::Net,
+       q2s(EditorToolbox::svgIcon(":/fa/solid/circle-nodes.svg")
+               .pixmap(48, 48))},
+  };
+
+  QVector<Candidate> filtered;
+  if (mTerm.isEmpty()) {
+    filtered = mCandidates;
+  } else {
+    filtered.reserve(mCandidates.count());
+    for (const auto& candidate : std::as_const(mCandidates)) {
+      if ((mTermRe && mTermRe->match(candidate.name).hasMatch()) ||
+          ((!mTermRe) && candidate.name.contains(mTerm, Qt::CaseInsensitive))) {
+        filtered.append(candidate);
+      }
+    }
+
+    // Move best matches to top, to ensure the first result is always the best.
+    // For example, the net "RXD" must appear before "MCU_RXD" if the search
+    // term "rxd" was entered. Or "RST" must appear before "!RST" when searching
+    // for "rst".
+    std::stable_sort(
+        filtered.begin(), filtered.end(),
+        [this](const Candidate& a, const Candidate& b) {
+          bool aMatch = a.name.compare(mTerm, Qt::CaseInsensitive) == 0;
+          bool bMatch = b.name.compare(mTerm, Qt::CaseInsensitive) == 0;
+          if (aMatch != bMatch) {
+            return aMatch;
+          }
+          aMatch = a.name.startsWith(mTerm, Qt::CaseInsensitive);
+          bMatch = b.name.startsWith(mTerm, Qt::CaseInsensitive);
+          if (aMatch != bMatch) {
+            return aMatch;
+          }
+          return false;
+        });
+  }
+
+  if (filtered != mCandidatesFiltered) {
+    mCandidatesFiltered = filtered;
+    std::vector<ui::SimpleListItemData> vector;
+    vector.reserve(mCandidatesFiltered.size());
+    for (const auto& candidate : std::as_const(mCandidatesFiltered)) {
+      vector.push_back(ui::SimpleListItemData{images.value(candidate.type),
+                                              q2s(candidate.name)});
+    }
+    mModel->set_vector(vector);
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/utils/searchcontext.h
+++ b/libs/librepcb/editor/utils/searchcontext.h
@@ -23,9 +23,12 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "ui.h"
+
 #include <QtCore>
 
-#include <slint.h>
+#include <memory>
+#include <optional>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -44,6 +47,17 @@ class SearchContext final : public QObject {
   Q_OBJECT
 
 public:
+  // Types
+  enum class ObjectType {
+    Component,
+    Net,
+  };
+  struct Candidate {
+    ObjectType type;
+    QString name;
+    bool operator==(const Candidate& rhs) const noexcept = default;
+  };
+
   // Constructors / Destructor
   SearchContext(const SearchContext& other) = delete;
   explicit SearchContext(QObject* parent = nullptr) noexcept;
@@ -54,10 +68,10 @@ public:
   void deinit() noexcept;
   void setTerm(const QString& term) noexcept;
   const QString& getTerm() const noexcept { return mTerm; }
-  void setSuggestions(const QStringList& list) noexcept;
-  const std::shared_ptr<slint::FilterModel<slint::SharedString>>&
-      getSuggestions() const noexcept {
-    return mSuggestionsFiltered;
+  void setCandidates(const QVector<Candidate>& list) noexcept;
+  const std::shared_ptr<slint::VectorModel<ui::SimpleListItemData>>& getModel()
+      const noexcept {
+    return mModel;
   }
   void findNext() noexcept;
   void findPrevious() noexcept;
@@ -66,15 +80,19 @@ public:
   SearchContext& operator=(const SearchContext& rhs) = delete;
 
 signals:
-  void goToTriggered(const QString& name, int index = 0);
+  void goToTriggered(const QVector<Candidate>& objects);
+
+private:
+  void applyFilter() noexcept;
 
 private:
   QString mTerm;
+  std::optional<QRegularExpression> mTermRe;  ///< If #mTerm contains wildcards
   bool mForward;  ///< Current search direction (forward or backward)
   int mIndex;  ///< Number of searches with the current search term
-
-  std::shared_ptr<slint::VectorModel<slint::SharedString>> mSuggestions;
-  std::shared_ptr<slint::FilterModel<slint::SharedString>> mSuggestionsFiltered;
+  QVector<Candidate> mCandidates;
+  QVector<Candidate> mCandidatesFiltered;
+  std::shared_ptr<slint::VectorModel<ui::SimpleListItemData>> mModel;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/ui/api.slint
+++ b/libs/librepcb/ui/api.slint
@@ -78,6 +78,7 @@ export {
     RuleCheckType,
     SchematicAction,
     SchematicTabData,
+    SimpleListItemData,
     SolderTechnology,
     SymbolTabData,
     TabAction,

--- a/libs/librepcb/ui/api/data.slint
+++ b/libs/librepcb/ui/api/data.slint
@@ -123,7 +123,12 @@ export global Data {
                         find: FeatureState.enabled,
                     },
                     unsaved-changes: true,
-                    find-autocompletions: ["C1", "C2", "C20", "U15"],
+                    find-autocompletions: [
+                        { text: "C1", icon: @image-url("../../../../img/app/librepcb.svg") },
+                        { text: "C2" },
+                        { text: "C20" },
+                        { text: "U15" },
+                    ],
                     layers: [
                         {
                             name: "Top Copper",

--- a/libs/librepcb/ui/api/types.slint
+++ b/libs/librepcb/ui/api/types.slint
@@ -132,6 +132,12 @@ export enum IpcDensityLevel {
 // Widgets data
 ////////////////////////////////////////////////////////////////////////////////
 
+// General-purpose list item data structure
+export struct SimpleListItemData {
+    icon: image,
+    text: string,
+}
+
 // Underlying data structure for LineEdit elements
 export struct LineEditData {
     enabled: bool,
@@ -857,7 +863,7 @@ export struct TabData {
 
     // Find
     find-term: string,  // Set by UI, handled in backend
-    find-autocompletions: [string],
+    find-autocompletions: [SimpleListItemData],
 
     // Layers
     layers: [GraphicsLayerData],

--- a/libs/librepcb/ui/controlsgallerytab.slint
+++ b/libs/librepcb/ui/controlsgallerytab.slint
@@ -248,7 +248,7 @@ component LineEditGallery inherits VerticalLayout {
         enabled: false;
         read-only: false;
         show-clear-button: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 
@@ -260,7 +260,7 @@ component LineEditGallery inherits VerticalLayout {
         enabled: false;
         read-only: false;
         show-clear-button: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 
@@ -272,7 +272,7 @@ component LineEditGallery inherits VerticalLayout {
         enabled: true;
         read-only: true;
         show-clear-button: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 
@@ -284,7 +284,7 @@ component LineEditGallery inherits VerticalLayout {
         enabled: true;
         read-only: true;
         show-clear-button: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 
@@ -296,7 +296,7 @@ component LineEditGallery inherits VerticalLayout {
         enabled: true;
         read-only: false;
         show-clear-button: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 
@@ -320,7 +320,7 @@ component LineEditGallery inherits VerticalLayout {
         enabled: true;
         read-only: false;
         show-clear-button: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 
@@ -336,7 +336,7 @@ component LineEditGallery inherits VerticalLayout {
         enabled: true;
         read-only: false;
         show-clear-button: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 
@@ -349,7 +349,7 @@ component LineEditGallery inherits VerticalLayout {
         read-only: false;
         show-clear-button: true;
         has-error: true;
-        autocompletions: ["Autocompletion 1", "Autocompletion 2"];
+        autocompletions: [{ text: "Autocompletion 1" }, { text: "Autocompletion 2" }];
         suggestions: ["Suggestion 1", "Suggestion 2"];
     }
 

--- a/libs/librepcb/ui/widgets/lineedit.slint
+++ b/libs/librepcb/ui/widgets/lineedit.slint
@@ -3,7 +3,7 @@ import { DropDownPopup } from "dropdownpopup.slint";
 import { ControlIconButton } from "iconbutton.slint";
 import { ScrollView } from "scrollview.slint";
 import { TextInput } from "textinput.slint";
-import { Data } from "../api.slint";
+import { Data, SimpleListItemData } from "../api.slint";
 
 export component LineEdit inherits Rectangle {
     in-out property <string> text;
@@ -16,7 +16,7 @@ export component LineEdit inherits Rectangle {
     in property <string> font-family;
     in property <length> font-size: 13px;
     in property <int> font-weight: 400;
-    in property <[string]> autocompletions;
+    in property <[SimpleListItemData]> autocompletions;
     in property <[string]> suggestions;
     in property <bool> frameless: false;
     out property <bool> has-focus <=> edt.has-focus;
@@ -183,7 +183,7 @@ export component LineEdit inherits Rectangle {
                             current-autocompletion-index = min(current-autocompletion-index + 1, autocompletions.length - 1);
                             return accept;
                         } else if (event.text == Key.Return) && (current-autocompletion-index >= 0) && (current-autocompletion-index < autocompletions.length) {
-                            autocompletion-accepted(autocompletions[current-autocompletion-index]);
+                            autocompletion-accepted(autocompletions[current-autocompletion-index].text);
                             current-autocompletion-index = -1;
                             return accept;
                         } else if (event.text == Key.UpArrow) && (autocompletions.length > 0) {
@@ -279,6 +279,8 @@ export component LineEdit inherits Rectangle {
             height: parent.height - 2px;
             viewport-width: autocompletions-l.width;
             viewport-height: autocompletions-l.height;
+            mouse-drag-pan-enabled: true;
+            consume-scroll-events: true;
 
             autocompletions-l := VerticalLayout {
                 width: root.width - 2px;
@@ -295,7 +297,7 @@ export component LineEdit inherits Rectangle {
                     accessible-item-index: index;
                     accessible-item-selectable: true;
                     accessible-item-selected: is-selected;
-                    accessible-label: item;
+                    accessible-label: item.text;
 
                     changed has-hover => {
                         if self.has-hover {
@@ -308,21 +310,37 @@ export component LineEdit inherits Rectangle {
                     Rectangle {
                         background: is-selected ? Data.theme.control-checked : transparent;
 
-                        autocompletion-item-txt := Text {
-                            x: 5px;
-                            y: (parent.height - self.height) / 2;
-                            width: parent.width - 2 * self.x;
-                            color: Data.theme.control-text;
-                            font-size: 12px;
-                            overflow: elide;
-                            vertical-alignment: center;
-                            text: item;
-                            accessible-role: none;
+                        HorizontalLayout {
+                            padding-left: 5px;
+                            padding-right: 5px;
+                            spacing: 5px;
+
+                            autocompletion-item-txt := Text {
+                                color: Data.theme.control-text;
+                                font-size: 12px;
+                                overflow: elide;
+                                vertical-alignment: center;
+                                text: item.text;
+                                accessible-role: none;
+                            }
+
+                            if item.icon.width > 0: Rectangle {
+                                width: 15px;
+
+                                Image {
+                                    width: 100%;
+                                    height: self.width;
+                                    source: item.icon;
+                                    colorize: Data.theme.control-text-disabled;
+                                    image-fit: contain;
+                                    accessible-role: none;
+                                }
+                            }
                         }
                     }
 
                     clicked => {
-                        autocompletion-accepted(item);
+                        autocompletion-accepted(item.text);
                     }
                 }
             }

--- a/libs/librepcb/ui/widgets/scrollview.slint
+++ b/libs/librepcb/ui/widgets/scrollview.slint
@@ -77,6 +77,7 @@ export component ScrollView {
     in property <bool> force-show-scrollbars: false;
     in property <bool> thin-scrollbars: false;
     in property <bool> mouse-drag-pan-enabled <=> flickable.interactive;
+    in property <bool> consume-scroll-events: false;
     in-out property <length> viewport-x <=> flickable.viewport-x;
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in-out property <length> viewport-width <=> flickable.viewport-width;
@@ -149,6 +150,12 @@ export component ScrollView {
             scrolled => {
                 root.scrolled()
             }
+        }
+
+        // Depending on context, we need to consume scroll events to avoid
+        // them to propagate to elements below the scroll view.
+        scroll-event(event) => {
+            consume-scroll-events ? accept : reject
         }
     }
 }


### PR DESCRIPTION
* Support searching for nets in addition to components
* Support wildcard '*' in the search term -> if multiple results are found, all of them will be selected
* Make use of the new cross-probing feature to gray out all objects *not* matching the search term (also in the schematic editor)
* Indicate in the UI autocompletion which item is a component and which is a net
* Improve order of autocompletions (most relevant items first)

Closes #683