### PR TITLE
DRC: Add checks for board outline intersections

### DIFF
--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheck.cpp
@@ -1989,32 +1989,44 @@ RuleCheckMessageList BoardDesignRuleCheck::checkBoardOutline(const Data& data) {
   RuleCheckMessageList messages;
   emitStatus(tr("Check board outline..."));
 
-  // Report all open polygons.
+  // Collect all valid outlines and report all open polygons.
+  struct Object {
+    const Data::Polygon* polygon;  // Always non-null.
+    const Data::Device* device;  // Can be nullptr.
+    Path path;  // In global board coordinates.
+  };
+  QVector<Object> closedOutlinesAndCutouts;
   const QSet<const Layer*> allOutlineLayers = {
       &Layer::boardOutlines(),
       &Layer::boardCutouts(),
       &Layer::boardPlatedCutouts(),
   };
   for (const Data::Polygon& polygon : data.polygons) {
-    if (allOutlineLayers.contains(polygon.layer) &&
-        (!polygon.path.isClosed())) {
-      const QVector<Path> locations = polygon.path.toOutlineStrokes(
-          PositiveLength(std::max(*polygon.lineWidth, Length(100000))));
-      messages.append(std::make_shared<DrcMsgOpenBoardOutlinePolygon>(
-          polygon.uuid, std::nullopt, locations));
+    if (allOutlineLayers.contains(polygon.layer)) {
+      if (polygon.path.isClosed()) {
+        closedOutlinesAndCutouts.append(
+            Object{&polygon, nullptr, polygon.path});
+      } else {
+        const QVector<Path> locations = polygon.path.toOutlineStrokes(
+            PositiveLength(std::max(*polygon.lineWidth, Length(100000))));
+        messages.append(std::make_shared<DrcMsgOpenBoardOutlinePolygon>(
+            polygon.uuid, std::nullopt, locations));
+      }
     }
   }
   for (const Data::Device& dev : data.devices) {
     Transform transform(dev.position, dev.rotation, dev.mirror);
     for (const Data::Polygon& polygon : dev.polygons) {
-      if (allOutlineLayers.contains(polygon.layer) &&
-          (!polygon.path.isClosed())) {
-        const QVector<Path> locations =
-            transform.map(polygon.path)
-                .toOutlineStrokes(PositiveLength(
-                    std::max(*polygon.lineWidth, Length(100000))));
-        messages.append(std::make_shared<DrcMsgOpenBoardOutlinePolygon>(
-            polygon.uuid, dev.uuid, locations));
+      const Path path = transform.map(polygon.path);
+      if (allOutlineLayers.contains(polygon.layer)) {
+        if (polygon.path.isClosed()) {
+          closedOutlinesAndCutouts.append(Object{&polygon, &dev, path});
+        } else {
+          const QVector<Path> locations = path.toOutlineStrokes(
+              PositiveLength(std::max(*polygon.lineWidth, Length(100000))));
+          messages.append(std::make_shared<DrcMsgOpenBoardOutlinePolygon>(
+              polygon.uuid, dev.uuid, locations));
+        }
       }
     }
   }
@@ -2028,12 +2040,47 @@ RuleCheckMessageList BoardDesignRuleCheck::checkBoardOutline(const Data& data) {
     messages.append(std::make_shared<DrcMsgMultipleBoardOutlines>(outlines));
   }
 
-  // Determine actually drawn board area.
-  QVector<Path> allOutlines = getBoardOutlines(data, allOutlineLayers);
-  ClipperLib::Paths drawnBoardArea =
-      ClipperHelpers::convert(allOutlines, maxArcTolerance());
-  const std::unique_ptr<ClipperLib::PolyTree> drawnBoardAreaTree =
-      ClipperHelpers::uniteToTree(drawnBoardArea, ClipperLib::pftEvenOdd);
+  // Check for intersections between several board outlines.
+  for (int i = 0; i < closedOutlinesAndCutouts.count(); ++i) {
+    const Object& obj1 = closedOutlinesAndCutouts.at(i);
+    for (int k = i + 1; k < closedOutlinesAndCutouts.count(); ++k) {
+      const Object& obj2 = closedOutlinesAndCutouts.at(k);
+      if ((obj1.polygon->layer == &Layer::boardOutlines()) &&
+          (obj2.polygon->layer == &Layer::boardOutlines())) {
+        ClipperLib::Paths intersections{
+            ClipperHelpers::convert(obj1.path, maxArcTolerance())};
+        ClipperHelpers::intersect(
+            intersections,
+            {ClipperHelpers::convert(obj2.path, maxArcTolerance())},
+            ClipperLib::pftEvenOdd, ClipperLib::pftEvenOdd);
+        if (!intersections.empty()) {
+          messages.append(std::make_shared<DrcMsgIntersectingBoardOutlines>(
+              *obj1.polygon, obj1.device, *obj2.polygon, obj2.device,
+              ClipperHelpers::convert(intersections)));
+        }
+      }
+    }
+  }
+
+  // Check if there are any cutouts located outside the board outline.
+  // Intended especially to catch cutouts at the board edge which were made
+  // with separate polygons instead of drawing a single board outline polygon.
+  ClipperLib::Paths outlinesArea =
+      ClipperHelpers::convert(outlines, maxArcTolerance());
+  for (const Object& obj : std::as_const(closedOutlinesAndCutouts)) {
+    if (obj.polygon->layer != &Layer::boardOutlines()) {
+      ClipperLib::Paths subtraction{
+          ClipperHelpers::convert(obj.path, maxArcTolerance())};
+      ClipperHelpers::subtract(subtraction, outlinesArea,
+                               ClipperLib::pftNonZero, ClipperLib::pftNonZero);
+      if (!subtraction.empty()) {
+        messages.append(std::make_shared<DrcMsgCutoutOutsideBoardArea>(
+            obj.polygon->uuid,
+            obj.device ? obj.device->uuid : std::optional<Uuid>(),
+            ClipperHelpers::convert(subtraction)));
+      }
+    }
+  }
 
   // Check if the board outline can be manufactured with the smallest tool.
   const UnsignedLength minEdgeRadius(data.settings.getMinOutlineToolDiameter() /
@@ -2041,12 +2088,16 @@ RuleCheckMessageList BoardDesignRuleCheck::checkBoardOutline(const Data& data) {
   if (minEdgeRadius > 0) {
     const Length offset1 = std::max(minEdgeRadius - Length(10000), Length(0));
     const Length offset2 = -minEdgeRadius;
-    drawnBoardArea = ClipperHelpers::treeToPaths(*drawnBoardAreaTree);
-    ClipperLib::Paths nonManufacturableAreas = drawnBoardArea;
+    const QVector<Path> cutouts = getBoardOutlines(
+        data, {&Layer::boardCutouts(), &Layer::boardPlatedCutouts()});
+    ClipperHelpers::subtract(
+        outlinesArea, ClipperHelpers::convert(cutouts, maxArcTolerance()),
+        ClipperLib::pftNonZero, ClipperLib::pftNonZero);
+    ClipperLib::Paths nonManufacturableAreas = outlinesArea;
     ClipperHelpers::offset(nonManufacturableAreas, offset1, maxArcTolerance());
     ClipperHelpers::offset(nonManufacturableAreas, offset2, maxArcTolerance());
     const std::unique_ptr<ClipperLib::PolyTree> difference =
-        ClipperHelpers::subtractToTree(nonManufacturableAreas, drawnBoardArea,
+        ClipperHelpers::subtractToTree(nonManufacturableAreas, outlinesArea,
                                        ClipperLib::pftEvenOdd,
                                        ClipperLib::pftEvenOdd);
     nonManufacturableAreas = ClipperHelpers::flattenTree(*difference);

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.cpp
@@ -283,6 +283,79 @@ DrcMsgOpenBoardOutlinePolygon::DrcMsgOpenBoardOutlinePolygon(
 }
 
 /*******************************************************************************
+ *  DrcMsgIntersectingBoardOutlines
+ ******************************************************************************/
+
+DrcMsgIntersectingBoardOutlines::DrcMsgIntersectingBoardOutlines(
+    const Data::Polygon& polygon1, const Data::Device* device1,
+    const BoardDesignRuleCheckData::Polygon& polygon2,
+    const BoardDesignRuleCheckData::Device* device2,
+    const QVector<Path>& locations) noexcept
+  : RuleCheckMessage(
+        Severity::Error, tr("Intersecting board outlines"),
+        tr("Two board outline polygons are intersecting each other, which will "
+           "lead to invalid production data.") %
+            "\n\n" %
+            tr("Make sure there is exactly one board outline polygon. Cutouts "
+               "at the board edge need to be part of the board outline "
+               "polygon, not separate polygons. Cutouts inside the board need "
+               "to be drawn on the '%1' layer.")
+                .arg(Layer::boardCutouts().getNameTr()),
+        "intersecting_board_outlines", locations) {
+  auto serialize = [](SExpression& node, const Data::Polygon& polygon,
+                      const Data::Device* device) {
+    node.ensureLineBreak();
+    if (device) {
+      node.appendChild("device", device->uuid);
+      node.ensureLineBreak();
+      node.appendChild("polygon", polygon.uuid);
+    } else {
+      node.appendChild("polygon", polygon.uuid);
+    }
+    node.ensureLineBreak();
+  };
+
+  mApproval->ensureLineBreak();
+  SExpression& node1 = mApproval->appendList("object");
+  mApproval->ensureLineBreak();
+  SExpression& node2 = mApproval->appendList("object");
+  mApproval->ensureLineBreak();
+
+  // Sort nodes to make the approval canonical.
+  serialize(node1, polygon1, device1);
+  serialize(node2, polygon2, device2);
+  if (node2 < node1) {
+    std::swap(node1, node2);
+  }
+}
+
+/*******************************************************************************
+ *  DrcMsgCutoutOutsideBoardArea
+ ******************************************************************************/
+
+DrcMsgCutoutOutsideBoardArea::DrcMsgCutoutOutsideBoardArea(
+    const Uuid& polygon, const std::optional<Uuid>& device,
+    const QVector<Path>& locations) noexcept
+  : RuleCheckMessage(
+        Severity::Error, tr("Cutout outside of board area"),
+        tr("A cutout polygon is outside the board area (either partially or "
+           "fully), which will lead to invalid production data.") %
+            "\n\n" %
+            tr("Make sure all cutouts are fully inside the board area. "
+               "Cutouts at the board edge need to be part of the board "
+               "outlines polygon on the '%1' layer, not separate polygons.")
+                .arg(Layer::boardOutlines().getNameTr()),
+        "cutout_outside_board_area", locations) {
+  mApproval->ensureLineBreak();
+  if (device) {
+    mApproval->appendChild("device", *device);
+    mApproval->ensureLineBreak();
+  }
+  mApproval->appendChild("polygon", polygon);
+  mApproval->ensureLineBreak();
+}
+
+/*******************************************************************************
  *  DrcMsgMinimumBoardOutlineInnerRadiusViolation
  ******************************************************************************/
 

--- a/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
+++ b/libs/librepcb/core/project/board/drc/boarddesignrulecheckmessages.h
@@ -272,6 +272,51 @@ public:
 };
 
 /*******************************************************************************
+ *  Class DrcMsgIntersectingBoardOutlines
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgIntersectingBoardOutlines class
+ */
+class DrcMsgIntersectingBoardOutlines final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgIntersectingBoardOutlines)
+
+public:
+  using Data = BoardDesignRuleCheckData;
+
+  // Constructors / Destructor
+  explicit DrcMsgIntersectingBoardOutlines(
+      const Data::Polygon& polygon1, const Data::Device* device1,
+      const Data::Polygon& polygon2, const Data::Device* device2,
+      const QVector<Path>& locations) noexcept;
+  DrcMsgIntersectingBoardOutlines(
+      const DrcMsgIntersectingBoardOutlines& other) noexcept
+    : RuleCheckMessage(other) {}
+  ~DrcMsgIntersectingBoardOutlines() noexcept override {}
+};
+
+/*******************************************************************************
+ *  Class DrcMsgCutoutOutsideBoardArea
+ ******************************************************************************/
+
+/**
+ * @brief The DrcMsgCutoutOutsideBoardArea class
+ */
+class DrcMsgCutoutOutsideBoardArea final : public RuleCheckMessage {
+  Q_DECLARE_TR_FUNCTIONS(DrcMsgCutoutOutsideBoardArea)
+
+public:
+  // Constructors / Destructor
+  explicit DrcMsgCutoutOutsideBoardArea(
+      const Uuid& polygon, const std::optional<Uuid>& device,
+      const QVector<Path>& locations) noexcept;
+  DrcMsgCutoutOutsideBoardArea(
+      const DrcMsgCutoutOutsideBoardArea& other) noexcept
+    : RuleCheckMessage(other) {}
+  ~DrcMsgCutoutOutsideBoardArea() noexcept override {}
+};
+
+/*******************************************************************************
  *  Class DrcMsgMinimumBoardOutlineInnerRadiusViolation
  ******************************************************************************/
 


### PR DESCRIPTION
* Warn on overlapping polygons on the board outlines layer
* Warn on cutout polygons outside the board area (whether fully or partially)