### PR TITLE
UI: Smart memorize & restore side panel page when switching tab

### DIFF
--- a/libs/librepcb/editor/mainwindow.cpp
+++ b/libs/librepcb/editor/mainwindow.cpp
@@ -480,7 +480,7 @@ std::shared_ptr<WindowTab> MainWindow::removeTab(
 }
 
 void MainWindow::showPanelPage(ui::PanelPage page) noexcept {
-  mWindow->global<ui::Data>().set_panel_page(page);
+  mWindow->global<ui::Data>().fn_set_panel_page(page);
 }
 
 void MainWindow::popUpNotifications() noexcept {

--- a/libs/librepcb/ui/api/data.slint
+++ b/libs/librepcb/ui/api/data.slint
@@ -49,7 +49,7 @@ export global Data {
 
     // State
     in-out property <float> panel-width-factor: 1;
-    in property <PanelPage> panel-page: PanelPage.home;
+    in-out property <PanelPage> panel-page: PanelPage.home;
     in property <bool> erc-zoom-to-location: true; // ERC panel: "zoom to location"
     in property <bool> drc-zoom-to-location: true; // DRC panel: "zoom to location"
     in property <bool> order-pcb-open-web-browser: true; // Order panel: "open web browser after upload"
@@ -1711,65 +1711,163 @@ export global Data {
         }
     };
 
+    property <PanelPage> previous-library-element-panel-page: PanelPage.none;
+    property <PanelPage> previous-package-panel-page: PanelPage.none;
+    property <PanelPage> previous-project-panel-page: PanelPage.none;
+    property <PanelPage> previous-board-2d-panel-page: PanelPage.none;
+    property <PanelPage> previous-board-3d-panel-page: PanelPage.none;
+    public function set-panel-page(page: PanelPage) {
+        if page == PanelPage.layers {
+            if current-tab.type == TabType.board-2d {
+                previous-board-2d-panel-page = page;
+            }
+        } else if page == PanelPage.place-devices {
+            if current-tab.type == TabType.board-2d {
+                previous-board-2d-panel-page = page;
+            }
+        } else if page == PanelPage.rule-check {
+            if current-tab.type == TabType.library {
+                previous-library-element-panel-page = page;
+            } else if current-tab.type == TabType.component-category {
+                previous-library-element-panel-page = page;
+            } else if current-tab.type == TabType.package-category {
+                previous-library-element-panel-page = page;
+            } else if current-tab.type == TabType.symbol {
+                previous-library-element-panel-page = page;
+            } else if current-tab.type == TabType.package {
+                previous-library-element-panel-page = page;
+                previous-package-panel-page = page;
+            } else if current-tab.type == TabType.component {
+                previous-library-element-panel-page = page;
+            } else if current-tab.type == TabType.device {
+                previous-library-element-panel-page = page;
+            } else if current-tab.type == TabType.organization {
+                previous-library-element-panel-page = page;
+            } else if current-tab.type == TabType.schematic {
+                previous-project-panel-page = page;
+            } else if current-tab.type == TabType.board-2d {
+                previous-board-2d-panel-page = page;
+            }
+            // Also memorize it for tabs which have no memory yet, to avoid
+            // them switching to the documents panel as fallback.
+            if previous-package-panel-page == PanelPage.none {
+                previous-package-panel-page = page;
+            }
+            if previous-project-panel-page == PanelPage.none {
+                previous-project-panel-page = page;
+            }
+            if previous-board-2d-panel-page == PanelPage.none {
+                previous-board-2d-panel-page = page;
+            }
+        } else if page == PanelPage.order {
+            previous-project-panel-page = page;
+            previous-board-2d-panel-page = page;
+            previous-board-3d-panel-page = page;
+        } else if page != PanelPage.none {
+            previous-library-element-panel-page = PanelPage.none;
+            previous-package-panel-page = PanelPage.none;
+            previous-project-panel-page = PanelPage.none;
+            previous-board-2d-panel-page = PanelPage.none;
+            previous-board-3d-panel-page = PanelPage.none;
+        }
+        panel-page = page;
+    }
+
     public function current-tab-changed() {
         if current-tab.type == TabType.library {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
             current-library-index = current-library-tab.library-index;
+            if previous-library-element-panel-page != PanelPage.none {
+                panel-page = previous-library-element-panel-page;
+            }
         } else if current-tab.type == TabType.component-category {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
             current-library-index = current-component-category-tab.library-index;
+            if previous-library-element-panel-page != PanelPage.none {
+                panel-page = previous-library-element-panel-page;
+            }
         } else if current-tab.type == TabType.package-category {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
             current-library-index = current-package-category-tab.library-index;
+            if previous-library-element-panel-page != PanelPage.none {
+                panel-page = previous-library-element-panel-page;
+            }
         } else if current-tab.type == TabType.symbol {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
             current-library-index = current-symbol-tab.library-index;
+            if previous-library-element-panel-page != PanelPage.none {
+                panel-page = previous-library-element-panel-page;
+            }
         } else if current-tab.type == TabType.package {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
             current-library-index = current-package-tab.library-index;
+            if previous-package-panel-page != PanelPage.none {
+                panel-page = previous-package-panel-page;
+            }
         } else if current-tab.type == TabType.component {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
             current-library-index = current-component-tab.library-index;
+            if previous-library-element-panel-page != PanelPage.none {
+                panel-page = previous-library-element-panel-page;
+            }
         } else if current-tab.type == TabType.device {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
+            if previous-library-element-panel-page != PanelPage.none {
+                panel-page = previous-library-element-panel-page;
+            }
         } else if current-tab.type == TabType.organization {
             current-project-index = -1;
             current-rule-check-project-index = -1;
             current-rule-check-board-index = -1;
+            if previous-library-element-panel-page != PanelPage.none {
+                panel-page = previous-library-element-panel-page;
+            }
         } else if current-tab.type == TabType.schematic {
             current-library-index = -1;
             current-project-index = current-schematic-tab.project-index;
             current-rule-check-project-index = current-project-index;
             current-rule-check-board-index = -1;
+            if previous-project-panel-page != PanelPage.none {
+                panel-page = previous-project-panel-page;
+            }
         } else if current-tab.type == TabType.board-2d {
             current-library-index = -1;
             current-project-index = current-board-2d-tab.project-index;
             current-rule-check-project-index = current-project-index;
             current-rule-check-board-index = current-board-2d-tab.board-index;
+            if previous-board-2d-panel-page != PanelPage.none {
+                panel-page = previous-board-2d-panel-page;
+            }
         } else if current-tab.type == TabType.board-3d {
             current-library-index = -1;
             current-project-index = current-board-3d-tab.project-index;
-            current-rule-check-project-index = current-project-index;
-            current-rule-check-board-index = current-board-3d-tab.board-index;
+            current-rule-check-project-index = -1; // Hide DRC
+            current-rule-check-board-index = -1; // Hide DRC
+            if previous-board-3d-panel-page != PanelPage.none {
+                panel-page = previous-board-3d-panel-page;
+            }
         } else if current-tab.type == TabType.project-library {
             current-library-index = -1;
             current-project-index = current-project-library-tab.project-index;
-            current-rule-check-project-index = current-project-index;
-            current-rule-check-board-index = -1;
+            current-rule-check-project-index = -1; // Hide ERC
+            current-rule-check-board-index = -1; // Hide ERC
+            if previous-project-panel-page != PanelPage.none {
+                panel-page = previous-project-panel-page;
+            }
         } else if current-tab.type != TabType.home {
             current-library-index = -1;
             current-project-index = -1;

--- a/libs/librepcb/ui/api/shortcuts.slint
+++ b/libs/librepcb/ui/api/shortcuts.slint
@@ -88,11 +88,11 @@ export global Shortcuts {
             return true;
         } else if Backend.is-shortcut(event, Cmd.run-quick-check) {
             Backend.trigger-board(project, board, BoardAction.run-quick-check);
-            Data.panel-page = PanelPage.rule-check;
+            Data.set-panel-page(PanelPage.rule-check);
             return true;
         } else if Backend.is-shortcut(event, Cmd.run-design-rule-check) {
             Backend.trigger-board(project, board, BoardAction.run-drc);
-            Data.panel-page = PanelPage.rule-check;
+            Data.set-panel-page(PanelPage.rule-check);
             return true;
         }
         false
@@ -1294,7 +1294,7 @@ export global Shortcuts {
             Backend.trigger(Action.workspace-libraries-rescan);
             return true;
         } else if Backend.is-shortcut(event, Cmd.library-manager) {
-            Data.panel-page = PanelPage.libraries;
+            Data.set-panel-page(PanelPage.libraries);
             return true;
         } else if Backend.is-shortcut(event, Cmd.project-new) {
             Backend.trigger(Action.project-new);
@@ -1310,19 +1310,19 @@ export global Shortcuts {
             return true;
         } else if Backend.is-shortcut(event, Cmd.dock-erc) && Data.current-project.valid {
             Data.current-rule-check-board-index = -1;
-            Data.panel-page = PanelPage.rule-check;
+            Data.set-panel-page(PanelPage.rule-check);
             return true;
         } else if Backend.is-shortcut(event, Cmd.dock-drc) && Data.current-tab.type == TabType.board-2d {
             Data.current-rule-check-board-index = Data.current-board-2d-tab.board-index;
-            Data.panel-page = PanelPage.rule-check;
+            Data.set-panel-page(PanelPage.rule-check);
             return true;
         } else if Backend.is-shortcut(event, Cmd.dock-layers) && (Data.current-tab.layers.length > 0) {
-            Data.panel-page = PanelPage.layers;
+            Data.set-panel-page(PanelPage.layers);
             return true;
         } else if Backend.is-shortcut(event, Cmd.dock-place-devices) && (Data.current-tab.type == TabType.board-2d) {
-            Data.panel-page = PanelPage.place-devices;
+            Data.set-panel-page(PanelPage.place-devices);
         } else if Backend.is-shortcut(event, Cmd.order-pcb) && Data.current-project.valid {
-            Data.panel-page = PanelPage.order;
+            Data.set-panel-page(PanelPage.order);
         } else if Backend.is-shortcut(event, Cmd.window-new) {
             Backend.trigger(Action.window-new);
             return true;
@@ -1333,7 +1333,7 @@ export global Shortcuts {
             Backend.trigger(Action.quit);
             return true;
         } else if Backend.is-shortcut(event, Cmd.about-librepcb) {
-            Data.panel-page = PanelPage.about;
+            Data.set-panel-page(PanelPage.about);
             return true;
         } else if Backend.is-shortcut(event, Cmd.website) {
             Backend.open-url(Constants.website-url);

--- a/libs/librepcb/ui/documentspanel.slint
+++ b/libs/librepcb/ui/documentspanel.slint
@@ -17,6 +17,7 @@ import {
     LibraryElementAction,
     OrganizationTabData,
     PackageTabData,
+    PanelPage,
     ProjectAction,
     ProjectData,
     SchematicAction,
@@ -99,6 +100,7 @@ component DocumentsListItem inherits Rectangle {
                 tooltip: Cmd.sheet-remove.text;
 
                 clicked => {
+                    Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                     schematic-action-triggered(SchematicAction.delete);
                 }
             }
@@ -110,6 +112,7 @@ component DocumentsListItem inherits Rectangle {
                 tooltip: @tr("Open 3D View");
 
                 clicked => {
+                    Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                     board-action-triggered(BoardAction.open-3d);
                 }
             }
@@ -132,6 +135,7 @@ component DocumentsListItem inherits Rectangle {
                 tooltip: Cmd.board-copy.text;
 
                 clicked => {
+                    Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                     board-action-triggered(BoardAction.copy);
                 }
             }
@@ -143,6 +147,7 @@ component DocumentsListItem inherits Rectangle {
                 tooltip: Cmd.board-remove.text;
 
                 clicked => {
+                    Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                     board-action-triggered(BoardAction.delete);
                 }
             }
@@ -177,6 +182,7 @@ component ProjectSection inherits Rectangle {
                     icon-scale: 60%;
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-project(project-index, ProjectAction.new-sheet);
                     }
                 }
@@ -187,6 +193,7 @@ component ProjectSection inherits Rectangle {
                     icon-scale: 60%;
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-project(project-index, ProjectAction.new-board);
                     }
                 }
@@ -205,6 +212,7 @@ component ProjectSection inherits Rectangle {
                     icon-scale: 60%;
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-project(project-index, ProjectAction.close);
                     }
                 }
@@ -223,6 +231,7 @@ component ProjectSection inherits Rectangle {
             selected: (Data.current-tab.type == TabType.schematic) && (Data.current-schematic-tab.project-index == project-index) && (Data.current-schematic-tab.schematic-index == index);
 
             clicked => {
+                Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                 Backend.trigger-schematic(project-index, index, SchematicAction.open);
             }
 
@@ -246,6 +255,7 @@ component ProjectSection inherits Rectangle {
             };
 
             clicked => {
+                Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                 Backend.trigger-board(project-index, index, BoardAction.open-2d);
             }
 
@@ -275,6 +285,7 @@ component LibrarySection inherits Rectangle {
                     icon-scale: 60%;
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(library.path, LibraryElementAction.close);
                     }
                 }
@@ -292,6 +303,7 @@ component LibrarySection inherits Rectangle {
             selected: (Data.current-tab.type == TabType.library) && (Data.current-library-tab.library-index == library-index);
 
             clicked => {
+                Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                 Backend.trigger-library-element(library.path, LibraryElementAction.open);
             }
         }
@@ -312,6 +324,7 @@ component LibrarySection inherits Rectangle {
                     selected: (Data.current-tab.type == TabType.component-category) && (Data.current-component-category-tab.library-index == library-index) && (Data.current-component-category-tab.path == derived-tab.path);
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(derived-tab.path, LibraryElementAction.open);
                     }
                 }
@@ -325,6 +338,7 @@ component LibrarySection inherits Rectangle {
                     selected: (Data.current-tab.type == TabType.package-category) && (Data.current-package-category-tab.library-index == library-index) && (Data.current-package-category-tab.path == derived-tab.path);
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(derived-tab.path, LibraryElementAction.open);
                     }
                 }
@@ -338,6 +352,7 @@ component LibrarySection inherits Rectangle {
                     selected: (Data.current-tab.type == TabType.symbol) && (Data.current-symbol-tab.library-index == library-index) && (Data.current-symbol-tab.path == derived-tab.path);
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(derived-tab.path, LibraryElementAction.open);
                     }
                 }
@@ -351,6 +366,7 @@ component LibrarySection inherits Rectangle {
                     selected: (Data.current-tab.type == TabType.package) && (Data.current-package-tab.library-index == library-index) && (Data.current-package-tab.path == derived-tab.path);
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(derived-tab.path, LibraryElementAction.open);
                     }
                 }
@@ -364,6 +380,7 @@ component LibrarySection inherits Rectangle {
                     selected: (Data.current-tab.type == TabType.component) && (Data.current-component-tab.library-index == library-index) && (Data.current-component-tab.path == derived-tab.path);
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(derived-tab.path, LibraryElementAction.open);
                     }
                 }
@@ -377,6 +394,7 @@ component LibrarySection inherits Rectangle {
                     selected: (Data.current-tab.type == TabType.device) && (Data.current-device-tab.library-index == library-index) && (Data.current-device-tab.path == derived-tab.path);
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(derived-tab.path, LibraryElementAction.open);
                     }
                 }
@@ -390,6 +408,7 @@ component LibrarySection inherits Rectangle {
                     selected: (Data.current-tab.type == TabType.organization) && (Data.current-organization-tab.library-index == library-index) && (Data.current-organization-tab.path == derived-tab.path);
 
                     clicked => {
+                        Data.set-panel-page(PanelPage.documents); // Avoid auto-switching.
                         Backend.trigger-library-element(derived-tab.path, LibraryElementAction.open);
                     }
                 }

--- a/libs/librepcb/ui/sidebar.slint
+++ b/libs/librepcb/ui/sidebar.slint
@@ -50,6 +50,7 @@ component SideBarButton inherits Rectangle {
     // Accessibility
     accessible-role: button;
     accessible-enabled: enabled;
+    accessible-checked: checked;
     accessible-label: tooltip;
     accessible-value: status;
     accessible-action-default => {
@@ -152,9 +153,19 @@ component SideBarButton inherits Rectangle {
 export component SideBar {
     function button-clicked(page: PanelPage) {
         if Data.panel-page == page {
-            Data.panel-page = PanelPage.none;
+            Data.set-panel-page(PanelPage.none);
         } else {
-            Data.panel-page = page;
+            Data.set-panel-page(page);
+        }
+    }
+
+    function button-enable-changed(enabled: bool, checked: bool) {
+        if checked && (!enabled) {
+            if documents-btn.enabled {
+                Data.panel-page = PanelPage.documents;
+            } else {
+                Data.panel-page = PanelPage.home;
+            }
         }
     }
 
@@ -182,9 +193,7 @@ export component SideBar {
             }
 
             changed enabled => {
-                if self.checked && (!self.enabled) {
-                    Data.panel-page = PanelPage.home;
-                }
+                button-enable-changed(self.enabled, self.checked);
             }
         }
 
@@ -200,13 +209,7 @@ export component SideBar {
             }
 
             changed enabled => {
-                if self.checked && (!self.enabled) {
-                    if documents-btn.enabled {
-                        Data.panel-page = PanelPage.documents;
-                    } else {
-                        Data.panel-page = PanelPage.home;
-                    }
-                }
+                button-enable-changed(self.enabled, self.checked);
             }
         }
 
@@ -240,13 +243,7 @@ export component SideBar {
             }
 
             changed enabled => {
-                if self.checked && (!self.enabled) {
-                    if documents-btn.enabled {
-                        Data.panel-page = PanelPage.documents;
-                    } else {
-                        Data.panel-page = PanelPage.home;
-                    }
-                }
+                button-enable-changed(self.enabled, self.checked);
             }
         }
 
@@ -302,13 +299,7 @@ export component SideBar {
             }
 
             changed enabled => {
-                if self.checked && (!self.enabled) {
-                    if documents-btn.enabled {
-                        Data.panel-page = PanelPage.documents;
-                    } else {
-                        Data.panel-page = PanelPage.home;
-                    }
-                }
+                button-enable-changed(self.enabled, self.checked);
             }
         }
 
@@ -335,9 +326,7 @@ export component SideBar {
             }
 
             changed enabled => {
-                if self.checked && (!self.enabled) {
-                    Data.panel-page = PanelPage.home;
-                }
+                button-enable-changed(self.enabled, self.checked);
             }
         }
 

--- a/tests/ui/mainwindow/test_side_panel_auto_switch.py
+++ b/tests/ui/mainwindow/test_side_panel_auto_switch.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test if the side panel automatically switches to the previously memorized
+page when the current tab changes.
+"""
+
+
+def test_1(librepcb):
+    librepcb.add_project("Empty Project")
+    librepcb.set_project("Empty Project/Empty Project.lpp")
+    with librepcb.open() as app:
+        tabs = app.get("#TabButton *")
+        tabs.wait(3)
+
+        # Switch to ERC panel
+        rule_check_btn = app.get("SideBar::rule-check-btn")
+        rule_check_btn.wait_for(enabled=True)
+        rule_check_btn.click()
+        rule_check_btn.wait_for(checked=True)
+        rule_check_header = app.get("RuleCheckPanel::header")
+        rule_check_header.wait_for(label="Electrical Rule Check".upper())
+
+        # Open board editor -> should still be on rule check panel (now DRC)
+        tabs[2].click()
+        rule_check_btn.wait_for(enabled=True, checked=True)
+        rule_check_header.wait_for(label="Design Rule Check".upper())
+
+        # Switch to place devices panel
+        place_devices_btn = app.get("SideBar::place-devices-btn")
+        place_devices_btn.click()
+        place_devices_header = app.get("PlaceDevicesPanel::header")
+        place_devices_header.wait_for(label="Place Devices".upper())
+
+        # Switch back to schematic tab -> shall open the ERC panel
+        tabs[1].click()
+        rule_check_btn.wait_for(enabled=True, checked=True)
+        rule_check_header.wait_for(label="Electrical Rule Check".upper())
+
+        # Switch back to board tab -> shall open the place devices panel
+        tabs[2].click()
+        place_devices_btn.wait_for(enabled=True, checked=True)
+        place_devices_header.wait_for(label="Place Devices".upper())
+
+
+def test_2(librepcb):
+    librepcb.add_project("Empty Project")
+    librepcb.set_project("Empty Project/Empty Project.lpp")
+    with librepcb.open() as app:
+        tabs = app.get("#TabButton *")
+        tabs.wait(3)
+
+        # Open board editor
+        tabs[2].click()
+
+        # Switch to DRC panel
+        rule_check_btn = app.get("SideBar::rule-check-btn")
+        rule_check_btn.wait_for(enabled=True)
+        rule_check_btn.click()
+        rule_check_btn.wait_for(enabled=True, checked=True)
+        rule_check_header = app.get("RuleCheckPanel::header")
+        rule_check_header.wait_for(label="Design Rule Check".upper())
+
+        # Switch to place devices panel
+        place_devices_btn = app.get("SideBar::place-devices-btn")
+        place_devices_btn.click()
+        place_devices_header = app.get("PlaceDevicesPanel::header")
+        place_devices_header.wait_for(label="Place Devices".upper())
+
+        # Switch to schematic tab -> should go back to rule check panel
+        # (now ERC) as this is probably the most intuitive behavior (better
+        # than switching to the documents panel).
+        tabs[1].click()
+        rule_check_btn.wait_for(enabled=True, checked=True)
+        rule_check_header = app.get("RuleCheckPanel::header")
+        rule_check_header.wait_for(label="Electrical Rule Check".upper())


### PR DESCRIPTION
Trying to implement some smart behavior to make the side panel switching automatically to the most intuitive panel page when the current tab changes. In many cases there is no automatic panel switching (as this would be very annoying), but for example when leaving the board editor tab on the "place devices" panel, and switching back to that tab later, the "place devices" panel will be reopened - unless the user explicitly switched to another panel page in the mean time.

See https://librepcb.discourse.group/t/change-tab-on-return-to-board/1034.