### PR TITLE
FreeBSD: Implement getProcessNameByPid() with sysctl()

### DIFF
--- a/libs/librepcb/core/systeminfo.cpp
+++ b/libs/librepcb/core/systeminfo.cpp
@@ -46,7 +46,7 @@
 #if defined(Q_OS_SOLARIS)
 #include <libproc.h>
 #endif
-#if defined(Q_OS_OPENBSD)
+#if defined(Q_OS_OPENBSD) || defined(Q_OS_FREEBSD)
 #include <sys/sysctl.h>
 #endif
 #elif defined(Q_OS_WIN32) || defined(Q_OS_WIN64)  // Windows
@@ -272,15 +272,30 @@ QString SystemInfo::getProcessNameByPid(qint64 pid) {
                        tr("proc_name() failed with error %1.").arg(errno));
   }
 #elif defined(Q_OS_FREEBSD)
-  char exePath[64];
-  char buf[PATH_MAX + 1];
-  sprintf(exePath, "/proc/%lld/file", pid);
-  size_t len = (size_t)readlink(exePath, buf, sizeof(buf));
-  if (len >= sizeof(buf)) {
-    return QString();  // process not running
+  char pathbuf[PATH_MAX] = { 0, };
+  size_t pathbufsz = PATH_MAX;
+  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, static_cast<pid_t>(pid) };
+  int rc = sysctl(mib, 4, pathbuf, &pathbufsz, NULL, 0);
+  if (rc == -1) {
+    switch (errno) {
+      case ESRCH: // explicitly No such process
+        return QString();
+      break;
+      default: {
+        int saved_errno = errno;
+        char errbuf[512] = { 0, };
+        // Should 512 not be enough, the error string returned by strerror_r() will
+        // be truncated but still be nul-terminated
+        strerror_r(saved_errno, errbuf, sizeof(errbuf));
+        throw RuntimeError(__FILE__, __LINE__,
+                           tr("sysctl() failed with errno=%1 (%2).")
+                               .arg(saved_errno)
+                               .arg(QString::fromLocal8Bit(errbuf)));
+      }
+      break;
+    }
   }
-  buf[len] = 0;
-  processName = QFileInfo(QFile::decodeName(buf)).fileName();
+  processName = QFileInfo(QFile::decodeName(pathbuf)).fileName();
 #elif defined(Q_OS_OPENBSD)
   // https://man.openbsd.org/sysctl.2
   // NOTE: This will return only the first 16 bytes of the process name. If

--- a/libs/librepcb/core/systeminfo.cpp
+++ b/libs/librepcb/core/systeminfo.cpp
@@ -272,27 +272,30 @@ QString SystemInfo::getProcessNameByPid(qint64 pid) {
                        tr("proc_name() failed with error %1.").arg(errno));
   }
 #elif defined(Q_OS_FREEBSD)
-  char pathbuf[PATH_MAX] = { 0, };
+  char pathbuf[PATH_MAX] = {
+      0,
+  };
   size_t pathbufsz = PATH_MAX;
-  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, static_cast<pid_t>(pid) };
+  int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME,
+                static_cast<pid_t>(pid)};
   int rc = sysctl(mib, 4, pathbuf, &pathbufsz, NULL, 0);
   if (rc == -1) {
     switch (errno) {
-      case ESRCH: // explicitly No such process
+      case ESRCH:  // explicitly No such process
         return QString();
-      break;
       default: {
         int saved_errno = errno;
-        char errbuf[512] = { 0, };
-        // Should 512 not be enough, the error string returned by strerror_r() will
-        // be truncated but still be nul-terminated
+        char errbuf[512] = {
+            0,
+        };
+        // Should 512 not be enough, the error string returned by strerror_r()
+        // will be truncated but still be nul-terminated.
         strerror_r(saved_errno, errbuf, sizeof(errbuf));
         throw RuntimeError(__FILE__, __LINE__,
                            tr("sysctl() failed with errno=%1 (%2).")
                                .arg(saved_errno)
                                .arg(QString::fromLocal8Bit(errbuf)));
       }
-      break;
     }
   }
   processName = QFileInfo(QFile::decodeName(pathbuf)).fileName();


### PR DESCRIPTION
The current version depends on /proc being mounted which is not necessarily a given. This commit switches the implementation to use a fitting sysctl(3) call to retrieve the executable path (name) from the kernel, uncoupling the implementation from procfs.