### PR TITLE
SlintGraphicsView: Process mouse button events asynchronously

### DIFF
--- a/libs/librepcb/editor/graphics/slintgraphicsview.cpp
+++ b/libs/librepcb/editor/graphics/slintgraphicsview.cpp
@@ -221,7 +221,7 @@ slint::Image SlintGraphicsView::render(GraphicsScene& scene, float width,
   return q2s(pixmap);
 }
 
-bool SlintGraphicsView::pointerEvent(
+void SlintGraphicsView::pointerEvent(
     const QPointF& pos, slint::private_api::PointerEvent e) noexcept {
   using slint::private_api::PointerEventButton;
   using slint::private_api::PointerEventKind;
@@ -246,49 +246,66 @@ bool SlintGraphicsView::pointerEvent(
 
   if ((e.button == PointerEventButton::Left) &&
       (e.kind == PointerEventKind::Down)) {
-    if (mEventHandler) {
-      if (isDoubleClick) {
-        if (mEventHandler->graphicsSceneLeftMouseButtonDoubleClicked(
-                mMouseEvent)) {
-          // Workaround for sticky button when a dialog is opened. It seems
-          // we don't receive the "button up" event from Slint in that case.
-          mMouseEvent.buttons.setFlag(s2q(e.button), false);
-          return true;
-        }
-      } else {
-        return mEventHandler->graphicsSceneLeftMouseButtonPressed(mMouseEvent);
-      }
+    // Process mouse events asynchronosuly to avoid focus issues as reported
+    // in https://github.com/LibrePCB/LibrePCB/issues/1740.
+    QMetaObject::invokeMethod(
+        this,
+        [this, isDoubleClick, e = mMouseEvent]() {
+          if (mEventHandler) {
+            if (isDoubleClick) {
+              mEventHandler->graphicsSceneLeftMouseButtonDoubleClicked(e);
+            } else {
+              mEventHandler->graphicsSceneLeftMouseButtonPressed(e);
+            }
+          }
+        },
+        Qt::QueuedConnection);
+    // Workaround for sticky button when a dialog is opened. It seems
+    // we don't receive the "button up" event from Slint in that case.
+    if (isDoubleClick) {
+      mMouseEvent.buttons.setFlag(s2q(e.button), false);
     }
   } else if ((e.button == PointerEventButton::Left) &&
              (e.kind == PointerEventKind::Up)) {
-    if (mEventHandler) {
-      return mEventHandler->graphicsSceneLeftMouseButtonReleased(mMouseEvent);
-    }
+    // Since the button down event was processed asynchronously, we should do
+    // the same for the button up event to keep all events in correct order.
+    QMetaObject::invokeMethod(
+        this,
+        [this, e = mMouseEvent]() {
+          if (mEventHandler) {
+            mEventHandler->graphicsSceneLeftMouseButtonReleased(e);
+          }
+        },
+        Qt::QueuedConnection);
   } else if ((e.button == PointerEventButton::Middle) &&
              (e.kind == PointerEventKind::Down)) {
     mPanningStartScreenPos = pos;
     mPanningStartScenePos = scenePosPx;
     mPanning = true;
     emit stateChanged();
-    return true;
   } else if ((e.button == PointerEventButton::Middle) &&
              (e.kind == PointerEventKind::Up)) {
     mPanning = false;
     emit stateChanged();
-    return true;
   } else if ((e.button == PointerEventButton::Right) &&
              (e.kind == PointerEventKind::Down)) {
     mPanningStartScreenPos = pos;
     mPanningStartScenePos = scenePosPx;
-    return true;
   } else if ((e.button == PointerEventButton::Right) &&
              (e.kind == PointerEventKind::Up)) {
     if (mPanning) {
       mPanning = false;
       emit stateChanged();
-      return true;
-    } else if (mEventHandler) {
-      return mEventHandler->graphicsSceneRightMouseButtonReleased(mMouseEvent);
+    } else {
+      // Process asynchronously too to keep all button events in correct order.
+      QMetaObject::invokeMethod(
+          this,
+          [this, e = mMouseEvent]() {
+            if (mEventHandler) {
+              mEventHandler->graphicsSceneRightMouseButtonReleased(e);
+            }
+          },
+          Qt::QueuedConnection);
     }
   } else if (e.kind == PointerEventKind::Move) {
     if ((!mPanning) && (mMouseEvent.buttons.testFlag(Qt::RightButton))) {
@@ -304,13 +321,10 @@ bool SlintGraphicsView::pointerEvent(
       projection.autoFitInView = false;
       projection.offset -= scenePosPx - mPanningStartScenePos;
       applyProjection(projection);
-      return true;
     } else if (mEventHandler) {
-      return mEventHandler->graphicsSceneMouseMoved(mMouseEvent);
+      mEventHandler->graphicsSceneMouseMoved(mMouseEvent);
     }
   }
-
-  return false;
 }
 
 bool SlintGraphicsView::scrollEvent(

--- a/libs/librepcb/editor/graphics/slintgraphicsview.h
+++ b/libs/librepcb/editor/graphics/slintgraphicsview.h
@@ -102,7 +102,7 @@ public:
   void setEventHandler(IF_GraphicsViewEventHandler* obj) noexcept;
   void setMirror(bool mirror) noexcept;
   slint::Image render(GraphicsScene& scene, float width, float height) noexcept;
-  bool pointerEvent(const QPointF& pos,
+  void pointerEvent(const QPointF& pos,
                     slint::private_api::PointerEvent e) noexcept;
   bool scrollEvent(const QPointF& pos,
                    slint::private_api::PointerScrollEvent e) noexcept;

--- a/libs/librepcb/editor/library/dev/devicetab.cpp
+++ b/libs/librepcb/editor/library/dev/devicetab.cpp
@@ -597,15 +597,13 @@ slint::Image DeviceTab::renderScene(float width, float height,
   }
 }
 
-bool DeviceTab::processScenePointerEvent(const QPointF& pos,
+void DeviceTab::processScenePointerEvent(const QPointF& pos,
                                          slint::private_api::PointerEvent e,
                                          int scene) noexcept {
   if (scene == 0) {
-    return mComponentView->pointerEvent(pos, e);
+    mComponentView->pointerEvent(pos, e);
   } else if (scene == 1) {
-    return mPackageView->pointerEvent(pos, e);
-  } else {
-    return false;
+    mPackageView->pointerEvent(pos, e);
   }
 }
 

--- a/libs/librepcb/editor/library/dev/devicetab.h
+++ b/libs/librepcb/editor/library/dev/devicetab.h
@@ -93,7 +93,7 @@ public:
   void trigger(ui::TabAction a) noexcept override;
   slint::Image renderScene(float width, float height,
                            int scene) noexcept override;
-  bool processScenePointerEvent(const QPointF& pos,
+  void processScenePointerEvent(const QPointF& pos,
                                 slint::private_api::PointerEvent e,
                                 int scene) noexcept override;
   bool processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -1017,14 +1017,14 @@ slint::Image PackageTab::renderScene(float width, float height,
   return slint::Image();
 }
 
-bool PackageTab::processScenePointerEvent(const QPointF& pos,
+void PackageTab::processScenePointerEvent(const QPointF& pos,
                                           slint::private_api::PointerEvent e,
                                           int scene) noexcept {
   Q_UNUSED(scene);
   if (mView3d && mOpenGlView) {
-    return mOpenGlView->pointerEvent(pos, e);
+    mOpenGlView->pointerEvent(pos, e);
   } else {
-    return mView->pointerEvent(pos, e);
+    mView->pointerEvent(pos, e);
   }
 }
 

--- a/libs/librepcb/editor/library/pkg/packagetab.h
+++ b/libs/librepcb/editor/library/pkg/packagetab.h
@@ -103,7 +103,7 @@ public:
   void trigger(ui::TabAction a) noexcept override;
   slint::Image renderScene(float width, float height,
                            int scene) noexcept override;
-  bool processScenePointerEvent(const QPointF& pos,
+  void processScenePointerEvent(const QPointF& pos,
                                 slint::private_api::PointerEvent e,
                                 int scene) noexcept override;
   bool processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -679,11 +679,11 @@ slint::Image SymbolTab::renderScene(float width, float height,
   return slint::Image();
 }
 
-bool SymbolTab::processScenePointerEvent(const QPointF& pos,
+void SymbolTab::processScenePointerEvent(const QPointF& pos,
                                          slint::private_api::PointerEvent e,
                                          int scene) noexcept {
   Q_UNUSED(scene);
-  return mView->pointerEvent(pos, e);
+  mView->pointerEvent(pos, e);
 }
 
 bool SymbolTab::processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/library/sym/symboltab.h
+++ b/libs/librepcb/editor/library/sym/symboltab.h
@@ -94,7 +94,7 @@ public:
   void trigger(ui::TabAction a) noexcept override;
   slint::Image renderScene(float width, float height,
                            int scene) noexcept override;
-  bool processScenePointerEvent(const QPointF& pos,
+  void processScenePointerEvent(const QPointF& pos,
                                 slint::private_api::PointerEvent e,
                                 int scene) noexcept override;
   bool processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -1060,16 +1060,13 @@ slint::Image Board2dTab::renderScene(float width, float height,
   }
 }
 
-bool Board2dTab::processScenePointerEvent(const QPointF& pos,
+void Board2dTab::processScenePointerEvent(const QPointF& pos,
                                           slint::private_api::PointerEvent e,
                                           int scene) noexcept {
   Q_UNUSED(scene);
   mProjectEditor.setCurrentTab(this);
-  if (mView->pointerEvent(pos, e)) {
-    restartIdleTimer();
-    return true;
-  }
-  return false;
+  mView->pointerEvent(pos, e);
+  restartIdleTimer();
 }
 
 bool Board2dTab::processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/project/board/board2dtab.h
+++ b/libs/librepcb/editor/project/board/board2dtab.h
@@ -117,7 +117,7 @@ public:
   void trigger(ui::TabAction a) noexcept override;
   slint::Image renderScene(float width, float height,
                            int scene) noexcept override;
-  bool processScenePointerEvent(const QPointF& pos,
+  void processScenePointerEvent(const QPointF& pos,
                                 slint::private_api::PointerEvent e,
                                 int scene) noexcept override;
   bool processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/project/board/board3dtab.cpp
+++ b/libs/librepcb/editor/project/board/board3dtab.cpp
@@ -277,11 +277,11 @@ slint::Image Board3dTab::renderScene(float width, float height,
   return slint::Image();
 }
 
-bool Board3dTab::processScenePointerEvent(const QPointF& pos,
+void Board3dTab::processScenePointerEvent(const QPointF& pos,
                                           slint::private_api::PointerEvent e,
                                           int scene) noexcept {
   Q_UNUSED(scene);
-  return mView ? mView->pointerEvent(pos, e) : false;
+  if (mView) mView->pointerEvent(pos, e);
 }
 
 bool Board3dTab::processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/project/board/board3dtab.h
+++ b/libs/librepcb/editor/project/board/board3dtab.h
@@ -77,7 +77,7 @@ public:
   void trigger(ui::TabAction a) noexcept override;
   slint::Image renderScene(float width, float height,
                            int scene) noexcept override;
-  bool processScenePointerEvent(const QPointF& pos,
+  void processScenePointerEvent(const QPointF& pos,
                                 slint::private_api::PointerEvent e,
                                 int scene) noexcept override;
   bool processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -759,12 +759,12 @@ slint::Image SchematicTab::renderScene(float width, float height,
   return slint::Image();
 }
 
-bool SchematicTab::processScenePointerEvent(const QPointF& pos,
+void SchematicTab::processScenePointerEvent(const QPointF& pos,
                                             slint::private_api::PointerEvent e,
                                             int scene) noexcept {
   Q_UNUSED(scene);
   mProjectEditor.setCurrentTab(this);
-  return mView->pointerEvent(pos, e);
+  mView->pointerEvent(pos, e);
 }
 
 bool SchematicTab::processSceneScrolled(

--- a/libs/librepcb/editor/project/schematic/schematictab.h
+++ b/libs/librepcb/editor/project/schematic/schematictab.h
@@ -90,7 +90,7 @@ public:
   void trigger(ui::TabAction a) noexcept override;
   slint::Image renderScene(float width, float height,
                            int scene) noexcept override;
-  bool processScenePointerEvent(const QPointF& pos,
+  void processScenePointerEvent(const QPointF& pos,
                                 slint::private_api::PointerEvent e,
                                 int scene) noexcept override;
   bool processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/windowsection.cpp
+++ b/libs/librepcb/editor/windowsection.cpp
@@ -206,13 +206,12 @@ slint::Image WindowSection::renderScene(float width, float height,
   return slint::Image();
 }
 
-bool WindowSection::processScenePointerEvent(const QPointF& pos,
+void WindowSection::processScenePointerEvent(const QPointF& pos,
                                              slint::private_api::PointerEvent e,
                                              int scene) noexcept {
   if (std::shared_ptr<WindowTab> t = getCurrentTab()) {
-    return t->processScenePointerEvent(pos, e, scene);
+    t->processScenePointerEvent(pos, e, scene);
   }
-  return false;
 }
 
 bool WindowSection::processSceneScrolled(

--- a/libs/librepcb/editor/windowsection.h
+++ b/libs/librepcb/editor/windowsection.h
@@ -78,7 +78,7 @@ public:
                                        bool* wasCurrent = nullptr) noexcept;
   void triggerTab(int index, ui::TabAction a) noexcept;
   slint::Image renderScene(float width, float height, int scene) noexcept;
-  bool processScenePointerEvent(const QPointF& pos,
+  void processScenePointerEvent(const QPointF& pos,
                                 slint::private_api::PointerEvent e,
                                 int scene) noexcept;
   bool processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/windowtab.cpp
+++ b/libs/librepcb/editor/windowtab.cpp
@@ -73,13 +73,12 @@ slint::Image WindowTab::renderScene(float width, float height,
   return slint::Image();
 }
 
-bool WindowTab::processScenePointerEvent(const QPointF& pos,
+void WindowTab::processScenePointerEvent(const QPointF& pos,
                                          slint::private_api::PointerEvent e,
                                          int scene) noexcept {
   Q_UNUSED(pos);
   Q_UNUSED(e);
   Q_UNUSED(scene);
-  return false;
 }
 
 bool WindowTab::processSceneScrolled(const QPointF& pos,

--- a/libs/librepcb/editor/windowtab.h
+++ b/libs/librepcb/editor/windowtab.h
@@ -71,7 +71,7 @@ public:
   virtual void trigger(ui::TabAction a) noexcept;
   virtual slint::Image renderScene(float width, float height,
                                    int scene) noexcept;
-  virtual bool processScenePointerEvent(const QPointF& pos,
+  virtual void processScenePointerEvent(const QPointF& pos,
                                         slint::private_api::PointerEvent e,
                                         int scene) noexcept;
   virtual bool processSceneScrolled(const QPointF& pos,


### PR DESCRIPTION
Fixes some mouse button events to disappear and causing focus issues when a modal dialog is opened in the mouse button event handlers (i.e. in the editors).

Fixes #1740