### PR TITLE
getProcessNameByPid: more correct implementation for FreeBSD

### DIFF
--- a/libs/librepcb/core/3d/occmodel.cpp
+++ b/libs/librepcb/core/3d/occmodel.cpp
@@ -47,6 +47,7 @@
 #include <Message_Messenger.hxx>
 #include <Message_Printer.hxx>
 #include <Message_SequenceOfPrinters.hxx>
+#include <NCollection_List.hxx>
 #include <Poly_Triangulation.hxx>
 #include <Quantity_Color.hxx>
 #include <Standard_Version.hxx>
@@ -616,9 +617,9 @@ std::unique_ptr<OccModel> OccModel::createBoard(const librepcb::Path& outline,
       // Cutting fails if there are no holes.
       face = pathToFace(outline.cleaned(), Length(0));
     } else {
-      TopTools_ListOfShape boardFaces;
+      NCollection_List<TopoDS_Shape> boardFaces;
       boardFaces.Append(pathToFace(outline.cleaned(), Length(0)));
-      TopTools_ListOfShape holeFaces;
+      NCollection_List<TopoDS_Shape> holeFaces;
       foreach (const Path& hole, holes) {
         holeFaces.Append(pathToFace({hole.cleaned()}, Length(0)));
       }

--- a/libs/librepcb/core/systeminfo.cpp
+++ b/libs/librepcb/core/systeminfo.cpp
@@ -46,7 +46,7 @@
 #if defined(Q_OS_SOLARIS)
 #include <libproc.h>
 #endif
-#if defined(Q_OS_OPENBSD)
+#if defined(Q_OS_OPENBSD) || defined(Q_OS_FREEBSD)
 #include <sys/sysctl.h>
 #endif
 #elif defined(Q_OS_WIN32) || defined(Q_OS_WIN64)  // Windows
@@ -272,15 +272,17 @@ QString SystemInfo::getProcessNameByPid(qint64 pid) {
                        tr("proc_name() failed with error %1.").arg(errno));
   }
 #elif defined(Q_OS_FREEBSD)
-  char exePath[64];
-  char buf[PATH_MAX + 1];
-  sprintf(exePath, "/proc/%lld/file", pid);
-  size_t len = (size_t)readlink(exePath, buf, sizeof(buf));
-  if (len >= sizeof(buf)) {
-    return QString();  // process not running
+  char pathbuf[PATH_MAX] = { 0, };
+  size_t pathbufsz = PATH_MAX;
+  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, static_cast<pid_t>(pid) };
+  if (sysctl(mib, 4, pathbuf, &pathbufsz, NULL, 0) != 0) {
+    int saved_errno = errno;
+    throw RuntimeError(__FILE__, __LINE__,
+                       tr("sysctl() failed with errno=%1 (%2).")
+                           .arg(saved_errno)
+                           .arg(QString::fromLocal8Bit(strerror(saved_errno))));
   }
-  buf[len] = 0;
-  processName = QFileInfo(QFile::decodeName(buf)).fileName();
+  processName = QFileInfo(QFile::decodeName(pathbuf)).fileName();
 #elif defined(Q_OS_OPENBSD)
   // https://man.openbsd.org/sysctl.2
   // NOTE: This will return only the first 16 bytes of the process name. If


### PR DESCRIPTION
The current version depends on /proc being mounted which is not necessarily a given. This commit switches the implementation to use a fitting sysctl(3) call to retrieve the executable path (name) from the kernel, uncoupling the implementation from procfs.