### PR TITLE
Trim whitespace around empty attribute substitutions

### DIFF
--- a/libs/librepcb/core/attribute/attributesubstitutor.cpp
+++ b/libs/librepcb/core/attribute/attributesubstitutor.cpp
@@ -55,8 +55,7 @@ QString AttributeSubstitutor::substitute(QString str, LookupFunction lookup,
       if (key.startsWith('\'') && key.endsWith('\'')) {
         // replace "{{'VALUE'}}" with "VALUE"
         str.replace(startPos, length, key.mid(1, key.length() - 2));
-        startPos +=
-            key.length() - 2;  // do not search for variables in the value
+        startPos += key.length() - 2;  // Do not search for variables in value
         keyFound = true;
         break;
       } else if ((getValueOfKey(key, value, lookup)) &&
@@ -69,7 +68,17 @@ QString AttributeSubstitutor::substitute(QString str, LookupFunction lookup,
       }
     }
     if (!keyFound) {
-      // attribute not found, remove "{{KEY}}" from str
+      // Attribute not found, remove "{{KEY}}" from str.
+      if ((startPos + length == str.length()) && (startPos > 0) &&
+          (str.at(startPos - 1).isSpace())) {
+        // At the end of str, also remove leading whitespace of "{{KEY}}".
+        --startPos;
+        ++length;
+      } else if ((str.length() > startPos + length) &&
+                 str.at(startPos + length).isSpace()) {
+        // Not the end of str, remove a trailing whitespace after "{{KEY}}".
+        ++length;
+      }
       str.remove(startPos, length);
     }
   }

--- a/libs/librepcb/core/utils/toolbox.cpp
+++ b/libs/librepcb/core/utils/toolbox.cpp
@@ -172,7 +172,7 @@ UnsignedLength Toolbox::shortestDistanceBetweenPointAndLine(
 }
 
 QString Toolbox::incrementNumberInString(QString string) noexcept {
-  rs::ffi_increment_number_in_string(&string);
+  rs::ffi_toolbox_increment_number_in_string(&string);
   return string;
 }
 

--- a/libs/librepcb/rust-core/Cargo.lock
+++ b/libs/librepcb/rust-core/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "cbindgen",
  "interactive-html-bom",
  "libm",
+ "lz-str",
  "parameterized_test",
  "regex",
  "zip",

--- a/libs/librepcb/rust-core/Cargo.toml
+++ b/libs/librepcb/rust-core/Cargo.toml
@@ -16,6 +16,7 @@ cbindgen = { version = "0.27", optional = true }
 [dependencies]
 interactive-html-bom = "0.2.0"
 libm = "0.2.16"
+lz-str = "0.2.1"  # Keep in sync with interactive-html-bom
 
 [dependencies.regex]
 version = "1.11"

--- a/libs/librepcb/rust-core/ffi.h
+++ b/libs/librepcb/rust-core/ffi.h
@@ -530,7 +530,12 @@ double ffi_math_arc_radius_and_center(double dx,
 /**
  * Wrapper for [increment_number_in_string]
  */
-void ffi_increment_number_in_string(QString * NONNULL s);
+void ffi_toolbox_increment_number_in_string(QString * NONNULL s);
+
+/**
+ * Wrapper for [lz_str::decompress_from_base64]
+ */
+bool ffi_toolbox_decode_base64_lzstring(QString * NONNULL s);
 
 /**
  * Create a new [ZipArchive] object from file path

--- a/libs/librepcb/rust-core/src/ffi/toolbox_ffi.rs
+++ b/libs/librepcb/rust-core/src/ffi/toolbox_ffi.rs
@@ -5,7 +5,20 @@ use crate::toolbox::*;
 
 /// Wrapper for [increment_number_in_string]
 #[no_mangle]
-extern "C" fn ffi_increment_number_in_string(s: &mut QString) {
+extern "C" fn ffi_toolbox_increment_number_in_string(s: &mut QString) {
   let r_str = increment_number_in_string(&from_qstring(s));
   qstring_set(s, &r_str);
+}
+
+/// Wrapper for [lz_str::decompress_from_base64]
+#[no_mangle]
+extern "C" fn ffi_toolbox_decode_base64_lzstring(s: &mut QString) -> bool {
+  let r_str = from_qstring(s);
+  if let Some(data) = lz_str::decompress_from_base64(&r_str) {
+    if let Ok(data_str) = String::from_utf16(&data) {
+      qstring_set(s, &data_str);
+      return true;
+    }
+  }
+  false
 }

--- a/tests/unittests/core/attribute/attributesubstitutortest.cpp
+++ b/tests/unittests/core/attribute/attributesubstitutortest.cpp
@@ -68,8 +68,8 @@ TEST_P(AttributeSubstitutorTest, testData) {
   const AttributeSubstitutorTestData& data = GetParam();
 
   QString output = AttributeSubstitutor::substitute(data.input, &lookup);
-  EXPECT_EQ(data.output, output)
-      << "Actual value: '" << qPrintable(output) << "'";
+  EXPECT_EQ(data.output, output) << "'" << qPrintable(output) << "' != '"
+                                 << qPrintable(data.output) << "'";
 }
 
 /*******************************************************************************
@@ -88,13 +88,13 @@ INSTANTIATE_TEST_SUITE_P(AttributeSubstitutorTest, AttributeSubstitutorTest, ::t
     //ASTD({"{{KEY_1}} {{KEY_1}}",                "Normal value Normal value"}),
     ASTD({"some {}}}{{ noise",                  "some {}}}{{ noise"}),
     ASTD({"{{KEY_2}}",                          "Value with {}}}{{ noise"}),
-    ASTD({"{{KEY_3}}",                          "Recursive  value"}),
+    ASTD({"{{KEY_3}}",                          "Recursive value"}),
     ASTD({"{{KEY_4}}",                          "Recursive Normal value value"}),
     ASTD({"{{KEY_5}}",                          "Recursive Recursive Normal value value value"}),
-    ASTD({"{{KEY_6}}",                          "Endless Endless  part 2 part 1"}),
-    ASTD({"{{KEY_7}}",                          "Endless Endless  part 1 part 2"}),
-    ASTD({"Foo {KEY_7 }}{{KEY_7}} {{KEYY}}",    "Foo {KEY_7 }}Endless Endless  part 1 part 2 "}),
-    ASTD({"{{KEY_3}} foo{ { KEY_5}} {{KEY}}",   "Recursive  value foo{ { KEY_5}} "}),
+    ASTD({"{{KEY_6}}",                          "Endless Endless part 2 part 1"}),
+    ASTD({"{{KEY_7}}",                          "Endless Endless part 1 part 2"}),
+    ASTD({"Foo {KEY_7 }}{{KEY_7}} {{KEYY}}",    "Foo {KEY_7 }}Endless Endless part 1 part 2"}),
+    ASTD({"{{KEY_3}} foo{ { KEY_5}} {{KEY}}",   "Recursive value foo{ { KEY_5}}"}),
     ASTD({"{{KEY_1}} {{KEY_2 or KEY_3}} foo",   "Normal value Value with {}}}{{ noise foo"}),
     //ASTD({"{{KEY_8 or KEY_1}}",                 "Normal value"}),
     //ASTD({"{{KEY or KEY_4 or KEY_3}} {{KEY_1}}","Recursive Normal value value Normal value"}),
@@ -106,7 +106,24 @@ INSTANTIATE_TEST_SUITE_P(AttributeSubstitutorTest, AttributeSubstitutorTest, ::t
     ASTD({"{{ '{{' }}",                         "{{"}),
     ASTD({"{{ '}}' }}",                         "}}"}),
     ASTD({"{{KEY_1}}KEY_2",                     "Normal valueKEY_2"}),
-    ASTD({"{{KEY_1 or FOO}} or KEY_1",          "Normal value or KEY_1"})
+    ASTD({"{{KEY_1 or FOO}} or KEY_1",          "Normal value or KEY_1"}),
+    // Whitespace trimming
+    ASTD({"{{KEY_1}} {{KEY_8}} foo",            "Normal value foo"}),
+    ASTD({"{{KEY_1}} {{NONEXISTENT}} foo",      "Normal value foo"}),
+    ASTD({"{{NONEXISTENT}} {{KEY_1}} foo",      "Normal value foo"}),
+    ASTD({"{{KEY}} {{KEY_1}} foo",              "Normal value foo"}),
+    ASTD({"{{KEY}} {{KEY_1}} {{KEY}}",          "Normal value"}),
+    ASTD({"{{KEY}} {{KEY}} {{KEY}}",            ""}),
+    ASTD({"{{NONEXISTENT}} {{NONEXISTENT}}",    ""}),
+    // Newline trimming
+    ASTD({"{{KEY_1}}\n{{KEY_8}}\nfoo",          "Normal value\nfoo"}),
+    ASTD({"{{KEY_1}}\n{{NONEXISTENT}}\nfoo",    "Normal value\nfoo"}),
+    ASTD({"{{NONEXISTENT}}\n{{KEY_1}}\nfoo",    "Normal value\nfoo"}),
+    ASTD({"{{KEY}}\n{{KEY_1}}\nfoo",            "Normal value\nfoo"}),
+    ASTD({"{{KEY}}\n{{KEY_1}}\n{{KEY}}",        "Normal value"}),
+    ASTD({"{{KEY}}\n{{KEY}}\n{{KEY}}",          ""}),
+    ASTD({"{{NONEXISTENT}}\n{{NONEXISTENT}}",   ""}),
+    ASTD({"Foo\n\nBar",                         "Foo\n\nBar"})
 ));
 // clang-format on
 

--- a/tests/unittests/core/project/board/boardinteractivehtmlbomgeneratortest.cpp
+++ b/tests/unittests/core/project/board/boardinteractivehtmlbomgeneratortest.cpp
@@ -29,6 +29,7 @@
 #include <librepcb/core/project/circuit/circuit.h>
 #include <librepcb/core/project/project.h>
 #include <librepcb/core/project/projectloader.h>
+#include <librepcb/rust-core/ffi.h>
 
 #include <QtCore>
 
@@ -55,7 +56,7 @@ TEST_F(BoardInteractiveHtmlBomGeneratorTest, test) {
       TEST_DATA_DIR
       "/unittests/librepcbproject/BoardInteractiveHtmlBomGeneratorTest");
 
-  // open project from test data directory
+  // Open project from test data directory.
   FilePath projectFp(TEST_DATA_DIR "/projects/Gerber Test/project.lpp");
   std::shared_ptr<TransactionalFileSystem> projectFs =
       TransactionalFileSystem::openRO(projectFp.getParentDir());
@@ -64,7 +65,7 @@ TEST_F(BoardInteractiveHtmlBomGeneratorTest, test) {
       loader.open(std::make_unique<TransactionalDirectory>(projectFs),
                   projectFp.getFilename());  // can throw
 
-  // export BOM
+  // Export BOM.
   Board* board = project->getBoards().first();
   BoardInteractiveHtmlBomGenerator gen(
       *board, project->getCircuit().getAssemblyVariants().first());
@@ -72,14 +73,24 @@ TEST_F(BoardInteractiveHtmlBomGeneratorTest, test) {
       gen.generate(QDateTime::fromSecsSinceEpoch(9, Qt::UTC));
   const QString actual = ibom->generateHtml();
 
-  // write to file
-  const FilePath fp = testDataDir.getPathTo("actual.html");
-  FileUtils::writeFile(fp, actual.toUtf8());
+  // For better diffs, extract the compressed data string (lz-string).
+  QRegularExpression re("var pcbdata =.*\\\"(.*)\\\"");
+  QString data = re.match(actual).captured(1);  // NOLINT
+  const bool success = rs::ffi_toolbox_decode_base64_lzstring(&data);
+  EXPECT_TRUE(success);
+  data = QJsonDocument::fromJson(data.toUtf8()).toJson(QJsonDocument::Indented);
 
-  // compare generated files with expected content
-  const QString expected =
-      FileUtils::readFile(testDataDir.getPathTo("expected.html"));
-  EXPECT_EQ(expected.toStdString(), actual.toStdString());
+  // Write to files.
+  FileUtils::writeFile(testDataDir.getPathTo("actual.html"), actual.toUtf8());
+  FileUtils::writeFile(testDataDir.getPathTo("actual.json"), data.toUtf8());
+
+  // Compare generated files with expected content.
+  EXPECT_EQ(
+      FileUtils::readFile(testDataDir.getPathTo("expected.html")).toStdString(),
+      actual.toStdString());
+  EXPECT_EQ(
+      FileUtils::readFile(testDataDir.getPathTo("expected.json")).toStdString(),
+      data.toStdString());
 }
 
 /*******************************************************************************


### PR DESCRIPTION
For any substituted attributes in texts like "{{VALUE}}", trim whitespaces before & after attributes which evaluated to an empty string. This allow e.g. to define a complex component value like this:

```
{{INDUCTANCE}} {{IMPEDANCE}} {{DC_RESISTANCE}}
{{RATED_CURRENT}} {{RATED_VOLTAGE}}
{{MPN or DEVICE}}
```

Where many of the attributes may not be defined, which currently ended up in strings like this:

```
  0.2Ω

SRF2012-300YA
```

By trimming the whitespaces, the result is now like this:

```
0.2Ω
SRF2012-300YA
```

See https://github.com/LibrePCB-Libraries/LibrePCB_Base.lplib/pull/193#issuecomment-4428810868 for a concrete use-case.

This change *can* lead to different behavior of existing projects. However, I think (and hope) such complex values were not used much yet (since they didn't work well), and at least not in critical production data. So I think it is pretty safe to make this change.