### PR TITLE
Add workaround for problems with libfreetype 2.14

### DIFF
--- a/apps/librepcb-cli/main.cpp
+++ b/apps/librepcb-cli/main.cpp
@@ -38,6 +38,12 @@ using namespace librepcb;
  ******************************************************************************/
 
 int main(int argc, char* argv[]) {
+  // From librepcb/main.cpp - not sure if we need this also in the CLI, but
+  // at least it shouldn't hurt.
+  if (qEnvironmentVariableIsEmpty("QT_MAX_CACHED_GLYPH_SIZE")) {
+    qputenv("QT_MAX_CACHED_GLYPH_SIZE", "32");
+  }
+
   // Creates the Debug object which installs the message handler. This must be
   // done as early as possible.
   Debug::instance();

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -68,6 +68,14 @@ static int openWorkspace(FilePath& path);
  ******************************************************************************/
 
 int main(int argc, char* argv[]) {
+  // Workaround for issues with libfreetype 2.14 (crash with older Qt versions,
+  // partially missing glyph rendering with Qt 6.11.1), see
+  // https://qt-project.atlassian.net/browse/QTBUG-145783. The problem occurred
+  // with small schematic texts (~<2mm) on relatively large zoom factors.
+  if (qEnvironmentVariableIsEmpty("QT_MAX_CACHED_GLYPH_SIZE")) {
+    qputenv("QT_MAX_CACHED_GLYPH_SIZE", "32");
+  }
+
   QApplication app(argc, argv);
 
   // Give the main thread a higher priority than most other threads as GUI

--- a/tests/unittests/main.cpp
+++ b/tests/unittests/main.cpp
@@ -38,6 +38,12 @@ using namespace librepcb;
  ******************************************************************************/
 
 int main(int argc, char* argv[]) {
+  // From librepcb/main.cpp - not sure if we need this also in the unit tests,
+  // but at least it shouldn't hurt.
+  if (qEnvironmentVariableIsEmpty("QT_MAX_CACHED_GLYPH_SIZE")) {
+    qputenv("QT_MAX_CACHED_GLYPH_SIZE", "32");
+  }
+
   // initialize a common locale for all tests
   QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
 


### PR DESCRIPTION
See https://github.com/LibrePCB/LibrePCB/issues/1767. Unfortunately, upgrading to Qt 6.11.1 only fixes the segfault, but then leads to some glyphs not being rendered on specific zoom levels :sob: Now found this workaround which was mentioned in https://qt-project.atlassian.net/browse/QTBUG-145783 and seems to fix the rendering problem.

I tried hard to report this bug to Qt, but their ***** Atlassian bugtracker does not let me doing it. Seems they are not interested in bug reports. One more reason to migrate away from Qt...