### PR TITLE
Schematic editor: Support placing remaining component gates

### DIFF
--- a/img/images.qrc
+++ b/img/images.qrc
@@ -70,6 +70,7 @@
         <file alias="/fa/solid/object-group.svg">../libs/font-awesome/svgs/solid/object-group.svg</file>
         <file alias="/fa/solid/pen-to-square.svg">../libs/font-awesome/svgs/solid/pen-to-square.svg</file>
         <file alias="/fa/solid/play.svg">../libs/font-awesome/svgs/solid/play.svg</file>
+        <file alias="/fa/solid/plus.svg">../libs/font-awesome/svgs/solid/plus.svg</file>
         <file alias="/fa/solid/rotate-left.svg">../libs/font-awesome/svgs/solid/rotate-left.svg</file>
         <file alias="/fa/solid/rotate-right.svg">../libs/font-awesome/svgs/solid/rotate-right.svg</file>
         <file alias="/fa/solid/ruler.svg">../libs/font-awesome/svgs/solid/ruler.svg</file>

--- a/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/erc/electricalrulecheckmessages.cpp
@@ -295,7 +295,9 @@ ErcMsgUnplacedRequiredGate::ErcMsgUnplacedRequiredGate(
                tr("The gate '%1' of '%2' is marked as required, but it "
                   "is not added to the schematic.")
                    .arg(*gate.getSuffix(), *component.getName()),
-               "unplaced_required_gate") {
+               "unplaced_required_gate"),
+    mComponent(component.getUuid()),
+    mGate(gate.getUuid()) {
   mApproval->ensureLineBreak();
   mApproval->appendChild("component", component.getUuid());
   mApproval->ensureLineBreak();
@@ -318,7 +320,9 @@ ErcMsgUnplacedOptionalGate::ErcMsgUnplacedOptionalGate(
             .arg(*component.getName(), *gate.getSuffix()),
         tr("The optional gate '%1' of '%2' is not added to the schematic.")
             .arg(*gate.getSuffix(), *component.getName()),
-        "unplaced_optional_gate") {
+        "unplaced_optional_gate"),
+    mComponent(component.getUuid()),
+    mGate(gate.getUuid()) {
   mApproval->ensureLineBreak();
   mApproval->appendChild("component", component.getUuid());
   mApproval->ensureLineBreak();

--- a/libs/librepcb/core/project/erc/electricalrulecheckmessages.h
+++ b/libs/librepcb/core/project/erc/electricalrulecheckmessages.h
@@ -270,8 +270,16 @@ public:
       const ComponentInstance& component,
       const ComponentSymbolVariantItem& gate) noexcept;
   ErcMsgUnplacedRequiredGate(const ErcMsgUnplacedRequiredGate& other) noexcept
-    : ErcMsgBase(other) {}
+    : ErcMsgBase(other), mComponent(other.mComponent), mGate(other.mGate) {}
   ~ErcMsgUnplacedRequiredGate() noexcept override {}
+
+  // Getters
+  const Uuid& getComponent() const noexcept { return mComponent; }
+  const Uuid& getGate() const noexcept { return mGate; }
+
+private:
+  const Uuid mComponent;
+  const Uuid mGate;
 };
 
 /*******************************************************************************
@@ -291,8 +299,16 @@ public:
       const ComponentInstance& component,
       const ComponentSymbolVariantItem& gate) noexcept;
   ErcMsgUnplacedOptionalGate(const ErcMsgUnplacedOptionalGate& other) noexcept
-    : ErcMsgBase(other) {}
+    : ErcMsgBase(other), mComponent(other.mComponent), mGate(other.mGate) {}
   ~ErcMsgUnplacedOptionalGate() noexcept override {}
+
+  // Getters
+  const Uuid& getComponent() const noexcept { return mComponent; }
+  const Uuid& getGate() const noexcept { return mGate; }
+
+private:
+  const Uuid mComponent;
+  const Uuid mGate;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/editorcommandset.h
+++ b/libs/librepcb/editor/editorcommandset.h
@@ -1852,6 +1852,15 @@ public:
       {QKeySequence(Qt::CTRL | Qt::Key_C)},
       &categoryContextMenu,
   };
+  EditorCommand placeRemainingGates{
+      "place_remaining_gates",  // clang-format break
+      QT_TR_NOOP("Place Remaining Gates"),
+      QT_TR_NOOP("Add more of the components gates to the schematic"),
+      ":/fa/solid/plus.svg",
+      EditorCommand::Flags(),
+      {},
+      &categoryContextMenu,
+  };
   EditorCommand openProductWebsite{
       "open_product_website",  // clang-format break
       QT_TR_NOOP("Open Product Website"),

--- a/libs/librepcb/editor/editorcommandsetupdater.h
+++ b/libs/librepcb/editor/editorcommandsetupdater.h
@@ -191,6 +191,7 @@ public:
     out.set_locked(l2s(cmd.locked, out.get_locked()));
     out.set_visible(l2s(cmd.visible, out.get_visible()));
     out.set_copy_mpn_to_clipboard(l2s(cmd.copyMpnToClipboard, out.get_copy_mpn_to_clipboard()));
+    out.set_place_remaining_gates(l2s(cmd.placeRemainingGates, out.get_place_remaining_gates()));
     out.set_open_product_website(l2s(cmd.openProductWebsite, out.get_open_product_website()));
     out.set_open_pricing_website(l2s(cmd.openPricingWebsite, out.get_open_pricing_website()));
     // clang-format on

--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -902,6 +902,17 @@ std::shared_ptr<MainWindow> GuiApplication::createNewWindow(
   return mw;
 }
 
+std::shared_ptr<MainWindow> GuiApplication::getCurrentWindow() noexcept {
+  for (auto& win : mWindows->values()) {
+    if (win->isCurrentWindow()) {
+      return win;
+    }
+  }
+  // TODO: This does not work in every case yet, so we implement some fallback
+  // as a workaround.
+  return mWindows->value(mWindows->count() - 1);
+}
+
 int GuiApplication::getWindowCount() const noexcept {
   return mWindows->count();
 }
@@ -1015,17 +1026,6 @@ void GuiApplication::highlightErcMessage(
   } else {
     qCritical() << "Unknown window ID:" << windowId;
   }
-}
-
-std::shared_ptr<MainWindow> GuiApplication::getCurrentWindow() noexcept {
-  for (auto& win : mWindows->values()) {
-    if (win->isCurrentWindow()) {
-      return win;
-    }
-  }
-  // TODO: This does not work in every case yet, so we implement some fallback
-  // as a workaround.
-  return mWindows->value(mWindows->count() - 1);
 }
 
 void GuiApplication::updateLibrariesContainStandardComponents() noexcept {

--- a/libs/librepcb/editor/guiapplication.h
+++ b/libs/librepcb/editor/guiapplication.h
@@ -127,6 +127,7 @@ public:
   NotificationsModel& getNotifications() noexcept { return *mNotifications; }
   std::shared_ptr<MainWindow> createNewWindow(int id = -1,
                                               int projectIndex = -1) noexcept;
+  std::shared_ptr<MainWindow> getCurrentWindow() noexcept;
   int getWindowCount() const noexcept;
   void stopWindowStateAutosaveTimer() noexcept;
 
@@ -152,7 +153,6 @@ private:
   void highlightErcMessage(std::shared_ptr<const RuleCheckMessage> msg,
                            bool zoomTo, int windowId) noexcept;
 
-  std::shared_ptr<MainWindow> getCurrentWindow() noexcept;
   void updateLibrariesContainStandardComponents() noexcept;
   void updateNoLibrariesInstalledNotification() noexcept;
   void updateDesktopIntegrationNotification() noexcept;

--- a/libs/librepcb/editor/project/projecteditor.cpp
+++ b/libs/librepcb/editor/project/projecteditor.cpp
@@ -24,6 +24,7 @@
 
 #include "../dialogs/filedialog.h"
 #include "../guiapplication.h"
+#include "../mainwindow.h"
 #include "../notification.h"
 #include "../notificationsmodel.h"
 #include "../rulecheck/rulecheckmessagesmodel.h"
@@ -51,8 +52,11 @@
 #include <librepcb/core/project/board/board.h>
 #include <librepcb/core/project/circuit/bus.h>
 #include <librepcb/core/project/circuit/circuit.h>
+#include <librepcb/core/project/circuit/componentinstance.h>
 #include <librepcb/core/project/erc/electricalrulecheck.h>
+#include <librepcb/core/project/erc/electricalrulecheckmessages.h>
 #include <librepcb/core/project/project.h>
+#include <librepcb/core/project/schematic/items/si_symbol.h>
 #include <librepcb/core/project/schematic/schematic.h>
 #include <librepcb/core/utils/scopeguard.h>
 #include <librepcb/core/workspace/workspace.h>
@@ -242,6 +246,7 @@ ProjectEditor::~ProjectEditor() noexcept {
   // Delete objects to avoid issues with still connected signal/slots.
   mCrossProbe->reset();
   if (mErcMessages) {
+    mErcMessages->setAutofixHandler(nullptr);
     mErcMessages->clear();
     mErcMessages.reset();
   }
@@ -594,7 +599,8 @@ void ProjectEditor::execRenameSheetDialog(int index) noexcept {
   emit abortBlockingToolsInOtherEditors(nullptr);  // Release undo stack.
 
   try {
-    std::unique_ptr<CmdSchematicEdit> cmd(new CmdSchematicEdit(*schematic));
+    std::unique_ptr<CmdSchematicEdit> cmd =
+        std::make_unique<CmdSchematicEdit>(*schematic);
     cmd->setName(ElementName(cleanElementName(name)));  // can throw
     mUndoStack->execCmd(cmd.release());
   } catch (const Exception& e) {
@@ -740,6 +746,9 @@ void ProjectEditor::runErc() noexcept {
     // Update UI.
     if (!mErcMessages) {
       mErcMessages = std::make_shared<RuleCheckMessagesModel>();
+      mErcMessages->setAutofixHandler(std::bind(&ProjectEditor::autoFixHandler,
+                                                this, std::placeholders::_1,
+                                                std::placeholders::_2));
       connect(mErcMessages.get(),
               &RuleCheckMessagesModel::unapprovedCountChanged, this,
               [this]() { onUiDataChanged.notify(); });
@@ -796,6 +805,73 @@ void ProjectEditor::refreshBuses() noexcept {
           ui::BusData{q2s(bus->getUuid().toStr()), q2s(*bus->getName())});
     }
   }
+}
+
+/*******************************************************************************
+ *  Rule Check Autofixes
+ ******************************************************************************/
+
+bool ProjectEditor::autoFixHandler(
+    const std::shared_ptr<const RuleCheckMessage>& msg,
+    bool checkOnly) noexcept {
+  try {
+    return autoFixImpl(msg, checkOnly);  // can throw
+  } catch (const Exception& e) {
+    if (!checkOnly) {
+      QMessageBox::critical(qApp->activeWindow(), tr("Error"), e.getMsg());
+    }
+  }
+  return false;
+}
+
+bool ProjectEditor::autoFixImpl(
+    const std::shared_ptr<const RuleCheckMessage>& msg, bool checkOnly) {
+  if (autoFixHelper<ErcMsgUnplacedOptionalGate>(msg, checkOnly)) return true;
+  if (autoFixHelper<ErcMsgUnplacedRequiredGate>(msg, checkOnly)) return true;
+  return false;
+}
+
+template <typename MessageType>
+bool ProjectEditor::autoFixHelper(
+    const std::shared_ptr<const RuleCheckMessage>& msg, bool checkOnly) {
+  if (msg) {
+    if (auto m = msg->as<MessageType>()) {
+      if (checkOnly) {
+        return true;
+      } else {
+        return autoFix(*m);  // can throw
+      }
+    }
+  }
+  return false;
+}
+
+static bool autoFixUnplacedGate(GuiApplication& app, Project& prj, int prjIndex,
+                                const Uuid& cmp, const Uuid& gate) {
+  const ComponentInstance* cmpObj =
+      prj.getCircuit().getComponentInstanceByUuid(cmp);
+  if ((!cmpObj) || (cmpObj->getSymbols().isEmpty())) return false;
+  const SI_Symbol* firstGate = cmpObj->getSymbols().begin().value();
+  Q_ASSERT(firstGate);
+  int schematicIndex = prj.getSchematicIndex(firstGate->getSchematic());
+  if (auto win = app.getCurrentWindow()) {
+    if (auto tab = win->openSchematicTab(prjIndex, schematicIndex)) {
+      return tab->startAddingRemainingComponentGates(cmp, gate);
+    }
+  }
+  return false;
+}
+
+template <>
+bool ProjectEditor::autoFix(const ErcMsgUnplacedOptionalGate& msg) {
+  return autoFixUnplacedGate(mApp, *mProject, mUiIndex, msg.getComponent(),
+                             msg.getGate());
+}
+
+template <>
+bool ProjectEditor::autoFix(const ErcMsgUnplacedRequiredGate& msg) {
+  return autoFixUnplacedGate(mApp, *mProject, mUiIndex, msg.getComponent(),
+                             msg.getGate());
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/projecteditor.h
+++ b/libs/librepcb/editor/project/projecteditor.h
@@ -206,6 +206,17 @@ private:
   void projectSettingsChanged() noexcept;
   void refreshBuses() noexcept;
 
+  // ERC Autofixes
+  bool autoFixHandler(const std::shared_ptr<const RuleCheckMessage>& msg,
+                      bool checkOnly) noexcept;
+  bool autoFixImpl(const std::shared_ptr<const RuleCheckMessage>& msg,
+                   bool checkOnly);
+  template <typename MessageType>
+  bool autoFixHelper(const std::shared_ptr<const RuleCheckMessage>& msg,
+                     bool checkOnly);
+  template <typename MessageType>
+  bool autoFix(const MessageType& msg);
+
 private:
   GuiApplication& mApp;
   Workspace& mWorkspace;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.cpp
@@ -68,6 +68,9 @@ SchematicEditorFsm::SchematicEditorFsm(const Context& context,
   foreach (SchematicEditorState* state, mStates) {
     connect(state, &SchematicEditorState::requestLeavingState, this,
             &SchematicEditorFsm::processSelect, Qt::QueuedConnection);
+    connect(state, &SchematicEditorState::requestAddRemainingGates, this,
+            &SchematicEditorFsm::processAddRemainingGates,
+            Qt::QueuedConnection);
   }
 
   enterNextState(State::SELECT);
@@ -118,6 +121,21 @@ bool SchematicEditorFsm::processAddComponent(const Uuid& cmp,
   }
   if (SchematicEditorState* state = getCurrentStateObj()) {
     if (state->processAddComponent(cmp, symbVar)) {
+      return true;
+    }
+  }
+  setNextState(oldState);  // restore previous state
+  return false;
+}
+
+bool SchematicEditorFsm::processAddRemainingGates(
+    const Uuid& cmp, const std::optional<Uuid>& gate) noexcept {
+  State oldState = mCurrentState;
+  if (!setNextState(State::ADD_COMPONENT)) {
+    return false;
+  }
+  if (SchematicEditorState* state = getCurrentStateObj()) {
+    if (state->processAddRemainingGates(cmp, gate)) {
       return true;
     }
   }

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorfsm.h
@@ -105,6 +105,8 @@ public:
   bool processSelect() noexcept;
   bool processAddComponent(const QString& searchTerm = QString()) noexcept;
   bool processAddComponent(const Uuid& cmp, const Uuid& symbVar) noexcept;
+  bool processAddRemainingGates(const Uuid& cmp,
+                                const std::optional<Uuid>& gate) noexcept;
   bool processAddNetLabel() noexcept;
   bool processDrawPolygon() noexcept;
   bool processAddText() noexcept;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate.h
@@ -32,6 +32,7 @@
 #include <QtCore>
 
 #include <memory>
+#include <optional>
 
 /*******************************************************************************
  *  Namespace / Forward Declarations
@@ -116,6 +117,12 @@ public:
     Q_UNUSED(symbVar);
     return false;
   }
+  virtual bool processAddRemainingGates(
+      const Uuid& cmp, const std::optional<Uuid>& gate) noexcept {
+    Q_UNUSED(cmp);
+    Q_UNUSED(gate);
+    return false;
+  }
   virtual bool processSelectAll() noexcept { return false; }
   virtual bool processCut() noexcept { return false; }
   virtual bool processCopy() noexcept { return false; }
@@ -187,6 +194,8 @@ signals:
    * the current state and entering the select tool.
    */
   void requestLeavingState();
+  void requestAddRemainingGates(const Uuid& uuid,
+                                const std::optional<Uuid>& gate);
 
 protected:  // Methods
   SchematicGraphicsScene* getActiveSchematicScene() noexcept;

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addcomponent.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addcomponent.cpp
@@ -62,6 +62,8 @@ SchematicEditorState_AddComponent::SchematicEditorState_AddComponent(
   : SchematicEditorState(context),
     mIsUndoCmdActive(false),
     mUseAddComponentDialog(true),
+    mAbortAfterCurrentGate(false),
+    mAbortAfterLastGate(false),
     mAddComponentDialog(nullptr),
     mCurrentAngle(0),
     mCurrentMirrored(false),
@@ -69,7 +71,6 @@ SchematicEditorState_AddComponent::SchematicEditorState_AddComponent(
     mCurrentValueSuggestions(),
     mCurrentValueAttribute(),
     mCurrentComponent(nullptr),
-    mCurrentSymbVarItemIndex(-1),
     mCurrentSymbolToPlace(nullptr),
     mCurrentSymbolEditCommand(nullptr) {
 }
@@ -121,11 +122,13 @@ bool SchematicEditorState_AddComponent::processAddComponent(
     mCurrentMirrored = false;
     setValue(QString());
     mUseAddComponentDialog = true;
+    mAbortAfterCurrentGate = false;
+    mAbortAfterLastGate = false;
     startAddingComponent(std::nullopt, std::nullopt, std::nullopt, searchTerm);
     return true;
-  } catch (UserCanceled& exc) {
-  } catch (Exception& exc) {
-    QMessageBox::critical(parentWidget(), tr("Error"), exc.getMsg());
+  } catch (const UserCanceled& e) {
+  } catch (const Exception& e) {
+    QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
   }
 
   return false;
@@ -140,13 +143,51 @@ bool SchematicEditorState_AddComponent::processAddComponent(
     mCurrentMirrored = false;
     setValue(QString());
     mUseAddComponentDialog = false;
+    mAbortAfterCurrentGate = false;
+    mAbortAfterLastGate = false;
     startAddingComponent(cmp, symbVar, std::nullopt);
     return true;
-  } catch (UserCanceled& exc) {
-  } catch (Exception& exc) {
-    QMessageBox::critical(parentWidget(), tr("Error"), exc.getMsg());
+  } catch (const UserCanceled& e) {
+  } catch (const Exception& e) {
+    QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
   }
 
+  return false;
+}
+
+bool SchematicEditorState_AddComponent::processAddRemainingGates(
+    const Uuid& cmp, const std::optional<Uuid>& gate) noexcept {
+  if (!abortCommand(true)) return false;
+
+  mCurrentComponent =
+      mContext.project.getCircuit().getComponentInstanceByUuid(cmp);
+  if (!mCurrentComponent) return false;
+
+  try {
+    // Start a new command.
+    Q_ASSERT(!mIsUndoCmdActive);
+    mContext.undoStack.beginCmdGroup(tr("Add Component Gate to Schematic"));
+    mIsUndoCmdActive = true;
+
+    mCurrentAngle = Angle::deg0();
+    mCurrentMirrored = false;
+    setValue(mCurrentComponent->getValue());
+    mUseAddComponentDialog = false;
+    mAbortAfterCurrentGate = gate.has_value();
+    mAbortAfterLastGate = true;
+
+    const Point pos = mAdapter.fsmMapGlobalPosToScenePos(QCursor::pos())
+                          .mappedToGrid(getGridInterval());
+    if (!startAddingNextGate(pos, gate)) {
+      throw LogicError(__FILE__, __LINE__);  // No remaining gates to place.
+    }
+    return true;
+  } catch (const UserCanceled& e) {
+  } catch (const Exception& e) {
+    QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
+  }
+
+  abortCommand(false);
   return false;
 }
 
@@ -228,41 +269,23 @@ bool SchematicEditorState_AddComponent::
     mContext.undoStack.beginCmdGroup(tr("Add Symbol to Schematic"));
     mIsUndoCmdActive = true;
 
-    // check if there is a next symbol to add
-    mCurrentSymbVarItemIndex++;
-    const ComponentSymbolVariantItem* currentSymbVarItem =
-        mCurrentComponent->getSymbolVariant()
-            .getSymbolItems()
-            .value(mCurrentSymbVarItemIndex)
-            .get();
-
-    if (currentSymbVarItem) {
-      // create the next symbol instance and add it to the schematic
-      CmdAddSymbolToSchematic* cmd = new CmdAddSymbolToSchematic(
-          mContext.workspace, mContext.schematic,
-          mCurrentSymbolToPlace->getComponentInstance(),
-          currentSymbVarItem->getUuid(), pos);
-      mContext.undoStack.appendToCmdGroup(cmd);
-      mCurrentSymbolToPlace = cmd->getSymbolInstance();
-      Q_ASSERT(mCurrentSymbolToPlace);
-
-      // add command to move the current symbol
-      Q_ASSERT(mCurrentSymbolEditCommand == nullptr);
-      mCurrentSymbolEditCommand =
-          new CmdSymbolInstanceEditAll(*mCurrentSymbolToPlace);
-      mCurrentSymbolEditCommand->setRotation(mCurrentAngle, true);
-      mCurrentSymbolEditCommand->setMirrored(mCurrentMirrored, true);
-    } else {
-      // all symbols placed, start adding the next component
+    // Place the next gate, if any.
+    if (mAbortAfterCurrentGate) {
+      abortCommand(false);  // reset attributes
+      emit requestLeavingState();
+    } else if (!startAddingNextGate(pos)) {
+      // All gates placed, start adding the next component.
       Uuid componentUuid = mCurrentComponent->getLibComponent().getUuid();
       Uuid symbVarUuid = mCurrentComponent->getSymbolVariant().getUuid();
       ComponentAssemblyOptionList options =
           mCurrentComponent->getAssemblyOptions();
-      mContext.undoStack.commitCmdGroup();
-      mIsUndoCmdActive = false;
       abortCommand(false);  // reset attributes
-      startAddingComponent(componentUuid, symbVarUuid, options, QString(),
-                           true);
+      if (mAbortAfterLastGate) {
+        emit requestLeavingState();
+      } else {
+        startAddingComponent(componentUuid, symbVarUuid, options, QString(),
+                             true);
+      }
     }
     return true;
   } catch (Exception& e) {
@@ -465,34 +488,15 @@ void SchematicEditorState_AddComponent::startAddingComponent(
       setValue(mCurrentComponent->getValue());
     }
 
-    // create the first symbol instance and add it to the schematic
-    mCurrentSymbVarItemIndex = 0;
-    const ComponentSymbolVariantItem* currentSymbVarItem =
-        mCurrentComponent->getSymbolVariant()
-            .getSymbolItems()
-            .value(mCurrentSymbVarItemIndex)
-            .get();
-    if (!currentSymbVarItem) {
+    // Add the first gate to the schematic.
+    const Point pos = mAdapter.fsmMapGlobalPosToScenePos(QCursor::pos())
+                          .mappedToGrid(getGridInterval());
+    if (!startAddingNextGate(pos)) {
       throw RuntimeError(__FILE__, __LINE__,
                          tr("The component with the UUID \"%1\" does "
                             "not have any symbol.")
                              .arg(mCurrentComponent->getUuid().toStr()));
     }
-    const Point pos = mAdapter.fsmMapGlobalPosToScenePos(QCursor::pos())
-                          .mappedToGrid(getGridInterval());
-    CmdAddSymbolToSchematic* cmd2 = new CmdAddSymbolToSchematic(
-        mContext.workspace, mContext.schematic, *mCurrentComponent,
-        currentSymbVarItem->getUuid(), pos);
-    mContext.undoStack.appendToCmdGroup(cmd2);
-    mCurrentSymbolToPlace = cmd2->getSymbolInstance();
-    Q_ASSERT(mCurrentSymbolToPlace);
-
-    // add command to move the current symbol
-    Q_ASSERT(mCurrentSymbolEditCommand == nullptr);
-    mCurrentSymbolEditCommand =
-        new CmdSymbolInstanceEditAll(*mCurrentSymbolToPlace);
-    mCurrentSymbolEditCommand->setRotation(mCurrentAngle, true);
-    mCurrentSymbolEditCommand->setMirrored(mCurrentMirrored, true);
 
     // If a schematic frame was added as the first symbol in the schematic,
     // place it at (0, 0) and exit this tool for convenience and to ensure
@@ -527,6 +531,45 @@ void SchematicEditorState_AddComponent::startAddingComponent(
   }
 }
 
+bool SchematicEditorState_AddComponent::startAddingNextGate(
+    const Point& pos, const std::optional<Uuid>& gate) {
+  if (!mCurrentComponent) return false;
+
+  // Check if there is a next gate to add.
+  const ComponentSymbolVariantItem* currentSymbVarItem = nullptr;
+  if (gate && (!mCurrentComponent->getSymbols().contains(*gate))) {
+    currentSymbVarItem = mCurrentComponent->getSymbolVariant()
+                             .getSymbolItems()
+                             .find(*gate)
+                             .get();
+  } else {
+    for (const auto& item : std::as_const(
+             mCurrentComponent->getSymbolVariant().getSymbolItems())) {
+      if (!mCurrentComponent->getSymbols().contains(item.getUuid())) {
+        currentSymbVarItem = &item;
+        break;
+      }
+    }
+  }
+  if (!currentSymbVarItem) return false;
+
+  // create the next symbol instance and add it to the schematic
+  CmdAddSymbolToSchematic* cmd = new CmdAddSymbolToSchematic(
+      mContext.workspace, mContext.schematic, *mCurrentComponent,
+      currentSymbVarItem->getUuid(), pos);
+  mContext.undoStack.appendToCmdGroup(cmd);
+  mCurrentSymbolToPlace = cmd->getSymbolInstance();
+  Q_ASSERT(mCurrentSymbolToPlace);
+
+  // add command to move the current symbol
+  Q_ASSERT(mCurrentSymbolEditCommand == nullptr);
+  mCurrentSymbolEditCommand =
+      new CmdSymbolInstanceEditAll(*mCurrentSymbolToPlace);
+  mCurrentSymbolEditCommand->setRotation(mCurrentAngle, true);
+  mCurrentSymbolEditCommand->setMirrored(mCurrentMirrored, true);
+  return true;
+}
+
 bool SchematicEditorState_AddComponent::abortCommand(
     bool showErrMsgBox) noexcept {
   try {
@@ -542,7 +585,6 @@ bool SchematicEditorState_AddComponent::abortCommand(
 
     // reset attributes, go back to idle state
     mCurrentComponent = nullptr;
-    mCurrentSymbVarItemIndex = -1;
     mCurrentSymbolToPlace = nullptr;
     return true;
   } catch (const Exception& e) {

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addcomponent.h
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_addcomponent.h
@@ -75,6 +75,8 @@ public:
       const QString& searchTerm = QString()) noexcept override;
   bool processAddComponent(const Uuid& cmp,
                            const Uuid& symbVar) noexcept override;
+  bool processAddRemainingGates(
+      const Uuid& cmp, const std::optional<Uuid>& gate) noexcept override;
   bool processRotate(const Angle& rotation) noexcept override;
   bool processMirror(Qt::Orientation orientation) noexcept override;
   bool processAbortCommand() noexcept override;
@@ -132,12 +134,16 @@ private:  // Methods
       const std::optional<librepcb::ComponentAssemblyOptionList>& options =
           std::nullopt,
       const QString& searchTerm = QString(), bool keepValue = false);
+  bool startAddingNextGate(const Point& pos,
+                           const std::optional<Uuid>& gate = std::nullopt);
   bool abortCommand(bool showErrMsgBox) noexcept;
   void applyValueAndAttributeToComponent() noexcept;
 
 private:  // Data
   bool mIsUndoCmdActive;
   bool mUseAddComponentDialog;
+  bool mAbortAfterCurrentGate;
+  bool mAbortAfterLastGate;
   QScopedPointer<AddComponentDialog> mAddComponentDialog;
 
   // Current tool settings
@@ -149,7 +155,6 @@ private:  // Data
 
   // Information about the current component/symbol to place
   ComponentInstance* mCurrentComponent;
-  int mCurrentSymbVarItemIndex;
   SI_Symbol* mCurrentSymbolToPlace;
   CmdSymbolInstanceEditAll* mCurrentSymbolEditCommand;
 };

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
@@ -645,6 +645,14 @@ bool SchematicEditorState_Select::processGraphicsSceneRightMouseButtonReleased(
     mb.addAction(cmd.deviceResetTextAll.createAction(
         &menu, this,
         &SchematicEditorState_Select::resetAllTextsOfSelectedItems));
+    const ComponentInstance& cmp = sym->getSymbol().getComponentInstance();
+    if (cmp.getSymbols().count() !=
+        cmp.getSymbolVariant().getSymbolItems().count()) {
+      mb.addAction(cmd.placeRemainingGates.createAction(
+          &menu, this, [this, uuid = cmp.getUuid()]() {
+            emit requestAddRemainingGates(uuid, std::nullopt);
+          }));
+    }
     EditorToolbox::addResourcesToMenu(mContext.workspace, mb,
                                       sym->getSymbol().getComponentInstance(),
                                       std::nullopt, parentWidget(), menu);

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -442,6 +442,11 @@ void SchematicTab::highlightErcMessage(
   }
 }
 
+bool SchematicTab::startAddingRemainingComponentGates(
+    const Uuid& cmp, const std::optional<Uuid>& gate) noexcept {
+  return mFsm->processAddRemainingGates(cmp, gate);
+}
+
 void SchematicTab::activate() noexcept {
   mScene = std::make_unique<SchematicGraphicsScene>(
       mSchematic, *mLayers,

--- a/libs/librepcb/editor/project/schematic/schematictab.h
+++ b/libs/librepcb/editor/project/schematic/schematictab.h
@@ -83,6 +83,8 @@ public:
   void setDerivedUiData(const ui::SchematicTabData& data) noexcept;
   void highlightErcMessage(const std::shared_ptr<const ErcMsgBase>& msg,
                            bool zoomTo) noexcept;
+  bool startAddingRemainingComponentGates(
+      const Uuid& cmp, const std::optional<Uuid>& gate) noexcept;
   void activate() noexcept override;
   void deactivate() noexcept override;
   void trigger(ui::TabAction a) noexcept override;

--- a/libs/librepcb/ui/api/editorcommandset.slint
+++ b/libs/librepcb/ui/api/editorcommandset.slint
@@ -1754,6 +1754,16 @@ export global EditorCommandSet {
         key: "c",
     };
 
+    in property <EditorCommand> place-remaining-gates: {
+        id: "place_remaining_gates",
+        icon: @image-url("../../../font-awesome/svgs/solid/plus.svg"),
+        text: "Place Remaining Gates",
+        status-tip: "Add more of the components gates to the schematic",
+        shortcut: "",
+        modifiers: { alt: false, control: false, shift: false, meta: false },
+        key: "",
+    };
+
     in property <EditorCommand> open-product-website: {
         id: "open_product_website",
         icon: @image-url("../../../font-awesome/svgs/solid/globe.svg"),


### PR DESCRIPTION
* Add context menu entry for components in schematic to add its remaining, unplaced gates.
* Provide "auto-fix" for the "Unplaced Component Gate" ERC messages, which will start the interactive placement tool.

Closes #448